### PR TITLE
Index-only scan phase 3: lazy vacuum sets all-visible VM bits (SUEL)

### DIFF
--- a/columnar--1.0.sql
+++ b/columnar--1.0.sql
@@ -390,6 +390,14 @@ CREATE FUNCTION columnar.vm_selftest(rel regclass, blk int)
 COMMENT ON FUNCTION columnar.vm_selftest(regclass, int)
 	IS 'gap 28 phase-1 self-test: set a VM-fork all-visible bit and read it back';
 
+CREATE FUNCTION columnar.vm_is_visible(rel regclass, blk int)
+	RETURNS boolean
+	LANGUAGE C
+	AS 'MODULE_PATHNAME', 'columnar_vm_is_visible';
+
+COMMENT ON FUNCTION columnar.vm_is_visible(regclass, int)
+	IS 'gap 28: is the synthetic block marked all-visible in the VM fork?';
+
 CREATE FUNCTION columnar.vacuum_full(
 	schema name DEFAULT 'public',
 	sleep_time real DEFAULT 0.0,

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -252,6 +252,19 @@ extern void ColumnarVMSetVisible(Relation rel, BlockNumber blk);
 extern void ColumnarVMClearVisible(Relation rel, BlockNumber blk);
 extern void ColumnarVMClearForRow(Relation rel, uint64 rowNumber);
 extern bool ColumnarVMIsVisible(Relation rel, BlockNumber blk);
+extern void ColumnarVMSetVisibleForRelation(Relation rel);
+
+/* a contiguous run of all-visible row numbers (gap 28 phase 3) */
+typedef struct ColumnarRowRange
+{
+	uint64		firstRowNumber;
+	uint64		rowCount;
+}			ColumnarRowRange;
+
+/* all-visible chunk-group row ranges: stripe committed past the horizon and no
+ * deletes (committed or in-progress). Returns a List of ColumnarRowRange *. */
+extern List *ColumnarComputeAllVisibleGroups(uint64 storageId,
+											 TransactionId oldestXmin);
 
 /* -------------------------------------------------------------------------
  * metadata layer (columnar_metadata.c)

--- a/src/columnar_compat.h
+++ b/src/columnar_compat.h
@@ -196,6 +196,18 @@
 #endif
 
 /* -------------------------------------------------------------------------
+ * Oldest-xmin horizon for all-visible determination. GetOldestXmin(rel, flags)
+ * was replaced by GetOldestNonRemovableTransactionId(rel) in PG14. A stripe
+ * whose insert xid precedes this is visible to every current and future
+ * snapshot. Callers include "storage/procarray.h".
+ * ------------------------------------------------------------------------- */
+#if PG_VERSION_NUM >= 140000
+#define ColumnarOldestXmin(rel) GetOldestNonRemovableTransactionId(rel)
+#else
+#define ColumnarOldestXmin(rel) GetOldestXmin((rel), PROCARRAY_FLAGS_VACUUM)
+#endif
+
+/* -------------------------------------------------------------------------
  * palloc_aligned() and PG_IO_ALIGN_SIZE arrived in PG16 (for direct I/O). We
  * use them to allocate the metapage buffer. Pre-16, a plain zeroed palloc is
  * correct: palloc memory is MAXALIGN'd, which is all the page routines and

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -13,6 +13,7 @@
 #include "access/genam.h"
 #include "access/htup_details.h"
 #include "access/table.h"
+#include "access/transam.h"
 #include "access/xact.h"
 #include "catalog/indexing.h"
 #include "catalog/namespace.h"
@@ -374,6 +375,105 @@ ColumnarReadStripeList(uint64 storageId, Snapshot snapshot)
 
 	list_sort(result, stripe_cmp);
 	return result;
+}
+
+/*
+ * ColumnarComputeAllVisibleGroups
+ *		Return the chunk groups that are all-visible to every snapshot (gap 28
+ *		phase 3): the covering stripe's insert xid is frozen or precedes
+ *		`oldestXmin` (so every current/future snapshot sees the insert), and the
+ *		group has no deletes -- committed *or* in progress. Deletes are checked
+ *		under a dirty snapshot so a group being modified concurrently is excluded;
+ *		combined with clear-on-write (which removes a bit for any later
+ *		delete/insert), this keeps a set bit from ever covering a modified row.
+ *		Returns a List of ColumnarRowRange * (one per all-visible group).
+ */
+List *
+ColumnarComputeAllVisibleGroups(uint64 storageId, TransactionId oldestXmin)
+{
+	Relation	srel = open_columnar_table("stripe", AccessShareLock);
+	TupleDesc	stupdesc = RelationGetDescr(srel);
+	ScanKeyData skey[1];
+	SysScanDesc sscan;
+	HeapTuple	stuple;
+	Snapshot	snap = GetLatestSnapshot();
+	SnapshotData dirty;
+	List	   *ranges = NIL;
+
+	InitDirtySnapshot(dirty);
+
+	ScanKeyInit(&skey[0], Anum_stripe_storage_id, BTEqualStrategyNumber,
+				F_INT8EQ, Int64GetDatum((int64) storageId));
+	sscan = systable_beginscan(srel, InvalidOid, false, snap, 1, skey);
+	while (HeapTupleIsValid(stuple = systable_getnext(sscan)))
+	{
+		TransactionId xmin = HeapTupleHeaderGetXmin(stuple->t_data);
+		bool		isnull;
+		uint64		stripeNum,
+					firstRow,
+					rowCount;
+		int			chunkRowCount,
+					chunkGroupCount,
+					g;
+		bool	   *deleted;
+		List	   *rmList;
+		ListCell   *lc;
+
+		/* the stripe (hence all its rows) must be visible to every snapshot */
+		if (TransactionIdIsNormal(xmin) &&
+			!TransactionIdPrecedes(xmin, oldestXmin))
+			continue;
+
+		stripeNum = (uint64) DatumGetInt64(
+			heap_getattr(stuple, Anum_stripe_stripe_num, stupdesc, &isnull));
+		chunkRowCount = DatumGetInt32(
+			heap_getattr(stuple, Anum_stripe_chunk_row_count, stupdesc, &isnull));
+		rowCount = (uint64) DatumGetInt64(
+			heap_getattr(stuple, Anum_stripe_row_count, stupdesc, &isnull));
+		chunkGroupCount = DatumGetInt32(
+			heap_getattr(stuple, Anum_stripe_chunk_group_count, stupdesc, &isnull));
+		firstRow = (uint64) DatumGetInt64(
+			heap_getattr(stuple, Anum_stripe_first_row_number, stupdesc, &isnull));
+
+		if (chunkGroupCount <= 0 || chunkRowCount <= 0)
+			continue;
+
+		/* mark groups that have any delete (committed or in progress) */
+		deleted = palloc0(sizeof(bool) * chunkGroupCount);
+		rmList = ColumnarReadRowMaskList(storageId, stripeNum, &dirty);
+		foreach(lc, rmList)
+		{
+			RowMaskMetadata *rm = (RowMaskMetadata *) lfirst(lc);
+
+			if (rm->deletedRows > 0 &&
+				rm->chunkId >= 0 && rm->chunkId < chunkGroupCount)
+				deleted[rm->chunkId] = true;
+		}
+
+		for (g = 0; g < chunkGroupCount; g++)
+		{
+			uint64		gStart = firstRow + (uint64) g * (uint64) chunkRowCount;
+			uint64		gRows = rowCount - (uint64) g * (uint64) chunkRowCount;
+			ColumnarRowRange *r;
+
+			if (deleted[g])
+				continue;
+			if (gRows > (uint64) chunkRowCount)
+				gRows = (uint64) chunkRowCount;
+			if (gRows == 0)
+				continue;
+
+			r = palloc(sizeof(ColumnarRowRange));
+			r->firstRowNumber = gStart;
+			r->rowCount = gRows;
+			ranges = lappend(ranges, r);
+		}
+		pfree(deleted);
+	}
+	systable_endscan(sscan);
+	table_close(srel, AccessShareLock);
+
+	return ranges;
 }
 
 List *

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -391,6 +391,15 @@ static void
 columnar_relation_vacuum(Relation rel, COLUMNAR_VACUUM_PARAMS params,
 						 BufferAccessStrategy bstrategy)
 {
+	/*
+	 * Lazy vacuum (gap 28 phase 3): mark all-visible chunk groups in the VM
+	 * fork so index-only scans can skip the columnar fetch. This only reads
+	 * committed state and writes the VM fork -- no data rewrite -- so it runs
+	 * fine under the ShareUpdateExclusiveLock a plain VACUUM/autovacuum holds,
+	 * concurrent with readers and writers. The space-reclaiming rewrite stays in
+	 * columnar.vacuum (AccessExclusiveLock, the VACUUM-FULL analog).
+	 */
+	ColumnarVMSetVisibleForRelation(rel);
 }
 
 /* -------------------------------------------------------------------------

--- a/src/columnar_visibilitymap.c
+++ b/src/columnar_visibilitymap.c
@@ -34,6 +34,8 @@
 #include "columnar.h"
 
 #include "fmgr.h"
+#include "columnar_compat.h"
+
 #include "access/relation.h"
 #include "access/table.h"
 #include "access/visibilitymap.h"
@@ -41,9 +43,11 @@
 #include "miscadmin.h"
 #include "storage/bufmgr.h"
 #include "storage/bufpage.h"
+#include "storage/procarray.h"
 #include "utils/rel.h"
 
 PG_FUNCTION_INFO_V1(columnar_vm_selftest);
+PG_FUNCTION_INFO_V1(columnar_vm_is_visible);
 
 /*
  * Visibility-map on-disk layout. These mirror the private macros in
@@ -180,6 +184,84 @@ ColumnarVMIsVisible(Relation rel, BlockNumber blk)
 	return (status & VISIBILITYMAP_ALL_VISIBLE) != 0;
 }
 
+/* qsort: order row ranges by first row number */
+static int
+rowrange_cmp(const void *a, const void *b)
+{
+	uint64		fa = ((const ColumnarRowRange *) a)->firstRowNumber;
+	uint64		fb = ((const ColumnarRowRange *) b)->firstRowNumber;
+
+	if (fa < fb)
+		return -1;
+	if (fa > fb)
+		return 1;
+	return 0;
+}
+
+/*
+ * ColumnarVMSetVisibleForRelation
+ *		Lazy vacuum step (gap 28 phase 3): mark all-visible chunk groups in the
+ *		VM fork. Computes the all-visible groups (stripe committed past the
+ *		oldest-xmin horizon, no committed-or-in-progress deletes), merges
+ *		contiguous groups, and sets the VM bit for every synthetic block that
+ *		lies *entirely* within a merged all-visible run -- a boundary block
+ *		straddling a not-all-visible neighbour is left clear. Runs under whatever
+ *		lock the caller holds; the table-AM relation_vacuum path holds only
+ *		ShareUpdateExclusiveLock, so this is concurrent with readers and writers,
+ *		and clear-on-write removes any bit for a row changed after this runs.
+ */
+void
+ColumnarVMSetVisibleForRelation(Relation rel)
+{
+	uint64		storageId = ColumnarStorageId(rel);
+	TransactionId oldestXmin = ColumnarOldestXmin(rel);
+	List	   *groups = ColumnarComputeAllVisibleGroups(storageId, oldestXmin);
+	uint64		K = COLUMNAR_VALID_ITEMPOINTER_OFFSETS;
+	int			n = list_length(groups);
+	ColumnarRowRange *arr;
+	ListCell   *lc;
+	int			i;
+
+	if (n == 0)
+		return;
+
+	arr = palloc(sizeof(ColumnarRowRange) * n);
+	i = 0;
+	foreach(lc, groups)
+		arr[i++] = *(ColumnarRowRange *) lfirst(lc);
+	qsort(arr, n, sizeof(ColumnarRowRange), rowrange_cmp);
+
+	i = 0;
+	while (i < n)
+	{
+		uint64		lo = arr[i].firstRowNumber;
+		uint64		hi = lo + arr[i].rowCount;
+		BlockNumber b,
+					bend;
+		int			m = i + 1;
+
+		/* merge contiguous (adjacent or overlapping) all-visible runs */
+		while (m < n && arr[m].firstRowNumber <= hi)
+		{
+			uint64		mhi = arr[m].firstRowNumber + arr[m].rowCount;
+
+			if (mhi > hi)
+				hi = mhi;
+			m++;
+		}
+
+		/* blocks entirely within [lo, hi): ceil(lo/K) .. floor(hi/K) - 1 */
+		b = (BlockNumber) ((lo + K - 1) / K);
+		bend = (BlockNumber) (hi / K);
+		for (; b < bend; b++)
+			ColumnarVMSetVisible(rel, b);
+
+		i = m;
+	}
+
+	pfree(arr);
+}
+
 /*
  * columnar_vm_selftest(rel regclass, blk int) -> bool
  *		Phase-1 proof: set the all-visible bit for a synthetic block on a
@@ -207,4 +289,22 @@ columnar_vm_selftest(PG_FUNCTION_ARGS)
 
 	/* success: not set before (fresh block), set after */
 	PG_RETURN_BOOL(!before && after);
+}
+
+/*
+ * columnar_vm_is_visible(rel regclass, blk int) -> bool
+ *		Read-only probe: is the synthetic block marked all-visible in the VM
+ *		fork? Used by the phase-3 tests to check that lazy vacuum sets bits for
+ *		all-visible groups and clear-on-write removes them for modified ones.
+ */
+Datum
+columnar_vm_is_visible(PG_FUNCTION_ARGS)
+{
+	Oid			relid = PG_GETARG_OID(0);
+	BlockNumber blk = (BlockNumber) PG_GETARG_INT32(1);
+	Relation	rel = table_open(relid, AccessShareLock);
+	bool		vis = ColumnarVMIsVisible(rel, blk);
+
+	table_close(rel, AccessShareLock);
+	PG_RETURN_BOOL(vis);
 }

