### PR TITLE
Index-only scan phase 4: planner enable behind GUC + MVCC tests

### DIFF
--- a/design/gaps/28-IMPL-index-only-scan.md
+++ b/design/gaps/28-IMPL-index-only-scan.md
@@ -163,15 +163,26 @@ Differential vs heap, plus MVCC-specific scenarios, all on the assert matrix:
    `visibilitymap_get_status`. Runtime round-trip passes; compiles PG13-19.
 2. **DONE (merged).** Clear-on-write in insert/`multi_insert`/delete, WAL-logged.
    No-op until phase 3 sets bits; establishes the invariant.
-3. Lazy set-in-vacuum: implement `columnar_relation_vacuum` (SUEL, autovacuum
-   path) to set all-visible bits per the horizon + zero-delete rule, with the
-   post-set recheck for concurrent modifiers. Single-session testable (insert →
-   commit → vacuum → bits set; delete → vacuum → bits cleared; fresh insert not
-   yet all-visible). Inert until phase 4. Keep the AccessExclusiveLock only on
-   the compaction rewrite.
-4. Planner enable behind `columnar.enable_index_only_scan` (default off);
-   executor uses the core IOS path via the VM fork.
-5. Full MVCC differential + **concurrency** + recovery suite (item list above),
-   proving the lazy-set concurrency protocol; flip the GUC default on only when
-   green across PG13-19. **Requires a reliable, non-interfering test container**
-   for the sustained multi-session concurrency scenarios.
+3. **DONE (merged, #26/#27/#28 + #29).** Lazy set-in-vacuum:
+   `columnar_relation_vacuum` (SUEL, autovacuum path) sets all-visible bits per
+   the horizon + zero-delete rule, with the post-set recheck for concurrent
+   modifiers. Single-session tested (insert → commit → vacuum → bits set; delete
+   → vacuum → bits cleared; fresh insert not yet all-visible). Kept the
+   AccessExclusiveLock only on the compaction rewrite. #29 fixed a PG18/19
+   backend crash: the all-visible stripe scan used an unregistered
+   `GetLatestSnapshot()`, tripping a PG18 MVCC-snapshot assertion under the
+   snapshotless vacuum path — now `RegisterSnapshot`/`UnregisterSnapshot`.
+4. **DONE (branch `feat/ios-phase4`).** Planner enable behind
+   `columnar.enable_index_only_scan` (PGC_USERSET, default off): when on,
+   `columnar_forbid_index_only_scan` is a no-op so the core IOS path is used,
+   served from the VM fork. Tested: with the GUC on the planner builds an Index
+   Only Scan, all-visible ranges report Heap Fetches: 0, results match the heap
+   oracle, and a delete forces the snapshot-checked fetch fallback (still
+   correct); with the GUC off no IOS is built.
+5. **DONE (branch `feat/ios-phase4`, MVCC subset).** MVCC concurrency test: a
+   persistent REPEATABLE READ session proves an old snapshot never sees
+   post-snapshot rows through an index-only scan, even after a concurrent
+   VACUUM — the all-visible horizon accounts for the open snapshot, so the new
+   block stays not-all-visible and the fetch fallback applies the snapshot.
+   Remaining before flipping the GUC default on: crash-recovery replay of
+   set/clear bits, and green across PG13-19.

--- a/design/gaps/28-IMPL-index-only-scan.md
+++ b/design/gaps/28-IMPL-index-only-scan.md
@@ -172,6 +172,12 @@ Differential vs heap, plus MVCC-specific scenarios, all on the assert matrix:
    backend crash: the all-visible stripe scan used an unregistered
    `GetLatestSnapshot()`, tripping a PG18 MVCC-snapshot assertion under the
    snapshotless vacuum path — now `RegisterSnapshot`/`UnregisterSnapshot`.
+   Known limitation (perf, not correctness): a synthetic block that straddles a
+   chunk-group boundary — or the leading block that nominally covers the unused
+   row-0 slot — is conservatively left not-all-visible, so rows in those boundary
+   blocks fall back to the (correct) fetch instead of being fetch-free. Interior
+   blocks of an all-visible group skip the fetch. A future optimization could
+   mark the leading block when its only real rows are all-visible.
 4. **DONE (branch `feat/ios-phase4`).** Planner enable behind
    `columnar.enable_index_only_scan` (PGC_USERSET, default off): when on,
    `columnar_forbid_index_only_scan` is a no-op so the core IOS path is used,

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -110,6 +110,7 @@ extern bool columnar_enable_compressed_execution;	/* run-based aggregate path (I
 extern bool columnar_enable_metadata_count;	/* count(*) from catalog metadata (gap 28) */
 extern bool columnar_enable_column_cache;	/* decompressed-chunk cache */
 extern bool columnar_enable_read_stream;	/* stream/prefetch block reads (PG17+) */
+extern bool columnar_enable_index_only_scan;	/* allow index-only scans (gap 28) */
 extern int columnar_column_cache_size;		/* cache budget in megabytes */
 
 /* issue #5: concurrent unique-key insert serialization */

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -1003,11 +1003,23 @@ columnar_relation_is_columnar(Oid relid)
 		get_rel_relam(relid) == columnar_am_oid_cache;
 }
 
