### PR TITLE
Index-only scan phase 1: columnar visibility-map fork write/read

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ OBJS = \
 	src/columnar_vacuum.o \
 	src/columnar_unique.o \
 	src/columnar_arrow.o \
-	src/columnar_parquet.o
+	src/columnar_parquet.o \
+	src/columnar_visibilitymap.o
 
 EXTENSION = columnar
 DATA = columnar--1.0.sql

--- a/columnar--1.0.sql
+++ b/columnar--1.0.sql
@@ -382,6 +382,14 @@ CREATE FUNCTION columnar.import_arrow(rel regclass, path text)
 COMMENT ON FUNCTION columnar.import_arrow(regclass, text)
 	IS 'insert rows from an Arrow IPC stream file into a columnar table; returns rows inserted';
 
+CREATE FUNCTION columnar.vm_selftest(rel regclass, blk int)
+	RETURNS boolean
+	LANGUAGE C
+	AS 'MODULE_PATHNAME', 'columnar_vm_selftest';
+
+COMMENT ON FUNCTION columnar.vm_selftest(regclass, int)
+	IS 'gap 28 phase-1 self-test: set a VM-fork all-visible bit and read it back';
+
 CREATE FUNCTION columnar.vacuum_full(
 	schema name DEFAULT 'public',
 	sleep_time real DEFAULT 0.0,

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -246,6 +246,13 @@ extern void ColumnarRowNumberToItemPointer(uint64 rowNumber, ItemPointer tid);
 extern uint64 ColumnarItemPointerToRowNumber(ItemPointer tid);
 
 /* -------------------------------------------------------------------------
+ * visibility map for index-only scans (columnar_visibilitymap.c, gap 28)
+ * ------------------------------------------------------------------------- */
+extern void ColumnarVMSetVisible(Relation rel, BlockNumber blk);
+extern void ColumnarVMClearVisible(Relation rel, BlockNumber blk);
+extern bool ColumnarVMIsVisible(Relation rel, BlockNumber blk);
+
+/* -------------------------------------------------------------------------
  * metadata layer (columnar_metadata.c)
  * ------------------------------------------------------------------------- */
 extern uint64 ColumnarNextStorageId(void);

--- a/src/columnar_visibilitymap.c
+++ b/src/columnar_visibilitymap.c
@@ -1,0 +1,194 @@
+/*-------------------------------------------------------------------------
+ *
+ * columnar_visibilitymap.c
+ *		Visibility-map fork maintenance for pgColumnar index-only scans
+ *		(gap 28 direction 1, phase 1: the load-bearing prototype).
+ *
+ *		PostgreSQL's index-only-scan executor (nodeIndexonlyscan.c) is
+ *		hard-wired to read the table's visibility-map fork via VM_ALL_VISIBLE /
+ *		visibilitymap_get_status; there is no table-AM hook to substitute a
+ *		different all-visible source. So to make the executor skip the columnar
+ *		fetch for an all-visible range, pgColumnar must maintain a real VM fork
+ *		on its relation, keyed by the same synthetic block numbers its TIDs use
+ *		(block = rowNumber / MaxHeapTuplesPerPage).
+ *
+ *		The catch: those TIDs are synthetic (columnar data is not stored as heap
+ *		pages at those blocks), so the stock write path visibilitymap_set() --
+ *		which requires the heap buffer and sets PD_ALL_VISIBLE on it, and whose
+ *		signature differs across majors -- cannot be used. This file writes the
+ *		VM bit directly: pin/extend the VM page with the stock visibilitymap_pin,
+ *		set the all-visible bit using the (stable since 9.6) two-bits-per-block
+ *		layout, WAL-log the whole page for crash safety, and leave reads to the
+ *		stock visibilitymap_get_status. This decouples the write from any heap
+ *		page and from the per-version visibilitymap_set signature.
+ *
+ *		Phase 1 exposes columnar.vm_selftest(rel, blk) to prove empirically that
+ *		a bit written here is read back by visibilitymap_get_status on a columnar
+ *		relation. Later phases wire set-in-vacuum and clear-on-write.
+ *
+ * Independent MIT implementation from the public PostgreSQL API and the
+ * documented visibility-map on-disk layout.
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "columnar.h"
+
+#include "fmgr.h"
+#include "access/relation.h"
+#include "access/table.h"
+#include "access/visibilitymap.h"
+#include "access/xloginsert.h"
+#include "miscadmin.h"
+#include "storage/bufmgr.h"
+#include "storage/bufpage.h"
+#include "utils/rel.h"
+
+PG_FUNCTION_INFO_V1(columnar_vm_selftest);
+
+/*
+ * Visibility-map on-disk layout. These mirror the private macros in
+ * src/backend/access/heap/visibilitymap.c; the two-bits-per-heap-block layout
+ * has been stable since PostgreSQL 9.6, and columnar.vm_selftest verifies at
+ * run time that a bit written with this layout is read back by the backend's
+ * own visibilitymap_get_status (which uses the real macros), so any divergence
+ * would surface immediately in the matrix rather than silently.
+ */
+#define COLUMNAR_VM_MAPSIZE			(BLCKSZ - MAXALIGN(SizeOfPageHeaderData))
+#define COLUMNAR_VM_BITS_PER_BLOCK	2
+#define COLUMNAR_VM_BLOCKS_PER_BYTE	(BITS_PER_BYTE / COLUMNAR_VM_BITS_PER_BLOCK)
+#define COLUMNAR_VM_BLOCKS_PER_PAGE	(COLUMNAR_VM_MAPSIZE * COLUMNAR_VM_BLOCKS_PER_BYTE)
+#define COLUMNAR_VM_TO_MAPBYTE(x) \
+	(((x) % COLUMNAR_VM_BLOCKS_PER_PAGE) / COLUMNAR_VM_BLOCKS_PER_BYTE)
+#define COLUMNAR_VM_TO_OFFSET(x) \
+	(((x) % COLUMNAR_VM_BLOCKS_PER_BYTE) * COLUMNAR_VM_BITS_PER_BLOCK)
+
+/*
+ * ColumnarVMSetVisible
+ *		Mark the synthetic block `blk` all-visible in the relation's VM fork,
+ *		WAL-logged. Idempotent: a no-op if the bit is already set. This writes
+ *		only the VM fork -- there is no heap page to flag -- which is why it does
+ *		not go through visibilitymap_set().
+ */
+void
+ColumnarVMSetVisible(Relation rel, BlockNumber blk)
+{
+	Buffer		vmbuf = InvalidBuffer;
+	Page		page;
+	char	   *map;
+	uint32		mapByte = COLUMNAR_VM_TO_MAPBYTE(blk);
+	uint8		mapBit = (uint8) (VISIBILITYMAP_ALL_VISIBLE << COLUMNAR_VM_TO_OFFSET(blk));
+
+	/* pin (extending the VM fork as needed) the page that holds blk's bit */
+	visibilitymap_pin(rel, blk, &vmbuf);
+	LockBuffer(vmbuf, BUFFER_LOCK_EXCLUSIVE);
+
+	page = BufferGetPage(vmbuf);
+	map = PageGetContents(page);
+
+	if (!(map[mapByte] & mapBit))
+	{
+		START_CRIT_SECTION();
+		map[mapByte] |= mapBit;
+		MarkBufferDirty(vmbuf);
+		if (RelationNeedsWAL(rel))
+		{
+			XLogRecPtr	recptr = log_newpage_buffer(vmbuf, false);
+
+			PageSetLSN(page, recptr);
+		}
+		END_CRIT_SECTION();
+	}
+
+	LockBuffer(vmbuf, BUFFER_LOCK_UNLOCK);
+	ReleaseBuffer(vmbuf);
+}
+
+/*
+ * ColumnarVMClearVisible
+ *		Clear the all-visible (and all-frozen) bits for `blk`, WAL-logged. Used
+ *		by write paths so a modified range is never reported all-visible.
+ */
+void
+ColumnarVMClearVisible(Relation rel, BlockNumber blk)
+{
+	Buffer		vmbuf = InvalidBuffer;
+	Page		page;
+	char	   *map;
+	uint32		mapByte = COLUMNAR_VM_TO_MAPBYTE(blk);
+	uint8		mapBits = (uint8) ((VISIBILITYMAP_ALL_VISIBLE | VISIBILITYMAP_ALL_FROZEN)
+								   << COLUMNAR_VM_TO_OFFSET(blk));
+
+	/* nothing to clear if the VM fork does not yet cover blk */
+	if (visibilitymap_get_status(rel, blk, &vmbuf) == 0)
+	{
+		if (BufferIsValid(vmbuf))
+			ReleaseBuffer(vmbuf);
+		return;
+	}
+
+	LockBuffer(vmbuf, BUFFER_LOCK_EXCLUSIVE);
+	page = BufferGetPage(vmbuf);
+	map = PageGetContents(page);
+
+	if (map[mapByte] & mapBits)
+	{
+		START_CRIT_SECTION();
+		map[mapByte] &= ~mapBits;
+		MarkBufferDirty(vmbuf);
+		if (RelationNeedsWAL(rel))
+		{
+			XLogRecPtr	recptr = log_newpage_buffer(vmbuf, false);
+
+			PageSetLSN(page, recptr);
+		}
+		END_CRIT_SECTION();
+	}
+
+	LockBuffer(vmbuf, BUFFER_LOCK_UNLOCK);
+	ReleaseBuffer(vmbuf);
+}
+
+/*
+ * ColumnarVMIsVisible
+ *		True if `blk` is marked all-visible in the VM fork. Thin wrapper over the
+ *		stock reader (the same call the index-only-scan executor makes).
+ */
+bool
+ColumnarVMIsVisible(Relation rel, BlockNumber blk)
+{
+	Buffer		vmbuf = InvalidBuffer;
+	uint8		status = visibilitymap_get_status(rel, blk, &vmbuf);
+
+	if (BufferIsValid(vmbuf))
+		ReleaseBuffer(vmbuf);
+	return (status & VISIBILITYMAP_ALL_VISIBLE) != 0;
+}
+
+/*
+ * columnar_vm_selftest(rel regclass, blk int) -> bool
+ *		Phase-1 proof: set the all-visible bit for a synthetic block on a
+ *		columnar relation, then read it back through the backend's own
+ *		visibilitymap_get_status. Returns true iff the round trip succeeds,
+ *		which validates that the custom VM write is layout-compatible with the
+ *		reader the index-only-scan executor uses.
+ */
+Datum
+columnar_vm_selftest(PG_FUNCTION_ARGS)
+{
+	Oid			relid = PG_GETARG_OID(0);
+	BlockNumber blk = (BlockNumber) PG_GETARG_INT32(1);
+	Relation	rel;
+	bool		before,
+				after;
+
+	rel = table_open(relid, RowExclusiveLock);
+
+	before = ColumnarVMIsVisible(rel, blk);
+	ColumnarVMSetVisible(rel, blk);
+	after = ColumnarVMIsVisible(rel, blk);
+
+	table_close(rel, RowExclusiveLock);
+
+	/* success: not set before (fresh block), set after */
+	PG_RETURN_BOOL(!before && after);
+}

--- a/test/index_only.sh
+++ b/test/index_only.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# pgColumnar index-only-scan coverage (gap 28 direction 1).
+#
+# Phase 1 (this file for now): prove the load-bearing assumption that a
+# visibility-map bit written by pgColumnar's custom VM writer on a columnar
+# relation -- whose TIDs are synthetic and have no heap page -- is read back by
+# the backend's own visibilitymap_get_status (the exact call the index-only-scan
+# executor makes). columnar.vm_selftest sets a bit for a synthetic block and
+# reads it back; it must return true. Later phases add the differential MVCC
+# coverage for actual index-only scans.
+#
+# Usage:  test/index_only.sh [PG_CONFIG]
+#
+# Written fresh for pgColumnar; it does not reuse any upstream test file.
+
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+echo "-- VM fork write/read round-trip on a columnar relation (phase 1)"
+make_pair "id int, v int"
+load_pair "SELECT g, g * 2 FROM generate_series(1, 50000) g"
+
+# sanity: the table is populated (guards against a dead cluster passing trivially)
+check "rows loaded" "$(q "SELECT count(*) FROM t_col;")" "50000"
+
+# A synthetic block covers MaxHeapTuplesPerPage (~291) row numbers, so 50000
+# rows span well over 100 blocks. Set + read back the all-visible bit for a few
+# blocks across that range; each must round-trip (false before, true after).
+for blk in 0 3 50 171; do
+	r="$(q "SELECT columnar.vm_selftest('t_col', $blk);")"
+	check "vm bit round-trips on columnar rel (block $blk)" "$r" "t"
+done
+
+# A second call on an already-set block returns false (bit was set before), which
+# confirms the write is persistent and the reader sees prior state.
+first="$(q "SELECT columnar.vm_selftest('t_col', 7);")"
+second="$(q "SELECT columnar.vm_selftest('t_col', 7);")"
+check "first set on fresh block succeeds" "$first" "t"
+check "second set on same block sees prior bit" "$second" "f"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -26,7 +26,7 @@ SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUITES=(smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
 	differential recovery fuzz hardening concurrent_diff parallel sorted_projection \
 	arrow_export parquet_export read_stream corruption \
-	generated_columns temporal arrow_import)
+	generated_columns temporal arrow_import index_only)
 
 # Default matrix: one assert-enabled pg_config per major, 13 through 19.
 DEFAULT_CONFIGS=(


### PR DESCRIPTION
Gap 28 direction 1, **phase 1 of 5** (spec: `design/gaps/28-IMPL-index-only-scan.md`). The load-bearing prototype that de-risks the whole feature.

## What and why
Core index-only scan (`nodeIndexonlyscan.c`) is hard-wired to read the table's VM fork via `VM_ALL_VISIBLE` and only calls `index_fetch_tuple` for not-all-visible blocks — so real IOS (fetch skipped) requires pgColumnar to maintain a real VM fork. But columnar TIDs are synthetic (`block = rowNumber / MaxHeapTuplesPerPage`) with no heap page, so stock `visibilitymap_set()` (needs the heap buffer, sets `PD_ALL_VISIBLE`, and changed signature in PG19) can't be used.

`columnar_visibilitymap.c` writes the VM bit directly: `visibilitymap_pin` → set the bit with the stable 2-bits-per-block layout → `log_newpage_buffer` for crash safety → reads via stock `visibilitymap_get_status`. Decoupled from any heap page and from the per-version `set()` signature.

## Proof
`columnar.vm_selftest(rel, blk)` sets a bit on a columnar relation and reads it back through the backend's **own** `visibilitymap_get_status` (the reader IOS uses). `test/index_only.sh` exercises the round trip across synthetic blocks + persistence, added to the PG13-19 matrix.

## Scope / safety
**Purely additive** — new file, new SQL function, new test; no GUC, no planner change, no effect on existing code paths. Compiles clean on PG13/17/18/19; runtime round-trip **passes on PG17**.

## Test caveat
The shared `plexcellent` container (primarily the plx project's; it periodically deletes files/kills processes on a ~45-60 min cycle) blocked multi-major runtime confirmation this session — pg13-16/pg19 runtime is covered by compile-clean + the version-independent VM layout + the pg17 pass. The `index_only` suite is wired into the matrix and will confirm on the next clean full-matrix window.

Next phases: clear-on-write, set-in-vacuum, planner enable behind `columnar.enable_index_only_scan`, MVCC differential suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)