### PR TITLE
Docs: index-only scan + multiple projections; gap-27 remainder plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pgColumnar
 
-**Release: 1.0-dev** (pre-release; on-disk format 2.1). The `VERSION` file is the
+**Release: 1.0-dev** (pre-release; on-disk format 2.2). The `VERSION` file is the
 source of truth for the release marker; a `-prod` build will be cut once the
 remaining gap work lands and the full matrix stays green.
 
@@ -84,13 +84,15 @@ Instance-wide behavior is controlled by GUCs, all in the `columnar.` namespace:
 `compression` (default `zstd`), `compression_level` (default 3),
 `stripe_row_limit` (default 150000), `chunk_group_row_limit` (default 10000),
 `enable_qual_pushdown`, `enable_custom_scan`, `enable_vectorization` (default
-on), `enable_column_cache` (default off), and `column_cache_size` (megabytes).
+on), `enable_column_cache` (default off), `column_cache_size` (megabytes),
+`enable_index_only_scan` (default on), and `enable_projection_scan` (default on).
 
 ## Features
 
 - Column-oriented storage in the relation's main fork, so the buffer manager,
-  WAL, and page checksums apply. The on-disk format is version 2.1, specified in
-  [design/FORMAT_AND_INTERFACE_SPEC.md](design/FORMAT_AND_INTERFACE_SPEC.md).
+  WAL, and page checksums apply. The on-disk format is version 2.2, specified in
+  [design/FORMAT_AND_INTERFACE_SPEC.md](design/FORMAT_AND_INTERFACE_SPEC.md);
+  2.0 and 2.1 files still read.
 - Lightweight, type-aware value encodings applied per chunk before compression:
   run-length (RLE), frame-of-reference with bit-packing (FOR), delta, delta-of-
   delta, Gorilla XOR for floats, and a dictionary for low-cardinality columns
@@ -108,8 +110,24 @@ on), `enable_column_cache` (default off), and `column_cache_size` (megabytes).
   changes results.
 - Indexes: `CREATE INDEX` builds btree and hash indexes over a columnar table.
   Every row is assigned a stable row number and synthetic item pointer at insert
-  time, so ordinary index scans fetch rows by item pointer. Index-only scans are
-  never chosen (there is no visibility map).
+  time, so ordinary index scans fetch rows by item pointer.
+- Index-only scans: a columnar visibility-map fork records which chunk groups are
+  all-visible. Lazy `VACUUM` sets the bits for groups whose inserting transaction
+  precedes the oldest snapshot horizon and that have no deletes; any write clears
+  them (WAL-logged). A covering index query then answers from the index tuple for
+  all-visible groups and falls back to the snapshot-checked row fetch otherwise,
+  so an index-only answer never returns a row not visible to the snapshot. On by
+  default (`enable_index_only_scan`).
+- Multiple projections (C-Store): `columnar.add_projection(table, name, columns,
+  sort_key)` declares an extra physical copy of a column subset, stored in its own
+  sort order and sharing the table's row identity. Every insert fans out to each
+  projection; a projection is stored sorted so its per-chunk min/max ranges are
+  tight. The planner scans a projection instead of the base when it covers the
+  query's columns and its leading sort column is restricted (EXPLAIN shows
+  `Columnar Projection: <name>`), pruning chunk groups by the projection's
+  min/max; deletes and MVCC visibility come from the base, and `columnar.vacuum`
+  keeps projections aligned. `columnar.drop_projection(table, name)` frees one.
+  On by default (`enable_projection_scan`); format 2.2.
 - Constraints: unique and primary-key constraints are enforced on insert and at
   index build time; NOT NULL and CHECK constraints are enforced through the
   insert path.
@@ -246,8 +264,21 @@ by default and was not part of this run.
   accepts a `stripe_count` argument for interface compatibility but ignores it
   and performs the full rewrite, which is the strongest form of the compaction
   contract. Because it renumbers rows, it rebuilds the table's indexes.
