### PR TITLE
Multiple projections phase 1: catalog + add/drop DDL + format 2.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ OBJS = \
 	src/columnar_unique.o \
 	src/columnar_arrow.o \
 	src/columnar_parquet.o \
-	src/columnar_visibilitymap.o
+	src/columnar_visibilitymap.o \
+	src/columnar_projection.o
 
 EXTENSION = columnar
 DATA = columnar--1.0.sql

--- a/columnar--1.0.sql
+++ b/columnar--1.0.sql
@@ -135,6 +135,38 @@ CREATE UNIQUE INDEX options_pkey
 	ON columnar.options USING btree (regclass);
 
 /* ---------------------------------------------------------------------------
+ * columnar.projection (gap 26, format 2.2)
+ *
+ * Multiple physical projections per table (C-Store). Each projection is a named,
+ * ordered subset of the table's columns stored as its own columnar storage
+ * (proj_storage_id) sorted on sort_key, sharing the row-number identity space.
+ * projection_id 0 is the implicit base projection (all columns, insert order);
+ * a table with no rows here has a single implicit base projection, so 2.0/2.1
+ * tables and tables with no declared projections behave exactly as before.
+ *
+ * Phase 1 records the catalog and DDL only; no rows are written to a
+ * projection's storage yet (write fan-out arrives in phase 2).
+ * ------------------------------------------------------------------------- */
+
+CREATE TABLE columnar.projection (
+	storage_id bigint NOT NULL,       -- the table's base storage id
+	projection_id integer NOT NULL,   -- 0 = base, 1..N additional
+	name name NOT NULL,
+	proj_storage_id bigint NOT NULL,  -- this projection's own storage id
+	sort_key smallint[] NOT NULL,     -- attnums in sort order ({} = insert order)
+	columns smallint[] NOT NULL       -- attnums stored (base = all live columns)
+);
+
+CREATE UNIQUE INDEX projection_pkey
+	ON columnar.projection USING btree (storage_id, projection_id);
+
+CREATE UNIQUE INDEX projection_name_idx
+	ON columnar.projection USING btree (storage_id, name);
+
+CREATE UNIQUE INDEX projection_storage_idx
+	ON columnar.projection USING btree (proj_storage_id);
+
+/* ---------------------------------------------------------------------------
  * Access method (spec 8.1)
  * ------------------------------------------------------------------------- */
 
@@ -311,6 +343,26 @@ CREATE FUNCTION columnar.get_storage_id(rel regclass)
 
 COMMENT ON FUNCTION columnar.get_storage_id(regclass)
 	IS 'storage id linking a columnar table to its metadata rows';
