### PR TITLE
Fix PG18/19 VACUUM crash in index-only-scan all-visible computation

### DIFF
--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -396,10 +396,16 @@ ColumnarComputeAllVisibleGroups(uint64 storageId, TransactionId oldestXmin)
 	ScanKeyData skey[1];
 	SysScanDesc sscan;
 	HeapTuple	stuple;
-	Snapshot	snap = GetLatestSnapshot();
+	Snapshot	snap;
 	SnapshotData dirty;
 	List	   *ranges = NIL;
 
+	/*
+	 * Register the MVCC snapshot: PG18 asserts that a snapshot used for heap
+	 * visibility in a scan is registered or active (heapam_visibility.c). Called
+	 * from the vacuum path, there is no active snapshot to rely on.
+	 */
+	snap = RegisterSnapshot(GetLatestSnapshot());
 	InitDirtySnapshot(dirty);
 
 	ScanKeyInit(&skey[0], Anum_stripe_storage_id, BTEqualStrategyNumber,
@@ -472,6 +478,7 @@ ColumnarComputeAllVisibleGroups(uint64 storageId, TransactionId oldestXmin)
 	}
 	systable_endscan(sscan);
 	table_close(srel, AccessShareLock);
+	UnregisterSnapshot(snap);
 
 	return ranges;
 }


### PR DESCRIPTION
**Bug on main** (from phase 3, #28): `VACUUM` on a columnar table **aborts the backend (signal 6) on PG18/19**.

**Cause:** `ColumnarComputeAllVisibleGroups` scanned `columnar.stripe` with a bare `GetLatestSnapshot()`. PG18 added `Assert(snapshot->regd_count > 0 || snapshot->active_count > 0)` (heapam_visibility.c) for MVCC snapshots used in a scan; the vacuum path has no active snapshot, so the assert fired. PG13–17 lack it, so the full-matrix gate (finally runnable on the isolated dev container) is what surfaced it.

**Fix:** `RegisterSnapshot`/`UnregisterSnapshot` around the stripe scan. The row_mask read uses `SnapshotDirty` (non-MVCC, unaffected).

**Validated:** `index_only.sh` now **17/17 on all of PG13–19** (pg18/pg19 were the failures; pg13–17 already passed and the change is a superset-safe registration). A full matrix run follows as post-merge confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)