### PR TITLE
I7: per-chunk bloom filters for equality skipping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ OBJS = \
 	src/columnar_write_state.o \
 	src/columnar_compression.o \
 	src/columnar_encoding.o \
+	src/columnar_bloom.o \
 	src/columnar_reader.o \
 	src/columnar_row_mask.o \
 	src/columnar_customscan.o \

--- a/columnar--1.0.sql
+++ b/columnar--1.0.sql
@@ -65,7 +65,8 @@ CREATE TABLE columnar.chunk (
 	value_decompressed_length bigint NOT NULL,
 	value_count bigint NOT NULL,
 	value_encoding_type integer,
-	value_raw_length bigint
+	value_raw_length bigint,
+	bloom_filter bytea
 );
 
 CREATE UNIQUE INDEX chunk_pkey

--- a/design/FORMAT_AND_INTERFACE_SPEC.md
+++ b/design/FORMAT_AND_INTERFACE_SPEC.md
@@ -221,9 +221,18 @@ Indexes:
 | 14 | value_count | bigint |
 | 15 | value_encoding_type | integer |
 | 16 | value_raw_length | bigint |
+| 17 | bloom_filter | bytea |
 
 Index:
 - `chunk_pkey` unique on (storage_id, stripe_num, attr_num, chunk_group_num)
+
+`bloom_filter` (format 2.1) is an optional per-chunk bloom filter over the
+column's non-null values, used to skip a chunk group on an equality predicate
+when the value is provably absent. It is present only for hashable,
+non-collatable columns and chunks large enough to benefit; it is NULL otherwise
+and absent in 2.0 chunks. Its layout is `[uint32 nbits][uint8 k][ceil(nbits/8)
+bytes]`, with nbits a power of two and k probe positions per value derived from
+the type's hash by double hashing.
 
 `value_decompressed_length` is the length of the stream produced by
 decompression, which is the encoded stream (5.1); for encoding type none it
@@ -333,6 +342,7 @@ flags:
 | columnar.planner_debug_level | debug3 | log level for planner messages |
 | columnar.enable_custom_scan | on | use the columnar custom scan path |
 | columnar.enable_compressed_execution | on | fold aggregates over runs of the value stream |
+| columnar.enable_bloom_filter | on | skip chunk groups on equality via per-chunk bloom filters |
 | columnar.enable_qual_pushdown | on | push filters into the scan for chunk skipping |
 | columnar.enable_columnar_index_scan | off | allow the custom index backed scan |
 | columnar.qual_pushdown_correlation_threshold | 0.4 | correlation threshold for pushdown |

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -100,6 +100,7 @@ extern int columnar_compression;		/* one of COLUMNAR_COMPRESSION_* */
 extern int columnar_compression_level;	/* zstd level */
 extern bool columnar_enable_qual_pushdown;
 extern bool columnar_enable_custom_scan;
+extern bool columnar_enable_bloom_filter;	/* bloom equality skipping (I7) */
 
 /* Phase 6 GUCs (spec 8.3) */
 extern bool columnar_enable_vectorization;	/* vectorized scan/aggregate path */
@@ -206,6 +207,14 @@ typedef struct ChunkMetadata
 	uint32		minEncodedLen;
 	char	   *maxEncoded;
 	uint32		maxEncodedLen;