-- Index-only scans are never chosen for a columnar table, because there is no
-  visibility map. Ordinary index scans and sequential (custom) scans are used.
+- Index-only scans use a columnar visibility-map fork populated by lazy `VACUUM`;
+  a group is only reported all-visible once its inserting transaction precedes the
+  oldest snapshot horizon and it has no deletes, and any later write clears the
+  bit, so a not-all-visible block always falls back to the snapshot-checked fetch.
+  Autovacuum (or an explicit `VACUUM`) is what makes recently loaded data
+  eligible; before that the scan simply fetches. Turn off with
+  `columnar.enable_index_only_scan = off`.
+- Multiple projections are additional sorted copies, so they add write and storage
+  cost proportional to the number of projections and are rebuilt by
+  `columnar.vacuum`. The planner uses a projection only when it covers every
+  referenced column (no system columns / whole-row) and its leading sort column is
+  restricted; other queries scan the base. A projection added to a populated table
+  is back-filled under `ShareLock` (blocks concurrent writes for the build, like
+  non-concurrent `CREATE INDEX`). Turn off projection scans with
+  `columnar.enable_projection_scan = off`.
 - Concurrent deletes or updates to rows in the same chunk group serialize on
   that chunk group's row-mask entry. Each delete mark is applied as an upsert of
   the chunk group's shared mask, guarded by a transaction-scoped chunk-group

--- a/design/FORMAT_AND_INTERFACE_SPEC.md
+++ b/design/FORMAT_AND_INTERFACE_SPEC.md
@@ -13,10 +13,13 @@ implementer works from without reading the existing source, which is the
 condition for the reimplementation to be free of the upstream copyright. See
 REWRITE_PLAN.md for how that condition is maintained.
 
-Format version described here is 2.1. Version 2.1 adds optional per-chunk
-value-stream encodings (section 5.1) and two chunk catalog columns (section 7.2);
-it is otherwise identical to 2.0, and 2.0 files are read unchanged by a 2.1
-implementation.
+Format version described here is 2.2. Version 2.1 adds optional per-chunk
+value-stream encodings (section 5.1) and two chunk catalog columns (section 7.2).
+Version 2.2 adds multiple physical projections: a `columnar.projection` catalog
+(section 7.7) and additional per-table columnar storages, all additive. Each
+minor is otherwise identical to its predecessor, and 2.0/2.1 files are read
+unchanged by a 2.2 implementation (only the metapage major version is validated;
+a table with no `columnar.projection` rows is a single implicit base projection).
 
 ## 1. Terminology
 
@@ -300,6 +303,31 @@ end_row_number]`; a set bit marks a deleted row. `id` is drawn from
 - `columnar.storageid_seq`: minimum value 10000000000, no cycle.
 - `columnar.row_mask_seq`: identifiers for row mask rows.
 
+### 7.7 columnar.projection (format 2.2)
+
+Records the physical projections of a table (multiple projections, the C-Store
+model). A projection is a named, ordered subset of the table's columns stored as
+its own columnar storage (its own `proj_storage_id`, with stripe/chunk/chunk_group
+rows keyed by that id, in the same relation file), sorted on `sort_key`, sharing
+the base table's row-number identity space.
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| storage_id | bigint | the base table's storage id |
+| projection_id | integer | 0 = implicit base projection, 1..N additional |
+| name | name | projection name, unique per storage_id |
+| proj_storage_id | bigint | this projection's own storage id (base uses the table's) |
+| sort_key | smallint[] | attnums in sort order (empty = insert order) |
+| columns | smallint[] | attnums stored (base = all live columns) |
+
+Unique indexes on `(storage_id, projection_id)`, `(storage_id, name)`, and
+`(proj_storage_id)`. A projection's stripes store, as a leading `int8` column, the
+base row number of each row, so a projection joins back to the base; deletes and
+MVCC visibility derive from the base row mask, so only INSERT fans out to
+projections. A table with no rows here has a single implicit base projection
+(so 2.0/2.1 tables are unaffected). Projection storage ids draw from
+`columnar.storageid_seq`.
+
 ## 8. SQL interface
 
 ### 8.1 Extension and access method
@@ -317,8 +345,12 @@ end_row_number]`; a set bit marks a deleted row. `id` is drawn from
 | alter_columnar_table_set | table_name regclass, chunk_group_row_limit int, stripe_row_limit int, compression name, compression_level int | set per table options, NULL leaves a value unchanged |
 | alter_columnar_table_reset | table_name regclass, chunk_group_row_limit bool, stripe_row_limit bool, compression bool, compression_level bool | reset options to instance defaults |
 | alter_table_set_access_method | t text, method text | convert a table between heap and columnar |
