### PR TITLE
Gap 27 (piece 2): Parquet export

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ OBJS = \
 	src/columnar_vector.o \
 	src/columnar_vacuum.o \
 	src/columnar_unique.o \
-	src/columnar_arrow.o
+	src/columnar_arrow.o \
+	src/columnar_parquet.o
 
 EXTENSION = columnar
 DATA = columnar--1.0.sql

--- a/columnar--1.0.sql
+++ b/columnar--1.0.sql
@@ -366,6 +366,14 @@ CREATE FUNCTION columnar.export_arrow(rel regclass, path text)
 COMMENT ON FUNCTION columnar.export_arrow(regclass, text)
 	IS 'export a columnar table to an Arrow IPC stream file; returns rows written';
 
+CREATE FUNCTION columnar.export_parquet(rel regclass, path text)
+	RETURNS bigint
+	LANGUAGE C
+	AS 'MODULE_PATHNAME', 'columnar_export_parquet';
+
+COMMENT ON FUNCTION columnar.export_parquet(regclass, text)
+	IS 'export a columnar table to a Parquet file; returns rows written';
+
 CREATE FUNCTION columnar.vacuum_full(
 	schema name DEFAULT 'public',
 	sleep_time real DEFAULT 0.0,

--- a/design/gaps/27-IMPL-parquet-export.md
+++ b/design/gaps/27-IMPL-parquet-export.md
@@ -1,0 +1,77 @@
+# Gap 27 — second slice implementation plan: Parquet export
+
+Adds `columnar.export_parquet(rel regclass, path text) -> bigint`, a
+self-contained Parquet file writer (no libparquet dependency). Verified with the
+DuckDB CLI (`read_parquet`, built in) and pyarrow, both against a heap oracle.
+
+## File layout
+
+```
+"PAR1"
+<data page per column, per row group>
+<FileMetaData (Thrift compact protocol)>
+<footer length: int32 LE>
+"PAR1"
+```
+
+One row group per PARQUET_ROWGROUP_ROWS (65536) rows. Within a row group, one
+column chunk per column, each a single DataPage v1:
+`[def levels: int32 LE length + RLE/bit-packed hybrid][values: PLAIN]`,
+UNCOMPRESSED.
+
+All columns are declared OPTIONAL (max definition level 1); a def level of 1
+means present, 0 means null. PLAIN values are written for non-null rows only.
+
+## Type mapping (first slice, matches export_arrow)
+
+| PG type | Parquet physical | converted/logical |
+| --- | --- | --- |
+| int2 | INT32 | INT_16 |
+| int4 | INT32 | (none) |
+| int8 | INT64 | (none) |
+| float4 | FLOAT | (none) |
+| float8 | DOUBLE | (none) |
+| bool | BOOLEAN | (none) |
+| text, varchar | BYTE_ARRAY | UTF8 |
+| bytea | BYTE_ARRAY | (none) |
+
+Other types rejected with a column/type error. Little-endian hosts only.
+Superuser only (server-side file write).
+
+## Encodings
+
+- PLAIN: INT32/INT64/FLOAT/DOUBLE little-endian fixed width; BOOLEAN bit-packed
+  LSB-first; BYTE_ARRAY as int32 LE length + bytes. Non-null values only.
+- Definition levels: RLE/bit-packed hybrid, bit width 1, written as one
+  bit-packed run (num_groups = ceil(nrows/8)); section prefixed with its int32 LE
+  byte length (DataPage v1 convention).
+
+## Thrift compact protocol
+
+Minimal writer: field header (delta id + compact type nibble; long form when
+delta > 15 or 0), zigzag varint for i16/i32/i64, binary/string (varint len +
+bytes), list header (size<<4 | elem type, long form when size >= 15), bool-as-
+field-type, struct stop 0x00. Structures emitted: FileMetaData, SchemaElement,
+RowGroup, ColumnChunk, ColumnMetaData, PageHeader, DataPageHeader.
+
+## Files / build
+
+New `src/columnar_parquet.c` (+ `src/columnar_parquet.o` in Makefile) and the SQL
+function in `columnar--1.0.sql`. Row read loop mirrors export_arrow
+(ColumnarReadNextRow, physical order, one row group flushed per
+PARQUET_ROWGROUP_ROWS).
+
+## Testing
+
+`test/parquet_export.sh` (added to the matrix, gated on the DuckDB CLI):
+export a mixed-type table mirroring a heap table (NULLs, int boundaries, NaN/Inf,
+empty/unicode text, bytea; > one row group), then for every column compare
+`read_parquet` output to the heap oracle (order-independent set hash per the
+existing differential harness). If pyarrow is present, also assert the Parquet
+schema types. Empty table and error cases (non-columnar, unsupported type).
+Full matrix PG13-19.
+
+## Out of scope
+
+Compression (UNCOMPRESSED only), dictionary/RLE value encodings, statistics,
+row-group size tuning, nested types, import, additional PG types.

--- a/src/columnar_parquet.c
+++ b/src/columnar_parquet.c
@@ -1,0 +1,650 @@
+/*-------------------------------------------------------------------------
+ *
+ * columnar_parquet.c
+ *		Parquet file export for pgColumnar (gap 27, piece 2).
+ *
+ *		columnar.export_parquet(rel regclass, path text) writes a columnar table
+ *		to a Parquet file. The writer is self-contained -- it emits the Thrift
+ *		compact-protocol metadata and PLAIN-encoded, UNCOMPRESSED data pages
+ *		directly -- so there is no libparquet build or run-time dependency. Rows
+ *		are read in physical order via the scalar reader; one row group is
+ *		emitted per PARQUET_ROWGROUP_ROWS rows, with one DATA_PAGE per column.
+ *
+ *		First-slice type mapping (matches columnar.export_arrow): int2/int4 ->
+ *		INT32 (int2 tagged INT_16), int8 -> INT64, float4 -> FLOAT, float8 ->
+ *		DOUBLE, bool -> BOOLEAN, text/varchar -> BYTE_ARRAY (UTF8), bytea ->
+ *		BYTE_ARRAY. All columns are OPTIONAL; nulls are carried in definition
+ *		levels. Little-endian hosts only.
+ *
+ * Independent MIT implementation built from the Apache Parquet format and
+ * Thrift compact-protocol specifications and the public PostgreSQL API only.
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "columnar.h"
+
+#include "fmgr.h"
+#include "access/relation.h"
+#include "access/table.h"
+#include "catalog/pg_type.h"
+#include "lib/stringinfo.h"
+#include "miscadmin.h"
+#include "storage/fd.h"
+#include "utils/builtins.h"
+#include "utils/memutils.h"
+#include "utils/rel.h"
+#include "utils/snapmgr.h"
+
+PG_FUNCTION_INFO_V1(columnar_export_parquet);
+
+#define PARQUET_ROWGROUP_ROWS 65536
+
+/* Parquet physical types */
+#define PQ_BOOLEAN		0
+#define PQ_INT32		1
+#define PQ_INT64		2
+#define PQ_FLOAT		4
+#define PQ_DOUBLE		5
+#define PQ_BYTE_ARRAY	6
+/* ConvertedType */
+#define PQ_CT_UTF8		0
+#define PQ_CT_INT_16	16
+/* Encoding */
+#define PQ_ENC_PLAIN	0
+#define PQ_ENC_RLE		3
+/* Thrift compact field types */
+#define TC_STOP			0
+#define TC_BOOL_TRUE	1
+#define TC_BOOL_FALSE	2
+#define TC_I32			5
+#define TC_I64			6
+#define TC_BINARY		8
+#define TC_LIST			9
+#define TC_STRUCT		12
+
+typedef enum ParquetKind
+{
+	P_INT16,
+	P_INT32,
+	P_INT64,
+	P_FLOAT,
+	P_DOUBLE,
+	P_BOOL,
+	P_UTF8,
+	P_BINARY
+}			ParquetKind;
+
+/* ---- Thrift compact-protocol writer (into a StringInfo) ---- */
+
+static void
+tc_varint(StringInfo b, uint64 v)
+{
+	while (v >= 0x80)
+	{
+		appendStringInfoChar(b, (char) ((v & 0x7f) | 0x80));
+		v >>= 7;
+	}
+	appendStringInfoChar(b, (char) v);
+}
+
+static void
+tc_zigzag32(StringInfo b, int32 v)
+{
+	tc_varint(b, (uint32) ((v << 1) ^ (v >> 31)));
+}
+
+static void
+tc_zigzag64(StringInfo b, int64 v)
+{
+	tc_varint(b, (uint64) ((v << 1) ^ (v >> 63)));
+}
+
+/* field header with delta-encoded id */
+static void
+tc_field(StringInfo b, int16 *lastId, int16 id, int type)
+{
+	int			delta = id - *lastId;
+
+	if (delta > 0 && delta <= 15)
+		appendStringInfoChar(b, (char) ((delta << 4) | type));
+	else
+	{
+		appendStringInfoChar(b, (char) type);
+		tc_zigzag32(b, id);
+	}
+	*lastId = id;
+}
+
+static void
+tc_i32_field(StringInfo b, int16 *lastId, int16 id, int32 v)
+{
+	tc_field(b, lastId, id, TC_I32);
+	tc_zigzag32(b, v);
+}
+
+static void
+tc_i64_field(StringInfo b, int16 *lastId, int16 id, int64 v)
+{
+	tc_field(b, lastId, id, TC_I64);
+	tc_zigzag64(b, v);
+}
+
+static void
+tc_string_field(StringInfo b, int16 *lastId, int16 id, const char *s, int len)
+{
+	tc_field(b, lastId, id, TC_BINARY);
+	tc_varint(b, (uint64) len);
+	if (len > 0)
+		appendBinaryStringInfo(b, s, len);
+}
+
+/* list header; caller then appends the elements */
+static void
+tc_list_header(StringInfo b, int size, int elemType)
+{
+	if (size < 15)
+		appendStringInfoChar(b, (char) ((size << 4) | elemType));
+	else
+	{
+		appendStringInfoChar(b, (char) (0xF0 | elemType));
+		tc_varint(b, (uint64) size);
+	}
+}
+
+static void
+tc_stop(StringInfo b)
+{
+	appendStringInfoChar(b, (char) TC_STOP);
+}
+
+/* ---- per-column accumulator for one row group ---- */
+typedef struct PqCol
+{
+	char	   *name;
+	ParquetKind kind;
+	int			ptype;			/* Parquet physical type */
+	int			convType;		/* ConvertedType, or -1 */
+	StringInfoData present;		/* 1 byte per row: 1 present, 0 null */
+	StringInfoData values;		/* PLAIN values, non-null only */
+	StringInfoData boolbits;	/* 1 byte per non-null bool value */
+	int64		numValues;		/* rows in the current group (incl nulls) */
+}			PqCol;
+
+typedef struct PqColMeta
+{
+	int64		dataPageOffset;
+	int64		totalSize;		/* page header + body */
+	int64		numValues;		/* rows */
+}			PqColMeta;
+
+typedef struct PqRowGroup
+{
+	PqColMeta  *cols;
+	int64		totalByteSize;
+	int64		numRows;
+}			PqRowGroup;
+
+static void
+pqcol_reset(PqCol *c)
+{
+	resetStringInfo(&c->present);
+	resetStringInfo(&c->values);
+	resetStringInfo(&c->boolbits);
+	c->numValues = 0;
+}
+
+static ParquetKind
+parquet_kind_for_type(Oid typid, int *ptype, int *convType)
+{
+	*convType = -1;
+	switch (typid)
+	{
+		case INT2OID:
+			*ptype = PQ_INT32;
+			*convType = PQ_CT_INT_16;
+			return P_INT16;
+		case INT4OID:
+			*ptype = PQ_INT32;
+			return P_INT32;
+		case INT8OID:
+			*ptype = PQ_INT64;
+			return P_INT64;
+		case FLOAT4OID:
+			*ptype = PQ_FLOAT;
+			return P_FLOAT;
+		case FLOAT8OID:
+			*ptype = PQ_DOUBLE;
+			return P_DOUBLE;
+		case BOOLOID:
+			*ptype = PQ_BOOLEAN;
+			return P_BOOL;
+		case TEXTOID:
+		case VARCHAROID:
+			*ptype = PQ_BYTE_ARRAY;
+			*convType = PQ_CT_UTF8;
+			return P_UTF8;
+		case BYTEAOID:
+			*ptype = PQ_BYTE_ARRAY;
+			return P_BINARY;
+		default:
+			*ptype = -1;
+			return P_INT32;
+	}
+}
+
+static void
+pqcol_append(PqCol *c, Datum d, bool isnull)
+{
+	c->numValues++;
+	appendStringInfoChar(&c->present, isnull ? 0 : 1);
+	if (isnull)
+		return;
+
+	switch (c->kind)
+	{
+		case P_INT16:
+			{
+				int32		v = (int32) DatumGetInt16(d);
+
+				appendBinaryStringInfo(&c->values, (char *) &v, 4);
+				break;
+			}
+		case P_INT32:
+			{
+				int32		v = DatumGetInt32(d);
+
+				appendBinaryStringInfo(&c->values, (char *) &v, 4);
+				break;
+			}
+		case P_INT64:
+			{
+				int64		v = DatumGetInt64(d);
+
+				appendBinaryStringInfo(&c->values, (char *) &v, 8);
+				break;
+			}
+		case P_FLOAT:
+			{
+				float4		v = DatumGetFloat4(d);
+
+				appendBinaryStringInfo(&c->values, (char *) &v, 4);
+				break;
+			}
+		case P_DOUBLE:
+			{
+				float8		v = DatumGetFloat8(d);
+
+				appendBinaryStringInfo(&c->values, (char *) &v, 8);
+				break;
+			}
+		case P_BOOL:
+			appendStringInfoChar(&c->boolbits, DatumGetBool(d) ? 1 : 0);
+			break;
+		case P_UTF8:
+		case P_BINARY:
+			{
+				struct varlena *v = PG_DETOAST_DATUM_PACKED(d);
+				int32		len = VARSIZE_ANY_EXHDR(v);
+
+				appendBinaryStringInfo(&c->values, (char *) &len, 4);
+				if (len > 0)
+					appendBinaryStringInfo(&c->values, VARDATA_ANY(v), len);
+				break;
+			}
+	}
+}
+
+/* build the RLE/bit-packed hybrid definition-level section (bit width 1),
+ * prefixed with its int32 LE byte length (DataPage v1 convention) */
+static void
+build_def_levels(StringInfo out, const char *present, int64 nrows)
+{
+	StringInfoData h;
+	int64		ngroups = (nrows + 7) / 8;
+	int64		g;
+	int32		len;
+
+	initStringInfo(&h);
+	/* one bit-packed run: header = (ngroups << 1) | 1 */
+	tc_varint(&h, (uint64) ((ngroups << 1) | 1));
+	for (g = 0; g < ngroups; g++)
+	{
+		uint8		byte = 0;
+		int			b;
+
+		for (b = 0; b < 8; b++)
+		{
+			int64		idx = g * 8 + b;
+
+			if (idx < nrows && present[idx])
+				byte |= (1 << b);
+		}
+		appendStringInfoChar(&h, (char) byte);
+	}
+	len = h.len;
+	appendBinaryStringInfo(out, (char *) &len, 4);
+	appendBinaryStringInfo(out, h.data, h.len);
+	pfree(h.data);
+}
+
+/* assemble the PLAIN values buffer for a column (from its accumulators) */
+static void
+build_values(StringInfo out, PqCol *c)
+{
+	if (c->kind == P_BOOL)
+	{
+		int64		n = c->boolbits.len;
+		int64		nbytes = (n + 7) / 8;
+		char	   *bits = palloc0(nbytes);
+		int64		i;
+
+		for (i = 0; i < n; i++)
+			if (c->boolbits.data[i])
+				bits[i >> 3] |= (1 << (i & 7));
+		appendBinaryStringInfo(out, bits, nbytes);
+		pfree(bits);
+	}
+	else
+		appendBinaryStringInfo(out, c->values.data, c->values.len);
+}
+
+/* write a DATA_PAGE PageHeader (Thrift) for a page of body_size bytes */
+static void
+write_page_header(StringInfo out, int64 nrows, int32 body_size)
+{
+	int16		last = 0;
+	int16		dlast = 0;
+
+	/* PageHeader */
+	tc_i32_field(out, &last, 1, 0);			/* type = DATA_PAGE */
+	tc_i32_field(out, &last, 2, body_size); /* uncompressed_page_size */
+	tc_i32_field(out, &last, 3, body_size); /* compressed_page_size */
+	/* field 5: data_page_header (struct) */
+	tc_field(out, &last, 5, TC_STRUCT);
+	tc_i32_field(out, &dlast, 1, (int32) nrows); /* num_values */
+	tc_i32_field(out, &dlast, 2, PQ_ENC_PLAIN);	/* encoding */
+	tc_i32_field(out, &dlast, 3, PQ_ENC_RLE);	/* def level encoding */
+	tc_i32_field(out, &dlast, 4, PQ_ENC_RLE);	/* rep level encoding */
+	tc_stop(out);								/* end data_page_header */
+	tc_stop(out);								/* end PageHeader */
+}
+
+/* ---- FileMetaData footer ---- */
+static void
+write_schema_element_root(StringInfo b, int ncols)
+{
+	int16		last = 0;
+
+	tc_string_field(b, &last, 4, "schema", 6);	/* name */
+	tc_i32_field(b, &last, 5, ncols);			/* num_children */
+	tc_stop(b);
+}
+
+static void
+write_schema_element_col(StringInfo b, PqCol *c)
+{
+	int16		last = 0;
+
+	tc_i32_field(b, &last, 1, c->ptype);	/* type */
+	tc_i32_field(b, &last, 3, 1);			/* repetition_type = OPTIONAL */
+	tc_string_field(b, &last, 4, c->name, (int) strlen(c->name));
+	if (c->convType >= 0)
+		tc_i32_field(b, &last, 6, c->convType); /* converted_type */
+	tc_stop(b);
+}
+
+static void
+write_column_chunk(StringInfo b, PqCol *c, PqColMeta *m)
+{
+	int16		last = 0;
+	int16		mlast = 0;
+
+	/* ColumnChunk.file_offset (2) */
+	tc_i64_field(b, &last, 2, m->dataPageOffset);
+	/* ColumnChunk.meta_data (3) = ColumnMetaData struct */
+	tc_field(b, &last, 3, TC_STRUCT);
+	tc_i32_field(b, &mlast, 1, c->ptype);	/* type */
+	/* encodings list [PLAIN, RLE] (2) */
+	tc_field(b, &mlast, 2, TC_LIST);
+	tc_list_header(b, 2, TC_I32);
+	tc_zigzag32(b, PQ_ENC_PLAIN);
+	tc_zigzag32(b, PQ_ENC_RLE);
+	/* path_in_schema list [name] (3) */
+	tc_field(b, &mlast, 3, TC_LIST);
+	tc_list_header(b, 1, TC_BINARY);
+	tc_varint(b, (uint64) strlen(c->name));
+	appendBinaryStringInfo(b, c->name, strlen(c->name));
+	tc_i32_field(b, &mlast, 4, 0);			/* codec = UNCOMPRESSED */
+	tc_i64_field(b, &mlast, 5, m->numValues);	/* num_values */
+	tc_i64_field(b, &mlast, 6, m->totalSize);	/* total_uncompressed_size */
+	tc_i64_field(b, &mlast, 7, m->totalSize);	/* total_compressed_size */
+	tc_i64_field(b, &mlast, 9, m->dataPageOffset);	/* data_page_offset */
+	tc_stop(b);								/* end ColumnMetaData */
+	tc_stop(b);								/* end ColumnChunk */
+}
+
+static void
+write_row_group(StringInfo b, PqCol *cols, int ncols, PqRowGroup *rg)
+{
+	int16		last = 0;
+	int			i;
+
+	/* columns list (1) */
+	tc_field(b, &last, 1, TC_LIST);
+	tc_list_header(b, ncols, TC_STRUCT);
+	for (i = 0; i < ncols; i++)
+		write_column_chunk(b, &cols[i], &rg->cols[i]);
+	tc_i64_field(b, &last, 2, rg->totalByteSize);	/* total_byte_size */
+	tc_i64_field(b, &last, 3, rg->numRows);			/* num_rows */
+	tc_stop(b);
+}
+
+/*
+ * columnar_export_parquet
+ *		SQL: columnar.export_parquet(rel regclass, path text) -> bigint.
+ */
+Datum
+columnar_export_parquet(PG_FUNCTION_ARGS)
+{
+	Oid			relid;
+	char	   *path;
+	Relation	rel;
+	TupleDesc	tupdesc;
+	int			ncols;
+	PqCol	   *cols;
+	Snapshot	snapshot;
+	ColumnarReadState *readState;
+	Datum	   *values;
+	bool	   *nulls;
+	uint64		rowNumber;
+	int64		total = 0;
+	int64		groupRows = 0;
+	int64		offset = 0;
+	FILE	   *f;
+	int			i;
+	PqRowGroup *rgs = NULL;
+	int			nrgs = 0;
+	int			rgCap = 0;
+	MemoryContext rgCtx = CurrentMemoryContext;
+
+	if (PG_ARGISNULL(0) || PG_ARGISNULL(1))
+		ereport(ERROR,
+				(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+				 errmsg("relation and path must not be null")));
+	if (!superuser())
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 errmsg("must be superuser to export to a server-side file")));
+
+	relid = PG_GETARG_OID(0);
+	path = text_to_cstring(PG_GETARG_TEXT_PP(1));
+
+	rel = table_open(relid, AccessShareLock);
+	if (!ColumnarIsColumnarRelation(relid))
+	{
+		table_close(rel, AccessShareLock);
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+				 errmsg("relation \"%s\" is not a columnar table",
+						RelationGetRelationName(rel))));
+	}
+
+	tupdesc = RelationGetDescr(rel);
+	ncols = tupdesc->natts;
+
+	cols = palloc0(sizeof(PqCol) * ncols);
+	for (i = 0; i < ncols; i++)
+	{
+		Form_pg_attribute att = TupleDescAttr(tupdesc, i);
+		int			ptype,
+					convType;
+		ParquetKind kind;
+
+		if (att->attisdropped)
+		{
+			table_close(rel, AccessShareLock);
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("columnar.export_parquet does not support dropped columns")));
+		}
+		kind = parquet_kind_for_type(att->atttypid, &ptype, &convType);
+		if (ptype < 0)
+		{
+			table_close(rel, AccessShareLock);
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("column \"%s\" has type %s, which columnar.export_parquet does not support",
+							NameStr(att->attname),
+							format_type_be(att->atttypid))));
+		}
+		cols[i].name = pstrdup(NameStr(att->attname));
+		cols[i].kind = kind;
+		cols[i].ptype = ptype;
+		cols[i].convType = convType;
+		initStringInfo(&cols[i].present);
+		initStringInfo(&cols[i].values);
+		initStringInfo(&cols[i].boolbits);
+	}
+
+	f = AllocateFile(path, PG_BINARY_W);
+	if (f == NULL)
+	{
+		table_close(rel, AccessShareLock);
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not open file \"%s\" for writing: %m", path)));
+	}
+
+	fwrite("PAR1", 1, 4, f);		/* magic header */
+	offset = 4;
+
+	values = palloc(sizeof(Datum) * ncols);
+	nulls = palloc(sizeof(bool) * ncols);
+
+	snapshot = ActiveSnapshotSet() ? GetActiveSnapshot() : GetTransactionSnapshot();
+	readState = ColumnarBeginRead(rel, snapshot, NULL, NULL, 0, NULL);
+
+	for (;;)
+	{
+		bool		got = ColumnarReadNextRow(readState, values, nulls, &rowNumber);
+
+		if (got)
+		{
+			CHECK_FOR_INTERRUPTS();
+			for (i = 0; i < ncols; i++)
+				pqcol_append(&cols[i], values[i], nulls[i]);
+			groupRows++;
+			total++;
+		}
+
+		/* flush a row group when full, or at end if it holds rows */
+		if ((groupRows == PARQUET_ROWGROUP_ROWS) || (!got && groupRows > 0))
+		{
+			PqRowGroup *rg;
+
+			if (nrgs == rgCap)
+			{
+				rgCap = rgCap ? rgCap * 2 : 8;
+				rgs = rgs ? repalloc(rgs, sizeof(PqRowGroup) * rgCap)
+					: palloc(sizeof(PqRowGroup) * rgCap);
+			}
+			rg = &rgs[nrgs++];
+			rg->cols = MemoryContextAlloc(rgCtx, sizeof(PqColMeta) * ncols);
+			rg->numRows = groupRows;
+			rg->totalByteSize = 0;
+
+			for (i = 0; i < ncols; i++)
+			{
+				StringInfoData body;
+				StringInfoData ph;
+				int64		pageStart = offset;
+
+				initStringInfo(&body);
+				build_def_levels(&body, cols[i].present.data, groupRows);
+				build_values(&body, &cols[i]);
+
+				initStringInfo(&ph);
+				write_page_header(&ph, groupRows, (int32) body.len);
+
+				fwrite(ph.data, 1, ph.len, f);
+				fwrite(body.data, 1, body.len, f);
+				offset += ph.len + body.len;
+
+				rg->cols[i].dataPageOffset = pageStart;
+				rg->cols[i].totalSize = ph.len + body.len;
+				rg->cols[i].numValues = groupRows;
+				rg->totalByteSize += ph.len + body.len;
+
+				pfree(body.data);
+				pfree(ph.data);
+				pqcol_reset(&cols[i]);
+			}
+			groupRows = 0;
+		}
+
+		if (!got)
+			break;
+	}
+	ColumnarEndRead(readState);
+
+	/* ---- FileMetaData footer ---- */
+	{
+		StringInfoData fmd;
+		int16		last = 0;
+		int32		footerLen;
+
+		initStringInfo(&fmd);
+		tc_i32_field(&fmd, &last, 1, 1);	/* version */
+		/* schema list (2): root + one per column */
+		tc_field(&fmd, &last, 2, TC_LIST);
+		tc_list_header(&fmd, ncols + 1, TC_STRUCT);
+		write_schema_element_root(&fmd, ncols);
+		for (i = 0; i < ncols; i++)
+			write_schema_element_col(&fmd, &cols[i]);
+		tc_i64_field(&fmd, &last, 3, total);	/* num_rows */
+		/* row_groups list (4) */
+		tc_field(&fmd, &last, 4, TC_LIST);
+		tc_list_header(&fmd, nrgs, TC_STRUCT);
+		for (i = 0; i < nrgs; i++)
+			write_row_group(&fmd, cols, ncols, &rgs[i]);
+		tc_string_field(&fmd, &last, 6, "pgColumnar", 10);	/* created_by */
+		tc_stop(&fmd);
+
+		fwrite(fmd.data, 1, fmd.len, f);
+		footerLen = fmd.len;
+		fwrite(&footerLen, 4, 1, f);	/* footer length, LE */
+		fwrite("PAR1", 1, 4, f);		/* magic footer */
+		pfree(fmd.data);
+	}
+
+	if (FreeFile(f) != 0)
+	{
+		table_close(rel, AccessShareLock);
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not write file \"%s\": %m", path)));
+	}
+
+	table_close(rel, AccessShareLock);
+	PG_RETURN_INT64(total);
+}

