### PR TITLE
Gap 22: intra-group late materialization (position lists)

### DIFF
--- a/design/gaps/22-position-list-late-materialization.md
+++ b/design/gaps/22-position-list-late-materialization.md
@@ -1,6 +1,6 @@
 # Gap 22: intra-group late materialization (position lists)
 
-Status: planned. Tier: performance. Format change: none.
+Status: IMPLEMENTED (feat/gap22-position-lists). Tier: performance. Format change: none.
 
 ## Motivation
 

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -379,7 +379,8 @@ extern bool ColumnarReadNextVector(ColumnarReadState *readState,
 extern bool ColumnarAdvanceGroup(ColumnarReadState *readState);
 extern void ColumnarDecodeGroupColumns(ColumnarReadState *readState,
 									   ColumnarVector *vec,
-									   Bitmapset *cols, bool init);
+									   Bitmapset *cols, bool init,
+									   const bool *sel);
 
 /* -------------------------------------------------------------------------
  * raw-group reader (columnar_reader.c, I3 compressed execution)

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -589,7 +589,7 @@ ColumnarScanNextVector(ScanState *ss)
 				if (!ColumnarAdvanceGroup(cstate->readState))
 					return NULL;
 				ColumnarDecodeGroupColumns(cstate->readState, &cstate->vec,
-										   cstate->vecPredCols, true);
+										   cstate->vecPredCols, true, NULL);
 			}
 			else
 			{
@@ -619,15 +619,28 @@ ColumnarScanNextVector(ScanState *ss)
 			 */
 			if (cstate->lateMat)
 			{
+				uint64		survivors = 0;
+
 				for (r = 0; r < cstate->vec.nrows; r++)
 					if (cstate->vecSel[r])
-					{
-						anyPass = true;
-						break;
-					}
+						survivors++;
+				anyPass = (survivors > 0);
+
+				/*
+				 * Decode the output columns only for surviving rows when the
+				 * filter is selective (position-list late materialization, gap
+				 * 22): passing the selection vector makes the decoder skip
+				 * copying unselected values. When most rows survive, a full
+				 * decode is simpler and more cache-friendly.
+				 */
 				if (anyPass)
+				{
+					const bool *gatherSel =
+						(survivors * 2 < cstate->vec.nrows) ? cstate->vecSel : NULL;
+
 					ColumnarDecodeGroupColumns(cstate->readState, &cstate->vec,
-											   NULL, false);
+											   NULL, false, gatherSel);
+				}
 			}
 			continue;			/* re-check bounds (handles an empty group) */
 		}

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -807,7 +807,7 @@ ColumnarReadNextRow(ColumnarReadState *readState, Datum *values, bool *nulls,
  */
 static void
 columnar_decode_group_columns(ColumnarReadState *readState, ColumnarVector *vec,
-							  Bitmapset *cols, bool init)
+							  Bitmapset *cols, bool init, const bool *sel)
 {
 	MemoryContext oldContext = MemoryContextSwitchTo(readState->groupContext);
 	int			natts = readState->natts;
@@ -885,9 +885,25 @@ columnar_decode_group_columns(ColumnarReadState *readState, ColumnarVector *vec,
 		{
 			if (existsBase[i])
 			{
-				vals[i] = ColumnarDecodeValue(att, &cursor,
-											  readState->groupContext);
-				nulls[i] = false;
+				if (sel == NULL || sel[i])
+				{
+					vals[i] = ColumnarDecodeValue(att, &cursor,
+												  readState->groupContext);
+					nulls[i] = false;
+				}
+				else
+				{
+					/*
+					 * Position-list late materialization (gap 22): a present but
+					 * unselected value is skipped -- advance the cursor past it
+					 * without copying it (the win for by-ref/varlena output
+					 * columns). The slot is never read (sel[i] is false).
+					 */
+					cursor += (att->attlen > 0) ? att->attlen
+						: (int) VARSIZE_ANY(cursor);
+					vals[i] = (Datum) 0;
+					nulls[i] = true;
+				}
 			}
 			else
 			{
@@ -907,7 +923,7 @@ columnar_decode_group_columns(ColumnarReadState *readState, ColumnarVector *vec,
 static void
 columnar_decode_group_to_vector(ColumnarReadState *readState, ColumnarVector *vec)
 {
-	columnar_decode_group_columns(readState, vec, NULL, true);
+	columnar_decode_group_columns(readState, vec, NULL, true, NULL);
 }
 
 /*
@@ -925,9 +941,9 @@ ColumnarAdvanceGroup(ColumnarReadState *readState)
 
 void
 ColumnarDecodeGroupColumns(ColumnarReadState *readState, ColumnarVector *vec,
-						   Bitmapset *cols, bool init)
+						   Bitmapset *cols, bool init, const bool *sel)
 {
-	columnar_decode_group_columns(readState, vec, cols, init);
+	columnar_decode_group_columns(readState, vec, cols, init, sel);
 }
 
 /*


### PR DESCRIPTION
Stacked on the gap-25 PR. Implements design/gaps/22.

Within a surviving chunk group, decode output-column values only at surviving positions when the filter is selective (survivors < half the group), skipping the per-row copy/detoast of by-ref/varlena output columns for filtered-out rows. `columnar_decode_group_columns` gains a selection-vector parameter; results are unchanged (unselected slots are never read).

Tests: differential late-materialization cases now exercise the gather path (GUC on/off) vs the heap oracle. Green on pg13/pg17/pg19 (differential 222, phase5/6, fuzz).

🤖 Generated with [Claude Code](https://claude.com/claude-code)