+/* GUC: when on, allow the planner to build index-only-scan paths for columnar
+ * tables, served by the VM fork (gap 28). Default off until the phase-5 MVCC
+ * concurrency suite proves the all-visible protocol. */
+bool		columnar_enable_index_only_scan = false;
+
 /* clear the "can return" flags of every index on a columnar relation */
 static void
 columnar_forbid_index_only_scan(Oid relid, RelOptInfo *rel)
 {
 	ListCell   *lc;
+
+	/* when index-only scans are enabled, leave the index canreturn flags intact
+	 * so the planner may choose an IOS; the VM fork (set by lazy vacuum) drives
+	 * whether the executor skips the fetch, and a not-all-visible block still
+	 * falls back to columnar_index_fetch_tuple, so results are always correct. */
+	if (columnar_enable_index_only_scan)
+		return;
 
 	if (!OidIsValid(relid) || !columnar_relation_is_columnar(relid))
 		return;
@@ -1172,6 +1184,16 @@ _PG_init(void)
 							 NULL,
 							 &columnar_enable_read_stream,
 							 true,
+							 PGC_USERSET,
+							 0,
+							 NULL, NULL, NULL);
+
+	DefineCustomBoolVariable("columnar.enable_index_only_scan",
+							 "Allow index-only scans on columnar tables, served by the "
+							 "visibility-map fork (gap 28). Experimental; off by default.",
+							 NULL,
+							 &columnar_enable_index_only_scan,
+							 false,
 							 PGC_USERSET,
 							 0,
 							 NULL, NULL, NULL);

--- a/test/index_only.sh
+++ b/test/index_only.sh
@@ -113,27 +113,33 @@ psql_run "ALTER DATABASE $PGC_DB SET enable_bitmapscan = off;"
 
 psql_run "VACUUM ios;"   # mark the all-visible groups in the VM fork
 
-planon="$(q "EXPLAIN (COSTS OFF) SELECT id FROM ios WHERE id BETWEEN 100 AND 2000;")"
+# Use an interior id range (1000..5000): a synthetic block spans ~291 row
+# numbers, so this range maps to blocks that sit wholly inside chunk group 0.
+# The all-visible bit is only set for blocks fully within an all-visible group
+# (the boundary block that would straddle the group edge or the unused row-0
+# slot is conservatively left unmarked and falls back to the fetch -- correct,
+# just not fetch-free), so an interior range is where "zero heap fetches" holds.
+planon="$(q "EXPLAIN (COSTS OFF) SELECT id FROM ios WHERE id BETWEEN 1000 AND 5000;")"
 check "GUC on: index-only scan chosen" "$(printf '%s' "$planon" | grep -c 'Index Only Scan')" "1"
 
-# All-visible after vacuum -> the executor skips every heap fetch.
-eaav="$(q "EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT id FROM ios WHERE id BETWEEN 100 AND 2000;")"
-check "all-visible: zero heap fetches" \
+# All-visible interior blocks after vacuum -> the executor skips every fetch.
+eaav="$(q "EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT id FROM ios WHERE id BETWEEN 1000 AND 5000;")"
+check "all-visible interior: zero heap fetches" \
 	"$(printf '%s' "$eaav" | grep -oE 'Heap Fetches: [0-9]+' | grep -oE '[0-9]+' | head -1)" "0"
 
 # Correctness of the index-only path against the heap oracle.
 check "index-only results match heap oracle (all-visible)" \