+
+CREATE FUNCTION columnar.add_projection(
+	rel regclass,
+	name text,
+	columns text[],
+	sort_key text[] DEFAULT '{}')
+	RETURNS void
+	LANGUAGE C
+	AS 'MODULE_PATHNAME', 'columnar_add_projection';
+
+COMMENT ON FUNCTION columnar.add_projection(regclass, text, text[], text[])
+	IS 'declare a physical projection: a named column subset sorted on sort_key (gap 26)';
+
+CREATE FUNCTION columnar.drop_projection(rel regclass, name text)
+	RETURNS void
+	LANGUAGE C
+	AS 'MODULE_PATHNAME', 'columnar_drop_projection';
+
+COMMENT ON FUNCTION columnar.drop_projection(regclass, text)
+	IS 'drop a declared projection and free its storage (gap 26)';
 
 CREATE FUNCTION columnar.stats(
 	rel regclass,

--- a/design/gaps/26-IMPL-projections-phase1-plan.md
+++ b/design/gaps/26-IMPL-projections-phase1-plan.md
@@ -1,0 +1,114 @@
+# Multiple projections — phase 1 implementation plan (grounded)
+
+Phase 1 of the 6-phase plan in `26-IMPL-multiple-projections.md`: catalog +
+`add_projection`/`drop_projection` DDL + format 2.2 + base projection recorded
+explicitly. **No write fan-out** (projections stay empty); reads unaffected.
+
+## Grounding decisions (from reading the code)
+
+- **Metapage version bump is safe.** `ColumnarReadMetapage` (columnar_storage.c)
+  validates only `versionMajor != COLUMNAR_VERSION_MAJOR`; the minor is only
+  echoed in error text. Bump `COLUMNAR_VERSION_MINOR` 1 → 2. Old 2.0/2.1 tables
+  (major 2) still read. Do **not** add fields to `struct ColumnarMetapage` — old
+  metapages wrote only `sizeof(old struct)` bytes; a wider struct would read
+  past the written region. Projection count/info lives in the catalog, which is
+  authoritative; the metapage change is version-only.
+- **Storage ids** come from `ColumnarNextStorageId()` (columnar.storageid_seq),
+  already used at table create (columnar_tableam.c:306). Reuse it for
+  `proj_storage_id`.
+- **Base projection** = projection_id 0, `columns` = all live attnums in attnum
+  order, `sort_key` = `{}` (insert order), `proj_storage_id` = the table's base
+  storage id (the metapage storageId). Recorded when the table is created.
+- **Implicit-base fallback.** Tables created before this extension version (or
+  during upgrade) have no `columnar.projection` rows. Treat "no rows for
+  storage_id" as "one implicit base projection" everywhere a reader consults the
+  catalog. So recording the base row is a convenience, not a correctness
+  dependency — matches how a 2.0/2.1 metapage implies a single base projection.
+
+## Catalog (columnar--1.0.sql)
+
+```sql
+CREATE TABLE columnar.projection (
+    storage_id      bigint  NOT NULL,   -- table's base storage id
+    projection_id   integer NOT NULL,   -- 0 = base, 1..N additional
+    name            name    NOT NULL,
+    proj_storage_id bigint  NOT NULL,   -- this projection's own storage id
+    sort_key        smallint[] NOT NULL,-- attnums in sort order ({} = insert order)
+    columns         smallint[] NOT NULL -- attnums stored (base = all)
+);
+CREATE UNIQUE INDEX projection_pkey       ON columnar.projection (storage_id, projection_id);
+CREATE UNIQUE INDEX projection_name_idx   ON columnar.projection (storage_id, name);
+CREATE UNIQUE INDEX projection_storage_idx ON columnar.projection (proj_storage_id);
+```
+
+DDL functions (C-backed):
+```sql
+CREATE FUNCTION columnar.add_projection(rel regclass, name text,
+    columns text[], sort_key text[] DEFAULT '{}') RETURNS void ...;
+CREATE FUNCTION columnar.drop_projection(rel regclass, name text) RETURNS void ...;
+```
+
+## C (new file src/columnar_projection.c)
+
+Catalog helpers (mirror columnar_metadata.c style: `ColumnarMetadataRelation`,
+heap_form_tuple, CatalogTupleInsert, systable_beginscan, ColumnarCatalogSnapshot):
+- `ColumnarRecordBaseProjection(Relation rel, uint64 storageId)` — insert
+  projection_id 0 with all live attnums; no-op if a row already exists (create
+  path may run under CONCURRENTLY-ish retries).
+- `ColumnarListProjections(uint64 storageId)` → List of a small struct; used by
+  drop + later phases.
+- `ColumnarInsertProjection(...)`, `ColumnarDeleteProjection(storageId, projId)`.
+
+SQL entrypoints:
+- `columnar_add_projection(rel, name, columns[], sort_key[])`:
+  1. Verify `rel` uses the columnar AM (get_rel_relam == columnar am oid), else
+     ereport(ERROR, "not a columnar table").
+  2. Ensure the base row exists (`ColumnarRecordBaseProjection`), so pre-existing
+     tables get their base recorded lazily on first add.
+  3. Resolve each `columns` name → attnum via `get_attnum`; reject missing,
+     dropped, system, or duplicate attnums. `columns` must be non-empty.
+  4. Resolve `sort_key` names → attnums; each must be a member of `columns`.
+  5. Reject duplicate projection `name` for this storage_id.
+  6. `projection_id` = max(existing) + 1.
+  7. `proj_storage_id` = `ColumnarNextStorageId()`.
+  8. Insert the row. (No stripes/streams written in phase 1.)
+- `columnar_drop_projection(rel, name)`:
+  1. Verify columnar table; look up (storage_id, name).
+  2. Refuse to drop projection_id 0 (the base): ereport(ERROR).
+  3. Delete the catalog row. (No storage to free yet in phase 1; later phases
+     free the projection's stripes.)
+
+Register both in the `.c` with `PG_FUNCTION_INFO_V1` and add prototypes to
+columnar.h. Add the new object file to the Makefile OBJS list.
+
+## Base-projection recording at create
+
+At the table-create path (columnar_tableam.c, where `storageId =
+ColumnarNextStorageId()` is written to the metapage), call
+`ColumnarRecordBaseProjection(rel, storageId)` after the metapage is
+initialized, inside the same transaction. Guard with the implicit-base fallback
+so it is never load-bearing.
+
+## Tests (new test/projections.sh, added to run_all_versions SUITES)
+
+Single cluster; no fan-out yet, so assertions are catalog-shape + DDL semantics:
+- Create a columnar table; base projection row exists: projection_id 0, columns
+  = all attnums, sort_key = {}.
+- `add_projection('p1', ARRAY['a','c'], ARRAY['c'])` → row with projection_id 1,
+  columns {1,3}, sort_key {3}, a fresh proj_storage_id distinct from base.
+- Add a second projection → projection_id 2; names unique.
+- Error cases: duplicate name; unknown column; sort_key column not in columns;
+  add_projection on a heap table; drop of the base projection; drop of unknown
+  name.
+- `drop_projection('p1')` removes exactly that row; others remain.
+- New table reports metapage version 2.2 via an existing introspection (or add a
+  tiny `columnar.format_version(regclass)` if none exists) — optional; only if
+  cheap. Otherwise assert nothing about the metapage (reads already unaffected).
+- Row-count sanity guard (cluster-up) per the harness note.
+
+## Sequencing
+
+Build on fresh `main` AFTER IOS phase 5 merges (FM4 green). Files are disjoint
+from the IOS change (new SQL catalog + new .c), so low conflict risk. One PR:
+"Multiple projections phase 1: catalog + add/drop DDL + format 2.2". Gate on the
+full PG13-19 matrix before merge.

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -27,10 +27,13 @@
 #include "utils/rel.h"
 #include "utils/snapshot.h"
 
-/* format version (spec 3). Minor 1 adds per-chunk value encodings (I1); 2.0
- * files still read (a chunk with no encoding type is treated as NONE). */
+/* format version (spec 3). Minor 1 adds per-chunk value encodings (I1); minor 2
+ * adds multiple projections (gap 26; the columnar.projection catalog, no
+ * metapage layout change). 2.0/2.1 files still read: only the major version is
+ * validated, a chunk with no encoding type is treated as NONE, and a table with
+ * no columnar.projection rows has a single implicit base projection. */
 #define COLUMNAR_VERSION_MAJOR 2
-#define COLUMNAR_VERSION_MINOR 1
+#define COLUMNAR_VERSION_MINOR 2
 
 /* first row number is 1 (spec 3) */
 #define COLUMNAR_FIRST_ROW_NUMBER 1
@@ -173,6 +176,25 @@ typedef struct RowMaskMetadata
 	uint32		maskLen;
 } RowMaskMetadata;
 
+/*
+ * One columnar.projection row (gap 26, format 2.2). A projection is a named,
+ * ordered column subset stored as its own columnar storage (projStorageId),
+ * sorted on sortKey, sharing the table's row-number identity space.
+ * projectionId 0 is the implicit base projection. attnums are 1-based; sortKey
+ * attnums are a subset of columns.
+ */
+typedef struct ColumnarProjection
+{
+	uint64		storageId;			/* the table's base storage id */
+	int			projectionId;		/* 0 = base, 1..N additional */
+	char	   *name;				/* projection name (caller's context) */
+	uint64		projStorageId;		/* this projection's own storage id */
+	int16	   *sortKey;			/* attnums in sort order, sortKeyLen entries */
+	int			sortKeyLen;
+	int16	   *columns;			/* stored attnums, columnsLen entries */
+	int			columnsLen;
+} ColumnarProjection;
+
 typedef struct ChunkMetadata
 {
 	uint64		stripeNum;
@@ -285,6 +307,12 @@ extern void ColumnarDeleteMetadata(uint64 storageId);
 /* per-table options catalog (spec 7.4) */
 extern bool ColumnarReadOptions(Oid relid, ColumnarOptions *opts);
 extern void ColumnarDeleteOptions(Oid relid);
+
+/* projection catalog (gap 26, format 2.2). List entries are ColumnarProjection*
+ * palloc'd in the current context, ordered by projection_id. */
+extern List *ColumnarListProjections(uint64 storageId);
+extern void ColumnarInsertProjectionRow(const ColumnarProjection *proj);
+extern void ColumnarDeleteProjectionRow(uint64 storageId, int projectionId);
 
 /* whether a relation uses the columnar table access method */
 extern bool ColumnarIsColumnarRelation(Oid relid);

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -17,10 +17,12 @@
 #include "access/xact.h"
 #include "catalog/indexing.h"
 #include "catalog/namespace.h"
+#include "catalog/pg_type.h"
 #include "commands/defrem.h"
 #include "commands/sequence.h"
 #include "miscadmin.h"
 #include "storage/lock.h"
+#include "utils/array.h"
 #include "utils/builtins.h"
 #include "utils/fmgroids.h"
 #include "utils/lsyscache.h"
@@ -73,6 +75,15 @@
 #define Anum_options_stripe_row_limit 3
 #define Anum_options_compression_level 4
 #define Anum_options_compression 5
+
+/* attribute numbers for columnar.projection (gap 26, format 2.2) */
+#define Anum_projection_storage_id 1
+#define Anum_projection_projection_id 2
+#define Anum_projection_name 3
+#define Anum_projection_proj_storage_id 4
+#define Anum_projection_sort_key 5
+#define Anum_projection_columns 6
+#define Natts_projection 6
 
 /* attribute numbers for columnar.row_mask (spec 7.5) */
 #define Anum_row_mask_id 1
@@ -1046,4 +1057,156 @@ ColumnarIsColumnarRelation(Oid relid)
 		columnarAmOid = get_am_oid("columnar", true);
 
 	return OidIsValid(columnarAmOid) && get_rel_relam(relid) == columnarAmOid;
+}
+
+/* -------------------------------------------------------------------------
+ * projection catalog (gap 26, format 2.2)
+ * ------------------------------------------------------------------------- */
+
+/* build a smallint[] Datum from a C int16 array (empty array when n <= 0) */
+static Datum
+int16_array_datum(const int16 *vals, int n)
+{
+	ArrayType  *arr;
+
+	if (n <= 0)
+		arr = construct_empty_array(INT2OID);
+	else
+	{
+		Datum	   *elems = palloc(sizeof(Datum) * n);
+		int			i;
+
+		for (i = 0; i < n; i++)
+			elems[i] = Int16GetDatum(vals[i]);
+		arr = construct_array(elems, n, INT2OID, 2, true, TYPALIGN_SHORT);
+		pfree(elems);
+	}
+	return PointerGetDatum(arr);
+}
+
+/* read a smallint[] Datum into a palloc'd C int16 array; *len set to count */
+static int16 *
+int16_array_from_datum(Datum d, int *len)
+{
+	ArrayType  *arr = DatumGetArrayTypeP(d);
+	Datum	   *elems;
+	bool	   *nulls;
+	int			n;
+	int16	   *out;
+	int			i;
+
+	deconstruct_array(arr, INT2OID, 2, true, TYPALIGN_SHORT, &elems, &nulls, &n);
+	out = (n > 0) ? palloc(sizeof(int16) * n) : NULL;
+	for (i = 0; i < n; i++)
+		out[i] = DatumGetInt16(elems[i]);
+	*len = n;
+	return out;
+}
+
+/* order a projection list by projection_id ascending (base first) */
+static int
+projection_cmp(const ListCell *a, const ListCell *b)
+{
+	const ColumnarProjection *pa = (const ColumnarProjection *) lfirst(a);
+	const ColumnarProjection *pb = (const ColumnarProjection *) lfirst(b);
+
+	if (pa->projectionId < pb->projectionId)
+		return -1;
+	if (pa->projectionId > pb->projectionId)
+		return 1;
+	return 0;
+}
+
+void
+ColumnarInsertProjectionRow(const ColumnarProjection *proj)
+{
+	Relation	rel = open_columnar_table("projection", RowExclusiveLock);
+	TupleDesc	tupdesc = RelationGetDescr(rel);
+	Datum		values[Natts_projection];
+	bool		nulls[Natts_projection];
+	HeapTuple	tuple;
+
+	memset(nulls, false, sizeof(nulls));
+	values[Anum_projection_storage_id - 1] = Int64GetDatum((int64) proj->storageId);
+	values[Anum_projection_projection_id - 1] = Int32GetDatum(proj->projectionId);
+	values[Anum_projection_name - 1] =
+		DirectFunctionCall1(namein, CStringGetDatum(proj->name));
+	values[Anum_projection_proj_storage_id - 1] =
+		Int64GetDatum((int64) proj->projStorageId);
+	values[Anum_projection_sort_key - 1] =
+		int16_array_datum(proj->sortKey, proj->sortKeyLen);
+	values[Anum_projection_columns - 1] =
+		int16_array_datum(proj->columns, proj->columnsLen);
+
+	tuple = heap_form_tuple(tupdesc, values, nulls);
+	CatalogTupleInsert(rel, tuple);
+	heap_freetuple(tuple);
+
+	table_close(rel, RowExclusiveLock);
+	CommandCounterIncrement();		/* make the row visible to later reads */
+}
+
+List *
+ColumnarListProjections(uint64 storageId)
+{
+	Relation	rel = open_columnar_table("projection", AccessShareLock);
+	TupleDesc	tupdesc = RelationGetDescr(rel);
+	ScanKeyData key[1];
+	SysScanDesc scan;
+	HeapTuple	tuple;
+	List	   *result = NIL;
+
+	ScanKeyInit(&key[0], Anum_projection_storage_id, BTEqualStrategyNumber,
+				F_INT8EQ, Int64GetDatum((int64) storageId));
+
+	/* NULL snapshot -> catalog snapshot: sees committed rows plus this
+	 * transaction's own writes after a CommandCounterIncrement (DDL semantics). */
+	scan = systable_beginscan(rel, InvalidOid, false, NULL, 1, key);
+	while (HeapTupleIsValid(tuple = systable_getnext(scan)))
+	{
+		ColumnarProjection *p = palloc0(sizeof(ColumnarProjection));
+		bool		isnull;
+		Datum		d;
+
+		p->storageId = storageId;
+		p->projectionId = DatumGetInt32(
+			heap_getattr(tuple, Anum_projection_projection_id, tupdesc, &isnull));
+		d = heap_getattr(tuple, Anum_projection_name, tupdesc, &isnull);
+		p->name = pstrdup(NameStr(*DatumGetName(d)));
+		p->projStorageId = (uint64) DatumGetInt64(
+			heap_getattr(tuple, Anum_projection_proj_storage_id, tupdesc, &isnull));
+		d = heap_getattr(tuple, Anum_projection_sort_key, tupdesc, &isnull);
+		p->sortKey = int16_array_from_datum(d, &p->sortKeyLen);
+		d = heap_getattr(tuple, Anum_projection_columns, tupdesc, &isnull);
+		p->columns = int16_array_from_datum(d, &p->columnsLen);
+
+		result = lappend(result, p);
+	}
+	systable_endscan(scan);
+	table_close(rel, AccessShareLock);
+
+	list_sort(result, projection_cmp);
+	return result;
+}
+
+void
+ColumnarDeleteProjectionRow(uint64 storageId, int projectionId)
+{
+	Relation	rel = open_columnar_table("projection", RowExclusiveLock);
+	ScanKeyData key[2];
+	SysScanDesc scan;
+	HeapTuple	tuple;
+
+	ScanKeyInit(&key[0], Anum_projection_storage_id, BTEqualStrategyNumber,
+				F_INT8EQ, Int64GetDatum((int64) storageId));
+	ScanKeyInit(&key[1], Anum_projection_projection_id, BTEqualStrategyNumber,
+				F_INT4EQ, Int32GetDatum(projectionId));
+
+	scan = systable_beginscan(rel, InvalidOid, false, NULL, 2, key);
+	while (HeapTupleIsValid(tuple = systable_getnext(scan)))
+		CatalogTupleDelete(rel, &tuple->t_self);
+	systable_endscan(scan);
+
+	table_close(rel, RowExclusiveLock);
+	CommandCounterIncrement();
 }

--- a/src/columnar_projection.c
+++ b/src/columnar_projection.c
@@ -1,0 +1,301 @@
+/*-------------------------------------------------------------------------
+ *
+ * columnar_projection.c
+ *		DDL for multiple physical projections (gap 26, format 2.2).
+ *
+ * A projection is a named, ordered subset of a table's columns stored as its
+ * own columnar storage, sorted on its sort key, sharing the table's row-number
+ * identity space (the C-Store model; see design/gaps/26-*). Phase 1 provides the
+ * catalog (columnar.projection) and the add/drop DDL only: declaring a
+ * projection allocates its storage id and records the row, but no data is
+ * written to a projection's storage yet (write fan-out is phase 2).
+ *
+ * projection_id 0 is the implicit base projection (all live columns, insert
+ * order). A table with no columnar.projection rows has a single implicit base
+ * projection, so pre-existing and 2.0/2.1 tables are unaffected. The base row is
+ * recorded lazily the first time a projection is added.
+ *
+ * Written fresh for pgColumnar; it does not reuse any upstream file.
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "columnar.h"
+
+#include "access/table.h"
+#include "catalog/pg_type.h"
+#include "miscadmin.h"
+#include "utils/array.h"
+#include "utils/builtins.h"
+#include "utils/lsyscache.h"
+#include "utils/rel.h"
+
+PG_FUNCTION_INFO_V1(columnar_add_projection);
+PG_FUNCTION_INFO_V1(columnar_drop_projection);
+
+/*
+ * Collect the live (non-dropped) attribute numbers of a relation, in attnum
+ * order. Returns a palloc'd int16 array and sets *n.
+ */
+static int16 *
+live_attnums(Relation rel, int *n)
+{
+	TupleDesc	tupdesc = RelationGetDescr(rel);
+	int16	   *out = palloc(sizeof(int16) * tupdesc->natts);
+	int			count = 0;
+	int			i;
+
+	for (i = 0; i < tupdesc->natts; i++)
+	{
+		Form_pg_attribute att = TupleDescAttr(tupdesc, i);
+
+		if (att->attisdropped)
+			continue;
+		out[count++] = (int16) att->attnum;
+	}
+	*n = count;
+	return out;
+}
+
+/*
+ * Resolve a text[] of column names to an int16 array of attnums against relid,
+ * validating that each names a live user column and that there are no
+ * duplicates. Returns a palloc'd array and sets *n. Errors on any problem.
+ */
+static int16 *
+resolve_columns(Oid relid, ArrayType *names, const char *what, int *n)
+{
+	Datum	   *elems;
+	bool	   *nulls;
+	int			count;
+	int16	   *out;
+	int			i,
+				j;
+
+	deconstruct_array(names, TEXTOID, -1, false, TYPALIGN_INT,
+					  &elems, &nulls, &count);
+
+	out = (count > 0) ? palloc(sizeof(int16) * count) : NULL;
+	for (i = 0; i < count; i++)
+	{
+		char	   *colname;
+		AttrNumber	attno;
+
+		if (nulls[i])
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("%s must not contain NULL", what)));
+
+		colname = text_to_cstring(DatumGetTextPP(elems[i]));
+		attno = get_attnum(relid, colname);
+		if (attno == InvalidAttrNumber || attno < 0)
+			ereport(ERROR,
+					(errcode(ERRCODE_UNDEFINED_COLUMN),
+					 errmsg("column \"%s\" does not exist", colname)));
+
+		for (j = 0; j < i; j++)
+			if (out[j] == (int16) attno)
+				ereport(ERROR,
+						(errcode(ERRCODE_DUPLICATE_COLUMN),
+						 errmsg("column \"%s\" appears more than once in %s",
+								colname, what)));
+		out[i] = (int16) attno;
+	}
+	*n = count;
+	return out;
+}
+
+/*
+ * Ensure the base projection row (projection_id 0) exists for this table,
+ * recording all live columns in insert order. No-op if already present.
+ */
+static void
+record_base_projection(Relation rel, uint64 storageId, List *existing)
+{
+	ListCell   *lc;
+	ColumnarProjection base;
+
+	foreach(lc, existing)
+	{
+		ColumnarProjection *p = (ColumnarProjection *) lfirst(lc);
+
+		if (p->projectionId == 0)
+			return;
+	}
+
+	memset(&base, 0, sizeof(base));
+	base.storageId = storageId;
+	base.projectionId = 0;
+	base.name = "base";
+	base.projStorageId = storageId;		/* base shares the table's storage */
+	base.sortKey = NULL;
+	base.sortKeyLen = 0;
+	base.columns = live_attnums(rel, &base.columnsLen);
+	ColumnarInsertProjectionRow(&base);
+}
+
+/*
+ * columnar.add_projection(rel, name, columns text[], sort_key text[])
+ *		Declare a projection: a named column subset sorted on sort_key.
+ */
+Datum
+columnar_add_projection(PG_FUNCTION_ARGS)
+{
+	Oid			relid;
+	char	   *projname;
+	ArrayType  *colsArr;
+	ArrayType  *sortArr;
+	Relation	rel;
+	uint64		storageId;
+	List	   *existing;
+	ListCell   *lc;
+	ColumnarProjection proj;
+	int			nextId = 1;
+	int			i,
+				j;
+
+	if (PG_ARGISNULL(0) || PG_ARGISNULL(1) || PG_ARGISNULL(2))
+		ereport(ERROR,
+				(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+				 errmsg("rel, name, and columns must not be NULL")));
+
+	relid = PG_GETARG_OID(0);
+	projname = text_to_cstring(PG_GETARG_TEXT_PP(1));
+	colsArr = PG_GETARG_ARRAYTYPE_P(2);
+	sortArr = PG_ARGISNULL(3) ? NULL : PG_GETARG_ARRAYTYPE_P(3);
+
+	if (!ColumnarIsColumnarRelation(relid))
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+				 errmsg("\"%s\" is not a columnar table",
+						get_rel_name(relid))));
+
+	if (strlen(projname) == 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("projection name must not be empty")));
+	if (strlen(projname) >= NAMEDATALEN)
+		ereport(ERROR,
+				(errcode(ERRCODE_NAME_TOO_LONG),
+				 errmsg("projection name \"%s\" is too long", projname)));
+
+	rel = table_open(relid, ShareUpdateExclusiveLock);
+	storageId = ColumnarStorageId(rel);
+
+	existing = ColumnarListProjections(storageId);
+	record_base_projection(rel, storageId, existing);
+	/* re-read so the base row is included when picking the next id / name check */
+	existing = ColumnarListProjections(storageId);
+
+	memset(&proj, 0, sizeof(proj));
+	proj.storageId = storageId;
+	proj.name = projname;
+	proj.columns = resolve_columns(relid, colsArr, "columns", &proj.columnsLen);
+	if (proj.columnsLen == 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("a projection must have at least one column")));
+
+	if (sortArr != NULL)
+		proj.sortKey = resolve_columns(relid, sortArr, "sort_key", &proj.sortKeyLen);
+
+	/* every sort_key column must be part of the projection's columns */
+	for (i = 0; i < proj.sortKeyLen; i++)
+	{
+		bool		found = false;
+
+		for (j = 0; j < proj.columnsLen; j++)
+			if (proj.columns[j] == proj.sortKey[i])
+			{
+				found = true;
+				break;
+			}
+		if (!found)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("sort_key column \"%s\" is not in the projection column list",
+							get_attname(relid, proj.sortKey[i], false))));
+	}
+
+	/* name must be unique for this table; next id is max + 1 */
+	foreach(lc, existing)
+	{
+		ColumnarProjection *p = (ColumnarProjection *) lfirst(lc);
+
+		if (strcmp(p->name, projname) == 0)
+			ereport(ERROR,
+					(errcode(ERRCODE_DUPLICATE_OBJECT),
+					 errmsg("projection \"%s\" already exists on \"%s\"",
+							projname, get_rel_name(relid))));
+		if (p->projectionId >= nextId)
+			nextId = p->projectionId + 1;
+	}
+
+	proj.projectionId = nextId;
+	proj.projStorageId = ColumnarNextStorageId();
+	ColumnarInsertProjectionRow(&proj);
+
+	table_close(rel, ShareUpdateExclusiveLock);
+	PG_RETURN_VOID();
+}
+
+/*
+ * columnar.drop_projection(rel, name)
+ *		Drop a declared projection. The base projection cannot be dropped.
+ */
+Datum
+columnar_drop_projection(PG_FUNCTION_ARGS)
+{
+	Oid			relid;
+	char	   *projname;
+	Relation	rel;
+	uint64		storageId;
+	List	   *existing;
+	ListCell   *lc;
+	int			targetId = -1;
+
+	if (PG_ARGISNULL(0) || PG_ARGISNULL(1))
+		ereport(ERROR,
+				(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+				 errmsg("rel and name must not be NULL")));
+
+	relid = PG_GETARG_OID(0);
+	projname = text_to_cstring(PG_GETARG_TEXT_PP(1));
+
+	if (!ColumnarIsColumnarRelation(relid))
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+				 errmsg("\"%s\" is not a columnar table",
+						get_rel_name(relid))));
+
+	rel = table_open(relid, ShareUpdateExclusiveLock);
+	storageId = ColumnarStorageId(rel);
+	existing = ColumnarListProjections(storageId);
+
+	foreach(lc, existing)
+	{
+		ColumnarProjection *p = (ColumnarProjection *) lfirst(lc);
+
+		if (strcmp(p->name, projname) == 0)
+		{
+			targetId = p->projectionId;
+			break;
+		}
+	}
+
+	if (targetId < 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+				 errmsg("projection \"%s\" does not exist on \"%s\"",
+						projname, get_rel_name(relid))));
+	if (targetId == 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("the base projection cannot be dropped")));
+
+	/* phase 1 writes no data to a projection's storage, so there is nothing to
+	 * free yet; later phases free the projection's stripes here. */
+	ColumnarDeleteProjectionRow(storageId, targetId);
+
+	table_close(rel, ShareUpdateExclusiveLock);
+	PG_RETURN_VOID();
+}