--- a/test/parquet_export.sh
+++ b/test/parquet_export.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+#
+# pgColumnar Parquet export suite (gap 27, piece 2).
+#
+# columnar.export_parquet(rel, path) writes a Parquet file. This suite exports a
+# mixed-type columnar table (NULLs, boundary integers, NaN/Inf floats,
+# empty/unicode text, bytea) that mirrors a heap table, reads it back, and
+# asserts every value equals the heap oracle. pyarrow provides exact typed
+# values for the comparison; if the DuckDB CLI is present it is used as a second
+# independent reader (row count and a sum). Also covers multiple row groups, an
+# empty table, and error cases.
+#
+# Requires pyarrow (python3-pyarrow); if it is not importable the suite skips
+# with a note.
+#
+# Usage:  test/parquet_export.sh [PG_CONFIG]
+#
+# Written fresh for pgColumnar; it does not reuse any upstream test file.
+
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+if ! python3 -c 'import pyarrow.parquet' 2>/dev/null; then
+	echo "-- pyarrow not available; skipping Parquet export verification"
+	pgc_summary
+	exit 0
+fi
+
+expect_error() {
+	local label="$1" sql="$2"
+	if psql_run "$sql" >/dev/null 2>&1; then
+		check "$label (expected error)" "succeeded" "error"
+	else
+		check "$label" "error" "error"
+	fi
+}
+
+PARQUET="$PGC_WORKDIR/t.parquet"
+PGCSV="$PGC_WORKDIR/pg.csv"
+
+# > PARQUET_ROWGROUP_ROWS (65536) rows to force multiple row groups, plus
+# explicit edge-case rows.
+make_pair "id int, a int2, b int4, c int8, d float4, e float8, f bool, g text, h bytea"
+load_pair "
+  SELECT s AS id, (s%30000-15000)::int2, s*2, s::int8*1000,
+         (s::float4/3), (s::float8/7), (s%2=0), 'r'||s,
+         decode(lpad(to_hex(s),6,'0'),'hex')
+  FROM generate_series(1,80000) s
+  UNION ALL VALUES
+   (100001, NULL::int2, NULL::int4, NULL::int8, NULL::float4, NULL::float8, NULL::bool, NULL::text, NULL::bytea),
+   (100002, (-32768)::int2, (-2147483648)::int4, (-9223372036854775808)::int8, '-Infinity'::float4, 'NaN'::float8, false, ''::text, '\\x'::bytea),
+   (100003, (32767)::int2, (2147483647)::int4, (9223372036854775807)::int8, 'Infinity'::float4, (3.14)::float8, true, 'unicode q'::text, '\\x00ff10'::bytea)
+"
+
+echo "-- export and verify against heap oracle via pyarrow"
+rows_written="$(q "SELECT columnar.export_parquet('t_col', '$PARQUET');")"
+check "export_parquet rows written" "$rows_written" "80003"
+
+psql_run "COPY (SELECT id, a, b, c, (d::float8), e, f, g, encode(h,'hex')
+                FROM t_heap ORDER BY id)
+          TO '$PGCSV' WITH (FORMAT csv, NULL E'\\\\N')"
+
+pyres="$(python3 - "$PARQUET" "$PGCSV" <<'PY'
+import sys, csv, math
+import pyarrow.parquet as pq
+tbl = pq.read_table(sys.argv[1])
+cols=['id','a','b','c','d','e','f','g','h']
+if tbl.schema.names != cols:
+    print("SCHEMA_NAMES_MISMATCH"); sys.exit(0)
+ad=tbl.to_pydict()
+ar={}
+for i in range(tbl.num_rows):
+    row=tuple(ad[c][i] for c in cols); ar[row[0]]=row
+def pf(x): return None if x==r'\N' else float(x)
+pg={}
+for r in csv.reader(open(sys.argv[2],newline='')):
+    i,a,b,c,d,e,fb,g,h=r
+    pg[int(i)]=(int(i),None if a==r'\N' else int(a),None if b==r'\N' else int(b),
+        None if c==r'\N' else int(c),pf(d),pf(e),None if fb==r'\N' else (fb=='t'),
+        None if g==r'\N' else g,None if h==r'\N' else bytes.fromhex(h))
+def feq(x,y):
+    if isinstance(x,float) or isinstance(y,float):
+        if x is None or y is None: return x is y
+        if math.isnan(x) and math.isnan(y): return True
+        return x==y
+    return x==y
+ok = set(ar)==set(pg) and all(all(feq(a,b) for a,b in zip(ar[k],pg[k])) for k in pg)
+print("MATCH" if ok else "MISMATCH")
+PY
+)"
+check "parquet values match heap oracle" "$pyres" "MATCH"
+
+sch="$(python3 - "$PARQUET" <<'PY'
+import sys, pyarrow.parquet as pq
+s=pq.read_table(sys.argv[1]).schema
+print(",".join(f"{f.name}:{f.type}" for f in s))
+PY
+)"
+check "parquet schema" "$sch" "id:int32,a:int16,b:int32,c:int64,d:float,e:double,f:bool,g:string,h:binary"
+
+# DuckDB as a second, independent reader.
+if command -v duckdb >/dev/null 2>&1; then
+	dcount="$(duckdb -noheader -list -c "SELECT count(*) FROM read_parquet('$PARQUET');" 2>/dev/null | tr -d '[:space:]')"
+	check "duckdb row count" "$dcount" "80003"
+	dsum_d="$(duckdb -noheader -list -c "SELECT count(b) FROM read_parquet('$PARQUET');" 2>/dev/null | tr -d '[:space:]')"
+	pcnt="$(q "SELECT count(b) FROM t_col;")"
+	check "duckdb non-null count(b)" "$dsum_d" "$pcnt"
+fi
+
+# Empty table.
+echo "-- empty table"
+psql_run "CREATE TABLE t_empty (a int, b text) USING columnar;"
+n0="$(q "SELECT columnar.export_parquet('t_empty', '$PGC_WORKDIR/e.parquet');")"
+check "empty export rows written" "$n0" "0"
+er="$(python3 - "$PGC_WORKDIR/e.parquet" <<'PY'
+import sys, pyarrow.parquet as pq
+t=pq.read_table(sys.argv[1]); print(t.num_rows, ",".join(t.schema.names))
+PY
+)"
+check "empty parquet readable" "$er" "0 a,b"
+
+# Errors.
+echo "-- argument validation"
+expect_error "reject non-columnar table" "SELECT columnar.export_parquet('t_heap', '$PGC_WORKDIR/x.parquet');"
+psql_run "CREATE TABLE t_js (a int, j json) USING columnar;"
+psql_run "INSERT INTO t_js VALUES (1, '{}');"
+expect_error "reject unsupported type" "SELECT columnar.export_parquet('t_js', '$PGC_WORKDIR/x.parquet');"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -25,7 +25,7 @@ set -uo pipefail
 SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUITES=(smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
 	differential recovery fuzz hardening concurrent_diff parallel sorted_projection \
-	arrow_export)
+	arrow_export parquet_export)
 
 # Default matrix: one assert-enabled pg_config per major, 13 through 19.
 DEFAULT_CONFIGS=(


### PR DESCRIPTION
## What

`columnar.export_parquet(rel regclass, path text) -> bigint` writes a columnar table to a Parquet file and returns the number of rows written.

The writer is self-contained: it emits the Thrift compact-protocol metadata (FileMetaData, row groups, column chunks, page headers) and PLAIN-encoded, UNCOMPRESSED data pages with RLE/bit-packed definition levels for nulls. **No libparquet build or run-time dependency.** One row group per 65536 rows, one DATA_PAGE per column; rows are read in physical order via the scalar reader.

## Type mapping (matches `export_arrow`)

int2/int4 → INT32 (int2 tagged INT_16), int8 → INT64, float4 → FLOAT, float8 → DOUBLE, bool → BOOLEAN, text/varchar → BYTE_ARRAY (UTF8), bytea → BYTE_ARRAY. All columns OPTIONAL; nulls carried in definition levels. Other types rejected. Little-endian hosts only; superuser only.

## Testing

`test/parquet_export.sh` (added to the matrix, gated on pyarrow) exports a mixed-type table mirroring a heap table — 80003 rows across multiple row groups, with NULLs, int boundaries, NaN/Inf, empty/unicode text, and bytea — reads it back with pyarrow and asserts every value equals the heap oracle, uses the DuckDB CLI as a second independent reader (`read_parquet`), and checks schema, an empty table, and error cases.

Full matrix PG13–19 (all 18 suites) green.

## Notes

- Base branch is `feat/gap27-arrow-export` (stacked); review that PR first.

Implementation plan: `design/gaps/27-IMPL-parquet-export.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)