### PR TITLE
Multiple projections phases 5-6: vacuum coordination, back-fill, recovery, MVCC

### DIFF
--- a/src/columnar.h
+++ b/src/columnar.h
@@ -347,6 +347,8 @@ extern uint64 ColumnarWriteRow(ColumnarWriteState *writeState, Relation rel,
 extern void ColumnarProjectionFanoutRow(Relation rel, ColumnarWriteState *baseWs,
 										uint64 rowNumber, Datum *values,
 										bool *nulls);
+extern void ColumnarBackfillProjection(Relation rel,
+									   const ColumnarProjection *proj);
 extern bool ColumnarBufferedRowByNumber(Relation rel, uint64 rowNumber,
 										Datum *values, bool *nulls);
 extern void ColumnarFlushWriteStateForRelation(Oid relid);

--- a/src/columnar_projection.c
+++ b/src/columnar_projection.c
@@ -183,7 +183,13 @@ columnar_add_projection(PG_FUNCTION_ARGS)
 				(errcode(ERRCODE_NAME_TOO_LONG),
 				 errmsg("projection name \"%s\" is too long", projname)));
 
-	rel = table_open(relid, ShareUpdateExclusiveLock);
+	/*
+	 * ShareLock: block concurrent INSERT/UPDATE/DELETE (RowExclusiveLock) while
+	 * we back-fill the projection from existing rows, so no concurrently written
+	 * row is missed -- the same lock non-concurrent CREATE INDEX takes. Reads are
+	 * unaffected. (A CONCURRENTLY variant is future work.)
+	 */
+	rel = table_open(relid, ShareLock);
 	storageId = ColumnarStorageId(rel);
 
 	existing = ColumnarListProjections(storageId);
@@ -239,7 +245,10 @@ columnar_add_projection(PG_FUNCTION_ARGS)
 	proj.projStorageId = ColumnarNextStorageId();
 	ColumnarInsertProjectionRow(&proj);
 
-	table_close(rel, ShareUpdateExclusiveLock);
+	/* populate the projection from the table's existing rows (gap 26 back-fill) */
+	ColumnarBackfillProjection(rel, &proj);
+
+	table_close(rel, ShareLock);
 	PG_RETURN_VOID();
 }
 

--- a/src/columnar_vacuum.c
+++ b/src/columnar_vacuum.c
@@ -102,11 +102,21 @@ columnar_compact_relation(Relation rel, int nsortkeys, AttrNumber *sortAtts)
 	TupleTableSlot *writeSlot;
 	uint64		rowNumber;
 
+	List	   *oldProjs;
+
 	/* persist any pending work so the read below sees it (spec 9) */
 	ColumnarFlushWriteStateForRelation(relid);
 	ColumnarFlushRowMaskForRelation(rel);
 
 	oldStorageId = ColumnarStorageId(rel);
+
+	/*
+	 * Capture the table's projections (gap 26) before the storage swap. Compaction
+	 * reassigns base row numbers, so each projection must be rebuilt from the
+	 * compacted base; we re-record the definitions under the new storage id below
+	 * and the rewrite loop re-fans-out every live row into them.
+	 */
+	oldProjs = ColumnarListProjections(oldStorageId);
 
 	snapshot = ActiveSnapshotSet() ? GetActiveSnapshot() : GetTransactionSnapshot();
 
@@ -183,16 +193,53 @@ columnar_compact_relation(Relation rel, int nsortkeys, AttrNumber *sortAtts)
 	ColumnarForgetWriteStateForRelation(relid);
 	ColumnarDeleteMetadata(oldStorageId);
 
