### PR TITLE
Gap 26 (piece 1): sorted single-projection via columnar.vacuum_sorted

### DIFF
--- a/columnar--1.0.sql
+++ b/columnar--1.0.sql
@@ -348,6 +348,16 @@ CREATE FUNCTION columnar.vacuum(tablename regclass, stripe_count int DEFAULT 0)
 COMMENT ON FUNCTION columnar.vacuum(regclass, int)
 	IS 'compact a columnar table by combining stripes and reclaiming deleted rows';
 
+CREATE FUNCTION columnar.vacuum_sorted(
+	tablename regclass,
+	VARIADIC sort_columns name[])
+	RETURNS void
+	LANGUAGE C
+	AS 'MODULE_PATHNAME', 'columnar_vacuum_sorted';
+
+COMMENT ON FUNCTION columnar.vacuum_sorted(regclass, name[])
+	IS 'compact a columnar table, storing rows sorted ascending on the given columns';
+
 CREATE FUNCTION columnar.vacuum_full(
 	schema name DEFAULT 'public',
 	sleep_time real DEFAULT 0.0,

--- a/design/gaps/26-IMPL-sorted-projection.md
+++ b/design/gaps/26-IMPL-sorted-projection.md
@@ -1,0 +1,89 @@
+# Gap 26 — first slice implementation plan: sorted single-projection
+
+Implements piece (1) of [26-projections-pax.md](26-projections-pax.md): store a
+columnar table physically sorted on a chosen key, via a sorting rewrite in the
+existing vacuum path. **No on-disk format change, no planner change, no new
+catalog.** This is a one-shot physical reorder (like `CLUSTER`): it is not
+auto-maintained; rows inserted after the sort append in insert order until the
+next sort.
+
+## Why this is contained
+
+`columnar_compact_relation()` (src/columnar_vacuum.c) already does a full-relation
+rewrite: read every live row into a tuplestore → swap to a fresh relfilenode →
+write rows back → reindex. Sorting is a drop-in swap of the tuplestore for a
+`tuplesort` keyed on the chosen columns. Once rows are stored sorted, min/max
+chunk-group skipping and the RLE/DELTA encodings on the sort key improve for free
+— no reader/planner changes.
+
+## SQL surface
+
+```
+columnar.vacuum_sorted(tablename regclass, VARIADIC sort_columns name[])
+```
+- Sorts ascending, NULLS LAST (PG default for ASC) on the given columns, in order.
+- Errors if: relation is not columnar; no sort columns given; a name is not a
+  column of the table; a column's type has no default btree ordering (no `<`).
+- Otherwise identical semantics/guarantees to `columnar.vacuum` (transactional
+  relfilenode swap, deleted rows reclaimed, indexes rebuilt).
+- DESC / NULLS FIRST deferred to a later slice (keep the first cut minimal).
+
+## C changes
+
+- Refactor `columnar_compact_relation(Relation rel)` →
+  `columnar_compact_relation(Relation rel, int nsortkeys, AttrNumber *sortAtts)`.
+  - `nsortkeys == 0`: current tuplestore path (plain vacuum) — unchanged behavior.
+  - `nsortkeys > 0`: use `tuplesort_begin_heap` with per-key `<` operator
+    (`lookup_type_cache(atttypid, TYPECACHE_LT_OPR)`, error if `lt_opr` invalid),
+    the attribute collation, nullsFirst=false; `tuplesort_puttupleslot` each row;
+    `tuplesort_performsort`; `tuplesort_gettupleslot` to write back in order.
+- New `PG_FUNCTION_INFO_V1(columnar_vacuum_sorted)` entry point: resolve column
+  names → attnums (reject system/dropped/absent), then call the refactored
+  compactor with the sort keys. `columnar_vacuum` calls it with `nsortkeys=0`.
+- Add tuplesort include (`utils/tuplesort.h`) and typcache include.
+
+## Version portability (PG13–19)
+
+`tuplesort_begin_heap`'s final argument changed at PG16: `bool randomAccess`
+(≤15) → `int sortopt` (≥16, use `TUPLESORT_NONE`). Add a compat macro in
+`columnar_compat.h`:
+```
+#if PG_VERSION_NUM >= 160000
+#define COLUMNAR_TUPLESORT_NONACCESS TUPLESORT_NONE
+#else
+#define COLUMNAR_TUPLESORT_NONACCESS false
+#endif
+```
+`tuplesort_puttupleslot` / `performsort` / `gettupleslot` / `end` are stable
+across 13–19.
+
+## SQL install
+
+Add the function to `columnar--1.0.sql` next to `columnar.vacuum`, with a COMMENT.
+No format/catalog change, so no new upgrade script and no metapage/version bump.
+
+## Testing (differential oracle — results must be identical to a heap)
+
+New `test/sorted_projection.sh`, added to `test/run_all_versions.sh` SUITES:
+1. **Correctness / invariance**: build a columnar table + heap mirror; run a
+   battery of query shapes (range, equality, ORDER BY, aggregates, `*`) and
+   compare order-independent result hashes **before and after**
+   `vacuum_sorted` — sorting must never change results.
+2. **Physical effect**: after sorting on a scattered column, a narrow range
+   predicate on the sort key skips strictly more chunk groups than before
+   (assert `Chunk Groups Removed by Filter` increases) — proves the reorder took
+   effect. Use `sum()`/filtered `count(*)` so the scan actually runs (the
+   covering-count path answers unfiltered `count(*)` from metadata; see phase5).
+3. **Reclaim + index**: delete a fraction, `vacuum_sorted`, verify live count,
+   sum, a point value, and an index lookup are all correct (row renumbering +
+   reindex).
+4. **Errors**: non-columnar relation; unknown column; no columns; a
+   non-btree-sortable column type.
+5. Idempotence: running `vacuum_sorted` twice yields identical results.
+
+Run the fixed full matrix (PG13–19) green before committing/PR.
+
+## Out of scope (later slices)
+
+Persisted sort key / auto-maintenance, DESC/NULLS FIRST, multiple projections
+(piece 2, format 2.2), planner projection selection.

--- a/design/gaps/README.md
+++ b/design/gaps/README.md
@@ -19,7 +19,7 @@ matrix on PostgreSQL 13-19.
 | [28](28-index-only-visibility-map.md) | Index-only scans via a visibility map | SLICE: covering count(*) (PR #15); full scan deferred |
 | [21](21-native-compressed-execution.md) | Native compressed execution on packed bytes | SUBSUMED by I3 |
 | [24](24-explicit-simd-kernels.md) | Explicit SIMD kernels | DEFERRED (auto-vectorized already) |
-| [26](26-projections-pax.md) | Projections / PAX layout | SPECED (very large project) |
+| [26](26-projections-pax.md) | Projections / PAX layout | PIECE 1 IMPLEMENTED (sorted single-projection: `columnar.vacuum_sorted`, see [26-IMPL](26-IMPL-sorted-projection.md)); multi-projection (piece 2) SPECED |
 | [27](27-arrow-parquet-interop.md) | Arrow/Parquet interop | SPECED (very large project) |
 
 Suggested order: 25, 21, 22, 24 (small/medium, self-contained), then 23

--- a/src/columnar_compat.h
+++ b/src/columnar_compat.h
@@ -316,4 +316,16 @@ ColumnarReindexRelation(Oid relid, int flags)
 #define PageSetChecksumInplace(page, blkno) PageSetChecksum((page), (blkno))
 #endif
 
+/* -------------------------------------------------------------------------
+ * tuplesort_begin_heap()'s final argument was a bool randomAccess through
+ * PG15; PG16 replaced it with an int sortopt bitmask. We never need random
+ * access to the sorted output (we read it once, forward), so pass the
+ * "no special options" value under both spellings.
+ * ------------------------------------------------------------------------- */
+#if PG_VERSION_NUM >= 160000
+#define COLUMNAR_TUPLESORT_NONACCESS TUPLESORT_NONE
+#else
+#define COLUMNAR_TUPLESORT_NONACCESS false
+#endif
+
 #endif							/* COLUMNAR_COMPAT_H */

--- a/src/columnar_vacuum.c
+++ b/src/columnar_vacuum.c
@@ -29,14 +29,19 @@
 #include "executor/tuptable.h"
 #include "miscadmin.h"
 #include "storage/lockdefs.h"
+#include "utils/array.h"
 #include "utils/builtins.h"
+#include "utils/lsyscache.h"
 #include "utils/relcache.h"
 #include "utils/rel.h"
 #include "utils/snapmgr.h"
+#include "utils/tuplesort.h"
 #include "utils/tuplestore.h"
+#include "utils/typcache.h"
 
 PG_FUNCTION_INFO_V1(columnar_relation_storageid);
 PG_FUNCTION_INFO_V1(columnar_vacuum);
+PG_FUNCTION_INFO_V1(columnar_vacuum_sorted);
 
 /*
  * columnar_relation_storageid
@@ -74,9 +79,16 @@ columnar_relation_storageid(PG_FUNCTION_ARGS)
  * columnar_compact_relation
  *		Rewrite every live row of a columnar relation into fresh stripes. The
  *		relation is already open with AccessExclusiveLock.
+ *
+ *		When nsortkeys == 0 the rows are rewritten in their existing order
+ *		(plain compaction). When nsortkeys > 0 the live rows are first sorted
+ *		ascending / NULLS LAST on the attributes in sortAtts[] (in order), so
+ *		the table is stored physically sorted on that key (gap 26, piece 1).
+ *		Sorting is a one-shot physical reorder; it is not persisted or
+ *		auto-maintained, so rows inserted afterward append in insert order.
  */
 static void
-columnar_compact_relation(Relation rel)
+columnar_compact_relation(Relation rel, int nsortkeys, AttrNumber *sortAtts)
 {
 	Oid			relid = RelationGetRelid(rel);
 	TupleDesc	tupdesc = RelationGetDescr(rel);
@@ -84,7 +96,8 @@ columnar_compact_relation(Relation rel)
 	Snapshot	snapshot;
 	ColumnarReadState *readState;
 	ColumnarWriteState *writeState;
-	Tuplestorestate *tstore;
+	Tuplestorestate *tstore = NULL;
+	Tuplesortstate *tsort = NULL;
 	TupleTableSlot *readSlot;
 	TupleTableSlot *writeSlot;
 	uint64		rowNumber;
@@ -99,12 +112,46 @@ columnar_compact_relation(Relation rel)
 
 	/*
 	 * Read every live row (the reader skips row-mask-deleted rows) and
-	 * materialize it into a tuplestore, copying values out of the scan so they
-	 * survive the storage swap below. A virtual slot receives the reader's
-	 * values; the tuplestore stores minimal tuples, so a separate minimal-tuple
-	 * slot is used to read them back.
+	 * materialize it, copying values out of the scan so they survive the
+	 * storage swap below. A virtual slot receives the reader's values. Without a
+	 * sort key the rows go into a tuplestore in read order; with a sort key they
+	 * go into a tuplesort so they come back ordered. Either way a minimal-tuple
+	 * slot reads them back.
 	 */
-	tstore = tuplestore_begin_heap(false, false, work_mem);
+	if (nsortkeys > 0)
+	{
+		Oid		   *sortOps = palloc(nsortkeys * sizeof(Oid));
+		Oid		   *sortColls = palloc(nsortkeys * sizeof(Oid));
+		bool	   *nullsFirst = palloc0(nsortkeys * sizeof(bool));
+		int			i;
+
+		for (i = 0; i < nsortkeys; i++)
+		{
+			Form_pg_attribute att = TupleDescAttr(tupdesc, sortAtts[i] - 1);
+			TypeCacheEntry *tce = lookup_type_cache(att->atttypid,
+													TYPECACHE_LT_OPR);
+
+			if (!OidIsValid(tce->lt_opr))
+				ereport(ERROR,
+						(errcode(ERRCODE_UNDEFINED_FUNCTION),
+						 errmsg("column \"%s\" of type %s has no default ordering operator",
+								NameStr(att->attname),
+								format_type_be(att->atttypid)),
+						 errhint("Sorting requires a type with a default btree operator class.")));
+
+			sortOps[i] = tce->lt_opr;
+			sortColls[i] = att->attcollation;
+			/* ascending, NULLS LAST (PostgreSQL's default for ASC) */
+			nullsFirst[i] = false;
+		}
+
+		tsort = tuplesort_begin_heap(tupdesc, nsortkeys, sortAtts, sortOps,
+									 sortColls, nullsFirst, maintenance_work_mem,
+									 NULL, COLUMNAR_TUPLESORT_NONACCESS);
+	}
+	else
+		tstore = tuplestore_begin_heap(false, false, work_mem);
+
 	readSlot = MakeSingleTupleTableSlot(tupdesc, &TTSOpsVirtual);
 	writeSlot = MakeSingleTupleTableSlot(tupdesc, &TTSOpsMinimalTuple);
 
@@ -114,11 +161,17 @@ columnar_compact_relation(Relation rel)
 	{
 		CHECK_FOR_INTERRUPTS();
 		ExecStoreVirtualTuple(readSlot);
-		tuplestore_puttupleslot(tstore, readSlot);
+		if (tsort != NULL)
+			tuplesort_puttupleslot(tsort, readSlot);
+		else
+			tuplestore_puttupleslot(tstore, readSlot);
 		ExecClearTuple(readSlot);
 	}
 	ColumnarEndRead(readState);
 	ExecDropSingleTupleTableSlot(readSlot);
+
+	if (tsort != NULL)
+		tuplesort_performsort(tsort);
 
 	/*
 	 * Swap to a brand-new relfilenode. This creates fresh, empty columnar
@@ -130,19 +183,36 @@ columnar_compact_relation(Relation rel)
 	ColumnarForgetWriteStateForRelation(relid);
 	ColumnarDeleteMetadata(oldStorageId);
 
-	/* write the live rows back into the fresh storage */
+	/* write the live rows back into the fresh storage, in sorted order if any */
 	writeState = ColumnarGetWriteState(rel);
-	while (tuplestore_gettupleslot(tstore, true, false, writeSlot))
+	if (tsort != NULL)
 	{
-		CHECK_FOR_INTERRUPTS();
-		slot_getallattrs(writeSlot);
-		(void) ColumnarWriteRow(writeState, rel, writeSlot->tts_values,
-								writeSlot->tts_isnull);
-		ExecClearTuple(writeSlot);
+		while (tuplesort_gettupleslot(tsort, true, false, writeSlot, NULL))
+		{
+			CHECK_FOR_INTERRUPTS();
+			slot_getallattrs(writeSlot);
+			(void) ColumnarWriteRow(writeState, rel, writeSlot->tts_values,
+									writeSlot->tts_isnull);
+			ExecClearTuple(writeSlot);
+		}
+	}
+	else
+	{
+		while (tuplestore_gettupleslot(tstore, true, false, writeSlot))
+		{
+			CHECK_FOR_INTERRUPTS();
+			slot_getallattrs(writeSlot);
+			(void) ColumnarWriteRow(writeState, rel, writeSlot->tts_values,
+									writeSlot->tts_isnull);
+			ExecClearTuple(writeSlot);
+		}
 	}
 	ColumnarFlushWriteStateForRelation(relid);
 
-	tuplestore_end(tstore);
+	if (tsort != NULL)
+		tuplesort_end(tsort);
+	else
+		tuplestore_end(tstore);
 	ExecDropSingleTupleTableSlot(writeSlot);
 
 	/*
@@ -179,7 +249,96 @@ columnar_vacuum(PG_FUNCTION_ARGS)
 						RelationGetRelationName(rel))));
 	}
 
-	columnar_compact_relation(rel);
+	columnar_compact_relation(rel, 0, NULL);
+
+	/* keep the lock until end of transaction */
+	table_close(rel, NoLock);
+
+	PG_RETURN_VOID();
+}
+
+/*
+ * columnar_vacuum_sorted
+ *		SQL: columnar.vacuum_sorted(tablename regclass, VARIADIC sort_columns name[]).
+ *		Like columnar.vacuum, but rewrites the live rows physically sorted
+ *		ascending / NULLS LAST on the named columns, in order (gap 26, piece 1).
+ *		Storing the table sorted on a key tightens per-chunk-group min/max ranges
+ *		and helps the RLE/DELTA encodings on that key, so range predicates and
+ *		ordered scans skip far more chunk groups. Results are unchanged; this only
+ *		reorders physical storage. It is a one-shot reorder (not auto-maintained).
+ */
+Datum
+columnar_vacuum_sorted(PG_FUNCTION_ARGS)
+{
+	Oid			relid = PG_GETARG_OID(0);
+	ArrayType  *colArray;
+	Datum	   *colDatums;
+	bool	   *colNulls;
+	int			ncols;
+	Relation	rel;
+	TupleDesc	tupdesc;
+	AttrNumber *sortAtts;
+	int			i;
+
+	if (PG_ARGISNULL(0))
+		ereport(ERROR,
+				(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+				 errmsg("table name cannot be null")));
+	if (PG_ARGISNULL(1))
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("at least one sort column is required")));
+
+	colArray = PG_GETARG_ARRAYTYPE_P(1);
+	deconstruct_array(colArray, NAMEOID, NAMEDATALEN, false, 'c',
+					  &colDatums, &colNulls, &ncols);
+	if (ncols < 1)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("at least one sort column is required")));
+
+	rel = table_open(relid, AccessExclusiveLock);
+
+	if (!ColumnarIsColumnarRelation(relid))
+	{
+		table_close(rel, AccessExclusiveLock);
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+				 errmsg("relation \"%s\" is not a columnar table",
+						RelationGetRelationName(rel))));
+	}
+
+	tupdesc = RelationGetDescr(rel);
+	sortAtts = palloc(ncols * sizeof(AttrNumber));
+
+	for (i = 0; i < ncols; i++)
+	{
+		char	   *colname;
+		AttrNumber	attno;
+
+		if (colNulls[i])
+		{
+			table_close(rel, AccessExclusiveLock);
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("sort column name cannot be null")));
+		}
+
+		colname = NameStr(*DatumGetName(colDatums[i]));
+		attno = get_attnum(relid, colname);
+		if (attno == InvalidAttrNumber || attno <= 0 ||
+			TupleDescAttr(tupdesc, attno - 1)->attisdropped)
+		{
+			table_close(rel, AccessExclusiveLock);
+			ereport(ERROR,
+					(errcode(ERRCODE_UNDEFINED_COLUMN),
+					 errmsg("column \"%s\" does not exist in table \"%s\"",
+							colname, RelationGetRelationName(rel))));
+		}
+		sortAtts[i] = attno;
+	}
+
+	columnar_compact_relation(rel, ncols, sortAtts);
 
 	/* keep the lock until end of transaction */
 	table_close(rel, NoLock);

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -24,7 +24,7 @@ set -uo pipefail
 
 SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUITES=(smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
-	differential recovery fuzz hardening concurrent_diff parallel)
+	differential recovery fuzz hardening concurrent_diff parallel sorted_projection)
 
 # Default matrix: one assert-enabled pg_config per major, 13 through 19.
 DEFAULT_CONFIGS=(

--- a/test/sorted_projection.sh
+++ b/test/sorted_projection.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# pgColumnar sorted single-projection suite (gap 26, piece 1).
+#
+# columnar.vacuum_sorted() rewrites a columnar table physically sorted on a
+# chosen key. This must never change query results (verified against a heap
+# oracle, order-independent), and it must actually reorder storage so that a
+# range predicate on the sort key skips more chunk groups than before. Also
+# checks deleted-row reclaim + index rebuild after the sorted rewrite, argument
+# validation, and idempotence.
+#
+# Usage:  test/sorted_projection.sh [PG_CONFIG]
+#
+# Written fresh for pgColumnar; it does not reuse any upstream test file.
+
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+# Number of chunk groups a filtered aggregate removes via min/max skipping.
+# sum() (not count(*)) is used so the scan actually runs -- an unfiltered
+# count(*) is answered from metadata and never scans (see test/phase5.sh).
+groups_removed() {
+	q "EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) $1" \
+		| grep -F 'Chunk Groups Removed by Filter' | grep -oE '[0-9]+$' | head -1
+}
+
+expect_error() {
+	local label="$1" sql="$2"
+	if psql_run "$sql" >/dev/null 2>&1; then
+		check "$label (expected error)" "succeeded" "error"
+	else
+		check "$label" "error" "error"
+	fi
+}
+
+# Many small chunk groups; the sort key k is scrambled relative to insert order
+# so that, before sorting, every group's [min,max] for k spans nearly the whole
+# domain and range skipping cannot prune. v is unique for aggregate checks.
+make_pair "id int, k int, v bigint, t text"
+q "SELECT columnar.alter_columnar_table_set('t_col', chunk_group_row_limit => 1000);" >/dev/null
+load_pair "SELECT g, ((g*7919)%1000), g::bigint*2, 'r'||g FROM generate_series(1,50000) g"
+
+# ---------------------------------------------------------------------------
+# Correctness is invariant under the sorted rewrite: identical to the heap
+# oracle both before and after vacuum_sorted, across query shapes.
+# ---------------------------------------------------------------------------
+echo "-- results identical to heap before sorting"
+diff_query "pre range"      "SELECT id, v, t FROM %T WHERE k BETWEEN 100 AND 120"
+diff_query "pre equality"   "SELECT id FROM %T WHERE k = 500"
+diff_query "pre order-by"   "SELECT k, v FROM %T ORDER BY k, v"
+diff_query "pre aggregate"  "SELECT k, count(*), sum(v) FROM %T GROUP BY k"
+diff_query "pre star"       "SELECT * FROM %T WHERE id % 997 = 0"
+
+removed_before="$(groups_removed "SELECT sum(v) FROM t_col WHERE k BETWEEN 100 AND 120")"
+
+echo "-- sort the columnar table on k"
+q "SELECT columnar.vacuum_sorted('t_col', 'k');" >/dev/null
+
+echo "-- results still identical to heap after sorting"
+diff_query "post range"     "SELECT id, v, t FROM %T WHERE k BETWEEN 100 AND 120"
+diff_query "post equality"  "SELECT id FROM %T WHERE k = 500"
+diff_query "post order-by"  "SELECT k, v FROM %T ORDER BY k, v"
+diff_query "post aggregate" "SELECT k, count(*), sum(v) FROM %T GROUP BY k"
+diff_query "post star"      "SELECT * FROM %T WHERE id % 997 = 0"
+
+# ---------------------------------------------------------------------------
+# The reorder took physical effect: a narrow range on the sort key now prunes
+# strictly more chunk groups than before.
+# ---------------------------------------------------------------------------
+echo "-- sorting improves chunk-group skipping on the sort key"
+removed_after="$(groups_removed "SELECT sum(v) FROM t_col WHERE k BETWEEN 100 AND 120")"
+check "pre-sort prunes little" "$removed_before" "0"
+if [ "${removed_after:-0}" -gt "$removed_before" ]; then
+	check "post-sort prunes more chunk groups" "more" "more"
+else
+	check "post-sort prunes more chunk groups" "removed_before=$removed_before removed_after=$removed_after" "more"
+fi
+
+# ---------------------------------------------------------------------------
+# Multi-column sort key, then reclaim + index rebuild after a sorted rewrite.
+# ---------------------------------------------------------------------------
+echo "-- multi-column sort key stays correct"
+q "SELECT columnar.vacuum_sorted('t_col', 'k', 'v');" >/dev/null
+diff_query "multi-key range" "SELECT id, v FROM %T WHERE k BETWEEN 100 AND 120"
+
+echo "-- reclaim and index rebuild after sorted rewrite"
+q "CREATE INDEX t_col_id_idx ON t_col (id);" >/dev/null
+psql_run "DELETE FROM t_heap WHERE id % 2 = 0;" >/dev/null
+psql_run "DELETE FROM t_col  WHERE id % 2 = 0;" >/dev/null
+q "SELECT columnar.vacuum_sorted('t_col', 'k');" >/dev/null
+check "live count after delete+sort" "$(q "SELECT count(*) FROM t_col;")" "25000"
+diff_query "count matches heap"  "SELECT count(*) FROM %T"
+diff_query "sum matches heap"    "SELECT sum(v) FROM %T"
+# SET prints its own command tag; the scalar value is the last line.
+check "index point lookup after sort" \
+	"$(q "SET enable_seqscan=off; SELECT t FROM t_col WHERE id = 4999;" | tail -1)" "r4999"
+check "index sees deletion after sort" \
+	"$(q "SET enable_seqscan=off; SELECT count(*) FROM t_col WHERE id = 5000;" | tail -1)" "0"
+
+# ---------------------------------------------------------------------------
+# Idempotence: sorting an already-sorted table changes nothing observable.
+# ---------------------------------------------------------------------------
+echo "-- idempotent"
+h1="$(pgc_set_hash "SELECT * FROM t_col")"
+q "SELECT columnar.vacuum_sorted('t_col', 'k');" >/dev/null
+h2="$(pgc_set_hash "SELECT * FROM t_col")"
+check "idempotent sorted rewrite" "$h2" "$h1"
+
+# ---------------------------------------------------------------------------
+# Argument validation.
+# ---------------------------------------------------------------------------
+echo "-- argument validation"
+expect_error "reject non-columnar table"   "SELECT columnar.vacuum_sorted('t_heap', 'k');"
+expect_error "reject unknown column"        "SELECT columnar.vacuum_sorted('t_col', 'nope');"
+expect_error "reject no sort columns"       "SELECT columnar.vacuum_sorted('t_col');"
+q "DROP TABLE IF EXISTS t_js;" >/dev/null
+q "CREATE TABLE t_js (a int, j json) USING columnar;" >/dev/null
+q "INSERT INTO t_js SELECT g, '{}'::json FROM generate_series(1,10) g;" >/dev/null
+expect_error "reject non-sortable type"     "SELECT columnar.vacuum_sorted('t_js', 'j');"
+
+pgc_summary


### PR DESCRIPTION
## What

Adds `columnar.vacuum_sorted(table regclass, VARIADIC sort_columns name[])` — a vacuum-path rewrite that stores a columnar table physically **sorted** on a chosen key.

Storing rows sorted on a key tightens per-chunk-group min/max ranges and helps the RLE/DELTA encodings on that key, so range predicates and ordered scans prune far more chunk groups — most of the C-Store *projection* benefit with:
- **no on-disk format change**
- **no new catalog**
- **no planner change**

It is a one-shot physical reorder (like `CLUSTER`), not auto-maintained: rows inserted afterward append in insert order until the next sort.

This is **piece 1** of [design/gaps/26-projections-pax.md](design/gaps/26-projections-pax.md); multiple-projection support (piece 2, format 2.2) remains specced.

## How

Reuses the existing full-relation compaction in `columnar_compact_relation()`: the live rows go through a `tuplesort` (keyed on the chosen attributes, using each type's default btree `<` operator and the column collation, NULLS LAST) instead of a `tuplestore`, then are written back into fresh storage and indexes are rebuilt. `nsortkeys == 0` keeps the original plain-vacuum path unchanged.

`tuplesort_begin_heap()`'s final argument changed from `bool randomAccess` (≤PG15) to `int sortopt` (≥PG16); handled with a `COLUMNAR_TUPLESORT_NONACCESS` compat macro.

Rejects: non-columnar relation, unknown column, zero sort columns, and column types with no default btree ordering.

## Testing

New differential suite `test/sorted_projection.sh` (added to the version matrix):
- results identical to a heap oracle **before and after** sorting, across range/equality/order-by/aggregate/`*` shapes;
- the reorder **measurably increases** chunk-group skipping on the sort key;
- reclaim + index rebuild after a sorted rewrite (count/sum/point/index all correct);
- idempotence;
- argument validation (non-columnar, unknown column, no columns, non-sortable type).

**Full matrix PG13–19, all 16 suites, zero failures.**

Implementation plan: `design/gaps/26-IMPL-sorted-projection.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)