### PR TITLE
Arrow/Parquet export: date, time, timestamp, uuid, numeric, json type coverage

### DIFF
--- a/design/gaps/27-IMPL-export-type-coverage.md
+++ b/design/gaps/27-IMPL-export-type-coverage.md
@@ -1,0 +1,58 @@
+# Gap 27 (impl): Arrow / Parquet export type coverage
+
+Extends `columnar.export_arrow` and `columnar.export_parquet` beyond the first
+slice (int2/4/8, float4/8, bool, text/varchar, bytea) with the common warehouse
+scalar types. Additive: no on-disk format change, no change to existing query
+results, existing exports byte-compatible. Little-endian hosts only, as before.
+
+## Type mapping added
+
+| PostgreSQL | Arrow | Parquet |
+| --- | --- | --- |
+| `date` | Date32 (days, unit=DAY) | INT32, ConvertedType DATE |
+| `time` | Time64 (unit=MICROSECOND) | INT64, ConvertedType TIME_MICROS |
+| `timestamp` | Timestamp (unit=us, no tz) | INT64, ConvertedType TIMESTAMP_MICROS |
+| `timestamptz` | Timestamp (unit=us, tz="UTC") | INT64, ConvertedType TIMESTAMP_MICROS |
+| `uuid` | FixedSizeBinary(16) | FIXED_LEN_BYTE_ARRAY(16) |
+| `numeric(p,s)`, p≤38, s∈[0,p] | Decimal128(p,s) | FIXED_LEN_BYTE_ARRAY(16), ConvertedType DECIMAL |
+| `numeric` unconstrained / p>38 / NaN / Inf | Utf8 (text) | BYTE_ARRAY, ConvertedType UTF8 |
+| `json`, `jsonb` | Utf8 (text) | BYTE_ARRAY, ConvertedType UTF8 |
+
+### Epoch and unit conversions
+
+- `date`: PostgreSQL stores int32 days since 2000-01-01. Both targets count days
+  since 1970-01-01, so add `POSTGRES_EPOCH_JDATE - UNIX_EPOCH_JDATE` (10957).
+- `time`: PostgreSQL stores int64 microseconds since midnight; both targets use
+  microseconds directly.
+- `timestamp`/`timestamptz`: PostgreSQL stores int64 microseconds since
+  2000-01-01 (timestamptz is held in UTC). Both targets count microseconds since
+  1970-01-01 UTC, so add `(POSTGRES_EPOCH_JDATE - UNIX_EPOCH_JDATE) * USECS_PER_DAY`
+  (946684800000000). `timestamptz` additionally carries the `UTC` zone in Arrow
+  and is implicitly UTC-adjusted in Parquet's TIMESTAMP_MICROS.
+- `uuid`: 16 raw bytes, copied verbatim.
+
+### Decimal
+
+`numeric(p,s)` with `1 ≤ p ≤ 38` and `0 ≤ s ≤ p` maps to a 128-bit decimal. The
+unscaled integer is produced by formatting the value (`numeric_out`), splitting on
+the decimal point, and padding the fraction to exactly `s` digits — the stored
+value already carries scale `s`, so no rounding is required. Arrow Decimal128
+values are 16-byte little-endian two's complement; Parquet DECIMAL in a
+FIXED_LEN_BYTE_ARRAY is 16-byte big-endian two's complement. `NaN`/`Infinity`
+(which a decimal cannot represent) and unconstrained or over-precision `numeric`
+fall back to the text representation, matched in both writers so a column's type
+is stable across formats.
+
+## Not in this slice
+
+Arrays and composite/row types require nested Arrow List buffers and Parquet
+repetition levels — the flat writers emit neither today. `jsonb` maps to text
+here; a structured mapping is out of scope. These remain follow-ups on the interop
+gap.
+
+## Testing
+
+`test/arrow_export.sh` and `test/parquet_export.sh` gain a mixed-type table
+covering every mapping above (including nulls, NaN/Inf numeric, unconstrained
+numeric, and the decimal path), exported and read back with pyarrow / the DuckDB
+CLI, and compared to the heap oracle. Gated like the existing export checks.

--- a/src/columnar_arrow.c
+++ b/src/columnar_arrow.c
@@ -31,14 +31,23 @@
 #include "miscadmin.h"
 #include "storage/fd.h"
 #include "utils/builtins.h"
+#include "utils/date.h"
+#include "utils/lsyscache.h"
 #include "utils/memutils.h"
+#include "utils/numeric.h"
 #include "utils/rel.h"
 #include "utils/snapmgr.h"
+#include "utils/timestamp.h"
+#include "utils/uuid.h"
 
 PG_FUNCTION_INFO_V1(columnar_export_arrow);
 
 /* one RecordBatch per this many rows */
 #define ARROW_BATCH_ROWS 16384
+
+/* PostgreSQL epoch (2000-01-01) to Unix epoch (1970-01-01) offsets */
+#define PG_TO_UNIX_DAYS		((int64) (POSTGRES_EPOCH_JDATE - UNIX_EPOCH_JDATE))
+#define PG_TO_UNIX_USECS	(PG_TO_UNIX_DAYS * USECS_PER_DAY)
 
 /* Arrow Type union tags (Schema.fbs) */
 #define ARROW_TYPE_Int			2
@@ -46,6 +55,11 @@ PG_FUNCTION_INFO_V1(columnar_export_arrow);
 #define ARROW_TYPE_Binary		4
 #define ARROW_TYPE_Utf8			5
 #define ARROW_TYPE_Bool			6
+#define ARROW_TYPE_Decimal		7
+#define ARROW_TYPE_Date			8
+#define ARROW_TYPE_Time			9
+#define ARROW_TYPE_Timestamp	10
+#define ARROW_TYPE_FixedSizeBinary 15
 /* Arrow MessageHeader union tags (Message.fbs) */
 #define ARROW_MSG_Schema		1
 #define ARROW_MSG_RecordBatch	3
@@ -62,8 +76,67 @@ typedef enum ArrowKind
 	A_FLOAT64,
 	A_BOOL,
 	A_UTF8,
