### PR TITLE
Multiple projections phase 2: write fan-out (buffer-sort-flush)

### DIFF
--- a/columnar--1.0.sql
+++ b/columnar--1.0.sql
@@ -364,6 +364,14 @@ CREATE FUNCTION columnar.drop_projection(rel regclass, name text)
 COMMENT ON FUNCTION columnar.drop_projection(regclass, text)
 	IS 'drop a declared projection and free its storage (gap 26)';
 
+CREATE FUNCTION columnar.read_projection(rel regclass, name text)
+	RETURNS SETOF text
+	LANGUAGE C STABLE
+	AS 'MODULE_PATHNAME', 'columnar_read_projection';
+
+COMMENT ON FUNCTION columnar.read_projection(regclass, text)
+	IS 'read a projection''s stored columns (live rows), joined by | -- verification/debug (gap 26)';
+
 CREATE FUNCTION columnar.stats(
 	rel regclass,
 	OUT stripeid bigint,

--- a/design/gaps/26-IMPL-projections-phase2-plan.md
+++ b/design/gaps/26-IMPL-projections-phase2-plan.md
@@ -1,0 +1,123 @@
+# Multiple projections — phase 2 implementation plan (grounded)
+
+Phase 2 of `26-IMPL-multiple-projections.md`: write fan-out with buffer-and-sort
+at flush, row-number sharing, and delete handling. After this phase every
+additional projection is populated and verifiably equal to the base by row
+number; the planner still does not use projections (phase 4).
+
+## Grounded storage model (from reading columnar_storage.c / columnar_write_state.c)
+
+- **One physical file per table, shared by all projections.** Data bytes live in
+  the table relation's main fork. `ColumnarReserveOffset(rel, len)` hands out a
+  page-aligned byte range from the metapage's `reservedOffset`; `stripe.file_offset`
+  is an offset into that one shared file. So a projection writes its stripes into
+  the *same* file as the base, using the shared metapage offset counter — offsets
+  stay globally unique across projections for free.
+- **Catalog rows are keyed by storage id.** columnar.stripe/chunk/chunk_group
+  rows carry `storage_id`; a projection's rows use its `proj_storage_id`, so they
+  are naturally separated from the base's while sharing the file.
+- **Row numbers are the base's.** `ColumnarReserveRowNumbers` advances the
+  metapage's `reservedRowNumber`; only the base does this. A projection reuses the
+  base row number assigned to each row (shared identity space) and must NOT
+  advance the row-number counter. It still needs its own stripe id + file offset.
+
+## Key simplification vs the spec draft: derive deletes/visibility from base
+
+The spec draft proposed a per-projection row_mask keyed by base row number. But a
+projection is sorted by its sort key, so a projection chunk holds an arbitrary,
+**non-contiguous** set of base row numbers — which does not fit the row_mask
+model (one contiguous [start,end] range per chunk). Instead:
+
+- **A projection stores the base row number of each physical row** (an int8
+  "row-number stream", written alongside the column value streams — conceptually
+  a leading system column of the projection's chunks).
+- **Visibility and deletes come from the base**, not a projection row_mask. When a
+  projection is read (phase 3 / planner), each physical row's base row number is
+  decoded and checked against the *base* row_mask (deleted?) and base stripe
+  visibility (MVCC via the base catalog snapshot). Deleted/invisible rows are
+  skipped.
+- Therefore **only INSERT fans out.** DELETE/UPDATE touch only the base row_mask
+  exactly as today; "a single delete marks the row dead everywhere" holds because
+  every projection consults the base row_mask. This removes per-projection delete
+  fan-out and its concurrency/recovery risk — the hardest part of the spec draft.
+  (Deviation from the spec's "row mask in every projection", chosen for
+  correctness+simplicity; recorded here and to be reflected in the spec.)
+
+A projection stripe's own columnar.stripe row commits with the inserting
+transaction, so the projection copy appears/disappears atomically with the base
+insert (crash leaves all-or-none, same as base). Per-row deletes after the fact
+are the base row_mask's job.
+
+## Write fan-out
+
+- **Per-projection write buffers.** Extend the write-state registry to key by
+  (relid, subid, projection_id). projection_id 0 is the base (today's path,
+  unchanged). Additional projections get their own ColumnarWriteState-like buffer
+  with storageId = proj_storage_id, but writing bytes/offsets through the *table*
+  relation and NOT reserving row numbers.
+- **Buffer-and-sort at flush.** The base encodes incrementally; a sorted
+  projection cannot. So a projection buffer accumulates raw projected tuples
+  (Datums + base row number) up to stripe_row_limit, then at flush: sort by the
+  projection sort key, encode into chunk groups (value streams + row-number
+  stream + min/max), reserve a stripe id and file offset from the shared
+  metapage, write, and insert catalog rows keyed by proj_storage_id. Memory is
+  bounded by stripe_row_limit rows.
+- **Insert path.** In columnar_tuple_insert / multi_insert: write the base row as
+  today, obtaining its base row number; then for each additional projection,
+  project the tuple to (its columns, base row number) and append to that
+  projection's buffer. Fan-out reads the projection list once per statement
+  (cache on the write state).
+- **Flush coordination.** ColumnarFlushWriteStateForRelation and the pre-commit
+  flush must flush the base and every projection buffer for the relation.
+  Subtransaction abort drops all of the relation's projection buffers too (they
+  are keyed by subid).
+
+## Row-number stream encoding
+
+Reuse the existing chunk stream machinery. Add an int8 value stream per chunk
+that stores the base row number of each row in physical order. On read, decode it
+first to get the row-number vector, then the requested column streams. Store it
+under a reserved attnum (e.g. 0) in columnar.chunk rows for the projection's
+storage, or as a distinguished stream. Confirm the chunk catalog can represent
+attnum 0 (it is `attr_num integer`; base columns are 1..natts, so 0 is free).
+
+## Vacuum / DDL interactions (phase 2 scope)
+
+- `columnar.add_projection` on a non-empty table: phase 1 records the catalog
+  row; phase 2 must back-fill the projection from existing base rows (scan base,
+  project, buffer-sort, flush) so the projection is complete. Do this under the
+  add_projection SUEL. (Alternatively defer back-fill to phase 5 vacuum and mark
+  the projection "unpopulated"; decide during implementation — back-fill at add
+  is simpler to reason about and test.)
+- `columnar.drop_projection`: free the projection's stripes — delete its
+  columnar.stripe/chunk/chunk_group rows (keyed by proj_storage_id). The shared
+  file's bytes become dead space reclaimed by a later full rewrite; acceptable.
+- `TRUNCATE` / table drop: ColumnarDeleteMetadata must also remove projection
+  storage rows for all proj_storage_ids of the table.
+
+## Testing (extend test/projections.sh + differential)
+
+- Fan-out agreement: after inserting N rows into a table with projections,
+  each projection's storage has N live rows (sum of stripe row_count for
+  proj_storage_id), and a low-level reader that scans a projection storage and
+  joins its row-number stream back to the base reproduces the base row for every
+  column the projection stores. (Add a debug function
+  `columnar.read_projection(rel, name)` returning setof record, used by the test
+  and reused by phase 3.)
+- Sort order: within a projection stripe, rows are ordered by the sort key
+  (min/max per chunk is monotonic across chunks within a stripe).
+- Delete/update: after deleting/updating base rows, reading a projection (via the
+  debug reader, which consults the base row_mask) reflects the deletes — matches
+  the base's live set.
+- Back-fill: add_projection on a populated table yields a projection whose live
+  set equals the base.
+- Recovery: crash after inserts (with projections) replays base + projection
+  stripes together; live sets agree after recovery.
+- Full PG13-19 matrix as the gate.
+
+## Sequencing
+
+Land after phase 1 merges. This is the largest phase; if it grows too big for one
+PR, split as 2a (write buffers + fan-out + row-number stream + debug reader +
+fan-out agreement tests) and 2b (add_projection back-fill, drop free, truncate,
+recovery). Keep the planner untouched until phase 4.

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -343,6 +343,9 @@ typedef struct ColumnarWriteState ColumnarWriteState;
 extern ColumnarWriteState *ColumnarGetWriteState(Relation rel);
 extern uint64 ColumnarWriteRow(ColumnarWriteState *writeState, Relation rel,
 							   Datum *values, bool *nulls);