-| vacuum | tablename regclass, stripe_count int default 0 | compact by combining recent stripes |
+| vacuum | tablename regclass, stripe_count int default 0 | compact by combining recent stripes (rebuilds projections and indexes) |
 | vacuum_full | schema name, sleep_time real, stripe_count int | vacuum across a schema |
+| add_projection | rel regclass, name text, columns text[], sort_key text[] default '{}' | declare a physical projection (format 2.2); back-fills existing rows |
+| drop_projection | rel regclass, name text | drop a projection and free its storage |
+| read_projection | rel regclass, name text | (debug) read a projection's stored columns for live rows |
+| reconstruct_via_projection | rel regclass, name text | (debug) read all rows via a projection, reconstructing non-covered columns from the base |
 | stats | regclass, out stripeid, fileoffset, rowcount, deletedrows, chunkcount, datalength | per stripe statistics |
 | create_table_row_mask | table_name regclass | create the row mask backing for a table |
 | upgrade_columnar_storage | rel regclass | upgrade a table's metapage to the current format |
@@ -345,6 +377,8 @@ flags:
 | columnar.enable_bloom_filter | on | skip chunk groups on equality via per-chunk bloom filters |
 | columnar.enable_late_materialization | on | decode output columns only after the filter selects rows |
 | columnar.enable_qual_pushdown | on | push filters into the scan for chunk skipping |
+| columnar.enable_index_only_scan | on | answer covering index queries from the visibility-map fork (gap 28) |
+| columnar.enable_projection_scan | on | let the planner scan a covering projection instead of the base (gap 26) |
 | columnar.enable_columnar_index_scan | off | allow the custom index backed scan |
 | columnar.qual_pushdown_correlation_threshold | 0.4 | correlation threshold for pushdown |
 
@@ -361,7 +395,16 @@ flags:
   rollback, and metadata rows created in an aborted transaction are not visible.
 - Temporary columnar tables are supported.
 - Btree and hash indexes and the constraints built on them are supported.