+	/*
+	 * Realign projections to the compacted base (gap 26): drop each old
+	 * projection's storage and its now-stale catalog row (keyed by the old base
+	 * storage id), then re-record the definitions under the new base storage id
+	 * with fresh projection storage ids. The rewrite loop below re-fans-out every
+	 * live row into them, so they end up sorted and aligned to the new row
+	 * numbers. No-op for a table without projections.
+	 */
+	if (oldProjs != NIL)
+	{
+		uint64		newStorageId = ColumnarStorageId(rel);
+		ListCell   *lc;
+
+		foreach(lc, oldProjs)
+		{
+			ColumnarProjection *p = (ColumnarProjection *) lfirst(lc);
+
+			if (p->projStorageId != oldStorageId)
+				ColumnarDeleteMetadata(p->projStorageId);
+			ColumnarDeleteProjectionRow(oldStorageId, p->projectionId);
+		}
+		foreach(lc, oldProjs)
+		{
+			ColumnarProjection *p = (ColumnarProjection *) lfirst(lc);
+			ColumnarProjection np = *p;
+
+			np.storageId = newStorageId;
+			np.projStorageId = (p->projectionId == 0) ? newStorageId
+				: ColumnarNextStorageId();
+			ColumnarInsertProjectionRow(&np);
+		}
+	}
+
 	/* write the live rows back into the fresh storage, in sorted order if any */
 	writeState = ColumnarGetWriteState(rel);
 	if (tsort != NULL)
 	{
 		while (tuplesort_gettupleslot(tsort, true, false, writeSlot, NULL))
 		{
+			uint64		newRowNumber;
+
 			CHECK_FOR_INTERRUPTS();
 			slot_getallattrs(writeSlot);
-			(void) ColumnarWriteRow(writeState, rel, writeSlot->tts_values,
-									writeSlot->tts_isnull);
+			newRowNumber = ColumnarWriteRow(writeState, rel, writeSlot->tts_values,
+											writeSlot->tts_isnull);
+			ColumnarProjectionFanoutRow(rel, writeState, newRowNumber,
+										writeSlot->tts_values, writeSlot->tts_isnull);
 			ExecClearTuple(writeSlot);
 		}
 	}
@@ -200,10 +247,14 @@ columnar_compact_relation(Relation rel, int nsortkeys, AttrNumber *sortAtts)
 	{
 		while (tuplestore_gettupleslot(tstore, true, false, writeSlot))
 		{
+			uint64		newRowNumber;
+
 			CHECK_FOR_INTERRUPTS();
 			slot_getallattrs(writeSlot);
-			(void) ColumnarWriteRow(writeState, rel, writeSlot->tts_values,
-									writeSlot->tts_isnull);
+			newRowNumber = ColumnarWriteRow(writeState, rel, writeSlot->tts_values,
+											writeSlot->tts_isnull);
+			ColumnarProjectionFanoutRow(rel, writeState, newRowNumber,
+										writeSlot->tts_values, writeSlot->tts_isnull);
 			ExecClearTuple(writeSlot);
 		}
 	}