+extern void ColumnarProjectionFanoutRow(Relation rel, ColumnarWriteState *baseWs,
+										uint64 rowNumber, Datum *values,
+										bool *nulls);
 extern bool ColumnarBufferedRowByNumber(Relation rel, uint64 rowNumber,
 										Datum *values, bool *nulls);
 extern void ColumnarFlushWriteStateForRelation(Oid relid);
@@ -373,6 +376,15 @@ extern ColumnarReadState *ColumnarBeginRead(Relation rel, Snapshot snapshot,
 											ParallelTableScanDesc parallelScan,
 											Bitmapset *projectedColumns,
 											int nkeys, ScanKey keys);
+/* like ColumnarBeginRead but reads an explicit storage id with an explicit
+ * tuple descriptor -- used to read a projection's storage (gap 26) */
+extern ColumnarReadState *ColumnarBeginReadWithStorage(Relation rel,
+													   Snapshot snapshot,
+													   uint64 storageId,
+													   TupleDesc tupdesc,
+													   ParallelTableScanDesc parallelScan,
+													   Bitmapset *projectedColumns,
+													   int nkeys, ScanKey keys);
 extern bool ColumnarReadNextRow(ColumnarReadState *readState,
 								Datum *values, bool *nulls,
 								uint64 *rowNumber);

--- a/src/columnar_projection.c
+++ b/src/columnar_projection.c
@@ -23,14 +23,19 @@
 
 #include "access/table.h"
 #include "catalog/pg_type.h"
+#include "funcapi.h"
 #include "miscadmin.h"
 #include "utils/array.h"
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
+#include "utils/memutils.h"
 #include "utils/rel.h"
+#include "utils/snapmgr.h"
+#include "utils/tuplestore.h"
 
 PG_FUNCTION_INFO_V1(columnar_add_projection);
 PG_FUNCTION_INFO_V1(columnar_drop_projection);
