### PR TITLE
Gap 29: read stream / async I/O for columnar block reads

### DIFF
--- a/bench/evict.c
+++ b/bench/evict.c
@@ -1,0 +1,50 @@
+/*
+ * evict.c - drop a file (and its segment files) from the OS page cache with
+ * posix_fadvise(POSIX_FADV_DONTNEED). Used by the read-stream/AIO benchmark to
+ * force cold reads from storage without needing /proc/sys/vm/drop_caches.
+ *
+ * Usage: evict <path> [<path> ...]   (each <path> plus <path>.1, .2, ... )
+ * Build: cc -O2 -o evict evict.c
+ */
+#define _GNU_SOURCE
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static void
+evict_one(const char *path)
+{
+	int fd = open(path, O_RDONLY);
+	if (fd < 0)
+		return;					/* segment does not exist; stop the caller's loop */
+	fdatasync(fd);				/* flush dirty pages so DONTNEED can drop them */
+	posix_fadvise(fd, 0, 0, POSIX_FADV_DONTNEED);
+	close(fd);
+}
+
+int
+main(int argc, char **argv)
+{
+	for (int i = 1; i < argc; i++)
+	{
+		char seg[4096];
+		int n;
+
+		evict_one(argv[i]);		/* base segment */
+		for (n = 1; n < 100000; n++)
+		{
+			int fd;
+
+			snprintf(seg, sizeof(seg), "%s.%d", argv[i], n);
+			fd = open(seg, O_RDONLY);
+			if (fd < 0)
+				break;			/* no more segments */
+			fdatasync(fd);
+			posix_fadvise(fd, 0, 0, POSIX_FADV_DONTNEED);
+			close(fd);
+		}
+	}
+	return 0;
+}