--- a/src/columnar_write_state.c
+++ b/src/columnar_write_state.c
@@ -948,6 +948,48 @@ build_proj_writer(Relation rel, const ColumnarProjection *proj,
 }
 
 /*
+ * append_proj_row
+ *		Buffer one row (the base row number plus the projection's columns) into a
+ *		projection writer, flushing a stripe when the buffer fills. Shared by the
+ *		insert fan-out and the add-projection back-fill.
+ */
+static void
+append_proj_row(ColumnarProjWriter *w, Relation rel, TupleDesc tableDesc,
+				uint64 rowNumber, Datum *values, bool *nulls)
+{
+	MemoryContext oldContext = MemoryContextSwitchTo(w->rowCtx);
+	ProjRow    *r = &w->rows[w->nrows];
+	int			i;
+
+	r->values = palloc(sizeof(Datum) * (w->ncols + 1));
+	r->nulls = palloc(sizeof(bool) * (w->ncols + 1));
+	r->values[0] = Int64GetDatum((int64) rowNumber);
+	r->nulls[0] = false;
+	for (i = 0; i < w->ncols; i++)
+	{
+		AttrNumber	a = w->colAttnums[i];
+		Form_pg_attribute att = TupleDescAttr(tableDesc, a - 1);
+
+		if (nulls[a - 1])
+		{
+			r->nulls[i + 1] = true;
+			r->values[i + 1] = (Datum) 0;
+		}
+		else
+		{
+			r->nulls[i + 1] = false;
+			r->values[i + 1] = datumCopy(values[a - 1], att->attbyval,
+										 att->attlen);
+		}
+	}
+	w->nrows++;
+	MemoryContextSwitchTo(oldContext);
+
+	if (w->nrows >= w->stripeRowLimit)
+		flush_proj_writer(w, rel);
+}
+
+/*
  * ColumnarProjectionFanoutRow
  *		Buffer a freshly inserted row into each additional projection of the
  *		relation. rowNumber is the base row number returned by ColumnarWriteRow.
@@ -988,39 +1030,69 @@ ColumnarProjectionFanoutRow(Relation rel, ColumnarWriteState *baseWs,
 		return;
 
 	foreach(lc, baseWs->projWriters)
+		append_proj_row((ColumnarProjWriter *) lfirst(lc), rel, tableDesc,
+						rowNumber, values, nulls);
+}
+
+/*
+ * ColumnarBackfillProjection
+ *		Populate a newly declared projection from the table's existing live rows
+ *		(gap 26): scan the base and buffer-sort-flush each row into the
+ *		projection's storage. Called by add_projection so a projection added to a
+ *		populated table is complete. The caller must hold a lock that blocks
+ *		concurrent writers (ShareLock) so no row is missed.
+ */
+void
+ColumnarBackfillProjection(Relation rel, const ColumnarProjection *proj)
+{
+	TupleDesc	tableDesc = RelationGetDescr(rel);
+	Oid			relid = RelationGetRelid(rel);
+	int			stripeRowLimit = columnar_stripe_row_limit;
+	int			chunkGroupRowLimit = columnar_chunk_group_row_limit;
+	int			compType = columnar_compression;
+	int			compLevel = columnar_compression_level;
+	ColumnarOptions opts;
+	ColumnarProjWriter *w;
+	ColumnarReadState *readState;
+	Snapshot	snapshot;
+	Datum	   *values;
+	bool	   *nulls;
+	uint64		rowNumber;
+
+	if (ColumnarWriteContext == NULL)
+		ColumnarWriteContext = AllocSetContextCreate(TopTransactionContext,
+													 "columnar write",
+													 ALLOCSET_DEFAULT_SIZES);
+
+	if (ColumnarReadOptions(relid, &opts))
 	{
-		ColumnarProjWriter *w = (ColumnarProjWriter *) lfirst(lc);
-		MemoryContext oldContext = MemoryContextSwitchTo(w->rowCtx);
-		ProjRow    *r = &w->rows[w->nrows];
-		int			i;
-
-		r->values = palloc(sizeof(Datum) * (w->ncols + 1));
-		r->nulls = palloc(sizeof(bool) * (w->ncols + 1));
-		r->values[0] = Int64GetDatum((int64) rowNumber);
-		r->nulls[0] = false;
-		for (i = 0; i < w->ncols; i++)
-		{
-			AttrNumber	a = w->colAttnums[i];
-			Form_pg_attribute att = TupleDescAttr(tableDesc, a - 1);
-
-			if (nulls[a - 1])
-			{
-				r->nulls[i + 1] = true;
-				r->values[i + 1] = (Datum) 0;
-			}
-			else
-			{
-				r->nulls[i + 1] = false;
-				r->values[i + 1] = datumCopy(values[a - 1], att->attbyval,
-											 att->attlen);
-			}
-		}
-		w->nrows++;
-		MemoryContextSwitchTo(oldContext);
-
-		if (w->nrows >= w->stripeRowLimit)
-			flush_proj_writer(w, rel);
+		if (opts.stripeRowLimitSet)
+			stripeRowLimit = opts.stripeRowLimit;
+		if (opts.chunkGroupRowLimitSet)
+			chunkGroupRowLimit = opts.chunkGroupRowLimit;
+		if (opts.compressionSet)
+			compType = opts.compressionType;
+		if (opts.compressionLevelSet)
+			compLevel = opts.compressionLevel;
 	}
+
+	/* flush any pending base writes so the scan sees this transaction's rows */
+	ColumnarFlushWriteStateForRelation(relid);
+	ColumnarFlushRowMaskForRelation(rel);
+
+	w = build_proj_writer(rel, proj, stripeRowLimit, chunkGroupRowLimit,
+						  compType, compLevel);
+
+	snapshot = ActiveSnapshotSet() ? GetActiveSnapshot() : GetTransactionSnapshot();
+	values = palloc(sizeof(Datum) * tableDesc->natts);
+	nulls = palloc(sizeof(bool) * tableDesc->natts);
+
+	readState = ColumnarBeginRead(rel, snapshot, NULL, NULL, 0, NULL);
+	while (ColumnarReadNextRow(readState, values, nulls, &rowNumber))
+		append_proj_row(w, rel, tableDesc, rowNumber, values, nulls);
+	ColumnarEndRead(readState);
+
+	flush_proj_writer(w, rel);
 }
 
 /* Flush all projection writers hanging off a base write state. */

