### PR TITLE
I6: vectorized branch-free predicate evaluation

### DIFF
--- a/src/columnar.h
+++ b/src/columnar.h
@@ -510,7 +510,23 @@ typedef struct ColumnarVecPredicate
 	FmgrInfo	opFn;			/* the operator function (returns bool) */
 	Datum		constValue;
 	Oid			collation;
+
+	/*
+	 * Typed fast path (I6). fastKind is one of COLUMNAR_VECFAST_* (0 = none,
+	 * use opFn); strategy is the btree strategy 1..5 (Less..Greater) already
+	 * normalized to "column op const". When fastKind is set, the predicate is
+	 * evaluated column-at-a-time with a branch-free typed loop instead of fmgr.
+	 */
+	int			fastKind;
+	int			strategy;
 } ColumnarVecPredicate;
+
+#define COLUMNAR_VECFAST_NONE 0
+#define COLUMNAR_VECFAST_I16 1
+#define COLUMNAR_VECFAST_I32 2
+#define COLUMNAR_VECFAST_I64 3
+#define COLUMNAR_VECFAST_F32 4
+#define COLUMNAR_VECFAST_F64 5
 
 /*
  * Build the array of evaluable predicates from a plan's restriction clauses.
@@ -529,5 +545,14 @@ extern ColumnarVecPredicate *ColumnarBuildVecPredicates(List *qual,
 /* whether row i of a decoded chunk group passes every predicate (AND) */
 extern bool ColumnarVecRowPasses(ColumnarVecPredicate *preds, int npreds,
 								 ColumnarVector *vec, uint64 i);
+
+/*
+ * Build a selection vector for a whole chunk group column-at-a-time (I6):
+ * sel[i] is true when row i is not deleted and passes every predicate. Uses a
+ * branch-free typed loop per predicate where possible, falling back to the
+ * operator function otherwise. sel must have room for vec->nrows entries.
+ */
+extern void ColumnarVecSelect(ColumnarVecPredicate *preds, int npreds,
+							  ColumnarVector *vec, bool *sel);
 
 #endif							/* PGCOLUMNAR_H */

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -79,6 +79,8 @@ typedef struct ColumnarCustomScanState
 	uint64		vecPos;
 	ColumnarVecPredicate *vecPreds;
 	int			nVecPreds;
+	bool	   *vecSel;			/* per-group selection vector (I6) */
+	uint64		vecSelCap;		/* allocated length of vecSel */
 } ColumnarCustomScanState;
 
 /* path -> plan */
@@ -520,6 +522,8 @@ ColumnarBeginCustomScan(CustomScanState *node, EState *estate, int eflags)
 		cstate->projectedColumns != NULL;
 	cstate->haveVec = false;
 	cstate->vecPos = 0;
+	cstate->vecSel = NULL;
+	cstate->vecSelCap = 0;
 	if (cstate->vectorized)
 	{
 		bool		allConvertible;
@@ -562,15 +566,25 @@ ColumnarScanNextVector(ScanState *ss)
 				return NULL;
 			cstate->haveVec = true;
 			cstate->vecPos = 0;
+
+			/* build the group's selection vector once, column-at-a-time (I6) */
+			if (cstate->vec.nrows > cstate->vecSelCap)
+			{
+				if (cstate->vecSel)
+					pfree(cstate->vecSel);
+				cstate->vecSel = MemoryContextAlloc(
+					cstate->css.ss.ps.state->es_query_cxt,
+					sizeof(bool) * cstate->vec.nrows);
+				cstate->vecSelCap = cstate->vec.nrows;
+			}
+			ColumnarVecSelect(cstate->vecPreds, cstate->nVecPreds,
+							  &cstate->vec, cstate->vecSel);
 			continue;			/* re-check bounds (handles an empty group) */
 		}
 
 		i = cstate->vecPos++;
 
-		if (cstate->vec.deleted[i])
-			continue;
-		if (!ColumnarVecRowPasses(cstate->vecPreds, cstate->nVecPreds,
-								  &cstate->vec, i))
+		if (!cstate->vecSel[i])
 			continue;
 
 		ExecClearTuple(slot);

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -61,6 +61,7 @@
 #include "utils/datum.h"
 #include "utils/fmgrprotos.h"
 #include "utils/lsyscache.h"
+#include "access/stratnum.h"
 #include "access/tupmacs.h"
 #include "utils/rel.h"
 #include "utils/typcache.h"