--- a/test/projections.sh
+++ b/test/projections.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# pgColumnar multiple-projections DDL/catalog coverage (gap 26, phase 1).
+#
+# Phase 1 adds the columnar.projection catalog and the add_projection /
+# drop_projection DDL; no data is written to a projection's storage yet, so this
+# suite checks catalog shape and DDL semantics only: base projection recorded
+# lazily, column/sort-key resolution and validation, name uniqueness, storage-id
+# allocation, and drop. Later phases add differential read/write coverage.
+#
+# Usage:  test/projections.sh [PG_CONFIG]
+#
+# Written fresh for pgColumnar; it does not reuse any upstream test file.
+
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+# Run a statement expected to FAIL; PASS the check when it errors out.
+expect_fail() {
+	local name="$1" sql="$2"
+	PGC_CHECKS=$((PGC_CHECKS + 1))
+	if psql_run "$sql" >/dev/null 2>&1; then
+		echo "FAIL  $name: statement unexpectedly succeeded"
+		PGC_FAIL=1
+	else
+		echo "PASS  $name"
+	fi
+}
+
+proj_q() { q "SELECT $1 FROM columnar.projection WHERE storage_id = $SID $2;"; }
+
+echo "-- setup"
+psql_run "CREATE TABLE p (a int, b text, c int) USING columnar;"
+psql_run "INSERT INTO p SELECT g, 'r'||g, g*2 FROM generate_series(1,100) g;"
+check "table populated" "$(q 'SELECT count(*) FROM p;')" "100"
+SID="$(q "SELECT columnar.get_storage_id('p');")"
+check "storage id resolves" "$([ -n "$SID" ] && echo ok)" "ok"
+
+# Base projection is recorded lazily, so before any add there are no rows.
+check "no projection rows before first add" "$(proj_q 'count(*)' '')" "0"
+
+echo "-- add_projection records base lazily and the new projection"
+psql_run "SELECT columnar.add_projection('p', 'p1', ARRAY['a','c'], ARRAY['c']);"
+check "two rows after first add (base + p1)" "$(proj_q 'count(*)' '')" "2"
+check "base id 0 columns are all attrs" "$(proj_q 'columns' 'AND projection_id = 0')" "{1,2,3}"
+check "base id 0 sort_key empty"         "$(proj_q 'sort_key' 'AND projection_id = 0')" "{}"
+check "base id 0 name"                    "$(proj_q 'name' 'AND projection_id = 0')" "base"
+check "base proj_storage_id == base"      "$(proj_q 'proj_storage_id = storage_id' 'AND projection_id = 0')" "t"
+check "p1 id is 1"                         "$(proj_q 'projection_id' \"AND name = 'p1'\")" "1"
+check "p1 columns"                         "$(proj_q 'columns' \"AND name = 'p1'\")" "{1,3}"
+check "p1 sort_key"                        "$(proj_q 'sort_key' \"AND name = 'p1'\")" "{3}"
+check "p1 has its own storage id"          "$(proj_q 'proj_storage_id <> storage_id' \"AND name = 'p1'\")" "t"
+
+echo "-- a second projection with no sort key"
+psql_run "SELECT columnar.add_projection('p', 'p2', ARRAY['b']);"
+check "p2 id is 2"        "$(proj_q 'projection_id' \"AND name = 'p2'\")" "2"
+check "p2 columns"        "$(proj_q 'columns' \"AND name = 'p2'\")" "{2}"
+check "p2 sort_key empty" "$(proj_q 'sort_key' \"AND name = 'p2'\")" "{}"
+check "distinct storage ids" \
+	"$(q "SELECT count(DISTINCT proj_storage_id) FROM columnar.projection WHERE storage_id = $SID;")" "3"
+
+echo "-- validation errors"
+expect_fail "duplicate name rejected"       "SELECT columnar.add_projection('p', 'p1', ARRAY['a']);"
+expect_fail "unknown column rejected"       "SELECT columnar.add_projection('p', 'px', ARRAY['zzz']);"
+expect_fail "empty columns rejected"        "SELECT columnar.add_projection('p', 'pe', ARRAY[]::text[]);"
+expect_fail "duplicate column rejected"     "SELECT columnar.add_projection('p', 'pd', ARRAY['a','a']);"
+expect_fail "sort key not in columns"       "SELECT columnar.add_projection('p', 'ps', ARRAY['a'], ARRAY['b']);"
+expect_fail "add on heap table rejected"    "CREATE TABLE h (x int); SELECT columnar.add_projection('h', 'ph', ARRAY['x']);"
+expect_fail "drop base rejected"            "SELECT columnar.drop_projection('p', 'base');"
+expect_fail "drop unknown rejected"         "SELECT columnar.drop_projection('p', 'nope');"
+
+echo "-- drop_projection"
+psql_run "SELECT columnar.drop_projection('p', 'p1');"
+check "p1 gone after drop"  "$(proj_q 'count(*)' \"AND name = 'p1'\")" "0"
+check "base + p2 remain"    "$(proj_q 'count(*)' '')" "2"
+check "table still readable after DDL" "$(q 'SELECT count(*) FROM p;')" "100"
+
+pgc_summary