--- a/bench/run_bench_readstream.sh
+++ b/bench/run_bench_readstream.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+#
+# pgColumnar read-stream / asynchronous-I/O benchmark (gap 29).
+#
+# Measures cold-cache scan latency across the PostgreSQL 18 io_method settings
+# (sync, worker, io_uring) with the columnar read stream on and off. Because a
+# columnar scan reads a whole stripe's blocks as one contiguous range, the read
+# stream (PostgreSQL 17+) lets the AIO subsystem (PostgreSQL 18) prefetch them.
+#
+# Cold reads are forced without /proc/sys/vm/drop_caches: the cluster is
+# restarted before each timed run (clearing shared_buffers) and the relation's
+# files are dropped from the OS page cache with posix_fadvise(DONTNEED) via
+# bench/evict. Run against a NON-assert server built --with-liburing for the
+# io_uring method (e.g. /usr/local/pg18_uring).
+#
+# Usage:   bench/run_bench_readstream.sh [PG_CONFIG]
+# Env:     BENCH_ROWS (default 60000000), BENCH_PORT (default 55490)
+#
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+
+PG_CONFIG="${1:-/usr/local/pg18_uring/bin/pg_config}"
+BINDIR="$("$PG_CONFIG" --bindir)"
+PORT="${BENCH_PORT:-55490}"
+ROWS="${BENCH_ROWS:-60000000}"
+SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKDIR="$(mktemp -d /tmp/pgcolumnar-rsbench.XXXXXX)"
+PGDATA="$WORKDIR/data"
+LOG="$WORKDIR/server.log"
+
+echo "== pgColumnar read-stream / AIO benchmark =="
+echo "PG_CONFIG=$PG_CONFIG  ($("$PG_CONFIG" --version))"
+echo "rows=$ROWS  workdir=$WORKDIR"
+
+echo "-- build + install"
+make -C "$SRCDIR" PG_CONFIG="$PG_CONFIG" clean >/dev/null 2>&1 || true
+make -C "$SRCDIR" PG_CONFIG="$PG_CONFIG" >/dev/null
+make -C "$SRCDIR" install PG_CONFIG="$PG_CONFIG" >/dev/null
+cc -O2 -o "$WORKDIR/evict" "$SRCDIR/bench/evict.c"
+
+if [ "$(id -u)" = "0" ]; then RUNPG=(runuser -u postgres --); chown -R postgres "$WORKDIR"; else RUNPG=(env); fi
+run_pg() { "${RUNPG[@]}" env PATH="$BINDIR:$PATH" bash -lc "$1"; }
+PSQL="psql -p $PORT -d bench -v ON_ERROR_STOP=1 -qAtX"
+
+cleanup() { run_pg "pg_ctl -D '$PGDATA' stop -m immediate -w" >/dev/null 2>&1 || true; rm -rf "$WORKDIR"; }
+trap cleanup EXIT
+
+echo "-- initdb"
+run_pg "initdb -D '$PGDATA' -A trust" >/dev/null 2>&1
+{
+	echo "port=$PORT"
+	echo "shared_preload_libraries='columnar'"
+	echo "shared_buffers=128MB"
+	echo "max_parallel_workers_per_gather=0"
+	echo "effective_io_concurrency=32"
+	echo "maintenance_io_concurrency=32"
+	echo "max_wal_size=8GB"
+	echo "checkpoint_timeout=60min"
+} | run_pg "cat >> '$PGDATA/postgresql.conf'"
+
+start_pg() { run_pg "pg_ctl -D '$PGDATA' -l '$LOG' start -w" >/dev/null 2>&1; }
+stop_pg()  { run_pg "pg_ctl -D '$PGDATA' stop -m fast -w" >/dev/null 2>&1; }
+
+start_pg
+run_pg "createdb -p $PORT bench"
+
+# Eight random bigint columns: random data defeats the lightweight encodings and
+# the block codec, so the on-disk streams are large and a cold scan is I/O-bound
+# (the regime where prefetch/AIO can help). A linear/monotonic column would
+# delta-encode to almost nothing and make the scan CPU/decode-bound instead.
+echo "-- load $ROWS rows x 8 random bigint columns (columnar, compression=none)"
+run_pg "$PSQL -c \"CREATE EXTENSION columnar;\""
+run_pg "$PSQL -c \"SET columnar.compression='none';
+  CREATE TABLE t (c0 bigint,c1 bigint,c2 bigint,c3 bigint,
+                  c4 bigint,c5 bigint,c6 bigint,c7 bigint) USING columnar;\""
+run_pg "$PSQL -c \"INSERT INTO t SELECT
+    (random()*9e18)::bigint,(random()*9e18)::bigint,(random()*9e18)::bigint,(random()*9e18)::bigint,
+    (random()*9e18)::bigint,(random()*9e18)::bigint,(random()*9e18)::bigint,(random()*9e18)::bigint
+  FROM generate_series(1,$ROWS) g;\""
+run_pg "$PSQL -c \"CHECKPOINT;\""
+
+RELPATH="$(run_pg "$PSQL -tAc \"SELECT pg_relation_filepath('t');\"")"
+ABSREL="$PGDATA/$RELPATH"
+TABLESIZE="$(run_pg "$PSQL -tAc \"SELECT pg_size_pretty(pg_table_size('t'));\"")"
+echo "   table size: $TABLESIZE   file: $RELPATH   shared_buffers: 128MB"
+
+# Scan all eight column streams so the cold read is as large as possible.
+QUERY="SELECT sum(c0)+sum(c1)+sum(c2)+sum(c3)+sum(c4)+sum(c5)+sum(c6)+sum(c7) FROM t"
+cold_median() {
+	local rs="$1" reps=3 t
+	local times=()
+	for _ in $(seq 1 $reps); do
+		stop_pg; start_pg >/dev/null
+		run_pg "$WORKDIR/evict '$ABSREL'" >/dev/null 2>&1
+		t="$(run_pg "psql -p $PORT -d bench -qAtX -c \"SET columnar.enable_read_stream=$rs;\" -c \"\\timing on\" -c \"$QUERY\" 2>&1 | sed -n 's/^Time: \\([0-9.]*\\) ms.*/\\1/p' | tail -1")"
+		times+=("${t:-0}")
+	done
+	printf '%s\n' "${times[@]}" | sort -n | awk '{a[NR]=$1} END{print a[int((NR+1)/2)]}'
+}
+
+echo
+echo "=== COLD-SCAN LATENCY: io_method x read_stream (median of 3, ms) ==="
+printf '%-10s | %-12s | %-12s | %s\n' io_method rs_on_ms rs_off_ms rs_speedup
+printf -- '-----------+--------------+--------------+-----------\n'
+declare -A ON
+for iom in sync worker io_uring; do
+	run_pg "$PSQL -c \"ALTER SYSTEM SET io_method='$iom';\"" >/dev/null 2>&1
+	stop_pg; start_pg >/dev/null 2>&1
+	got="$(run_pg "$PSQL -tAc \"SHOW io_method;\"" 2>/dev/null)"
+	if [ "$got" != "$iom" ]; then
+		printf '%-10s | %s\n' "$iom" "unavailable (server reports io_method=$got); skipped"
+		continue
+	fi
+	on_ms="$(cold_median on)"
+	off_ms="$(cold_median off)"
+	ON[$iom]="$on_ms"
+	sp="$(awk -v a="$off_ms" -v b="$on_ms" 'BEGIN{ if(b>0) printf "%.2f", a/b; else print "n/a"}')"
+	printf '%-10s | %-12s | %-12s | %sx\n' "$iom" "$on_ms" "$off_ms" "$sp"
+done
+
+echo
+echo "=== io_method speedup vs sync (read_stream on) ==="
+base="${ON[sync]:-}"
+for iom in sync worker io_uring; do
+	v="${ON[$iom]:-}"
+	[ -z "$v" ] && continue
+	sp="$(awk -v a="$base" -v b="$v" 'BEGIN{ if(a!="" && b>0) printf "%.2f", a/b; else print "n/a"}')"
+	printf '%-10s  %s ms  (%sx vs sync)\n' "$iom" "$v" "$sp"
+done
+
+echo
+echo "== benchmark complete =="