+PG_FUNCTION_INFO_V1(columnar_read_projection);
 
 /*
  * Collect the live (non-dropped) attribute numbers of a relation, in attnum
@@ -298,4 +303,155 @@ columnar_drop_projection(PG_FUNCTION_ARGS)
 
 	table_close(rel, ShareUpdateExclusiveLock);
 	PG_RETURN_VOID();
+}
+
+/*
+ * columnar.read_projection(rel, name) -> setof text
+ *		Debug/verification reader for a projection's storage (gap 26, phase 2).
+ *		Scans the projection's stripes (in stored sort order), skips rows whose
+ *		base row number is deleted or invisible per the base row_mask/visibility,
+ *		and returns each live row's projection columns rendered by their output
+ *		functions and joined by '|' (a NULL column renders as \N). The base is
+ *		flushed first so rows written earlier in this transaction are visible.
+ */
+Datum
+columnar_read_projection(PG_FUNCTION_ARGS)
+{
+	Oid			relid;
+	char	   *projname;
+	ReturnSetInfo *rsinfo = (ReturnSetInfo *) fcinfo->resultinfo;
+	Relation	rel;
+	uint64		storageId;
+	List	   *projs;
+	ListCell   *lc;
+	ColumnarProjection *proj = NULL;
+	TupleDesc	projTupdesc;
+	TupleDesc	retdesc;
+	Tuplestorestate *tupstore;
+	MemoryContext oldContext;
+	FmgrInfo   *outFns;
+	int			ncols;
+	int			tnatts;
+	int			i;
+	Snapshot	snap;
+	ColumnarReadState *readState;
+	Datum	   *rvals;
+	bool	   *rnulls;
+	Datum	   *basevals;
+	bool	   *basenulls;
+	uint64		projRowNum;
+
+	if (PG_ARGISNULL(0) || PG_ARGISNULL(1))
+		ereport(ERROR,
+				(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+				 errmsg("rel and name must not be NULL")));
+	relid = PG_GETARG_OID(0);
+	projname = text_to_cstring(PG_GETARG_TEXT_PP(1));
+
+	if (rsinfo == NULL || !IsA(rsinfo, ReturnSetInfo) ||
+		!(rsinfo->allowedModes & SFRM_Materialize))
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("set-valued function called in context that cannot accept a set")));
+
+	if (!ColumnarIsColumnarRelation(relid))
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+				 errmsg("\"%s\" is not a columnar table", get_rel_name(relid))));
+
+	rel = table_open(relid, AccessShareLock);
+	/* persist pending base + projection writes so this read sees them */
+	ColumnarFlushWriteStateForRelation(relid);
+	storageId = ColumnarStorageId(rel);
+
+	projs = ColumnarListProjections(storageId);
+	foreach(lc, projs)
+	{
+		ColumnarProjection *p = (ColumnarProjection *) lfirst(lc);
+
+		if (strcmp(p->name, projname) == 0)
+		{
+			proj = p;
+			break;
+		}
+	}
+	if (proj == NULL || proj->projectionId == 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+				 errmsg("projection \"%s\" does not exist on \"%s\"",
+						projname, get_rel_name(relid))));
+
+	ncols = proj->columnsLen;
+	tnatts = RelationGetDescr(rel)->natts;
+
+	/* projection storage layout: [rownumber int8, projcol1..projcolK] */
+	projTupdesc = CreateTemplateTupleDesc(ncols + 1);
+	TupleDescInitEntry(projTupdesc, 1, "rownumber", INT8OID, -1, 0);
+	for (i = 0; i < ncols; i++)
+		TupleDescCopyEntry(projTupdesc, i + 2, RelationGetDescr(rel),
+						   (AttrNumber) proj->columns[i]);
+
+	outFns = palloc(sizeof(FmgrInfo) * ncols);
+	for (i = 0; i < ncols; i++)
+	{
+		Form_pg_attribute att = TupleDescAttr(projTupdesc, i + 1);
+		Oid			outOid;
+		bool		isVarlena;
+
+		getTypeOutputInfo(att->atttypid, &outOid, &isVarlena);
+		fmgr_info(outOid, &outFns[i]);
+	}
+
+	/* one text column result, materialized into a tuplestore */
+	retdesc = CreateTemplateTupleDesc(1);
+	TupleDescInitEntry(retdesc, 1, "row", TEXTOID, -1, 0);
+
+	oldContext = MemoryContextSwitchTo(rsinfo->econtext->ecxt_per_query_memory);
+	tupstore = tuplestore_begin_heap(true, false, work_mem);
+	rsinfo->returnMode = SFRM_Materialize;
+	rsinfo->setResult = tupstore;
+	rsinfo->setDesc = retdesc;
+	MemoryContextSwitchTo(oldContext);
+
+	snap = GetActiveSnapshot();
+	rvals = palloc(sizeof(Datum) * (ncols + 1));
+	rnulls = palloc(sizeof(bool) * (ncols + 1));
+	basevals = palloc(sizeof(Datum) * tnatts);
+	basenulls = palloc(sizeof(bool) * tnatts);
+
+	readState = ColumnarBeginReadWithStorage(rel, snap, proj->projStorageId,
+											 projTupdesc, NULL, NULL, 0, NULL);
+
+	while (ColumnarReadNextRow(readState, rvals, rnulls, &projRowNum))
+	{
+		uint64		baseRow = (uint64) DatumGetInt64(rvals[0]);
+		StringInfoData buf;
+		Datum		result;
+		bool		resnull = false;
+
+		/* deletes/visibility come from the base */
+		if (!ColumnarReadRowByNumber(rel, snap, baseRow, basevals, basenulls))
+			continue;
+
+		initStringInfo(&buf);
+		for (i = 0; i < ncols; i++)
+		{
+			if (i > 0)
+				appendStringInfoChar(&buf, '|');
+			if (rnulls[i + 1])
+				appendStringInfoString(&buf, "\\N");
+			else
+				appendStringInfoString(&buf,
+									   OutputFunctionCall(&outFns[i], rvals[i + 1]));
+		}
+
+		result = CStringGetTextDatum(buf.data);
+		tuplestore_putvalues(tupstore, retdesc, &result, &resnull);
+		pfree(buf.data);
+	}
+
+	ColumnarEndRead(readState);
+	table_close(rel, AccessShareLock);
+
+	return (Datum) 0;
 }

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -214,6 +214,17 @@ ColumnarBeginRead(Relation rel, Snapshot snapshot,
 				  ParallelTableScanDesc parallelScan,
 				  Bitmapset *projectedColumns, int nkeys, ScanKey keys)
 {
+	return ColumnarBeginReadWithStorage(rel, snapshot, ColumnarStorageId(rel),
+										RelationGetDescr(rel), parallelScan,
+										projectedColumns, nkeys, keys);
+}
+
+ColumnarReadState *
+ColumnarBeginReadWithStorage(Relation rel, Snapshot snapshot,
+							 uint64 storageId, TupleDesc tupdesc,
+							 ParallelTableScanDesc parallelScan,
+							 Bitmapset *projectedColumns, int nkeys, ScanKey keys)
+{
 	ColumnarReadState *readState;
 	MemoryContext readContext;
 	MemoryContext oldContext;
@@ -227,9 +238,9 @@ ColumnarBeginRead(Relation rel, Snapshot snapshot,
 	readState->rel = rel;
 	readState->snapshot = snapshot;
 	readState->metaSnapshot = ColumnarCatalogSnapshot(snapshot);
-	readState->tupdesc = RelationGetDescr(rel);
+	readState->tupdesc = tupdesc;
 	readState->natts = readState->tupdesc->natts;
-	readState->storageId = ColumnarStorageId(rel);
+	readState->storageId = storageId;
 
 	/*
 	 * Resolve each column's missing value once, for stripes that predate an

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -230,6 +230,10 @@ columnar_tuple_insert(Relation rel, TupleTableSlot *slot, CommandId cid,
 	rowNumber = ColumnarWriteRow(writeState, rel, slot->tts_values,
 								 slot->tts_isnull);
 
+	/* fan the row out to every additional projection of this table (gap 26) */
+	ColumnarProjectionFanoutRow(rel, writeState, rowNumber, slot->tts_values,
+								slot->tts_isnull);
+
 	/*
 	 * A new row makes its block not all-visible; clear any VM bit so an
 	 * index-only scan never skips the fetch for a block that just changed
@@ -262,6 +266,8 @@ columnar_multi_insert(Relation rel, TupleTableSlot **slots, int nslots,
 		ColumnarLockUniqueKeys(rel, slots[i]);	/* issue #5 */
 		rowNumber = ColumnarWriteRow(writeState, rel, slots[i]->tts_values,
 									 slots[i]->tts_isnull);
+		ColumnarProjectionFanoutRow(rel, writeState, rowNumber,
+									slots[i]->tts_values, slots[i]->tts_isnull);
 		ColumnarVMClearForRow(rel, rowNumber);	/* gap 28: block changed */
 		ColumnarRowNumberToItemPointer(rowNumber, &slots[i]->tts_tid);
 		slots[i]->tts_tableOid = RelationGetRelid(rel);

--- a/src/columnar_write_state.c
+++ b/src/columnar_write_state.c
@@ -13,10 +13,16 @@
  */
 #include "columnar.h"
 
+#include "access/htup_details.h"
 #include "access/table.h"
 #include "access/xact.h"
+#include "catalog/pg_type.h"
+#include "executor/tuptable.h"
 #include "storage/lmgr.h"
+#include "utils/builtins.h"
 #include "utils/datum.h"
+#include "utils/fmgroids.h"
+#include "utils/lsyscache.h"
 #include "utils/memutils.h"
 #include "utils/rel.h"
 #include "utils/snapmgr.h"
@@ -92,6 +98,16 @@ struct ColumnarWriteState
 	bool		haveReservation;
 	uint64		stripeId;
 	uint64		stripeFirstRowNumber;
+
+	/*
+	 * Phase 2 (gap 26): additional projections fanned out from this relation's
+	 * inserts. projWriters hangs off the base write state so it shares the
+	 * (relid, subid) lifecycle -- flush, discard, subxact abort/promote all
+	 * follow the base automatically. projInited guards the one-time catalog
+	 * lookup that builds the list.
+	 */
+	bool		projInited;
+	List	   *projWriters;	/* list of ColumnarProjWriter * */
 };
 
 /* per-backend registry of pending write states, in ColumnarWriteContext */
@@ -689,6 +705,337 @@ columnar_flush_stripe(ColumnarWriteState *writeState)
 		PopActiveSnapshot();
 }
 
