### PR TITLE
Index-only scan phase 2: clear VM bits on write

### DIFF
--- a/src/columnar.h
+++ b/src/columnar.h
@@ -250,6 +250,7 @@ extern uint64 ColumnarItemPointerToRowNumber(ItemPointer tid);
  * ------------------------------------------------------------------------- */
 extern void ColumnarVMSetVisible(Relation rel, BlockNumber blk);
 extern void ColumnarVMClearVisible(Relation rel, BlockNumber blk);
+extern void ColumnarVMClearForRow(Relation rel, uint64 rowNumber);
 extern bool ColumnarVMIsVisible(Relation rel, BlockNumber blk);
 
 /* -------------------------------------------------------------------------

--- a/src/columnar_row_mask.c
+++ b/src/columnar_row_mask.c
@@ -236,6 +236,13 @@ ColumnarMarkRowDeleted(Relation rel, uint64 rowNumber)
 
 	bitIndex = rowNumber - startRowNumber;
 	chunk->mask[bitIndex >> 3] |= (char) (1 << (bitIndex & 7));
+
+	/*
+	 * The deleted row makes its block not all-visible; clear any VM bit so an
+	 * index-only scan never skips the fetch for a block with a dead row
+	 * (gap 28). A no-op unless a prior vacuum had marked the block visible.
+	 */
+	ColumnarVMClearForRow(rel, rowNumber);
 }
 
 /*

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -231,6 +231,13 @@ columnar_tuple_insert(Relation rel, TupleTableSlot *slot, CommandId cid,
 								 slot->tts_isnull);
 
 	/*
+	 * A new row makes its block not all-visible; clear any VM bit so an
+	 * index-only scan never skips the fetch for a block that just changed
+	 * (gap 28). A no-op unless a prior vacuum had marked the block visible.
+	 */
+	ColumnarVMClearForRow(rel, rowNumber);
+
+	/*
 	 * Publish the row's synthetic item pointer (spec 6) so the executor can
 	 * insert correct (index value, TID) entries into any indexes on this
 	 * relation and enforce unique constraints (spec 9).
@@ -255,6 +262,7 @@ columnar_multi_insert(Relation rel, TupleTableSlot **slots, int nslots,
 		ColumnarLockUniqueKeys(rel, slots[i]);	/* issue #5 */
 		rowNumber = ColumnarWriteRow(writeState, rel, slots[i]->tts_values,
 									 slots[i]->tts_isnull);
+		ColumnarVMClearForRow(rel, rowNumber);	/* gap 28: block changed */
 		ColumnarRowNumberToItemPointer(rowNumber, &slots[i]->tts_tid);
 		slots[i]->tts_tableOid = RelationGetRelid(rel);
 	}

--- a/src/columnar_visibilitymap.c
+++ b/src/columnar_visibilitymap.c
@@ -149,6 +149,22 @@ ColumnarVMClearVisible(Relation rel, BlockNumber blk)
 }
 
 /*
+ * ColumnarVMClearForRow
+ *		Clear the all-visible bit for the synthetic block that holds `rowNumber`.
+ *		The block is computed the same way ColumnarRowNumberToItemPointer derives
+ *		a TID block, so it matches the block the index-only-scan executor probes.
+ *		Called by every write path (insert/delete/update) so a modified block is
+ *		never left all-visible. Cheap when no bit is set (a short-circuit read).
+ */
+void
+ColumnarVMClearForRow(Relation rel, uint64 rowNumber)
+{
+	BlockNumber blk = (BlockNumber) (rowNumber / COLUMNAR_VALID_ITEMPOINTER_OFFSETS);
+
+	ColumnarVMClearVisible(rel, blk);
+}
+
+/*
  * ColumnarVMIsVisible
  *		True if `blk` is marked all-visible in the VM fork. Thin wrapper over the
  *		stock reader (the same call the index-only-scan executor makes).


### PR DESCRIPTION
Gap 28 direction 1, **phase 2 of 5**. Establishes the clear-on-write invariant before phase 3 sets any bits.

Wires `ColumnarVMClearForRow` into every write path:
- `columnar_tuple_insert` / `columnar_multi_insert` — clear the block a new row falls in.
- `ColumnarMarkRowDeleted` (single delete/update choke point) — clear the block of the deleted row.

Runs in the same transaction as the data change (WAL-logged), so a crash can't leave a set bit over changed data. No bits are set yet (phase 3), so these clears short-circuit on the unset-bit read — **functional no-op for now**, purely establishing the invariant.

Compiles clean on PG13/17/18/19; smoke, **differential** (heavy insert/delete vs heap oracle), and index_only pass on PG17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)