--- a/bench/sample_readstream_pg18_uring.txt
+++ b/bench/sample_readstream_pg18_uring.txt
@@ -1,0 +1,44 @@
+== pgColumnar read-stream / AIO benchmark ==
+PG_CONFIG=/usr/local/pg18_uring/bin/pg_config  (PostgreSQL 18.4, --with-liburing, non-assert)
+rows=30000000 x 8 random bigint columns, compression=none
+table size: 2038 MB    shared_buffers: 128MB    effective_io_concurrency: 32
+cold reads forced by cluster restart + posix_fadvise(DONTNEED) on the relation files
+query: SELECT sum(c0)+...+sum(c7) FROM t   (scans all 8 column streams cold)
+
+=== COLD-SCAN LATENCY: io_method x read_stream (median of 3, ms) ===
+io_method  | rs_on_ms     | rs_off_ms    | rs_speedup
+-----------+--------------+--------------+-----------
+sync       | 16171.784    | 16242.102    | 1.00x
+worker     | 15880.983    | 16241.464    | 1.02x
+io_uring   | 15901.153    | 16217.671    | 1.02x
+
+=== io_method speedup vs sync (read_stream on) ===
+sync        16171.784 ms  (1.00x vs sync)
+worker      15880.983 ms  (1.02x vs sync)
+io_uring    15901.153 ms  (1.02x vs sync)
+
+Interpretation
+--------------
+On this hardware (local NVMe) and workload, the read stream + AIO give about 2%
+(io_uring and worker are within noise of each other; read_stream on vs off is
+1.00-1.02x). Two reasons:
+
+1. A columnar scan is decode-CPU-bound here, not I/O-bound. Reading 2 GB cold
+   takes ~16 s wall clock = ~15 M values/s over 240 M decoded values (~65 ns per
+   value), so the CPU decode dominates and there is little I/O wait for AIO to
+   overlap.
+2. Sequential reads already benefit from Linux kernel read-ahead, so explicit
+   prefetch/AIO adds little on top for a sequential scan on local storage.
+
+Where read stream + AIO (especially io_uring) is expected to help more, and why
+the integration is still worth having:
+- High-latency storage (network/cloud block devices, EBS-class) where per-block
+  I/O latency is large and OS read-ahead is less effective.
+- Higher I/O concurrency and random-access patterns (index-driven fetches,
+  future bitmap paths) where AIO can keep many requests in flight.
+- Staying current with the PostgreSQL 18 I/O model; the path is gated and falls
+  back to synchronous reads on PostgreSQL 13-16.
+
+Correctness (byte-identical output with read_stream on vs off, PG13-19) is
+covered by test/read_stream.sh and the full matrix; this benchmark measures only
+latency.

