### PR TITLE
Format 2.1 hardening: codec PBT, corruption, 2.0-compat, concurrency, harness fixes + gap specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,19 @@ and is self-contained:
     test/audit.sh  /path/to/pg_config   # regression tests for audited defects
     test/concurrency.sh /path/to/pg_config  # concurrent same-chunk-group deletes (issue #4)
     test/unique_conc.sh /path/to/pg_config  # concurrent same-unique-key inserts (issue #5)
+    test/differential.sh /path/to/pg_config # heap-vs-columnar oracle: types, boundaries, encodings, exec
+    test/recovery.sh /path/to/pg_config  # SIGKILL crash recovery and atomicity
+    test/fuzz.sh   /path/to/pg_config    # seeded randomized differential
+    test/hardening.sh /path/to/pg_config # format 2.0 compatibility and corrupted-input robustness
+    test/concurrent_diff.sh /path/to/pg_config # concurrent DML vs a heap oracle
+
+`test/differential.sh`, `recovery`, `fuzz`, `hardening`, and `concurrent_diff`
+share `test/lib.sh`, a heap-vs-columnar differential oracle: a query is run
+against a heap mirror and the columnar table and compared as an order-independent
+result-set hash, so heap is the correctness oracle. `test/pbt/run.sh` is a
+separate, PostgreSQL-independent C property test of the value-stream codecs
+(round-trip over randomized and boundary inputs); run it with `test/pbt/run.sh
+[seed] [iterations]`.
 
 To build and run every suite across a set of PostgreSQL majors in one pass, each
 in its own fresh build directory, pass their `pg_config` paths to the matrix
@@ -307,4 +320,6 @@ helper. With no arguments it uses a default list of PostgreSQL 13 through 19:
 
     test/run_all_versions.sh /usr/local/pg13/bin/pg_config ... /usr/local/pg19/bin/pg_config
 
-All suites pass on PostgreSQL 13 through 19.
+All suites pass on PostgreSQL 13 through 19 (PostgreSQL 19 validated against
+19beta2; revalidation against the final PostgreSQL 19 release is pending that
+release).

--- a/design/FORMAT_AND_INTERFACE_SPEC.md
+++ b/design/FORMAT_AND_INTERFACE_SPEC.md
@@ -371,3 +371,12 @@ An independent implementation that follows sections 2 through 8 can create,
 read, and write format 2.0 storage and can operate on tables created by the
 existing extension. The metapage version fields let an implementation detect and
 refuse or upgrade older formats.
+
+Version 2.1 is on-disk compatible with 2.0 at the value-stream level: 2.0 value
+streams are encoding none and read unchanged. The catalog gained three chunk
+columns (7.2); a 2.1 reader treats them as NULL for any 2.0 chunk row, meaning
+encoding none, raw length equal to the decompressed length, and no bloom filter.
+A catalog created by a 2.0 implementation lacks those columns physically, so an
+in-place upgrade of an existing 2.0 database first adds them (nullable, default
+NULL) before a 2.1 binary reads it; a fresh 2.1 install creates the columns
+directly. The behavior of the NULL-default path is covered by test/hardening.sh.

--- a/design/gaps/21-native-compressed-execution.md
+++ b/design/gaps/21-native-compressed-execution.md
@@ -1,0 +1,68 @@
+# Gap 21: native compressed execution on packed bytes
+
+Status: planned. Tier: performance. Format change: none.
+
+## Motivation
+
+I3 gave "compressed execution" in the sense that the vectorized aggregate folds
+each column one run at a time (`ColumnarBlockReader` coalesces adjacent equal
+values over the decoded raw stream). That captures the RLE win but still fully
+decodes FOR/DELTA/DoD/dict chunks to the raw value stream first. The literature's
+headline result (Abadi, SIGMOD 2006: 3-10x) comes from operating on the *packed*
+representation without materializing every value -- e.g. `SUM` over a
+frame-of-reference block as `base*n + sum(offsets)`, and predicate evaluation on
+dictionary codes rather than decoded values.
+
+## Current state
+
+- `columnar_encoding.c`: `ColumnarDecodeChunk` always reconstructs the full raw
+  stream; `ColumnarBlockReader` iterates that stream.
+- `columnar_vector.c`: `columnar_apply_run` sums `value * runLength`; it never
+  sees the packed form.
+
+## Design
+
+Add an operator-facing block API alongside the run iterator, one implementation
+per encoding, exposing what an operator needs without full decode:
+
+- `ColumnarBlockSum(block) -> int128/numeric` for FOR/DELTA/DoD/RLE:
+  - FOR: `min * n + sum(unpacked offsets)`; offsets summed from the bit-packed
+    body (still unpacks offsets, but no per-value Datum, and no `base` re-add per
+    value).
+  - RLE: `sum(value_i * run_i)` (already the run path).
+  - DELTA/DoD: reconstruct running value with integer adds only (no Datum).
+- `ColumnarBlockMinMax(block)` from FOR header (`min`) and a single pass for max,
+  or dict dictionary min/max.
+- Dictionary predicate pushdown: evaluate `col = const` by finding the const's
+  code once, then testing codes (int compares) instead of decoded values; for
+  range predicates, precompute the set of matching codes.
+- A block "all one value" fast path (FOR width 0, RLE single run, dict single
+  code) that answers count/sum/min/max in O(1).
+
+Keep the existing decode path as the correctness fallback and for any
+encoding/operator pair without a native kernel. Selection: the aggregate asks the
+block for a native kernel; if absent, it falls back to the run/per-row path.
+
+## On-disk / API impact
+
+None on disk. New internal functions in `columnar_encoding.c` and dispatch in
+`columnar_vector.c`. No new GUC required (reuse
+`columnar.enable_compressed_execution`).
+
+## Testing
+
+Extend the differential suite so every aggregate over every encoding is compared
+to the heap oracle with compressed execution on and off (already partly there);
+add integer-overflow boundary data (sum near int64 limits routes to numeric, must
+match heap). The codec PBT (test/pbt) gains a "sum over decoded == native block
+sum" property per encoding.
+
+## Effort / risk
+
+Medium. Risk is arithmetic correctness (overflow, signedness, numeric promotion)
+matching PostgreSQL exactly; the differential oracle plus PBT contain it.
+
+## Source
+
+Abadi, Madden, Ferreira, "Integrating Compression and Execution in
+Column-Oriented Database Systems," SIGMOD 2006; Abadi PhD thesis (MIT 2008).