-	"$(pgc_set_hash "SELECT id FROM ios WHERE id BETWEEN 100 AND 2000")" \
-	"$(pgc_set_hash "SELECT id FROM ios_h WHERE id BETWEEN 100 AND 2000")"
+	"$(pgc_set_hash "SELECT id FROM ios WHERE id BETWEEN 1000 AND 5000")" \
+	"$(pgc_set_hash "SELECT id FROM ios_h WHERE id BETWEEN 1000 AND 5000")"
 
 # A delete clears the VM bit for the affected blocks (clear-on-write); the scan
 # must fall back to the fetch for those and never return a deleted row.
-psql_run "DELETE FROM ios   WHERE id BETWEEN 500 AND 700;"
-psql_run "DELETE FROM ios_h WHERE id BETWEEN 500 AND 700;"
+psql_run "DELETE FROM ios   WHERE id BETWEEN 2000 AND 2200;"
+psql_run "DELETE FROM ios_h WHERE id BETWEEN 2000 AND 2200;"
 check "index-only results match heap oracle after delete (fallback)" \
-	"$(pgc_set_hash "SELECT id FROM ios WHERE id BETWEEN 100 AND 2000")" \
-	"$(pgc_set_hash "SELECT id FROM ios_h WHERE id BETWEEN 100 AND 2000")"
-eadel="$(q "EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT id FROM ios WHERE id BETWEEN 100 AND 2000;")"
+	"$(pgc_set_hash "SELECT id FROM ios WHERE id BETWEEN 1000 AND 5000")" \
+	"$(pgc_set_hash "SELECT id FROM ios_h WHERE id BETWEEN 1000 AND 5000")"
+eadel="$(q "EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT id FROM ios WHERE id BETWEEN 1000 AND 5000;")"
 hf="$(printf '%s' "$eadel" | grep -oE 'Heap Fetches: [0-9]+' | grep -oE '[0-9]+' | head -1)"
 check "after delete: some heap fetches occur" "$([ "${hf:-0}" -gt 0 ] && echo yes || echo no)" "yes"
 

--- a/test/index_only.sh
+++ b/test/index_only.sh
@@ -83,4 +83,130 @@ psql_run "INSERT INTO iv_heap SELECT g, g*2 FROM generate_series(1,50000) g WHER
 oh="$(pgc_set_hash "SELECT id, v FROM iv_heap")"
 check "iv contents match heap oracle after vacuum/delete" "$dh" "$oh"
 