-	A_BINARY
+	A_BINARY,
+	A_DATE32,					/* date -> Date32 (days from Unix epoch) */
+	A_TIME64,					/* time -> Time64[us] */
+	A_TIMESTAMP,				/* timestamp -> Timestamp[us], no zone */
+	A_TIMESTAMPTZ,				/* timestamptz -> Timestamp[us], zone "UTC" */
+	A_UUID,						/* uuid -> FixedSizeBinary(16) */
+	A_DECIMAL128				/* numeric(p,s) -> Decimal128(p,s) */
 }			ArrowKind;
+
+/* Parse a numeric value (via its text form) into a 128-bit unscaled integer at
+ * the given scale. Returns false for NaN/Infinity, which a decimal cannot hold.
+ * The stored value already carries scale s, so padding suffices; the defensive
+ * truncation branch never fires for a validly scaled numeric. */
+static bool
+numeric_to_int128(Datum numd, int scale, __int128 *out)
+{
+	char	   *s = DatumGetCString(DirectFunctionCall1(numeric_out, numd));
+	char	   *p = s;
+	bool		neg = false;
+	bool		seenDot = false;
+	int			fracDigits = 0;
+	__int128	acc = 0;
+
+	if (*p == '-')
+	{
+		neg = true;
+		p++;
+	}
+	else if (*p == '+')
+		p++;
+
+	for (; *p; p++)
+	{
+		if (*p == '.')
+		{
+			seenDot = true;
+			continue;
+		}
+		if (*p < '0' || *p > '9')	/* NaN, Infinity: not representable */
+		{
+			pfree(s);
+			return false;
+		}
+		acc = acc * 10 + (*p - '0');
+		if (seenDot)
+			fracDigits++;
+	}
+	while (fracDigits < scale)
+	{
+		acc *= 10;
+		fracDigits++;
+	}
+	while (fracDigits > scale)
+	{
+		acc /= 10;
+		fracDigits--;
+	}
+	*out = neg ? -acc : acc;
+	pfree(s);
+	return true;
+}
 
 /* -------------------------------------------------------------------------
  * Minimal FlatBuffers builder (little-endian). The buffer is built back to
@@ -334,7 +407,7 @@ fb_create_string(FBB *b, const char *s)
 
 /* ---- Arrow Type table for one column; returns tag via *typetag ---- */
 static uint32
-fb_arrow_type(FBB *b, ArrowKind kind, uint8 *typetag)
+fb_arrow_type(FBB *b, ArrowKind kind, int precision, int scale, uint8 *typetag)
 {
 	switch (kind)
 	{
@@ -368,6 +441,46 @@ fb_arrow_type(FBB *b, ArrowKind kind, uint8 *typetag)
 			fb_start(b, 0);
 			*typetag = ARROW_TYPE_Binary;
 			return fb_end(b);
+		case A_DATE32:
+			/* Date { unit: DateUnit = MILLISECOND (1) }; want DAY (0) */
+			fb_start(b, 1);
+			fb_add_i16(b, 0, 0, 1);
+			*typetag = ARROW_TYPE_Date;
+			return fb_end(b);
+		case A_TIME64:
+			/* Time { unit: TimeUnit = MILLISECOND (1); bitWidth: int = 32 } */
+			fb_start(b, 2);
+			fb_add_i16(b, 0, 2, 1);		/* MICROSECOND */
+			fb_add_i32(b, 1, 64, 32);
+			*typetag = ARROW_TYPE_Time;
+			return fb_end(b);
+		case A_TIMESTAMP:
+		case A_TIMESTAMPTZ:
+			{
+				uint32		tzOff = 0;
+
+				if (kind == A_TIMESTAMPTZ)
+					tzOff = fb_create_string(b, "UTC");
+				/* Timestamp { unit: TimeUnit = SECOND (0); timezone: string } */
+				fb_start(b, 2);
+				fb_add_i16(b, 0, 2, 0);		/* MICROSECOND */
+				fb_add_offset(b, 1, tzOff);
+				*typetag = ARROW_TYPE_Timestamp;
+				return fb_end(b);
+			}
+		case A_UUID:
+			/* FixedSizeBinary { byteWidth: int } */
+			fb_start(b, 1);
+			fb_add_i32(b, 0, 16, 0);
+			*typetag = ARROW_TYPE_FixedSizeBinary;
+			return fb_end(b);
+		case A_DECIMAL128:
+			/* Decimal { precision: int; scale: int; bitWidth: int = 128 } */
+			fb_start(b, 3);
+			fb_add_i32(b, 0, precision, 0);
+			fb_add_i32(b, 1, scale, 0);
+			*typetag = ARROW_TYPE_Decimal;
+			return fb_end(b);
 	}
 	*typetag = 0;
 	return 0;					/* unreachable */
@@ -382,6 +495,10 @@ typedef struct ArrowCol
 	char	   *name;
 	ArrowKind	kind;
 	int			width;			/* fixed-width byte size, 0 otherwise */
+	int			precision;		/* decimal precision (A_DECIMAL128) */
+	int			scale;			/* decimal scale (A_DECIMAL128) */
+	bool		convertText;	/* A_UTF8 fallback needs the type output fn */
+	FmgrInfo	outFinfo;		/* output function (when convertText) */
 	StringInfoData valid;		/* 1 byte per row: 1 valid, 0 null */
 	int64		nullCount;
 	StringInfoData fixed;		/* fixed-width raw values */
@@ -410,8 +527,10 @@ arrowcol_reset(ArrowCol *c)
 }
 
 static ArrowKind
