### PR TITLE
Projection scan: cache base liveness (fix per-row catalog-scan pessimization)

### DIFF
--- a/bench/run_bench.sh
+++ b/bench/run_bench.sh
@@ -272,6 +272,70 @@ SELECT 'after vacuum_sorted'  AS state,
 SQL
 "
 
+# ---- index-only scan (gap 28) ----------------------------------------------
+# A covering index query over an all-visible table answers from the index tuple
+# (Heap Fetches: 0) instead of fetching each row's chunk group. Measure the same
+# covering range aggregate with columnar.enable_index_only_scan on vs off; both
+# runs disable seqscan/custom scan so the planner uses the index either way.
+echo "-- index-only scan"
+run_pg "$PSQL <<SQL
+\\pset pager off
+SET max_parallel_workers_per_gather = 0;
+SET enable_seqscan = off;
+SET columnar.enable_custom_scan = off;
+CREATE TABLE iosb (id bigint, val int) USING columnar;
+INSERT INTO iosb SELECT g, (g % 1000)::int FROM generate_series(1, $SCALE) g;
+CREATE INDEX iosb_id ON iosb (id);
+VACUUM iosb;            -- set all-visible bits in the visibility-map fork
+ANALYZE iosb;
+
+\\echo
+\\echo === INDEX-ONLY SCAN on vs off (covering range count, median ms) ===
+SELECT descr AS query, on_ms, off_ms,
+       round(off_ms / nullif(on_ms,0), 2) AS speedup_ios
+FROM (
+  SELECT 'covering count, id range (~2%)'::text AS descr,
+    set_config('columnar.enable_index_only_scan','on',false)  AS s1,
+    bench_time('SELECT count(*) FROM iosb WHERE id BETWEEN $LO AND $HI', $REPS) AS on_ms,
+    set_config('columnar.enable_index_only_scan','off',false) AS s2,
+    bench_time('SELECT count(*) FROM iosb WHERE id BETWEEN $LO AND $HI', $REPS) AS off_ms
+) t;
+SET columnar.enable_index_only_scan = on;
+SQL
+"
+
+# ---- projection scan (gap 26) ----------------------------------------------
+# A projection sorted on a key that is scattered in the base gives tight,
+# non-overlapping per-chunk min/max, so a range query on that key prunes chunk
+# groups and reads only the projection's (narrow) columns. Compare on (projection
+# scan) vs off (base scan, no skipping since the base is insert-ordered). A
+# row-returning covering query is used: an aggregate is instead answered by the
+# base's fused vectorized aggregate, which a projection scan does not replace.
+echo "-- projection scan"
+run_pg "$PSQL <<SQL
+\\pset pager off
+SET max_parallel_workers_per_gather = 0;
+CREATE TABLE pjb (id bigint, sortk int, val int, filler text) USING columnar;
+SELECT columnar.add_projection('pjb', 'pjbp', ARRAY['sortk','val'], ARRAY['sortk']);
+INSERT INTO pjb SELECT g, ((g * 2654435761) % 1000000)::int, (g % 1000)::int, 'x'||g
+FROM generate_series(1, $SCALE) g;
+ANALYZE pjb;
+
+\\echo
+\\echo === PROJECTION SCAN on vs off (covering row scan on a scattered sort key, median ms) ===
+SELECT descr AS query, on_ms, off_ms,
+       round(off_ms / nullif(on_ms,0), 2) AS speedup_proj
+FROM (
+  SELECT 'sortk,val where sortk in ~0.1% range'::text AS descr,
+    set_config('columnar.enable_projection_scan','on',false)  AS s1,
+    bench_time('SELECT sortk, val FROM pjb WHERE sortk BETWEEN 500000 AND 501000', $REPS) AS on_ms,
+    set_config('columnar.enable_projection_scan','off',false) AS s2,
+    bench_time('SELECT sortk, val FROM pjb WHERE sortk BETWEEN 500000 AND 501000', $REPS) AS off_ms
+) t;
+SET columnar.enable_projection_scan = on;
+SQL
+"
+
 # ---- export to Arrow and Parquet (gap 27) ----------------------------------
 # Export a table of exportable-typed columns and report wall time, file size,
 # and throughput. cz has a timestamptz column, so a projection is used.

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -419,6 +419,14 @@ extern void ColumnarReadStats(ColumnarReadState *readState,
  */
 extern bool ColumnarRowIsLive(Relation rel, Snapshot snapshot,
 							  uint64 rowNumber);
+/* cached base-liveness for a projection scan (gap 26): build once per scan,
+ * probe per row with a binary search instead of a per-row catalog scan */
+typedef struct ColumnarLivenessCache ColumnarLivenessCache;
+extern ColumnarLivenessCache *ColumnarBuildLivenessCache(Relation rel,
+														 Snapshot snapshot);
+extern bool ColumnarLivenessCacheIsLive(ColumnarLivenessCache *cache,
+										uint64 rowNumber);
+extern void ColumnarFreeLivenessCache(ColumnarLivenessCache *cache);
 extern bool ColumnarReadRowByNumber(Relation rel, Snapshot snapshot,
 									uint64 rowNumber, Datum *values, bool *nulls);
 

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -109,6 +109,7 @@ typedef struct ColumnarCustomScanState
 	int		   *projColMap;			/* base attno-1 -> index into projValues, or -1 */
 	Datum	   *projValues;			/* scratch, length K+1 (index 0 = rownumber) */
 	bool	   *projNulls;
+	ColumnarLivenessCache *livenessCache;	/* cached base liveness for the scan */
 } ColumnarCustomScanState;
 
 /* path -> plan */