--- a/test/projections.sh
+++ b/test/projections.sh
@@ -78,10 +78,13 @@ check "p1 gone after drop"  "$(proj_q 'count(*)' "AND name = 'p1'")" "0"
 check "base + p2 remain"    "$(proj_q 'count(*)' '')" "2"
 check "table still readable after DDL" "$(q 'SELECT count(*) FROM p;')" "100"
 
-# Phase 2a does not back-fill: p2 was added after p already had 100 rows, so its
-# storage is empty until a future statement inserts (or a back-fill phase).
-check "no back-fill: p2 empty on populated table" \
-	"$(q "SELECT count(*) FROM columnar.read_projection('p', 'p2');")" "0"
+# add_projection back-fills from existing rows (gap 26 phase 6): p2 was added
+# after p already had 100 rows, so its storage is populated with those rows.
+check "back-fill: p2 populated from existing rows" \
+	"$(q "SELECT count(*) FROM columnar.read_projection('p', 'p2');")" "100"
+check "back-fill: p2 matches base (b column)" \
+	"$(pgc_set_hash "SELECT columnar.read_projection('p','p2')")" \
+	"$(pgc_set_hash "SELECT b FROM p")"
 
 # ---------------------------------------------------------------------------
 # Phase 2: write fan-out. Projections declared before load are populated by
@@ -196,5 +199,89 @@ check "projection scan matches oracle after delete" \
 check "full-range projection scan matches oracle" \
 	"$(pgc_set_hash "SELECT a, c FROM ps")" \
 	"$(pgc_set_hash "SELECT a, c FROM ps_h")"