+
+	/*
+	 * Optional per-chunk bloom filter over the column's non-null values (I7),
+	 * for equality chunk-group skipping. NULL when absent (older chunks, or a
+	 * collatable/non-hashable column, or a chunk too small to be worth it).
+	 */
+	char	   *bloomFilter;
+	uint32		bloomLen;
 } ChunkMetadata;
 
 /* -------------------------------------------------------------------------
@@ -404,6 +413,13 @@ extern char *ColumnarDecodeChunk(const char *enc, uint32 encLen,
 								 uint64 valueCount, uint32 rawLen,
 								 MemoryContext cx);
 extern const char *ColumnarEncodingName(int encodingType);
+
+/* -------------------------------------------------------------------------
+ * per-chunk bloom filters (columnar_bloom.c, I7)
+ * ------------------------------------------------------------------------- */
+extern bool ColumnarBloomBuild(const uint32 *hashes, uint32 n,
+							   char **out, uint32 *outLen);
+extern bool ColumnarBloomProbe(const char *bloom, uint32 bloomLen, uint32 hash);
 
 /* -------------------------------------------------------------------------
  * compression-block run iterator (columnar_encoding.c, I2)

--- a/src/columnar_bloom.c
+++ b/src/columnar_bloom.c
@@ -1,0 +1,132 @@
+/*-------------------------------------------------------------------------
+ *
+ * columnar_bloom.c
+ *		Per-chunk bloom filters for equality chunk-group skipping (I7).
+ *
+ * min/max skip lists (spec 7.2) prune equality predicates only when the probed
+ * value falls outside a chunk's range. For an unsorted column an equality probe
+ * usually falls inside every chunk's range, so nothing is skipped and a point
+ * lookup decodes every chunk group -- the documented point-lookup weakness. A
+ * bloom filter per chunk lets an equality probe skip a chunk group when the
+ * value is provably absent, with a small false-positive rate.
+ *
+ * The filter is stored as [uint32 nbits][uint8 k][ceil(nbits/8) bytes], nbits a
+ * power of two so a bit index is hash & (nbits-1). k positions per value are
+ * derived from one 32-bit hash by double hashing. Build and probe hash values
+ * the same way (the type's hash opclass proc), so a set built over a chunk's
+ * values answers membership for a probe of the same type.
+ *
+ * Written from the standard bloom-filter construction and the public PostgreSQL
+ * hashing API only (clean-room; see PROVENANCE.md).
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "columnar.h"
+
+/* target ~1% false positives: ~10 bits/value, 6 probes */
+#define BLOOM_BITS_PER_VALUE 10
+#define BLOOM_K 6
+#define BLOOM_MIN_BITS 64
+#define BLOOM_MAX_BITS (1u << 21)	/* 256 KB cap per chunk */
+
+static uint32
+next_pow2(uint32 x)
+{
+	uint32		p = BLOOM_MIN_BITS;
+
+	while (p < x && p < BLOOM_MAX_BITS)
+		p <<= 1;
+	return p;
+}
+
+/* two derived hashes for double hashing; h2 forced odd for full coverage */
+static inline void
+bloom_hashes(uint32 h, uint32 *h1, uint32 *h2)
+{
+	*h1 = h;
+	*h2 = ((h >> 16) | (h << 16)) | 1u;
+}
+
+/*
+ * ColumnarBloomBuild
+ *		Build a filter over n precomputed value hashes. Returns false (no filter)
+ *		when n is too small for a filter to be worthwhile.
+ */
+bool
+ColumnarBloomBuild(const uint32 *hashes, uint32 n, char **out, uint32 *outLen)
+{
+	uint32		nbits;
+	uint32		nbytes;
+	uint32		total;
+	char	   *buf;
+	unsigned char *bits;
+	uint8		k = BLOOM_K;
+	uint32		i;
+
+	if (n < 64)
+		return false;			/* min/max and per-group scan suffice */
+
+	nbits = next_pow2(n * BLOOM_BITS_PER_VALUE);
+	nbytes = nbits / 8;
+	total = sizeof(uint32) + sizeof(uint8) + nbytes;
+
+	buf = palloc0(total);
+	memcpy(buf, &nbits, sizeof(uint32));
+	buf[sizeof(uint32)] = (char) k;
+	bits = (unsigned char *) buf + sizeof(uint32) + sizeof(uint8);
+
+	for (i = 0; i < n; i++)
+	{
+		uint32		h1;
+		uint32		h2;
+		int			j;
+
+		bloom_hashes(hashes[i], &h1, &h2);
+		for (j = 0; j < k; j++)
+		{
+			uint32		pos = (h1 + (uint32) j * h2) & (nbits - 1);
+
+			bits[pos >> 3] |= (unsigned char) (1u << (pos & 7));
+		}
+	}
+
+	*out = buf;
+	*outLen = total;
+	return true;
+}
+
+/*
+ * ColumnarBloomProbe
+ *		Return true when the hash may be present (all k bits set), false when it
+ *		is definitely absent. A malformed/empty filter conservatively returns
+ *		true (never skips wrongly).
+ */
+bool
+ColumnarBloomProbe(const char *bloom, uint32 bloomLen, uint32 hash)
+{
+	uint32		nbits;
+	uint8		k;
+	const unsigned char *bits;
+	uint32		h1;
+	uint32		h2;
+	int			j;
+
+	if (bloom == NULL || bloomLen < sizeof(uint32) + sizeof(uint8))
+		return true;
+
+	memcpy(&nbits, bloom, sizeof(uint32));
+	k = (uint8) bloom[sizeof(uint32)];
+	bits = (const unsigned char *) bloom + sizeof(uint32) + sizeof(uint8);
+	if (nbits == 0 || (nbits & (nbits - 1)) != 0)
+		return true;			/* not a power of two: treat as no filter */
+
+	bloom_hashes(hash, &h1, &h2);
+	for (j = 0; j < k; j++)
+	{
+		uint32		pos = (h1 + (uint32) j * h2) & (nbits - 1);
+
+		if (((bits[pos >> 3] >> (pos & 7)) & 1) == 0)
+			return false;		/* a required bit is unset: definitely absent */
+	}
+	return true;
+}

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -55,7 +55,8 @@
 #define Anum_chunk_value_count 14
 #define Anum_chunk_value_encoding_type 15
 #define Anum_chunk_value_raw_length 16
