### PR TITLE
Gap 27: Parquet nested-type export (arrays -> LIST, composite -> group) + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,10 +167,18 @@ on), `enable_column_cache` (default off), `column_cache_size` (megabytes),
   method)` rewrites a table through the target access method.
 - Export to Arrow and Parquet: `columnar.export_arrow(table, path)` writes an
   Arrow IPC stream file and `columnar.export_parquet(table, path)` writes a
-  Parquet file, both without a libarrow or libparquet dependency. Supported
-  column types are int2/int4/int8, float4/float8, bool, text/varchar, and bytea;
-  nulls are preserved. Both require superuser (they write a server-side file) and
+  Parquet file, both without a libarrow or libparquet dependency. Scalar column
+  types (int2/int4/int8, float4/float8, bool, text/varchar, bytea, date, time,
+  timestamp[tz], uuid, numeric, json) plus **1-D arrays** (Arrow List / Parquet
+  LIST) and **composite types** (Arrow Struct / Parquet group) are supported, with
+  nulls (including null elements and null fields). Both require superuser and
   return the number of rows written.
+- Import from Arrow and Parquet: `columnar.import_arrow(table, path)` and
+  `columnar.import_parquet(table, path)` insert a file's rows into an existing
+  target table (its column types define what is expected). The Parquet reader is
+  self-contained — Thrift metadata, Snappy decompression, PLAIN and dictionary
+  encodings, and both data-page v1 and v2 (what pyarrow writes by default) — with
+  no libparquet dependency. Flat (non-nested) schemas; superuser only.
 
 ## Benchmarks
 

--- a/design/FORMAT_AND_INTERFACE_SPEC.md
+++ b/design/FORMAT_AND_INTERFACE_SPEC.md
@@ -349,6 +349,8 @@ projections. A table with no rows here has a single implicit base projection
 | vacuum_full | schema name, sleep_time real, stripe_count int | vacuum across a schema |
 | add_projection | rel regclass, name text, columns text[], sort_key text[] default '{}' | declare a physical projection (format 2.2); back-fills existing rows |
 | drop_projection | rel regclass, name text | drop a projection and free its storage |
+| export_arrow / export_parquet | rel regclass, path text | write the table to an Arrow IPC / Parquet file (scalars, 1-D arrays, composites); returns rows written |
+| import_arrow / import_parquet | rel regclass, path text | insert an Arrow / Parquet file's rows into a table; returns rows inserted (flat schema) |
 | read_projection | rel regclass, name text | (debug) read a projection's stored columns for live rows |
 | reconstruct_via_projection | rel regclass, name text | (debug) read all rows via a projection, reconstructing non-covered columns from the base |
 | stats | regclass, out stripeid, fileoffset, rowcount, deletedrows, chunkcount, datalength | per stripe statistics |

--- a/design/ROADMAP.md
+++ b/design/ROADMAP.md
@@ -23,32 +23,22 @@ matrix. Gap specifications are in [gaps/](gaps/).
 | Arrow IPC import (`columnar.import_arrow`) | gap 27 |
 | PG18/19 coverage: generated columns, temporal constraints; REPACK investigated | PG18_19_OPPORTUNITIES.md |
 | Full index-only scan (visibility-map fork, lazy vacuum, default on) | gap 28 |
+| Multiple projections (C-Store): catalog, write fan-out, planner scan, vacuum, back-fill | gap 26 piece 2 |
+| Arrow/Parquet nested export (arrays → List, composite → Struct/group) | gap 27 |
+| Parquet import (`columnar.import_parquet`): Snappy, dictionary, data page v1/v2 | gap 27 |
 
 ## Remaining
 
 Ordered by value-to-effort.
 
-1. Arrow/Parquet export/import: arrays and composite types, and Parquet import.
-   Export/import now cover the scalar warehouse types. Still open: array and
-   composite columns (need nested Arrow List buffers and Parquet repetition
-   levels — the flat writers emit neither), and a Parquet *reader* (pyarrow's
-   defaults are SNAPPY + RLE_DICTIONARY + DATA_PAGE_V2, so a useful importer needs
-   Snappy decompression, dictionary decoding, and page-v2 support). Additive.
+1. Nested-type Parquet/Arrow *import*. The importers are flat-schema only:
+   importing a file whose columns are List/Struct is future work (the reader would
+   reconstruct rows from repetition/definition levels, the inverse of the nested
+   exporters). Export (Arrow and Parquet, arrays and composites) and flat import
+   (Arrow, Parquet) are done.
    Spec: [gaps/27-arrow-parquet-interop.md](gaps/27-arrow-parquet-interop.md).
 
-2. Multiple projections (gap 26 piece 2) — IN PROGRESS. C-Store projections: N
-   physical copies of a column subset, each in its own sort order, sharing the
-   row-identity space. On-disk format 2.2, additive for reads of 2.0/2.1.
-   **Merged:** phase 1 (columnar.projection catalog + add/drop DDL), phase 2
-   (write fan-out), phase 3 (row-number reconstruction). **Built:** phase 4
-   (per-chunk min/max on projections + planner selection + executor projection
-   scan, columnar.enable_projection_scan). **Remaining:** phase 5 (vacuum
-   coordination — a vacuum on a table with projections is not yet realigned to
-   the rewritten base row numbers), phase 6 (full differential + concurrency +
-   recovery, enable by default). Specs: gaps/26-IMPL-multiple-projections.md and
-   the phase plans gaps/26-IMPL-projections-phase{1,2,4}-plan.md.
-
-3. Skip virtual generated-column storage. pgColumnar currently writes an all-null
+2. Skip virtual generated-column storage. pgColumnar currently writes an all-null
    chunk for a virtual generated column (PostgreSQL 18+); reads are correct but
    the bytes are wasted. Skip the write for `attgenerated = 'v'` columns and have
    the reader return NULL for them. Small-to-medium write/read/vacuum change with

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -211,8 +211,19 @@ text/varchar, and bytea; other types are rejected. Little-endian hosts only.
 Parquet export (`columnar.export_parquet`, gap 27). A self-contained Thrift
 compact-protocol writer emits the file metadata (row groups, column chunks, page
 headers) and PLAIN-encoded, UNCOMPRESSED data pages with RLE/bit-packed
-definition levels for nulls. One row group per 65536 rows, one data page per
-column. No libparquet dependency; same type coverage as the Arrow writer.
+levels. Columns shred into leaf column chunks with repetition and definition
+levels (Dremel): scalars (one leaf), 1-D arrays (a 3-level LIST), and composites
+(a group with one leaf per field). One row group per 65536 rows. No libparquet
+dependency; same scalar type coverage as the Arrow writer.
+
+### columnar_parquet_reader.c
+Parquet import (`columnar.import_parquet`, gap 27). A self-contained reader: a
+Thrift compact-protocol decoder for the footer and page headers, clean-room
+Snappy decompression, the RLE/bit-packed hybrid decoder for definition levels and
+dictionary indices, PLAIN and dictionary value decoding, and both DATA_PAGE v1
+and v2 (what pyarrow writes). Rows are inserted into an existing target table via
+`table_tuple_insert`, mirroring the Arrow importer. Flat schemas; no libparquet
+dependency.
 
 ### columnar_visibilitymap.c
 Index-only-scan support (gap 28). A columnar visibility-map fork records which

--- a/src/columnar_parquet.c
+++ b/src/columnar_parquet.c
@@ -24,6 +24,7 @@
 #include "columnar.h"
 
 #include "fmgr.h"
+#include "access/htup_details.h"
 #include "access/relation.h"
 #include "access/table.h"
 #include "catalog/pg_type.h"
@@ -35,9 +36,11 @@
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
 #include "utils/numeric.h"
+#include "utils/array.h"
 #include "utils/rel.h"
 #include "utils/snapmgr.h"
 #include "utils/timestamp.h"
+#include "utils/typcache.h"
 #include "utils/uuid.h"
 
 PG_FUNCTION_INFO_V1(columnar_export_parquet);
@@ -227,23 +230,56 @@ tc_stop(StringInfo b)
 	appendStringInfoChar(b, (char) TC_STOP);
 }
 
-/* ---- per-column accumulator for one row group ---- */
-typedef struct PqCol
+/*
+ * A leaf column is one Parquet column chunk: a scalar column, an array's element,
+ * or one field of a composite. Nesting is expressed through repetition and
+ * definition levels (the Dremel model). For a plain scalar, max_rep is 0 and
+ * max_def is 1, so the encoding is byte-identical to the flat writer.
+ */
+typedef struct PqLeaf
 {
-	char	   *name;
+	const char *path[3];		/* schema path from the top column to the leaf */
+	int			pathlen;
 	ParquetKind kind;
 	int			ptype;			/* Parquet physical type */
 	int			convType;		/* ConvertedType, or -1 */
 	int			typeLength;		/* FIXED_LEN_BYTE_ARRAY length, else 0 */
-	int			precision;		/* decimal precision (P_DECIMAL) */
-	int			scale;			/* decimal scale (P_DECIMAL) */
-	bool		convertText;	/* P_UTF8 fallback needs the type output fn */
-	FmgrInfo	outFinfo;		/* output function (when convertText) */
-	StringInfoData present;		/* 1 byte per row: 1 present, 0 null */
+	int			precision;
+	int			scale;
+	bool		convertText;
+	FmgrInfo	outFinfo;
+	int			max_def;
+	int			max_rep;
+	StringInfoData defs;		/* one byte per level entry (definition level) */
+	StringInfoData reps;		/* one byte per level entry (repetition level) */
 	StringInfoData values;		/* PLAIN values, non-null only */
 	StringInfoData boolbits;	/* 1 byte per non-null bool value */
-	int64		numValues;		/* rows in the current group (incl nulls) */
-}			PqCol;
+	int64		nEntries;		/* level entries in the current row group */
+}			PqLeaf;
+
+/* how a top-level column shreds into leaves */
+typedef enum
+{
+	TOP_SCALAR,
+	TOP_LIST,					/* 1-D array -> LIST of one scalar element */
+	TOP_STRUCT					/* composite -> group of scalar fields */
+}			TopKind;
+
+typedef struct TopColumn
+{
+	char	   *name;
+	TopKind		tkind;
+	int			firstLeaf;		/* index of the first leaf in leaves[] */
+	int			nleaves;		/* 1 for scalar/list, #fields for struct */
+	/* list element decode */
+	Oid			elemtype;
+	int16		elemlen;
+	bool		elembyval;
+	char		elemalign;
+	/* struct */
+	TupleDesc	structDesc;
+	int		   *fieldLeaf;		/* [structDesc->natts] leaf index, -1 if dropped */
+}			TopColumn;
 
 typedef struct PqColMeta
 {
@@ -260,12 +296,13 @@ typedef struct PqRowGroup
 }			PqRowGroup;
 
 static void
-pqcol_reset(PqCol *c)
+pqleaf_reset(PqLeaf *c)
 {
-	resetStringInfo(&c->present);
+	resetStringInfo(&c->defs);
+	resetStringInfo(&c->reps);
 	resetStringInfo(&c->values);
 	resetStringInfo(&c->boolbits);
-	c->numValues = 0;
+	c->nEntries = 0;
 }
 
 static ParquetKind
@@ -352,39 +389,27 @@ parquet_kind_for_type(Oid typid, int32 typmod, int *ptype, int *convType,
 	}
 }
 
-static void
-pqcol_append(PqCol *c, Datum d, bool isnull)
+/* whether a value has a Parquet representation (else it is folded to null) */
+static bool
+leaf_value_representable(PqLeaf *c, Datum d, __int128 *dec)
 {
-	__int128	dec = 0;
-
-	/* Fold values with no Parquet representation (±infinity dates/timestamps,
-	 * NaN/Infinity numerics) to null. */
-	if (!isnull)
+	switch (c->kind)
 	{
-		switch (c->kind)
-		{
-			case P_DATE:
-				if (DATE_NOT_FINITE(DatumGetDateADT(d)))
-					isnull = true;
-				break;
-			case P_TIMESTAMP:
-				if (TIMESTAMP_NOT_FINITE(DatumGetTimestamp(d)))
-					isnull = true;
-				break;
-			case P_DECIMAL:
-				if (!numeric_to_int128(d, c->scale, &dec))
-					isnull = true;
-				break;
-			default:
-				break;
-		}
+		case P_DATE:
+			return !DATE_NOT_FINITE(DatumGetDateADT(d));
+		case P_TIMESTAMP:
+			return !TIMESTAMP_NOT_FINITE(DatumGetTimestamp(d));
+		case P_DECIMAL:
+			return numeric_to_int128(d, c->scale, dec);
+		default:
+			return true;
 	}
+}
 
-	c->numValues++;
-	appendStringInfoChar(&c->present, isnull ? 0 : 1);
-	if (isnull)
-		return;
-
+/* append one PLAIN value to a leaf's value buffer */
+static void
+write_leaf_value(PqLeaf *c, Datum d, __int128 dec)
+{
 	switch (c->kind)
 	{
 		case P_INT16:
@@ -488,42 +513,155 @@ pqcol_append(PqCol *c, Datum d, bool isnull)
 	}
 }
 
-/* build the RLE/bit-packed hybrid definition-level section (bit width 1),
- * prefixed with its int32 LE byte length (DataPage v1 convention) */
+/*
+ * Append one Dremel entry to a leaf: its definition and repetition levels, and
+ * the PLAIN value when present. A present value with no Parquet representation
+ * is folded to the "container present, value absent" level (max_def - 1).
+ */
 static void
-build_def_levels(StringInfo out, const char *present, int64 nrows)
+leaf_entry(PqLeaf *c, int def, int rep, bool hasValue, Datum d)
+{
+	__int128	dec = 0;
+
+	if (hasValue && !leaf_value_representable(c, d, &dec))
+	{
+		hasValue = false;
+		def = c->max_def - 1;
+	}
+	appendStringInfoChar(&c->defs, (char) def);
+	if (c->max_rep > 0)
+		appendStringInfoChar(&c->reps, (char) rep);
+	c->nEntries++;
+	if (hasValue)
+		write_leaf_value(c, d, dec);
+}
+
+/* shred one top-level column value for a row into its leaf/leaves */
+static void
+shred_top(TopColumn *tc, PqLeaf *leaves, Datum d, bool isnull)
+{
+	switch (tc->tkind)
+	{
+		case TOP_SCALAR:
+			leaf_entry(&leaves[tc->firstLeaf], isnull ? 0 : 1, 0, !isnull, d);
+			break;
+		case TOP_LIST:
+			{
+				PqLeaf	   *leaf = &leaves[tc->firstLeaf];
+
+				if (isnull)
+					leaf_entry(leaf, 0, 0, false, (Datum) 0);
+				else
+				{
+					ArrayType  *arr = DatumGetArrayTypeP(d);
+					Datum	   *elems;
+					bool	   *enulls;
+					int			n;
+					int			k;
+
+					if (ARR_NDIM(arr) > 1)
+						ereport(ERROR,
+								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+								 errmsg("columnar.export_parquet does not support multi-dimensional arrays")));
+					deconstruct_array(arr, tc->elemtype, tc->elemlen,
+									  tc->elembyval, tc->elemalign, &elems, &enulls, &n);
+					if (n == 0)
+						leaf_entry(leaf, 1, 0, false, (Datum) 0);	/* empty list */
+					else
+						for (k = 0; k < n; k++)
+							leaf_entry(leaf, enulls[k] ? 2 : 3, k == 0 ? 0 : 1,
+									   !enulls[k], elems[k]);
+				}
+				break;
+			}
+		case TOP_STRUCT:
+			{
+				Datum	   *fv = NULL;
+				bool	   *fn = NULL;
+				int			a;
+
+				if (!isnull)
+				{
+					HeapTupleHeader th = DatumGetHeapTupleHeader(d);
+					HeapTupleData tmp;
+
+					fv = palloc(sizeof(Datum) * tc->structDesc->natts);
+					fn = palloc(sizeof(bool) * tc->structDesc->natts);
+					tmp.t_len = HeapTupleHeaderGetDatumLength(th);
+					ItemPointerSetInvalid(&tmp.t_self);
+					tmp.t_tableOid = InvalidOid;
+					tmp.t_data = th;
+					heap_deform_tuple(&tmp, tc->structDesc, fv, fn);
+				}
+				for (a = 0; a < tc->structDesc->natts; a++)
+				{
+					int			li = tc->fieldLeaf[a];
+
+					if (li < 0)
+						continue;	/* dropped field */
+					if (isnull)
+						leaf_entry(&leaves[li], 0, 0, false, (Datum) 0);
+					else if (fn[a])
+						leaf_entry(&leaves[li], 1, 0, false, (Datum) 0);
+					else
+						leaf_entry(&leaves[li], 2, 0, true, fv[a]);
+				}
+				break;
+			}
+	}
+}
+
+static int
+bits_for(int m)
+{
+	int			b = 0;
+
+	while ((1 << b) <= m)
+		b++;
+	return b;
+}
+
+/*
+ * Build an RLE/bit-packed hybrid level section (one bit-packed run at the given
+ * bit width), prefixed with its int32 LE byte length (DataPage v1 convention).
+ * With bit width 1 this is byte-identical to the flat writer's def levels.
+ */
+static void
+build_rle_levels(StringInfo out, const uint8 *levels, int64 n, int bit_width)
 {
 	StringInfoData h;
-	int64		ngroups = (nrows + 7) / 8;
-	int64		g;
+	int64		ngroups = (n + 7) / 8;
+	int64		nbytes = ngroups * bit_width;
+	uint8	   *packed = palloc0(Max(nbytes, 1));
+	int64		i;
 	int32		len;
 
 	initStringInfo(&h);
-	/* one bit-packed run: header = (ngroups << 1) | 1 */
-	tc_varint(&h, (uint64) ((ngroups << 1) | 1));
-	for (g = 0; g < ngroups; g++)
+	tc_varint(&h, (uint64) ((ngroups << 1) | 1));	/* one bit-packed run */
+	for (i = 0; i < n; i++)
 	{
-		uint8		byte = 0;
+		uint32		v = levels[i];
 		int			b;
 
-		for (b = 0; b < 8; b++)
-		{
-			int64		idx = g * 8 + b;
+		for (b = 0; b < bit_width; b++)
+			if (v & (1u << b))
+			{
+				int64		abs = i * bit_width + b;
 
-			if (idx < nrows && present[idx])
-				byte |= (1 << b);
-		}
-		appendStringInfoChar(&h, (char) byte);
+				packed[abs >> 3] |= (1 << (abs & 7));
+			}
 	}
+	appendBinaryStringInfo(&h, (char *) packed, nbytes);
 	len = h.len;
 	appendBinaryStringInfo(out, (char *) &len, 4);
 	appendBinaryStringInfo(out, h.data, h.len);
+	pfree(packed);
 	pfree(h.data);
 }
 
-/* assemble the PLAIN values buffer for a column (from its accumulators) */
+/* assemble the PLAIN values buffer for a leaf (from its accumulators) */
 static void
-build_values(StringInfo out, PqCol *c)
+build_values(StringInfo out, PqLeaf *c)
 {
 	if (c->kind == P_BOOL)
 	{
@@ -540,6 +678,18 @@ build_values(StringInfo out, PqCol *c)
 	}
 	else
 		appendBinaryStringInfo(out, c->values.data, c->values.len);
+}
+
+/* build a data page body for a leaf: [rep levels][def levels][values] */
+static void
+build_leaf_body(StringInfo body, PqLeaf *c)
+{
+	if (c->max_rep > 0)
+		build_rle_levels(body, (const uint8 *) c->reps.data, c->nEntries,
+						 bits_for(c->max_rep));
+	build_rle_levels(body, (const uint8 *) c->defs.data, c->nEntries,
+					 bits_for(c->max_def));
+	build_values(body, c);
 }
 
 /* write a DATA_PAGE PageHeader (Thrift) for a page of body_size bytes */
@@ -574,70 +724,271 @@ write_schema_element_root(StringInfo b, int ncols)
 	tc_stop(b);
 }
 
+/* one leaf SchemaElement (a primitive) */
 static void
-write_schema_element_col(StringInfo b, PqCol *c)
+write_schema_leaf(StringInfo b, const char *name, PqLeaf *leaf, int repetition)
 {
 	int16		last = 0;
 
-	tc_i32_field(b, &last, 1, c->ptype);	/* type */
-	if (c->ptype == PQ_FIXED_LEN_BYTE_ARRAY)
-		tc_i32_field(b, &last, 2, c->typeLength);	/* type_length */
-	tc_i32_field(b, &last, 3, 1);			/* repetition_type = OPTIONAL */
-	tc_string_field(b, &last, 4, c->name, (int) strlen(c->name));
-	if (c->convType >= 0)
-		tc_i32_field(b, &last, 6, c->convType); /* converted_type */
-	if (c->convType == PQ_CT_DECIMAL)
+	tc_i32_field(b, &last, 1, leaf->ptype);	/* type */
+	if (leaf->ptype == PQ_FIXED_LEN_BYTE_ARRAY)
+		tc_i32_field(b, &last, 2, leaf->typeLength);
+	tc_i32_field(b, &last, 3, repetition);
+	tc_string_field(b, &last, 4, name, (int) strlen(name));
+	if (leaf->convType >= 0)
+		tc_i32_field(b, &last, 6, leaf->convType);
+	if (leaf->convType == PQ_CT_DECIMAL)
 	{
-		tc_i32_field(b, &last, 7, c->scale);		/* scale */
-		tc_i32_field(b, &last, 8, c->precision);	/* precision */
+		tc_i32_field(b, &last, 7, leaf->scale);
+		tc_i32_field(b, &last, 8, leaf->precision);
 	}
 	tc_stop(b);
 }
 
+/* one group SchemaElement (no physical type; has num_children) */
 static void
-write_column_chunk(StringInfo b, PqCol *c, PqColMeta *m)
+write_schema_group(StringInfo b, const char *name, int repetition,
+				   int num_children, int convType)
+{
+	int16		last = 0;
+
+	tc_i32_field(b, &last, 3, repetition);
+	tc_string_field(b, &last, 4, name, (int) strlen(name));
+	tc_i32_field(b, &last, 5, num_children);
+	if (convType >= 0)
+		tc_i32_field(b, &last, 6, convType);
+	tc_stop(b);
+}
+
+/* number of SchemaElements a top column contributes (excluding the root) */
+static int
+schema_count_for_top(TopColumn *tc)
+{
+	switch (tc->tkind)
+	{
+		case TOP_LIST:
+			return 3;			/* group(LIST), group(list), element */
+		case TOP_STRUCT:
+			return 1 + tc->nleaves;
+		default:
+			return 1;
+	}
+}
+
+/* emit a top column's schema subtree (pre-order) */
+static void
+write_top_schema(StringInfo b, TopColumn *tc, PqLeaf *leaves)
+{
+	switch (tc->tkind)
+	{
+		case TOP_SCALAR:
+			write_schema_leaf(b, tc->name, &leaves[tc->firstLeaf], 1);
+			break;
+		case TOP_LIST:
+			write_schema_group(b, tc->name, 1, 1, 3 /* LIST */);
+			write_schema_group(b, "list", 2 /* REPEATED */, 1, -1);
+			write_schema_leaf(b, "element", &leaves[tc->firstLeaf], 1);
+			break;
+		case TOP_STRUCT:
+			{
+				int			a;
+
+				write_schema_group(b, tc->name, 1, tc->nleaves, -1);
+				for (a = 0; a < tc->structDesc->natts; a++)
+				{
+					int			li = tc->fieldLeaf[a];
+
+					if (li < 0)
+						continue;
+					write_schema_leaf(b,
+									  NameStr(TupleDescAttr(tc->structDesc, a)->attname),
+									  &leaves[li], 1);
+				}
+				break;
+			}
+	}
+}
+
+/* one column chunk for a leaf (path_in_schema is the full leaf path) */
+static void
+write_column_chunk(StringInfo b, PqLeaf *c, PqColMeta *m)
 {
 	int16		last = 0;
 	int16		mlast = 0;
+	int			p;
 
-	/* ColumnChunk.file_offset (2) */
-	tc_i64_field(b, &last, 2, m->dataPageOffset);
-	/* ColumnChunk.meta_data (3) = ColumnMetaData struct */
-	tc_field(b, &last, 3, TC_STRUCT);
-	tc_i32_field(b, &mlast, 1, c->ptype);	/* type */
-	/* encodings list [PLAIN, RLE] (2) */
-	tc_field(b, &mlast, 2, TC_LIST);
+	tc_i64_field(b, &last, 2, m->dataPageOffset);	/* file_offset */
+	tc_field(b, &last, 3, TC_STRUCT);				/* meta_data */
+	tc_i32_field(b, &mlast, 1, c->ptype);			/* type */
+	tc_field(b, &mlast, 2, TC_LIST);				/* encodings [PLAIN, RLE] */
 	tc_list_header(b, 2, TC_I32);
 	tc_zigzag32(b, PQ_ENC_PLAIN);
 	tc_zigzag32(b, PQ_ENC_RLE);
-	/* path_in_schema list [name] (3) */
-	tc_field(b, &mlast, 3, TC_LIST);
-	tc_list_header(b, 1, TC_BINARY);
-	tc_varint(b, (uint64) strlen(c->name));
-	appendBinaryStringInfo(b, c->name, strlen(c->name));
-	tc_i32_field(b, &mlast, 4, 0);			/* codec = UNCOMPRESSED */
-	tc_i64_field(b, &mlast, 5, m->numValues);	/* num_values */
-	tc_i64_field(b, &mlast, 6, m->totalSize);	/* total_uncompressed_size */
-	tc_i64_field(b, &mlast, 7, m->totalSize);	/* total_compressed_size */
+	tc_field(b, &mlast, 3, TC_LIST);				/* path_in_schema */
+	tc_list_header(b, c->pathlen, TC_BINARY);
+	for (p = 0; p < c->pathlen; p++)
+	{
+		tc_varint(b, (uint64) strlen(c->path[p]));
+		appendBinaryStringInfo(b, c->path[p], strlen(c->path[p]));
+	}
+	tc_i32_field(b, &mlast, 4, 0);					/* codec = UNCOMPRESSED */
+	tc_i64_field(b, &mlast, 5, m->numValues);		/* num_values */
+	tc_i64_field(b, &mlast, 6, m->totalSize);		/* total_uncompressed_size */
+	tc_i64_field(b, &mlast, 7, m->totalSize);		/* total_compressed_size */
 	tc_i64_field(b, &mlast, 9, m->dataPageOffset);	/* data_page_offset */
-	tc_stop(b);								/* end ColumnMetaData */
-	tc_stop(b);								/* end ColumnChunk */
+	tc_stop(b);										/* end ColumnMetaData */
+	tc_stop(b);										/* end ColumnChunk */
 }
 
 static void
-write_row_group(StringInfo b, PqCol *cols, int ncols, PqRowGroup *rg)
+write_row_group(StringInfo b, PqLeaf *leaves, int nleaves, PqRowGroup *rg)
 {
 	int16		last = 0;
 	int			i;
 
-	/* columns list (1) */
-	tc_field(b, &last, 1, TC_LIST);
-	tc_list_header(b, ncols, TC_STRUCT);
-	for (i = 0; i < ncols; i++)
-		write_column_chunk(b, &cols[i], &rg->cols[i]);
-	tc_i64_field(b, &last, 2, rg->totalByteSize);	/* total_byte_size */
-	tc_i64_field(b, &last, 3, rg->numRows);			/* num_rows */
+	tc_field(b, &last, 1, TC_LIST);					/* columns */
+	tc_list_header(b, nleaves, TC_STRUCT);
+	for (i = 0; i < nleaves; i++)
+		write_column_chunk(b, &leaves[i], &rg->cols[i]);
+	tc_i64_field(b, &last, 2, rg->totalByteSize);
+	tc_i64_field(b, &last, 3, rg->numRows);
 	tc_stop(b);
+}
+
+/* initialize a scalar leaf for a given type; *ok=false if unsupported */
+static void
+build_leaf_scalar(PqLeaf *leaf, Oid typid, int32 typmod,
+				  int max_def, int max_rep, bool *ok)
+{
+	int			ptype,
+				convType,
+				typeLength,
+				precision,
+				scale;
+	ParquetKind kind = parquet_kind_for_type(typid, typmod, &ptype, &convType,
+											 &typeLength, &precision, &scale);
+
+	if (ptype < 0)
+	{
+		*ok = false;
+		return;
+	}
+	leaf->kind = kind;
+	leaf->ptype = ptype;
+	leaf->convType = convType;
+	leaf->typeLength = typeLength;
+	leaf->precision = precision;
+	leaf->scale = scale;
+	leaf->max_def = max_def;
+	leaf->max_rep = max_rep;
+	leaf->convertText = (kind == P_UTF8 &&
+						 (typid == NUMERICOID || typid == JSONBOID));
+	if (leaf->convertText)
+	{
+		Oid			outfunc;
+		bool		isvarlena;
+
+		getTypeOutputInfo(typid, &outfunc, &isvarlena);
+		fmgr_info(outfunc, &leaf->outFinfo);
+	}
+	initStringInfo(&leaf->defs);
+	initStringInfo(&leaf->reps);
+	initStringInfo(&leaf->values);
+	initStringInfo(&leaf->boolbits);
+}
+
+/* number of leaves a top column of this type contributes */
+static int
+count_leaves_for(Oid typid, int32 typmod)
+{
+	if (OidIsValid(get_element_type(typid)))
+		return 1;
+	if (get_typtype(typid) == TYPTYPE_COMPOSITE)
+	{
+		TupleDesc	td = lookup_rowtype_tupdesc(typid, typmod);
+		int			a,
+					live = 0;
+
+		for (a = 0; a < td->natts; a++)
+			if (!TupleDescAttr(td, a)->attisdropped)
+				live++;
+		ReleaseTupleDesc(td);
+		return live;
+	}
+	return 1;
+}
+
+/* build one top column and its leaves; *ok=false if any leaf type is unsupported */
+static void
+build_top_column(TopColumn *tc, const char *name, Oid typid, int32 typmod,
+				 PqLeaf *leaves, int *nleaves, bool *ok)
+{
+	Oid			elemtype = get_element_type(typid);
+
+	tc->name = pstrdup(name);
+	tc->structDesc = NULL;
+	tc->fieldLeaf = NULL;
+
+	if (OidIsValid(elemtype))
+	{
+		PqLeaf	   *leaf;
+
+		tc->tkind = TOP_LIST;
+		tc->firstLeaf = *nleaves;
+		tc->nleaves = 1;
+		tc->elemtype = elemtype;
+		get_typlenbyvalalign(elemtype, &tc->elemlen, &tc->elembyval, &tc->elemalign);
+		leaf = &leaves[(*nleaves)++];
+		build_leaf_scalar(leaf, elemtype, -1, 3, 1, ok);
+		leaf->path[0] = tc->name;
+		leaf->path[1] = "list";
+		leaf->path[2] = "element";
+		leaf->pathlen = 3;
+		return;
+	}
+	if (get_typtype(typid) == TYPTYPE_COMPOSITE)
+	{
+		TupleDesc	td = lookup_rowtype_tupdesc(typid, typmod);
+		int			a;
+		int			live = 0;
+
+		tc->tkind = TOP_STRUCT;
+		tc->firstLeaf = *nleaves;
+		tc->structDesc = CreateTupleDescCopy(td);
+		tc->fieldLeaf = palloc(sizeof(int) * td->natts);
+		for (a = 0; a < td->natts; a++)
+		{
+			Form_pg_attribute fa = TupleDescAttr(td, a);
+			PqLeaf	   *leaf;
+
+			if (fa->attisdropped)
+			{
+				tc->fieldLeaf[a] = -1;
+				continue;
+			}
+			leaf = &leaves[*nleaves];
+			build_leaf_scalar(leaf, fa->atttypid, fa->atttypmod, 2, 0, ok);
+			leaf->path[0] = tc->name;
+			leaf->path[1] = pstrdup(NameStr(fa->attname));
+			leaf->pathlen = 2;
+			tc->fieldLeaf[a] = (*nleaves)++;
+			live++;
+		}
+		tc->nleaves = live;
+		ReleaseTupleDesc(td);
+		return;
+	}
+
+	tc->tkind = TOP_SCALAR;
+	tc->firstLeaf = *nleaves;
+	tc->nleaves = 1;
+	{
+		PqLeaf	   *leaf = &leaves[(*nleaves)++];
+
+		build_leaf_scalar(leaf, typid, typmod, 1, 0, ok);
+		leaf->path[0] = tc->name;
+		leaf->pathlen = 1;
+	}
 }
 
 /*
@@ -651,8 +1002,11 @@ columnar_export_parquet(PG_FUNCTION_ARGS)
 	char	   *path;
 	Relation	rel;
 	TupleDesc	tupdesc;
-	int			ncols;
-	PqCol	   *cols;
+	int			ntop;
+	TopColumn  *tops;
+	PqLeaf	   *leaves;
+	int			nleaves = 0;
+	int			totalLeaves = 0;
 	Snapshot	snapshot;
 	ColumnarReadState *readState;
 	Datum	   *values;
@@ -691,18 +1045,13 @@ columnar_export_parquet(PG_FUNCTION_ARGS)
 	}
 
 	tupdesc = RelationGetDescr(rel);
-	ncols = tupdesc->natts;
+	ntop = tupdesc->natts;
 
-	cols = palloc0(sizeof(PqCol) * ncols);
-	for (i = 0; i < ncols; i++)
+	/* reject dropped columns and count the leaf columns (arrays and composites
+	 * expand to more than one leaf) */
+	for (i = 0; i < ntop; i++)
 	{
 		Form_pg_attribute att = TupleDescAttr(tupdesc, i);
-		int			ptype,
-					convType,
-					typeLength,
-					precision,
-					scale;
-		ParquetKind kind;
 
 		if (att->attisdropped)
 		{
@@ -711,10 +1060,19 @@ columnar_export_parquet(PG_FUNCTION_ARGS)
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("columnar.export_parquet does not support dropped columns")));
 		}
-		kind = parquet_kind_for_type(att->atttypid, att->atttypmod,
-									 &ptype, &convType, &typeLength,
-									 &precision, &scale);
-		if (ptype < 0)
+		totalLeaves += count_leaves_for(att->atttypid, att->atttypmod);
+	}
+
+	tops = palloc0(sizeof(TopColumn) * ntop);
+	leaves = palloc0(sizeof(PqLeaf) * Max(totalLeaves, 1));
+	for (i = 0; i < ntop; i++)
+	{
+		Form_pg_attribute att = TupleDescAttr(tupdesc, i);
+		bool		ok = true;
+
+		build_top_column(&tops[i], NameStr(att->attname), att->atttypid,
+						 att->atttypmod, leaves, &nleaves, &ok);
+		if (!ok)
 		{
 			table_close(rel, AccessShareLock);
 			ereport(ERROR,
@@ -723,27 +1081,6 @@ columnar_export_parquet(PG_FUNCTION_ARGS)
 							NameStr(att->attname),
 							format_type_be(att->atttypid))));
 		}
-		cols[i].name = pstrdup(NameStr(att->attname));
-		cols[i].kind = kind;
-		cols[i].ptype = ptype;
-		cols[i].convType = convType;
-		cols[i].typeLength = typeLength;
-		cols[i].precision = precision;
-		cols[i].scale = scale;
-		cols[i].convertText = (kind == P_UTF8 &&
-							   (att->atttypid == NUMERICOID ||
-								att->atttypid == JSONBOID));
-		if (cols[i].convertText)
-		{
-			Oid			outfunc;
-			bool		isvarlena;
-
-			getTypeOutputInfo(att->atttypid, &outfunc, &isvarlena);
-			fmgr_info(outfunc, &cols[i].outFinfo);
-		}
-		initStringInfo(&cols[i].present);
-		initStringInfo(&cols[i].values);
-		initStringInfo(&cols[i].boolbits);
 	}
 
 	f = AllocateFile(path, PG_BINARY_W);
@@ -758,8 +1095,8 @@ columnar_export_parquet(PG_FUNCTION_ARGS)
 	fwrite("PAR1", 1, 4, f);		/* magic header */
 	offset = 4;
 
-	values = palloc(sizeof(Datum) * ncols);
-	nulls = palloc(sizeof(bool) * ncols);
+	values = palloc(sizeof(Datum) * ntop);
+	nulls = palloc(sizeof(bool) * ntop);
 
 	snapshot = ActiveSnapshotSet() ? GetActiveSnapshot() : GetTransactionSnapshot();
 	readState = ColumnarBeginRead(rel, snapshot, NULL, NULL, 0, NULL);
@@ -771,8 +1108,8 @@ columnar_export_parquet(PG_FUNCTION_ARGS)
 		if (got)
 		{
 			CHECK_FOR_INTERRUPTS();
-			for (i = 0; i < ncols; i++)
-				pqcol_append(&cols[i], values[i], nulls[i]);
+			for (i = 0; i < ntop; i++)
+				shred_top(&tops[i], leaves, values[i], nulls[i]);
 			groupRows++;
 			total++;
 		}
@@ -789,22 +1126,21 @@ columnar_export_parquet(PG_FUNCTION_ARGS)
 					: palloc(sizeof(PqRowGroup) * rgCap);
 			}
 			rg = &rgs[nrgs++];
-			rg->cols = MemoryContextAlloc(rgCtx, sizeof(PqColMeta) * ncols);
+			rg->cols = MemoryContextAlloc(rgCtx, sizeof(PqColMeta) * Max(nleaves, 1));
 			rg->numRows = groupRows;
 			rg->totalByteSize = 0;
 
-			for (i = 0; i < ncols; i++)
+			for (i = 0; i < nleaves; i++)
 			{
 				StringInfoData body;
 				StringInfoData ph;
 				int64		pageStart = offset;
 
 				initStringInfo(&body);
-				build_def_levels(&body, cols[i].present.data, groupRows);
-				build_values(&body, &cols[i]);
+				build_leaf_body(&body, &leaves[i]);
 
 				initStringInfo(&ph);
-				write_page_header(&ph, groupRows, (int32) body.len);
+				write_page_header(&ph, leaves[i].nEntries, (int32) body.len);
 
 				fwrite(ph.data, 1, ph.len, f);
 				fwrite(body.data, 1, body.len, f);
@@ -812,12 +1148,12 @@ columnar_export_parquet(PG_FUNCTION_ARGS)
 
 				rg->cols[i].dataPageOffset = pageStart;
 				rg->cols[i].totalSize = ph.len + body.len;
-				rg->cols[i].numValues = groupRows;
+				rg->cols[i].numValues = leaves[i].nEntries;
 				rg->totalByteSize += ph.len + body.len;
 
 				pfree(body.data);
 				pfree(ph.data);
-				pqcol_reset(&cols[i]);
+				pqleaf_reset(&leaves[i]);
 			}
 			groupRows = 0;
 		}
@@ -832,21 +1168,25 @@ columnar_export_parquet(PG_FUNCTION_ARGS)
 		StringInfoData fmd;
 		int16		last = 0;
 		int32		footerLen;
+		int			nschema = 1;
+
+		for (i = 0; i < ntop; i++)
+			nschema += schema_count_for_top(&tops[i]);
 
 		initStringInfo(&fmd);
 		tc_i32_field(&fmd, &last, 1, 1);	/* version */
-		/* schema list (2): root + one per column */
+		/* schema list (2): root + the (possibly nested) elements per column */
 		tc_field(&fmd, &last, 2, TC_LIST);
-		tc_list_header(&fmd, ncols + 1, TC_STRUCT);
-		write_schema_element_root(&fmd, ncols);
-		for (i = 0; i < ncols; i++)
-			write_schema_element_col(&fmd, &cols[i]);
+		tc_list_header(&fmd, nschema, TC_STRUCT);
+		write_schema_element_root(&fmd, ntop);
+		for (i = 0; i < ntop; i++)
+			write_top_schema(&fmd, &tops[i], leaves);
 		tc_i64_field(&fmd, &last, 3, total);	/* num_rows */
 		/* row_groups list (4) */
 		tc_field(&fmd, &last, 4, TC_LIST);
 		tc_list_header(&fmd, nrgs, TC_STRUCT);
 		for (i = 0; i < nrgs; i++)
-			write_row_group(&fmd, cols, ncols, &rgs[i]);
+			write_row_group(&fmd, leaves, nleaves, &rgs[i]);
 		tc_string_field(&fmd, &last, 6, "pgColumnar", 10);	/* created_by */
 		tc_stop(&fmd);
 

--- a/test/parquet_nested.sh
+++ b/test/parquet_nested.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# pgColumnar Parquet nested-type export (gap 27): 1-D arrays -> Parquet LIST and
+# named composites -> Parquet group, using Dremel repetition/definition levels.
+# Exports a columnar table with an int[], a text[], and a composite column
+# (covering NULL arrays, empty arrays, NULL elements, and NULL structs), reads
+# the file back with pyarrow, and checks the field types are list/struct and
+# every value matches an expectation recomputed in Python from the generator.
+#
+# Requires pyarrow; skips with a note if it is not importable.
+#
+# Usage:  test/parquet_nested.sh [PG_CONFIG]
+#
+# Written fresh for pgColumnar; it does not reuse any upstream test file.
+
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+if ! python3 -c 'import pyarrow' 2>/dev/null; then
+	echo "-- pyarrow not available; skipping Parquet nested export verification"
+	pgc_summary
+	exit 0
+fi
+
+expect_error() {
+	local label="$1" sql="$2"
+	if psql_run "$sql" >/dev/null 2>&1; then
+		check "$label (expected error)" "succeeded" "error"
+	else
+		check "$label" "error" "error"
+	fi
+}
+
+NF="$PGC_WORKDIR/nt.parquet"
+
+echo "-- nested Parquet export: int[], text[], composite"
+psql_run "CREATE TYPE npc AS (x int, y text);"
+psql_run "CREATE TABLE np (id int, ia int[], ta text[], c npc) USING columnar;"
+psql_run "INSERT INTO np SELECT g,
+    CASE WHEN g % 10 = 0 THEN NULL
+         WHEN g % 7 = 0 THEN '{}'::int[]
+         ELSE ARRAY[g, NULL, g + 3] END,
+    ARRAY['a' || g, 'b' || g],
+    CASE WHEN g % 5 = 0 THEN NULL ELSE ROW(g * 2, 'c' || g)::npc END
+  FROM generate_series(1, 5000) g;"
+
+check "nested Parquet export rows written" "$(q "SELECT columnar.export_parquet('np', '$NF');")" "5000"
+
+types="$(python3 - "$NF" <<'PY'
+import sys, pyarrow as pa, pyarrow.parquet as pq
+s = pq.read_schema(sys.argv[1])
+ia, ta, c = s.field('ia').type, s.field('ta').type, s.field('c').type
+print(pa.types.is_list(ia), ia.value_type,
+      pa.types.is_list(ta), ta.value_type,
+      pa.types.is_struct(c), c.num_fields,
+      c.field(0).name, c.field(0).type, c.field(1).name, c.field(1).type)
+PY
+)"
+check "nested Parquet field types" "$types" "True int32 True string True 2 x int32 y string"
+
+vals="$(python3 - "$NF" <<'PY'
+import sys, pyarrow as pa, pyarrow.parquet as pq
+d = pq.read_table(sys.argv[1]).to_pydict()
+bad = None
+for i in range(len(d['id'])):
+    g = d['id'][i]
+    ia = None if g % 10 == 0 else ([] if g % 7 == 0 else [g, None, g + 3])
+    ta = ['a%d' % g, 'b%d' % g]
+    c = None if g % 5 == 0 else {'x': g * 2, 'y': 'c%d' % g}
+    if d['ia'][i] != ia or d['ta'][i] != ta or d['c'][i] != c:
+        bad = g
+        break
+print("MATCH" if bad is None else ("MISMATCH@%d" % bad))
+PY
+)"
+check "nested Parquet values match expectation" "$vals" "MATCH"
+
+# Larger data to exercise multiple row groups (page-per-column-chunk still one
+# per row group here, but multiple row groups stress the leaf/level pipeline).
+echo "-- nested Parquet export: multiple row groups"
+psql_run "CREATE TABLE np2 (id int, ia int[]) USING columnar;"
+psql_run "INSERT INTO np2 SELECT g, ARRAY[g, g*2] FROM generate_series(1, 70000) g;"
+check "np2 export rows" "$(q "SELECT columnar.export_parquet('np2', '$PGC_WORKDIR/np2.parquet');")" "70000"
+check "np2 values match" "$(python3 - "$PGC_WORKDIR/np2.parquet" <<'PY'
+import sys, pyarrow.parquet as pq
+d = pq.read_table(sys.argv[1]).to_pydict()
+ok = all(d['ia'][i] == [d['id'][i], d['id'][i]*2] for i in range(len(d['id'])))
+print("MATCH" if ok and len(d['id'])==70000 else "MISMATCH")
+PY
+)" "MATCH"
+
+echo "-- multi-dimensional array rejected"
+psql_run "CREATE TABLE npm (id int, m int[]) USING columnar;"
+psql_run "INSERT INTO npm VALUES (1, ARRAY[[1,2],[3,4]]);"
+expect_error "reject multi-dim array" "SELECT columnar.export_parquet('npm', '$PGC_WORKDIR/npm.parquet');"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -26,7 +26,7 @@ SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUITES=(smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
 	differential recovery fuzz hardening concurrent_diff parallel sorted_projection \
 	arrow_export parquet_export read_stream corruption \
-	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import)
+	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested)
 
 # Default matrix: one assert-enabled pg_config per major, 13 through 19.
 DEFAULT_CONFIGS=(


### PR DESCRIPTION
Completes gap 27. Extends the self-contained Parquet writer to nested types (Dremel):
- Columns shred into leaf column chunks with repetition + definition levels: 1-D array → 3-level LIST (max_rep 1, max_def 3); composite → group with one leaf per field (max_def 2); scalar → one leaf (byte-identical to the old flat writer).
- General RLE level encoder; per-leaf page body [rep levels][def levels][values]; nested schema with children + LIST logical type; leaf path_in_schema.
- NULLs/empty/null-element/null-field handled; multi-dim rejected.
- Docs: gap 27 marked complete across README, ROADMAP, spec, ARCHITECTURE.

Full PG13-19 matrix: **ALL VERSIONS PASSED**. Flat parquet_export.sh stays green; new parquet_nested.sh added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)