### PR TITLE
Gap 23: parallel scan

### DIFF
--- a/design/gaps/23-parallel-scan.md
+++ b/design/gaps/23-parallel-scan.md
@@ -1,6 +1,6 @@
 # Gap 23: parallel scan
 
-Status: planned. Tier: performance (largest user-visible win). Format change: none.
+Status: IMPLEMENTED (feat/gap23-parallel-scan). Tier: performance (largest user-visible win). Format change: none.
 
 ## Motivation
 

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -18,6 +18,7 @@
 
 #include "access/skey.h"
 #include "access/tableam.h"
+#include "port/atomics.h"
 #include "lib/stringinfo.h"
 #include "nodes/bitmapset.h"
 #include "nodes/pg_list.h"
@@ -325,6 +326,14 @@ extern bool ColumnarReadNextRow(ColumnarReadState *readState,
 								uint64 *rowNumber);
 extern void ColumnarRescanRead(ColumnarReadState *readState);
 extern void ColumnarEndRead(ColumnarReadState *readState);
+
+/*
+ * Parallel scan (gap 23): point the read state at a shared atomic that hands out
+ * stripe indices, so several workers scanning the same relation each claim
+ * distinct stripes. Set by the custom scan's DSM init callbacks.
+ */
+extern void ColumnarReadSetParallelCounter(ColumnarReadState *readState,
+										   pg_atomic_uint32 *counter);
 
 /*
  * Chunk-group skip counters for the current scan (spec 9), used by the custom

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -13,8 +13,9 @@
  * never changes results: a filtered query returns the same rows whether or
  * not columnar.enable_qual_pushdown is set.
  *
- * Parallel sequential scans are disabled for columnar relations by dropping
- * the relation's partial paths, so plans are deterministic.
+ * The scan is parallel-aware (gap 23): a parallel-aware partial custom path lets
+ * the planner Gather over several workers that each claim distinct stripes from
+ * a shared atomic counter in the scan's DSM segment.
  *
  * Independent MIT implementation built from design/FORMAT_AND_INTERFACE_SPEC.md
  * (format 2.0), design/REWRITE_PLAN.md section 6, and the public PostgreSQL 17
@@ -25,9 +26,11 @@
  */
 #include "columnar.h"
 
+#include "access/parallel.h"
 #include "access/relation.h"
 #include "access/relscan.h"
 #include "access/stratnum.h"
+#include "storage/shm_toc.h"
 #include "commands/explain.h"
 #if PG_VERSION_NUM >= 180000
 /* PG18 split the ExplainProperty* helpers out into explain_format.h. */
@@ -84,6 +87,7 @@ typedef struct ColumnarCustomScanState
 	uint64		vecSelCap;		/* allocated length of vecSel */
 	Bitmapset  *vecPredCols;	/* predicate columns, decoded first (I8) */
 	bool		lateMat;		/* two-phase decode enabled for this scan */
+	pg_atomic_uint32 *parallelCounter;	/* shared stripe claimer (gap 23) */
 } ColumnarCustomScanState;
 
 /* path -> plan */