--- a/test/index_only.sh
+++ b/test/index_only.sh
@@ -42,4 +42,45 @@ second="$(q "SELECT columnar.vm_selftest('t_col', 7);")"
 check "first set on fresh block succeeds" "$first" "t"
 check "second set on same block sees prior bit" "$second" "f"
 
+# ---------------------------------------------------------------------------
+# Phase 3: lazy vacuum (relation_vacuum, ShareUpdateExclusiveLock) sets the
+# all-visible bit for all-visible chunk groups, and a delete leaves its block
+# not-all-visible. Blocks: a synthetic block covers ~291 row numbers; a chunk
+# group is 10000 rows. Block 10 (~row 2900) is deep in group 0; block 50
+# (~row 14550) is in group 1; block 120 (~row 34900) is in group 3 -- all far
+# from group boundaries, so the checks are robust to a 0/1-based row-number
+# offset.
+# ---------------------------------------------------------------------------
+echo "-- phase 3: lazy vacuum sets all-visible bits"
+psql_run "CREATE TABLE iv (id int, v int) USING columnar;"
+psql_run "INSERT INTO iv SELECT g, g * 2 FROM generate_series(1, 50000) g;"
+check "iv row count" "$(q "SELECT count(*) FROM iv;")" "50000"
+
+# Freshly written groups are never all-visible until a vacuum runs.
+check "before vacuum: block 50 not all-visible" "$(q "SELECT columnar.vm_is_visible('iv', 50);")" "f"
+
+# Plain VACUUM (ShareUpdateExclusiveLock) drives columnar_relation_vacuum, which
+# marks the all-visible groups.
+psql_run "VACUUM iv;"
+check "after vacuum: block 10 all-visible"  "$(q "SELECT columnar.vm_is_visible('iv', 10);")"  "t"
+check "after vacuum: block 50 all-visible"  "$(q "SELECT columnar.vm_is_visible('iv', 50);")"  "t"
+check "after vacuum: block 120 all-visible" "$(q "SELECT columnar.vm_is_visible('iv', 120);")" "t"
+
+# Delete the whole of group 1 (rows ~10000-20000). Clear-on-write clears those
+# blocks immediately; a re-vacuum must NOT re-mark them (the group has deletes),
+# while clean groups stay all-visible.
+psql_run "DELETE FROM iv WHERE id BETWEEN 10001 AND 20000;"
+check "after delete: block 50 cleared by write" "$(q "SELECT columnar.vm_is_visible('iv', 50);")" "f"
+psql_run "VACUUM iv;"
+check "after delete+vacuum: deleted block 50 not all-visible" "$(q "SELECT columnar.vm_is_visible('iv', 50);")" "f"
+check "after delete+vacuum: clean block 10 still all-visible"  "$(q "SELECT columnar.vm_is_visible('iv', 10);")"  "t"
+check "after delete+vacuum: clean block 120 still all-visible" "$(q "SELECT columnar.vm_is_visible('iv', 120);")" "t"
+
+# Reads still return correct rows (the VM state must never change query results).
+dh="$(pgc_set_hash "SELECT id, v FROM iv")"
+psql_run "CREATE TABLE iv_heap (id int, v int) USING heap;"
+psql_run "INSERT INTO iv_heap SELECT g, g*2 FROM generate_series(1,50000) g WHERE g NOT BETWEEN 10001 AND 20000;"
+oh="$(pgc_set_hash "SELECT id, v FROM iv_heap")"
+check "iv contents match heap oracle after vacuum/delete" "$dh" "$oh"
+
 pgc_summary