-arrow_kind_for_type(Oid typid, int *width)
+arrow_kind_for_type(Oid typid, int32 typmod, int *width, int *precision, int *scale)
 {
+	*precision = 0;
+	*scale = 0;
 	switch (typid)
 	{
 		case INT2OID:
@@ -434,11 +553,47 @@ arrow_kind_for_type(Oid typid, int *width)
 			return A_BOOL;
 		case TEXTOID:
 		case VARCHAROID:
+		case JSONOID:
+		case JSONBOID:
 			*width = 0;
 			return A_UTF8;
 		case BYTEAOID:
 			*width = 0;
 			return A_BINARY;
+		case DATEOID:
+			*width = 4;
+			return A_DATE32;
+		case TIMEOID:
+			*width = 8;
+			return A_TIME64;
+		case TIMESTAMPOID:
+			*width = 8;
+			return A_TIMESTAMP;
+		case TIMESTAMPTZOID:
+			*width = 8;
+			return A_TIMESTAMPTZ;
+		case UUIDOID:
+			*width = 16;
+			return A_UUID;
+		case NUMERICOID:
+			/* numeric(p,s) with p<=38 and 0<=s<=p -> Decimal128; otherwise
+			 * (unconstrained, over-precision) fall back to text. */
+			if (typmod >= (int32) VARHDRSZ)
+			{
+				int32		tmp = typmod - VARHDRSZ;
+				int			p = (tmp >> 16) & 0xffff;
+				int			s = tmp & 0xffff;
+
+				if (p >= 1 && p <= 38 && s >= 0 && s <= p)
+				{
+					*width = 16;
+					*precision = p;
+					*scale = s;
+					return A_DECIMAL128;
+				}
+			}
+			*width = 0;
+			return A_UTF8;		/* text fallback */
 		default:
 			*width = -1;
 			return A_INT32;		/* caller checks width == -1 */
@@ -451,6 +606,35 @@ arrowcol_append(ArrowCol *c, Datum d, bool isnull)
 {
 	char		one = 1,
 				zero = 0;
+	__int128	dec = 0;
+
+	/*
+	 * A few types can carry values with no target representation (±infinity
+	 * dates/timestamps, NaN/Infinity numerics). Fold those to null, computing
+	 * the decimal here so a non-finite value is detected before validity is
+	 * written.
+	 */
+	if (!isnull)
+	{
+		switch (c->kind)
+		{
+			case A_DATE32:
+				if (DATE_NOT_FINITE(DatumGetDateADT(d)))
+					isnull = true;
+				break;
+			case A_TIMESTAMP:
+			case A_TIMESTAMPTZ:
+				if (TIMESTAMP_NOT_FINITE(DatumGetTimestamp(d)))
+					isnull = true;
+				break;
+			case A_DECIMAL128:
+				if (!numeric_to_int128(d, c->scale, &dec))
+					isnull = true;
+				break;
+			default:
+				break;
+		}
+	}
 
 	appendStringInfoChar(&c->valid, isnull ? zero : one);
 	if (isnull)
@@ -493,6 +677,52 @@ arrowcol_append(ArrowCol *c, Datum d, bool isnull)
 				appendBinaryStringInfo(&c->fixed, (char *) &v, 8);
 				break;
 			}
+		case A_DATE32:
+			{
+				int32		v = isnull ? 0 :
+					(int32) (DatumGetDateADT(d) + PG_TO_UNIX_DAYS);
+
+				appendBinaryStringInfo(&c->fixed, (char *) &v, 4);
+				break;
+			}
+		case A_TIME64:
+			{
+				int64		v = isnull ? 0 : (int64) DatumGetTimeADT(d);
+
+				appendBinaryStringInfo(&c->fixed, (char *) &v, 8);
+				break;
+			}
+		case A_TIMESTAMP:
+		case A_TIMESTAMPTZ:
+			{
+				int64		v = isnull ? 0 :
+					(int64) DatumGetTimestamp(d) + PG_TO_UNIX_USECS;
+
+				appendBinaryStringInfo(&c->fixed, (char *) &v, 8);
+				break;
+			}
+		case A_UUID:
+			{
+				static const char zeros[UUID_LEN] = {0};
+
+				if (isnull)
+					appendBinaryStringInfo(&c->fixed, zeros, UUID_LEN);
+				else
+					appendBinaryStringInfo(&c->fixed,
+										   (char *) DatumGetUUIDP(d)->data, UUID_LEN);
+				break;
+			}
+		case A_DECIMAL128:
+			{
+				char		buf[16];
+
+				if (isnull)
+					memset(buf, 0, 16);
+				else
+					memcpy(buf, &dec, 16);	/* little-endian two's complement */
+				appendBinaryStringInfo(&c->fixed, buf, 16);
+				break;
+			}
 		case A_BOOL:
 			appendStringInfoChar(&c->boolvals,
 								 (!isnull && DatumGetBool(d)) ? 1 : 0);
@@ -502,11 +732,24 @@ arrowcol_append(ArrowCol *c, Datum d, bool isnull)
 			{
 				if (!isnull)
 				{
-					struct varlena *v = PG_DETOAST_DATUM_PACKED(d);
-					int			len = VARSIZE_ANY_EXHDR(v);
+					if (c->convertText)
+					{
+						char	   *str = OutputFunctionCall(&c->outFinfo, d);
+						int			len = (int) strlen(str);
 
-					appendBinaryStringInfo(&c->vardata, VARDATA_ANY(v), len);
-					c->running += len;
+						if (len > 0)
+							appendBinaryStringInfo(&c->vardata, str, len);
+						c->running += len;
+						pfree(str);
+					}
+					else
+					{
+						struct varlena *v = PG_DETOAST_DATUM_PACKED(d);
+						int			len = VARSIZE_ANY_EXHDR(v);
+
+						appendBinaryStringInfo(&c->vardata, VARDATA_ANY(v), len);
+						c->running += len;
+					}
 				}
 				appendBinaryStringInfo(&c->offs, (char *) &c->running, 4);
 				break;
@@ -722,6 +965,8 @@ columnar_export_arrow(PG_FUNCTION_ARGS)
 	{
 		Form_pg_attribute att = TupleDescAttr(tupdesc, i);
 		int			width;
+		int			precision,
+					scale;
 		ArrowKind	kind;
 
 		if (att->attisdropped)
@@ -731,7 +976,8 @@ columnar_export_arrow(PG_FUNCTION_ARGS)
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("columnar.export_arrow does not support dropped columns")));
 		}
-		kind = arrow_kind_for_type(att->atttypid, &width);
+		kind = arrow_kind_for_type(att->atttypid, att->atttypmod,
+								   &width, &precision, &scale);
 		if (width < 0)
 		{
 			table_close(rel, AccessShareLock);
@@ -744,6 +990,19 @@ columnar_export_arrow(PG_FUNCTION_ARGS)
 		cols[i].name = pstrdup(NameStr(att->attname));
 		cols[i].kind = kind;
 		cols[i].width = width;
+		cols[i].precision = precision;
+		cols[i].scale = scale;
+		cols[i].convertText = (kind == A_UTF8 &&
+							   (att->atttypid == NUMERICOID ||
+								att->atttypid == JSONBOID));
+		if (cols[i].convertText)
+		{
+			Oid			outfunc;
+			bool		isvarlena;
+
+			getTypeOutputInfo(att->atttypid, &outfunc, &isvarlena);
+			fmgr_info(outfunc, &cols[i].outFinfo);
+		}
 		initStringInfo(&cols[i].valid);
 		initStringInfo(&cols[i].fixed);
 		initStringInfo(&cols[i].boolvals);
@@ -768,7 +1027,9 @@ columnar_export_arrow(PG_FUNCTION_ARGS)
 	{
 		uint32		nameOff = fb_create_string(&b, cols[i].name);
 		uint8		typetag;
-		uint32		typeOff = fb_arrow_type(&b, cols[i].kind, &typetag);
+		uint32		typeOff = fb_arrow_type(&b, cols[i].kind,
+											cols[i].precision, cols[i].scale,
+											&typetag);
 
 		fb_start(&b, 7);
 		fb_add_offset(&b, 0, nameOff);	/* name */

--- a/src/columnar_parquet.c
+++ b/src/columnar_parquet.c
@@ -31,13 +31,22 @@
 #include "miscadmin.h"
 #include "storage/fd.h"
 #include "utils/builtins.h"
+#include "utils/date.h"
+#include "utils/lsyscache.h"
 #include "utils/memutils.h"
+#include "utils/numeric.h"
 #include "utils/rel.h"
 #include "utils/snapmgr.h"
+#include "utils/timestamp.h"
+#include "utils/uuid.h"
 
 PG_FUNCTION_INFO_V1(columnar_export_parquet);
 
 #define PARQUET_ROWGROUP_ROWS 65536
+
+/* PostgreSQL epoch (2000-01-01) to Unix epoch (1970-01-01) offsets */
+#define PG_TO_UNIX_DAYS		((int64) (POSTGRES_EPOCH_JDATE - UNIX_EPOCH_JDATE))
+#define PG_TO_UNIX_USECS	(PG_TO_UNIX_DAYS * USECS_PER_DAY)
 
 /* Parquet physical types */
 #define PQ_BOOLEAN		0
@@ -46,8 +55,13 @@ PG_FUNCTION_INFO_V1(columnar_export_parquet);
 #define PQ_FLOAT		4
 #define PQ_DOUBLE		5
 #define PQ_BYTE_ARRAY	6
+#define PQ_FIXED_LEN_BYTE_ARRAY 7
 /* ConvertedType */
 #define PQ_CT_UTF8		0
+#define PQ_CT_DECIMAL	5
+#define PQ_CT_DATE		6
+#define PQ_CT_TIME_MICROS 8
+#define PQ_CT_TIMESTAMP_MICROS 10
 #define PQ_CT_INT_16	16
 /* Encoding */
 #define PQ_ENC_PLAIN	0
@@ -71,8 +85,64 @@ typedef enum ParquetKind
 	P_DOUBLE,
 	P_BOOL,
 	P_UTF8,
-	P_BINARY
+	P_BINARY,
+	P_DATE,						/* date -> INT32 (days from Unix epoch) */
+	P_TIME,						/* time -> INT64 TIME_MICROS */
+	P_TIMESTAMP,				/* timestamp/tz -> INT64 TIMESTAMP_MICROS */
+	P_UUID,						/* uuid -> FIXED_LEN_BYTE_ARRAY(16) */
+	P_DECIMAL					/* numeric(p,s) -> FIXED_LEN_BYTE_ARRAY(16) */
 }			ParquetKind;
+
+/* Parse a numeric value (via its text form) into a 128-bit unscaled integer at
+ * the given scale. Returns false for NaN/Infinity, which a decimal cannot hold. */
+static bool
+numeric_to_int128(Datum numd, int scale, __int128 *out)
+{
+	char	   *s = DatumGetCString(DirectFunctionCall1(numeric_out, numd));
+	char	   *p = s;
+	bool		neg = false;
+	bool		seenDot = false;
+	int			fracDigits = 0;
+	__int128	acc = 0;
+
+	if (*p == '-')
+	{
+		neg = true;
+		p++;
+	}
+	else if (*p == '+')
+		p++;
+
+	for (; *p; p++)
+	{
+		if (*p == '.')
+		{
+			seenDot = true;
+			continue;
+		}
+		if (*p < '0' || *p > '9')	/* NaN, Infinity: not representable */
+		{
+			pfree(s);
+			return false;
+		}
+		acc = acc * 10 + (*p - '0');
+		if (seenDot)
+			fracDigits++;
+	}
+	while (fracDigits < scale)
+	{
+		acc *= 10;
+		fracDigits++;
+	}
+	while (fracDigits > scale)
+	{
+		acc /= 10;
+		fracDigits--;
+	}
+	*out = neg ? -acc : acc;
+	pfree(s);
+	return true;
+}
 
 /* ---- Thrift compact-protocol writer (into a StringInfo) ---- */
 
@@ -164,6 +234,11 @@ typedef struct PqCol
 	ParquetKind kind;
 	int			ptype;			/* Parquet physical type */
 	int			convType;		/* ConvertedType, or -1 */
+	int			typeLength;		/* FIXED_LEN_BYTE_ARRAY length, else 0 */
+	int			precision;		/* decimal precision (P_DECIMAL) */
+	int			scale;			/* decimal scale (P_DECIMAL) */
+	bool		convertText;	/* P_UTF8 fallback needs the type output fn */
+	FmgrInfo	outFinfo;		/* output function (when convertText) */
 	StringInfoData present;		/* 1 byte per row: 1 present, 0 null */
 	StringInfoData values;		/* PLAIN values, non-null only */
 	StringInfoData boolbits;	/* 1 byte per non-null bool value */
@@ -194,9 +269,13 @@ pqcol_reset(PqCol *c)
 }
 
 static ParquetKind
-parquet_kind_for_type(Oid typid, int *ptype, int *convType)
+parquet_kind_for_type(Oid typid, int32 typmod, int *ptype, int *convType,
+					  int *typeLength, int *precision, int *scale)
 {
 	*convType = -1;
+	*typeLength = 0;
+	*precision = 0;
+	*scale = 0;
 	switch (typid)
 	{
 		case INT2OID:
@@ -220,12 +299,53 @@ parquet_kind_for_type(Oid typid, int *ptype, int *convType)
 			return P_BOOL;
 		case TEXTOID:
 		case VARCHAROID:
+		case JSONOID:
+		case JSONBOID:
 			*ptype = PQ_BYTE_ARRAY;
 			*convType = PQ_CT_UTF8;
 			return P_UTF8;
 		case BYTEAOID:
 			*ptype = PQ_BYTE_ARRAY;
 			return P_BINARY;
+		case DATEOID:
+			*ptype = PQ_INT32;
+			*convType = PQ_CT_DATE;
+			return P_DATE;
+		case TIMEOID:
+			*ptype = PQ_INT64;
+			*convType = PQ_CT_TIME_MICROS;
+			return P_TIME;
+		case TIMESTAMPOID:
+		case TIMESTAMPTZOID:
+			*ptype = PQ_INT64;
+			*convType = PQ_CT_TIMESTAMP_MICROS;
+			return P_TIMESTAMP;
+		case UUIDOID:
+			*ptype = PQ_FIXED_LEN_BYTE_ARRAY;
+			*typeLength = 16;
+			return P_UUID;
+		case NUMERICOID:
+			/* numeric(p,s) with p<=38 and 0<=s<=p -> DECIMAL in a 16-byte
+			 * FIXED_LEN_BYTE_ARRAY; otherwise fall back to text. */
+			if (typmod >= (int32) VARHDRSZ)
+			{
+				int32		tmp = typmod - VARHDRSZ;
+				int			p = (tmp >> 16) & 0xffff;
+				int			s = tmp & 0xffff;
+
+				if (p >= 1 && p <= 38 && s >= 0 && s <= p)
+				{
+					*ptype = PQ_FIXED_LEN_BYTE_ARRAY;
+					*typeLength = 16;
+					*convType = PQ_CT_DECIMAL;
+					*precision = p;
+					*scale = s;
+					return P_DECIMAL;
+				}
+			}
+			*ptype = PQ_BYTE_ARRAY;
+			*convType = PQ_CT_UTF8;
+			return P_UTF8;			/* text fallback */
 		default:
 			*ptype = -1;
 			return P_INT32;
@@ -235,6 +355,31 @@ parquet_kind_for_type(Oid typid, int *ptype, int *convType)
 static void
 pqcol_append(PqCol *c, Datum d, bool isnull)
 {
+	__int128	dec = 0;
+
+	/* Fold values with no Parquet representation (±infinity dates/timestamps,
+	 * NaN/Infinity numerics) to null. */
+	if (!isnull)
+	{
+		switch (c->kind)
+		{
+			case P_DATE:
+				if (DATE_NOT_FINITE(DatumGetDateADT(d)))
+					isnull = true;
+				break;
+			case P_TIMESTAMP:
+				if (TIMESTAMP_NOT_FINITE(DatumGetTimestamp(d)))
+					isnull = true;
+				break;
+			case P_DECIMAL:
+				if (!numeric_to_int128(d, c->scale, &dec))
+					isnull = true;
+				break;
+			default:
+				break;
+		}
+	}
+
 	c->numValues++;
 	appendStringInfoChar(&c->present, isnull ? 0 : 1);
 	if (isnull)
@@ -277,11 +422,60 @@ pqcol_append(PqCol *c, Datum d, bool isnull)
 				appendBinaryStringInfo(&c->values, (char *) &v, 8);
 				break;
 			}
+		case P_DATE:
+			{
+				int32		v = (int32) (DatumGetDateADT(d) + PG_TO_UNIX_DAYS);
+
+				appendBinaryStringInfo(&c->values, (char *) &v, 4);
+				break;
+			}
+		case P_TIME:
+			{
+				int64		v = (int64) DatumGetTimeADT(d);
+
+				appendBinaryStringInfo(&c->values, (char *) &v, 8);
+				break;
+			}
+		case P_TIMESTAMP:
+			{
+				int64		v = (int64) DatumGetTimestamp(d) + PG_TO_UNIX_USECS;
+
+				appendBinaryStringInfo(&c->values, (char *) &v, 8);
+				break;
+			}
+		case P_UUID:
+			appendBinaryStringInfo(&c->values,
+								   (char *) DatumGetUUIDP(d)->data, UUID_LEN);
+			break;
+		case P_DECIMAL:
+			{
+				/* big-endian two's complement, 16 bytes */
+				char		be[16];
+				char	   *le = (char *) &dec;
+				int			j;
+
+				for (j = 0; j < 16; j++)
+					be[j] = le[15 - j];
+				appendBinaryStringInfo(&c->values, be, 16);
+				break;
+			}
 		case P_BOOL:
 			appendStringInfoChar(&c->boolbits, DatumGetBool(d) ? 1 : 0);
 			break;
 		case P_UTF8:
 		case P_BINARY:
+			if (c->convertText)
+			{
+				/* numeric/jsonb fallback: canonical text via output function */
+				char	   *str = OutputFunctionCall(&c->outFinfo, d);
+				int32		len = (int32) strlen(str);
+
+				appendBinaryStringInfo(&c->values, (char *) &len, 4);
+				if (len > 0)
+					appendBinaryStringInfo(&c->values, str, len);
+				pfree(str);
+			}
+			else
 			{
 				struct varlena *v = PG_DETOAST_DATUM_PACKED(d);
 				int32		len = VARSIZE_ANY_EXHDR(v);
@@ -289,8 +483,8 @@ pqcol_append(PqCol *c, Datum d, bool isnull)
 				appendBinaryStringInfo(&c->values, (char *) &len, 4);
 				if (len > 0)
 					appendBinaryStringInfo(&c->values, VARDATA_ANY(v), len);
-				break;
 			}
+			break;
 	}
 }
 
@@ -386,10 +580,17 @@ write_schema_element_col(StringInfo b, PqCol *c)
 	int16		last = 0;
 
 	tc_i32_field(b, &last, 1, c->ptype);	/* type */
+	if (c->ptype == PQ_FIXED_LEN_BYTE_ARRAY)
+		tc_i32_field(b, &last, 2, c->typeLength);	/* type_length */
 	tc_i32_field(b, &last, 3, 1);			/* repetition_type = OPTIONAL */
 	tc_string_field(b, &last, 4, c->name, (int) strlen(c->name));
 	if (c->convType >= 0)
 		tc_i32_field(b, &last, 6, c->convType); /* converted_type */
+	if (c->convType == PQ_CT_DECIMAL)
+	{
+		tc_i32_field(b, &last, 7, c->scale);		/* scale */
+		tc_i32_field(b, &last, 8, c->precision);	/* precision */
+	}
 	tc_stop(b);
 }
 
