### PR TITLE
Lightweight encodings, compressed execution, and a differential test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ OBJS = \
 	src/columnar_metadata.o \
 	src/columnar_write_state.o \
 	src/columnar_compression.o \
+	src/columnar_encoding.o \
 	src/columnar_reader.o \
 	src/columnar_row_mask.o \
 	src/columnar_customscan.o \

--- a/columnar--1.0.sql
+++ b/columnar--1.0.sql
@@ -63,7 +63,9 @@ CREATE TABLE columnar.chunk (
 	value_compression_type integer NOT NULL,
 	value_compression_level integer NOT NULL,
 	value_decompressed_length bigint NOT NULL,
-	value_count bigint NOT NULL
+	value_count bigint NOT NULL,
+	value_encoding_type integer,
+	value_raw_length bigint
 );
 
 CREATE UNIQUE INDEX chunk_pkey

--- a/design/FORMAT_AND_INTERFACE_SPEC.md
+++ b/design/FORMAT_AND_INTERFACE_SPEC.md
@@ -326,6 +326,7 @@ flags:
 | columnar.min_parallel_processes | 8 | minimum parallel processes for columnar work |
 | columnar.planner_debug_level | debug3 | log level for planner messages |
 | columnar.enable_custom_scan | on | use the columnar custom scan path |
+| columnar.enable_compressed_execution | on | fold aggregates over runs of the value stream |
 | columnar.enable_qual_pushdown | on | push filters into the scan for chunk skipping |
 | columnar.enable_columnar_index_scan | off | allow the custom index backed scan |
 | columnar.qual_pushdown_correlation_threshold | 0.4 | correlation threshold for pushdown |

--- a/design/FORMAT_AND_INTERFACE_SPEC.md
+++ b/design/FORMAT_AND_INTERFACE_SPEC.md
@@ -149,10 +149,13 @@ downstream decoding is unchanged. Encoding types are:
 | 1 | rle (run-length of a fixed-width value) |
 | 2 | for (frame of reference + bit-packing) |
 | 3 | delta (delta + zigzag + bit-packing) |
+| 4 | gorilla (XOR-against-previous for float4/float8) |
+| 5 | dod (delta-of-delta + zigzag + bit-packing) |
 
-Codes 1-3 apply to fixed-width columns; for and delta apply to fixed-width
-by-value integer-family types (attribute length 1, 2, 4, or 8). An encoding is
-used only when it produces a smaller stream; otherwise the chunk records type 0.
+rle applies to any fixed-width column; for, delta, and dod apply to fixed-width
+by-value integer-family types (attribute length 1, 2, 4, or 8); gorilla applies
+to float4 and float8. An encoding is used only when it produces a smaller
+stream; otherwise the chunk records type 0.
 Format 2.0 chunks carry no encoding fields and are read as type 0 (none), with
 the raw length equal to the decompressed length (see 7.2).
 

--- a/design/FORMAT_AND_INTERFACE_SPEC.md
+++ b/design/FORMAT_AND_INTERFACE_SPEC.md
@@ -13,7 +13,10 @@ implementer works from without reading the existing source, which is the
 condition for the reimplementation to be free of the upstream copyright. See
 REWRITE_PLAN.md for how that condition is maintained.
 
-Format version described here is 2.0.
+Format version described here is 2.1. Version 2.1 adds optional per-chunk
+value-stream encodings (section 5.1) and two chunk catalog columns (section 7.2);
+it is otherwise identical to 2.0, and 2.0 files are read unchanged by a 2.1
+implementation.
 
 ## 1. Terminology
 
@@ -131,6 +134,28 @@ The compression level applies to zstd. If a chunk does not compress smaller than
 its raw form, it is stored uncompressed with type 0. The exists stream is never
 compressed.
 
+### 5.1 Value-stream encoding (format 2.1)
+
+Before block compression, a chunk's value stream may be transformed by a
+lightweight, reversible encoding whose code is recorded per chunk. An encoding
+maps the raw value stream bytes to a smaller encoded stream; block compression is
+then applied to the encoded stream. The reader decompresses to the encoded stream
+and reverses the encoding to obtain the byte-identical raw stream, so all
+downstream decoding is unchanged. Encoding types are:
+
+| Code | Type |
+| --- | --- |
+| 0 | none |
+| 1 | rle (run-length of a fixed-width value) |
+| 2 | for (frame of reference + bit-packing) |
+| 3 | delta (delta + zigzag + bit-packing) |
+
+Codes 1-3 apply to fixed-width columns; for and delta apply to fixed-width
+by-value integer-family types (attribute length 1, 2, 4, or 8). An encoding is
+used only when it produces a smaller stream; otherwise the chunk records type 0.
+Format 2.0 chunks carry no encoding fields and are read as type 0 (none), with
+the raw length equal to the decompressed length (see 7.2).
+
 ## 6. Row identity and item pointers
 
 Rows carry a stable 1 based row number. Row numbers are mapped to synthetic
@@ -188,9 +213,18 @@ Indexes:
 | 12 | value_compression_level | integer |
 | 13 | value_decompressed_length | bigint |
 | 14 | value_count | bigint |
+| 15 | value_encoding_type | integer |
+| 16 | value_raw_length | bigint |
 
 Index:
 - `chunk_pkey` unique on (storage_id, stripe_num, attr_num, chunk_group_num)
+
+`value_decompressed_length` is the length of the stream produced by
+decompression, which is the encoded stream (5.1); for encoding type none it
+equals the raw value-stream length. `value_encoding_type` (5.1) and
+`value_raw_length` (the fully decoded raw value-stream length) are present from
+format 2.1; they are absent/NULL in 2.0 chunks, where a reader assumes encoding
+none and `value_raw_length` = `value_decompressed_length`.
 
 `minimum_value` and `maximum_value` are the encoded per chunk min and max of the
 column, used as a skip list for chunk group filtering. They are present only for

--- a/design/FORMAT_AND_INTERFACE_SPEC.md
+++ b/design/FORMAT_AND_INTERFACE_SPEC.md
@@ -151,11 +151,14 @@ downstream decoding is unchanged. Encoding types are:
 | 3 | delta (delta + zigzag + bit-packing) |
 | 4 | gorilla (XOR-against-previous for float4/float8) |
 | 5 | dod (delta-of-delta + zigzag + bit-packing) |
+| 6 | dict (dictionary of distinct values + bit-packed codes) |
 
 rle applies to any fixed-width column; for, delta, and dod apply to fixed-width
 by-value integer-family types (attribute length 1, 2, 4, or 8); gorilla applies
-to float4 and float8. An encoding is used only when it produces a smaller
-stream; otherwise the chunk records type 0.
+to float4 and float8; dict applies to any fixed-width or varlena column and is
+the encoding for low-cardinality text and other variable-length types. Each
+chunk is encoded with whichever applicable encoding yields the smallest stream,
+and records type 0 when none helps.
 Format 2.0 chunks carry no encoding fields and are read as type 0 (none), with
 the raw length equal to the decompressed length (see 7.2).
 

--- a/design/IMPROVEMENT_PLAN.md
+++ b/design/IMPROVEMENT_PLAN.md
@@ -1,0 +1,187 @@
+# pgColumnar improvement plan (research-driven)
+
+This plan proposes the next phase of pgColumnar work. It is derived entirely
+from publicly readable academic literature on columnar storage and from the
+current pgColumnar source and format spec. It names each technique, cites its
+public source, states where pgColumnar stands today, and proposes concrete,
+prioritized work. It preserves the clean-room discipline (see PROVENANCE.md and
+REWRITE_PLAN.md): all techniques below come from the cited papers and the public
+PostgreSQL API, never from any copyleft columnar project's source.
+
+## Method and constraints
+
+- **Sources.** The survey behind this plan (foundational and modern column-store
+  papers) produced 15 high-confidence, independently verified findings. The key
+  primary sources, all freely readable, are cited inline by short tag and listed
+  in full at the end.
+- **Format versioning.** Any on-disk change bumps the format minor version
+  (currently 2.0, see FORMAT_AND_INTERFACE_SPEC.md section 3) and must keep read
+  compatibility with existing 2.0 files. New encodings are additive: an old
+  reader refuses an unknown code; a new reader still reads code 0 (none).
+- **Test net.** The differential/recovery/fuzz suites (test/lib.sh and friends)
+  are the regression net for everything here. They compare columnar output
+  against a heap oracle across a broad type/null/boundary matrix and randomized
+  rounds, which is exactly what value-stream encoding changes stress. Every item
+  below lands with new differential cases before it is considered done.
+
+## Where pgColumnar stands today
+
+Confirmed from source (src/columnar_compression.c, columnar_reader.c,
+columnar_vector.c, columnar_cache.c) and FORMAT_AND_INTERFACE_SPEC.md:
+
+- **Compression is block-level only.** Each chunk's value stream is the raw
+  serialized column values, then optionally run through a general-purpose codec
+  (pglz/lz4/zstd) as a whole, with a store-verbatim fallback. There is no
+  lightweight, type-aware, or order-aware encoding.
+- **No compressed execution.** The reader fully decodes a chunk group into
+  arrays; the vectorized aggregates and scan then run over decoded values.
+  Operators never see the encoded form.
+- **Data skipping is min/max only.** Per-chunk minimum_value/maximum_value drive
+  chunk-group skipping. There are no bloom filters or richer zone maps, and a
+  point lookup decodes a whole chunk group (the documented latency weakness).
+- **Vectorization is partial.** Vectorized scan and count/sum/avg/min/max exist,
+  but predicate evaluation is row-at-a-time (ColumnarVecRowPasses) and there are
+  no branch-free/SIMD primitives.
+- **One encoding choice per table.** Compression type/level is a per-table
+  option; there is no per-chunk adaptive selection.
+
+## Gap analysis
+
+| Technique (source) | pgColumnar today | Gap |
+| --- | --- | --- |
+| Lightweight encodings: RLE, dictionary, bit-pack, FOR/delta [C-Store, Abadi-SIGMOD06] | block codec over raw stream | no encoding layer at all |
+| Super-scalar PFOR / PFOR-DELTA / PDICT, branch-free [X100-Compress] | none | none |
+| Float XOR + delta-of-delta timestamps [Gorilla] | none | none |
+| Operate directly on compressed data [Abadi-SIGMOD06, thesis] | decode-then-compute | no compressed execution |
+| Compression-block abstraction API [Abadi-SIGMOD06] | none | needed to avoid operator explosion |
+| Per-chunk adaptive encoding selection [Abadi-SIGMOD06 decision tree] | one codec per table | no per-chunk choice |
+| Vectorized, cache-sized, branch-free primitives [X100] | partial; row-at-a-time filter | vectorized predicates + SIMD |
+| Late materialization / position lists [Abadi-ICDE07] | projection pushdown only | delayed reconstruction |
+| Zone maps beyond min/max; bloom filters | min/max only | equality skipping, point-lookup |
+| RAM-CPU cache compression (JIT decode at cache granularity) [X100-Compress] | decompressed-chunk cache | aligned; revisit granularity |
+| C-Store projections (multiple sort orders); PAX/hybrid [C-Store, PAX] | single layout | optional, larger effort |
+| Arrow/Parquet interop | none | optional export/interchange |
+
+## Prioritized roadmap
+
+Ordered by impact per unit effort, and by dependency. Tiers 1–2 are the core
+value; tier 3 is higher-effort or optional. Each item notes impact, effort,
+risk, and on-disk-format impact.
+
+### Tier 1 — the encoding foundation (biggest win, protected by the new tests)
+
+**I1. Lightweight encoding layer + first encodings (RLE, dictionary, delta/FOR,
+bit-packing).**
+Insert a type-aware encoding stage between the raw value stream and the
+general-purpose block codec. Encode a chunk's values with the best lightweight
+scheme, then optionally still block-compress. Start with integer/‑family types
+(int2/4/8, date, timestamp) for FOR+bit-packing and delta; RLE for low-cardinality
+runs; dictionary for low-distinct text/values.
+- Source: [C-Store] four-encoding scheme; [Abadi-SIGMOD06] encodings and results.
+- Impact: high (size and scan CPU). Effort: high. Risk: medium (format).
+- Format: add a per-chunk `value_encoding_type` (and any encoding header) to
+  columnar.chunk; bump to 2.1; readers ignore/none for old chunks.
+
+**I2. Compression-block abstraction API.**
+A small internal interface exposing block properties `isOneValue`,
+`isValueSorted`, `isPosContig` plus an iterator (`getNext`/`asArray`) and block
+info (`getSize`/`getStartValue`/`getEndPosition`). Operators consume this instead
+of raw per-encoding details, so we avoid N encodings × M operators variants.
+- Source: [Abadi-SIGMOD06] compression-block API.
+- Impact: high (enables I3 cleanly). Effort: medium. Risk: low. Format: none.
+
+**I3. Compressed execution for scan filters and aggregates.**
+Using I2, run operators directly on encoded blocks: SUM over an RLE block as
+value × run-length; COUNT/MIN/MAX on RLE/dictionary without materializing;
+predicate evaluation on dictionary codes; skip whole single-value blocks. This is
+the result that turns compression from a ~3x space win into a 3–10x speed win.
+- Source: [Abadi-SIGMOD06] (SUM speedups 3.3x RLE, 10.3x bit-vector, 3.94x dict);
+  [Abadi-thesis].
+- Impact: high. Effort: medium (after I2). Risk: medium. Format: none.
+
+### Tier 2 — specialization and adaptivity
+
+**I4. Float and timestamp specialized encodings (Gorilla).**
+XOR-against-previous for float4/float8 (zero XOR = 1 bit; else leading-zero and
+meaningful-bit control fields); delta-of-delta variable-length for timestamps.
+Large win for time-series / append-mostly analytic tables.
+- Source: [Gorilla].
+- Impact: high for time-series. Effort: medium. Risk: low. Format: new encoding
+  codes under I1's scheme.
+
+**I5. Per-chunk adaptive encoding selection.**
+Sample each chunk's cardinality, run-length, and sortedness and pick the encoding
+by a decision tree (RLE for avg run > ~4; dictionary for distinct < ~50k or
+position-contiguous access; bit-vector for very low cardinality; LZ/none
+otherwise). Store the chosen code per chunk (already provided by I1).
+- Source: [Abadi-SIGMOD06] Figure 10 decision tree.
+- Impact: medium-high. Effort: medium. Risk: low. Format: none beyond I1.
+
+**I6. Vectorized, branch-free predicate evaluation.**
+Replace row-at-a-time ColumnarVecRowPasses with primitives that evaluate a
+predicate over a decoded (or encoded, via I2) array into a selection vector,
+written to be auto-vectorizable (restrict-qualified, no data-dependent branches).
+- Source: [X100] vector primitives and cycle-per-tuple results.
+- Impact: medium-high. Effort: medium. Risk: low. Format: none.
+
+### Tier 3 — skipping, materialization, and larger bets
+
+**I7. Bloom-filter / richer zone maps per chunk group.**
+Optional per-chunk bloom filter for equality predicates, and consider count of
+distinct / null counts in zone maps. Directly mitigates the point-lookup
+weakness (a fetch decodes a whole chunk group) by skipping non-matching groups
+on equality.
+- Source: general zone-map/data-skipping practice; complements [C-Store] skipping.
+- Impact: medium (point lookups, equality scans). Effort: medium. Risk: low.
+- Format: optional bloom stream per chunk; bump minor; additive.
+
+**I8. Late materialization with position lists.**
+Delay tuple reconstruction until after predicates and (where possible)
+aggregation, carrying position lists instead of reconstructed rows.
+- Source: [Abadi-ICDE07] materialization strategies (~3x on average).
+- Impact: medium. Effort: medium-high. Risk: medium. Format: none.
+
+**I9 (optional, larger). C-Store-style projections and/or Arrow interop.**
+Multiple sort-order projections of the same columns for query-specific ordering,
+or Arrow/Parquet export for interchange and external vectorized tools. Both are
+substantial; list as exploratory.
+- Source: [C-Store] projections; Arrow/Parquet ecosystem.
+- Impact: workload-dependent. Effort: high. Risk: medium-high.
+
+## Suggested sequencing
+
+1. I2 (block API) and I1 (encoding layer) together — the API shapes the encoding
+   interface. Land RLE + dictionary + FOR/bit-pack first.
+2. I3 (compressed execution) on the encodings from I1, via I2.
+3. I5 (adaptive selection) once several encodings exist.
+4. I4 (Gorilla) for float/timestamp.
+5. I6 (vectorized predicates) — independent; can proceed in parallel.
+6. I7/I8 skipping and materialization.
+7. I9 only if a workload justifies it.
+
+Each step: implement from the cited paper, extend the differential type-matrix
+and fuzz suites with cases that target the new encoding/operator, run the full
+version matrix, and append to PROVENANCE.md.
+
+## Sources
+
+- **[C-Store]** Stonebraker et al., "C-Store: A Column-oriented DBMS," VLDB 2005.
+  https://web.stanford.edu/class/cs345d-01/rl/cstore.pdf
+- **[X100]** Boncz, Zukowski, Nes, "MonetDB/X100: Hyper-Pipelining Query
+  Execution," CIDR 2005. http://cidrdb.org/cidr2005/papers/P19.pdf
+- **[Abadi-SIGMOD06]** Abadi, Madden, Ferreira, "Integrating Compression and
+  Execution in Column-Oriented Database Systems," SIGMOD 2006.
+  https://doi.org/10.1145/1142473.1142548
+- **[Abadi-ICDE07]** Abadi, Myers, DeWitt, Madden, "Materialization Strategies
+  in a Column-Oriented DBMS," ICDE 2007.
+  http://www.cs.umd.edu/~abadi/papers/abadiicde2007.pdf
+- **[Abadi-thesis]** Abadi, "Query Execution in Column-Oriented Database
+  Systems," PhD thesis, MIT 2008.
+  http://www.cs.umd.edu/~abadi/papers/abadiphd.pdf
+- **[X100-Compress]** Zukowski, Heman, Nes, Boncz, "Super-Scalar RAM-CPU Cache
+  Compression," ICDE 2006 (PFOR, PFOR-DELTA, PDICT).
+  https://paperhub.s3.amazonaws.com/7558905a56f370848a04fa349dd8bb9d.pdf
+- **[Gorilla]** Pelkonen et al., "Gorilla: A Fast, Scalable, In-Memory Time
+  Series Database," VLDB 2015. https://www.vldb.org/pvldb/vol8/p1816-teller.pdf
+- Boncz lecture notes (survey framing):
+  https://homepages.cwi.nl/~boncz/mimuw/boncz_mimuw.pdf

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -26,9 +26,10 @@
 #include "utils/rel.h"
 #include "utils/snapshot.h"
 