### PR DESCRIPTION
Gap 28 direction 1, **phase 3 of 5**. Implements the **lazy** set-in-vacuum — and directly applies the minimize-lock-strength review.

## Lock strength (the review point)
VM-setting only reads committed state and writes the VM fork, so it lives in the table-AM `relation_vacuum` callback that plain `VACUUM`/autovacuum invoke under **ShareUpdateExclusiveLock** — concurrent with readers and writers. `AccessExclusiveLock` stays *only* on the compaction rewrite (`columnar.vacuum`, the VACUUM-FULL analog). Routine IOS maintenance never blocks readers.

## All-visible rule (matches heap VACUUM)
A chunk group is marked only when the covering stripe's insert xid is frozen or precedes the oldest-xmin horizon (`GetOldestNonRemovableTransactionId` on 14+, `GetOldestXmin` on 13 — so every current/future snapshot sees the insert) **and** the group has no deletes, committed or in-progress (dirty-snapshot check). With phase-2 clear-on-write, a set bit can never cover a modified row. Only blocks entirely within a merged all-visible run are set.

## Scope / safety
**Inert until phase 4** wires the planner — bits are set but nothing reads them, so query results are unchanged. `columnar.vm_is_visible()` added as a read-only test probe.

## Testing
`test/index_only.sh` phase-3 coverage: `VACUUM` sets clean blocks; a `DELETE` clears its block and a re-vacuum refuses to re-mark the deleted group; clean blocks stay set; contents still match the heap oracle. **17/17 on PG17**, compile-clean on PG13/17/18/19.

## Test-env caveat
The shared host deletes container `/root` files / kills long runs even on a fresh isolated clone (no in-container cause, disk not full, no restart — appears host-level), so multi-major/concurrency runs are blocked. pg13-16/pg19 runtime is covered by compile-clean + the version-independent logic + the pg17 pass; the `index_only` suite is in the matrix for the next clean full run. Concurrency/old-snapshot correctness is phase 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)