-  Index only scans are not supported because there is no visibility map.
+  Index-only scans are supported through a columnar visibility-map fork
+  (format-independent, in the relation's VM fork): lazy `VACUUM` marks a chunk
+  group all-visible only when its inserting transaction precedes the oldest
+  removable-xid horizon and it has no deletes, every write clears the bit
+  (WAL-logged), and a not-all-visible block falls back to the snapshot-checked
+  fetch, so an index-only answer never returns a row invisible to the snapshot.
+- Multiple projections (format 2.2) are honored: every write fans out to each
+  projection, `columnar.vacuum` rebuilds them aligned to the compacted base, and
+  the planner may scan a covering projection whose leading sort column is
+  restricted. Results are identical to a base scan.
 - Unsupported: logical replication of columnar tables, unlogged columnar tables,
   and table sample scans.
 

--- a/design/gaps/27-IMPL-nested-and-parquet-reader-plan.md
+++ b/design/gaps/27-IMPL-nested-and-parquet-reader-plan.md
@@ -1,0 +1,77 @@
+# Gap 27 remainder — grounded plan: nested types + Parquet reader
+
+Two pieces remain in gap 27 (the rest — Arrow/Parquet scalar export, Arrow
+import, export type coverage — shipped). Both are large and land as their own
+matrix-gated PRs.
+
+## A. Nested-type export: arrays and composite (Arrow List / Struct, Parquet)
+
+Grounded in columnar_arrow.c (hand-rolled FlatBuffers writer) and
+columnar_parquet.c. Today `ArrowCol` is flat: one validity buffer plus either a
+fixed buffer or (offsets, vardata). Nested types make a column recursive.
+
+Arrow:
+- Make `ArrowCol` hold optional children: for `A_LIST`, one child ArrowCol (the
+  element) plus the list's own int32 offsets (n+1) and validity; for `A_STRUCT`,
+  N child ArrowCols and only a validity buffer (no data buffer).
+- `arrowcol_append`: for a list datum, `deconstruct_array` the element type and
+  append each element to the child, push the running element count as the list
+  offset; for a composite datum, `heap_deform_tuple` and append each field to its
+  child. Recurse (one level covers 1-D arrays and flat composites; nested-of-
+  nested is a later extension).
+- `write_record_batch`: emit FieldNodes and buffers depth-first (parent before
+  children), matching the schema's child order. List buffers: [validity,
+  offsets] then the child's buffers; Struct buffers: [validity] then each child's
+  buffers.
+- Schema: `fb_arrow_type` gains ARROW_TYPE_List (12) and ARROW_TYPE_Struct (13);
+  the Field writer emits a `children` vector of child Fields (recursive).
+- Type mapping: `arrow_kind_for_type` maps `get_element_type(typid) != InvalidOid`
+  -> A_LIST(child = element kind); `typtype == 'c'` (composite) -> A_STRUCT with
+  child Fields from the composite's TupleDesc.
+
+Parquet (columnar_parquet.c): arrays/composite need repetition + definition
+levels. A 1-D array of a required element is rep/def-level pattern
+(def 0=null list, 1=empty/null elem, 2=value; rep 0=new record, 1=same list).
+Composite maps to a Parquet group. This is the harder writer; land Arrow nested
+first, then Parquet nested.
+
+Tests: extend arrow_export.sh / parquet_export.sh with int[]/text[] and a simple
+composite column; read back with pyarrow (List<...>, Struct<...>) and compare to
+the heap oracle rendered the same way. Empty arrays, NULL arrays, NULL elements,
+NULL fields.
+
+## B. Parquet reader (columnar.import_parquet)
+
+pyarrow writes SNAPPY + RLE_DICTIONARY + DATA_PAGE_V2 by default, so a useful
+reader needs all three. Pieces:
+1. **Footer**: read the 4-byte `PAR1` magic + footer length; parse the
+   `FileMetaData` Thrift **compact protocol** (schema elements, row groups,
+   column chunks, codec, encodings, num_values, dictionary/data page offsets). A
+   small compact-Thrift decoder (varint zigzag, field deltas, list/struct) is
+   ~150 lines — implement from the Thrift compact spec (clean-room).
+2. **Snappy**: `libsnappy.so.1` is present but there is no dev symlink/header;
+   implement `snappy_raw_uncompress` from the Snappy format spec (preamble
+   varint length + LZ77 copies) — ~150 lines, clean-room, matches the pglz-style
+   codecs already in the tree.
+3. **Pages**: DATA_PAGE_V2 header (Thrift), definition/repetition level bytes
+   (RLE-only in v2), then values. Encodings: PLAIN (fixed + byte-array), and
+   RLE_DICTIONARY (a dictionary page of PLAIN values + data pages of
+   bit-packed/RLE indices). Implement the RLE/bit-packing hybrid decoder.
+4. **Map to columnar**: for each row group/column, decode to Datums by Parquet
+   physical/logical type -> PG type, and write through ColumnarWriteRow, matching
+   import_arrow's target-table handling.
+
+Scope order: scalar required/optional columns first (INT32/64, FLOAT/DOUBLE,
+BYTE_ARRAY=text/bytea, BOOLEAN), PLAIN then dictionary, DATA_PAGE_V2 then V1.
+Nested Parquet import last (rep/def reconstruction).
+
+Tests: write Parquet from pyarrow (default options) for the scalar warehouse
+types with NULLs and multiple row groups; import and compare to the heap oracle.
+Gate on the full PG13-19 matrix (guard with a pyarrow-available check like the
+export suites).
+
+## Risk / sequencing
+Land in this order, each its own gated PR: (A1) Arrow nested export, (A2) Parquet
+nested export, (B1) Parquet reader scalar PLAIN+Snappy+pagev2, (B2) Parquet
+dictionary, (B3) Parquet nested import. Keep changes additive; never regress the
+scalar Arrow/Parquet writers (their suites must stay green each step).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -37,8 +37,9 @@ Major-version compatibility shims. pgColumnar keeps one source tree that builds
 on PostgreSQL 13 through 19. PostgreSQL changed several of its own API and
 callback contracts across those majors (for example the RelFileNode to
 RelFileLocator rename in 16, the table-AM signature changes in 19, and the
-planner hook that suppresses index-only scans moving in 19). Each shim here only
-selects the correct core API for the running major; none of them change
+planner hook that edits the index list -- get_relation_info_hook through 18,
+build_simple_rel_hook in 19 -- used to enable index-only scans). Each shim here
+only selects the correct core API for the running major; none of them change
 pgColumnar's behavior.
 
 ### columnar_storage.c