@@ -143,6 +144,94 @@ columnar_clause_to_predicate(Node *clause, Index scanrelid, TupleDesc tupdesc,
 	pred->constValue = con->constvalue;
 	pred->collation = op->inputcollid;
 
+	/*
+	 * Resolve a typed fast path (I6): a storage kind from the column type and a
+	 * btree strategy from the operator, normalized to "column op const". Only
+	 * used when the constant has exactly the column's type (so the raw Datum can
+	 * be read as that C type); anything else keeps the operator-function path.
+	 * The eligible types compare byte-for-byte without collation, so the fast
+	 * path is collation-agnostic.
+	 */
+	pred->fastKind = COLUMNAR_VECFAST_NONE;
+	pred->strategy = 0;
+	if (con->consttype == var->vartype)
+	{
+		int			fk = COLUMNAR_VECFAST_NONE;
+
+		switch (var->vartype)
+		{
+			case INT2OID:
+				fk = COLUMNAR_VECFAST_I16;
+				break;
+			case INT4OID:
+			case DATEOID:
+				fk = COLUMNAR_VECFAST_I32;
+				break;
+			case INT8OID:
+			case TIMESTAMPOID:
+			case TIMESTAMPTZOID:
+				fk = COLUMNAR_VECFAST_I64;
+				break;
+			case FLOAT4OID:
+				fk = COLUMNAR_VECFAST_F32;
+				break;
+			case FLOAT8OID:
+				fk = COLUMNAR_VECFAST_F64;
+				break;
+			default:
+				break;
+		}
+
+		if (fk != COLUMNAR_VECFAST_NONE)
+		{
+			TypeCacheEntry *tce = lookup_type_cache(var->vartype,
+													TYPECACHE_BTREE_OPFAMILY);
+			int			strat = 0;
+
+			/* match the operator to a btree strategy of the type's opfamily */
+			if (OidIsValid(tce->btree_opf))
+			{
+				int			s;
+
+				for (s = BTLessStrategyNumber; s <= BTGreaterStrategyNumber; s++)
+				{
+					if (get_opfamily_member(tce->btree_opf, tce->btree_opintype,
+											tce->btree_opintype, s) == op->opno)
+					{
+						strat = s;
+						break;
+					}
+				}
+			}
+
+			if (strat != 0)
+			{
+				if (!varOnLeft)
+				{
+					switch (strat)
+					{
+						case BTLessStrategyNumber:
+							strat = BTGreaterStrategyNumber;
+							break;
+						case BTLessEqualStrategyNumber:
+							strat = BTGreaterEqualStrategyNumber;
+							break;
+						case BTGreaterEqualStrategyNumber:
+							strat = BTLessEqualStrategyNumber;
+							break;
+						case BTGreaterStrategyNumber:
+							strat = BTLessStrategyNumber;
+							break;
+						default:
+							break;	/* equal is symmetric */
+					}
+				}
+				pred->fastKind = fk;
+				pred->strategy = strat;
+			}
+		}
+	}
+
 	return true;
 }
 
@@ -204,6 +293,97 @@ ColumnarVecRowPasses(ColumnarVecPredicate *preds, int npreds,
 	}
 
 	return true;