-#define Natts_chunk 16
+#define Anum_chunk_bloom_filter 17
+#define Natts_chunk 17
 
 /* attribute numbers for columnar.chunk_group (spec 7.3) */
 #define Anum_chunk_group_storage_id 1
@@ -277,6 +278,17 @@ ColumnarInsertChunkRow(uint64 storageId, const ChunkMetadata *chunk)
 	values[Anum_chunk_value_encoding_type - 1] = Int32GetDatum(chunk->valueEncodingType);
 	values[Anum_chunk_value_raw_length - 1] = Int64GetDatum((int64) chunk->valueRawLength);
 
+	if (chunk->bloomFilter != NULL)
+	{
+		bytea	   *bl = (bytea *) palloc(VARHDRSZ + chunk->bloomLen);
+
+		SET_VARSIZE(bl, VARHDRSZ + chunk->bloomLen);
+		memcpy(VARDATA(bl), chunk->bloomFilter, chunk->bloomLen);
+		values[Anum_chunk_bloom_filter - 1] = PointerGetDatum(bl);
+	}
+	else
+		nulls[Anum_chunk_bloom_filter - 1] = true;
+
 	tuple = heap_form_tuple(tupdesc, values, nulls);
 	CatalogTupleInsert(rel, tuple);
 	heap_freetuple(tuple);
@@ -462,6 +474,22 @@ ColumnarReadChunkList(uint64 storageId, uint64 stripeNum, Snapshot snapshot)
 				: DatumGetInt32(encDatum);
 			chunk->valueRawLength = rawNull ? chunk->valueDecompressedLength
 				: (uint64) DatumGetInt64(rawDatum);
+		}
+
+		/* optional per-chunk bloom filter (I7) */
+		{
+			bool		bloomNull;
+			Datum		bloomDatum = heap_getattr(tuple, Anum_chunk_bloom_filter,
+												  tupdesc, &bloomNull);
+
+			if (!bloomNull)
+			{
+				bytea	   *bl = DatumGetByteaP(bloomDatum);
+
+				chunk->bloomLen = VARSIZE(bl) - VARHDRSZ;
+				chunk->bloomFilter = palloc(chunk->bloomLen);
+				memcpy(chunk->bloomFilter, VARDATA(bl), chunk->bloomLen);
+			}
 		}
 
 		/* min/max skip list (spec 7.2), decoded on demand by the reader */

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -37,6 +37,11 @@ typedef struct SkipPredicate
 	Datum		compareValue;	/* the constant */
 	FmgrInfo	cmpFn;			/* column type's default btree comparison */
 	Oid			collation;
