### PR TITLE
design: implementation specs for index-only scan and multiple projections

### DIFF
--- a/design/gaps/26-IMPL-multiple-projections.md
+++ b/design/gaps/26-IMPL-multiple-projections.md
@@ -1,0 +1,122 @@
+# Gap 26 (impl): multiple projections (C-Store), format 2.2
+
+Piece (2) of gap 26. Piece (1), sorted single-projection (`columnar.vacuum_sorted`),
+ships. This adds N physical projections per table, each a column subset in its own
+sort order, sharing the row-identity space — the central C-Store idea.
+
+Status: SPEC. This is a multi-PR subsystem (catalog, write fan-out, planner
+selection, row reconstruction, vacuum, recovery) with a format bump to 2.2. It
+must be built and merged in phases, each with full differential coverage on a
+stable cluster. Reads of 2.0/2.1 tables are unaffected (one implicit projection).
+
+## Model
+
+A projection is a named, ordered subset of the table's columns, stored as its own
+columnar storage (its own `storage_id`, stripes, chunk groups, streams) sorted on
+the projection's sort key. Every base table has an implicit "base projection"
+containing all columns in insert order (today's single storage). Additional
+projections are declared by the user. All projections of a table cover the same
+logical rows and share the row-number identity space so a subset projection can be
+completed by row-number join against a superset projection (usually the base).
+
+Invariant: for every logical row, every projection has exactly one physical row,
+and a given row number denotes the same logical row in every projection.
+
+## Catalog (format 2.2)
+
+New catalog `columnar.projection`:
+
+    storage_id      bigint    -- the table's base storage id
+    projection_id   int       -- 0 = base, 1..N additional
+    name            name
+    proj_storage_id bigint    -- this projection's own storage id
+    sort_key        int2[]    -- attnums, in sort order (empty = insert order)
+    columns         int2[]    -- attnums stored in this projection (base = all)
+
+The metapage records format 2.2 and the projection count; a 2.0/2.1 metapage
+implies a single base projection. Additive: old readers ignore the new catalog.
+
+New SQL surface (shape, not final):
+`columnar.add_projection(rel, name, columns text[], sort_key text[])`,
+`columnar.drop_projection(rel, name)`.
+
+## Write fan-out
+
+Every INSERT / multi_insert / bulk load writes the base projection as today, then
+writes each additional projection: project the tuple to the projection's columns
+and append to that projection's write buffer. Additional projections are stored
+sorted, so they cannot simply append in insert order like the base — options:
+
+- **Buffer-and-sort at flush**: accumulate a projection's rows in the write buffer
+  and sort by the projection sort key when the stripe flushes. Cheap on load,
+  gives per-stripe (not global) sort order — enough for min/max skipping within a
+  stripe. This is the pragmatic choice and mirrors how load-then-`vacuum_sorted`
+  already works.
+- **Global sort via vacuum**: `columnar.vacuum` re-sorts each projection globally,
+  as `vacuum_sorted` does for the single projection today.
+
+Row numbers are assigned once (by the base projection) and carried into each
+projection's rows so identity is shared; a projection stores the row number
+alongside its columns (an implicit system column in its streams) to support
+reconstruction and delete propagation.
+
+## Delete / update
+
+`ColumnarMarkRowDeleted` marks a row number deleted; the mark must apply to *all*
+projections (each has a row-mask keyed by the shared row number). Update =
+delete + insert, fanned out to every projection. The row mask is keyed by the
+base row number in every projection so a single delete marks the row dead
+everywhere.
+
+## Planner selection and reconstruction
+
+- For a scan, the custom scan provider chooses the projection whose sort key and
+  column set best serve the query (predicate on the sort key → tight min/max
+  skipping; projection covers all referenced columns → no reconstruction).
+- If the chosen projection is a subset missing some referenced columns, the
+  remaining columns are fetched from the base projection by row number (a
+  row-number lookup, the same `ReadRowByNumber` path index fetch uses). The
+  planner weighs the reconstruction cost against the skipping benefit.
+- Default when no projection helps: the base projection (today's behavior).
+
+## Vacuum / rebuild
+
+`columnar.vacuum` must rewrite every projection consistently, re-deriving row
+numbers so all projections stay aligned, and re-sorting each per its key.
+`vacuum_sorted` becomes a special case (base projection sorted). Dropping a
+projection frees its storage.
+
+## Concurrency / recovery
+
+Every projection is written under the same transaction as the base insert, so a
+crash leaves either all or none of a row's projection copies (the stripe catalog
+rows commit together). Recovery replays each projection's stripes with the base.
+The differential suite must confirm all projections agree after concurrent
+inserts/deletes and after crash recovery.
+
+## Testing
+
+Differential vs heap for every query shape, on tables with 1..N projections,
+asserting identical results regardless of which projection the planner picks;
+write-fan-out agreement (each projection, read alone by row number, reproduces the
+base row); delete/update propagation to all projections; vacuum/rebuild alignment;
+per-projection crash recovery; `EXPLAIN` shows the chosen projection.
+
+## Phasing (each a tested PR)
+
+1. Catalog + `add_projection`/`drop_projection` DDL; format 2.2 metapage; base
+   projection recorded explicitly. No write fan-out yet (projections empty).
+2. Write fan-out with buffer-and-sort at flush; row-number sharing; delete
+   propagation. Projections populated but not yet used by the planner.
+3. Read path: read a projection by itself; row-number reconstruction from base.
+4. Planner selection: choose a projection per query; cost model; `EXPLAIN`.
+5. Vacuum coordination across projections; global re-sort.
+6. Full differential + concurrency + recovery; enable by default.
+
+## Effort / risk
+
+Very large. Primary risks: keeping N copies consistent under concurrency and
+recovery, and planner integration. Recommendation: land phases 1-2 first (catalog
++ fan-out, projections written and verified equal to base by row number) before
+any planner change, so correctness is established before the optimizer depends on
+it.

--- a/design/gaps/28-IMPL-index-only-scan.md
+++ b/design/gaps/28-IMPL-index-only-scan.md
@@ -1,0 +1,125 @@
+# Gap 28 (impl): full index-only scan via a columnar visibility map
+
+Direction (1) of gap 28. Direction (2), covering `count(*)` from metadata, already
+ships. This adds true index-only scans: for an all-visible range the executor
+answers from the index tuple and skips the columnar fetch (and its whole
+chunk-group decode).
+
+Status: SPEC. Implementation is MVCC-critical and must be developed against the
+differential/concurrency suites on a stable cluster; it is a multi-phase change,
+not a single drop. On-disk impact: additive (a visibility-map fork + an
+`all_visible` summary), 2.0/2.1 tables without it fall back to the current fetch.
+
+## Why a real VM fork
+
+PostgreSQL's index-only scan (`nodeIndexonlyscan.c`) is hard-wired to the table's
+visibility-map fork: for each index tuple it calls `VM_ALL_VISIBLE(rel, block,
+&vmbuf)` and only calls `table_index_fetch_tuple` when the block is *not*
+all-visible. A table AM cannot substitute a different all-visible source into that
+node. So to get real IOS (with the fetch skipped) pgColumnar must maintain an
+actual `VISIBILITYMAP_FORKNUM` on its relation, keyed by the same block numbers
+its TIDs use. This is the "literal heap-style VM" the exploratory note set aside;
+it is in fact the only way the core IOS path will skip the fetch.
+
+## TID / block / chunk-group mapping
+
+`ColumnarRowNumberToItemPointer` packs a row number into a synthetic TID:
+
+    block  = rowNumber / MaxHeapTuplesPerPage      (~291 rows per block)
+    offset = rowNumber % MaxHeapTuplesPerPage + 1
+
+Row numbers are global and contiguous per relation, so VM block `b` covers rows
+`[b*K, (b+1)*K)` with `K = MaxHeapTuplesPerPage`. A chunk group (default 10000
+rows) spans ~34 whole VM blocks plus up to two boundary blocks shared with the
+adjacent group. The VM fork therefore has `ceil(nextRowNumber / K)` bits.
+
+## All-visible rule (MVCC)
+
+A columnar row is visible to a snapshot iff its **stripe** catalog row is visible
+to that snapshot AND its **row_mask** delete bit is unset (both are ordinary
+catalog rows read through `ColumnarCatalogSnapshot`). A VM block may be marked
+all-visible only when *every* row it covers is visible to *every* snapshot, i.e.:
+
+1. Each stripe covering the block is committed and older than the all-visible
+   horizon `GetOldestNonRemovableTransactionId(rel)` (PG14+) /
+   `GetOldestXmin` (PG13) — no snapshot can fail to see the insert.
+2. `deleted_rows == 0` for every chunk group the block touches, in the committed
+   catalog — no row in the block is dead for any snapshot, and no delete is
+   in flight (an in-flight delete leaves an uncommitted `row_mask` row, so the
+   group is not yet all-committed-clean; we require the delete count observed
+   under a fresh catalog snapshot to be zero and the stripe/mask rows to be all
+   committed past the horizon).
+
+A boundary block shared by two groups is all-visible only if both groups satisfy
+the rule. The determination is deliberately conservative: when in doubt, leave the
+bit clear (a false "not all-visible" only costs a fetch; a false "all-visible"
+returns a row a snapshot must not see — a correctness failure). It is never set
+from within the inserting/deleting transaction.
+
+## Setting and clearing bits
+
+- **Set** (all-visible): only `columnar.vacuum` sets bits. After it computes, per
+  chunk group, the committed `deleted_rows` and confirms the covering stripes are
+  older than the horizon, it sets the VM bits for the fully-covered blocks (and
+  boundary blocks whose both groups qualify) with `visibilitymap_set`, WAL-logged
+  like heap VACUUM. Newly written groups are never all-visible until a later
+  vacuum, exactly as for heap.
+- **Clear**: any write that can change a block's visibility clears its bits before
+  commit, via `visibilitymap_clear`:
+  - INSERT / `multi_insert` / bulk load: clear the block(s) the new row numbers
+    fall in (the tail blocks of the relation).
+  - DELETE / UPDATE (`ColumnarMarkRowDeleted`): clear the block(s) covering the
+    deleted row numbers.
+  - `columnar.vacuum` compaction that rewrites stripes: clear all bits for the
+    rewritten range, then re-set for groups that qualify after the rewrite.
+  Clearing must be WAL-logged and must happen in the same transaction as the data
+  change so a crash cannot leave a set bit over changed data.
+
+## Planner / executor wiring
+
+- Remove `columnar_forbid_index_only_scan` (it currently clears the IOS path in
+  `columnar_build_simple_rel` / `columnar_get_relation_info`) — but gate the
+  removal behind a GUC `columnar.enable_index_only_scan` (default off until the
+  MVCC suite is green) so the change cannot affect correctness before it is
+  proven.
+- With IOS enabled, the planner considers an index-only path when the index can
+  return all referenced columns; at runtime `VM_ALL_VISIBLE` reads our VM fork
+  and the fetch is skipped for set blocks. Not-all-visible blocks fall through to
+  `columnar_index_fetch_tuple`, which already applies snapshot + row mask, so the
+  result is correct regardless of VM state — the VM only affects *whether* the
+  fetch happens, never correctness, provided the set-rule is conservative.
+
+## Crash safety / recovery
+
+VM set/clear are WAL-logged (`visibilitymap.c` already emits
+`XLOG_HEAP2_VISIBLE` / clear via the buffer). On a table AM the same routines
+apply to our fork. A torn or lost VM bit is safe in one direction only (a lost
+*set* just costs a fetch); a spuriously *set* bit would be a correctness bug, so
+the clear-before-write ordering and WAL are mandatory. Recovery replays the VM
+records with the data records.
+
+## Testing (must pass before enabling the GUC / merging)
+
+Differential vs heap, plus MVCC-specific scenarios, all on the assert matrix:
+
+1. Covering query and `count(*)` served by IOS returns identical rows to heap and
+   to the same query with `columnar.enable_index_only_scan = off`.
+2. Snapshot isolation: open a repeatable-read snapshot, delete rows in another
+   session, vacuum — the old snapshot's IOS must still see the deleted rows (the
+   block must not be treated all-visible for that snapshot). This is the core
+   correctness test.
+3. Concurrent insert/delete during an IOS; after-vacuum all-visible; after a
+   subsequent delete the bit is cleared and the fetch resumes.
+4. Recovery: crash after vacuum sets bits / after a delete clears them; replay and
+   verify no set bit covers a changed row.
+5. `EXPLAIN` shows Index Only Scan and "Heap Fetches: 0" for an all-visible range.
+
+## Phasing
+
+1. VM fork read/write plumbing on the columnar relation + block/group mapping
+   helpers (no planner change; GUC off). Compile + unit-level checks.
+2. Clear-on-write in insert/delete/vacuum-rewrite paths, WAL-logged.
+3. Set-in-vacuum for qualifying groups, WAL-logged.
+4. Planner enable behind the GUC; executor uses core IOS path.
+5. Full MVCC differential + concurrency + recovery suite; flip the GUC default on
+   only when green across PG13-19.


### PR DESCRIPTION
Design-first specs (docs only, no code) for the two remaining large roadmap items, ahead of phased implementation.

- `design/gaps/28-IMPL-index-only-scan.md` — real index-only scans via a columnar VM fork; conservative MVCC all-visible rule; 5 phases; planner enable gated behind `columnar.enable_index_only_scan` (default off until proven).
- `design/gaps/26-IMPL-multiple-projections.md` — C-Store projections in format 2.2; catalog + write fan-out + planner selection + reconstruction; 6 phases.

Both are MVCC/format-critical and will be built phase-by-phase against the differential/concurrency/recovery suites. Docs only — no matrix gate needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)