@@ -497,7 +698,10 @@ columnar_export_parquet(PG_FUNCTION_ARGS)
 	{
 		Form_pg_attribute att = TupleDescAttr(tupdesc, i);
 		int			ptype,
-					convType;
+					convType,
+					typeLength,
+					precision,
+					scale;
 		ParquetKind kind;
 
 		if (att->attisdropped)
@@ -507,7 +711,9 @@ columnar_export_parquet(PG_FUNCTION_ARGS)
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("columnar.export_parquet does not support dropped columns")));
 		}
-		kind = parquet_kind_for_type(att->atttypid, &ptype, &convType);
+		kind = parquet_kind_for_type(att->atttypid, att->atttypmod,
+									 &ptype, &convType, &typeLength,
+									 &precision, &scale);
 		if (ptype < 0)
 		{
 			table_close(rel, AccessShareLock);
@@ -521,6 +727,20 @@ columnar_export_parquet(PG_FUNCTION_ARGS)
 		cols[i].kind = kind;
 		cols[i].ptype = ptype;
 		cols[i].convType = convType;
+		cols[i].typeLength = typeLength;
+		cols[i].precision = precision;
+		cols[i].scale = scale;
+		cols[i].convertText = (kind == P_UTF8 &&
+							   (att->atttypid == NUMERICOID ||
+								att->atttypid == JSONBOID));
+		if (cols[i].convertText)
+		{
+			Oid			outfunc;
+			bool		isvarlena;
+
+			getTypeOutputInfo(att->atttypid, &outfunc, &isvarlena);
+			fmgr_info(outfunc, &cols[i].outFinfo);
+		}
 		initStringInfo(&cols[i].present);
 		initStringInfo(&cols[i].values);
 		initStringInfo(&cols[i].boolbits);

--- a/test/arrow_export.sh
+++ b/test/arrow_export.sh
@@ -112,8 +112,90 @@ check "empty arrow readable" "$emptyrows" "0 a,b"
 # Errors.
 echo "-- argument validation"
 expect_error "reject non-columnar table" "SELECT columnar.export_arrow('t_heap', '$PGC_WORKDIR/x.arrows');"
-psql_run "CREATE TABLE t_js (a int, j json) USING columnar;"
-psql_run "INSERT INTO t_js VALUES (1, '{}');"
-expect_error "reject unsupported type" "SELECT columnar.export_arrow('t_js', '$PGC_WORKDIR/x.arrows');"
+psql_run "CREATE TABLE t_un (a int, p point) USING columnar;"
+psql_run "INSERT INTO t_un VALUES (1, '(1,2)');"
+expect_error "reject unsupported type" "SELECT columnar.export_arrow('t_un', '$PGC_WORKDIR/x.arrows');"
+
+# ---------------------------------------------------------------------------
+# Extended type coverage: date, time, timestamp(+tz), uuid, numeric(p,s) as
+# Decimal128, unconstrained numeric as text, json, jsonb. Verified against a
+# heap oracle rendered to the same canonical form each type maps to (raw
+# day/us integers, uuid hex, decimal/numeric text). Non-finite dates and
+# timestamps and NaN numerics are documented to export as null.
+# ---------------------------------------------------------------------------
+echo "-- extended type coverage"
+EXT="$PGC_WORKDIR/ext.arrows"
+EXTCSV="$PGC_WORKDIR/ext.csv"
+psql_run "CREATE TABLE t_ext_heap (id int, dt date, tm time, ts timestamp,
+          tz timestamptz, u uuid, num numeric(20,4), numun numeric,
+          j json, jb jsonb);"
+psql_run "CREATE TABLE t_ext_col (LIKE t_ext_heap) USING columnar;"
+psql_run "INSERT INTO t_ext_heap VALUES
+  (1,'2021-03-04','12:34:56.789012','2021-03-04 12:34:56.789012',
+     '2021-03-04 12:34:56.789012+00','11111111-2222-3333-4444-555555555555',
+     12345.6789, 9999999999999999.1234, '{\"a\": 1}', '{\"b\": 2}'),
+  (2,'1970-01-01','00:00:00','2000-01-01 00:00:00','2000-01-01 00:00:00+00',
+     '00000000-0000-0000-0000-000000000000', -0.0001, -1234567890.5,
+     '[1, 2, 3]', '[3, 2, 1]'),
+  (3, NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
+  (4,'infinity','23:59:59.999999','infinity','-infinity',
+     'ffffffff-ffff-ffff-ffff-ffffffffffff', 'NaN', 'NaN', 'null', 'true');"
+psql_run "INSERT INTO t_ext_col SELECT * FROM t_ext_heap;"
+
+extrows="$(q "SELECT columnar.export_arrow('t_ext_col', '$EXT');")"
+check "extended export rows written" "$extrows" "4"
+
+# Canonical oracle: the exact representation each type maps into.
+psql_run "COPY (SELECT id,
+    CASE WHEN dt IS NULL OR NOT isfinite(dt) THEN NULL
+         ELSE (dt - DATE '1970-01-01') END,
+    CASE WHEN tm IS NULL THEN NULL
+         ELSE (extract(epoch from tm)*1000000)::bigint END,
+    CASE WHEN ts IS NULL OR NOT isfinite(ts) THEN NULL
+         ELSE (extract(epoch from ts)*1000000)::bigint END,
+    CASE WHEN tz IS NULL OR NOT isfinite(tz) THEN NULL
+         ELSE (extract(epoch from tz)*1000000)::bigint END,
+    CASE WHEN u IS NULL THEN NULL ELSE replace(u::text,'-','') END,
+    CASE WHEN num IS NULL OR num = 'NaN'::numeric THEN NULL ELSE num::text END,
+    CASE WHEN numun IS NULL THEN NULL ELSE numun::text END,
+    j::text, jb::text
+   FROM t_ext_heap ORDER BY id)
+   TO '$EXTCSV' WITH (FORMAT csv, NULL E'\\\\N')"
+
+extres="$(python3 - "$EXT" "$EXTCSV" <<'PY'
+import sys, csv
+import pyarrow as pa, pyarrow.ipc as ipc
+t = ipc.open_stream(pa.OSFile(sys.argv[1],'rb')).read_all()
+def col(n): return t.column(n)
+def i(n): return col(n).cast(pa.int64()).to_pylist()
+ids = col('id').to_pylist()
+dt = col('dt').cast(pa.int32()).to_pylist()   # date32 casts to int32, not int64
+tm = i('tm'); ts = i('ts'); tz = i('tz')
+u  = [None if v is None else v.hex() for v in col('u').to_pylist()]
+num= [None if v is None else str(v) for v in col('num').to_pylist()]
+nun= [None if v is None else str(v) for v in col('numun').to_pylist()]
+j  = col('j').to_pylist(); jb = col('jb').to_pylist()
+ar = {}
+for k in range(t.num_rows):
+    ar[ids[k]] = (ids[k], dt[k], tm[k], ts[k], tz[k], u[k], num[k], nun[k], j[k], jb[k])
+def N(x): return None if x==r'\N' else x
+def I(x): return None if x==r'\N' else int(x)
+pg = {}
+for r in csv.reader(open(sys.argv[2],newline='')):
+    pg[int(r[0])] = (int(r[0]), I(r[1]), I(r[2]), I(r[3]), I(r[4]),
+                     N(r[5]), N(r[6]), N(r[7]), N(r[8]), N(r[9]))
+print("MATCH" if ar==pg else "MISMATCH %r %r"%(ar,pg))
+PY
+)"
+check "extended values match heap oracle" "$extres" "MATCH"
+
+extsch="$(python3 - "$EXT" <<'PY'
+import sys, pyarrow as pa, pyarrow.ipc as ipc
+s=ipc.open_stream(pa.OSFile(sys.argv[1],'rb')).read_all().schema
+print(",".join(f"{f.name}:{f.type}" for f in s))
+PY
+)"
+check "extended arrow schema" "$extsch" \
+"id:int32,dt:date32[day],tm:time64[us],ts:timestamp[us],tz:timestamp[us, tz=UTC],u:fixed_size_binary[16],num:decimal128(20, 4),numun:string,j:string,jb:string"
 
 pgc_summary