@@ -212,6 +213,29 @@ compact-protocol writer emits the file metadata (row groups, column chunks, page
 headers) and PLAIN-encoded, UNCOMPRESSED data pages with RLE/bit-packed
 definition levels for nulls. One row group per 65536 rows, one data page per
 column. No libparquet dependency; same type coverage as the Arrow writer.
+
+### columnar_visibilitymap.c
+Index-only-scan support (gap 28). A columnar visibility-map fork records which
+synthetic blocks (chunk groups) are all-visible. Lazy `VACUUM`
+(`columnar_relation_vacuum`, ShareUpdateExclusiveLock) sets a block's bit only
+when its stripe's inserting xid precedes the oldest removable-xid horizon and the
+group has no deletes; every insert/delete/update clears the bit. Both set and
+clear are WAL-logged (`log_newpage_buffer`). The core index-only-scan executor
+reads these bits through `visibilitymap_get_status`, so an all-visible group is
+answered from the index tuple and any other block falls back to the
+snapshot-checked fetch. Gated by `columnar.enable_index_only_scan` (default on).
+
+### columnar_projection.c
+Multiple projections DDL and reader (gap 26, format 2.2). `add_projection` /
+`drop_projection` manage the `columnar.projection` catalog; `add_projection`
+back-fills the projection from existing rows under ShareLock. The catalog CRUD
+lives in `columnar_metadata.c`; write fan-out and the sorted per-stripe encoder
+live in `columnar_write_state.c` (each projection stores the base row number as a
+leading column); the planner selection and executor projection scan live in
+`columnar_customscan.c` (a covering projection with a restricted sort key is
+scanned instead of the base, pruning chunk groups by the projection's min/max,
+with deletes/visibility taken from the base). `columnar.vacuum` rebuilds
+projections aligned to the compacted base.
 
 ## Data flow summaries
 


### PR DESCRIPTION
Documentation only (Markdown; no code change, so the build/tests are unaffected).

- **README**: on-disk format 2.2; feature bullets for index-only scan and multiple projections; new GUCs (`enable_index_only_scan`, `enable_projection_scan`); refreshed Limitations (index-only scan behavior, projections).
- **FORMAT_AND_INTERFACE_SPEC**: 2.2 version intro; `columnar.projection` catalog (7.7); add/drop/read/reconstruct_projection functions; new GUCs; updated behavioral contracts (index-only scan + projections).
- **ARCHITECTURE**: `columnar_visibilitymap.c` and `columnar_projection.c` module entries; corrected the index-only-scan compatibility note.
- **design/gaps/27-IMPL-nested-and-parquet-reader-plan.md**: grounded plan for the remaining gap-27 work (nested-type export + Parquet reader).

🤖 Generated with [Claude Code](https://claude.com/claude-code)