+# ---------------------------------------------------------------------------
+# Phase 4: the planner builds a real index-only scan for a columnar table when
+# columnar.enable_index_only_scan is on, the executor skips the fetch for
+# all-visible blocks (Heap Fetches: 0), and results still match the heap oracle.
+#
+# The GUC (and planner knobs that steer the plan to the index) are set at the
+# database level so the fresh connection opened by q/pgc_set_hash inherits them;
+# a per-session SET would not survive across those helpers.
+# ---------------------------------------------------------------------------
+echo "-- phase 4: index-only scan chosen + served from the VM fork"
+psql_run "CREATE TABLE ios (id int, v int) USING columnar;"
+psql_run "INSERT INTO ios SELECT g, g*3 FROM generate_series(1,50000) g;"
+psql_run "CREATE INDEX ios_id ON ios (id);"
+psql_run "CREATE TABLE ios_h (id int, v int) USING heap;"
+psql_run "INSERT INTO ios_h SELECT g, g*3 FROM generate_series(1,50000) g;"
+psql_run "CREATE INDEX ios_h_id ON ios_h (id);"
+
+# Baseline: with the GUC off (default) the planner must NOT build an index-only
+# scan even with seqscan disabled -- canreturn is cleared, so it falls back.
+planoff="$(q "SET enable_seqscan=off; EXPLAIN (COSTS OFF) SELECT id FROM ios WHERE id BETWEEN 100 AND 2000;")"
+check "GUC off: no index-only scan" "$(printf '%s' "$planoff" | grep -c 'Index Only Scan')" "0"
+
+# Enable index-only scans and steer the planner to the index for the rest.
+psql_run "ALTER DATABASE $PGC_DB SET columnar.enable_index_only_scan = on;"
+psql_run "ALTER DATABASE $PGC_DB SET columnar.enable_custom_scan = off;"
+psql_run "ALTER DATABASE $PGC_DB SET enable_seqscan = off;"
+psql_run "ALTER DATABASE $PGC_DB SET enable_bitmapscan = off;"
+
+psql_run "VACUUM ios;"   # mark the all-visible groups in the VM fork
+
+planon="$(q "EXPLAIN (COSTS OFF) SELECT id FROM ios WHERE id BETWEEN 100 AND 2000;")"
+check "GUC on: index-only scan chosen" "$(printf '%s' "$planon" | grep -c 'Index Only Scan')" "1"
+
+# All-visible after vacuum -> the executor skips every heap fetch.
+eaav="$(q "EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT id FROM ios WHERE id BETWEEN 100 AND 2000;")"
+check "all-visible: zero heap fetches" \
+	"$(printf '%s' "$eaav" | grep -oE 'Heap Fetches: [0-9]+' | grep -oE '[0-9]+' | head -1)" "0"
+
+# Correctness of the index-only path against the heap oracle.
+check "index-only results match heap oracle (all-visible)" \
+	"$(pgc_set_hash "SELECT id FROM ios WHERE id BETWEEN 100 AND 2000")" \
+	"$(pgc_set_hash "SELECT id FROM ios_h WHERE id BETWEEN 100 AND 2000")"
+
+# A delete clears the VM bit for the affected blocks (clear-on-write); the scan
+# must fall back to the fetch for those and never return a deleted row.
+psql_run "DELETE FROM ios   WHERE id BETWEEN 500 AND 700;"
+psql_run "DELETE FROM ios_h WHERE id BETWEEN 500 AND 700;"
+check "index-only results match heap oracle after delete (fallback)" \
+	"$(pgc_set_hash "SELECT id FROM ios WHERE id BETWEEN 100 AND 2000")" \
+	"$(pgc_set_hash "SELECT id FROM ios_h WHERE id BETWEEN 100 AND 2000")"
+eadel="$(q "EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT id FROM ios WHERE id BETWEEN 100 AND 2000;")"
+hf="$(printf '%s' "$eadel" | grep -oE 'Heap Fetches: [0-9]+' | grep -oE '[0-9]+' | head -1)"
+check "after delete: some heap fetches occur" "$([ "${hf:-0}" -gt 0 ] && echo yes || echo no)" "yes"
+
+# ---------------------------------------------------------------------------
+# Phase 5: MVCC correctness of the index-only path under a concurrent writer.
+# An old REPEATABLE READ snapshot must never see rows committed after it, even
+# when a later VACUUM has run -- the VM all-visible horizon accounts for the
+# open snapshot, so the new rows' block is left not-all-visible and the scan
+# falls back to the snapshot-checked fetch (which does not see them either).
+#
+# Session A is a persistent psql fed through a FIFO; a sentinel token in its
+# output file lets us wait for each step without racing the concurrent writer.
+# ---------------------------------------------------------------------------
+echo "-- phase 5: old snapshot never sees post-snapshot rows via index-only scan"
+psql_run "CREATE TABLE mv (id int, v int) USING columnar;"
+psql_run "INSERT INTO mv SELECT g, g*3 FROM generate_series(1,10000) g;"   # batch 1
+psql_run "CREATE INDEX mv_id ON mv (id);"
+psql_run "VACUUM mv;"   # batch 1 marked all-visible
+
+A_IN="$PGC_WORKDIR/sessA.in"; A_OUT="$PGC_WORKDIR/sessA.out"
+mkfifo "$A_IN"; : > "$A_OUT"
+env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+	-d "$PGC_DB" -At -f "$A_IN" >> "$A_OUT" 2>&1 &
+A_PID=$!
+exec 8> "$A_IN"                        # hold the write end open so psql waits
+a_send() { printf '%s\n' "$*" >&8; }
+a_wait() {                             # poll A_OUT for a token (~20s budget)
+	local token="$1" i
+	for i in $(seq 1 200); do
+		grep -q "$token" "$A_OUT" && return 0
+		sleep 0.1
+	done
+	return 1
+}
+
+# A opens a REPEATABLE READ snapshot (materialized by a first read) that sees
+# only batch 1. The GUC/planner knobs are inherited from the ALTER DATABASE above.
+a_send "BEGIN ISOLATION LEVEL REPEATABLE READ;"
+a_send "SELECT 'A_SNAP_' || count(id) FROM mv WHERE id BETWEEN 1 AND 20000;"
+if a_wait "A_SNAP_"; then
+	snap="$(grep -o 'A_SNAP_[0-9]*' "$A_OUT" | tail -1 | sed 's/A_SNAP_//')"
+	check "session A baseline sees batch 1 only" "$snap" "10000"
+
+	# Concurrent writer commits batch 2, then vacuums. The vacuum must NOT mark
+	# batch 2 all-visible because A's snapshot pins the removable horizon.
+	psql_run "INSERT INTO mv SELECT g, g*3 FROM generate_series(10001,20000) g;"
+	psql_run "VACUUM mv;"
+
+	# A's index-only scan under its old snapshot must still see batch 1 only.
+	a_send "SELECT 'A_SEE_' || count(id) FROM mv WHERE id BETWEEN 1 AND 20000;"
+	a_send "EXPLAIN (COSTS OFF) SELECT id FROM mv WHERE id BETWEEN 1 AND 20000;"
+	a_send "SELECT 'A_PLAN_DONE';"
+	if a_wait "A_PLAN_DONE"; then
+		see="$(grep -o 'A_SEE_[0-9]*' "$A_OUT" | tail -1 | sed 's/A_SEE_//')"
+		check "old snapshot IOS does not see post-snapshot rows" "$see" "10000"
+		check "session A used an index-only scan" \
+			"$(grep -c 'Index Only Scan' "$A_OUT")" "1"
+	else
+		check "session A responded to post-commit query" "timeout" "ok"
+	fi
+	a_send "COMMIT;"
+else
+	check "session A opened its snapshot" "timeout" "ok"
+fi
+
+# A now sees both batches (new snapshot); after a vacuum it also matches the
+# heap oracle, confirming batch 2 is fully readable once the snapshot advances.
+a_send "SELECT 'A_FINAL_' || count(id) FROM mv WHERE id BETWEEN 1 AND 20000;"
+a_wait "A_FINAL_" || true
+final="$(grep -o 'A_FINAL_[0-9]*' "$A_OUT" | tail -1 | sed 's/A_FINAL_//')"
+check "new snapshot sees both batches" "$final" "20000"
+
+exec 8>&-                              # close write end -> psql gets EOF and exits
+wait "$A_PID" 2>/dev/null || true
+
 pgc_summary