--- a/test/parquet_export.sh
+++ b/test/parquet_export.sh
@@ -125,8 +125,99 @@ check "empty parquet readable" "$er" "0 a,b"
 # Errors.
 echo "-- argument validation"
 expect_error "reject non-columnar table" "SELECT columnar.export_parquet('t_heap', '$PGC_WORKDIR/x.parquet');"
-psql_run "CREATE TABLE t_js (a int, j json) USING columnar;"
-psql_run "INSERT INTO t_js VALUES (1, '{}');"
-expect_error "reject unsupported type" "SELECT columnar.export_parquet('t_js', '$PGC_WORKDIR/x.parquet');"
+psql_run "CREATE TABLE t_un (a int, p point) USING columnar;"
+psql_run "INSERT INTO t_un VALUES (1, '(1,2)');"
+expect_error "reject unsupported type" "SELECT columnar.export_parquet('t_un', '$PGC_WORKDIR/x.parquet');"
+
+# ---------------------------------------------------------------------------
+# Extended type coverage: date, time, timestamp(+tz), uuid, numeric(p,s) as
+# DECIMAL, unconstrained numeric as text, json, jsonb. Verified against a heap
+# oracle rendered to the canonical form each type maps to. Parquet's
+# TIMESTAMP_MICROS is UTC-normalized, so timestamps are compared by their raw
+# microsecond value rather than by schema. Non-finite dates/timestamps and NaN
+# numerics export as null.
+# ---------------------------------------------------------------------------
+echo "-- extended type coverage"
+EXT="$PGC_WORKDIR/ext.parquet"
+EXTCSV="$PGC_WORKDIR/ext.csv"
+psql_run "CREATE TABLE t_ext_heap (id int, dt date, tm time, ts timestamp,
+          tz timestamptz, u uuid, num numeric(20,4), numun numeric,
+          j json, jb jsonb);"
+psql_run "CREATE TABLE t_ext_col (LIKE t_ext_heap) USING columnar;"
+psql_run "INSERT INTO t_ext_heap VALUES
+  (1,'2021-03-04','12:34:56.789012','2021-03-04 12:34:56.789012',
+     '2021-03-04 12:34:56.789012+00','11111111-2222-3333-4444-555555555555',
+     12345.6789, 9999999999999999.1234, '{\"a\": 1}', '{\"b\": 2}'),
+  (2,'1970-01-01','00:00:00','2000-01-01 00:00:00','2000-01-01 00:00:00+00',
+     '00000000-0000-0000-0000-000000000000', -0.0001, -1234567890.5,
+     '[1, 2, 3]', '[3, 2, 1]'),
+  (3, NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
+  (4,'infinity','23:59:59.999999','infinity','-infinity',
+     'ffffffff-ffff-ffff-ffff-ffffffffffff', 'NaN', 'NaN', 'null', 'true');"
+psql_run "INSERT INTO t_ext_col SELECT * FROM t_ext_heap;"
+
+extrows="$(q "SELECT columnar.export_parquet('t_ext_col', '$EXT');")"
+check "extended export rows written" "$extrows" "4"
+
+psql_run "COPY (SELECT id,
+    CASE WHEN dt IS NULL OR NOT isfinite(dt) THEN NULL
+         ELSE (dt - DATE '1970-01-01') END,
+    CASE WHEN tm IS NULL THEN NULL
+         ELSE (extract(epoch from tm)*1000000)::bigint END,
+    CASE WHEN ts IS NULL OR NOT isfinite(ts) THEN NULL
+         ELSE (extract(epoch from ts)*1000000)::bigint END,
+    CASE WHEN tz IS NULL OR NOT isfinite(tz) THEN NULL
+         ELSE (extract(epoch from tz)*1000000)::bigint END,
+    CASE WHEN u IS NULL THEN NULL ELSE replace(u::text,'-','') END,
+    CASE WHEN num IS NULL OR num = 'NaN'::numeric THEN NULL ELSE num::text END,
+    CASE WHEN numun IS NULL THEN NULL ELSE numun::text END,
+    j::text, jb::text
+   FROM t_ext_heap ORDER BY id)
+   TO '$EXTCSV' WITH (FORMAT csv, NULL E'\\\\N')"
+
+extres="$(python3 - "$EXT" "$EXTCSV" <<'PY'
+import sys, csv
+import pyarrow as pa, pyarrow.parquet as pq
+t = pq.read_table(sys.argv[1])
+def col(n): return t.column(n)
+def i(n): return col(n).cast(pa.int64()).to_pylist()
+ids = col('id').to_pylist()
+dt = col('dt').cast(pa.int32()).to_pylist()   # date32 casts to int32, not int64
+tm = i('tm'); ts = i('ts'); tz = i('tz')
+u  = [None if v is None else v.hex() for v in col('u').to_pylist()]
+num= [None if v is None else str(v) for v in col('num').to_pylist()]
+nun= [None if v is None else str(v) for v in col('numun').to_pylist()]
+j  = col('j').to_pylist(); jb = col('jb').to_pylist()
+ar = {}
+for k in range(t.num_rows):
+    ar[ids[k]] = (ids[k], dt[k], tm[k], ts[k], tz[k], u[k], num[k], nun[k], j[k], jb[k])
+def N(x): return None if x==r'\N' else x
+def I(x): return None if x==r'\N' else int(x)
+pg = {}
+for r in csv.reader(open(sys.argv[2],newline='')):
+    pg[int(r[0])] = (int(r[0]), I(r[1]), I(r[2]), I(r[3]), I(r[4]),
+                     N(r[5]), N(r[6]), N(r[7]), N(r[8]), N(r[9]))
+print("MATCH" if ar==pg else "MISMATCH %r %r"%(ar,pg))
+PY
+)"
+check "extended values match heap oracle" "$extres" "MATCH"
+
+# Key type mappings visible in the Parquet schema.
+exttypes="$(python3 - "$EXT" <<'PY'
+import sys, pyarrow.parquet as pq
+s=pq.read_table(sys.argv[1]).schema
+d=dict((f.name,str(f.type)) for f in s)
+print("%s|%s|%s|%s" % (d['dt'], d['tm'], d['u'], d['num']))
+PY
+)"
+check "extended parquet types" "$exttypes" \
+"date32[day]|time64[us]|fixed_size_binary[16]|decimal128(20, 4)"
+
+if command -v duckdb >/dev/null 2>&1; then
+	dnum="$(duckdb -noheader -list -c "SELECT num FROM read_parquet('$EXT') WHERE id=1;" 2>/dev/null | tr -d '[:space:]')"
+	check "duckdb reads decimal" "$dnum" "12345.6789"
+	dext="$(duckdb -noheader -list -c "SELECT count(*) FROM read_parquet('$EXT');" 2>/dev/null | tr -d '[:space:]')"
+	check "duckdb extended row count" "$dext" "4"
+fi
 
 pgc_summary