+
+	/* bloom-filter probe for equality (I7): set only for a hashable,
+	 * non-collatable equality predicate, matching how the filter was built */
+	bool		hasHash;
+	FmgrInfo	hashFn;
 } SkipPredicate;
 
 struct ColumnarReadState
@@ -315,7 +320,9 @@ columnar_build_predicates(ColumnarReadState *readState, int nkeys, ScanKey keys)
 		if (OidIsValid(key->sk_subtype) && key->sk_subtype != att->atttypid)
 			continue;
 
-		tce = lookup_type_cache(att->atttypid, TYPECACHE_CMP_PROC_FINFO);
+		tce = lookup_type_cache(att->atttypid,
+								TYPECACHE_CMP_PROC_FINFO |
+								TYPECACHE_HASH_PROC_FINFO);
 		if (!OidIsValid(tce->cmp_proc_finfo.fn_oid))
 			continue;
 
@@ -325,6 +332,20 @@ columnar_build_predicates(ColumnarReadState *readState, int nkeys, ScanKey keys)
 		fmgr_info_copy(&readState->predicates[n].cmpFn, &tce->cmp_proc_finfo,
 					   readState->readContext);
 		readState->predicates[n].collation = att->attcollation;
+
+		/*
+		 * For an equality predicate on a hashable, non-collatable column, also
+		 * enable the bloom-filter probe (I7), matching how the filter was built.
+		 */
+		readState->predicates[n].hasHash = false;
+		if (key->sk_strategy == BTEqualStrategyNumber &&
+			att->attcollation == InvalidOid &&
+			OidIsValid(tce->hash_proc_finfo.fn_oid))
+		{
+			readState->predicates[n].hasHash = true;
+			fmgr_info_copy(&readState->predicates[n].hashFn,
+						   &tce->hash_proc_finfo, readState->readContext);
+		}
 		n++;
 	}
 
@@ -392,6 +413,22 @@ columnar_group_can_match(ColumnarReadState *readState, int groupIndex)
 													 pred->compareValue, maxv));
 				if (c1 < 0 || c2 > 0)
 					return false;