--- a/design/gaps/29-read-stream-aio.md
+++ b/design/gaps/29-read-stream-aio.md
@@ -1,0 +1,87 @@
+# Gap 29: read stream / asynchronous I/O in the scan
+
+Status: PLANNED. Tier: performance. Format change: none. Effort: medium.
+
+Adopt the PostgreSQL read stream API (PostgreSQL 17+) for the columnar block
+reads so the PostgreSQL 18 asynchronous I/O subsystem prefetches chunk blocks
+during a scan. Falls back to the current synchronous path on PostgreSQL 13-16.
+No on-disk or SQL-surface change; results are unchanged. See
+[../PG18_19_OPPORTUNITIES.md](../PG18_19_OPPORTUNITIES.md) item 1.
+
+## Current state
+
+`ColumnarReadLogicalData` (src/columnar_storage.c) reads a contiguous logical
+byte range by walking its blocks, each with a synchronous `ReadBuffer` +
+share-lock + memcpy + unlock. Both callers (src/columnar_reader.c) pass a whole
+stripe's `fileOffset` and `dataLength`, so each call is a large, contiguous,
+ascending block range that is fully known up front. There is no prefetch: a cold
+scan waits on each block in turn.
+
+## API (verified on the installed majors)
+
+`storage/read_stream.h` is present in PostgreSQL 17, 18, and 19 and absent in 16
+and earlier. The functions used are identical across 17-19:
+
+- `ReadStream *read_stream_begin_relation(int flags, BufferAccessStrategy strategy,
+  Relation rel, ForkNumber forknum, ReadStreamBlockNumberCB callback,
+  void *callback_private_data, size_t per_buffer_data_size)`
+- `Buffer read_stream_next_buffer(ReadStream *stream, void **per_buffer_data)`
+- `void read_stream_end(ReadStream *stream)`
+- `typedef BlockNumber (*ReadStreamBlockNumberCB)(ReadStream *stream,
+  void *callback_private_data, void *per_buffer_data)`
+
+PostgreSQL 18 adds `block_range_read_stream_cb` and `READ_STREAM_USE_BATCHING`;
+we do not depend on them, so one code path covers 17-19. Gate is
+`PG_VERSION_NUM >= 170000`.
+
+## Design
+
+Rewrite `ColumnarReadLogicalData` with two paths, selected at compile time and by
+a GUC:
+
+- PostgreSQL 17+ and `columnar.enable_read_stream = on` (default): open a read
+  stream over the block range `[logicalOffset / COLUMNAR_BYTES_PER_PAGE ..
+  (logicalOffset + length - 1) / COLUMNAR_BYTES_PER_PAGE]` with a trivial
+  contiguous-range callback (return next block, then `InvalidBlockNumber`).
+  `read_stream_next_buffer` returns the pinned buffers in that order; for each,
+  share-lock, memcpy the page slice (`SizeOfPageHeaderData + pageOffset`, same
+  math as today), unlock and release. `read_stream_end` at the end. Flags:
+  `READ_STREAM_SEQUENTIAL`; strategy `NULL` (keep current buffer-cache behavior;
+  a `BAS_BULKREAD` strategy is a possible follow-up); `per_buffer_data_size` 0.
+- Otherwise: the current synchronous `ReadBuffer` loop, unchanged.
+
+Callback private state: `{ BlockNumber next; BlockNumber last; }`. `length == 0`
+returns immediately without opening a stream. Buffers come back in request order,
+so the existing `L`/`pageOffset`/`n` walk drives the copy unchanged; assert each
+returned buffer's block number matches the expected block.
+
+Only `ColumnarReadLogicalData` changes. Single-block metapage reads keep plain
+`ReadBuffer` (no benefit from streaming).
+
+## Compatibility
+
+New shim region in `src/columnar_compat.h` (or guarded include in
+columnar_storage.c): `#if PG_VERSION_NUM >= 170000 #include "storage/read_stream.h"`.
+The callback and its state struct are guarded the same way. GUC
+`columnar.enable_read_stream` (bool, default on) registered in
+columnar_tableam.c; on PostgreSQL 16 and earlier the GUC still exists but has no
+effect (the streaming path is compiled out).
+
+## Testing
+
+- The whole existing suite exercises this path (every columnar read goes through
+  `ColumnarReadLogicalData`), so the differential/recovery/fuzz suites and the
+  full matrix are the correctness gate: streaming must return byte-identical data.
+- Add `test/read_stream.sh`: load a columnar table and a heap mirror, then diff a
+  range of query shapes with `columnar.enable_read_stream` on and off (both must
+  equal the heap oracle), including a multi-stripe table so the streamed range
+  spans many blocks. Add it to `test/run_all_versions.sh`.
+- Benchmark (follow-up): cold-scan latency with the stream on vs off on
+  PostgreSQL 18 (`io_method = worker`/`io_uring` vs `sync`); requires dropping
+  caches, so it is measured separately from the standard bench.
+
+## Effort / risk
+
+Medium. Risk is confined to the read path and is caught by the differential
+oracle. The API shape is stable across 17-19; the GUC gives an instant fallback
+if a regression appears.

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -109,6 +109,7 @@ extern bool columnar_enable_vectorization;	/* vectorized scan/aggregate path */
 extern bool columnar_enable_compressed_execution;	/* run-based aggregate path (I3) */
 extern bool columnar_enable_metadata_count;	/* count(*) from catalog metadata (gap 28) */
 extern bool columnar_enable_column_cache;	/* decompressed-chunk cache */
