### PR TITLE
Gap 25: bloom filters for deterministic-collation text columns

### DIFF
--- a/design/gaps/25-text-bloom-filters.md
+++ b/design/gaps/25-text-bloom-filters.md
@@ -1,6 +1,6 @@
 # Gap 25: bloom filters for collatable/text columns
 
-Status: planned. Tier: performance. Format change: none (reuses the 2.1 bloom column).
+Status: IMPLEMENTED (feat/gap25-text-bloom). Tier: performance. Format change: none (reuses the 2.1 bloom column).
 
 ## Motivation
 

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -435,6 +435,14 @@ extern bool ColumnarBloomBuild(const uint32 *hashes, uint32 n,
 							   char **out, uint32 *outLen);
 extern bool ColumnarBloomProbe(const char *bloom, uint32 bloomLen, uint32 hash);
 
+/*
+ * True when a column of the given collation can carry a bloom filter (I7/gap 25):
+ * a non-collatable type (InvalidOid), or a deterministic collation, so equal
+ * values are byte-identical and hash consistently between build and probe.
+ * Nondeterministic collations return false and are left unbloomed.
+ */
+extern bool ColumnarCollationIsDeterministic(Oid collid);
+
 /* -------------------------------------------------------------------------
  * compression-block run iterator (columnar_encoding.c, I2)
  *

--- a/src/columnar_bloom.c
+++ b/src/columnar_bloom.c
@@ -23,6 +23,35 @@
  */
 #include "columnar.h"
 
+#include "access/htup_details.h"
+#include "catalog/pg_collation.h"
+#include "utils/syscache.h"
+
+/*
+ * ColumnarCollationIsDeterministic
+ *		Whether a bloom filter is safe for this collation: InvalidOid (a
+ *		non-collatable type) and deterministic collations qualify; a
+ *		nondeterministic collation does not, since equal values need not be
+ *		byte-identical and would hash inconsistently.
+ */
+bool
+ColumnarCollationIsDeterministic(Oid collid)
+{
+	HeapTuple	tp;
+	bool		result = true;
+
+	if (!OidIsValid(collid))
+		return true;
+
+	tp = SearchSysCache1(COLLOID, ObjectIdGetDatum(collid));
+	if (HeapTupleIsValid(tp))
+	{
+		result = ((Form_pg_collation) GETSTRUCT(tp))->collisdeterministic;
+		ReleaseSysCache(tp);
+	}
+	return result;
+}
+
 /* target ~1% false positives: ~10 bits/value, 6 probes */
 #define BLOOM_BITS_PER_VALUE 10
 #define BLOOM_K 6

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -38,10 +38,11 @@ typedef struct SkipPredicate
 	FmgrInfo	cmpFn;			/* column type's default btree comparison */
 	Oid			collation;
 
-	/* bloom-filter probe for equality (I7): set only for a hashable,
-	 * non-collatable equality predicate, matching how the filter was built */
+	/* bloom-filter probe for equality (I7, gap 25): set for a hashable equality
+	 * predicate on a safe collation, matching how the filter was built */
 	bool		hasHash;
 	FmgrInfo	hashFn;
+	Oid			hashCollation;
 } SkipPredicate;
 
 struct ColumnarReadState
@@ -335,17 +336,21 @@ columnar_build_predicates(ColumnarReadState *readState, int nkeys, ScanKey keys)
 		readState->predicates[n].collation = att->attcollation;
 
 		/*
-		 * For an equality predicate on a hashable, non-collatable column, also
-		 * enable the bloom-filter probe (I7), matching how the filter was built.
+		 * For an equality predicate on a hashable column with a safe collation,
+		 * enable the bloom-filter probe (I7, gap 25), matching how the filter was
+		 * built. The scan key already matches the column collation (a
+		 * differently collated predicate is not pushed; see ColumnarBuildScanKeys),
+		 * so hashing the constant under the column collation is consistent.
 		 */
 		readState->predicates[n].hasHash = false;
 		if (key->sk_strategy == BTEqualStrategyNumber &&
-			att->attcollation == InvalidOid &&
-			OidIsValid(tce->hash_proc_finfo.fn_oid))
+			OidIsValid(tce->hash_proc_finfo.fn_oid) &&
+			ColumnarCollationIsDeterministic(att->attcollation))
 		{
 			readState->predicates[n].hasHash = true;
 			fmgr_info_copy(&readState->predicates[n].hashFn,
 						   &tce->hash_proc_finfo, readState->readContext);
+			readState->predicates[n].hashCollation = att->attcollation;
 		}
 		n++;
 	}