@@ -101,6 +105,16 @@ static void ColumnarBeginCustomScan(CustomScanState *node, EState *estate,
 static TupleTableSlot *ColumnarExecCustomScan(CustomScanState *node);
 static void ColumnarEndCustomScan(CustomScanState *node);
 static void ColumnarReScanCustomScan(CustomScanState *node);
+static Size ColumnarEstimateDSMCustomScan(CustomScanState *node,
+										  ParallelContext *pcxt);
+static void ColumnarInitializeDSMCustomScan(CustomScanState *node,
+											ParallelContext *pcxt,
+											void *coordinate);
+static void ColumnarReInitializeDSMCustomScan(CustomScanState *node,
+											  ParallelContext *pcxt,
+											  void *coordinate);
+static void ColumnarInitializeWorkerCustomScan(CustomScanState *node,
+											   shm_toc *toc, void *coordinate);
 static void ColumnarExplainCustomScan(CustomScanState *node, List *ancestors,
 									  ExplainState *es);
 
@@ -125,6 +139,10 @@ static const CustomExecMethods columnar_exec_methods = {
 	.ExecCustomScan = ColumnarExecCustomScan,
 	.EndCustomScan = ColumnarEndCustomScan,
 	.ReScanCustomScan = ColumnarReScanCustomScan,
+	.EstimateDSMCustomScan = ColumnarEstimateDSMCustomScan,
+	.InitializeDSMCustomScan = ColumnarInitializeDSMCustomScan,
+	.ReInitializeDSMCustomScan = ColumnarReInitializeDSMCustomScan,
+	.InitializeWorkerCustomScan = ColumnarInitializeWorkerCustomScan,
 	.ExplainCustomScan = ColumnarExplainCustomScan,
 };
 
@@ -414,7 +432,7 @@ ColumnarSetRelPathlist(PlannerInfo *root, RelOptInfo *rel, Index rti,
 	}
 	rel->pathlist = keep;
 
-	/* disable parallel sequential scan: no partial paths for columnar */
+	/* drop the seqscan partial paths; a columnar partial path is added below */
 	rel->partial_pathlist = NIL;
 
 	cpath = makeNode(CustomPath);
@@ -444,6 +462,45 @@ ColumnarSetRelPathlist(PlannerInfo *root, RelOptInfo *rel, Index rti,
 	cpath->methods = &columnar_path_methods;
 
 	add_path(rel, &cpath->path);
+
+	/*
+	 * Add a parallel-aware partial path (gap 23) so the planner can put a Gather
+	 * over a parallel columnar scan. Workers each claim distinct stripes from a
+	 * shared counter set up by the DSM callbacks. The cost model mirrors a
+	 * parallel seqscan: the per-tuple work is divided among the workers.
+	 */
+	if (rel->consider_parallel && seqpath != NULL)
+	{
+		int			workers = compute_parallel_worker(rel, rel->pages, -1,
+													  max_parallel_workers_per_gather);
+
+		if (workers > 0)
+		{
+			CustomPath *ppath = makeNode(CustomPath);
+			double		divisor = (double) workers;
+
+			ppath->path.pathtype = T_CustomScan;
+			ppath->path.parent = rel;
+			ppath->path.pathtarget = rel->reltarget;
+			ppath->path.param_info = NULL;
+			ppath->path.parallel_aware = true;
+			ppath->path.parallel_safe = true;
+			ppath->path.parallel_workers = workers;
+			ppath->path.rows = rel->rows / divisor;
+			ppath->path.startup_cost = seqpath->startup_cost;
+			ppath->path.total_cost = seqpath->startup_cost +
+				(seqpath->total_cost - seqpath->startup_cost) / divisor;
+			ppath->path.pathkeys = NIL;
+			ppath->flags = 0;
+			ppath->custom_paths = NIL;
+			ppath->custom_private = NIL;
+#if PG_VERSION_NUM >= 170000
+			ppath->custom_restrictinfo = rel->baserestrictinfo;
+#endif
+			ppath->methods = &columnar_path_methods;
+			add_partial_path(rel, &ppath->path);
+		}
+	}
 }
 
 /* -------------------------------------------------------------------------
@@ -717,12 +774,65 @@ ColumnarReScanCustomScan(CustomScanState *node)
 	ColumnarCustomScanState *cstate = (ColumnarCustomScanState *) node;
 
 	if (cstate->readState != NULL)
+	{
 		ColumnarRescanRead(cstate->readState);
+		/* a parallel rescan keeps sharing the same stripe counter */
+		if (cstate->parallelCounter != NULL)
+			ColumnarReadSetParallelCounter(cstate->readState,
+										   cstate->parallelCounter);
+	}
 
 	cstate->haveVec = false;
 	cstate->vecPos = 0;
 
 	ExecScanReScan(&node->ss);