+/* -------------------------------------------------------------------------
+ * projection write fan-out (gap 26, phase 2)
+ *
+ * Each additional projection of a table has its own storage id but shares the
+ * table's relation file and row-number space. On insert, the projected columns
+ * plus the base row number are buffered; at flush the batch is sorted on the
+ * projection's sort key and written as a stripe to the projection's storage,
+ * reusing the base stripe encoder (ColumnarWriteRow + columnar_flush_stripe).
+ * The base row number is stored as a leading int8 column so the projection can
+ * be joined back to the base; deletes/visibility come from the base row_mask, so
+ * only INSERT fans out (see design/gaps/26-IMPL-projections-phase2-plan.md).
+ * ------------------------------------------------------------------------- */
+
+/* one buffered projection row: [rownumber, projcol1..projcolK] */
+typedef struct ProjRow
+{
+	Datum	   *values;
+	bool	   *nulls;
+} ProjRow;
+
+typedef struct ColumnarProjWriter
+{
+	uint64		projStorageId;
+	int			ncols;			/* number of projection columns (K) */
+	AttrNumber *colAttnums;		/* table attnums of the K columns (1-based) */
+	TupleDesc	projTupdesc;	/* [rownumber int8, projcol1..projcolK] */
+
+	int			nsort;
+	int		   *sortBufIdx;		/* index into a row's values[] for each sort col */
+	FmgrInfo   *sortCmp;		/* btree cmp proc per sort col */
+	Oid		   *sortColl;		/* collation per sort col */
+
+	int			stripeRowLimit;
+	int			chunkGroupRowLimit;
+	int			compType;
+	int			compLevel;
+
+	ProjRow    *rows;			/* buffered rows (capacity stripeRowLimit) */
+	int			nrows;
+	MemoryContext ctx;			/* persists: struct arrays, projTupdesc */
+	MemoryContext rowCtx;		/* reset after each stripe flush: row datums */
+	ColumnarWriteState *innerWs;	/* reused stripe encoder for this projection */
+} ColumnarProjWriter;
+
+/*
+ * columnar_build_write_state
+ *		Allocate a standalone stripe encoder for the given tuple descriptor and
+ *		storage id, not registered in ColumnarWriteStates. Used for a
+ *		projection's inner writer; colDefs are zeroed (no min/max or bloom in
+ *		phase 2 -- projection storage is sorted but carries no skip metadata yet).
+ */
+static ColumnarWriteState *
+columnar_build_write_state(Oid relid, TupleDesc srcTupdesc, uint64 storageId,
+						   int stripeRowLimit, int chunkGroupRowLimit,
+						   int compType, int compLevel)
+{
+	MemoryContext oldContext;
+	ColumnarWriteState *ws;
+
+	if (ColumnarWriteContext == NULL)
+		ColumnarWriteContext = AllocSetContextCreate(TopTransactionContext,
+													 "columnar write",
+													 ALLOCSET_DEFAULT_SIZES);
+	oldContext = MemoryContextSwitchTo(ColumnarWriteContext);
+
+	ws = palloc0(sizeof(ColumnarWriteState));
+	ws->relid = relid;
+	ws->subid = GetCurrentSubTransactionId();
+	ws->tupdesc = CreateTupleDescCopy(srcTupdesc);
+	ws->natts = ws->tupdesc->natts;
+	ws->stripeRowLimit = stripeRowLimit;
+	ws->chunkGroupRowLimit = chunkGroupRowLimit;
+	ws->compressionType = compType;
+	ws->compressionLevel = compLevel;
+	ws->storageId = storageId;
+	ws->colDefs = palloc0(sizeof(ColumnarColumnDef) * ws->natts);
+	ws->stripeContext = AllocSetContextCreate(ColumnarWriteContext,
+											  "columnar proj stripe",
+											  ALLOCSET_DEFAULT_SIZES);
+	ws->writeContext = ColumnarWriteContext;
+	ws->chunkGroups = NIL;
+	ws->currentGroup = NULL;
+	ws->stripeRowCount = 0;
+	ws->haveReservation = false;
+
+	MemoryContextSwitchTo(oldContext);
+	return ws;
+}
+
+/* qsort_arg comparator: ascending, NULLS LAST, over the projection sort key */
+static int
+proj_row_cmp(const void *a, const void *b, void *arg)
+{
+	const ProjRow *ra = (const ProjRow *) a;
+	const ProjRow *rb = (const ProjRow *) b;
+	ColumnarProjWriter *w = (ColumnarProjWriter *) arg;
+	int			i;
+
+	for (i = 0; i < w->nsort; i++)
+	{
+		int			idx = w->sortBufIdx[i];
+		bool		na = ra->nulls[idx];
+		bool		nb = rb->nulls[idx];
+		int32		c;
+
+		if (na && nb)
+			continue;
+		if (na)
+			return 1;			/* nulls last */
+		if (nb)
+			return -1;
+		c = DatumGetInt32(FunctionCall2Coll(&w->sortCmp[i], w->sortColl[i],
+											ra->values[idx], rb->values[idx]));
+		if (c != 0)
+			return c;
+	}
+	return 0;
+}
+
+/*
+ * flush_proj_writer
+ *		Sort the buffered rows on the projection's sort key and write them as one
+ *		stripe to the projection's storage, then reset the buffer.
+ */
+static void
+flush_proj_writer(ColumnarProjWriter *w, Relation tableRel)
+{
+	int			i;
+
+	if (w->nrows == 0)
+		return;
+
+	if (w->nsort > 0)
+		qsort_arg(w->rows, w->nrows, sizeof(ProjRow), proj_row_cmp, w);
+
+	if (w->innerWs == NULL)
+		w->innerWs = columnar_build_write_state(RelationGetRelid(tableRel),
+												w->projTupdesc, w->projStorageId,
+												w->stripeRowLimit,
+												w->chunkGroupRowLimit,
+												w->compType, w->compLevel);
+
+	for (i = 0; i < w->nrows; i++)
+		ColumnarWriteRow(w->innerWs, tableRel, w->rows[i].values, w->rows[i].nulls);
+
+	if (w->innerWs->stripeRowCount > 0)
+		columnar_flush_stripe(w->innerWs);
+
+	MemoryContextReset(w->rowCtx);
+	w->nrows = 0;
+}
+
+/*
+ * build_proj_writer
+ *		Construct a ColumnarProjWriter for one projection catalog row.
+ */
+static ColumnarProjWriter *
+build_proj_writer(Relation rel, const ColumnarProjection *proj,
+				  int stripeRowLimit, int chunkGroupRowLimit,
+				  int compType, int compLevel)
+{
+	TupleDesc	tableDesc = RelationGetDescr(rel);
+	MemoryContext ctx;
+	MemoryContext oldContext;
+	ColumnarProjWriter *w;
+	int			i;
+
+	ctx = AllocSetContextCreate(ColumnarWriteContext, "columnar proj writer",
+								ALLOCSET_DEFAULT_SIZES);
+	oldContext = MemoryContextSwitchTo(ctx);
+
+	w = palloc0(sizeof(ColumnarProjWriter));
+	w->projStorageId = proj->projStorageId;
+	w->ncols = proj->columnsLen;
+	w->stripeRowLimit = stripeRowLimit;
+	w->chunkGroupRowLimit = chunkGroupRowLimit;
+	w->compType = compType;
+	w->compLevel = compLevel;
+	w->ctx = ctx;
+	w->rowCtx = AllocSetContextCreate(ctx, "columnar proj rows",
+									  ALLOCSET_DEFAULT_SIZES);
+	w->rows = palloc0(sizeof(ProjRow) * stripeRowLimit);
+	w->nrows = 0;
+	w->innerWs = NULL;
+
+	w->colAttnums = palloc(sizeof(AttrNumber) * w->ncols);
+	for (i = 0; i < w->ncols; i++)
+		w->colAttnums[i] = (AttrNumber) proj->columns[i];
+
+	/* synthetic tuple descriptor: rownumber int8, then the projection columns */
+	w->projTupdesc = CreateTemplateTupleDesc(w->ncols + 1);
+	TupleDescInitEntry(w->projTupdesc, 1, "rownumber", INT8OID, -1, 0);
+	for (i = 0; i < w->ncols; i++)
+		TupleDescCopyEntry(w->projTupdesc, i + 2, tableDesc, w->colAttnums[i]);
+
+	/* sort-key comparators; each sort attnum is one of the projection columns */
+	w->nsort = proj->sortKeyLen;
+	if (w->nsort > 0)
+	{
+		w->sortBufIdx = palloc(sizeof(int) * w->nsort);
+		w->sortCmp = palloc(sizeof(FmgrInfo) * w->nsort);
+		w->sortColl = palloc(sizeof(Oid) * w->nsort);
+		for (i = 0; i < w->nsort; i++)
+		{
+			int16		attno = proj->sortKey[i];
+			Form_pg_attribute att = TupleDescAttr(tableDesc, attno - 1);
+			TypeCacheEntry *tce;
+			int			p;
+
+			/* position of this sort column within the projection's columns */
+			w->sortBufIdx[i] = -1;
+			for (p = 0; p < w->ncols; p++)
+				if (w->colAttnums[p] == attno)
+				{
+					w->sortBufIdx[i] = p + 1;	/* +1 for the leading rownumber */
+					break;
+				}
+			if (w->sortBufIdx[i] < 0)
+				elog(ERROR, "columnar: sort column not in projection columns");
+
+			tce = lookup_type_cache(att->atttypid, TYPECACHE_CMP_PROC_FINFO);
+			if (!OidIsValid(tce->cmp_proc_finfo.fn_oid))
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg("cannot sort projection on column of type %s",
+								format_type_be(att->atttypid))));
+			fmgr_info_copy(&w->sortCmp[i], &tce->cmp_proc_finfo, ctx);
+			w->sortColl[i] = att->attcollation;
+		}
+	}
+
+	MemoryContextSwitchTo(oldContext);
+	return w;
+}
+
+/*
+ * ColumnarProjectionFanoutRow
+ *		Buffer a freshly inserted row into each additional projection of the
+ *		relation. rowNumber is the base row number returned by ColumnarWriteRow.
+ *		The projection writers hang off the base write state, so they share its
+ *		(relid, subid) lifecycle.
+ */
+void
+ColumnarProjectionFanoutRow(Relation rel, ColumnarWriteState *baseWs,
+							uint64 rowNumber, Datum *values, bool *nulls)
+{
+	TupleDesc	tableDesc = RelationGetDescr(rel);
+	ListCell   *lc;
+
+	if (!baseWs->projInited)
+	{
+		List	   *projs = ColumnarListProjections(baseWs->storageId);
+		MemoryContext oldContext = MemoryContextSwitchTo(ColumnarWriteContext);
+		ListCell   *pc;
+
+		foreach(pc, projs)
+		{
+			ColumnarProjection *p = (ColumnarProjection *) lfirst(pc);
+
+			if (p->projectionId == 0)
+				continue;		/* base projection is the table itself */
+			baseWs->projWriters =
+				lappend(baseWs->projWriters,
+						build_proj_writer(rel, p, baseWs->stripeRowLimit,
+										  baseWs->chunkGroupRowLimit,
+										  baseWs->compressionType,
+										  baseWs->compressionLevel));
+		}
+		baseWs->projInited = true;
+		MemoryContextSwitchTo(oldContext);
+	}
+
+	if (baseWs->projWriters == NIL)
+		return;
+
+	foreach(lc, baseWs->projWriters)
+	{
+		ColumnarProjWriter *w = (ColumnarProjWriter *) lfirst(lc);
+		MemoryContext oldContext = MemoryContextSwitchTo(w->rowCtx);
+		ProjRow    *r = &w->rows[w->nrows];
+		int			i;
+
+		r->values = palloc(sizeof(Datum) * (w->ncols + 1));
+		r->nulls = palloc(sizeof(bool) * (w->ncols + 1));
+		r->values[0] = Int64GetDatum((int64) rowNumber);
+		r->nulls[0] = false;
+		for (i = 0; i < w->ncols; i++)
+		{
+			AttrNumber	a = w->colAttnums[i];
+			Form_pg_attribute att = TupleDescAttr(tableDesc, a - 1);
+
+			if (nulls[a - 1])
+			{
+				r->nulls[i + 1] = true;
+				r->values[i + 1] = (Datum) 0;
+			}
+			else
+			{
+				r->nulls[i + 1] = false;
+				r->values[i + 1] = datumCopy(values[a - 1], att->attbyval,
+											 att->attlen);
+			}
+		}
+		w->nrows++;
+		MemoryContextSwitchTo(oldContext);
+
+		if (w->nrows >= w->stripeRowLimit)
+			flush_proj_writer(w, rel);
+	}
+}
+
+/* Flush all projection writers hanging off a base write state. */
+static void
+flush_ws_projections(ColumnarWriteState *ws)
+{
+	ListCell   *lc;
+	Relation	rel;
+	bool		any = false;
+
+	foreach(lc, ws->projWriters)
+		if (((ColumnarProjWriter *) lfirst(lc))->nrows > 0)
+			any = true;
+	if (!any)
+		return;
+
+	rel = table_open(ws->relid, RowExclusiveLock);
+	foreach(lc, ws->projWriters)
+		flush_proj_writer((ColumnarProjWriter *) lfirst(lc), rel);
+	table_close(rel, RowExclusiveLock);
+}
+
 /*
  * ColumnarFlushWriteStateForRelation
  *		Flush any pending partial stripe for a single relation. Used at scan
@@ -703,8 +1050,11 @@ ColumnarFlushWriteStateForRelation(Oid relid)
 	{
 		ColumnarWriteState *writeState = (ColumnarWriteState *) lfirst(lc);
 
-		if (writeState->relid == relid && writeState->stripeRowCount > 0)
+		if (writeState->relid != relid)
+			continue;
+		if (writeState->stripeRowCount > 0)
 			columnar_flush_stripe(writeState);
+		flush_ws_projections(writeState);
 	}
 }
 
@@ -749,7 +1099,12 @@ ColumnarFlushAllPendingWrites(void)
 	ListCell   *lc;
 
 	foreach(lc, ColumnarWriteStates)
-		columnar_flush_stripe((ColumnarWriteState *) lfirst(lc));
+	{
+		ColumnarWriteState *writeState = (ColumnarWriteState *) lfirst(lc);
+
+		columnar_flush_stripe(writeState);
+		flush_ws_projections(writeState);
+	}
 }
 
 /*

--- a/test/projections.sh
+++ b/test/projections.sh
@@ -78,4 +78,55 @@ check "p1 gone after drop"  "$(proj_q 'count(*)' "AND name = 'p1'")" "0"
 check "base + p2 remain"    "$(proj_q 'count(*)' '')" "2"
 check "table still readable after DDL" "$(q 'SELECT count(*) FROM p;')" "100"
 
+# Phase 2a does not back-fill: p2 was added after p already had 100 rows, so its
+# storage is empty until a future statement inserts (or a back-fill phase).
+check "no back-fill: p2 empty on populated table" \
+	"$(q "SELECT count(*) FROM columnar.read_projection('p', 'p2');")" "0"
+
+# ---------------------------------------------------------------------------
+# Phase 2: write fan-out. Projections declared before load are populated by
+# INSERT; read_projection reproduces the base's live rows for the projection's
+# columns (deletes come from the base row_mask). Values are rendered by their
+# output functions and joined by '|' on both sides for an exact multiset match.
+# ---------------------------------------------------------------------------
+echo "-- phase 2: write fan-out populates projections"
+psql_run "CREATE TABLE fo (a int, b text, c int) USING columnar;"
+psql_run "SELECT columnar.add_projection('fo', 'fp', ARRAY['a','c'], ARRAY['c']);"
+psql_run "SELECT columnar.add_projection('fo', 'fq', ARRAY['b']);"
+psql_run "INSERT INTO fo SELECT g, 'r'||g, (g*7)%100 FROM generate_series(1,5000) g;"
+
+check "fp fan-out matches base (a,c)" \
+	"$(pgc_set_hash "SELECT columnar.read_projection('fo','fp')")" \
+	"$(pgc_set_hash "SELECT a::text || '|' || c::text FROM fo")"
+check "fq fan-out matches base (b)" \
+	"$(pgc_set_hash "SELECT columnar.read_projection('fo','fq')")" \
+	"$(pgc_set_hash "SELECT b FROM fo")"
+check "fp row count matches base" \
+	"$(q "SELECT count(*) FROM columnar.read_projection('fo','fp');")" \
+	"$(q 'SELECT count(*) FROM fo;')"
+
+echo "-- phase 2: deletes reflected via the base row_mask"
+psql_run "DELETE FROM fo WHERE a BETWEEN 1000 AND 2000;"
+check "fp reflects deletes (a,c)" \
+	"$(pgc_set_hash "SELECT columnar.read_projection('fo','fp')")" \
+	"$(pgc_set_hash "SELECT a::text || '|' || c::text FROM fo")"
+check "fp count after delete matches base" \
+	"$(q "SELECT count(*) FROM columnar.read_projection('fo','fp');")" \
+	"$(q 'SELECT count(*) FROM fo;')"
+
+echo "-- phase 2: multi-stripe fan-out (exceed the stripe row limit)"
+psql_run "SELECT columnar.alter_columnar_table_set('fo', stripe_row_limit => 2000);"
+psql_run "CREATE TABLE fo2 (a int, c int) USING columnar;"
+psql_run "SELECT columnar.alter_columnar_table_set('fo2', stripe_row_limit => 2000);"
+psql_run "SELECT columnar.add_projection('fo2', 'fp2', ARRAY['a','c'], ARRAY['c']);"
+psql_run "INSERT INTO fo2 SELECT g, (g*13)%1000 FROM generate_series(1,7000) g;"
+check "fp2 multi-stripe fan-out matches base" \
+	"$(pgc_set_hash "SELECT columnar.read_projection('fo2','fp2')")" \
+	"$(pgc_set_hash "SELECT a::text || '|' || c::text FROM fo2")"
+check "fp2 spans multiple projection stripes" \
+	"$([ "$(q "SELECT count(*) FROM columnar.stripe WHERE storage_id = (SELECT proj_storage_id FROM columnar.projection WHERE storage_id = columnar.get_storage_id('fo2') AND name='fp2');")" -ge 2 ] && echo yes || echo no)" "yes"
+
+echo "-- phase 2: reading the base projection by name is rejected"
+expect_fail "read_projection base rejected" "SELECT columnar.read_projection('fo', 'base');"
+
 pgc_summary


### PR DESCRIPTION
Second phase of gap 26. Populates additional projections on write; the planner still does not use them (phase 4).

## Changes
- **Write fan-out**: every INSERT/multi_insert fans each row out to the table's additional projections. The projected columns + the base row number are buffered, **sorted on the projection sort key at flush**, and written as a stripe to the projection's own storage (`proj_storage_id`) in the shared relation file — reusing the base stripe encoder (`ColumnarWriteRow` + `columnar_flush_stripe`). Sorting uses an in-memory bounded batch (no cross-statement tuplesort/resource-owner issues).
- **Base row number stored as a leading int8 column** so a projection can be joined back to the base. **Deletes/visibility derive from the base row_mask** (a projection read decodes each row's base row number and consults `ColumnarReadRowByNumber`), so only INSERT fans out — no per-projection delete propagation, which removes the spec draft's main concurrency/recovery risk.
- Projection writers hang off the base write state, sharing its (relid, subid) flush/abort/promote lifecycle.
- New: `ColumnarBeginReadWithStorage` (read an explicit storage id + tuple descriptor), `ColumnarProjectionFanoutRow`, and `columnar.read_projection(rel, name)` SRF for verification.
- **Not yet**: back-fill of a projection added to a populated table (deferred), planner use (phase 4), vacuum coordination (phase 5). Min/max skip metadata on projection chunks is deferred to when the planner consumes it.

## Validation
- Full PG13-19 matrix, all 25 suites: **ALL VERSIONS PASSED**.
- `projections.sh` (36 checks): fan-out multiset match vs base, delete reflection via base row_mask, multi-stripe fan-out, base-read rejection, no-back-fill documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)