--- a/design/gaps/22-position-list-late-materialization.md
+++ b/design/gaps/22-position-list-late-materialization.md
@@ -1,0 +1,65 @@
+# Gap 22: intra-group late materialization (position lists)
+
+Status: planned. Tier: performance. Format change: none.
+
+## Motivation
+
+I8 added late materialization at group granularity: the scan decodes the
+predicate columns, builds the selection vector, and decodes the output columns
+only when *some* row in the group survives. It does not yet avoid decoding output
+values for the *non-surviving rows within* a surviving group. For a filter that
+keeps, say, 2% of a group's rows, we still decode 100% of the output columns for
+that group. Carrying a position list of survivors and gathering only those output
+values is the standard late-materialization win (Abadi, ICDE 2007: ~3x average).
+
+## Current state
+
+- `columnar_reader.c`: `columnar_decode_group_columns` decodes a column by
+  walking the value stream sequentially (`ColumnarDecodeValue` per present row).
+  `ColumnarDecodeGroupColumns` decodes a whole column for the group.
+- `columnar_customscan.c`: `ColumnarScanNextVector` computes `vecSel[]` then
+  emits surviving rows, reading `vec.values[c][i]` for all output columns (which
+  were fully decoded).
+
+## Design
+
+Add a position-gather decode for output columns:
+
+- `ColumnarDecodeColumnAtPositions(readState, c, positions[], npos, vec)`:
+  decode only the values at the given row positions of the group. For a
+  fixed-width, no-null, uncompressed-none chunk this is a direct indexed read
+  (`base + pos*width`); for compressed/encoded chunks and nullable columns, walk
+  the stream but materialize a Datum only at requested positions (still O(rows)
+  to walk, but O(npos) Datums and O(npos) detoast/copy for varlena, which is the
+  real cost for wide output columns).
+- The scan: after `ColumnarVecSelect`, build the position list from `vecSel`; if
+  selectivity is below a threshold (e.g. < 50%), decode output columns by
+  position; otherwise decode the whole column (the current path) since gather has
+  overhead when most rows survive.
+- Encodings that support random access without a full walk (FOR, dict, none over
+  fixed width) can gather in O(npos); RLE/delta/DoD/gorilla need a walk to reach
+  a position (sequential dependence), so for those, gather still walks but skips
+  Datum construction for non-selected positions.
+
+## On-disk / API impact
+
+None on disk. New reader entry point; scan chooses gather vs full decode by
+selectivity. Gate with `columnar.enable_late_materialization` (reuse) or a sub-
+threshold GUC `columnar.late_materialization_selectivity`.
+
+## Testing
+
+Differential: selective filters (point, narrow range, no-match) over wide tables
+with by-value and varlena output columns, on and off, versus the heap oracle
+(I8's cases extended). Correctness is the property; the win is fewer decodes.
+
+## Effort / risk
+
+Medium. Risk: the random-access gather for each encoding must return exactly what
+the sequential decode would (esp. nulls via the exists stream, and varlena
+sizing). Contained by the oracle.
+
+## Source
+
+Abadi, Myers, DeWitt, Madden, "Materialization Strategies in a Column-Oriented
+DBMS," ICDE 2007.

--- a/design/gaps/23-parallel-scan.md
+++ b/design/gaps/23-parallel-scan.md
@@ -1,0 +1,74 @@
+# Gap 23: parallel scan
+
+Status: planned. Tier: performance (largest user-visible win). Format change: none.
+
+## Motivation
+
+The custom scan currently removes the parallel paths for plan stability, so a
+large columnar scan or aggregate runs on a single core. Analytic workloads are
+exactly where parallelism pays off, and the columnar layout (independent stripes
+and chunk groups) parallelizes cleanly. This is likely the biggest remaining
+real-world speedup.
+
+## Current state
+
+- `columnar_customscan.c`: `set_rel_pathlist_hook` replaces the seqscan path with
+  a non-parallel custom scan and drops parallel paths.
+- `columnar_reader.c`: `ColumnarBeginRead` already accepts a
+  `ParallelTableScanDesc` parameter (currently always NULL) -- the plumbing point
+  exists but is unused.
+
+## Design
+
+Make the custom scan parallel-aware:
+
+1. Planner: expose a partial custom path (`CUSTOMPATH_SUPPORT_*`,
+   `parallel_workers`), so the planner can put a Gather above a parallel columnar
+   scan for large relations.
+2. Executor: implement the CustomScan parallel callbacks --
+   `EstimateDSMCustomScan`, `InitializeDSMCustomScan`, `InitializeWorkerCustomScan`
+   (and `ReInitializeDSM`). Put a shared atomic "next chunk-group index" (or
+   next-stripe) counter in the DSM segment.
+3. Work distribution: each worker atomically claims the next chunk group (or
+   stripe) across the whole relation and scans it with its own read state.
+   Chunk-group granularity balances better than stripe granularity for skewed
+   stripe sizes; stripe granularity is simpler and has less contention -- start
+   with stripe-level claiming, measure, refine to chunk-group if needed.
+4. The vectorized aggregate: a partial-aggregate parallel plan (workers produce
+   partial aggregates, Gather + Finalize combines). Simplest first step: only
+   parallelize the base scan (Gather above it, aggregation stays above Gather),
+   then add partial aggregation as a follow-up.
+
+Row-mask, min/max skipping, bloom, projection, and encoding all already work per
+read state, so a worker's read state behaves like the serial one over its subset.
+
+## On-disk / API impact
+
+None on disk. New parallel CustomScan callbacks and a DSM layout (a shared
+counter plus the immutable scan parameters). No new format fields.
+
+## Testing
+
+- Differential: run every scan/aggregate query with
+  `max_parallel_workers_per_gather` = 0 and > 0 and assert identical results
+  against the heap oracle (extend lib.sh to toggle it).
+- A dedicated test forcing a parallel plan (small `parallel_setup_cost`,
+  `parallel_tuple_cost`, `min_parallel_table_scan_size`) and asserting via
+  EXPLAIN that a Gather over the parallel columnar scan is chosen and returns
+  correct rows.
+- The full matrix (parallel worker APIs differ across majors -- watch the
+  CustomScan parallel callback signatures in columnar_compat.h).
+
+## Effort / risk
+
+Large. Risk: cross-version CustomScan parallel API differences; correct DSM
+lifecycle; ensuring read-your-writes (pending writes are per-backend, so a
+parallel scan must flush and see only committed/flushed data consistently, as the
+serial scan does via ColumnarFlushWriteStateForRelation before scan start --
+workers must not each re-flush). Design note: flush in the leader before workers
+launch.
+
+## Source
+
+MonetDB/X100 (vectorized, cache-efficient execution) motivates CPU parallelism;
+PostgreSQL parallel-query and custom-scan parallel APIs.

--- a/design/gaps/24-explicit-simd-kernels.md
+++ b/design/gaps/24-explicit-simd-kernels.md
@@ -1,0 +1,64 @@
+# Gap 24: explicit SIMD kernels
+
+Status: planned. Tier: performance. Format change: none.
+
+## Motivation
+
+I6's typed predicate loops (`VEC_CMP` in `columnar_vector.c`) and the aggregate
+fold loops are written to be auto-vectorizable, but they rely on the compiler.
+Explicit SIMD (AVX2 on x86-64, NEON on arm64) for the hottest kernels --
+comparison-into-selection-vector and sum/min/max over a decoded array -- gives a
+further, more predictable per-tuple win, and is a natural pairing with the
+run-at-a-time paths.
+
+## Current state
+
+- `columnar_vector.c`: `vecsel_i16/i32/i64/f32/f64` compare a Datum array against
+  a constant into `sel[]` with a scalar loop the compiler may or may not
+  vectorize; the aggregates fold scalar loops.
+
+## Design
+
+- Add SIMD kernels behind a narrow, well-tested interface, one per (type, op):
+  `simd_cmp_i32_lt(const int32 *in, int32 c, uint8 *sel, n)` etc., plus
+  `simd_sum_i32`, `simd_min/max`. Selection vector as a byte-per-row `uint8`
+  (SIMD-friendly) rather than `bool`.
+- Runtime dispatch: detect CPU features once (`__builtin_cpu_supports("avx2")` on
+  gcc/clang x86; compile NEON unconditionally on aarch64) and pick the kernel;
+  always keep a scalar kernel as the fallback and the reference.
+- Values feeding the kernels must be contiguous typed arrays. The decoded vector
+  already stores `Datum[]`; for by-value fixed-width types a `Datum` array is
+  effectively an array of the widened type -- add a compaction step (or decode
+  directly into a typed array) so the kernel sees `int32*`/`float8*` without
+  Datum overhead. This is the main plumbing cost.
+- Build system: compile the SIMD translation unit with target attributes
+  (`__attribute__((target("avx2")))` per function, so the base build stays
+  portable and PGXS flags are unchanged).
+
+## On-disk / API impact
+
+None. New `columnar_simd.c` (or kernels within columnar_vector.c) with a scalar
+fallback. No format or GUC change required (optional `columnar.enable_simd` for
+A/B testing and safety).
+
+## Testing
+
+- The scalar kernel is the oracle for the SIMD kernel: a C unit/property test
+  (extend test/pbt) asserts `simd_kernel(x) == scalar_kernel(x)` over randomized
+  arrays and lengths, including non-multiple-of-vector-width tails and NaN/Inf
+  for floats.
+- Differential: all filtered/aggregate queries with `columnar.enable_simd` on and
+  off versus the heap oracle.
+- Matrix across majors and, ideally, both x86-64 and arm64 (SIMD divergence is a
+  known bug class -- see the hegel catalogue).
+
+## Effort / risk
+
+Medium. Risk: SIMD/scalar divergence (especially float NaN/sign, tail handling)
+and per-arch behavior; the scalar-oracle PBT is the guard. Portability: keep all
+SIMD optional and gated behind runtime detection.
+
+## Source
+
+MonetDB/X100 (super-scalar, SIMD-friendly primitives); standard SIMD kernel
+practice.

--- a/design/gaps/25-text-bloom-filters.md
+++ b/design/gaps/25-text-bloom-filters.md
@@ -1,0 +1,66 @@
+# Gap 25: bloom filters for collatable/text columns
+
+Status: planned. Tier: performance. Format change: none (reuses the 2.1 bloom column).
+
+## Motivation
+
+I7 built per-chunk bloom filters only for hashable, *non-collatable* types
+(int/bigint/uuid/date/timestamp/bytea) to stay collation-safe. Text and varchar
+keys -- a common filter target -- get no bloom skipping. Extending bloom to text
+under deterministic collations covers that case without risking the
+collation-mismatch bug the audit already fixed for min/max skipping.
+
+## Current state
+
+- `columnar_write_state.c`: builds a bloom only when
+  `att->attcollation == InvalidOid` (non-collatable), hashing with `InvalidOid`.
+- `columnar_reader.c`: `columnar_build_predicates` enables the bloom probe for an
+  equality predicate only when `att->attcollation == InvalidOid`.
+- `columnar_bloom.c`: build/probe are hash-agnostic; they take a precomputed
+  32-bit hash.
+
+## Design
+
+Enable bloom for collatable types when the collation is *deterministic*, hashing
+with that collation on both build and probe, and only probing when the query's
+equality collation matches the column's:
+
+1. Build: for a collatable column whose collation is deterministic
+   (`get_collation_isdeterministic(att->attcollation)`, true for C/POSIX and most
+   ICU collations), resolve the type's hash-with-collation proc
+   (`TYPECACHE_HASH_PROC_FINFO`) and hash each value with `att->attcollation`.
+   Nondeterministic collations are skipped (equal-but-not-byte-identical values
+   would hash inconsistently) -- keep them unbloomed.
+2. Probe: enable only when (a) the column collation is deterministic and (b) the
+   scan key's collation equals the column collation. The scan key carries an
+   input collation; compare it to `att->attcollation`. On mismatch, do not probe
+   (exactly the guard the audit applied to min/max skipping). This makes a wrong
+   skip impossible.
+3. Reuse the existing `bloom_filter` catalog column and `columnar_bloom.c`
+   verbatim; only the eligibility checks and the hash collation change.
+
+## On-disk / API impact
+
+None -- the 2.1 `bloom_filter` column already exists; this widens which columns
+populate it. Older tables simply have no bloom for text (NULL), still correct.
+
+## Testing
+
+- Differential: low-cardinality and high-cardinality text/varchar columns under
+  the default and `C` collations; equality for present and absent values on and
+  off (`columnar.enable_bloom_filter`), versus the heap oracle; plus the
+  audit-style case: `col = const COLLATE "different"` must not wrongly skip
+  (results still correct because the probe is disabled on collation mismatch).
+- An EXPLAIN-ANALYZE assertion (as in the I7 test) that bloom removes groups
+  min/max cannot for a deterministic-collation text column.
+
+## Effort / risk
+
+Small-medium. Risk is collation correctness; the deterministic-only +
+matching-collation-only guards, plus the audit-style differential case, contain
+it (a bloom false negative would show as missing rows against the oracle).
+
+## Source
+
+Standard bloom-filter data skipping; the collation handling mirrors the existing
+min/max collation guard (see test/audit.sh and PROVENANCE).

--- a/design/gaps/26-projections-pax.md
+++ b/design/gaps/26-projections-pax.md
@@ -1,0 +1,68 @@
+# Gap 26: projections / PAX layout
+
+Status: exploratory. Tier: capability. Format change: major (2.2). Effort: very large.
+
+## Motivation
+
+C-Store's central idea is *projections*: keep the same columns in multiple
+physical copies, each sorted on a different attribute. A query uses the copy
+whose sort order best serves it, which makes range scans, point lookups, and
+min/max skipping dramatically more effective (a sorted column has tight,
+non-overlapping per-chunk ranges, so skipping prunes almost everything). PAX /
+hybrid layouts are a smaller-scope relative that improves cache behavior. This is
+the single largest structural lever left, and correspondingly the largest effort.
+
+## Current state
+
+One physical layout per table, in insert order. min/max skipping only helps
+columns correlated with insert order; bloom (I7) helps equality on any column but
+not ranges. There is no notion of an alternate sort order.
+
+## Design (sketch -- this is a project, not a task)
+
+Two independently shippable pieces:
+
+1. Sorted single-projection (smaller): allow a table (or a `columnar.vacuum`
+   variant) to be stored sorted on a chosen key. Implementation: a sorting
+   rewrite in the vacuum path (already a full-relation rewrite) that orders rows
+   by the key before re-striping. No planner change needed; min/max skipping and
+   the encodings (RLE/delta on the now-sorted key) immediately improve. This
+   delivers most of the range/skip benefit with far less machinery than full
+   projections. Recommended first step.
+2. Multiple projections (full C-Store): a table has N projections, each a
+   column subset in its own sort order, materialized as separate physical
+   storages sharing the row identity space. Requires: catalog for projections
+   (columns, sort key, storage id per projection), write fan-out (every insert
+   writes all projections), a planner that picks the projection per query and
+   reconstructs full rows via row-number join when a projection is a subset, and
+   vacuum/index coordination. This is a major subsystem.
+
+PAX/hybrid layout is an alternative to (2) focused on cache locality within a
+page rather than multiple sort orders; lower value here since data already lives
+in per-column chunk streams.
+
+## On-disk / API impact
+
+Format 2.2: a projections catalog and per-projection storage ids; the metapage
+or a new catalog records the projection set. Additive for reads of 2.0/2.1
+(single implicit projection). New SQL surface to declare projections.
+
+## Testing
+
+Differential oracle for every query shape against a heap, for tables with 1..N
+projections, verifying identical results regardless of which projection the
+planner picks; plus write-fan-out correctness (all projections agree),
+vacuum/rebuild, and crash recovery per projection.
+
+## Effort / risk
+
+Very large (multiple subsystems: catalog, writer fan-out, planner selection, row
+reconstruction, vacuum). Risk: planner integration and keeping N copies
+consistent under concurrency and recovery. Recommendation: ship piece (1) sorted
+single-projection first as a contained, high-value increment; treat piece (2) as
+a separate multi-PR project.
+
+## Source
+
+Stonebraker et al., "C-Store," VLDB 2005 (projections); Ailamaki et al., "Weaving
+Relations for Cache Performance" (PAX), VLDB 2001.

--- a/design/gaps/27-arrow-parquet-interop.md
+++ b/design/gaps/27-arrow-parquet-interop.md
@@ -1,0 +1,66 @@
+# Gap 27: Arrow / Parquet interop
+
+Status: exploratory. Tier: capability. Format change: additive. Effort: very large.
+
+## Motivation
+
+Columnar data in pgColumnar is naturally close to Apache Arrow (in-memory) and
+Parquet (on-disk) shapes. Exporting to those formats gives zero-friction
+interchange with the analytics ecosystem (DuckDB, pandas/pyarrow, Spark) and lets
+users move large results out of Postgres cheaply. Import is a secondary,
+lower-priority direction.
+
+## Current state
+
+None. Data is only accessible via SQL through the table access method.
+
+## Design (sketch -- a project)
+
+Prefer export first, and prefer a pure-Postgres path that does not hard-depend on
+libarrow/libparquet at build time:
+
+1. Parquet export via a function: `columnar.export_parquet(rel regclass, path
+   text)` (or `COPY ... TO ... (FORMAT parquet)` if a COPY handler is feasible on
+   the target majors). Write Parquet directly: the format is well-specified
+   (Thrift metadata + column chunks with encodings we already produce -- RLE,
+   dictionary, delta, bit-packing map almost one-to-one onto Parquet encodings).
+   A self-contained Parquet writer avoids a libparquet build dependency but is
+   substantial; alternatively link libparquet/libarrow when present (pkg-config,
+   like lz4/zstd) and compile the feature out otherwise.
+2. Arrow export: produce Arrow IPC (Feather) record batches, or expose data
+   through the Arrow C Data Interface (a stable ABI of struct definitions, no
+   libarrow link needed) so external consumers can pull batches. The C Data
+   Interface is the lightest-dependency option and pairs well with the existing
+   decoded-vector batches (`ColumnarReadNextVector`).
+3. Type mapping: define and document the pgColumnar-type to Arrow/Parquet-type
+   mapping (numeric, timestamp units, text, bytea, arrays, jsonb-as-string), with
+   explicit handling of types that have no clean Arrow equivalent.
+
+Recommendation: start with Arrow C Data Interface export from the vector reader
+(smallest dependency, immediate DuckDB/pyarrow consumption), then Parquet file
+export.
+
+## On-disk / API impact
+
+No change to pgColumnar's own on-disk format. New SQL functions and an optional
+build dependency (libarrow/libparquet) detected via pkg-config, compiled out when
+absent, mirroring the codec dependency handling.
+
+## Testing
+
+Round-trip against a reference: export a table, read it back with DuckDB /
+pyarrow (available in some environments; gate like BENCH_DUCKDB), and assert the
+values equal a heap oracle. Type-matrix coverage for the type mapping. No change
+to existing query results, so the differential suites are unaffected.
+
+## Effort / risk
+
+Very large (a format writer or an external library integration, plus a type
+mapping). Risk: type-mapping fidelity and dependency/build portability across
+majors and platforms. Recommendation: scope to Arrow C Data Interface export
+first as a contained deliverable.
+
+## Source
+
+Apache Arrow (columnar in-memory format, C Data Interface) and Apache Parquet
+specifications.

--- a/design/gaps/28-index-only-visibility-map.md
+++ b/design/gaps/28-index-only-visibility-map.md
@@ -1,0 +1,67 @@
+# Gap 28: index-only scans via a visibility map
+
+Status: exploratory. Tier: capability. Format change: additive. Effort: large.
+
+## Motivation
+
+Index-only scans are never chosen for a columnar table because there is no
+visibility map, so a covering query (e.g. `SELECT indexed_col ... WHERE
+indexed_col ...`, or `count(*)` served by an index) still fetches from the
+columnar storage, and each fetch decodes a whole chunk group -- the documented
+point-lookup weakness. A visibility mechanism would let the planner choose
+index-only scans and skip the storage fetch entirely for all-visible ranges.
+
+## Current state
+
+- `columnar_tableam.c`: the table AM reports no visibility map;
+  `amgetbitmap`/index-only paths are effectively disabled, and
+  `ColumnarReadRowByNumber` decodes a chunk group per fetch.
+- Deletes/updates are tracked in `columnar.row_mask`, not a per-page VM.
+
+## Design (sketch -- a subsystem)
+
+The columnar main fork is not organized as heap pages with a parallel VM fork, so
+a literal heap-style visibility map does not apply. Two viable directions:
+
+1. All-visible chunk groups: maintain, per chunk group, an "all-visible" flag
+   (no in-progress or recently-deleted rows relative to a horizon) derived from
+   the row mask and the group's transaction metadata. Teach the table AM's
+   index-only path to answer from the index tuple when the group is all-visible,
+   consulting the row mask only for not-all-visible groups. This reuses existing
+   row-mask machinery and adds a small per-group summary rather than a new fork.
+2. `count(*)` / covering fast path: even without full index-only-scan support,
+   the custom scan can already answer `count(*)` from chunk-group row counts minus
+   row-mask deletes (partly done in the vectorized aggregate). Extend the planner
+   so a covering aggregate/scan avoids value decode using only catalog counts and
+   the row mask. This captures much of the practical benefit with far less
+   machinery.
+
+Direction (2) is the pragmatic first step (large-analytic `count`/covering
+queries) ; direction (1) is the fuller index-only-scan capability.
+
+## On-disk / API impact
+
+Additive: an optional per-chunk-group all-visible summary (a catalog column on
+`columnar.chunk_group` or a derived cache), and table-AM callback wiring for the
+index-only path. 2.0/2.1 tables without the summary fall back to consulting the
+row mask (correct, just not skipping the fetch).
+
+## Testing
+
+Differential/oracle: covering and `count(*)` queries with and without the fast
+path, across visibility scenarios (fresh insert, concurrent readers, after
+delete/update, after vacuum), versus heap -- results must be identical and, under
+MVCC, respect each snapshot exactly (a not-all-visible group must not be answered
+from the index). Concurrency and recovery coverage for the all-visible summary.
+
+## Effort / risk
+
+Large. Risk: MVCC correctness -- an index-only answer must never return a row not
+visible to the snapshot, so the all-visible determination must be conservative
+and snapshot-aware. Recommendation: ship direction (2) covering-count first;
+treat direction (1) as a separate project with heavy MVCC differential testing.
+
+## Source
+
+PostgreSQL visibility map and index-only scan design; adapted to the columnar
+row-mask model.

--- a/design/gaps/README.md
+++ b/design/gaps/README.md
@@ -1,0 +1,27 @@
+# pgColumnar gap specifications
+
+Design specs for the forward-looking gaps identified after the format 2.1
+encoding/execution work (I1-I8). Each is a self-contained plan to be picked up as
+its own tested branch/PR. They are derived from the public column-store
+literature (see ../IMPROVEMENT_PLAN.md) and the current implementation; they
+preserve the clean-room discipline in ../../PROVENANCE.md.
+
+Every gap here changes only *how* results are produced (or adds an optional
+capability); none may change query results. Each lands with differential/fuzz
+coverage proving equality against the heap oracle, and passes the full version
+matrix on PostgreSQL 13-19.
+
+| Spec | Gap | Tier | Format change | Rough effort |
+| --- | --- | --- | --- | --- |
+| [21](21-native-compressed-execution.md) | Native compressed execution on packed bytes | perf | none | medium |
+| [22](22-position-list-late-materialization.md) | Intra-group late materialization (position lists) | perf | none | medium |
+| [23](23-parallel-scan.md) | Parallel scan | perf | none | large |
+| [24](24-explicit-simd-kernels.md) | Explicit SIMD kernels | perf | none | medium |
+| [25](25-text-bloom-filters.md) | Bloom filters for collatable/text columns | perf | none | small |
+| [26](26-projections-pax.md) | Projections / PAX layout | capability | major (2.2) | very large |
+| [27](27-arrow-parquet-interop.md) | Arrow/Parquet interop | capability | additive | very large |
+| [28](28-index-only-visibility-map.md) | Index-only scans via a visibility map | capability | additive | large |
+
+Suggested order: 25, 21, 22, 24 (small/medium, self-contained), then 23
+(parallel scan, the biggest user-visible win), then the capability bets 28, 27,
+26 as their own projects.

--- a/test/concurrent_diff.sh
+++ b/test/concurrent_diff.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# pgColumnar concurrent-DML differential suite.
+#
+# Several backends concurrently run the same INSERT/DELETE/UPDATE workload,
+# partitioned into disjoint id ranges, against both a heap table and a columnar
+# table. Because the ranges are disjoint the final logical state is deterministic
+# regardless of interleaving, so the columnar table must end byte-for-byte equal
+# to the heap oracle. This exercises concurrent writers to one columnar relation
+# (stripe/row-number reservation, the row mask, and index maintenance) with the
+# format 2.1 encoding and bloom-filter write paths active.
+#
+# Usage:  test/concurrent_diff.sh [PG_CONFIG]
+#
+# Written fresh for pgColumnar; it does not reuse any upstream test file.
+
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+make_pair "id int, cat int, v bigint, txt text"
+q "SELECT columnar.alter_columnar_table_set('t_col', chunk_group_row_limit => 500, stripe_row_limit => 2000);" >/dev/null
+
+WORKERS=6
+PER=3000
+
+echo "-- launching $WORKERS concurrent workers"
+pids=()
+for w in $(seq 0 $((WORKERS - 1))); do
+	lo=$((w * PER + 1))
+	hi=$(((w + 1) * PER))
+	sql="
+		INSERT INTO t_heap SELECT g, g%5, g*3, md5(g::text) FROM generate_series($lo,$hi) g;
+		INSERT INTO t_col  SELECT g, g%5, g*3, md5(g::text) FROM generate_series($lo,$hi) g;
+		DELETE FROM t_heap WHERE id BETWEEN $lo AND $hi AND id % 7 = 0;
+		DELETE FROM t_col  WHERE id BETWEEN $lo AND $hi AND id % 7 = 0;
+		UPDATE t_heap SET v = v + 1 WHERE id BETWEEN $lo AND $hi AND id % 5 = 0;
+		UPDATE t_col  SET v = v + 1 WHERE id BETWEEN $lo AND $hi AND id % 5 = 0;"
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -v ON_ERROR_STOP=1 -q -c "$sql" \
+		>/dev/null 2>>"$PGC_WORKDIR/worker.$w.err" &
+	pids+=($!)
+done
+
+fail_workers=0
+for pid in "${pids[@]}"; do
+	wait "$pid" || fail_workers=1
+done
+check "all workers succeeded" "$fail_workers" "0"
+
+# The columnar table must match the heap oracle exactly after concurrent DML.
+diff_query "concurrent whole-row" "SELECT * FROM %T"
+diff_query "concurrent count/sum" "SELECT count(*), sum(v), count(distinct cat) FROM %T"
+diff_query "concurrent bloom eq"  "SELECT count(*) FROM %T WHERE v = 900"
+diff_query "concurrent range"     "SELECT count(*) FROM %T WHERE id BETWEEN 4000 AND 12000"
+check "row count sane" "$([ "$(q 'SELECT count(*) FROM t_col;')" -gt 0 ] && echo ok)" "ok"
+
+pgc_summary

--- a/test/hardening.sh
+++ b/test/hardening.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# pgColumnar format 2.1 hardening suite: on-disk backward compatibility and
+# corrupted-input robustness for the encoding and bloom-filter metadata.
+#
+#   1. Format 2.0 compatibility. A 2.0 chunk row carries no value_encoding_type,
+#      value_raw_length, or bloom_filter. The reader must treat a NULL encoding
+#      type as "none" with raw length equal to the decompressed length, and a
+#      NULL bloom as absent. We simulate 2.0 rows by NULLing those columns for
+#      the chunks that were actually stored with encoding none, then check reads
+#      still match the heap oracle.
+#   2. Corrupted input. An invalid encoding type must raise a clean error, not
+#      crash the backend (a following query still works). A malformed bloom
+#      filter must be ignored (conservatively "may match"), so results stay
+#      correct.
+#
+# Usage:  test/hardening.sh [PG_CONFIG]
+#
+# Written fresh for pgColumnar; it does not reuse any upstream test file.
+
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+# ---------------------------------------------------------------------------
+# Part 1: format 2.0 compatibility (NULL-default reader path)
+# ---------------------------------------------------------------------------
+echo "-- part 1: format 2.0 compatibility"
+
+make_pair "id int, lowc int, rnd bigint, txt text"
+q "SELECT columnar.alter_columnar_table_set('t_col', chunk_group_row_limit => 1000, stripe_row_limit => 20000);" >/dev/null
+load_pair "SELECT g, g%4, ((g*2654435761)%1000000000)::bigint, md5(g::text)
+	FROM generate_series(1,8000) g"
+
+# Simulate 2.0 chunk rows: drop the 2.1 columns for chunks stored with no
+# encoding (so NULL genuinely means encoding none, matching a 2.0 writer).
+psql_run "UPDATE columnar.chunk
+		  SET value_encoding_type = NULL, value_raw_length = NULL, bloom_filter = NULL
+		  WHERE storage_id = columnar.get_storage_id('t_col')
+			AND value_encoding_type = 0;"
+
+check "compat some chunks look like 2.0" \
+	"$([ "$(q "SELECT count(*) FROM columnar.chunk WHERE storage_id=columnar.get_storage_id('t_col') AND value_encoding_type IS NULL;")" -gt 0 ] && echo yes)" \
+	"yes"
+diff_query "compat whole-row" "SELECT * FROM %T"
+diff_query "compat aggregate" "SELECT count(*), sum(rnd), min(txt), max(txt) FROM %T"
+diff_query "compat filter"    "SELECT id FROM %T WHERE lowc = 2"
+
+# ---------------------------------------------------------------------------
+# Part 2: corrupted input robustness
+# ---------------------------------------------------------------------------
+echo "-- part 2: corrupted input"
+
+# An invalid encoding type must error cleanly, not crash the backend.
+make_pair "id int, v bigint"
+load_pair "SELECT g, g*2 FROM generate_series(1,3000) g"
+psql_run "UPDATE columnar.chunk SET value_encoding_type = 99
+		  WHERE storage_id = columnar.get_storage_id('t_col')
+			AND attr_num = 2 AND chunk_group_num = 0;"
+badresult="$(q "SELECT * FROM t_col;")"
+check "invalid encoding raises error" "$([ -z "$badresult" ] && echo errored)" "errored"
+check "backend alive after invalid encoding" "$(q "SELECT 1;")" "1"
+
+# A malformed bloom filter must be ignored, keeping results correct.
+make_pair "id int, k bigint"
+q "SELECT columnar.alter_columnar_table_set('t_col', chunk_group_row_limit => 1000, stripe_row_limit => 20000);" >/dev/null
+load_pair "SELECT g, ((g*2654435761)%100000)::bigint FROM generate_series(1,8000) g"
+psql_run "UPDATE columnar.chunk SET bloom_filter = '\\\\x00'::bytea
+		  WHERE storage_id = columnar.get_storage_id('t_col') AND attr_num = 2;"
+diff_query "corrupt bloom present" "SELECT id FROM %T WHERE k = ((7*2654435761)%100000)::bigint"
+diff_query "corrupt bloom absent"  "SELECT count(*) FROM %T WHERE k = 424242424"
+check "backend alive after corrupt bloom" "$(q "SELECT 1;")" "1"
+
+pgc_summary

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -97,7 +97,28 @@ pgc_setup() {
 			sleep 2
 		done
 	}
-	psql_admin "CREATE DATABASE $PGC_DB;" >/dev/null
+	# Wait until the postmaster actually accepts connections, then create the
+	# test database and verify it exists. Under heavy parallel churn pg_ctl -w
+	# can return just before the server is connectable, which would otherwise
+	# leave CREATE DATABASE a silent no-op and every later query failing with
+	# "database does not exist".
+	{
+		local _a
+
+		for _a in $(seq 1 30); do
+			if psql_admin "SELECT 1;" >/dev/null 2>&1; then
+				break
+			fi
+			sleep 1
+		done
+		for _a in $(seq 1 10); do
+			if [ "$(psql_admin "SELECT 1 FROM pg_database WHERE datname = '$PGC_DB';" 2>/dev/null | tr -dc 0-9)" = "1" ]; then
+				break
+			fi
+			psql_admin "CREATE DATABASE $PGC_DB;" >/dev/null 2>&1 || true
+			sleep 1
+		done
+	}
 	psql_run "CREATE EXTENSION columnar;" >/dev/null
 }
 

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -89,12 +89,16 @@ pgc_setup() {
 	echo "-- start"
 	{
 		local _a
-		for _a in 1 2 3 4 5; do
+		for _a in 1 2 3 4 5 6 7 8; do
 			if pgc_pg "pg_ctl -D '$PGC_PGDATA' -l '$PGC_LOGFILE' start -w" >/dev/null 2>&1; then
 				break
 			fi
-			echo "-- start attempt $_a failed; retrying"
-			sleep 2
+			echo "-- start attempt $_a failed; retrying on a fresh port"
+			pgc_pg "pg_ctl -D '$PGC_PGDATA' stop -m immediate -w" >/dev/null 2>&1 || true
+			# the assigned port was taken by another cluster; pick a new one
+			PGC_PORT=$(( 2048 + (PGC_PORT + 1 + RANDOM % 40000) % 60000 ))
+			pgc_pg "sed -i 's/^port=.*/port=$PGC_PORT/' '$PGC_PGDATA/postgresql.conf'"
+			sleep 1
 		done
 	}
 	# Wait until the postmaster actually accepts connections, then create the

--- a/test/pbt/catalog/pg_type.h
+++ b/test/pbt/catalog/pg_type.h
@@ -1,0 +1,5 @@
+#ifndef PBT_PGTYPE_H
+#define PBT_PGTYPE_H
+#define FLOAT4OID 700
+#define FLOAT8OID 701
+#endif

--- a/test/pbt/columnar.h
+++ b/test/pbt/columnar.h
@@ -1,0 +1,42 @@
+/*
+ * Stub columnar.h for the standalone codec property test (test/pbt). It exposes
+ * only the encoding codes, the block-reader struct, and the codec prototypes
+ * that columnar_encoding.c needs, over the minimal PG shim. The real header is
+ * src/columnar.h; this one is picked up only when compiling the codec source
+ * from the test/pbt build directory.
+ */
+#ifndef PGCOLUMNAR_PBT_COLUMNAR_H
+#define PGCOLUMNAR_PBT_COLUMNAR_H
+
+#include "pgstub.h"
+
+#define COLUMNAR_ENCODING_NONE 0
+#define COLUMNAR_ENCODING_RLE 1
+#define COLUMNAR_ENCODING_FOR 2
+#define COLUMNAR_ENCODING_DELTA 3
+#define COLUMNAR_ENCODING_GORILLA 4
+#define COLUMNAR_ENCODING_DOD 5
+#define COLUMNAR_ENCODING_DICT 6
+
+typedef struct ColumnarBlockReader
+{
+	const char *raw;
+	uint64		valueCount;
+	int			width;
+	uint64		pos;
+} ColumnarBlockReader;
+
+extern int ColumnarEncodeChunk(const char *raw, uint32 rawLen,
+							   Form_pg_attribute att, uint64 valueCount,
+							   char **out, uint32 *outLen);
+extern char *ColumnarDecodeChunk(const char *enc, uint32 encLen,
+								 int encodingType, Form_pg_attribute att,
+								 uint64 valueCount, uint32 rawLen,
+								 MemoryContext cx);
+extern const char *ColumnarEncodingName(int encodingType);
+extern void ColumnarBlockReaderInit(ColumnarBlockReader *br, const char *raw,
+									uint64 valueCount, int width);
+extern bool ColumnarBlockNextRun(ColumnarBlockReader *br,
+								 const char **valBytes, uint64 *runLen);
+
+#endif							/* PGCOLUMNAR_PBT_COLUMNAR_H */

--- a/test/pbt/pgstub.h
+++ b/test/pbt/pgstub.h
@@ -1,0 +1,103 @@
+/*
+ * Minimal PostgreSQL shim for property-testing the value-stream codecs
+ * (columnar_encoding.c) as a standalone C program, with no PostgreSQL backend.
+ * It provides just the types, StringInfo, palloc, varlena, and error macros the
+ * codec functions use, so the same source compiles and runs under a normal C
+ * compiler and a property-test driver. Not a PostgreSQL header; used only by the
+ * test harness under test/pbt.
+ */
+#ifndef PGCOLUMNAR_PBT_PGSTUB_H
+#define PGCOLUMNAR_PBT_PGSTUB_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+typedef int16_t int16;
+typedef int32_t int32;
+typedef int64_t int64;
+typedef uint8_t uint8;
+typedef uint16_t uint16;
+typedef uint32_t uint32;
+typedef uint64_t uint64;
+typedef size_t Size;
+typedef unsigned int Oid;
+#define InvalidOid ((Oid) 0)
+
+/* memory: the codecs allocate output buffers; a leak in a test process is fine */
+typedef void *MemoryContext;
+#define palloc(sz) malloc(sz)
+#define palloc0(sz) calloc(1, (sz))
+#define pfree(p) free(p)
+#define MemoryContextAlloc(cx, sz) malloc(sz)
+
+/* error path: only the unknown-encoding branch calls ereport; abort loudly */
+#define ereport(elevel, ...) do { fprintf(stderr, "ereport called\n"); abort(); } while (0)
+#define errcode(x) 0
+#define errmsg(...) 0
+
+/* attribute: the codecs read attlen, attbyval, atttypid only */
+typedef struct FormData_pg_attribute
+{
+	int16		attlen;
+	bool		attbyval;
+	Oid			atttypid;
+} FormData_pg_attribute;
+typedef FormData_pg_attribute *Form_pg_attribute;
+
+/*
+ * varlena: dict encoding sizes values with VARSIZE_ANY. The test builds varlena
+ * values with a 4-byte total-length header (no flag bits), so a plain 32-bit
+ * read is the size, matching how the codec round-trips the bytes.
+ */
+#define VARSIZE_ANY(p) (*((const uint32 *) (p)))
+
+/* StringInfo: a growable byte buffer */
+typedef struct StringInfoData
+{
+	char	   *data;
+	int			len;
+	int			maxlen;
+} StringInfoData;
+typedef StringInfoData *StringInfo;
+
+static inline void
+initStringInfo(StringInfo s)
+{
+	s->maxlen = 64;
+	s->data = (char *) malloc(s->maxlen);
+	s->len = 0;
+	s->data[0] = '\0';
+}
+
+static inline void
+enlargeStringInfo(StringInfo s, int needed)
+{
+	if (s->len + needed + 1 > s->maxlen)
+	{
+		while (s->len + needed + 1 > s->maxlen)
+			s->maxlen *= 2;
+		s->data = (char *) realloc(s->data, s->maxlen);
+	}
+}
+
+static inline void
+appendBinaryStringInfo(StringInfo s, const char *data, int datalen)
+{
+	enlargeStringInfo(s, datalen);
+	memcpy(s->data + s->len, data, datalen);
+	s->len += datalen;
+	s->data[s->len] = '\0';
+}
+
+static inline void
+appendStringInfoChar(StringInfo s, char ch)
+{
+	enlargeStringInfo(s, 1);
+	s->data[s->len++] = ch;
+	s->data[s->len] = '\0';
+}
+
+#endif							/* PGCOLUMNAR_PBT_PGSTUB_H */

--- a/test/pbt/run.sh
+++ b/test/pbt/run.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Build and run the standalone codec property test (test/pbt/test_encoding.c).
+# Compiles src/columnar_encoding.c against the minimal PG shim in this directory
+# and runs the randomized + boundary round-trip driver. No PostgreSQL needed;
+# runs anywhere with a C compiler.
+#
+# Usage: test/pbt/run.sh [seed] [iterations]
+
+set -uo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo="$(cd "$here/../.." && pwd)"
+cc="${CC:-cc}"
+
+b="$(mktemp -d /tmp/pgc-pbt.XXXXXX)"
+cp "$repo/src/columnar_encoding.c" "$b/"
+cp "$here/pgstub.h" "$here/columnar.h" "$here/test_encoding.c" "$b/"
+mkdir -p "$b/catalog" "$b/utils"
+cp "$here/catalog/pg_type.h" "$b/catalog/"
+cp "$here/utils/memutils.h" "$b/utils/"
+
+echo "-- compiling codec + harness"
+"$cc" -O2 -Wall -I"$b" -c "$b/columnar_encoding.c" -o "$b/columnar_encoding.o"
+"$cc" -O2 -Wall -I"$b" "$b/test_encoding.c" "$b/columnar_encoding.o" -o "$b/test_encoding"
+
+"$b/test_encoding" "${1:-1}" "${2:-200000}"
+rc=$?
+
+rm -rf "$b"
+exit $rc

--- a/test/pbt/test_encoding.c
+++ b/test/pbt/test_encoding.c
@@ -1,0 +1,311 @@
+/*
+ * Property test for the value-stream codecs (src/columnar_encoding.c), run
+ * standalone against the test/pbt PostgreSQL shim.
+ *
+ * The governing property is round-trip: for any raw value stream,
+ * ColumnarDecodeChunk(ColumnarEncodeChunk(raw)) reproduces the exact bytes. It
+ * is exercised over randomized data shaped to hit each encoding (constant,
+ * alternating, monotonic, clustered, low-cardinality, runs, random) across all
+ * fixed widths, floats (gorilla), and varlena (dict), plus explicit boundary
+ * cases (empty, single value, integer extremes). Applies hegel's methodology
+ * (round-trip, boundary values, no-crash); the hegel C client is not installed
+ * here, so this is a self-contained randomized driver with a reproducible seed.
+ *
+ * Usage: test_encoding [seed] [iterations]
+ */
+#include "columnar.h"
+#include "catalog/pg_type.h"
+
+static unsigned long rng_state;
+static void
+rng_seed(unsigned long s)
+{
+	rng_state = s ? s : 0x9e3779b97f4a7c15UL;
+}
+static uint64
+rng_next(void)
+{
+	/* xorshift64* */
+	rng_state ^= rng_state >> 12;
+	rng_state ^= rng_state << 25;
+	rng_state ^= rng_state >> 27;
+	return rng_state * 0x2545F4914F6CDD1DUL;
+}
+static uint64
+rng_below(uint64 n)
+{
+	return n ? rng_next() % n : 0;
+}
+
+static int failures = 0;
+static long checks = 0;
+
+/* store the low w bytes of v (matches the codec's load/store_uint) */
+static void
+put_uint(char *p, uint64 v, int w)
+{
+	memcpy(p, &v, w);
+}
+
+/* one fixed-width round-trip check */
+static void
+check_fixed(int w, Oid typid, uint32 n, const char *raw)
+{
+	FormData_pg_attribute att;
+	uint32		rawLen = n * (uint32) w;
+	char	   *enc;
+	uint32		encLen;
+	int			code;
+	char	   *dec;
+
+	att.attlen = (int16) w;
+	att.attbyval = true;
+	att.atttypid = typid;
+
+	code = ColumnarEncodeChunk(raw, rawLen, &att, n, &enc, &encLen);
+	dec = ColumnarDecodeChunk(enc, encLen, code, &att, n, rawLen, NULL);
+	checks++;
+
+	if (rawLen > 0 && memcmp(dec, raw, rawLen) != 0)
+	{
+		failures++;
+		fprintf(stderr,
+				"FAIL fixed w=%d typid=%u n=%u code=%s(%d) encLen=%u\n",
+				w, typid, n, ColumnarEncodingName(code), code, encLen);
+	}
+}
+
+/* fill n values of width w following a pattern, then round-trip */
+static void
+gen_fixed(int w, Oid typid, uint32 n, int pattern)
+{
+	char	   *raw = (char *) malloc(n ? (size_t) n * w : 1);
+	uint64		mask = (w == 8) ? ~0UL : (((uint64) 1 << (w * 8)) - 1);
+	uint64		base = rng_next() & mask;
+	uint64		lo = 1 + rng_below(6);	/* low-cardinality modulus */
+	uint64		step = rng_below(8);
+	uint32		i;
+	uint64		cur = base;
+
+	for (i = 0; i < n; i++)
+	{
+		uint64		v;
+
+		switch (pattern)
+		{
+			case 0:				/* constant */
+				v = base;
+				break;
+			case 1:				/* alternating two values */
+				v = (i & 1) ? base : (base ^ 0x5a5a5a5aUL);
+				break;
+			case 2:				/* monotonic small random step */
+				cur += rng_below(4);
+				v = cur;
+				break;
+			case 3:				/* monotonic constant step (favors dod) */
+				v = base + (uint64) i *step;
+				break;
+			case 4:				/* low cardinality (favors dict/rle/for) */
+				v = base + (rng_next() % lo);
+				break;
+			case 5:				/* clustered (favors for) */
+				v = base + rng_below(16);
+				break;
+			case 6:				/* runs of a repeated value */
+				if (rng_below(8) == 0)
+					cur = rng_next();
+				v = cur;
+				break;
+			default:			/* fully random (favors none) */
+				v = rng_next();
+				break;
+		}
+		put_uint(raw + (size_t) i * w, v & mask, w);
+	}
+	check_fixed(w, typid, n, raw);
+	free(raw);
+}
+
+/* float round-trip (gorilla eligible), width 4 or 8 */
+static void
+gen_float(int w, uint32 n, int pattern)
+{
+	char	   *raw = (char *) malloc(n ? (size_t) n * w : 1);
+	uint32		i;
+	double		cur = (double) (int64) rng_next() / 1000.0;
+
+	for (i = 0; i < n; i++)
+	{
+		double		d;
+
+		switch (pattern)
+		{
+			case 0:
+				d = 3.14159;
+				break;			/* constant */
+			case 1:
+				cur += ((double) (rng_below(200)) - 100.0) / 100.0;
+				d = cur;
+				break;			/* random walk */
+			case 2:
+				d = (double) i * 1.5;
+				break;			/* linear */
+			default:
+				d = (double) (int64) rng_next();
+				break;			/* random */
+		}
+		if (w == 4)
+		{
+			float		f = (float) d;
+
+			memcpy(raw + (size_t) i * 4, &f, 4);
+		}
+		else
+			memcpy(raw + (size_t) i * 8, &d, 8);
+	}
+	check_fixed(w, (w == 4) ? FLOAT4OID : FLOAT8OID, n, raw);
+	free(raw);
+}
+
+/* varlena round-trip (dict eligible): [uint32 len][len-4 payload bytes] each */
+static void
+gen_varlena(uint32 n, int lowcard)
+{
+	StringInfoData s;
+	uint32		i;
+	FormData_pg_attribute att;
+	char	   *enc;
+	uint32		encLen;
+	int			code;
+	char	   *dec;
+
+	initStringInfo(&s);
+	for (i = 0; i < n; i++)
+	{
+		uint32		pick = lowcard ? (uint32) rng_below(6) : (uint32) rng_next();
+		char		body[24];
+		int			blen = 1 + (int) (pick % 20);
+		uint32		total = 4 + (uint32) blen;
+		int			j;
+
+		for (j = 0; j < blen; j++)
+			body[j] = (char) ('a' + (pick + j) % 26);
+		appendBinaryStringInfo(&s, (char *) &total, 4);
+		appendBinaryStringInfo(&s, body, blen);
+	}
+
+	att.attlen = -1;
+	att.attbyval = false;
+	att.atttypid = 25;			/* text */
+
+	code = ColumnarEncodeChunk(s.data, (uint32) s.len, &att, n, &enc, &encLen);
+	dec = ColumnarDecodeChunk(enc, encLen, code, &att, n, (uint32) s.len, NULL);
+	checks++;
+	if (s.len > 0 && memcmp(dec, s.data, s.len) != 0)
+	{
+		failures++;
+		fprintf(stderr, "FAIL varlena n=%u code=%s rawLen=%d\n",
+				n, ColumnarEncodingName(code), s.len);
+	}
+	free(s.data);
+}
+
+/* explicit boundary cases that randomized runs might under-sample */
+static void
+boundary_cases(void)
+{
+	int			widths[] = {1, 2, 4, 8};
+	Oid			typ[] = {18, 21, 23, 20};
+	int			wi;
+
+	for (wi = 0; wi < 4; wi++)
+	{
+		int			w = widths[wi];
+		uint64		mask = (w == 8) ? ~0UL : (((uint64) 1 << (w * 8)) - 1);
+		uint32		n;
+
+		/* empty, single, and a couple of tiny counts */
+		for (n = 0; n <= 3; n++)
+		{
+			char	   *raw = (char *) malloc(n ? (size_t) n * w : 1);
+			uint32		i;
+
+			for (i = 0; i < n; i++)
+				put_uint(raw + (size_t) i * w, (uint64) i & mask, w);
+			check_fixed(w, typ[wi], n, raw);
+			free(raw);
+		}
+
+		/* integer extremes: all-min, all-max, alternating min/max, 0/-1 mix */
+		{
+			uint32		cnt = 300;
+			char	   *raw = (char *) malloc((size_t) cnt * w);
+			uint64		ex[] = {0, mask, mask >> 1, (mask >> 1) + 1};
+			int			e;
+
+			for (e = 0; e < 4; e++)
+			{
+				uint32		i;
+
+				for (i = 0; i < cnt; i++)
+					put_uint(raw + (size_t) i * w, ex[e] & mask, w);
+				check_fixed(w, typ[wi], cnt, raw);
+			}
+			/* alternating extremes stresses delta/dod zigzag on huge deltas */
+			{
+				uint32		i;
+
+				for (i = 0; i < cnt; i++)
+					put_uint(raw + (size_t) i * w, (i & 1 ? mask : 0), w);
+				check_fixed(w, typ[wi], cnt, raw);
+			}
+			free(raw);
+		}
+	}
+}
+
+int
+main(int argc, char **argv)
+{
+	unsigned long seed = (argc > 1) ? strtoul(argv[1], NULL, 0) : 1;
+	long		iters = (argc > 2) ? strtol(argv[2], NULL, 0) : 200000;
+	long		it;
+
+	rng_seed(seed);
+	printf("codec property test: seed=%lu iters=%ld\n", seed, iters);
+
+	boundary_cases();
+
+	for (it = 0; it < iters; it++)
+	{
+		int			kind = (int) rng_below(3);
+		uint32		n;
+
+		/* mostly small, sometimes large; include 0/1/2 boundaries */
+		if (rng_below(10) == 0)
+			n = (uint32) rng_below(3);
+		else
+			n = (uint32) rng_below(3000);
+
+		if (kind == 0)
+		{
+			int			ws[] = {1, 2, 4, 8};
+			Oid			ts[] = {18, 21, 23, 20};
+			int			wi = (int) rng_below(4);
+
+			gen_fixed(ws[wi], ts[wi], n, (int) rng_below(8));
+		}
+		else if (kind == 1)
+			gen_float((rng_below(2) ? 8 : 4), n, (int) rng_below(4));
+		else
+			gen_varlena(n, (int) rng_below(2));
+	}
+
+	printf("checks=%ld failures=%d\n", checks, failures);
+	if (failures == 0)
+		printf("CODEC PBT PASSED\n");
+	else
+		printf("CODEC PBT FAILED\n");
+	return failures == 0 ? 0 : 1;
+}

--- a/test/pbt/utils/memutils.h
+++ b/test/pbt/utils/memutils.h
@@ -1,0 +1,3 @@
+#ifndef PBT_MEMUTILS_H
+#define PBT_MEMUTILS_H
+#endif

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -24,7 +24,7 @@ set -uo pipefail
 
 SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUITES=(smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
-	differential recovery fuzz)
+	differential recovery fuzz hardening concurrent_diff)
 
 # Default matrix: one assert-enabled pg_config per major, 13 through 19.
 DEFAULT_CONFIGS=(


### PR DESCRIPTION
Stacked on #10. Hardening pass for the format 2.1 work, plus durable specs for the gap backlog.

- **Codec property test** (`test/pbt/`): standalone C round-trip over all encodings/widths/floats/varlena + integer extremes (0 failures, 500k+ cases). PostgreSQL-independent.
- **`test/hardening.sh`**: 2.0-format NULL-default reader path + corrupted-input robustness (invalid encoding type errors cleanly; malformed bloom is ignored).
- **`test/concurrent_diff.sh`**: concurrent disjoint-range DML vs a heap oracle.
- **Harness reliability fixes** (`test/lib.sh`): wait for server readiness + verify the DB (fixed the "recovery/fuzz flake" = a `CREATE DATABASE`-skipped-under-churn harness bug), and retry cluster start on a fresh port under port contention. These were harness bugs, never the product.
- **Docs**: README testing section, spec section 10 (2.0→2.1 catalog compatibility).
- **`design/gaps/`**: a spec per forward-looking gap (21–28).

Full version matrix: **ALL VERSIONS PASSED** on PostgreSQL 13–19 (all 14 suites each). PG19 validated against 19beta2 (final not yet released).

🤖 Generated with [Claude Code](https://claude.com/claude-code)