+
+# ---------------------------------------------------------------------------
+# Phase 5: columnar.vacuum compacts the base into fresh storage with new row
+# numbers, so it must rebuild every projection aligned to the compacted base.
+# After vacuum the projection must still exist, still be chosen by the planner,
+# and still match the heap oracle.
+# ---------------------------------------------------------------------------
+echo "-- phase 5: columnar.vacuum rebuilds projections aligned to the compacted base"
+psql_run "CREATE TABLE pv (a int, b text, c int) USING columnar;"
+psql_run "SELECT columnar.add_projection('pv', 'pvp', ARRAY['a','c'], ARRAY['c']);"
+psql_run "INSERT INTO pv SELECT g, 'r'||g, (g*7)%1000 FROM generate_series(1,20000) g;"
+psql_run "DELETE FROM pv WHERE a BETWEEN 5000 AND 8000;"
+psql_run "CREATE TABLE pv_h (a int, b text, c int) USING heap;"
+psql_run "INSERT INTO pv_h SELECT g, 'r'||g, (g*7)%1000 FROM generate_series(1,20000) g WHERE g NOT BETWEEN 5000 AND 8000;"
+
+psql_run "SELECT columnar.vacuum('pv');"
+check "projection survives vacuum" \
+	"$(q "SELECT count(*) FROM columnar.projection WHERE storage_id = columnar.get_storage_id('pv') AND name='pvp';")" "1"
+check "read_projection matches base after vacuum" \
+	"$(pgc_set_hash "SELECT columnar.read_projection('pv','pvp')")" \
+	"$(pgc_set_hash "SELECT a::text || '|' || c::text FROM pv_h")"
+check "planner still uses projection after vacuum" \
+	"$(q "EXPLAIN (COSTS OFF) SELECT a, c FROM pv WHERE c BETWEEN 100 AND 200;" | grep -c 'Columnar Projection: pvp')" "1"
+check "projection-scan matches oracle after vacuum" \
+	"$(pgc_set_hash "SELECT a, c FROM pv WHERE c BETWEEN 100 AND 200")" \
+	"$(pgc_set_hash "SELECT a, c FROM pv_h WHERE c BETWEEN 100 AND 200")"
+check "reconstruct (a,b,c) matches base after vacuum" \
+	"$(pgc_set_hash "SELECT columnar.reconstruct_via_projection('pv','pvp')")" \
+	"$(pgc_set_hash "SELECT a::text||'|'||b||'|'||c::text FROM pv_h")"
+
+echo "-- phase 5: a second vacuum stays correct (fresh row numbers again)"
+psql_run "DELETE FROM pv   WHERE a BETWEEN 100 AND 200;"
+psql_run "DELETE FROM pv_h WHERE a BETWEEN 100 AND 200;"
+psql_run "SELECT columnar.vacuum('pv');"
+check "projection matches base after second vacuum" \
+	"$(pgc_set_hash "SELECT columnar.read_projection('pv','pvp')")" \
+	"$(pgc_set_hash "SELECT a::text || '|' || c::text FROM pv_h")"
+
+# ---------------------------------------------------------------------------
+# Phase 6: MVCC. An old REPEATABLE READ snapshot must not see rows committed by
+# another session after it, even through a projection scan -- the projection
+# stripe list and the base liveness check both use the query snapshot.
+# ---------------------------------------------------------------------------
+echo "-- phase 6: old snapshot never sees post-snapshot rows via a projection scan"
+psql_run "CREATE TABLE pm (a int, c int) USING columnar;"
+psql_run "SELECT columnar.add_projection('pm', 'pmp', ARRAY['a','c'], ARRAY['c']);"
+psql_run "INSERT INTO pm SELECT g, g FROM generate_series(1,10000) g;"   # batch 1
+
+A_IN="$PGC_WORKDIR/pmA.in"; A_OUT="$PGC_WORKDIR/pmA.out"
+mkfifo "$A_IN"; : > "$A_OUT"
+env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+	-d "$PGC_DB" -At -f "$A_IN" >> "$A_OUT" 2>&1 &
+A_PID=$!
+exec 9> "$A_IN"
+pa_send() { printf '%s\n' "$*" >&9; }
+pa_wait() { local t="$1" i; for i in $(seq 1 200); do grep -q "$t" "$A_OUT" && return 0; sleep 0.1; done; return 1; }
+
+# A opens a snapshot that sees batch 1, using a projection scan.
+pa_send "SET columnar.enable_projection_scan = on;"
+pa_send "BEGIN ISOLATION LEVEL REPEATABLE READ;"
+pa_send "SELECT 'PMA_' || count(a) FROM pm WHERE c BETWEEN 1 AND 20000;"
+if pa_wait "PMA_"; then
+	snap="$(grep -o 'PMA_[0-9]*' "$A_OUT" | tail -1 | sed 's/PMA_//')"
+	check "session A baseline via projection sees batch 1" "$snap" "10000"
+
+	psql_run "INSERT INTO pm SELECT g, g FROM generate_series(10001,20000) g;"  # batch 2 commits
+
+	pa_send "SELECT 'PMB_' || count(a) FROM pm WHERE c BETWEEN 1 AND 20000;"
+	if pa_wait "PMB_"; then
+		see="$(grep -o 'PMB_[0-9]*' "$A_OUT" | tail -1 | sed 's/PMB_//')"
+		check "old snapshot projection scan does not see post-snapshot rows" "$see" "10000"
+	else
+		check "session A responded post-commit" "timeout" "ok"
+	fi
+	pa_send "COMMIT;"
+else
+	check "session A opened snapshot" "timeout" "ok"
+fi
+pa_send "SELECT 'PMF_' || count(a) FROM pm WHERE c BETWEEN 1 AND 20000;"
+pa_wait "PMF_" || true
+final="$(grep -o 'PMF_[0-9]*' "$A_OUT" | tail -1 | sed 's/PMF_//')"
+check "new snapshot projection scan sees both batches" "$final" "20000"
+exec 9>&-
+wait "$A_PID" 2>/dev/null || true
 
 pgc_summary