+
+				/*
+				 * min/max did not rule the group out; consult the bloom filter
+				 * (I7). If the value is provably absent, skip the group -- this
+				 * is what prunes equality probes on unsorted columns.
+				 */
+				if (columnar_enable_bloom_filter && pred->hasHash &&
+					m->bloomFilter != NULL)
+				{
+					uint32		h = DatumGetUInt32(
+						FunctionCall1Coll(&pred->hashFn, InvalidOid,
+										  pred->compareValue));
+
+					if (!ColumnarBloomProbe(m->bloomFilter, m->bloomLen, h))
+						return false;
+				}
 				break;
 			case BTGreaterEqualStrategyNumber:	/* col >= const : skip if max<const */
 				c2 = DatumGetInt32(FunctionCall2Coll(&pred->cmpFn,

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -48,6 +48,7 @@ int			columnar_chunk_group_row_limit = 10000;
 int			columnar_compression = COLUMNAR_COMPRESSION_ZSTD;
 int			columnar_compression_level = 3;
 bool		columnar_enable_qual_pushdown = true;
+bool		columnar_enable_bloom_filter = true;
 
 /* value set for columnar.compression (spec 5, 8.3) */
 static const struct config_enum_entry columnar_compression_options[] = {
@@ -1108,6 +1109,15 @@ _PG_init(void)
 							 "Compute aggregates over runs of the encoded value stream.",
 							 NULL,
 							 &columnar_enable_compressed_execution,
+							 true,
+							 PGC_USERSET,
+							 0,
+							 NULL, NULL, NULL);
+
+	DefineCustomBoolVariable("columnar.enable_bloom_filter",
+							 "Skip chunk groups on equality using per-chunk bloom filters.",
+							 NULL,
+							 &columnar_enable_bloom_filter,
 							 true,
 							 PGC_USERSET,
 							 0,

--- a/src/columnar_write_state.c
+++ b/src/columnar_write_state.c
@@ -28,6 +28,14 @@ typedef struct ColumnarColumnDef
 	bool		orderable;		/* type has a default btree comparison proc */
 	FmgrInfo	cmpFn;			/* the comparison proc, when orderable */
 	Oid			collation;		/* collation to compare under */
+
+	/*
+	 * Bloom-filter support (I7): hashable and non-collatable, so a value's hash
+	 * is collation-independent and a probe of the same type is consistent. Only
+	 * such columns accumulate hashes for a per-chunk bloom filter.
+	 */
+	bool		bloomable;
+	FmgrInfo	hashFn;
 } ColumnarColumnDef;
 
 /* one column's two streams within one chunk group */
@@ -41,6 +49,9 @@ typedef struct ColumnChunkBuffer
 	bool		hasMinMax;
 	Datum		minValue;		/* held in the stripe context */
 	Datum		maxValue;
+
+	/* accumulated 4-byte value hashes for the per-chunk bloom filter (I7) */
+	StringInfoData hashBuf;
 } ColumnChunkBuffer;
 
 /* one chunk group: all columns for a horizontal slice of rows */
@@ -173,13 +184,29 @@ ColumnarGetWriteState(Relation rel)
 			if (att->attisdropped)
 				continue;
 
-			tce = lookup_type_cache(att->atttypid, TYPECACHE_CMP_PROC_FINFO);
+			tce = lookup_type_cache(att->atttypid,
+									TYPECACHE_CMP_PROC_FINFO |
+									TYPECACHE_HASH_PROC_FINFO);
 			if (OidIsValid(tce->cmp_proc_finfo.fn_oid))
 			{
 				writeState->colDefs[c].orderable = true;
 				fmgr_info_copy(&writeState->colDefs[c].cmpFn,
 							   &tce->cmp_proc_finfo, ColumnarWriteContext);
 				writeState->colDefs[c].collation = att->attcollation;
+			}
+
+			/*
+			 * Bloom filter only for hashable, non-collatable types (I7): their
+			 * hash is collation-independent, so a chunk built here answers an
+			 * equality probe of the same type without the collation caveats that
+			 * apply to text.
+			 */
+			if (att->attcollation == InvalidOid &&
+				OidIsValid(tce->hash_proc_finfo.fn_oid))
+			{
+				writeState->colDefs[c].bloomable = true;
+				fmgr_info_copy(&writeState->colDefs[c].hashFn,
+							   &tce->hash_proc_finfo, ColumnarWriteContext);
 			}
 		}
 	}
@@ -220,6 +247,7 @@ columnar_start_chunk_group(ColumnarWriteState *writeState)
 	{
 		initStringInfo(&group->columns[c].valueStream);
 		initStringInfo(&group->columns[c].existsStream);
+		initStringInfo(&group->columns[c].hashBuf);
 		group->columns[c].valueCount = 0;
 	}
 
