### PR TITLE
Index-only scan phase 5: crash-recovery test + enable by default

### DIFF
--- a/design/gaps/28-IMPL-index-only-scan.md
+++ b/design/gaps/28-IMPL-index-only-scan.md
@@ -178,17 +178,25 @@ Differential vs heap, plus MVCC-specific scenarios, all on the assert matrix:
    blocks fall back to the (correct) fetch instead of being fetch-free. Interior
    blocks of an all-visible group skip the fetch. A future optimization could
    mark the leading block when its only real rows are all-visible.
-4. **DONE (branch `feat/ios-phase4`).** Planner enable behind
-   `columnar.enable_index_only_scan` (PGC_USERSET, default off): when on,
+4. **DONE (merged, #30).** Planner enable behind
+   `columnar.enable_index_only_scan` (PGC_USERSET): when on,
    `columnar_forbid_index_only_scan` is a no-op so the core IOS path is used,
    served from the VM fork. Tested: with the GUC on the planner builds an Index
-   Only Scan, all-visible ranges report Heap Fetches: 0, results match the heap
-   oracle, and a delete forces the snapshot-checked fetch fallback (still
-   correct); with the GUC off no IOS is built.
-5. **DONE (branch `feat/ios-phase4`, MVCC subset).** MVCC concurrency test: a
-   persistent REPEATABLE READ session proves an old snapshot never sees
-   post-snapshot rows through an index-only scan, even after a concurrent
-   VACUUM — the all-visible horizon accounts for the open snapshot, so the new
-   block stays not-all-visible and the fetch fallback applies the snapshot.
-   Remaining before flipping the GUC default on: crash-recovery replay of
-   set/clear bits, and green across PG13-19.
+   Only Scan, all-visible interior ranges report Heap Fetches: 0, results match
+   the heap oracle, and a delete forces the snapshot-checked fetch fallback
+   (still correct); with the GUC off no IOS is built.
+5. **DONE.** MVCC + concurrency + recovery, then default flipped on.
+   - MVCC concurrency (merged #30): a persistent REPEATABLE READ session proves
+     an old snapshot never sees post-snapshot rows through an index-only scan,
+     even after a concurrent VACUUM — the all-visible horizon accounts for the
+     open snapshot, so the new block stays not-all-visible and the fetch fallback
+     applies the snapshot.
+   - Crash recovery (`recovery.sh` scenario 4): a VM bit flushed by a checkpoint
+     and then cleared by a delete stays cleared after a SIGKILL crash — WAL
+     replay of the clear (log_newpage_buffer) wins over the on-disk set bit, so
+     no all-visible bit survives over a deleted row; a clean block keeps its bit;
+     contents match the heap oracle after recovery.
+   - **GUC default flipped to on** once the above were green across PG13-19: the
+     protocol is proven and the not-all-visible fetch fallback is always
+     snapshot-correct, so the feature is safe on by default (`set off` forces a
+     plain index scan).

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -1004,9 +1004,12 @@ columnar_relation_is_columnar(Oid relid)
 }
 
 /* GUC: when on, allow the planner to build index-only-scan paths for columnar
- * tables, served by the VM fork (gap 28). Default off until the phase-5 MVCC
- * concurrency suite proves the all-visible protocol. */
-bool		columnar_enable_index_only_scan = false;
+ * tables, served by the VM fork (gap 28). Default on: the phase-5 MVCC,
+ * concurrency, and crash-recovery suites prove the all-visible protocol (the
+ * horizon accounts for open snapshots and every write clears the bit, both
+ * WAL-logged), and a not-all-visible block always falls back to the
+ * snapshot-checked fetch, so results are correct regardless. */
+bool		columnar_enable_index_only_scan = true;
 
 /* clear the "can return" flags of every index on a columnar relation */
 static void
@@ -1190,10 +1193,11 @@ _PG_init(void)
 
 	DefineCustomBoolVariable("columnar.enable_index_only_scan",
 							 "Allow index-only scans on columnar tables, served by the "
-							 "visibility-map fork (gap 28). Experimental; off by default.",
+							 "visibility-map fork (gap 28). On by default; set off to force "
+							 "a plain index scan.",
 							 NULL,
 							 &columnar_enable_index_only_scan,
-							 false,
+							 true,
 							 PGC_USERSET,
 							 0,
 							 NULL, NULL, NULL);

--- a/test/index_only.sh
+++ b/test/index_only.sh
@@ -100,9 +100,9 @@ psql_run "CREATE TABLE ios_h (id int, v int) USING heap;"
 psql_run "INSERT INTO ios_h SELECT g, g*3 FROM generate_series(1,50000) g;"
 psql_run "CREATE INDEX ios_h_id ON ios_h (id);"
 
-# Baseline: with the GUC off (default) the planner must NOT build an index-only
+# Baseline: with the GUC explicitly off the planner must NOT build an index-only
 # scan even with seqscan disabled -- canreturn is cleared, so it falls back.
-planoff="$(q "SET enable_seqscan=off; EXPLAIN (COSTS OFF) SELECT id FROM ios WHERE id BETWEEN 100 AND 2000;")"
+planoff="$(q "SET columnar.enable_index_only_scan=off; SET enable_seqscan=off; EXPLAIN (COSTS OFF) SELECT id FROM ios WHERE id BETWEEN 100 AND 2000;")"
 check "GUC off: no index-only scan" "$(printf '%s' "$planoff" | grep -c 'Index Only Scan')" "0"
 
 # Enable index-only scans and steer the planner to the index for the rest.

--- a/test/phase4.sh
+++ b/test/phase4.sh
@@ -4,8 +4,9 @@
 # build and scan over a columnar table, index fetch by item pointer respecting
 # the row mask, unique/primary-key constraint enforcement (across statements and
 # within a single statement), NOT NULL and CHECK constraints, heap<->columnar
-# conversion round-trips, and confirmation that index-only scans are never
-# chosen while ordinary index scans are.
+# conversion round-trips, and confirmation that ordinary index scans work (with
+# the index-only-scan fallback verified when the feature is turned off; the
+# feature itself is covered by index_only.sh).
 #
 # Builds and installs the extension, spins up a throwaway PostgreSQL cluster as
 # the postgres OS user, and exercises the phase 4 feature set. Written fresh for
@@ -198,16 +199,22 @@ check "conv heap value"    "$(q 'SELECT b FROM conv WHERE a = 7777;')" "v7777"
 check "conv heap sum"      "$(q 'SELECT sum(a) FROM conv;')" "50005000"
 
 # ---------------------------------------------------------------------------
-# Index-only scan must not be chosen (no visibility map); an index scan is.
+# Index-only scans are a real feature now (gap 28, columnar.enable_index_only_scan,
+# on by default) and are exercised comprehensively in index_only.sh. Here we only
+# confirm the fallback path: with the GUC off the planner builds a plain Index
+# Scan for a covering query, and that scan returns the correct value.
 # ---------------------------------------------------------------------------
-echo "-- index-only scan is never selected"
+echo "-- index-only scan can be turned off (plain index scan fallback)"
 q "CREATE TABLE ios (a int, b int) USING columnar;" >/dev/null
 q "INSERT INTO ios SELECT g, g*2 FROM generate_series(1,20000) g;" >/dev/null
 q "CREATE INDEX ios_a_idx ON ios (a);" >/dev/null
-# selecting only the indexed column with a covering index would be an
-# Index Only Scan on heap; on columnar it must fall back to an Index Scan.
-assert_plan "no index-only scan" "SELECT a FROM ios WHERE a = 100;" \
-	"Index Scan" "Index Only Scan"
+# With index-only scans disabled, a covering query falls back to an Index Scan.
+iosoff_plan="$(run_pg "$PSQL -c \"SET columnar.enable_index_only_scan=off; SET enable_seqscan=off; EXPLAIN (COSTS OFF) SELECT a FROM ios WHERE a = 100;\"")"
+if echo "$iosoff_plan" | grep -q "Index Scan" && ! echo "$iosoff_plan" | grep -q "Index Only Scan"; then
+	echo "PASS  IOS off: plain index scan"
+else
+	echo "FAIL  IOS off: plain index scan: plan was:"; echo "$iosoff_plan" | sed 's/^/        /'; fail=1
+fi
 check "covering value"    "$(q 'SET enable_seqscan=off; SELECT a FROM ios WHERE a = 100;')" "100"
 # a full-table scan is still available when index/bitmap scans are disabled.
 # As of phase 5 the columnar full scan is the custom scan (ColumnarScan); with