+}
+
+/* -------------------------------------------------------------------------
+ * parallel scan (gap 23): a shared atomic hands out stripe indices so several
+ * workers scanning the same relation each claim distinct stripes. The custom
+ * scan framework sizes and allocates the DSM chunk from EstimateDSM and passes
+ * its address as `coordinate` to the DSM/worker init callbacks.
+ * ------------------------------------------------------------------------- */
+
+static Size
+ColumnarEstimateDSMCustomScan(CustomScanState *node, ParallelContext *pcxt)
+{
+	return sizeof(pg_atomic_uint32);
+}
+
+static void
+ColumnarInitializeDSMCustomScan(CustomScanState *node, ParallelContext *pcxt,
+								void *coordinate)
+{
+	ColumnarCustomScanState *cstate = (ColumnarCustomScanState *) node;
+	pg_atomic_uint32 *counter = (pg_atomic_uint32 *) coordinate;
+
+	pg_atomic_init_u32(counter, 0);
+	cstate->parallelCounter = counter;
+	if (cstate->readState != NULL)
+		ColumnarReadSetParallelCounter(cstate->readState, counter);
+}
+
+static void
+ColumnarReInitializeDSMCustomScan(CustomScanState *node, ParallelContext *pcxt,
+								  void *coordinate)
+{
+	pg_atomic_uint32 *counter = (pg_atomic_uint32 *) coordinate;
+
+	pg_atomic_write_u32(counter, 0);
+}
+
+static void
+ColumnarInitializeWorkerCustomScan(CustomScanState *node, shm_toc *toc,
+								   void *coordinate)
+{
+	ColumnarCustomScanState *cstate = (ColumnarCustomScanState *) node;
+	pg_atomic_uint32 *counter = (pg_atomic_uint32 *) coordinate;
+
+	cstate->parallelCounter = counter;
+	if (cstate->readState != NULL)
+		ColumnarReadSetParallelCounter(cstate->readState, counter);
 }
 
 static void

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -75,6 +75,13 @@ struct ColumnarReadState
 
 	ParallelTableScanDesc parallelScan;
 
+	/*
+	 * Parallel scan work claiming (gap 23). When non-NULL, this shared atomic
+	 * hands out the next stripe index across all workers; each worker scans the
+	 * whole stripes it claims. NULL for a serial scan, which walks stripeIndex.
+	 */
+	pg_atomic_uint32 *parallelCounter;
+
 	/* current stripe decode state (in stripeContext) */
 	StripeMetadata *stripe;
 	char	   *stripeBuffer;
@@ -108,6 +115,7 @@ struct ColumnarReadState
 static void columnar_load_stripe(ColumnarReadState *readState,
 								 StripeMetadata *stripe);
 static bool columnar_advance_group(ColumnarReadState *readState);
+static int	columnar_next_stripe_index(ColumnarReadState *readState);
 static void columnar_setup_group(ColumnarReadState *readState, int groupIndex);
 static bool columnar_position_group(ColumnarReadState *readState);
 static bool columnar_group_can_match(ColumnarReadState *readState, int groupIndex);
@@ -686,16 +694,16 @@ ColumnarReadNextRow(ColumnarReadState *readState, Datum *values, bool *nulls,
 
 		if (readState->stripe == NULL)
 		{
-			if (readState->stripeIndex >= list_length(readState->stripeList))
+			int			si = columnar_next_stripe_index(readState);
+
+			if (si < 0)
 			{
 				readState->exhausted = true;
 				return false;
 			}
 
 			columnar_load_stripe(readState,
-								 list_nth(readState->stripeList,
-										  readState->stripeIndex));
-			readState->stripeIndex++;
+								 list_nth(readState->stripeList, si));
 
 			readState->groupIndex = 0;
 			if (!columnar_position_group(readState))
@@ -939,6 +947,33 @@ ColumnarAdvanceGroup(ColumnarReadState *readState)
 	return columnar_advance_group(readState);
 }
 
+/*
+ * columnar_next_stripe_index
+ *		The next stripe to scan, or -1 when none remain. A parallel scan claims
+ *		it from the shared atomic (each worker gets distinct stripes); a serial
+ *		scan walks stripeIndex (gap 23).
+ */
+static int
+columnar_next_stripe_index(ColumnarReadState *readState)
+{
+	int			nstripes = list_length(readState->stripeList);
+	uint32		si;
+
+	if (readState->parallelCounter != NULL)
+		si = pg_atomic_fetch_add_u32(readState->parallelCounter, 1);
+	else
+		si = (uint32) readState->stripeIndex++;
+
+	return (si < (uint32) nstripes) ? (int) si : -1;
+}
+
+void
+ColumnarReadSetParallelCounter(ColumnarReadState *readState,
+							   pg_atomic_uint32 *counter)
+{
+	readState->parallelCounter = counter;
+}
+
 void
 ColumnarDecodeGroupColumns(ColumnarReadState *readState, ColumnarVector *vec,
 						   Bitmapset *cols, bool init, const bool *sel)