### PR DESCRIPTION
Extends `columnar.export_arrow` and `columnar.export_parquet` beyond the first slice with the common warehouse scalar types. Additive: no on-disk format change, existing exports byte-compatible, existing query results unchanged. Roadmap item 1.

## Type mapping added

| PostgreSQL | Arrow | Parquet |
| --- | --- | --- |
| `date` | Date32 | INT32 DATE |
| `time` | Time64[us] | INT64 TIME_MICROS |
| `timestamp` | Timestamp[us] | INT64 TIMESTAMP_MICROS |
| `timestamptz` | Timestamp[us, UTC] | INT64 TIMESTAMP_MICROS |
| `uuid` | FixedSizeBinary(16) | FIXED_LEN_BYTE_ARRAY(16) |
| `numeric(p,s)`, p≤38 | Decimal128(p,s) | DECIMAL FLBA(16) |
| `numeric` (unconstrained/p>38/NaN/Inf) | Utf8 | BYTE_ARRAY UTF8 |
| `json`, `jsonb` | Utf8 | BYTE_ARRAY UTF8 |

Non-finite dates/timestamps and NaN/Infinity numerics have no target representation and export as null, matched by both writers. Details in `design/gaps/27-IMPL-export-type-coverage.md`.

## Not in this slice
Arrays and composite types require nested Arrow List buffers and Parquet repetition levels (the flat writers emit neither); documented as follow-ups.

## Testing
`test/arrow_export.sh` and `test/parquet_export.sh` gain a mixed-type table covering every mapping (nulls, non-finite values, the decimal path, unconstrained numeric, json/jsonb), verified against the heap oracle via pyarrow and the DuckDB CLI. Export suites green on PG17 and PG19; full PG13-19 matrix running as the merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)