+extern bool columnar_enable_read_stream;	/* stream/prefetch block reads (PG17+) */
 extern int columnar_column_cache_size;		/* cache budget in megabytes */
 
 /* issue #5: concurrent unique-key insert serialization */

--- a/src/columnar_storage.c
+++ b/src/columnar_storage.c
@@ -21,10 +21,43 @@
 #include "storage/smgr.h"
 #include "utils/rel.h"
 
+#if PG_VERSION_NUM >= 170000
+#include "storage/read_stream.h"
+#endif
+
 /* the metapage struct lives right after the page header on block 0 */
 #define COLUMNAR_METAPAGE_BLOCKNO 0
 #define COLUMNAR_EMPTY_BLOCKNO 1
 #define ColumnarMetapagePointer(page) ((ColumnarMetapage *) PageGetContents(page))
+
+/*
+ * Stream/prefetch the block reads in ColumnarReadLogicalData via the read
+ * stream API (PostgreSQL 17+), which lets the PostgreSQL 18 asynchronous I/O
+ * subsystem read ahead. On by default; off falls back to synchronous ReadBuffer.
+ * On PostgreSQL 16 and earlier the streaming path is compiled out and this GUC
+ * has no effect.
+ */
+bool		columnar_enable_read_stream = true;
+
+#if PG_VERSION_NUM >= 170000
+/* contiguous ascending block range for the read stream callback */
+typedef struct ColumnarBlockRange
+{
+	BlockNumber next;
+	BlockNumber last;
+}			ColumnarBlockRange;
+
+static BlockNumber
+columnar_read_stream_next(ReadStream *stream, void *private_data,
+						  void *per_buffer_data)
+{
+	ColumnarBlockRange *range = (ColumnarBlockRange *) private_data;
+
+	if (range->next > range->last)
+		return InvalidBlockNumber;
+	return range->next++;
+}
+#endif
 
 /*
  * ColumnarWriteNewMetapage
@@ -274,6 +307,54 @@ ColumnarReadLogicalData(Relation rel, uint64 logicalOffset,
 	uint64		L = logicalOffset;
 	uint64		remaining = length;
 	char	   *dst = dest;
+
+	if (remaining == 0)
+		return;
+
+#if PG_VERSION_NUM >= 170000
+	if (columnar_enable_read_stream)
+	{
+		/*
+		 * The blocks map to a contiguous ascending range, so a read stream can
+		 * prefetch them (and use asynchronous I/O on PostgreSQL 18+).
+		 * read_stream_next_buffer returns the pinned buffers in request order,
+		 * so the same L/pageOffset walk drives the copy; the buffers are share-
+		 * locked here just as the synchronous path does.
+		 */
+		ColumnarBlockRange range;
+		ReadStream *stream;
+
+		range.next = (BlockNumber) (L / COLUMNAR_BYTES_PER_PAGE);
+		range.last = (BlockNumber) ((L + remaining - 1) / COLUMNAR_BYTES_PER_PAGE);
+
+		stream = read_stream_begin_relation(READ_STREAM_SEQUENTIAL, NULL, rel,
+											MAIN_FORKNUM,
+											columnar_read_stream_next, &range, 0);
+
+		while (remaining > 0)
+		{
+			uint32		pageOffset = (uint32) (L % COLUMNAR_BYTES_PER_PAGE);
+			uint32		n = (uint32) Min(COLUMNAR_BYTES_PER_PAGE - pageOffset,
+										 remaining);
+			Buffer		buffer = read_stream_next_buffer(stream, NULL);
+			Page		page;
+
+			Assert(BufferIsValid(buffer));
+			Assert(BufferGetBlockNumber(buffer) ==
+				   (BlockNumber) (L / COLUMNAR_BYTES_PER_PAGE));
+			LockBuffer(buffer, BUFFER_LOCK_SHARE);
+			page = BufferGetPage(buffer);
+			memcpy(dst, (char *) page + SizeOfPageHeaderData + pageOffset, n);
+			UnlockReleaseBuffer(buffer);
+
+			dst += n;
+			L += n;
+			remaining -= n;
+		}
+		read_stream_end(stream);
+		return;
+	}
+#endif
 
 	while (remaining > 0)
 	{

--- a/src/columnar_storage.c
+++ b/src/columnar_storage.c
@@ -339,7 +339,19 @@ ColumnarReadLogicalData(Relation rel, uint64 logicalOffset,
 			Buffer		buffer = read_stream_next_buffer(stream, NULL);
 			Page		page;
 
-			Assert(BufferIsValid(buffer));
+			/*
+			 * The stream must yield exactly one buffer per block in the range.
+			 * Guard at run time (not just Assert) so a corrupt offset that
+			 * miscomputes the range ends the stream early with a clean error
+			 * instead of LockBuffer(InvalidBuffer) dereferencing out of bounds.
+			 */
+			if (!BufferIsValid(buffer))
+			{
+				read_stream_end(stream);
+				ereport(ERROR,
+						(errcode(ERRCODE_DATA_CORRUPTED),
+						 errmsg("columnar: read stream ended before the requested range")));
+			}
 			Assert(BufferGetBlockNumber(buffer) ==
 				   (BlockNumber) (L / COLUMNAR_BYTES_PER_PAGE));
 			LockBuffer(buffer, BUFFER_LOCK_SHARE);

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -1150,6 +1150,15 @@ _PG_init(void)
 							 0,
 							 NULL, NULL, NULL);
 
+	DefineCustomBoolVariable("columnar.enable_read_stream",
+							 "Prefetch block reads with the read stream API (PostgreSQL 17+).",
+							 NULL,
+							 &columnar_enable_read_stream,
+							 true,
+							 PGC_USERSET,
+							 0,
+							 NULL, NULL, NULL);
+
 	DefineCustomIntVariable("columnar.column_cache_size",
 							"Size of the decompressed-chunk cache, in megabytes.",
 							NULL,

--- a/test/read_stream.sh
+++ b/test/read_stream.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# pgColumnar read stream / prefetch suite (gap 29).
+#
+# The columnar block reads go through the read stream API on PostgreSQL 17+
+# (columnar.enable_read_stream, on by default), which must return byte-identical
+# data to the synchronous ReadBuffer path. This runs a battery of scan shapes
+# against a heap oracle with the stream on and off, over a multi-stripe table so
+# the streamed block range spans many blocks. On PostgreSQL 13-16 the streaming
+# path is compiled out and the GUC has no effect; both modes still match.
+#
+# Usage:  test/read_stream.sh [PG_CONFIG]
+#
+# Written fresh for pgColumnar; it does not reuse any upstream test file.
+
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+# Small stripes and wide-ish rows so each stripe spans many blocks.
+make_pair "id int, k int, v bigint, t text"
+q "SELECT columnar.alter_columnar_table_set('t_col', stripe_row_limit => 2000, chunk_group_row_limit => 1000);" >/dev/null
+load_pair "SELECT g, g%100, g::bigint*3, repeat('x', (g%40)+1) FROM generate_series(1,50000) g"
+check "multiple stripes present" "$([ "$(stripe_count t_col)" -ge 10 ] && echo yes || echo no)" "yes"
+
+setg() { q "ALTER DATABASE $PGC_DB SET $1 = $2;" >/dev/null; }
+
+for mode in on off; do
+	setg columnar.enable_read_stream "$mode"
+	diff_query "[$mode] full scan"     "SELECT id, k, v, t FROM %T"
+	diff_query "[$mode] filtered"      "SELECT id, v FROM %T WHERE k = 7"
+	diff_query "[$mode] range"         "SELECT id, t FROM %T WHERE id BETWEEN 10000 AND 20000"
+	diff_query "[$mode] aggregate"     "SELECT k, count(*), sum(v) FROM %T GROUP BY k"
+	diff_query "[$mode] wide sample"   "SELECT * FROM %T WHERE id % 997 = 0"
+done
+
+setg columnar.enable_read_stream on
+q "ALTER DATABASE $PGC_DB RESET ALL;" >/dev/null
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -25,7 +25,7 @@ set -uo pipefail
 SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUITES=(smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
 	differential recovery fuzz hardening concurrent_diff parallel sorted_projection \
-	arrow_export parquet_export)
+	arrow_export parquet_export read_stream)
 
 # Default matrix: one assert-enabled pg_config per major, 13 through 19.
 DEFAULT_CONFIGS=(


### PR DESCRIPTION
## What

Route the block reads in `ColumnarReadLogicalData` through the PostgreSQL read stream API (PostgreSQL 17+) so the PostgreSQL 18 asynchronous I/O subsystem prefetches chunk blocks during a scan. Both callers read a whole stripe, so each call is a large, contiguous, ascending block range — exactly what the read stream prefetches well. On PostgreSQL 16 and earlier the streaming path is compiled out and the original synchronous `ReadBuffer` loop runs unchanged.

Results are unchanged; this only changes how blocks are fetched.

## How

- A trivial contiguous-range callback (return the next block until the range is exhausted) covers PostgreSQL 17, 18, and 19 identically; `read_stream_begin_relation` / `read_stream_next_buffer` / `read_stream_end` are stable across those majors (verified against the installed headers). Buffers return in request order, so the existing `L`/`pageOffset` walk drives the copy and each buffer is share-locked exactly as before.
- New GUC `columnar.enable_read_stream` (default on) gives an instant fallback to the synchronous path.
- Gated on `PG_VERSION_NUM >= 170000` (the `read_stream.h` header is absent in 16 and earlier).

## Testing

Every columnar read goes through this function, so the differential/recovery/fuzz suites and the full matrix are the correctness gate. New `test/read_stream.sh` (added to the matrix) diffs a battery of scan shapes with the stream on and off against a heap oracle over a multi-stripe table; both modes match.

Full matrix **PG13–19, all 19 suites, ALL VERSIONS PASSED** (streaming path on 17/18/19, fallback on 13–16).

Spec: `design/gaps/29-read-stream-aio.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)