### PR DESCRIPTION
Completes the index-only-scan work (gap 28) through phase 4, with the phase-5 MVCC correctness test.

## What
- **New GUC `columnar.enable_index_only_scan`** (PGC_USERSET, **default off**). When on, `columnar_forbid_index_only_scan` becomes a no-op, so the core index-only-scan path runs, served from the visibility-map fork set by lazy vacuum (phase 3). When a block is not all-visible the executor falls back to `columnar_index_fetch_tuple` -> `ColumnarReadRowByNumber`, which applies the query snapshot via the catalog stripe/row-mask lists. Correct either way.
- **Tests** (`index_only.sh`, now 27 checks):
  - Phase 4: GUC off builds no IOS; GUC on builds an Index Only Scan; all-visible *interior* blocks report Heap Fetches: 0; results match the heap oracle; a delete forces the snapshot-checked fetch fallback (heap fetches > 0, still correct).
  - Phase 5: a persistent REPEATABLE READ session proves an old snapshot never sees post-snapshot rows through an IOS, even after a concurrent VACUUM — the all-visible horizon accounts for the open snapshot, so the new block stays not-all-visible and the fetch fallback applies the snapshot. A fresh snapshot then sees both batches.

## Why default off
Correctness is proven for the MVCC/insert/delete/vacuum scenarios, but crash-recovery replay of VM set/clear is still to be added before flipping the default on. Off by default means zero behavior change on existing installs.

## Known limitation (perf, not correctness)
A synthetic block that straddles a chunk-group boundary (or the leading block covering the unused row-0 slot) is left not-all-visible, so its rows fall back to the correct fetch instead of being fetch-free. Interior blocks skip the fetch. Documented in the spec.

## Validation
- `index_only.sh`: **27/27 on PG13–19** (fresh per-major builds, isolated container).
- `main` full matrix (all 24 suites × PG13–19) is green as of the #29 merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)