-/* format version (spec 3) */
+/* format version (spec 3). Minor 1 adds per-chunk value encodings (I1); 2.0
+ * files still read (a chunk with no encoding type is treated as NONE). */
 #define COLUMNAR_VERSION_MAJOR 2
-#define COLUMNAR_VERSION_MINOR 0
+#define COLUMNAR_VERSION_MINOR 1
 
 /* first row number is 1 (spec 3) */
 #define COLUMNAR_FIRST_ROW_NUMBER 1
@@ -59,6 +60,16 @@
 #define COLUMNAR_COMPRESSION_PGLZ 1
 #define COLUMNAR_COMPRESSION_LZ4 2
 #define COLUMNAR_COMPRESSION_ZSTD 3
+
+/*
+ * Value-stream encoding codes (I1, format 2.1). An encoding is a reversible
+ * transform of the raw value-stream bytes, applied before block compression on
+ * write and reversed after decompression on read (columnar_encoding.c).
+ */
+#define COLUMNAR_ENCODING_NONE 0
+#define COLUMNAR_ENCODING_RLE 1		/* run-length of a fixed-width value */
+#define COLUMNAR_ENCODING_FOR 2		/* frame-of-reference + bit-packing */
+#define COLUMNAR_ENCODING_DELTA 3	/* delta + zigzag + bit-packing */
 
 /* schema that holds the metadata catalog */
 #define COLUMNAR_SCHEMA_NAME "columnar"
@@ -163,8 +174,20 @@ typedef struct ChunkMetadata
 	uint64		existsStreamLength;
 	int			valueCompressionType;
 	int			valueCompressionLevel;
-	uint64		valueDecompressedLength;
+	uint64		valueDecompressedLength;	/* length after decompression (= encoded
+										 * stream length; for NONE encoding this
+										 * equals the raw length) */
 	uint64		valueCount;
+
+	/*
+	 * Value-stream encoding (I1, format 2.1). valueEncodingType is one of
+	 * COLUMNAR_ENCODING_*; valueRawLength is the length of the fully decoded raw
+	 * value stream (what decode reconstructs). For format 2.0 chunks the catalog
+	 * columns are absent/NULL and the reader defaults to NONE with
+	 * valueRawLength == valueDecompressedLength.
+	 */
+	int			valueEncodingType;
+	uint64		valueRawLength;
 
 	/*
 	 * Per-chunk min/max skip list (spec 7.2). Stored only for orderable types;
@@ -336,6 +359,18 @@ extern void ColumnarEncodeValue(StringInfo buf, Form_pg_attribute att,
 								Datum value);
 extern Datum ColumnarDecodeValue(Form_pg_attribute att, char **cursor,
 								 MemoryContext targetContext);
+
+/* -------------------------------------------------------------------------
+ * lightweight value-stream encodings (columnar_encoding.c, I1)
+ * ------------------------------------------------------------------------- */
+extern int ColumnarEncodeChunk(const char *raw, uint32 rawLen,
+							   Form_pg_attribute att, uint64 valueCount,
+							   char **out, uint32 *outLen);
+extern char *ColumnarDecodeChunk(const char *enc, uint32 encLen,
+								 int encodingType, Form_pg_attribute att,
+								 uint64 valueCount, uint32 rawLen,
+								 MemoryContext cx);
+extern const char *ColumnarEncodingName(int encodingType);
 
 /* -------------------------------------------------------------------------
  * compression (columnar_compression.c, spec 5)

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -70,6 +70,8 @@
 #define COLUMNAR_ENCODING_RLE 1		/* run-length of a fixed-width value */
 #define COLUMNAR_ENCODING_FOR 2		/* frame-of-reference + bit-packing */
 #define COLUMNAR_ENCODING_DELTA 3	/* delta + zigzag + bit-packing */
+#define COLUMNAR_ENCODING_GORILLA 4 /* Gorilla XOR for float4/float8 */
+#define COLUMNAR_ENCODING_DOD 5		/* delta-of-delta + zigzag + bit-packing */
 
 /* schema that holds the metadata catalog */
 #define COLUMNAR_SCHEMA_NAME "columnar"

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -100,6 +100,7 @@ extern bool columnar_enable_custom_scan;
 
 /* Phase 6 GUCs (spec 8.3) */
 extern bool columnar_enable_vectorization;	/* vectorized scan/aggregate path */
+extern bool columnar_enable_compressed_execution;	/* run-based aggregate path (I3) */
 extern bool columnar_enable_column_cache;	/* decompressed-chunk cache */
 extern int columnar_column_cache_size;		/* cache budget in megabytes */
 
@@ -354,6 +355,35 @@ typedef struct ColumnarVector
 extern bool ColumnarReadNextVector(ColumnarReadState *readState,
 								   ColumnarVector *vec);
 
+/* -------------------------------------------------------------------------
+ * raw-group reader (columnar_reader.c, I3 compressed execution)
+ *
+ * Like ColumnarReadNextVector but hands back each projected column's raw value
+ * stream (packed non-null values) instead of a decoded Datum array, so an
+ * aggregate can run over runs (ColumnarBlockReader) without materializing
+ * Datums. Only the non-null values are present in valueCursor; deletedCount
+ * reports how many of the group's rows are row-mask-deleted. When deletedCount
+ * is non-zero the caller falls back to ColumnarDecodeCurrentGroupVector, which
+ * decodes the currently positioned group into a full vector (with per-row null
+ * and deleted flags). The arrays live in the read state's per-group context and
+ * are valid only until the next raw-group / vector call.
+ * ------------------------------------------------------------------------- */
+typedef struct ColumnarRawGroup
+{
+	uint64		nrows;			/* rows in this chunk group */
+	uint64		firstRowNumber;
+	uint64		deletedCount;	/* rows in this group marked deleted */
+	int			natts;
+	char	  **valueCursor;	/* [natts]; raw value stream, or NULL */
+	uint64	   *groupValueCount;	/* [natts]; non-null values per column */
+	bool	   *columnAbsent;	/* [natts]; true if column predates the stripe */
+} ColumnarRawGroup;
+
+extern bool ColumnarReadNextRawGroup(ColumnarReadState *readState,
+									 ColumnarRawGroup *rg);
+extern void ColumnarDecodeCurrentGroupVector(ColumnarReadState *readState,
+											 ColumnarVector *vec);
+
 /* value stream encode/decode shared by writer and reader */
 extern void ColumnarEncodeValue(StringInfo buf, Form_pg_attribute att,
 								Datum value);
@@ -371,6 +401,34 @@ extern char *ColumnarDecodeChunk(const char *enc, uint32 encLen,
 								 uint64 valueCount, uint32 rawLen,
 								 MemoryContext cx);
 extern const char *ColumnarEncodingName(int encodingType);
+
+/* -------------------------------------------------------------------------
+ * compression-block run iterator (columnar_encoding.c, I2)
+ *
+ * Exposes a column chunk's (non-null) values as a sequence of (value, run
+ * length) pairs so operators run once per run instead of once per row (I3
+ * compressed execution). It iterates the decoded raw value stream and coalesces
+ * adjacent equal fixed-width values, so a repetitive or run-length-encoded
+ * column yields long runs. Fixed-width columns only.
+ * ------------------------------------------------------------------------- */
+typedef struct ColumnarBlockReader
+{
+	const char *raw;			/* raw value stream (packed fixed-width values) */
+	uint64		valueCount;		/* number of values in the stream */
+	int			width;			/* bytes per value (attlen) */
+	uint64		pos;			/* next value index */
+} ColumnarBlockReader;
+
+extern void ColumnarBlockReaderInit(ColumnarBlockReader *br, const char *raw,
+									uint64 valueCount, int width);
+
+/*
+ * Yield the next run: *valBytes points at the run's value (width bytes, valid
+ * while the underlying stream is), *runLen is how many consecutive values equal
+ * it. Returns false at end of stream.
+ */
+extern bool ColumnarBlockNextRun(ColumnarBlockReader *br,
+								 const char **valBytes, uint64 *runLen);
 
 /* -------------------------------------------------------------------------
  * compression (columnar_compression.c, spec 5)

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -72,6 +72,7 @@
 #define COLUMNAR_ENCODING_DELTA 3	/* delta + zigzag + bit-packing */
 #define COLUMNAR_ENCODING_GORILLA 4 /* Gorilla XOR for float4/float8 */
 #define COLUMNAR_ENCODING_DOD 5		/* delta-of-delta + zigzag + bit-packing */
+#define COLUMNAR_ENCODING_DICT 6	/* dictionary of distinct values + codes */
 
 /* schema that holds the metadata catalog */
 #define COLUMNAR_SCHEMA_NAME "columnar"

--- a/src/columnar_encoding.c
+++ b/src/columnar_encoding.c
@@ -28,6 +28,7 @@
  */
 #include "columnar.h"
 
+#include "catalog/pg_type.h"
 #include "utils/memutils.h"
 
 /* -------------------------------------------------------------------------
@@ -145,13 +146,21 @@ unzigzag(uint64 z)
 	return (int64) (z >> 1) ^ -(int64) (z & 1);
 }
 
-/* is this a fixed-width integer-family value we can FOR/DELTA encode? */
+/* is this a fixed-width integer-family value we can FOR/DELTA/DOD encode? */
 static inline bool
 is_packable_int(Form_pg_attribute att)
 {
 	return att->attbyval &&
 		(att->attlen == 1 || att->attlen == 2 ||
 		 att->attlen == 4 || att->attlen == 8);
+}
+
+/* is this a float we can Gorilla-encode? */
+static inline bool
+is_gorilla_float(Form_pg_attribute att)
+{
+	return att->attbyval &&
+		(att->atttypid == FLOAT4OID || att->atttypid == FLOAT8OID);
 }
 
 /* -------------------------------------------------------------------------
@@ -367,6 +376,291 @@ decode_delta(const char *enc, uint32 encLen, uint32 n, uint32 rawLen,
 }
 
 /* -------------------------------------------------------------------------
+ * streaming bit writer/reader (LSB-first) for variable-width fields
+ * ------------------------------------------------------------------------- */
+
+typedef struct BitWriter
+{
+	StringInfoData buf;
+	uint8		cur;
+	int			nbits;			/* bits currently held in cur (0..7) */
+} BitWriter;
+
+static void
+bw_init(BitWriter *bw)
+{
+	initStringInfo(&bw->buf);
+	bw->cur = 0;
+	bw->nbits = 0;
+}
+
+/* append the low `bits` bits of v, least-significant first */
+static void
+bw_put(BitWriter *bw, uint64 v, int bits)
+{
+	int			i;
+
+	for (i = 0; i < bits; i++)
+	{
+		if ((v >> i) & 1)
+			bw->cur |= (uint8) (1u << bw->nbits);
+		bw->nbits++;
+		if (bw->nbits == 8)
+		{
+			appendStringInfoChar(&bw->buf, (char) bw->cur);
+			bw->cur = 0;
+			bw->nbits = 0;
+		}
+	}
+}
+
+static void
+bw_flush(BitWriter *bw)
+{
+	if (bw->nbits > 0)
+	{
+		appendStringInfoChar(&bw->buf, (char) bw->cur);
+		bw->cur = 0;
+		bw->nbits = 0;
+	}
+}
+
+typedef struct BitReader
+{
+	const unsigned char *data;
+	uint64		bitpos;
+} BitReader;
+
+static void
+br_init(BitReader *br, const unsigned char *data)
+{
+	br->data = data;
+	br->bitpos = 0;
+}
+
+static uint64
+br_get(BitReader *br, int bits)
+{
+	uint64		v = 0;
+	int			i;
+
+	for (i = 0; i < bits; i++)
+	{
+		uint64		p = br->bitpos + i;
+
+		if ((br->data[p >> 3] >> (p & 7)) & 1)
+			v |= (uint64) 1 << i;
+	}
+	br->bitpos += bits;
+	return v;
+}
+
+/* leading/trailing zero counts of a non-zero value within a `total`-bit window */
+static inline int
+clz_in(uint64 x, int total)
+{
+	int			n = 0;
+
+	while (n < total && ((x >> (total - 1 - n)) & 1) == 0)
+		n++;
+	return n;
+}
+
+static inline int
+ctz_in(uint64 x)
+{
+	int			n = 0;
+
+	while (((x >> n) & 1) == 0)
+		n++;
+	return n;
+}
+
+/* -------------------------------------------------------------------------
+ * GORILLA: XOR-against-previous for float4/float8 (Facebook Gorilla, VLDB 2015),
+ * simplified without the previous-window reuse. Per value after the first:
+ *   XOR==0            -> control bit 0
+ *   else              -> control bit 1, [lz][mlen-1][mlen meaningful bits]
+ * where lz/len fields are 5 bits for 32-bit values, 6 bits for 64-bit.
+ * ------------------------------------------------------------------------- */
+
+static bool
+encode_gorilla(const char *raw, uint32 rawLen, int w, uint32 n,
+			   char **out, uint32 *outLen)
+{
+	int			total = w * 8;
+	int			field = (w == 8) ? 6 : 5;
+	BitWriter	bw;
+	uint64		prev;
+	uint32		i;
+
+	bw_init(&bw);
+	prev = load_uint(raw, w);
+	bw_put(&bw, prev, total);	/* first value verbatim */
+
+	for (i = 1; i < n; i++)
+	{
+		uint64		v = load_uint(raw + (uint64) i * w, w);
+		uint64		x = v ^ prev;
+
+		if (x == 0)
+			bw_put(&bw, 0, 1);
+		else
+		{
+			int			lz = clz_in(x, total);
+			int			tz = ctz_in(x);
+			int			mlen = total - lz - tz;
+
+			bw_put(&bw, 1, 1);
+			bw_put(&bw, (uint64) lz, field);
+			bw_put(&bw, (uint64) (mlen - 1), field);
+			bw_put(&bw, x >> tz, mlen);
+		}
+		prev = v;
+	}
+	bw_flush(&bw);
+
+	if ((uint32) bw.buf.len >= rawLen)
+	{
+		pfree(bw.buf.data);
+		return false;
+	}
+	*out = bw.buf.data;
+	*outLen = bw.buf.len;
+	return true;
+}
+
+static char *
+decode_gorilla(const char *enc, uint32 encLen, int w, uint32 n, uint32 rawLen,
+			   MemoryContext cx)
+{
+	char	   *raw = MemoryContextAlloc(cx, rawLen > 0 ? rawLen : 1);
+	int			total = w * 8;
+	int			field = (w == 8) ? 6 : 5;
+	BitReader	br;
+	uint64		prev;
+	uint32		i;
+
+	br_init(&br, (const unsigned char *) enc);
+	prev = br_get(&br, total);
+	if (n > 0)
+		store_uint(raw, prev, w);
+
+	for (i = 1; i < n; i++)
+	{
+		uint64		v;
+
+		if (br_get(&br, 1) == 0)
+			v = prev;
+		else
+		{
+			int			lz = (int) br_get(&br, field);
+			int			mlen = (int) br_get(&br, field) + 1;
+			int			tz = total - lz - mlen;
+			uint64		meaningful = br_get(&br, mlen);
+
+			v = prev ^ (meaningful << tz);
+		}
+		store_uint(raw + (uint64) i * w, v, w);
+		prev = v;
+	}
+	return raw;
+}
+
+/* -------------------------------------------------------------------------
+ * DOD: delta-of-delta + zigzag + bit-packing, for fixed-width int-family types.
+ * Regular sequences (e.g. fixed-interval timestamps) have zero second
+ * differences and pack to almost nothing.
+ * header: [uint8 w][uint8 width][uint64 base][int64 firstDelta]
+ * body: bit-packed zigzag(delta[i]-delta[i-1]) for i >= 2
+ * ------------------------------------------------------------------------- */
+
+static bool
+encode_dod(const char *raw, uint32 rawLen, int w, uint32 n,
+		   char **out, uint32 *outLen)
+{
+	uint64	   *vals = palloc(sizeof(uint64) * n);
+	uint64	   *dods;
+	uint64		base;
+	int64		firstDelta;
+	uint64		maxz = 0;
+	int			width;
+	StringInfoData buf;
+	uint32		i;
+
+	for (i = 0; i < n; i++)
+		vals[i] = load_uint(raw + (uint64) i * w, w);
+
+	base = vals[0];
+	firstDelta = (n > 1) ? (int64) vals[1] - (int64) vals[0] : 0;
+	dods = palloc(sizeof(uint64) * (n > 2 ? n - 2 : 1));
+	for (i = 2; i < n; i++)
+	{
+		int64		d = (int64) vals[i] - (int64) vals[i - 1];
+		int64		dd = d - ((int64) vals[i - 1] - (int64) vals[i - 2]);
+		uint64		z = zigzag(dd);
+
+		dods[i - 2] = z;
+		if (z > maxz)
+			maxz = z;
+	}
+	width = bits_needed(maxz);
+
+	initStringInfo(&buf);
+	appendStringInfoChar(&buf, (char) w);
+	appendStringInfoChar(&buf, (char) width);
+	appendBinaryStringInfo(&buf, (char *) &base, sizeof(uint64));
+	appendBinaryStringInfo(&buf, (char *) &firstDelta, sizeof(int64));
+	if (n > 2)
+		bitpack(dods, n - 2, width, &buf);
+	pfree(vals);
+	pfree(dods);
+
+	if ((uint32) buf.len >= rawLen)
+	{
+		pfree(buf.data);
+		return false;
+	}
+	*out = buf.data;
+	*outLen = buf.len;
+	return true;
+}
+
+static char *
+decode_dod(const char *enc, uint32 encLen, uint32 n, uint32 rawLen,
+		   MemoryContext cx)
+{
+	char	   *raw = MemoryContextAlloc(cx, rawLen > 0 ? rawLen : 1);
+	int			w = (unsigned char) enc[0];
+	int			width = (unsigned char) enc[1];
+	uint64		base;
+	int64		firstDelta;
+	uint64	   *dods;
+	int64		delta;
+	uint64		cur;
+	uint32		i;
+
+	memcpy(&base, enc + 2, sizeof(uint64));
+	memcpy(&firstDelta, enc + 10, sizeof(int64));
+	dods = palloc(sizeof(uint64) * (n > 2 ? n - 2 : 1));
+	if (n > 2)
+		bitunpack((const unsigned char *) enc + 18, n - 2, width, dods);
+
+	cur = base;
+	if (n > 0)
+		store_uint(raw, cur, w);
+	delta = firstDelta;
+	for (i = 1; i < n; i++)
+	{
+		if (i >= 2)
+			delta += unzigzag(dods[i - 2]);
+		cur = (uint64) ((int64) cur + delta);
+		store_uint(raw + (uint64) i * w, cur, w);
+	}
+	return raw;
+}
+
+/* -------------------------------------------------------------------------
  * public entry points
  * ------------------------------------------------------------------------- */
 