--- a/test/recovery.sh
+++ b/test/recovery.sh
@@ -122,4 +122,45 @@ check "s3 deletes persisted"  "$(q 'SELECT count(*) FROM t_col WHERE id % 7 = 0;
 diff_query "s3 whole-row"     "SELECT * FROM %T"
 diff_query "s3 aggregate"     "SELECT count(*), sum(n) FROM %T"
 
+# ---------------------------------------------------------------------------
+# Scenario 4: visibility-map (index-only-scan) durability across a crash.
+#   Lazy vacuum sets all-visible bits and every write clears them, both
+#   WAL-logged (log_newpage_buffer). The load-bearing correctness case: a bit
+#   that was flushed to disk by a checkpoint and then CLEARED by a later delete
+#   must stay cleared after a crash -- recovery must replay the clear over the
+#   on-disk set bit, or an index-only scan would skip the fetch over a deleted
+#   row. A clean block untouched by the delete keeps its all-visible bit.
+#   Blocks: a synthetic block spans ~291 row numbers and a chunk group is 10000
+#   rows, so block 20 (~row 5820) is deep in group 0 and block 120 (~row 34920)
+#   is deep in group 3 -- both far from group boundaries.
+# ---------------------------------------------------------------------------
+echo "-- scenario 4: visibility-map durability"
+psql_run "CREATE TABLE rv (id int, v int) USING columnar;"
+psql_run "INSERT INTO rv SELECT g, g*2 FROM generate_series(1,50000) g;"
+psql_run "CREATE INDEX rv_id ON rv (id);"
+psql_run "VACUUM rv;"                       # set all-visible bits (WAL-logged)
+check "s4 pre-crash group-0 block all-visible" "$(q "SELECT columnar.vm_is_visible('rv', 20);")" "t"
+check "s4 pre-crash group-3 block all-visible" "$(q "SELECT columnar.vm_is_visible('rv', 120);")" "t"
+psql_run "CHECKPOINT;"                       # flush the set bits to disk
+
+# Delete all of group 3; clear-on-write clears block 120's bit. Do NOT checkpoint
+# afterwards, so the clear is recovered from WAL replayed over the on-disk bit.
+psql_run "DELETE FROM rv WHERE id BETWEEN 30001 AND 40000;"
+check "s4 pre-crash deleted block cleared" "$(q "SELECT columnar.vm_is_visible('rv', 120);")" "f"
+
+crash_cluster
+restart_cluster
+check "s4 recovery ran" "$([ "$(recovery_ran)" -ge 1 ] && echo ok)" "ok"
+
+# The critical assertion: the cleared bit must not resurrect from the on-disk
+# checkpointed page -- WAL replay of the clear must win.
+check "s4 post-crash deleted block stays not-all-visible" "$(q "SELECT columnar.vm_is_visible('rv', 120);")" "f"
+check "s4 post-crash clean block still all-visible"       "$(q "SELECT columnar.vm_is_visible('rv', 20);")"  "t"
+
+# Contents are correct after recovery (deleted rows gone), against a heap oracle.
+psql_run "CREATE TABLE rv_h (id int, v int) USING heap;"
+psql_run "INSERT INTO rv_h SELECT g, g*2 FROM generate_series(1,50000) g WHERE g NOT BETWEEN 30001 AND 40000;"
+check "s4 col count == heap oracle" "$(q 'SELECT count(*) FROM rv;')" "$(q 'SELECT count(*) FROM rv_h;')"
+check "s4 contents match oracle"    "$(pgc_set_hash 'SELECT id,v FROM rv')" "$(pgc_set_hash 'SELECT id,v FROM rv_h')"
+
 pgc_summary