+}
+
+/*
+ * Typed, branch-free predicate loops (I6). Each ANDs one predicate's result
+ * into sel over the whole column array. The comparison is chosen once (outside
+ * the inner loop) so the loop body has no data-dependent branch beyond the
+ * comparison, which the compiler can auto-vectorize.
+ */
+#define VEC_CMP_BODY(GET, OP) \
+	{ for (i = 0; i < n; i++) { sel[i] = sel[i] & !isn[i] & (GET(vals[i]) OP c); } break; }
+#define VEC_CMP(NAME, CTYPE, GET) \
+static void \
+NAME(bool *sel, const Datum *vals, const bool *isn, uint64 n, int strat, Datum cdat) \
+{ \
+	CTYPE c = GET(cdat); \
+	uint64 i; \
+	switch (strat) \
+	{ \
+		case BTLessStrategyNumber: VEC_CMP_BODY(GET, <) \
+		case BTLessEqualStrategyNumber: VEC_CMP_BODY(GET, <=) \
+		case BTEqualStrategyNumber: VEC_CMP_BODY(GET, ==) \
+		case BTGreaterEqualStrategyNumber: VEC_CMP_BODY(GET, >=) \
+		case BTGreaterStrategyNumber: VEC_CMP_BODY(GET, >) \
+	} \
+}
+
+VEC_CMP(vecsel_i16, int16, DatumGetInt16)
+VEC_CMP(vecsel_i32, int32, DatumGetInt32)
+VEC_CMP(vecsel_i64, int64, DatumGetInt64)
+VEC_CMP(vecsel_f32, float4, DatumGetFloat4)
+VEC_CMP(vecsel_f64, float8, DatumGetFloat8)
+
+void
+ColumnarVecSelect(ColumnarVecPredicate *preds, int npreds,
+				  ColumnarVector *vec, bool *sel)
+{
+	uint64		n = vec->nrows;
+	uint64		i;
+	int			p;
+
+	/* start from the non-deleted rows */
+	for (i = 0; i < n; i++)
+		sel[i] = !vec->deleted[i];
+
+	for (p = 0; p < npreds; p++)
+	{
+		ColumnarVecPredicate *pred = &preds[p];
+		const Datum *vals = vec->values[pred->attidx];
+		const bool *isn = vec->isnull[pred->attidx];
+
+		switch (pred->fastKind)
+		{
+			case COLUMNAR_VECFAST_I16:
+				vecsel_i16(sel, vals, isn, n, pred->strategy, pred->constValue);
+				break;
+			case COLUMNAR_VECFAST_I32:
+				vecsel_i32(sel, vals, isn, n, pred->strategy, pred->constValue);
+				break;
+			case COLUMNAR_VECFAST_I64:
+				vecsel_i64(sel, vals, isn, n, pred->strategy, pred->constValue);
+				break;
+			case COLUMNAR_VECFAST_F32:
+				vecsel_f32(sel, vals, isn, n, pred->strategy, pred->constValue);
+				break;
+			case COLUMNAR_VECFAST_F64:
+				vecsel_f64(sel, vals, isn, n, pred->strategy, pred->constValue);
+				break;
+			default:
+				/* operator-function fallback, still column-at-a-time */
+				for (i = 0; i < n; i++)
+				{
+					Datum		r;
+
+					if (!sel[i])
+						continue;
+					if (isn[i])
+					{
+						sel[i] = false;
+						continue;
+					}
+					if (pred->varOnLeft)
+						r = FunctionCall2Coll(&pred->opFn, pred->collation,
+											  vals[i], pred->constValue);
+					else
+						r = FunctionCall2Coll(&pred->opFn, pred->collation,
+											  pred->constValue, vals[i]);
+					sel[i] = DatumGetBool(r);
+				}
+				break;
+		}
+	}
 }
 
 /* -------------------------------------------------------------------------
@@ -880,15 +1060,26 @@ columnar_run_agg(ColumnarAggScanState *state)
 	}
 	else
 	{
+		bool	   *sel = NULL;
+		uint64		selCap = 0;
+
 		while (ColumnarReadNextVector(readState, &vec))
 		{
 			uint64		i;
 
+			/* build the selection vector for the whole group once (I6) */
+			if (vec.nrows > selCap)
+			{
+				if (sel)
+					pfree(sel);
+				sel = palloc(sizeof(bool) * vec.nrows);
+				selCap = vec.nrows;
+			}
+			ColumnarVecSelect(state->preds, state->npreds, &vec, sel);
+
 			for (i = 0; i < vec.nrows; i++)
 			{
-				if (vec.deleted[i])
-					continue;
-				if (!ColumnarVecRowPasses(state->preds, state->npreds, &vec, i))
+				if (!sel[i])
 					continue;
 
 				for (a = 0; a < state->naggs; a++)
@@ -903,6 +1094,8 @@ columnar_run_agg(ColumnarAggScanState *state)
 				}
 			}
 		}
+		if (sel)
+			pfree(sel);
 	}
 
 	table_close(rel, AccessShareLock);


### PR DESCRIPTION
Stacked on #6 (feat/encoding-layer).

Evaluate pushed-down predicates **column-at-a-time into a selection vector**
(`ColumnarVecSelect`) instead of row-at-a-time through the operator function. The
scan and the vectorized aggregate build the vector once per chunk group.

- Typed branch-free loops for int2/4/8, float4/8, date/timestamp(tz) (auto-vectorizable); btree strategy resolved portably via the type's default btree opfamily; constant must match the column type. Everything else falls back to the operator function, still column-at-a-time.
- Nulls and row-mask deletes fold into the selection vector.
- Results unchanged — the scan re-applies the full qual and the aggregate uses the same predicates; the differential/fuzz oracle + phase5 qual pushdown validate.

Tests: differential (200), phase5, phase6, fuzz pass on pg13, pg17, pg19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)