@@ -281,6 +309,16 @@ ColumnarWriteRow(ColumnarWriteState *writeState, Relation rel,
 			appendStringInfoChar(&col->existsStream, 1);
 			ColumnarEncodeValue(&col->valueStream, att, values[c]);
 			col->valueCount++;
+
+			/* accumulate the value's hash for the per-chunk bloom filter (I7) */
+			if (writeState->colDefs[c].bloomable)
+			{
+				uint32		h = DatumGetUInt32(
+					FunctionCall1Coll(&writeState->colDefs[c].hashFn,
+									  InvalidOid, values[c]));
+
+				appendBinaryStringInfo(&col->hashBuf, (char *) &h, sizeof(uint32));
+			}
 
 			/* maintain the per-chunk min/max for orderable types */
 			if (writeState->colDefs[c].orderable)
@@ -553,6 +591,21 @@ columnar_flush_stripe(ColumnarWriteState *writeState)
 			else
 			{
 				m->minMaxValid = false;
+			}
+
+			/* build the per-chunk bloom filter from accumulated hashes (I7) */
+			if (col->hashBuf.len > 0)
+			{
+				char	   *bloom;
+				uint32		bloomLen;
+
+				if (ColumnarBloomBuild((const uint32 *) col->hashBuf.data,
+									   col->hashBuf.len / sizeof(uint32),
+									   &bloom, &bloomLen))
+				{
+					m->bloomFilter = bloom;
+					m->bloomLen = bloomLen;
+				}
 			}
 
 			g++;

--- a/test/differential.sh
+++ b/test/differential.sh
@@ -320,4 +320,46 @@ for mode in on off; do
 done
 q "ALTER DATABASE $PGC_DB RESET columnar.enable_compressed_execution;" >/dev/null
 
+# ---------------------------------------------------------------------------
+# Part 5: bloom-filter equality skipping (I7)
+#
+# Values are hash-spread so every chunk's min/max spans the domain and cannot
+# skip an in-range equality probe; the bloom filter is what prunes it. Correct-
+# ness is checked against the heap oracle; a bloom is confirmed built; and an
+# absent in-range value is shown to remove more chunk groups with the filter on
+# than off (min/max alone).
+# ---------------------------------------------------------------------------
+echo "-- part 5: bloom equality skipping"
+
+make_pair "id int, k bigint, u uuid"
+q "SELECT columnar.alter_columnar_table_set('t_col', chunk_group_row_limit => 1000, stripe_row_limit => 20000);" >/dev/null
+load_pair "SELECT g, ((g*2654435761)%100000)::bigint, md5((g%99999)::text)::uuid
+	FROM generate_series(1,20000) g"
+
+diff_query "bloom k present" "SELECT id FROM %T WHERE k = ((7*2654435761)%100000)::bigint"
+diff_query "bloom u eq"      "SELECT count(*) FROM %T WHERE u = md5('123')::uuid"
+diff_query "bloom k range"   "SELECT count(*) FROM %T WHERE k < 50000"
+
+bloom_built() {
+	q "SELECT bool_or(bloom_filter IS NOT NULL) FROM columnar.chunk
+	   WHERE storage_id = columnar.get_storage_id('t_col') AND attr_num = $1;"
+}
+check "bloom built for k" "$(bloom_built 2)" "t"
+check "bloom built for u" "$(bloom_built 3)" "t"
+
+# an absent value strictly inside the global min/max, so min/max alone cannot
+# skip it (every hash-spread chunk's range contains it) -- only bloom can.
+absent=$(q "SELECT v FROM generate_series((SELECT min(k)+1 FROM t_heap)::int,
+											(SELECT max(k)-1 FROM t_heap)::int) v
+			WHERE v NOT IN (SELECT k FROM t_heap) LIMIT 1;")
+removed() {
+	q "SET columnar.enable_bloom_filter=$1;
+	   EXPLAIN (ANALYZE, TIMING off, SUMMARY off) SELECT id FROM t_col WHERE k = ${absent}::bigint;" \
+		| grep -oiE 'Removed by Filter: [0-9]+' | grep -oE '[0-9]+$'
+}
+on=$(removed on)
+off=$(removed off)
+check "bloom absent correct"   "$(q "SELECT count(*) FROM t_col WHERE k = ${absent}::bigint;")" "0"
+check "bloom removes >= minmax" "$([ "${on:-0}" -gt "${off:-0}" ] && echo yes)" "yes"
+
 pgc_summary


### PR DESCRIPTION
Stacked on #7 (I6).

Adds an optional **per-chunk bloom filter** so an equality probe can skip a chunk group when the value is provably absent — mitigating the point-lookup weakness (min/max can't skip an in-range equality on an unsorted column).

- `columnar_bloom.c`: build/probe (power-of-two bit array, k probes by double hashing, ~1% FPR). Writer accumulates value hashes per chunk; reader probes in `columnar_group_can_match` after min/max.
- Restricted to **hashable, non-collatable** types (int/bigint/uuid/date/timestamp/bytea/…) so the hash is collation-independent and consistent build↔probe — covers the common id/uuid point-lookup case, avoids text collation caveats.
- Format 2.1: nullable `bloom_filter bytea` (Anum 17); 2.0 / non-eligible chunks are NULL. GUC `columnar.enable_bloom_filter` (default on).
- Never a false negative → results unchanged. Differential checks equality correctness (present/absent) and an EXPLAIN ANALYZE assertion shows bloom removes groups min/max cannot (on vs off).

Tests: differential (207), phase4, fuzz pass on pg13, pg17, pg19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)