@@ -783,6 +784,9 @@ columnar_setup_projection_scan(ColumnarCustomScanState *cstate, Relation rel,
 													 proj->projStorageId,
 													 projTupdesc, NULL, NULL,
 													 nProjKeys, projKeys);
+	/* cache base liveness once so the per-row deletion test is a binary search,
+	 * not a per-row catalog scan */
+	cstate->livenessCache = ColumnarBuildLivenessCache(rel, snapshot);
 	cstate->projScan = true;
 }
 
@@ -1009,7 +1013,6 @@ columnar_projection_scan_next(ScanState *ss)
 	ColumnarCustomScanState *cstate = (ColumnarCustomScanState *) ss;
 	TupleTableSlot *slot = ss->ss_ScanTupleSlot;
 	Relation	rel = ss->ss_currentRelation;
-	Snapshot	snap = ss->ps.state->es_snapshot;
 	int			natts = cstate->nTotalColumns;
 
 	for (;;)
@@ -1023,9 +1026,9 @@ columnar_projection_scan_next(ScanState *ss)
 			return NULL;
 
 		/* deletes/visibility come from the base (gap 26): the projection stores
-		 * no row mask, so filter by the stored base row number */
+		 * no row mask, so filter by the stored base row number via the cache */
 		baseRow = (uint64) DatumGetInt64(cstate->projValues[0]);
-		if (!ColumnarRowIsLive(rel, snap, baseRow))
+		if (!ColumnarLivenessCacheIsLive(cstate->livenessCache, baseRow))
 			continue;
 
 		ExecClearTuple(slot);
@@ -1167,6 +1170,11 @@ ColumnarEndCustomScan(CustomScanState *node)
 	{
 		ColumnarEndRead(cstate->readState);
 		cstate->readState = NULL;
+	}
+	if (cstate->livenessCache != NULL)
+	{
+		ColumnarFreeLivenessCache(cstate->livenessCache);
+		cstate->livenessCache = NULL;
 	}
 }
 

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -1143,6 +1143,140 @@ ColumnarDecodeCurrentGroupVector(ColumnarReadState *readState,
 	columnar_decode_group_to_vector(readState, vec);
 }
 