### PR DESCRIPTION
Completes gap 28 (index-only scans). Builds on phases 1-4 (#26/#27/#28/#29/#30).

## Changes
- **Crash-recovery test** (`recovery.sh` scenario 4): proves VM-fork durability. A visibility-map bit flushed by a checkpoint and then cleared by a delete must stay cleared after a SIGKILL crash — WAL replay of the clear (`log_newpage_buffer`) wins over the on-disk set bit, so no all-visible bit survives over a deleted row. A clean block keeps its bit; contents match the heap oracle after recovery.
- **Enable `columnar.enable_index_only_scan` by default.** MVCC (old-snapshot), concurrency, and now crash-recovery are all proven across PG13-19, and a not-all-visible block always falls back to the snapshot-checked fetch, so the feature is safe on by default. `set off` forces a plain index scan.
- **phase4.sh**: its pre-gap-28 assertion "index-only scan is never selected" is now stale (that covering query correctly plans an Index Only Scan). Rewritten to verify the *off* fallback (GUC off → plain Index Scan); the feature itself is covered by `index_only.sh`.

## Validation
- `recovery.sh` scenario 4: green on pg13/18/19 (all 8 checks incl. the critical cleared-bit-stays-cleared).
- Full PG13-19 matrix (all 24 suites, **IOS exercised by default**): green. The default-on flip first surfaced the stale `phase4` assertion, which this PR fixes; re-run confirms all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)