@@ -424,7 +429,7 @@ columnar_group_can_match(ColumnarReadState *readState, int groupIndex)
 					m->bloomFilter != NULL)
 				{
 					uint32		h = DatumGetUInt32(
-						FunctionCall1Coll(&pred->hashFn, InvalidOid,
+						FunctionCall1Coll(&pred->hashFn, pred->hashCollation,
 										  pred->compareValue));
 
 					if (!ColumnarBloomProbe(m->bloomFilter, m->bloomLen, h))

--- a/src/columnar_write_state.c
+++ b/src/columnar_write_state.c
@@ -36,6 +36,7 @@ typedef struct ColumnarColumnDef
 	 */
 	bool		bloomable;
 	FmgrInfo	hashFn;
+	Oid			hashCollation;	/* collation to hash under (InvalidOid if none) */
 } ColumnarColumnDef;
 
 /* one column's two streams within one chunk group */
@@ -196,17 +197,19 @@ ColumnarGetWriteState(Relation rel)
 			}
 
 			/*
-			 * Bloom filter only for hashable, non-collatable types (I7): their
-			 * hash is collation-independent, so a chunk built here answers an
-			 * equality probe of the same type without the collation caveats that
-			 * apply to text.
+			 * Bloom filter for hashable columns whose collation is safe (I7,
+			 * gap 25): non-collatable types and deterministic collations, so a
+			 * value hashes consistently between this build and an equality
+			 * probe. Values are hashed under the column's collation. A
+			 * nondeterministic collation is left unbloomed.
 			 */
-			if (att->attcollation == InvalidOid &&
-				OidIsValid(tce->hash_proc_finfo.fn_oid))
+			if (OidIsValid(tce->hash_proc_finfo.fn_oid) &&
+				ColumnarCollationIsDeterministic(att->attcollation))
 			{
 				writeState->colDefs[c].bloomable = true;
 				fmgr_info_copy(&writeState->colDefs[c].hashFn,
 							   &tce->hash_proc_finfo, ColumnarWriteContext);
+				writeState->colDefs[c].hashCollation = att->attcollation;
 			}
 		}
 	}
@@ -315,7 +318,8 @@ ColumnarWriteRow(ColumnarWriteState *writeState, Relation rel,
 			{
 				uint32		h = DatumGetUInt32(
 					FunctionCall1Coll(&writeState->colDefs[c].hashFn,
-									  InvalidOid, values[c]));
+									  writeState->colDefs[c].hashCollation,
+									  values[c]));
 
 				appendBinaryStringInfo(&col->hashBuf, (char *) &h, sizeof(uint32));
 			}

--- a/test/differential.sh
+++ b/test/differential.sh
@@ -362,6 +362,22 @@ off=$(removed off)
 check "bloom absent correct"   "$(q "SELECT count(*) FROM t_col WHERE k = ${absent}::bigint;")" "0"
 check "bloom removes >= minmax" "$([ "${on:-0}" -gt "${off:-0}" ] && echo yes)" "yes"
 
+# Text bloom (gap 25): deterministic-collation text/varchar columns are bloomed;
+# equality skipping works and results stay correct, including under a mismatched
+# explicit COLLATE (which must not be pushed, so it never wrongly skips).
+make_pair "id int, tk text, tc text COLLATE \"C\""
+q "SELECT columnar.alter_columnar_table_set('t_col', chunk_group_row_limit => 1000, stripe_row_limit => 20000);" >/dev/null
+load_pair "SELECT g, 'k' || ((g*2654435761)%50000), 'c' || ((g*40503)%50000)
+	FROM generate_series(1,16000) g"
+diff_query "textbloom present"  "SELECT id FROM %T WHERE tk = 'k' || ((7*2654435761)%50000)"
+diff_query "textbloom absent"   "SELECT count(*) FROM %T WHERE tk = 'zzzzzzzz'"
+diff_query "textbloom C absent" "SELECT count(*) FROM %T WHERE tc = 'zzzzzzzz'"
+diff_query "textbloom C eq"     "SELECT count(*) FROM %T WHERE tc = 'c123'"
+check "textbloom built for tk" "$(bloom_built 2)" "t"
+check "textbloom built for tc" "$(bloom_built 3)" "t"
+# mismatched explicit COLLATE must still return correct results (not pushed)
+diff_query "textbloom collate-mismatch" "SELECT count(*) FROM %T WHERE tk = 'k100' COLLATE \"C\""
+
 # ---------------------------------------------------------------------------
 # Part 6: late materialization (I8)
 #


### PR DESCRIPTION
Stacked on the hardening PR. Implements design/gaps/25.

Extends per-chunk bloom filters (I7) from non-collatable types to collatable types under **deterministic** collations (text, varchar), hashing under the column's collation on build and probe; nondeterministic collations stay unbloomed. Safe because a differently-collated predicate is never pushed as a scan key, so the constant hashes consistently with stored values.

Tests: differential (222) incl. text present/absent, C collation, and a mismatched explicit COLLATE that must stay correct; audit collation test still passes. Green on pg13/pg17/pg19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)