+/* -------------------------------------------------------------------------
+ * Liveness cache (gap 26, phase 4): a projection scan must test each row's base
+ * row number for deletion/visibility. Doing that per row via ColumnarRowIsLive
+ * re-scans the stripe and row-mask catalogs every call -- O(rows x stripes).
+ * The cache reads the base stripe list and row masks once (at the scan's
+ * snapshot) into memory, then answers each test with a binary search over
+ * stripes plus a bitmap probe. Consistent with the scan's fixed snapshot, the
+ * same way ColumnarBeginRead reads those lists once at begin.
+ * ------------------------------------------------------------------------- */
+typedef struct LiveStripeEntry
+{
+	uint64		firstRowNumber;
+	uint64		rowCount;
+	int			chunkRowCount;
+	int			chunkGroupCount;
+	char	  **masks;			/* [chunkGroupCount], deleted bitmap or NULL */
+	uint32	   *maskLens;		/* [chunkGroupCount] */
+} LiveStripeEntry;
+
+struct ColumnarLivenessCache
+{
+	LiveStripeEntry *stripes;	/* sorted ascending by firstRowNumber */
+	int			nstripes;
+	MemoryContext ctx;
+};
+
+static int
+livestripe_cmp(const void *a, const void *b)
+{
+	const LiveStripeEntry *ea = (const LiveStripeEntry *) a;
+	const LiveStripeEntry *eb = (const LiveStripeEntry *) b;
+
+	if (ea->firstRowNumber < eb->firstRowNumber)
+		return -1;
+	if (ea->firstRowNumber > eb->firstRowNumber)
+		return 1;
+	return 0;
+}
+
+ColumnarLivenessCache *
+ColumnarBuildLivenessCache(Relation rel, Snapshot snapshot)
+{
+	uint64		storageId = ColumnarStorageId(rel);
+	Snapshot	metaSnapshot = ColumnarCatalogSnapshot(snapshot);
+	MemoryContext ctx = AllocSetContextCreate(CurrentMemoryContext,
+											  "columnar liveness cache",
+											  ALLOCSET_DEFAULT_SIZES);
+	MemoryContext oldContext = MemoryContextSwitchTo(ctx);
+	List	   *stripeList = ColumnarReadStripeList(storageId, metaSnapshot);
+	ColumnarLivenessCache *cache = palloc0(sizeof(ColumnarLivenessCache));
+	ListCell   *lc;
+	int			i = 0;
+
+	cache->ctx = ctx;
+	cache->nstripes = list_length(stripeList);
+	cache->stripes = palloc0(sizeof(LiveStripeEntry) * Max(cache->nstripes, 1));
+
+	foreach(lc, stripeList)
+	{
+		StripeMetadata *s = (StripeMetadata *) lfirst(lc);
+		LiveStripeEntry *e = &cache->stripes[i++];
+		List	   *rml;
+		ListCell   *mc;
+
+		e->firstRowNumber = s->firstRowNumber;
+		e->rowCount = s->rowCount;
+		e->chunkRowCount = s->chunkRowCount;
+		e->chunkGroupCount = s->chunkGroupCount;
+		e->masks = palloc0(sizeof(char *) * Max(s->chunkGroupCount, 1));
+		e->maskLens = palloc0(sizeof(uint32) * Max(s->chunkGroupCount, 1));
+
+		rml = ColumnarReadRowMaskList(storageId, s->stripeNum, metaSnapshot);
+		foreach(mc, rml)
+		{
+			RowMaskMetadata *rm = (RowMaskMetadata *) lfirst(mc);
+
+			if (rm->chunkId >= 0 && rm->chunkId < s->chunkGroupCount &&
+				rm->mask != NULL && rm->maskLen > 0)
+			{
+				e->masks[rm->chunkId] = palloc(rm->maskLen);
+				memcpy(e->masks[rm->chunkId], rm->mask, rm->maskLen);
+				e->maskLens[rm->chunkId] = rm->maskLen;
+			}
+		}
+	}
+
+	if (cache->nstripes > 1)
+		qsort(cache->stripes, cache->nstripes, sizeof(LiveStripeEntry),
+			  livestripe_cmp);
+
+	MemoryContextSwitchTo(oldContext);
+	return cache;
+}
+
+bool
+ColumnarLivenessCacheIsLive(ColumnarLivenessCache *cache, uint64 rowNumber)
+{
+	int			lo = 0;
+	int			hi = cache->nstripes - 1;
+
+	while (lo <= hi)
+	{
+		int			mid = (lo + hi) / 2;
+		LiveStripeEntry *e = &cache->stripes[mid];
+
+		if (rowNumber < e->firstRowNumber)
+			hi = mid - 1;
+		else if (rowNumber >= e->firstRowNumber + e->rowCount)
+			lo = mid + 1;
+		else
+		{
+			uint64		off = rowNumber - e->firstRowNumber;
+			int			chunkId = (e->chunkRowCount > 0)
+				? (int) (off / (uint64) e->chunkRowCount) : 0;
+			uint64		inGroup = off - (uint64) chunkId * (uint64) e->chunkRowCount;
+
+			if (chunkId >= 0 && chunkId < e->chunkGroupCount &&
+				e->masks[chunkId] != NULL &&
+				(inGroup >> 3) < e->maskLens[chunkId] &&
+				(e->masks[chunkId][inGroup >> 3] & (1 << (inGroup & 7))) != 0)
+				return false;	/* deleted */
+			return true;		/* covered and not deleted */
+		}
+	}
+	return false;				/* no covering stripe: not visible */
+}
+
+void
+ColumnarFreeLivenessCache(ColumnarLivenessCache *cache)
+{
+	if (cache != NULL)
+		MemoryContextDelete(cache->ctx);
+}
+
 /*
  * ColumnarRowIsLive
  *		Whether the base row addressed by rowNumber is visible to snapshot: a


### PR DESCRIPTION
The phase-4 projection scan tested each row's base row number for deletion/visibility with `ColumnarRowIsLive`, which re-scans the stripe and row_mask catalogs on every row (O(rows x stripes)). A pruned covering scan was ~6x **slower** than the base scan despite reading far fewer chunk groups — a pessimization for a default-on feature.

Add `ColumnarLivenessCache`: read the base stripe list and row masks once per scan (at the scan's snapshot, like `ColumnarBeginRead`) into memory, then answer each liveness test with a binary search over stripes + a bitmap probe. Built in `columnar_setup_projection_scan`, probed per row, freed in `EndCustomScan`.

**Measured** (pg17 non-assert, 3M rows, covering range on a scattered sort key pruning 280/300 chunk groups): projection scan **76.3ms → 19.3ms, now 3.9x faster** than the base scan (was 6.5x slower). Also fixes the benchmark's projection query to a row-returning covering scan (an aggregate is served by the base's fused vectorized aggregate).

Full PG13-19 matrix: **ALL VERSIONS PASSED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)