--- a/test/projections.sh
+++ b/test/projections.sh
@@ -49,16 +49,16 @@ check "base id 0 columns are all attrs" "$(proj_q 'columns' 'AND projection_id =
 check "base id 0 sort_key empty"         "$(proj_q 'sort_key' 'AND projection_id = 0')" "{}"
 check "base id 0 name"                    "$(proj_q 'name' 'AND projection_id = 0')" "base"
 check "base proj_storage_id == base"      "$(proj_q 'proj_storage_id = storage_id' 'AND projection_id = 0')" "t"
-check "p1 id is 1"                         "$(proj_q 'projection_id' \"AND name = 'p1'\")" "1"
-check "p1 columns"                         "$(proj_q 'columns' \"AND name = 'p1'\")" "{1,3}"
-check "p1 sort_key"                        "$(proj_q 'sort_key' \"AND name = 'p1'\")" "{3}"
-check "p1 has its own storage id"          "$(proj_q 'proj_storage_id <> storage_id' \"AND name = 'p1'\")" "t"
+check "p1 id is 1"                         "$(proj_q 'projection_id' "AND name = 'p1'")" "1"
+check "p1 columns"                         "$(proj_q 'columns' "AND name = 'p1'")" "{1,3}"
+check "p1 sort_key"                        "$(proj_q 'sort_key' "AND name = 'p1'")" "{3}"
+check "p1 has its own storage id"          "$(proj_q 'proj_storage_id <> storage_id' "AND name = 'p1'")" "t"
 
 echo "-- a second projection with no sort key"
 psql_run "SELECT columnar.add_projection('p', 'p2', ARRAY['b']);"