@@ -419,6 +713,10 @@ ColumnarEncodingName(int encodingType)
 			return "for";
 		case COLUMNAR_ENCODING_DELTA:
 			return "delta";
+		case COLUMNAR_ENCODING_GORILLA:
+			return "gorilla";
+		case COLUMNAR_ENCODING_DOD:
+			return "dod";
 		default:
 			return "unknown";
 	}
@@ -484,6 +782,24 @@ ColumnarEncodeChunk(const char *raw, uint32 rawLen, Form_pg_attribute att,
 				bestBuf = buf;
 				bestLen = len;
 			}
+			if (encode_dod(raw, rawLen, w, n, &buf, &len) && len < bestLen)
+			{
+				if (bestBuf)
+					pfree(bestBuf);
+				bestCode = COLUMNAR_ENCODING_DOD;
+				bestBuf = buf;
+				bestLen = len;
+			}
+		}
+
+		if (is_gorilla_float(att) &&
+			encode_gorilla(raw, rawLen, w, n, &buf, &len) && len < bestLen)
+		{
+			if (bestBuf)
+				pfree(bestBuf);
+			bestCode = COLUMNAR_ENCODING_GORILLA;
+			bestBuf = buf;
+			bestLen = len;
 		}
 	}
 
@@ -521,6 +837,10 @@ ColumnarDecodeChunk(const char *enc, uint32 encLen, int encodingType,
 			return decode_for(enc, encLen, n, rawLen, cx);
 		case COLUMNAR_ENCODING_DELTA:
 			return decode_delta(enc, encLen, n, rawLen, cx);
+		case COLUMNAR_ENCODING_GORILLA:
+			return decode_gorilla(enc, encLen, att->attlen, n, rawLen, cx);
+		case COLUMNAR_ENCODING_DOD:
+			return decode_dod(enc, encLen, n, rawLen, cx);
 		default:
 			ereport(ERROR,
 					(errcode(ERRCODE_DATA_CORRUPTED),

--- a/src/columnar_encoding.c
+++ b/src/columnar_encoding.c
@@ -146,11 +146,15 @@ unzigzag(uint64 z)
 	return (int64) (z >> 1) ^ -(int64) (z & 1);
 }
 
-/* is this a fixed-width integer-family value we can FOR/DELTA/DOD encode? */
+/* is this a fixed-width integer-family value we can FOR/DELTA/DOD encode?
+ * Floats are excluded: their bit patterns are not integers, and they have their
+ * own encoding (gorilla). Applying integer delta to float bits happens to help
+ * same-exponent runs but is not the right tool. */
 static inline bool
 is_packable_int(Form_pg_attribute att)
 {
 	return att->attbyval &&
+		att->atttypid != FLOAT4OID && att->atttypid != FLOAT8OID &&
 		(att->attlen == 1 || att->attlen == 2 ||
 		 att->attlen == 4 || att->attlen == 8);
 }
@@ -661,6 +665,155 @@ decode_dod(const char *enc, uint32 encLen, uint32 n, uint32 rawLen,
 }
 
 /* -------------------------------------------------------------------------
+ * DICT: dictionary encoding for low-cardinality columns, fixed-width or varlena.
+ * This is the cardinality axis of per-chunk selection (I5): distinct values are
+ * stored once and each position becomes a small bit-packed code.
+ *   [uint32 nDistinct][dictionary][uint8 codeWidth][bit-packed codes]
+ * dictionary is nDistinct fixed-width values, or for varlena each entry is
+ * [uint32 len][len bytes]. Only attempted up to a bounded distinct count.
+ * ------------------------------------------------------------------------- */
+
+#define DICT_MAX_DISTINCT 1024
+
+static bool
+encode_dict(const char *raw, uint32 rawLen, Form_pg_attribute att, uint32 n,
+			char **out, uint32 *outLen)
+{
+	int			w = att->attlen;
+	uint32	   *codes = palloc(sizeof(uint32) * n);
+	uint32		distOff[DICT_MAX_DISTINCT];
+	uint32		distLen[DICT_MAX_DISTINCT];
+	int			nd = 0;
+	uint64	   *codes64;
+	int			codeWidth;
+	StringInfoData buf;
+	uint32		pos = 0;
+	uint32		i;
+	int			j;
+
+	for (i = 0; i < n; i++)
+	{
+		const char *vp = raw + pos;
+		uint32		vlen = (w > 0) ? (uint32) w : (uint32) VARSIZE_ANY(vp);
+		int			code = -1;
+
+		for (j = 0; j < nd; j++)
+			if (distLen[j] == vlen &&
+				memcmp(raw + distOff[j], vp, vlen) == 0)
+			{
+				code = j;
+				break;
+			}
+
+		if (code < 0)
+		{
+			if (nd >= DICT_MAX_DISTINCT)
+			{
+				pfree(codes);
+				return false;	/* too many distinct values for a dictionary */
+			}
+			distOff[nd] = pos;
+			distLen[nd] = vlen;
+			code = nd;
+			nd++;
+		}
+		codes[i] = (uint32) code;
+		pos += vlen;
+	}
+
+	codeWidth = bits_needed(nd > 0 ? (uint64) (nd - 1) : 0);
+
+	initStringInfo(&buf);
+	{
+		uint32		ndVal = (uint32) nd;
+
+		appendBinaryStringInfo(&buf, (char *) &ndVal, sizeof(uint32));
+	}
+	for (j = 0; j < nd; j++)
+	{
+		if (w > 0)
+			appendBinaryStringInfo(&buf, raw + distOff[j], w);
+		else
+		{
+			appendBinaryStringInfo(&buf, (char *) &distLen[j], sizeof(uint32));
+			appendBinaryStringInfo(&buf, raw + distOff[j], distLen[j]);
+		}
+	}
+	appendStringInfoChar(&buf, (char) codeWidth);
+
+	codes64 = palloc(sizeof(uint64) * n);
+	for (i = 0; i < n; i++)
+		codes64[i] = codes[i];
+	bitpack(codes64, n, codeWidth, &buf);
+	pfree(codes64);
+	pfree(codes);
+
+	if ((uint32) buf.len >= rawLen)
+	{
+		pfree(buf.data);
+		return false;
+	}
+	*out = buf.data;
+	*outLen = buf.len;
+	return true;
+}
+
+static char *
+decode_dict(const char *enc, uint32 encLen, Form_pg_attribute att, uint32 n,
+			uint32 rawLen, MemoryContext cx)
+{
+	int			w = att->attlen;
+	char	   *raw = MemoryContextAlloc(cx, rawLen > 0 ? rawLen : 1);
+	const char *p = enc;
+	uint32		nd;
+	const char **dptr;
+	uint32	   *dlen;
+	int			codeWidth;
+	uint64	   *codes;
+	uint32		pos = 0;
+	uint32		i;
+	uint32		j;
+
+	memcpy(&nd, p, sizeof(uint32));
+	p += sizeof(uint32);
+
+	dptr = palloc(sizeof(char *) * (nd > 0 ? nd : 1));
+	dlen = palloc(sizeof(uint32) * (nd > 0 ? nd : 1));
+	for (j = 0; j < nd; j++)
+	{
+		if (w > 0)
+		{
+			dptr[j] = p;
+			dlen[j] = (uint32) w;
+			p += w;
+		}
+		else
+		{
+			memcpy(&dlen[j], p, sizeof(uint32));
+			p += sizeof(uint32);
+			dptr[j] = p;
+			p += dlen[j];
+		}
+	}
+
+	codeWidth = (unsigned char) *p;
+	p++;
+
+	codes = palloc(sizeof(uint64) * (n > 0 ? n : 1));
+	bitunpack((const unsigned char *) p, n, codeWidth, codes);
+
+	for (i = 0; i < n; i++)
+	{
+		uint32		code = (uint32) codes[i];
+
+		memcpy(raw + pos, dptr[code], dlen[code]);
+		pos += dlen[code];
+	}
+	pfree(codes);
+	return raw;
+}
+
+/* -------------------------------------------------------------------------
  * public entry points
  * ------------------------------------------------------------------------- */
 
@@ -717,6 +870,8 @@ ColumnarEncodingName(int encodingType)
 			return "gorilla";
 		case COLUMNAR_ENCODING_DOD:
 			return "dod";
+		case COLUMNAR_ENCODING_DICT:
+			return "dict";
 		default:
 			return "unknown";
 	}
@@ -731,8 +886,11 @@ ColumnarEncodingName(int encodingType)
  *		read-only and must not free it. Encoded buffers for the other cases are
  *		palloc'd in the current memory context.
  *
- *		Selection here is deliberately simple (smallest pre-compression encoded
- *		size); adaptive, sampled selection is a later step (I5).
+ *		Selection is adaptive per chunk: each applicable encoding is measured and
+ *		the smallest pre-compression result wins (each encoder bails cheaply when
+ *		it cannot help). The candidate set spans the encoding axes -- runs (rle),
+ *		range (for), sequences (delta, dod), cardinality (dict), and floats
+ *		(gorilla) -- so the choice adapts to the column's data (I5).
  */
 int
 ColumnarEncodeChunk(const char *raw, uint32 rawLen, Form_pg_attribute att,
@@ -754,7 +912,7 @@ ColumnarEncodeChunk(const char *raw, uint32 rawLen, Form_pg_attribute att,
 		return COLUMNAR_ENCODING_NONE;
 	}
 
-	/* lightweight encodings currently target fixed-width columns */
+	/* fixed-width encodings (rle/for/delta/dod/gorilla); dict handled below */
 	if (w > 0)
 	{
 		if (encode_rle(raw, rawLen, w, n, &buf, &len) && len < bestLen)
@@ -803,6 +961,24 @@ ColumnarEncodeChunk(const char *raw, uint32 rawLen, Form_pg_attribute att,
 		}
 	}
 
+	/*
+	 * Dictionary (the cardinality axis of selection) applies to any fixed-width
+	 * or varlena column, and is the only lightweight encoding available for
+	 * varlena (text/bytea/jsonb) low-cardinality columns. It bails cheaply when
+	 * the distinct count is too high to help.
+	 */
+	if (w > 0 || w == -1)
+	{
+		if (encode_dict(raw, rawLen, att, n, &buf, &len) && len < bestLen)
+		{
+			if (bestBuf)
+				pfree(bestBuf);
+			bestCode = COLUMNAR_ENCODING_DICT;
+			bestBuf = buf;
+			bestLen = len;
+		}
+	}
+
 	if (bestCode == COLUMNAR_ENCODING_NONE)
 	{
 		*out = (char *) raw;
@@ -841,6 +1017,8 @@ ColumnarDecodeChunk(const char *enc, uint32 encLen, int encodingType,
 			return decode_gorilla(enc, encLen, att->attlen, n, rawLen, cx);
 		case COLUMNAR_ENCODING_DOD:
 			return decode_dod(enc, encLen, n, rawLen, cx);
+		case COLUMNAR_ENCODING_DICT:
+			return decode_dict(enc, encLen, att, n, rawLen, cx);
 		default:
 			ereport(ERROR,
 					(errcode(ERRCODE_DATA_CORRUPTED),

--- a/src/columnar_encoding.c
+++ b/src/columnar_encoding.c
@@ -1,0 +1,495 @@
+/*-------------------------------------------------------------------------
+ *
+ * columnar_encoding.c
+ *		Lightweight, type-aware value-stream encodings (I1) and the
+ *		compression-block abstraction they implement (I2).
+ *
+ * The encoding layer sits between the raw serialized value stream that the
+ * writer builds (a packed sequence of ColumnarEncodeValue outputs, spec 4) and
+ * the general-purpose block codec (columnar_compression.c, spec 5). An encoding
+ * is a reversible transform of the raw value-stream BYTES: encode(raw) -> a
+ * smaller encoded buffer, and decode(encoded) -> the byte-identical raw stream.
+ * Because decode reconstructs the exact raw stream, every downstream consumer
+ * (per-value ColumnarDecodeValue, the vectorized group decoder, the min/max
+ * skip list) is unchanged; only the flush and load paths gain one step.
+ *
+ * The techniques come from the public column-store literature (see
+ * design/IMPROVEMENT_PLAN.md): run-length encoding and frame-of-reference with
+ * bit-packing [C-Store; Abadi SIGMOD 2006], and delta+bit-packing
+ * [Abadi SIGMOD 2006; Zukowski et al. Super-Scalar Compression]. This file is
+ * an independent implementation written from those descriptions and the public
+ * PostgreSQL API only (clean-room; see PROVENANCE.md).
+ *
+ * On-disk: columnar.chunk records value_encoding_type per chunk, and
+ * value_raw_length (the decoded raw stream length). A NULL/absent encoding type
+ * (old format 2.0 chunks) is treated as NONE, so 2.0 files still read.
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "columnar.h"
+
+#include "utils/memutils.h"
+
+/* -------------------------------------------------------------------------
+ * fixed-width value load/store and bit-packing helpers
+ * ------------------------------------------------------------------------- */
+
+/*
+ * Load/store a fixed-width value as a uint64. We copy the low W bytes so the
+ * transform is exactly reversible on any architecture; the integer value is
+ * only used to cluster/delta and never leaves this file, so its interpretation
+ * (little-endian on x86) does not affect correctness of the round trip.
+ */
+static inline uint64
+load_uint(const char *p, int w)
+{
+	uint64		v = 0;
+
+	memcpy(&v, p, w);
+	return v;
+}
+
+static inline void
+store_uint(char *p, uint64 v, int w)
+{
+	memcpy(p, &v, w);
+}
+
+/* number of bits needed to represent maxval; 0 when maxval == 0 */
+static int
+bits_needed(uint64 maxval)
+{
+	int			n = 0;
+
+	while (maxval > 0)
+	{
+		n++;
+		maxval >>= 1;
+	}
+	return n;
+}
+
+/* pack n values of `width` bits each (LSB-first) and append to out */
+static void
+bitpack(const uint64 *vals, uint32 n, int width, StringInfo out)
+{
+	uint64		totalbits;
+	uint32		nbytes;
+	unsigned char *buf;
+	uint64		bitpos = 0;
+	uint32		i;
+
+	if (width == 0 || n == 0)
+		return;
+
+	totalbits = (uint64) n * (uint64) width;
+	nbytes = (uint32) ((totalbits + 7) / 8);
+	buf = palloc0(nbytes);
+
+	for (i = 0; i < n; i++)
+	{
+		uint64		v = vals[i];
+		int			b;
+
+		for (b = 0; b < width; b++)
+		{
+			if ((v >> b) & 1)
+				buf[(bitpos + b) >> 3] |= (unsigned char) (1u << ((bitpos + b) & 7));
+		}
+		bitpos += width;
+	}
+
+	appendBinaryStringInfo(out, (char *) buf, nbytes);
+	pfree(buf);
+}
+
+/* inverse of bitpack: unpack n values of `width` bits each into out[] */
+static void
+bitunpack(const unsigned char *in, uint32 n, int width, uint64 *out)
+{
+	uint64		bitpos = 0;
+	uint32		i;
+
+	if (width == 0)
+	{
+		for (i = 0; i < n; i++)
+			out[i] = 0;
+		return;
+	}
+
+	for (i = 0; i < n; i++)
+	{
+		uint64		v = 0;
+		int			b;
+
+		for (b = 0; b < width; b++)
+		{
+			if ((in[(bitpos + b) >> 3] >> ((bitpos + b) & 7)) & 1)
+				v |= (uint64) 1 << b;
+		}
+		out[i] = v;
+		bitpos += width;
+	}
+}
+
+/* zigzag map signed<->unsigned so small-magnitude deltas pack tightly */
+static inline uint64
+zigzag(int64 x)
+{
+	return ((uint64) x << 1) ^ (uint64) (x >> 63);
+}
+
+static inline int64
+unzigzag(uint64 z)
+{
+	return (int64) (z >> 1) ^ -(int64) (z & 1);
+}
+
+/* is this a fixed-width integer-family value we can FOR/DELTA encode? */
+static inline bool
+is_packable_int(Form_pg_attribute att)
+{
+	return att->attbyval &&
+		(att->attlen == 1 || att->attlen == 2 ||
+		 att->attlen == 4 || att->attlen == 8);
+}
+
+/* -------------------------------------------------------------------------
+ * RLE: runs of an equal fixed-width value, [uint32 count][W bytes] per run
+ * ------------------------------------------------------------------------- */
+
+static bool
+encode_rle(const char *raw, uint32 rawLen, int w, uint32 n,
+		   char **out, uint32 *outLen)
+{
+	StringInfoData buf;
+	uint32		i = 0;
+
+	initStringInfo(&buf);
+	while (i < n)
+	{
+		const char *val = raw + (uint64) i * w;
+		uint32		run = 1;
+
+		while (i + run < n &&
+			   memcmp(raw + (uint64) (i + run) * w, val, w) == 0)
+			run++;
+
+		appendBinaryStringInfo(&buf, (char *) &run, sizeof(uint32));
+		appendBinaryStringInfo(&buf, val, w);
+		i += run;
+
+		/* give up early if we are not beating the raw size */
+		if ((uint32) buf.len >= rawLen)
+		{
+			pfree(buf.data);
+			return false;
+		}
+	}
+
+	*out = buf.data;
+	*outLen = buf.len;
+	return true;
+}
+
+static char *
+decode_rle(const char *enc, uint32 encLen, int w, uint32 n, uint32 rawLen,
+		   MemoryContext cx)
+{
+	char	   *raw = MemoryContextAlloc(cx, rawLen > 0 ? rawLen : 1);
+	const char *p = enc;
+	const char *end = enc + encLen;
+	uint32		produced = 0;
+
+	while (p < end && produced < n)
+	{
+		uint32		run;
+
+		memcpy(&run, p, sizeof(uint32));
+		p += sizeof(uint32);
+		while (run-- > 0 && produced < n)
+		{
+			memcpy(raw + (uint64) produced * w, p, w);
+			produced++;
+		}
+		p += w;
+	}
+	return raw;
+}
+
+/* -------------------------------------------------------------------------
+ * FOR: frame of reference + bit-packing.
+ * header: [uint8 w][uint8 width][uint64 min], body: bit-packed (value - min)
+ * ------------------------------------------------------------------------- */
+
+static bool
+encode_for(const char *raw, uint32 rawLen, int w, uint32 n,
+		   char **out, uint32 *outLen)
+{
+	uint64	   *vals = palloc(sizeof(uint64) * n);
+	uint64		minv;
+	uint64		maxoff = 0;
+	int			width;
+	StringInfoData buf;
+	uint32		i;
+
+	for (i = 0; i < n; i++)
+		vals[i] = load_uint(raw + (uint64) i * w, w);
+
+	minv = vals[0];
+	for (i = 1; i < n; i++)
+		if (vals[i] < minv)
+			minv = vals[i];
+	for (i = 0; i < n; i++)
+	{
+		vals[i] -= minv;
+		if (vals[i] > maxoff)
+			maxoff = vals[i];
+	}
+	width = bits_needed(maxoff);
+
+	initStringInfo(&buf);
+	appendStringInfoChar(&buf, (char) w);
+	appendStringInfoChar(&buf, (char) width);
+	appendBinaryStringInfo(&buf, (char *) &minv, sizeof(uint64));
+	bitpack(vals, n, width, &buf);
+	pfree(vals);
+
+	if ((uint32) buf.len >= rawLen)
+	{
+		pfree(buf.data);
+		return false;
+	}
+	*out = buf.data;
+	*outLen = buf.len;
+	return true;
+}
+
+static char *
+decode_for(const char *enc, uint32 encLen, uint32 n, uint32 rawLen,
+		   MemoryContext cx)
+{
+	char	   *raw = MemoryContextAlloc(cx, rawLen > 0 ? rawLen : 1);
+	int			w = (unsigned char) enc[0];
+	int			width = (unsigned char) enc[1];
+	uint64		minv;
+	uint64	   *vals;
+	uint32		i;
+
+	memcpy(&minv, enc + 2, sizeof(uint64));
+	vals = palloc(sizeof(uint64) * (n > 0 ? n : 1));
+	bitunpack((const unsigned char *) enc + 10, n, width, vals);
+	for (i = 0; i < n; i++)
+		store_uint(raw + (uint64) i * w, vals[i] + minv, w);
+	pfree(vals);
+	return raw;
+}
+
+/* -------------------------------------------------------------------------
+ * DELTA: store first value, then zigzag(value[i]-value[i-1]) bit-packed.
+ * header: [uint8 w][uint8 width][uint64 base], body: bit-packed zigzag deltas
+ * ------------------------------------------------------------------------- */
+
+static bool
+encode_delta(const char *raw, uint32 rawLen, int w, uint32 n,
+			 char **out, uint32 *outLen)
+{
+	uint64	   *vals = palloc(sizeof(uint64) * n);
+	uint64	   *deltas;
+	uint64		base;
+	uint64		maxz = 0;
+	int			width;
+	StringInfoData buf;
+	uint32		i;
+
+	for (i = 0; i < n; i++)
+		vals[i] = load_uint(raw + (uint64) i * w, w);
+
+	base = vals[0];
+	deltas = palloc(sizeof(uint64) * (n > 1 ? n - 1 : 1));
+	for (i = 1; i < n; i++)
+	{
+		int64		d = (int64) vals[i] - (int64) vals[i - 1];
+		uint64		z = zigzag(d);
+
+		deltas[i - 1] = z;
+		if (z > maxz)
+			maxz = z;
+	}
+	width = bits_needed(maxz);
+
+	initStringInfo(&buf);
+	appendStringInfoChar(&buf, (char) w);
+	appendStringInfoChar(&buf, (char) width);
+	appendBinaryStringInfo(&buf, (char *) &base, sizeof(uint64));
+	if (n > 1)
+		bitpack(deltas, n - 1, width, &buf);
+	pfree(vals);
+	pfree(deltas);
+
+	if ((uint32) buf.len >= rawLen)
+	{
+		pfree(buf.data);
+		return false;
+	}
+	*out = buf.data;
+	*outLen = buf.len;
+	return true;
+}
+
+static char *
+decode_delta(const char *enc, uint32 encLen, uint32 n, uint32 rawLen,
+			 MemoryContext cx)
+{
+	char	   *raw = MemoryContextAlloc(cx, rawLen > 0 ? rawLen : 1);
+	int			w = (unsigned char) enc[0];
+	int			width = (unsigned char) enc[1];
+	uint64		base;
+	uint64	   *deltas;
+	uint64		cur;
+	uint32		i;
+
+	memcpy(&base, enc + 2, sizeof(uint64));
+	deltas = palloc(sizeof(uint64) * (n > 1 ? n - 1 : 1));
+	if (n > 1)
+		bitunpack((const unsigned char *) enc + 10, n - 1, width, deltas);
+
+	cur = base;
+	if (n > 0)
+		store_uint(raw, cur, w);
+	for (i = 1; i < n; i++)
+	{
+		cur = (uint64) ((int64) cur + unzigzag(deltas[i - 1]));
+		store_uint(raw + (uint64) i * w, cur, w);
+	}
+	pfree(deltas);
+	return raw;
+}
+
+/* -------------------------------------------------------------------------
+ * public entry points
+ * ------------------------------------------------------------------------- */
+
+const char *
+ColumnarEncodingName(int encodingType)
+{
+	switch (encodingType)
+	{
+		case COLUMNAR_ENCODING_NONE:
+			return "none";
+		case COLUMNAR_ENCODING_RLE:
+			return "rle";
+		case COLUMNAR_ENCODING_FOR:
+			return "for";
+		case COLUMNAR_ENCODING_DELTA:
+			return "delta";
+		default:
+			return "unknown";
+	}
+}
+
+/*
+ * ColumnarEncodeChunk
+ *		Choose and apply the best lightweight encoding for one chunk's raw value
+ *		stream. Returns the encoding code used and sets out and outLen to the
+ *		encoded buffer. When no encoding beats the raw size, returns NONE and
+ *		sets out to the raw pointer itself (no copy); callers must treat it as
+ *		read-only and must not free it. Encoded buffers for the other cases are
+ *		palloc'd in the current memory context.
+ *
+ *		Selection here is deliberately simple (smallest pre-compression encoded
+ *		size); adaptive, sampled selection is a later step (I5).
+ */
+int
+ColumnarEncodeChunk(const char *raw, uint32 rawLen, Form_pg_attribute att,
+					uint64 valueCount, char **out, uint32 *outLen)
+{
+	int			w = att->attlen;
+	uint32		n = (uint32) valueCount;
+	int			bestCode = COLUMNAR_ENCODING_NONE;
+	char	   *bestBuf = NULL;
+	uint32		bestLen = rawLen;
+	char	   *buf;
+	uint32		len;
+
+	/* nothing to do for an empty (all-null) chunk */
+	if (rawLen == 0 || n == 0)
+	{
+		*out = (char *) raw;
+		*outLen = rawLen;
+		return COLUMNAR_ENCODING_NONE;
+	}
+
+	/* lightweight encodings currently target fixed-width columns */
+	if (w > 0)
+	{
+		if (encode_rle(raw, rawLen, w, n, &buf, &len) && len < bestLen)
+		{
+			bestCode = COLUMNAR_ENCODING_RLE;
+			bestBuf = buf;
+			bestLen = len;
+		}
+
+		if (is_packable_int(att))
+		{
+			if (encode_for(raw, rawLen, w, n, &buf, &len) && len < bestLen)
+			{
+				if (bestBuf)
+					pfree(bestBuf);
+				bestCode = COLUMNAR_ENCODING_FOR;
+				bestBuf = buf;
+				bestLen = len;
+			}
+			if (encode_delta(raw, rawLen, w, n, &buf, &len) && len < bestLen)
+			{
+				if (bestBuf)
+					pfree(bestBuf);
+				bestCode = COLUMNAR_ENCODING_DELTA;
+				bestBuf = buf;
+				bestLen = len;
+			}
+		}
+	}
+
+	if (bestCode == COLUMNAR_ENCODING_NONE)
+	{
+		*out = (char *) raw;
+		*outLen = rawLen;
+		return COLUMNAR_ENCODING_NONE;
+	}
+
+	*out = bestBuf;
+	*outLen = bestLen;
+	return bestCode;
+}
+
+/*
+ * ColumnarDecodeChunk
+ *		Reverse an encoding, reconstructing the byte-identical raw value stream
+ *		in cx. For NONE, returns the input pointer unchanged (no copy).
+ */
+char *
+ColumnarDecodeChunk(const char *enc, uint32 encLen, int encodingType,
+					Form_pg_attribute att, uint64 valueCount, uint32 rawLen,
+					MemoryContext cx)
+{
+	uint32		n = (uint32) valueCount;
+
+	switch (encodingType)
+	{
+		case COLUMNAR_ENCODING_NONE:
+			return (char *) enc;
+		case COLUMNAR_ENCODING_RLE:
+			return decode_rle(enc, encLen, att->attlen, n, rawLen, cx);
+		case COLUMNAR_ENCODING_FOR:
+			return decode_for(enc, encLen, n, rawLen, cx);
+		case COLUMNAR_ENCODING_DELTA:
+			return decode_delta(enc, encLen, n, rawLen, cx);
+		default:
+			ereport(ERROR,
+					(errcode(ERRCODE_DATA_CORRUPTED),
+					 errmsg("columnar: unknown value encoding type %d",
+							encodingType)));
+			return NULL;			/* keep the compiler happy */
+	}
+}

--- a/src/columnar_encoding.c
+++ b/src/columnar_encoding.c
@@ -370,6 +370,42 @@ decode_delta(const char *enc, uint32 encLen, uint32 n, uint32 rawLen,
  * public entry points
  * ------------------------------------------------------------------------- */
 
+/* -------------------------------------------------------------------------
+ * compression-block run iterator (I2)
+ * ------------------------------------------------------------------------- */
+
+void
+ColumnarBlockReaderInit(ColumnarBlockReader *br, const char *raw,
+						uint64 valueCount, int width)
+{
+	br->raw = raw;
+	br->valueCount = valueCount;
+	br->width = width;
+	br->pos = 0;
+}
+
+bool
+ColumnarBlockNextRun(ColumnarBlockReader *br, const char **valBytes,
+					 uint64 *runLen)
+{
+	const char *v;
+	uint64		run = 1;
+	int			w = br->width;
+
+	if (br->pos >= br->valueCount)
+		return false;
+
+	v = br->raw + br->pos * (uint64) w;
+	while (br->pos + run < br->valueCount &&
+		   memcmp(br->raw + (br->pos + run) * (uint64) w, v, w) == 0)
+		run++;
+
+	*valBytes = v;
+	*runLen = run;
+	br->pos += run;
+	return true;
+}
+
 const char *
 ColumnarEncodingName(int encodingType)
 {

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -53,7 +53,9 @@
 #define Anum_chunk_value_compression_level 12
 #define Anum_chunk_value_decompressed_length 13
 #define Anum_chunk_value_count 14
-#define Natts_chunk 14
+#define Anum_chunk_value_encoding_type 15
+#define Anum_chunk_value_raw_length 16
+#define Natts_chunk 16
 
 /* attribute numbers for columnar.chunk_group (spec 7.3) */
 #define Anum_chunk_group_storage_id 1
@@ -272,6 +274,8 @@ ColumnarInsertChunkRow(uint64 storageId, const ChunkMetadata *chunk)
 	values[Anum_chunk_value_compression_level - 1] = Int32GetDatum(chunk->valueCompressionLevel);
 	values[Anum_chunk_value_decompressed_length - 1] = Int64GetDatum((int64) chunk->valueDecompressedLength);
 	values[Anum_chunk_value_count - 1] = Int64GetDatum((int64) chunk->valueCount);
+	values[Anum_chunk_value_encoding_type - 1] = Int32GetDatum(chunk->valueEncodingType);
+	values[Anum_chunk_value_raw_length - 1] = Int64GetDatum((int64) chunk->valueRawLength);
 
 	tuple = heap_form_tuple(tupdesc, values, nulls);
 	CatalogTupleInsert(rel, tuple);
@@ -440,6 +444,25 @@ ColumnarReadChunkList(uint64 storageId, uint64 stripeNum, Snapshot snapshot)
 			heap_getattr(tuple, Anum_chunk_value_decompressed_length, tupdesc, &isnull));
 		chunk->valueCount = (uint64) DatumGetInt64(
 			heap_getattr(tuple, Anum_chunk_value_count, tupdesc, &isnull));
+
+		/*
+		 * Value-stream encoding (I1, format 2.1). Format 2.0 chunks predate
+		 * these columns; a NULL encoding type means NONE, and the raw length
+		 * then equals the decompressed length.
+		 */
+		{
+			bool		encNull;
+			bool		rawNull;
+			Datum		encDatum = heap_getattr(tuple, Anum_chunk_value_encoding_type,
+												tupdesc, &encNull);
+			Datum		rawDatum = heap_getattr(tuple, Anum_chunk_value_raw_length,
+												tupdesc, &rawNull);
+
+			chunk->valueEncodingType = encNull ? COLUMNAR_ENCODING_NONE
+				: DatumGetInt32(encDatum);
+			chunk->valueRawLength = rawNull ? chunk->valueDecompressedLength
+				: (uint64) DatumGetInt64(rawDatum);
+		}
 
 		/* min/max skip list (spec 7.2), decoded on demand by the reader */
 		{

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -853,8 +853,15 @@ columnar_decode_group_to_vector(ColumnarReadState *readState, ColumnarVector *ve
  *		reads exactly the same groups (including chunk-group skipping and the row
  *		mask) but hands back a whole group at a time for vectorized processing.
  */
-bool
-ColumnarReadNextVector(ColumnarReadState *readState, ColumnarVector *vec)
+/*
+ * columnar_advance_group
+ *		Drive the stripe/group state machine to the next chunk group that
+ *		survives min/max skipping (spec 9), loading stripes as needed. Returns
+ *		true when positioned on a readable group (readState->groupIndex), false
+ *		when the scan is exhausted. Shared by the vector and raw-group readers.
+ */
+static bool
+columnar_advance_group(ColumnarReadState *readState)
 {
 	columnar_read_start(readState);
 
@@ -896,9 +903,84 @@ ColumnarReadNextVector(ColumnarReadState *readState, ColumnarVector *vec)
 			}
 		}
 
-		columnar_decode_group_to_vector(readState, vec);
 		return true;
 	}
+}
+
+bool
+ColumnarReadNextVector(ColumnarReadState *readState, ColumnarVector *vec)
+{
+	if (!columnar_advance_group(readState))
+		return false;
+
+	columnar_decode_group_to_vector(readState, vec);
+	return true;
+}
+
+/*
+ * ColumnarReadNextRawGroup
+ *		Advance to the next readable chunk group and expose each projected
+ *		column's raw value stream (packed non-null values) without decoding to
+ *		Datums, for the aggregate's compressed-execution run path (I3).
+ */
+bool
+ColumnarReadNextRawGroup(ColumnarReadState *readState, ColumnarRawGroup *rg)
+{
+	MemoryContext oldContext;
+	int			natts = readState->natts;
+	int			c;
+	uint64		i;
+
+	if (!columnar_advance_group(readState))
+		return false;
+
+	oldContext = MemoryContextSwitchTo(readState->groupContext);
+
+	rg->nrows = readState->groupRowCount;
+	rg->firstRowNumber = readState->stripe->firstRowNumber +
+		readState->rowOffsetInStripe;
+	rg->natts = natts;
+	rg->valueCursor = palloc0(sizeof(char *) * natts);
+	rg->groupValueCount = palloc0(sizeof(uint64) * natts);
+	rg->columnAbsent = palloc0(sizeof(bool) * natts);
+
+	for (c = 0; c < natts; c++)
+	{
+		ChunkMetadata *m = readState->chunkMap[c][readState->groupIndex];
+
+		if (m == NULL)
+		{
+			rg->columnAbsent[c] = true;
+			continue;
+		}
+		rg->valueCursor[c] = readState->valueCursor[c];
+		rg->groupValueCount[c] = m->valueCount;
+	}
+
+	/* how many of this group's rows are row-mask-deleted (spec 7.5) */
+	rg->deletedCount = 0;
+	if (readState->currentMask != NULL)
+	{
+		for (i = 0; i < rg->nrows; i++)
+			if ((i >> 3) < readState->currentMaskLen &&
+				(readState->currentMask[i >> 3] & (1 << (i & 7))) != 0)
+				rg->deletedCount++;
+	}
+
+	MemoryContextSwitchTo(oldContext);
+	return true;
+}
+
+/*
+ * ColumnarDecodeCurrentGroupVector
+ *		Decode the currently positioned chunk group into a full vector, used by
+ *		the aggregate to fall back from the run path when the group has deletes.
+ */
+void
+ColumnarDecodeCurrentGroupVector(ColumnarReadState *readState,
+								 ColumnarVector *vec)
+{
+	columnar_decode_group_to_vector(readState, vec);
 }
 
 /*

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -456,7 +456,9 @@ columnar_setup_group(ColumnarReadState *readState, int groupIndex)
 		readState->existsBase[c] = readState->stripeBuffer + m->existsStreamOffset;
 
 		if (columnar_is_projected(readState, c))
-			readState->valueCursor[c] =
+		{
+			Form_pg_attribute att = TupleDescAttr(readState->tupdesc, c);
+			char	   *decompressed =
 				ColumnarGetDecompressedStream(readState->storageId,
 											  readState->stripe->fileOffset +
 											  m->valueStreamOffset,
@@ -466,6 +468,13 @@ columnar_setup_group(ColumnarReadState *readState, int groupIndex)
 											  m->valueCompressionType,
 											  m->valueDecompressedLength,
 											  readState->groupContext);
+
+			/* reverse the lightweight encoding to the raw value stream (I1) */
+			readState->valueCursor[c] =
+				ColumnarDecodeChunk(decompressed, m->valueDecompressedLength,
+									m->valueEncodingType, att, m->valueCount,
+									m->valueRawLength, readState->groupContext);
+		}
 		else
 			readState->valueCursor[c] = NULL;
 	}
@@ -1011,6 +1020,10 @@ ColumnarReadRowByNumber(Relation rel, Snapshot snapshot, uint64 rowNumber,
 											   m->valueCompressionType,
 											   m->valueDecompressedLength,
 											   tmp);
+		/* reverse the lightweight encoding to the raw value stream (I1) */
+		cursor = ColumnarDecodeChunk(cursor, m->valueDecompressedLength,
+									 m->valueEncodingType, att, m->valueCount,
+									 m->valueRawLength, tmp);
 
 		for (i = 0; i <= rowInGroup; i++)
 		{

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -1104,6 +1104,15 @@ _PG_init(void)
 							 0,
 							 NULL, NULL, NULL);
 
+	DefineCustomBoolVariable("columnar.enable_compressed_execution",
+							 "Compute aggregates over runs of the encoded value stream.",
+							 NULL,
+							 &columnar_enable_compressed_execution,
+							 true,
+							 PGC_USERSET,
+							 0,
+							 NULL, NULL, NULL);
+
 	DefineCustomBoolVariable("columnar.enable_column_cache",
 							 "Cache decompressed chunk groups to reuse across reads.",
 							 NULL,

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -61,11 +61,16 @@
 #include "utils/datum.h"
 #include "utils/fmgrprotos.h"
 #include "utils/lsyscache.h"
+#include "access/tupmacs.h"
 #include "utils/rel.h"
 #include "utils/typcache.h"
 
 /* GUC: use the vectorized scan/aggregate path (spec 8.3 scan control) */
 bool		columnar_enable_vectorization = true;
+
+/* GUC: run aggregates over runs of the encoded value stream (I3). Off falls
+ * back to the per-row vectorized path; both must return identical results. */
+bool		columnar_enable_compressed_execution = true;
 
 /* -------------------------------------------------------------------------
  * shared column-at-a-time filter
@@ -609,12 +614,148 @@ ColumnarBeginAggScan(CustomScanState *node, EState *estate, int eflags)
 }
 
 /*
+ * columnar_apply_one
+ *		Fold one value (or a null) into an aggregate accumulator. This is the
+ *		reference per-row semantics, shared by the vectorized per-row path and
+ *		the run path's fallback and min/max handling.
+ */
+static void
+columnar_apply_one(ColumnarAggScanState *state, ColumnarAggSpec *spec,
+				   Datum val, bool isnull)
+{
+	switch (spec->kind)
+	{
+		case COLUMNAR_AGG_COUNT_STAR:
+			spec->count++;
+			break;
+
+		case COLUMNAR_AGG_COUNT_COL:
+			if (!isnull)
+				spec->count++;
+			break;
+
+		case COLUMNAR_AGG_SUM_INT:
+			if (!isnull)
+			{
+				int64		v = (spec->inputType == INT2OID)
+					? (int64) DatumGetInt16(val)
+					: (int64) DatumGetInt32(val);
+
+				spec->sum += v;
+				spec->sawValue = true;
+			}
+			break;
+
+		case COLUMNAR_AGG_AVG_INT:
+			if (!isnull)
+			{
+				int64		v = (spec->inputType == INT2OID)
+					? (int64) DatumGetInt16(val)
+					: (int64) DatumGetInt32(val);
+
+				spec->sum += v;
+				spec->count++;
+			}
+			break;
+
+		case COLUMNAR_AGG_MIN:
+		case COLUMNAR_AGG_MAX:
+			if (!isnull)
+			{
+				bool		take;
+
+				if (!spec->sawValue)
+					take = true;
+				else
+				{
+					int32		cmp = DatumGetInt32(
+						FunctionCall2Coll(&spec->cmpFn, spec->collation,
+										  val, spec->extreme));
+
+					take = (spec->kind == COLUMNAR_AGG_MIN)
+						? (cmp < 0) : (cmp > 0);
+				}
+
+				if (take)
+				{
+					MemoryContext old =
+						MemoryContextSwitchTo(state->resultContext);
+
+					if (spec->sawValue && !spec->byval)
+						pfree(DatumGetPointer(spec->extreme));
+					spec->extreme = datumCopy(val, spec->byval, spec->typlen);
+					spec->sawValue = true;
+					MemoryContextSwitchTo(old);
+				}
+			}
+			break;
+	}
+}
+
+/*
+ * columnar_apply_run
+ *		Fold a run of `runLen` copies of one non-null value into an accumulator,
+ *		processing the whole run in O(1) for count/sum/avg (I3). The value's raw
+ *		bytes come straight from the value stream. count(*) is handled by the
+ *		caller at the group level.
+ */
+static void
+columnar_apply_run(ColumnarAggScanState *state, ColumnarAggSpec *spec,
+				   const char *valBytes, Form_pg_attribute att, uint64 runLen)
+{
+	switch (spec->kind)
+	{
+		case COLUMNAR_AGG_COUNT_STAR:
+			break;				/* group-level */
+
+		case COLUMNAR_AGG_COUNT_COL:
+			/* the value stream holds only non-null values */
+			spec->count += (int64) runLen;
+			break;
+
+		case COLUMNAR_AGG_SUM_INT:
+			{
+				Datum		d = fetch_att(valBytes, true, att->attlen);
+				int64		v = (spec->inputType == INT2OID)
+					? (int64) DatumGetInt16(d) : (int64) DatumGetInt32(d);
+
+				spec->sum += v * (int64) runLen;
+				spec->sawValue = true;
+			}
+			break;
+
+		case COLUMNAR_AGG_AVG_INT:
+			{
+				Datum		d = fetch_att(valBytes, true, att->attlen);
+				int64		v = (spec->inputType == INT2OID)
+					? (int64) DatumGetInt16(d) : (int64) DatumGetInt32(d);
+
+				spec->sum += v * (int64) runLen;
+				spec->count += (int64) runLen;
+			}
+			break;
+
+		case COLUMNAR_AGG_MIN:
+		case COLUMNAR_AGG_MAX:
+			{
+				/* the extreme of a repeated value is the value itself */
+				Datum		d = fetch_att(valBytes, spec->byval, spec->typlen);
+
+				columnar_apply_one(state, spec, d, false);
+			}
+			break;
+	}
+}
+
+/*
  * columnar_run_agg
- *		Scan the base relation once, vectorized, and fold every chunk group into
- *		the aggregate accumulators. The reader (ColumnarBeginRead) applies min/max
- *		chunk-group skipping and the row mask; we apply the exact per-row filter
- *		and the aggregate arithmetic here. Returns the read state so the caller
- *		can read skip counters for EXPLAIN before ending it.
+ *		Scan the base relation once and fold every chunk group into the aggregate
+ *		accumulators. The reader (ColumnarBeginRead) applies min/max chunk-group
+ *		skipping and the row mask. With no pushed-down predicates and fixed-width
+ *		aggregate columns, groups are folded run-at-a-time over the value stream
+ *		(I3 compressed execution); otherwise, and for groups with deletes, the
+ *		per-row vectorized path is used. Returns the read state so the caller can
+ *		read skip counters for EXPLAIN before ending it.
  */
 static ColumnarReadState *
 columnar_run_agg(ColumnarAggScanState *state)
@@ -627,6 +768,7 @@ columnar_run_agg(ColumnarAggScanState *state)
 	int			nScanKeys;
 	ColumnarReadState *readState;
 	ColumnarVector vec;
+	bool		useRuns;
 	int			a;
 	int			p;
 
@@ -652,92 +794,112 @@ columnar_run_agg(ColumnarAggScanState *state)
 	readState = ColumnarBeginRead(rel, estate->es_snapshot, NULL, projected,
 								  nScanKeys, scanKeys);
 
-	while (ColumnarReadNextVector(readState, &vec))
+	/*
+	 * Decide the fold strategy. The run path needs no per-row predicate work
+	 * (npreds == 0) and fixed-width aggregate columns; otherwise use the per-row
+	 * vectorized path, which handles predicates, nulls, and deletes uniformly.
+	 */
+	useRuns = columnar_enable_compressed_execution && state->npreds == 0;
+	if (useRuns)
 	{
-		uint64		i;
-
-		for (i = 0; i < vec.nrows; i++)
+		for (a = 0; a < state->naggs; a++)
 		{
-			if (vec.deleted[i])
-				continue;
-			if (!ColumnarVecRowPasses(state->preds, state->npreds, &vec, i))
-				continue;
+			int			c = state->specs[a].attidx;
 
+			if (c >= 0 && TupleDescAttr(tupdesc, c)->attlen <= 0)
+			{
+				useRuns = false;
+				break;
+			}
+		}
+	}
+
+	if (useRuns)
+	{
+		ColumnarRawGroup rg;
+
+		while (ColumnarReadNextRawGroup(readState, &rg))
+		{
+			bool		fallback = (rg.deletedCount > 0);
+
+			/* an absent column (post-ADD COLUMN stripe) needs its missing value */
+			for (a = 0; !fallback && a < state->naggs; a++)
+			{
+				int			c = state->specs[a].attidx;
+
+				if (c >= 0 && rg.columnAbsent[c])
+					fallback = true;
+			}
+
+			if (fallback)
+			{
+				uint64		i;
+
+				ColumnarDecodeCurrentGroupVector(readState, &vec);
+				for (i = 0; i < vec.nrows; i++)
+				{
+					if (vec.deleted[i])
+						continue;
+					for (a = 0; a < state->naggs; a++)
+					{
+						ColumnarAggSpec *spec = &state->specs[a];
+						int			c = spec->attidx;
+						bool		isnull = (c >= 0) ? vec.isnull[c][i] : true;
+						Datum		val = (c >= 0 && !isnull) ? vec.values[c][i]
+							: (Datum) 0;
+
+						columnar_apply_one(state, spec, val, isnull);
+					}
+				}
+				continue;
+			}
+
+			/* run path: no deletes, all aggregate columns present */
 			for (a = 0; a < state->naggs; a++)
 			{
 				ColumnarAggSpec *spec = &state->specs[a];
 				int			c = spec->attidx;
-				bool		isnull = (c >= 0) ? vec.isnull[c][i] : true;
-				Datum		val = (c >= 0 && !isnull) ? vec.values[c][i] : (Datum) 0;
+				Form_pg_attribute att;
+				ColumnarBlockReader br;
+				const char *vb;
+				uint64		runLen;
 
-				switch (spec->kind)
+				if (spec->kind == COLUMNAR_AGG_COUNT_STAR)
 				{
-					case COLUMNAR_AGG_COUNT_STAR:
-						spec->count++;
-						break;
+					spec->count += (int64) rg.nrows;
+					continue;
+				}
 
-					case COLUMNAR_AGG_COUNT_COL:
-						if (!isnull)
-							spec->count++;
-						break;
+				att = TupleDescAttr(tupdesc, c);
+				ColumnarBlockReaderInit(&br, rg.valueCursor[c],
+										rg.groupValueCount[c], att->attlen);
+				while (ColumnarBlockNextRun(&br, &vb, &runLen))
+					columnar_apply_run(state, spec, vb, att, runLen);
+			}
+		}
+	}
+	else
+	{
+		while (ColumnarReadNextVector(readState, &vec))
+		{
+			uint64		i;
 
-					case COLUMNAR_AGG_SUM_INT:
-						if (!isnull)
-						{
-							int64		v = (spec->inputType == INT2OID)
-								? (int64) DatumGetInt16(val)
-								: (int64) DatumGetInt32(val);
+			for (i = 0; i < vec.nrows; i++)
+			{
+				if (vec.deleted[i])
+					continue;
+				if (!ColumnarVecRowPasses(state->preds, state->npreds, &vec, i))
+					continue;
 
-							spec->sum += v;	/* matches int2_sum/int4_sum */
-							spec->sawValue = true;
-						}
-						break;
+				for (a = 0; a < state->naggs; a++)
+				{
+					ColumnarAggSpec *spec = &state->specs[a];
+					int			c = spec->attidx;
+					bool		isnull = (c >= 0) ? vec.isnull[c][i] : true;
+					Datum		val = (c >= 0 && !isnull) ? vec.values[c][i]
+						: (Datum) 0;
 
-					case COLUMNAR_AGG_AVG_INT:
-						if (!isnull)
-						{
-							int64		v = (spec->inputType == INT2OID)
-								? (int64) DatumGetInt16(val)
-								: (int64) DatumGetInt32(val);
-
-							spec->sum += v;
-							spec->count++;
-						}
-						break;
-
-					case COLUMNAR_AGG_MIN:
-					case COLUMNAR_AGG_MAX:
-						if (!isnull)
-						{
-							bool		take;
-
-							if (!spec->sawValue)
-								take = true;
-							else
-							{
-								int32		cmp = DatumGetInt32(
-									FunctionCall2Coll(&spec->cmpFn,
-													  spec->collation,
-													  val, spec->extreme));
-
-								take = (spec->kind == COLUMNAR_AGG_MIN)
-									? (cmp < 0) : (cmp > 0);
-							}
-
-							if (take)
-							{
-								MemoryContext old =
-									MemoryContextSwitchTo(state->resultContext);
-
-								if (spec->sawValue && !spec->byval)
-									pfree(DatumGetPointer(spec->extreme));
-								spec->extreme = datumCopy(val, spec->byval,
-														  spec->typlen);
-								spec->sawValue = true;
-								MemoryContextSwitchTo(old);
-							}
-						}
-						break;
+					columnar_apply_one(state, spec, val, isnull);
 				}
 			}
 		}

--- a/src/columnar_write_state.c
+++ b/src/columnar_write_state.c
@@ -489,6 +489,9 @@ columnar_flush_stripe(ColumnarWriteState *writeState)
 			ChunkGroupBuffer *group = (ChunkGroupBuffer *) lfirst(lc);
 			ColumnChunkBuffer *col = &group->columns[c];
 			ChunkMetadata *m = &chunkMeta[c * numGroups + g];
+			char	   *encData;
+			uint32		encLen;
+			int			encType;
 			char	   *compData;
 			uint32		compLen;
 			int			usedType;
@@ -498,12 +501,16 @@ columnar_flush_stripe(ColumnarWriteState *writeState)
 			m->chunkGroupNum = g;
 
 			/*
-			 * Compress the value stream independently (spec 5). The codec may
-			 * fall back to "none" when it does not shrink the data. The exists
-			 * stream is never compressed.
+			 * Apply a lightweight, type-aware encoding to the raw value stream
+			 * (I1), then block-compress the encoded form (spec 5). Both steps
+			 * fall back to "none" when they do not shrink the data. The exists
+			 * stream is neither encoded nor compressed.
 			 */
-			ColumnarCompressValueStream(col->valueStream.data,
-										col->valueStream.len,
+			encType = ColumnarEncodeChunk(col->valueStream.data,
+										  col->valueStream.len, att,
+										  col->valueCount, &encData, &encLen);
+
+			ColumnarCompressValueStream(encData, encLen,
 										writeState->compressionType,
 										writeState->compressionLevel,
 										&compData, &compLen,
@@ -521,8 +528,10 @@ columnar_flush_stripe(ColumnarWriteState *writeState)
 
 			m->valueCompressionType = usedType;
 			m->valueCompressionLevel = usedLevel;
-			m->valueDecompressedLength = col->valueStream.len;
+			m->valueDecompressedLength = encLen;
 			m->valueCount = col->valueCount;
+			m->valueEncodingType = encType;
+			m->valueRawLength = col->valueStream.len;
 
 			/* encode the min/max skip list for orderable types (spec 7.2) */
 			if (col->hasMinMax)

--- a/test/differential.sh
+++ b/test/differential.sh
@@ -210,4 +210,42 @@ load_pair "SELECT $WIDE_SEL FROM generate_series(1,500) g"
 diff_query "wide row scan" "SELECT * FROM %T"
 diff_query "wide row proj" "SELECT id, c1, c30, c60 FROM %T WHERE c30 > 5000"
 
+# ---------------------------------------------------------------------------
+# Part 3: lightweight encodings (I1)
+#
+# Data shaped so each encoding is chosen, then checked two ways: the oracle
+# proves round-trip correctness, and columnar.chunk is inspected to prove the
+# encoding was actually applied (guards against the layer silently regressing to
+# none). A high-entropy column is expected to stay unencoded.
+# ---------------------------------------------------------------------------
+echo "-- part 3: lightweight encodings"
+
+make_pair "id int, seqv bigint, lowcard int, constv int, rnd bigint"
+q "SELECT columnar.alter_columnar_table_set('t_col', chunk_group_row_limit => 2000, stripe_row_limit => 20000, compression => 'none');" >/dev/null
+load_pair "SELECT g, g::bigint*3, g%4, 42, ((g*2654435761)%1000000000)::bigint FROM generate_series(1,10000) g"
+
+# correctness through the oracle
+diff_query "enc whole-row"  "SELECT * FROM %T"
+diff_query "enc seq range"  "SELECT id FROM %T WHERE seqv BETWEEN 100 AND 5000"
+diff_query "enc lowcard eq" "SELECT id FROM %T WHERE lowcard = 2"
+diff_query "enc const scan" "SELECT id FROM %T WHERE constv = 42"
+diff_query "enc aggregate"  "SELECT sum(seqv), min(lowcard), max(lowcard), count(constv), sum(rnd) FROM %T"
+
+# the encoding was actually applied for the shaped columns
+enc_applied() {
+	q "SELECT bool_and(value_encoding_type <> 0) FROM columnar.chunk
+	   WHERE storage_id = columnar.get_storage_id('t_col') AND attr_num = $1;"
+}
+check "enc id encoded"      "$(enc_applied 1)" "t"
+check "enc seqv encoded"    "$(enc_applied 2)" "t"
+check "enc lowcard encoded" "$(enc_applied 3)" "t"
+check "enc constv encoded"  "$(enc_applied 4)" "t"
+
+# a NONE-compression table still round-trips (encoding independent of codec)
+make_pair "id int, v bigint"
+q "SELECT columnar.alter_columnar_table_set('t_col', compression => 'none');" >/dev/null
+load_pair "SELECT g, (g%7)::bigint FROM generate_series(1,5000) g"
+diff_query "enc+nocompress scan" "SELECT * FROM %T"
+diff_query "enc+nocompress agg"  "SELECT count(*), sum(v), min(v), max(v) FROM %T"
+
 pgc_summary

--- a/test/differential.sh
+++ b/test/differential.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+#
+# pgColumnar differential type-matrix and boundary suite.
+#
+# The governing property: a columnar table and a heap table loaded with the
+# same data must answer every query identically. Heap is the oracle. This
+# catches encode/decode, null-handling, and chunk-skipping bugs generically,
+# across a broad matrix of data types, null patterns, and boundary sizes, which
+# is exactly what upcoming lightweight-encoding work will stress.
+#
+# Usage:  test/differential.sh [PG_CONFIG]
+#
+# Written fresh for pgColumnar; it does not reuse any upstream test file.
+
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+# ---------------------------------------------------------------------------
+# Part 1: type matrix
+#
+# One column per type, a moderate null density, negatives and extremes, empty
+# strings distinct from NULL, and a few toast-sized text values. Small chunk and
+# stripe limits force many chunk groups and several stripes over modest data.
+# ---------------------------------------------------------------------------
+echo "-- part 1: type matrix"
+
+MATRIX_DEFS="
+	id        int,
+	c_int     int,
+	c_big     bigint,
+	c_small   smallint,
+	c_num     numeric(24,6),
+	c_f4      real,
+	c_f8      double precision,
+	c_bool    boolean,
+	c_date    date,
+	c_ts      timestamp,
+	c_tstz    timestamptz,
+	c_uuid    uuid,
+	c_bytea   bytea,
+	c_vc      varchar(50),
+	c_char    char(10),
+	c_iv      interval,
+	c_jsonb   jsonb,
+	c_arr     int[],
+	c_text    text,
+	c_ztext   text"
+
+make_pair "$MATRIX_DEFS"
+q "SELECT columnar.alter_columnar_table_set('t_col', chunk_group_row_limit => 1000, stripe_row_limit => 5000);" >/dev/null
+
+load_pair "SELECT
+	g AS id,
+	CASE WHEN g%5=0  THEN NULL ELSE (g*7-100) END,
+	CASE WHEN g%17=0 THEN NULL ELSE (g::bigint*1000000000) END,
+	CASE WHEN g%17=0 THEN NULL ELSE ((g%100)-50)::smallint END,
+	CASE WHEN g%11=0 THEN NULL ELSE (g::numeric*1.250000-1000) END,
+	CASE WHEN g%17=0 THEN NULL ELSE (g*0.5-10)::real END,
+	CASE WHEN g%3=0  THEN NULL ELSE (sqrt(g::float8)*(CASE WHEN g%2=0 THEN -1 ELSE 1 END)) END,
+	CASE WHEN g%17=0 THEN NULL ELSE (g%3=0) END,
+	CASE WHEN g%17=0 THEN NULL ELSE (DATE '2000-01-01' + g) END,
+	CASE WHEN g%17=0 THEN NULL ELSE (TIMESTAMP '2000-01-01' + make_interval(hours => g)) END,
+	CASE WHEN g%17=0 THEN NULL ELSE (TIMESTAMPTZ '2000-01-01 00:00:00+00' + make_interval(hours => g)) END,
+	CASE WHEN g%13=0 THEN NULL ELSE (md5(g::text)::uuid) END,
+	CASE WHEN g%13=0 THEN NULL ELSE decode(md5(g::text),'hex') END,
+	CASE WHEN g%7=0  THEN NULL ELSE ('v'||g) END,
+	CASE WHEN g%17=0 THEN NULL ELSE lpad(g::text,10,'0') END,
+	CASE WHEN g%17=0 THEN NULL ELSE make_interval(days => g%1000, hours => g%24) END,
+	CASE WHEN g%13=0 THEN NULL ELSE jsonb_build_object('n',g,'neg',-g,'s','x'||g) END,
+	CASE WHEN g%17=0 THEN NULL ELSE ARRAY[g, g+1, -g] END,
+	CASE WHEN g%7=0  THEN NULL WHEN g%500=0 THEN repeat('abc',4000) ELSE ('t'||g) END,
+	CASE WHEN g%2=0  THEN '' ELSE ('z'||g) END
+	FROM generate_series(1,12000) g"
+
+# Sanity: the data actually spans multiple chunk groups and stripes.
+check "matrix row count"       "$(q 'SELECT count(*) FROM t_col;')" "12000"
+check "matrix chunk groups>=12" "$([ "$(chunk_group_count)" -ge 12 ] && echo ok)" "ok"
+check "matrix stripes>=2"       "$([ "$(stripe_count)" -ge 2 ] && echo ok)" "ok"
+
+# Whole-row equality across the entire table.
+diff_query "matrix whole-row" "SELECT * FROM %T"
+
+# Every column: full projection, non-null count, and IS NULL positions.
+ALL_COLS="c_int c_big c_small c_num c_f4 c_f8 c_bool c_date c_ts c_tstz c_uuid c_bytea c_vc c_char c_iv c_jsonb c_arr c_text c_ztext"
+for c in $ALL_COLS; do
+	diff_query "$c project"   "SELECT id, $c FROM %T"
+	diff_query "$c count"     "SELECT count($c) FROM %T"
+	diff_query "$c is null"   "SELECT id FROM %T WHERE $c IS NULL"
+	diff_query "$c not null"  "SELECT id FROM %T WHERE $c IS NOT NULL"
+done
+
+# Ordered types with a min/max aggregate (uuid and bytea order under btree but
+# have no min/max aggregate; their ordering is covered by the range predicates).
+ORDERED="c_int c_big c_small c_num c_f4 c_f8 c_date c_ts c_tstz c_vc c_char c_iv c_text c_ztext"
+for c in $ORDERED; do
+	diff_query "$c min/max" "SELECT min($c), max($c) FROM %T"
+done
+
+# Numeric types: sum and avg.
+for c in c_int c_big c_small c_num c_f4 c_f8; do
+	diff_query "$c sum/avg" "SELECT sum($c), avg($c) FROM %T"
+done
+
+# Range predicates that drive chunk-group skipping, per type.
+diff_query "c_int range"   "SELECT id FROM %T WHERE c_int BETWEEN -50 AND 5000"
+diff_query "c_big range"   "SELECT id FROM %T WHERE c_big > 6000000000000"
+diff_query "c_num range"   "SELECT id FROM %T WHERE c_num BETWEEN 0 AND 5000"
+diff_query "c_f8 range"    "SELECT id FROM %T WHERE c_f8 < 0"
+diff_query "c_date range"  "SELECT id FROM %T WHERE c_date BETWEEN DATE '2005-01-01' AND DATE '2010-01-01'"
+diff_query "c_ts range"    "SELECT id FROM %T WHERE c_ts >= TIMESTAMP '2000-06-01'"
+diff_query "c_tstz range"  "SELECT id FROM %T WHERE c_tstz < TIMESTAMPTZ '2000-03-01 00:00:00+00'"
+diff_query "c_vc range"    "SELECT id FROM %T WHERE c_vc BETWEEN 'v100' AND 'v200'"
+diff_query "c_uuid range"  "SELECT id FROM %T WHERE c_uuid > '80000000-0000-0000-0000-000000000000'::uuid"
+diff_query "c_bytea range" "SELECT id FROM %T WHERE c_bytea > '\\\\x80'::bytea"
+diff_query "c_text range"  "SELECT id FROM %T WHERE c_text > 't5000'"
+
+# Equality predicates.
+diff_query "c_int eq"   "SELECT id FROM %T WHERE c_int = 600"
+diff_query "c_vc eq"    "SELECT id FROM %T WHERE c_vc = 'v500'"
+diff_query "c_bool eq"  "SELECT id FROM %T WHERE c_bool = true"
+diff_query "c_uuid eq"  "SELECT id FROM %T WHERE c_uuid = md5('999')::uuid"
+diff_query "c_jsonb eq" "SELECT id FROM %T WHERE c_jsonb = jsonb_build_object('n',600,'neg',-600,'s','x600')"
+diff_query "c_arr eq"   "SELECT id FROM %T WHERE c_arr = ARRAY[600,601,-600]"
+
+# Ordered projections with LIMIT (deterministic order on unique id).
+diff_query "order limit head" "SELECT id, c_int, c_text FROM %T ORDER BY id LIMIT 25"
+diff_query "order limit tail" "SELECT id, c_num, c_vc FROM %T ORDER BY id DESC LIMIT 25"
+
+# Compound predicate mixing several columns.
+diff_query "compound" "SELECT id FROM %T WHERE c_int > 0 AND c_bool AND c_vc IS NOT NULL AND c_num < 8000"
+
+# ---------------------------------------------------------------------------
+# Part 2: boundary conditions
+# ---------------------------------------------------------------------------
+echo "-- part 2: boundary conditions"
+
+# Empty table.
+make_pair "id int, v text"
+diff_query "empty scan"  "SELECT * FROM %T"
+diff_query "empty count" "SELECT count(*) FROM %T"
+diff_query "empty agg"   "SELECT min(id), max(id), sum(id) FROM %T"
+
+# Single row.
+make_pair "id int, v text"
+load_pair "SELECT 1, 'only'"
+diff_query "single scan"  "SELECT * FROM %T"
+diff_query "single count" "SELECT count(*) FROM %T"
+
+# Chunk-group boundary: with a 100-row chunk group limit, N rows must produce
+# ceil(N/100) chunk groups, and results must match at N-1, N, N+1.
+for N in 99 100 101 200 201 250; do
+	make_pair "id int, v text"
+	q "SELECT columnar.alter_columnar_table_set('t_col', chunk_group_row_limit => 100, stripe_row_limit => 100000);" >/dev/null
+	load_pair "SELECT g, 'r'||g FROM generate_series(1,$N) g"
+	want=$(( (N + 99) / 100 ))
+	check "cg boundary N=$N groups"  "$(chunk_group_count)" "$want"
+	diff_query "cg boundary N=$N scan"  "SELECT * FROM %T"
+	diff_query "cg boundary N=$N range" "SELECT id FROM %T WHERE id BETWEEN 50 AND $((N-10))"
+done
+
+# Stripe boundary: the product enforces stripe_row_limit >= 1000, so use a
+# 1000-row stripe limit with 100-row chunk groups and check N-1, N, N+1.
+for N in 1000 1001 2000 2001; do
+	make_pair "id int, v text"
+	q "SELECT columnar.alter_columnar_table_set('t_col', chunk_group_row_limit => 100, stripe_row_limit => 1000);" >/dev/null
+	load_pair "SELECT g, 'r'||g FROM generate_series(1,$N) g"
+	want=$(( (N + 999) / 1000 ))
+	check "stripe boundary N=$N stripes" "$(stripe_count)" "$want"
+	diff_query "stripe boundary N=$N scan" "SELECT * FROM %T"
+	diff_query "stripe boundary N=$N agg"  "SELECT count(*), min(id), max(id), sum(id) FROM %T"
+done
+
+# All-null column across many rows.
+make_pair "id int, allnull int, v text"
+q "SELECT columnar.alter_columnar_table_set('t_col', chunk_group_row_limit => 100);" >/dev/null
+load_pair "SELECT g, NULL::int, 'r'||g FROM generate_series(1,350) g"
+diff_query "allnull column scan"  "SELECT * FROM %T"
+diff_query "allnull column count" "SELECT count(allnull) FROM %T"
+diff_query "allnull column isnull" "SELECT count(*) FROM %T WHERE allnull IS NULL"
+diff_query "allnull column minmax" "SELECT min(allnull), max(allnull) FROM %T"
+
+# All-null chunk group: with 100-row groups, rows 101..200 have a NULL column,
+# the rest have values, so exactly one whole chunk group is all-null.
+make_pair "id int, sometimes int"
+q "SELECT columnar.alter_columnar_table_set('t_col', chunk_group_row_limit => 100);" >/dev/null
+load_pair "SELECT g, CASE WHEN g BETWEEN 101 AND 200 THEN NULL ELSE g END FROM generate_series(1,400) g"
+diff_query "allnull chunk scan"   "SELECT * FROM %T"
+diff_query "allnull chunk range"  "SELECT id FROM %T WHERE sometimes BETWEEN 150 AND 250"
+diff_query "allnull chunk isnull" "SELECT id FROM %T WHERE sometimes IS NULL"
+
+# Empty string vs NULL must stay distinct.
+make_pair "id int, s text"
+load_pair "SELECT g, CASE WHEN g%2=0 THEN '' WHEN g%3=0 THEN NULL ELSE 'x'||g END FROM generate_series(1,300) g"
+diff_query "empty-vs-null scan"    "SELECT * FROM %T"
+diff_query "empty-vs-null empties" "SELECT count(*) FROM %T WHERE s = ''"
+diff_query "empty-vs-null nulls"   "SELECT count(*) FROM %T WHERE s IS NULL"
+
+# Wide row: many columns.
+WIDE_DEFS="id int"
+WIDE_SEL="g"
+for i in $(seq 1 60); do
+	WIDE_DEFS="$WIDE_DEFS, c$i int"
+	WIDE_SEL="$WIDE_SEL, (g*$i - $i)"
+done
+make_pair "$WIDE_DEFS"
+load_pair "SELECT $WIDE_SEL FROM generate_series(1,500) g"
+diff_query "wide row scan" "SELECT * FROM %T"
+diff_query "wide row proj" "SELECT id, c1, c30, c60 FROM %T WHERE c30 > 5000"
+
+pgc_summary

--- a/test/differential.sh
+++ b/test/differential.sh
@@ -248,4 +248,34 @@ load_pair "SELECT g, (g%7)::bigint FROM generate_series(1,5000) g"
 diff_query "enc+nocompress scan" "SELECT * FROM %T"
 diff_query "enc+nocompress agg"  "SELECT count(*), sum(v), min(v), max(v) FROM %T"
 
+# ---------------------------------------------------------------------------
+# Part 4: compressed execution (I3)
+#
+# Aggregates over runs of the value stream must match the heap oracle whether
+# the run path is on or off. Data has low-cardinality runs (run path), nulls
+# (skipped by the value stream), and deletes (force the per-group fallback), so
+# both the run path and its fallback are exercised. Setting the GUC per database
+# makes it apply to the fresh session each query opens.
+# ---------------------------------------------------------------------------
+echo "-- part 4: compressed execution"
+
+set_guc() { q "ALTER DATABASE $PGC_DB SET $1 = $2;" >/dev/null; }
+
+make_pair "id int, k int, big int, s smallint, nv int"
+q "SELECT columnar.alter_columnar_table_set('t_col', chunk_group_row_limit => 1000, stripe_row_limit => 5000);" >/dev/null
+load_pair "SELECT g, g%6, g*2, ((g%100)-50)::smallint,
+	CASE WHEN g%9=0 THEN NULL ELSE g%13 END
+	FROM generate_series(1,20000) g"
+psql_run "DELETE FROM t_heap WHERE id % 50 = 0;"
+psql_run "DELETE FROM t_col  WHERE id % 50 = 0;"
+
+for mode in on off; do
+	set_guc columnar.enable_compressed_execution "$mode"
+	diff_query "cexec=$mode count"  "SELECT count(*), count(k), count(nv) FROM %T"
+	diff_query "cexec=$mode sum"    "SELECT sum(big), sum(k), sum(nv) FROM %T"
+	diff_query "cexec=$mode avg"    "SELECT avg(k), avg(nv) FROM %T"
+	diff_query "cexec=$mode minmax" "SELECT min(k), max(k), min(big), max(big), min(s), max(s), min(nv), max(nv) FROM %T"
+done
+q "ALTER DATABASE $PGC_DB RESET columnar.enable_compressed_execution;" >/dev/null
+
 pgc_summary

--- a/test/differential.sh
+++ b/test/differential.sh
@@ -242,12 +242,13 @@ check "enc lowcard encoded" "$(enc_applied 3)" "t"
 check "enc constv encoded"  "$(enc_applied 4)" "t"
 
 # Gorilla (float XOR) and delta-of-delta (regular-interval timestamp), I4.
-# alt: two close values with no adjacent runs -> Gorilla beats none and RLE.
-# tsreg: fixed-interval timestamps -> zero delta-of-delta -> DOD beats delta.
+# alt: a random walk -> many distinct (dict bails), irregular bit deltas (for/
+# delta lose), but small consecutive XOR -> Gorilla wins. tsreg: fixed-interval
+# timestamps -> zero delta-of-delta -> DOD beats delta.
 make_pair "id int, alt float8, tsreg timestamp, fr float8"
 q "SELECT columnar.alter_columnar_table_set('t_col', chunk_group_row_limit => 2000, stripe_row_limit => 20000, compression => 'none');" >/dev/null
 load_pair "SELECT g,
-	(CASE WHEN g%2=0 THEN 1000.0 ELSE 1000.5 END)::float8,
+	(1000 + sum(random() - 0.5) OVER (ORDER BY g))::float8,
 	TIMESTAMP '2020-01-01' + make_interval(mins => g),
 	(100 + (g%7) * 0.25)::float8
 	FROM generate_series(1,10000) g"
@@ -261,6 +262,26 @@ enc_has() {
 }
 check "i4 alt uses gorilla" "$(enc_has 2 4)" "t"
 check "i4 tsreg uses dod"   "$(enc_has 3 5)" "t"
+
+# Dictionary (I5) for low-cardinality columns, including varlena/text which had
+# no lightweight encoding before. cat/tag repeat a few distinct values.
+make_pair "id int, cat text, tag varchar(16), code int, hicard text"
+q "SELECT columnar.alter_columnar_table_set('t_col', chunk_group_row_limit => 2000, stripe_row_limit => 20000, compression => 'none');" >/dev/null
+load_pair "SELECT g,
+	(ARRAY['north','south','east','west'])[1 + g%4],
+	('t' || (g%6))::varchar(16),
+	g%5,
+	md5(g::text)
+	FROM generate_series(1,10000) g"
+diff_query "dict whole-row"   "SELECT * FROM %T"
+diff_query "dict text eq"     "SELECT id FROM %T WHERE cat = 'east'"
+diff_query "dict text agg"    "SELECT count(cat), min(cat), max(cat), count(distinct tag) FROM %T"
+diff_query "dict text group"  "SELECT cat, count(*) FROM %T GROUP BY cat"
+check "dict cat uses dict"    "$(enc_has 2 6)" "t"
+check "dict tag uses dict"    "$(enc_has 3 6)" "t"
+check "dict code encoded"     "$(enc_applied 4)" "t"
+# a high-cardinality text column stays unencoded (dict bails)
+check "dict hicard none"      "$(enc_has 5 0)" "t"
 
 # a NONE-compression table still round-trips (encoding independent of codec)
 make_pair "id int, v bigint"

--- a/test/differential.sh
+++ b/test/differential.sh
@@ -241,6 +241,27 @@ check "enc seqv encoded"    "$(enc_applied 2)" "t"
 check "enc lowcard encoded" "$(enc_applied 3)" "t"
 check "enc constv encoded"  "$(enc_applied 4)" "t"
 
+# Gorilla (float XOR) and delta-of-delta (regular-interval timestamp), I4.
+# alt: two close values with no adjacent runs -> Gorilla beats none and RLE.
+# tsreg: fixed-interval timestamps -> zero delta-of-delta -> DOD beats delta.
+make_pair "id int, alt float8, tsreg timestamp, fr float8"
+q "SELECT columnar.alter_columnar_table_set('t_col', chunk_group_row_limit => 2000, stripe_row_limit => 20000, compression => 'none');" >/dev/null
+load_pair "SELECT g,
+	(CASE WHEN g%2=0 THEN 1000.0 ELSE 1000.5 END)::float8,
+	TIMESTAMP '2020-01-01' + make_interval(mins => g),
+	(100 + (g%7) * 0.25)::float8
+	FROM generate_series(1,10000) g"
+diff_query "i4 whole-row"  "SELECT * FROM %T"
+diff_query "i4 float agg"  "SELECT count(alt), min(alt), max(alt), count(fr), min(fr), max(fr) FROM %T"
+diff_query "i4 ts range"   "SELECT id FROM %T WHERE tsreg >= TIMESTAMP '2020-01-05'"
+diff_query "i4 ts minmax"  "SELECT min(tsreg), max(tsreg) FROM %T"
+enc_has() {
+	q "SELECT bool_or(value_encoding_type = $2) FROM columnar.chunk
+	   WHERE storage_id = columnar.get_storage_id('t_col') AND attr_num = $1;"
+}
+check "i4 alt uses gorilla" "$(enc_has 2 4)" "t"
+check "i4 tsreg uses dod"   "$(enc_has 3 5)" "t"
+
 # a NONE-compression table still round-trips (encoding independent of codec)
 make_pair "id int, v bigint"
 q "SELECT columnar.alter_columnar_table_set('t_col', compression => 'none');" >/dev/null

--- a/test/fuzz.sh
+++ b/test/fuzz.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# pgColumnar randomized differential (property-based) suite.
+#
+# Each iteration picks, from a seeded PRNG, a random row count (including values
+# near chunk/stripe boundaries), null density, chunk-group and stripe limits,
+# compression codec and level, and filter bounds, loads a heap/columnar pair
+# with the same data, and asserts every query in the battery agrees. Heap is the
+# oracle. The seed is printed up front; a failing run reproduces exactly with
+# PGC_SEED=<seed>.
+#
+# Usage:  test/fuzz.sh [PG_CONFIG]
+#   PGC_SEED=<int>   fix the seed (default 12345)
+#   PGC_ITERS=<int>  iterations (default 25)
+#
+# Written fresh for pgColumnar; it does not reuse any upstream test file.
+
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+SEED="${PGC_SEED:-12345}"
+ITERS="${PGC_ITERS:-25}"
+RANDOM=$SEED
+echo "-- fuzz seed=$SEED iters=$ITERS  (reproduce a failure with PGC_SEED=$SEED)"
+
+# Uniform integer in [0, n).
+rnd() { echo $(( RANDOM % $1 )); }
+# Pick one element of the argument list.
+pick() { local n=$#; local i=$(( RANDOM % n )); shift "$i"; echo "$1"; }
+
+CODECS="none pglz lz4 zstd"
+
+# Fixed but type-diverse schema; randomness is in volume, nulls, storage
+# parameters, codec, and predicate bounds.
+FUZZ_DEFS="id int, c_int int, c_num numeric(20,4), c_f8 double precision,
+	c_bool boolean, c_date date, c_ts timestamp, c_vc varchar(40), c_text text"
+
+for it in $(seq 1 "$ITERS"); do
+	N=$(( 1 + $(rnd 5000) ))
+	# Occasionally snap N to a boundary of the chosen chunk-group limit.
+	NULLMOD=$(( 2 + $(rnd 18) ))
+	CG=$(pick 100 250 500 1000)
+	SR=$(pick 1000 2000 5000)
+	CODEC=$(pick $CODECS)
+	LVL=$(( 1 + $(rnd 19) ))
+	# Filter bounds within the generated ranges.
+	span=$(( N > 1 ? N : 2 ))
+	LO=$(rnd "$span")
+	HI=$(( LO + 1 + $(rnd 500) ))
+	EQ=$(( 1 + $(rnd "$span") ))
+
+	tag="it=$it N=$N nullmod=$NULLMOD cg=$CG sr=$SR codec=$CODEC lvl=$LVL"
+	echo "-- $tag"
+
+	make_pair "$FUZZ_DEFS"
+	q "SELECT columnar.alter_columnar_table_set('t_col',
+		chunk_group_row_limit => $CG, stripe_row_limit => $SR,
+		compression => '$CODEC', compression_level => $LVL);" >/dev/null
+
+	load_pair "SELECT
+		g,
+		CASE WHEN g%$NULLMOD=0 THEN NULL ELSE (g*3 - 500) END,
+		CASE WHEN g%$((NULLMOD+1))=0 THEN NULL ELSE (g::numeric*0.5 - 100) END,
+		CASE WHEN g%$NULLMOD=0 THEN NULL ELSE (sqrt(g::float8) * (CASE WHEN g%2=0 THEN -1 ELSE 1 END)) END,
+		CASE WHEN g%$NULLMOD=0 THEN NULL ELSE (g%2=0) END,
+		CASE WHEN g%$NULLMOD=0 THEN NULL ELSE (DATE '2010-01-01' + g) END,
+		CASE WHEN g%$NULLMOD=0 THEN NULL ELSE (TIMESTAMP '2010-01-01' + make_interval(mins => g)) END,
+		CASE WHEN g%$NULLMOD=0 THEN NULL ELSE ('v'||lpad(g::text,6,'0')) END,
+		CASE WHEN g%$NULLMOD=0 THEN NULL WHEN g%997=0 THEN repeat('q',3000) ELSE ('t'||g) END
+		FROM generate_series(1,$N) g"
+
+	check "$tag :: row count" "$(q 'SELECT count(*) FROM t_col;')" "$N"
+
+	diff_query "$tag :: whole-row"  "SELECT * FROM %T"
+	diff_query "$tag :: count"      "SELECT count(*), count(c_int), count(c_text) FROM %T"
+	diff_query "$tag :: minmax"     "SELECT min(c_int), max(c_int), min(c_vc), max(c_vc), min(c_date), max(c_date) FROM %T"
+	diff_query "$tag :: sumavg"     "SELECT sum(c_int), avg(c_num), sum(c_f8) FROM %T"
+	diff_query "$tag :: range int"  "SELECT id FROM %T WHERE c_int BETWEEN $LO AND $HI"
+	diff_query "$tag :: range date" "SELECT id FROM %T WHERE c_date >= DATE '2010-06-01'"
+	diff_query "$tag :: eq"         "SELECT id, c_vc FROM %T WHERE id = $EQ"
+	diff_query "$tag :: isnull"     "SELECT count(*) FROM %T WHERE c_text IS NULL"
+	diff_query "$tag :: compound"   "SELECT id FROM %T WHERE c_int > 0 AND c_bool AND c_num < 1000"
+done
+
+pgc_summary

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -83,8 +83,20 @@ pgc_setup() {
 		echo "max_parallel_workers_per_gather=0"
 	} | pgc_pg "cat >> '$PGC_PGDATA/postgresql.conf'"
 
+	# Start, retrying a few times: under rapid cluster churn (the version matrix
+	# runs many throwaway clusters back to back) a start can transiently fail to
+	# bind or acquire resources before the previous cluster is fully gone.
 	echo "-- start"
-	pgc_pg "pg_ctl -D '$PGC_PGDATA' -l '$PGC_LOGFILE' start -w" >/dev/null
+	{
+		local _a
+		for _a in 1 2 3 4 5; do
+			if pgc_pg "pg_ctl -D '$PGC_PGDATA' -l '$PGC_LOGFILE' start -w" >/dev/null 2>&1; then
+				break
+			fi
+			echo "-- start attempt $_a failed; retrying"
+			sleep 2
+		done
+	}
 	psql_admin "CREATE DATABASE $PGC_DB;" >/dev/null
 	psql_run "CREATE EXTENSION columnar;" >/dev/null
 }

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+#
+# pgColumnar shared test harness.
+#
+# Sourced by the differential/recovery/fuzz suites. Provides a throwaway
+# cluster lifecycle, a heap-vs-columnar differential oracle, and pass/fail
+# accounting. Written fresh for pgColumnar; it does not reuse any upstream test
+# file or expected-output file.
+#
+# The differential oracle is the core idea: every table under test has a heap
+# mirror loaded with identical data, and a query is run against both. The two
+# result sets are compared as order-independent hashes, so heap acts as the
+# reference oracle for columnar. This catches encode/decode and skipping bugs
+# generically instead of via hardcoded expected values.
+#
+# Conventions for suites that source this file:
+#   - Call pgc_setup "$@" once (passes through the optional PG_CONFIG arg).
+#   - Use q "SQL" for a scalar, psql_run for a statement, psql_file FILE.
+#   - Use diff_query LABEL "SQL with %T" to compare a heap/columnar pair.
+#   - Finish with pgc_summary (exits non-zero if any check failed).
+#
+# Client SQL runs as the current (root) user over TCP with trust auth, so
+# -f files never have postgres-ownership problems; only initdb and pg_ctl run
+# as the postgres OS user.
+
+# Do not set -e here: the suite sets its own shell options. The oracle helpers
+# must not abort the run on a single mismatch or a SQL error; they record a
+# failure and continue.
+
+PGC_FAIL=0
+PGC_CHECKS=0
+
+# ---- setup / teardown ------------------------------------------------------
+
+pgc_setup() {
+	PGC_PG_CONFIG="${1:-/usr/local/pg17/bin/pg_config}"
+	PGC_BINDIR="$("$PGC_PG_CONFIG" --bindir)"
+	PGC_PORT="${PGC_PORT:-54329}"
+	PGC_DB="${PGC_DB:-regress}"
+	PGC_LIBDIR="$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)")"
+	PGC_SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+	PGC_WORKDIR="$(mktemp -d /tmp/pgcolumnar-test.XXXXXX)"
+	PGC_PGDATA="$PGC_WORKDIR/data"
+	PGC_LOGFILE="$PGC_WORKDIR/server.log"
+	PGC_SQLDIR="$PGC_WORKDIR/sql"
+	mkdir -p "$PGC_SQLDIR"
+	chmod 777 "$PGC_WORKDIR" "$PGC_SQLDIR"
+
+	echo "== pgColumnar test: $(basename "$0") =="
+	echo "PG_CONFIG=$PGC_PG_CONFIG"
+	echo "version=$("$PGC_PG_CONFIG" --version)"
+	echo "workdir=$PGC_WORKDIR"
+
+	echo "-- building"
+	make -C "$PGC_SRCDIR" PG_CONFIG="$PGC_PG_CONFIG" >/dev/null
+	echo "-- installing"
+	make -C "$PGC_SRCDIR" install PG_CONFIG="$PGC_PG_CONFIG" >/dev/null
+
+	# initdb and pg_ctl cannot run as root; use postgres when we are root.
+	if [ "$(id -u)" = "0" ]; then
+		PGC_RUNPG=(runuser -u postgres --)
+		chown -R postgres "$PGC_WORKDIR"
+		chmod 777 "$PGC_WORKDIR" "$PGC_SQLDIR"
+	else
+		PGC_RUNPG=(env)
+	fi
+
+	trap pgc_teardown EXIT
+
+	echo "-- initdb"
+	pgc_pg "initdb -D '$PGC_PGDATA' -A trust" >/dev/null 2>&1
+	{
+		echo "port=$PGC_PORT"
+		echo "listen_addresses='127.0.0.1'"
+		echo "shared_preload_libraries='columnar'"
+		# Deterministic text output so heap and columnar hashes match.
+		echo "extra_float_digits=3"
+		echo "timezone='UTC'"
+		echo "datestyle='ISO, MDY'"
+		echo "bytea_output='hex'"
+		# Keep planner honest but let small tables use the custom scan.
+		echo "max_parallel_workers_per_gather=0"
+	} | pgc_pg "cat >> '$PGC_PGDATA/postgresql.conf'"
+
+	echo "-- start"
+	pgc_pg "pg_ctl -D '$PGC_PGDATA' -l '$PGC_LOGFILE' start -w" >/dev/null
+	psql_admin "CREATE DATABASE $PGC_DB;" >/dev/null
+	psql_run "CREATE EXTENSION columnar;" >/dev/null
+}
+
+pgc_teardown() {
+	pgc_pg "pg_ctl -D '$PGC_PGDATA' stop -m immediate -w" >/dev/null 2>&1 || true
+	rm -rf "$PGC_WORKDIR"
+}
+
+# Run a command as the postgres OS user (for initdb/pg_ctl).
+pgc_pg() {
+	"${PGC_RUNPG[@]}" env PATH="$PGC_BINDIR:$PATH" bash -lc "$1"
+}
+
+# ---- SQL helpers (run as root over TCP, trust auth) ------------------------
+
+PGC_PSQL_BASE() {
+	echo "psql -h 127.0.0.1 -p $PGC_PORT -U postgres"
+}
+
+# Run a statement against the test database, stop on error.
+psql_run() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -v ON_ERROR_STOP=1 -q -c "$1"
+}
+
+# Run a statement against the maintenance database (for CREATE DATABASE etc.).
+psql_admin() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d postgres -v ON_ERROR_STOP=1 -q -c "$1"
+}
+
+# Scalar query: echo a single value (empty on error).
+q() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -At -c "$1" 2>/dev/null || true
+}
+
+# Run a SQL file, returning At output.
+psql_file() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -At -f "$1" 2>/dev/null || true
+}
+
+# ---- assertions ------------------------------------------------------------
+
+check() {
+	local name="$1" got="$2" want="$3"
+	PGC_CHECKS=$((PGC_CHECKS + 1))
+	if [ "$got" = "$want" ]; then
+		echo "PASS  $name"
+	else
+		echo "FAIL  $name: got [$got] want [$want]"
+		PGC_FAIL=1
+	fi
+}
+
+# Order-independent set hash of an arbitrary query's result. The row is cast to
+# text as a whole composite so any column list works. No single quotes are used
+# in the wrapper (dollar-quoting + chr(10)) so the inner query may contain its
+# own quotes freely.
+pgc_set_hash() {
+	local query="$1" out
+	out="$PGC_SQLDIR/h.$$.$RANDOM.sql"
+	cat > "$out" <<SQL
+SELECT coalesce(md5(string_agg(t, chr(10) ORDER BY t)), \$e\$EMPTY\$e\$)
+FROM (SELECT _row::text AS t FROM ( $query ) _row) _s;
+SQL
+	psql_file "$out"
+	rm -f "$out"
+}
+
+# diff_query LABEL "QUERY with %T placeholder for the table name"
+# Runs QUERY against t_heap and t_col and asserts identical result sets.
+diff_query() {
+	local label="$1" tmpl="$2"
+	local hq hc
+	hq="$(pgc_set_hash "${tmpl//%T/t_heap}")"
+	hc="$(pgc_set_hash "${tmpl//%T/t_col}")"
+	# A blank result means the query errored; surface it as a distinct value.
+	[ -z "$hq" ] && hq="HEAP_ERROR"
+	[ -z "$hc" ] && hc="COL_ERROR"
+	check "$label" "$hc" "$hq"
+}
+
+# ---- pair construction -----------------------------------------------------
+
+# make_pair "COLUMN DEFS" ["WITH options for columnar"]
+# Creates t_heap (heap) and t_col (columnar) with the same schema.
+make_pair() {
+	local defs="$1"
+	psql_run "DROP TABLE IF EXISTS t_heap; DROP TABLE IF EXISTS t_col;"
+	psql_run "CREATE TABLE t_heap ($defs) USING heap;"
+	psql_run "CREATE TABLE t_col  ($defs) USING columnar;"
+}
+
+# load_pair "INSERT SELECT body" : insert identical rows into both. The body is
+# everything after INSERT INTO <t>, e.g. "SELECT g, g::text FROM generate_series(1,10) g".
+# Data is generated once into heap, then copied to columnar, so both hold
+# byte-identical logical contents regardless of any volatile generators.
+load_pair() {
+	local body="$1"
+	psql_run "INSERT INTO t_heap $body;"
+	psql_run "INSERT INTO t_col SELECT * FROM t_heap;"
+}
+
+# Storage id for a columnar relation by name.
+storage_id_of() {
+	q "SELECT columnar.get_storage_id('$1');"
+}
+
+# Number of stripes physically written for a columnar relation (default t_col).
+stripe_count() {
+	local rel="${1:-t_col}"
+	q "SELECT count(*) FROM columnar.stripe
+	   WHERE storage_id = columnar.get_storage_id('$rel');"
+}
+
+# Number of chunk groups written for a columnar relation (default t_col).
+chunk_group_count() {
+	local rel="${1:-t_col}"
+	q "SELECT count(*) FROM columnar.chunk_group
+	   WHERE storage_id = columnar.get_storage_id('$rel');"
+}
+
+# ---- summary ---------------------------------------------------------------
+
+pgc_summary() {
+	echo
+	echo "checks run: $PGC_CHECKS"
+	if [ "$PGC_FAIL" = "0" ]; then
+		echo "$(basename "$0"): PASSED"
+	else
+		echo "$(basename "$0"): FAILED"
+		echo "---- server log tail ----"
+		pgc_pg "tail -40 '$PGC_LOGFILE'" 2>/dev/null || true
+	fi
+	exit $PGC_FAIL
+}

--- a/test/recovery.sh
+++ b/test/recovery.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+#
+# pgColumnar crash/recovery and WAL durability suite.
+#
+# Columnar data lives in the relation main fork through the buffer manager and
+# WAL, and metadata lives in WAL-logged heap catalogs, so a committed write must
+# survive an immediate crash via WAL replay, and an in-flight (uncommitted)
+# write must leave nothing visible. This suite crashes the cluster with SIGKILL
+# and verifies both, using a heap mirror (itself crash-safe) as the oracle.
+#
+# Usage:  test/recovery.sh [PG_CONFIG]
+#
+# Written fresh for pgColumnar; it does not reuse any upstream test file.
+
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+# Hard-crash the test cluster: SIGKILL the whole postmaster process group so the
+# backends die too. Backends inherit the postmaster's listen socket, so killing
+# only the postmaster would leave the TCP port bound and block the restart with
+# "address already in use". pg_ctl starts the postmaster as a session/group
+# leader (PGID == PID), so a negative-PID kill reaches the entire cluster. We
+# then wait for the postmaster PID to actually disappear before returning.
+crash_cluster() {
+	local pm i
+	pm="$(head -1 "$PGC_PGDATA/postmaster.pid" 2>/dev/null || true)"
+	echo "-- SIGKILL cluster (postmaster pid=$pm)"
+	if [ -n "$pm" ]; then
+		kill -9 -"$pm" 2>/dev/null || true   # whole process group
+		kill -9 "$pm" 2>/dev/null || true    # fallback: just the postmaster
+	fi
+	pkill -9 -f -- "$PGC_PGDATA" 2>/dev/null || true
+	for i in $(seq 1 100); do
+		{ [ -n "$pm" ] && kill -0 "$pm" 2>/dev/null; } || break
+		sleep 0.1
+	done
+	sleep 1
+}
+
+# Restart into crash recovery, retrying in case the port is briefly still held.
+restart_cluster() {
+	local attempt
+	echo "-- restart (crash recovery)"
+	for attempt in 1 2 3 4 5 6; do
+		if pgc_pg "pg_ctl -D '$PGC_PGDATA' -l '$PGC_LOGFILE' start -w" >/dev/null 2>&1; then
+			return 0
+		fi
+		echo "-- restart attempt $attempt failed; retrying"
+		sleep 2
+	done
+	echo "-- restart FAILED after retries"
+	return 1
+}
+
+# Confirm recovery actually happened (a redo entry in the log).
+recovery_ran() {
+	pgc_pg "grep -c -E 'redo (starts|done)|database system was not properly shut down' '$PGC_LOGFILE'" 2>/dev/null || echo 0
+}
+
+make_pair "id int, v text, n numeric"
+q "SELECT columnar.alter_columnar_table_set('t_col', chunk_group_row_limit => 1000, stripe_row_limit => 2000);" >/dev/null
+
+# ---------------------------------------------------------------------------
+# Scenario 1: committed writes survive an immediate crash.
+#   batch1 is checkpointed (reaches disk); batch2 is committed but not
+#   checkpointed (recoverable only from WAL). Both must be present after crash.
+# ---------------------------------------------------------------------------
+echo "-- scenario 1: committed durability"
+load_pair "SELECT g, 'a'||g, g*1.5 FROM generate_series(1,3000) g"
+psql_run "CHECKPOINT;"
+psql_run "INSERT INTO t_heap SELECT g, 'b'||g, g*2.5 FROM generate_series(3001,5000) g;"
+psql_run "INSERT INTO t_col  SELECT g, 'b'||g, g*2.5 FROM generate_series(3001,5000) g;"
+
+crash_cluster
+restart_cluster
+
+check "s1 recovery ran"       "$([ "$(recovery_ran)" -ge 1 ] && echo ok)" "ok"
+check "s1 col count"          "$(q 'SELECT count(*) FROM t_col;')" "5000"
+check "s1 heap count"         "$(q 'SELECT count(*) FROM t_heap;')" "5000"
+diff_query "s1 whole-row"     "SELECT * FROM %T"
+diff_query "s1 aggregate"     "SELECT count(*), sum(n), min(v), max(v) FROM %T"
+diff_query "s1 range"         "SELECT id FROM %T WHERE id BETWEEN 2500 AND 3500"
+
+# ---------------------------------------------------------------------------
+# Scenario 2: an uncommitted transaction leaves nothing visible after a crash.
+#   A background session opens a transaction, inserts, and holds it open. We
+#   checkpoint (to try to flush anything) and crash. After recovery the row
+#   count must be unchanged and the pair must still agree.
+# ---------------------------------------------------------------------------
+echo "-- scenario 2: uncommitted atomicity"
+env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" \
+	-c "BEGIN; INSERT INTO t_col SELECT g,'c'||g,g FROM generate_series(9001,11000) g; SELECT pg_sleep(30);" \
+	>/dev/null 2>&1 &
+BGPID=$!
+sleep 5   # let the INSERT run inside the open transaction
+psql_run "CHECKPOINT;"
+crash_cluster
+kill "$BGPID" 2>/dev/null || true
+restart_cluster
+
+check "s2 col count unchanged"  "$(q 'SELECT count(*) FROM t_col;')" "5000"
+check "s2 heap count unchanged" "$(q 'SELECT count(*) FROM t_heap;')" "5000"
+check "s2 no phantom rows"      "$(q 'SELECT count(*) FROM t_col WHERE id >= 9001;')" "0"
+diff_query "s2 whole-row"       "SELECT * FROM %T"
+
+# ---------------------------------------------------------------------------
+# Scenario 3: committed deletes (row-mask writes) survive a crash.
+# ---------------------------------------------------------------------------
+echo "-- scenario 3: row-mask durability"
+psql_run "DELETE FROM t_heap WHERE id % 7 = 0;"
+psql_run "DELETE FROM t_col  WHERE id % 7 = 0;"
+expect_after_delete="$(q 'SELECT count(*) FROM t_heap;')"
+
+crash_cluster
+restart_cluster
+
+check "s3 col count == heap"  "$(q 'SELECT count(*) FROM t_col;')" "$expect_after_delete"
+check "s3 deletes persisted"  "$(q 'SELECT count(*) FROM t_col WHERE id % 7 = 0;')" "0"
+diff_query "s3 whole-row"     "SELECT * FROM %T"
+diff_query "s3 aggregate"     "SELECT count(*), sum(n) FROM %T"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -4,7 +4,8 @@
 #
 # For each pg_config given, this builds the extension fresh in a per-major build
 # directory (so nothing leaks between majors) and runs every suite
-# (smoke + phase2..phase6 + audit + concurrency + unique_conc) against it. It prints a
+# (smoke + phase2..phase6 + audit + concurrency + unique_conc + differential +
+# recovery + fuzz) against it. It prints a
 # per-version PASS/FAIL line and
 # a final summary table, and exits non-zero if any version fails to build or any
 # suite fails.
@@ -22,7 +23,8 @@
 set -uo pipefail
 
 SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-SUITES=(smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc)
+SUITES=(smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
+	differential recovery fuzz)
 
 # Default matrix: one assert-enabled pg_config per major, 13 through 19.
 DEFAULT_CONFIGS=(


### PR DESCRIPTION
This branch adds a differential test foundation and the first phase of the
research-driven roadmap (see design/IMPROVEMENT_PLAN.md). Full version matrix
**ALL VERSIONS PASSED** on PostgreSQL 13–19 (all suites, assert-enabled).

## Test foundation
- `test/lib.sh` heap-vs-columnar **differential oracle** (order-independent result-set hashing).
- `test/differential.sh` (type matrix, boundaries, encodings, compressed execution), `test/recovery.sh` (SIGKILL WAL replay / atomicity / row-mask durability), `test/fuzz.sh` (seeded randomized differential). Wired into `run_all_versions.sh`.

## I1 — lightweight value-stream encodings (format 2.1)
Type-aware encoding layer between the raw value stream and the block codec, as a reversible byte transform: **RLE, FOR (frame-of-reference + bit-packing), DELTA, Gorilla (float XOR), delta-of-delta**. Additive catalog columns (`value_encoding_type`, `value_raw_length`); 2.0 files still read. Measured pre-codec shrink up to ~32× on sequential ids, ~10× low-cardinality; 25 MB heap → 1.5 MB columnar end-to-end.

## I2 + I3 — compression-block run iterator and compressed aggregate execution
`ColumnarBlockReader` exposes a chunk as `(value, run-length)` pairs; the vectorized aggregate folds each run once (`count`/`sum`/`avg` in O(1) per run, `min`/`max` once per run) when there are no predicates and columns are fixed-width, falling back per-group for deletes/absent columns. New GUC `columnar.enable_compressed_execution` (default on); off must match on.

Clean-room throughout (implemented from the cited public papers; PROVENANCE preserved). No behavior change to results — the differential/fuzz suites verify columnar output equals heap across the matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)