@@ -973,16 +1008,16 @@ columnar_advance_group(ColumnarReadState *readState)
 
 		if (readState->stripe == NULL)
 		{
-			if (readState->stripeIndex >= list_length(readState->stripeList))
+			int			si = columnar_next_stripe_index(readState);
+
+			if (si < 0)
 			{
 				readState->exhausted = true;
 				return false;
 			}
 
 			columnar_load_stripe(readState,
-								 list_nth(readState->stripeList,
-										  readState->stripeIndex));
-			readState->stripeIndex++;
+								 list_nth(readState->stripeList, si));
 			readState->groupIndex = 0;
 
 			if (!columnar_position_group(readState))

--- a/test/parallel.sh
+++ b/test/parallel.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# pgColumnar parallel scan suite (gap 23).
+#
+# Forces a parallel plan and checks that (1) the planner puts a Gather over a
+# parallel columnar scan, and (2) results are identical to the heap oracle
+# whether the scan runs parallel or serial. Several backends claim distinct
+# stripes from a shared counter, so correctness under concurrent claiming is the
+# property.
+#
+# Usage:  test/parallel.sh [PG_CONFIG]
+#
+# Written fresh for pgColumnar; it does not reuse any upstream test file.
+
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+# Many stripes so parallel workers have distinct work to claim.
+make_pair "id int, k int, v bigint, t text"
+q "SELECT columnar.alter_columnar_table_set('t_col', chunk_group_row_limit => 1000, stripe_row_limit => 2000);" >/dev/null
+load_pair "SELECT g, g%100, g::bigint*2, 'r'||g FROM generate_series(1,50000) g"
+
+setg() { q "ALTER DATABASE $PGC_DB SET $1 = $2;" >/dev/null; }
+
+# Force parallelism.
+setg max_parallel_workers_per_gather 4
+setg parallel_setup_cost 0
+setg parallel_tuple_cost 0
+setg min_parallel_table_scan_size 0
+
+# A row-returning scan should plan a Gather over a parallel ColumnarScan.
+plan="$(q "EXPLAIN (COSTS off) SELECT id, v FROM t_col WHERE k = 5;")"
+check "parallel plan has Gather"        "$(echo "$plan" | grep -c -i 'Gather')" "1"
+check "parallel plan has ColumnarScan"  "$(echo "$plan" | grep -c -i 'ColumnarScan')" "1"
+
+# Results must match the heap oracle under the parallel plan.
+diff_query "par filtered scan"  "SELECT id, v, t FROM %T WHERE k = 7"
+diff_query "par range scan"     "SELECT id FROM %T WHERE k < 30"
+diff_query "par whole sample"   "SELECT * FROM %T WHERE id % 997 = 0"
+diff_query "par count"          "SELECT count(*), sum(v) FROM %T WHERE k < 50"
+diff_query "par no-filter"      "SELECT count(*) FROM %T"
+
+# The same queries, forced serial, must give the same answers.
+setg max_parallel_workers_per_gather 0
+diff_query "serial filtered scan" "SELECT id, v, t FROM %T WHERE k = 7"
+diff_query "serial range scan"    "SELECT id FROM %T WHERE k < 30"
+diff_query "serial count"         "SELECT count(*), sum(v) FROM %T WHERE k < 50"
+
+q "ALTER DATABASE $PGC_DB RESET ALL;" >/dev/null
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -24,7 +24,7 @@ set -uo pipefail
 
 SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUITES=(smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
-	differential recovery fuzz hardening concurrent_diff)
+	differential recovery fuzz hardening concurrent_diff parallel)
 
 # Default matrix: one assert-enabled pg_config per major, 13 through 19.
 DEFAULT_CONFIGS=(


### PR DESCRIPTION
Stacked on the gap-22 PR. Implements design/gaps/23.

The custom scan is now **parallel-aware**: a parallel-aware partial custom path lets the planner Gather over workers that each claim distinct stripes from a shared atomic counter in the scan's DSM segment. `columnar_next_stripe_index` claims from the atomic when parallel (both the vector and scalar read loops use it); the DSM callbacks size/share the counter and point the read state at it. The leader flushes pending writes before workers launch, preserving read-your-writes. Row-mask, min/max + bloom skipping, projection, late materialization, and encodings all work per read state.

Tests: `test/parallel.sh` forces a parallel plan (asserts Gather over ColumnarScan) and checks results equal the heap oracle both parallel and serial; wired into the matrix. Green on pg13/pg17/pg19 (differential 222, parallel 10, phase5/6, fuzz).

🤖 Generated with [Claude Code](https://claude.com/claude-code)