-check "p2 id is 2"        "$(proj_q 'projection_id' \"AND name = 'p2'\")" "2"
-check "p2 columns"        "$(proj_q 'columns' \"AND name = 'p2'\")" "{2}"
-check "p2 sort_key empty" "$(proj_q 'sort_key' \"AND name = 'p2'\")" "{}"
+check "p2 id is 2"        "$(proj_q 'projection_id' "AND name = 'p2'")" "2"
+check "p2 columns"        "$(proj_q 'columns' "AND name = 'p2'")" "{2}"
+check "p2 sort_key empty" "$(proj_q 'sort_key' "AND name = 'p2'")" "{}"
 check "distinct storage ids" \
 	"$(q "SELECT count(DISTINCT proj_storage_id) FROM columnar.projection WHERE storage_id = $SID;")" "3"
 
@@ -74,7 +74,7 @@ expect_fail "drop unknown rejected"         "SELECT columnar.drop_projection('p'
 
 echo "-- drop_projection"
 psql_run "SELECT columnar.drop_projection('p', 'p1');"
-check "p1 gone after drop"  "$(proj_q 'count(*)' \"AND name = 'p1'\")" "0"
+check "p1 gone after drop"  "$(proj_q 'count(*)' "AND name = 'p1'")" "0"
 check "base + p2 remain"    "$(proj_q 'count(*)' '')" "2"
 check "table still readable after DDL" "$(q 'SELECT count(*) FROM p;')" "100"
 

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -26,7 +26,7 @@ SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUITES=(smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
 	differential recovery fuzz hardening concurrent_diff parallel sorted_projection \
 	arrow_export parquet_export read_stream corruption \
-	generated_columns temporal arrow_import index_only)
+	generated_columns temporal arrow_import index_only projections)
 
 # Default matrix: one assert-enabled pg_config per major, 13 through 19.
 DEFAULT_CONFIGS=(


### PR DESCRIPTION
First phase of gap 26 (C-Store multiple projections). Catalog + DDL only; no write fan-out yet (phase 2).

## Changes
- **`columnar.projection` catalog**: (storage_id, projection_id, name, proj_storage_id, sort_key smallint[], columns smallint[]) with unique indexes on (storage_id, projection_id), (storage_id, name), and (proj_storage_id).
- **DDL**: `columnar.add_projection(rel, name, columns[], sort_key[])` and `columnar.drop_projection(rel, name)` (new `src/columnar_projection.c`; catalog CRUD in `columnar_metadata.c`). Validates columnar table, column/sort-key resolution, sort-key ⊆ columns, name uniqueness; allocates a fresh `proj_storage_id`; refuses to drop the base. DDL under ShareUpdateExclusiveLock (serializes concurrent DDL, does not block DML).
- **Base projection** (projection_id 0, all live columns, insert order) recorded lazily on first add; a table with no rows behaves as a single implicit base projection, so 2.0/2.1 and projection-free tables are unaffected.
- **Format minor 2.1 → 2.2** (catalog-only; metapage layout unchanged, only the major version is validated).
- **test/projections.sh** (27 checks): base recording, column/sort-key resolution + validation, name uniqueness, storage-id allocation, drop; added to the version matrix.

## Validation
- Full PG13-19 matrix, all 25 suites incl. `projections`: **ALL VERSIONS PASSED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)