--- a/test/recovery.sh
+++ b/test/recovery.sh
@@ -163,4 +163,31 @@ psql_run "INSERT INTO rv_h SELECT g, g*2 FROM generate_series(1,50000) g WHERE g
 check "s4 col count == heap oracle" "$(q 'SELECT count(*) FROM rv;')" "$(q 'SELECT count(*) FROM rv_h;')"
 check "s4 contents match oracle"    "$(pgc_set_hash 'SELECT id,v FROM rv')" "$(pgc_set_hash 'SELECT id,v FROM rv_h')"
 
+# ---------------------------------------------------------------------------
+# Scenario 5: projection storage survives a crash (gap 26). A projection's
+# stripes are written through the same WAL-logged path as the base, so a
+# committed-but-not-checkpointed projection copy must replay. After recovery the
+# projection must reproduce the base's live rows.
+# ---------------------------------------------------------------------------
+echo "-- scenario 5: projection durability"
+psql_run "CREATE TABLE rp (a int, c int) USING columnar;"
+psql_run "SELECT columnar.add_projection('rp', 'rpp', ARRAY['a','c'], ARRAY['c']);"
+psql_run "INSERT INTO rp SELECT g, (g*7)%1000 FROM generate_series(1,4000) g;"
+psql_run "CHECKPOINT;"
+psql_run "INSERT INTO rp SELECT g, (g*7)%1000 FROM generate_series(4001,8000) g;"
+
+crash_cluster
+restart_cluster
+check "s5 recovery ran" "$([ "$(recovery_ran)" -ge 1 ] && echo ok)" "ok"
+
+psql_run "CREATE TABLE rp_h (a int, c int) USING heap;"
+psql_run "INSERT INTO rp_h SELECT g, (g*7)%1000 FROM generate_series(1,8000) g;"
+check "s5 base count == heap oracle" "$(q 'SELECT count(*) FROM rp;')" "$(q 'SELECT count(*) FROM rp_h;')"
+check "s5 projection survives crash" \
+	"$(pgc_set_hash "SELECT columnar.read_projection('rp','rpp')")" \
+	"$(pgc_set_hash "SELECT a::text || '|' || c::text FROM rp_h")"
+check "s5 projection scan matches oracle after recovery" \
+	"$(pgc_set_hash "SELECT a, c FROM rp WHERE c BETWEEN 100 AND 200")" \
+	"$(pgc_set_hash "SELECT a, c FROM rp_h WHERE c BETWEEN 100 AND 200")"
+
 pgc_summary


### PR DESCRIPTION
Completes gap 26 (multiple projections).

**Phase 5 (vacuum):** columnar.vacuum compacts the base into fresh storage with new row numbers, so it now captures the projections before the swap, drops their stale storage + catalog rows, re-records them under the new base storage id with fresh storage ids, and re-fans-out every rewritten live row — projections stay aligned and sorted after vacuum/vacuum_sorted.

**Phase 6:**
- **Back-fill**: add_projection populates a projection from existing rows (ColumnarBackfillProjection); takes ShareLock so concurrent DML can't slip rows past the scan (as non-concurrent CREATE INDEX does). append_proj_row shared by fan-out and back-fill.
- **Recovery**: recovery.sh scenario 5 — a committed-but-not-checkpointed projection replays after a crash and matches the base.
- **MVCC**: projections.sh — an old REPEATABLE READ snapshot never sees post-snapshot rows through a projection scan (stripe visibility + base liveness both use the query snapshot).

## Validation
- Full PG13-19 matrix, all 25 suites: **ALL VERSIONS PASSED**.
- projections.sh: 57 checks; recovery.sh: 26 checks (incl. projection durability).

Gap 26 (C-Store multiple projections) is now complete: catalog + DDL, write fan-out, reconstruction, planner selection + executor scan, vacuum coordination, back-fill, and MVCC/recovery coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)