### PR TITLE
docs: mark gap 27 (Arrow/Parquet interop) fully complete

### DIFF
--- a/design/ROADMAP.md
+++ b/design/ROADMAP.md
@@ -28,11 +28,14 @@ matrix. Gap specifications are in [gaps/](gaps/).
 | Parquet import (`columnar.import_parquet`): Snappy, dictionary, data page v1/v2 | gap 27 |
 | Arrow nested import (List → array, Struct → composite) | gap 27 |
 | Parquet nested import (LIST → array, group → composite; Dremel level assembly) | gap 27 |
+| **Gap 27 complete** — Arrow/Parquet interop: export + import, flat + nested, both formats | gap 27 |
 
 ## Remaining
 
-Ordered by value-to-effort. Gap 27 (Arrow/Parquet interop) is now complete:
-export and import, flat and nested, for both formats.
+Ordered by value-to-effort. **Gap 27 (Arrow/Parquet interop) is fully complete**:
+export and import, flat and nested, for both Arrow and Parquet, all self-contained
+(no libarrow/libparquet dependency) and matrix-gated. See
+[gaps/27-arrow-parquet-interop.md](gaps/27-arrow-parquet-interop.md).
 
 1. Skip virtual generated-column storage. pgColumnar currently writes an all-null
    chunk for a virtual generated column (PostgreSQL 18+); reads are correct but

--- a/design/gaps/27-arrow-parquet-interop.md
+++ b/design/gaps/27-arrow-parquet-interop.md
@@ -1,6 +1,7 @@
 # Gap 27: Arrow / Parquet interop
 
-Status: exploratory. Tier: capability. Format change: additive. Effort: very large.
+Status: **complete** — every slice shipped and matrix-gated. Tier: capability.
+Format change: additive. Effort: very large.
 
 ## Motivation
 
@@ -12,7 +13,28 @@ lower-priority direction.
 
 ## Current state
 
-None. Data is only accessible via SQL through the table access method.
+Complete in both directions, for both formats, self-contained (no
+libarrow/libparquet build or link dependency; pyarrow/DuckDB are test oracles
+only). What shipped:
+
+- **Export** — `columnar.export_arrow` (hand-rolled Arrow IPC / FlatBuffers) and
+  `columnar.export_parquet` (hand-rolled Thrift + Snappy). Scalars (int2/4/8,
+  float4/8, bool, text/varchar, bytea, date/time/timestamp[tz], uuid, numeric,
+  json), **1-D arrays** (Arrow List / Parquet LIST), and **composites** (Arrow
+  Struct / Parquet group), with nulls at every level.
+- **Import** — `columnar.import_arrow` and `columnar.import_parquet` into an
+  existing target table. The Parquet reader parses Thrift metadata, decompresses
+  Snappy, and decodes PLAIN and dictionary (RLE_DICTIONARY / PLAIN_DICTIONARY)
+  values from data-page v1 and v2. Both readers reconstruct arrays and composites
+  — Arrow from its List/Struct buffers, Parquet from the Dremel repetition and
+  definition levels — including null arrays/elements/fields and empty arrays.
+  Both bound transient memory with per-row scratch contexts.
+
+Coverage: differential round-trips against a heap oracle plus pyarrow/DuckDB
+cross-checks (`arrow_export`, `parquet_export`, `arrow_import`, `parquet_import`,
+`arrow_nested`, `parquet_nested`, `arrow_nested_import`, `parquet_nested_import`),
+green across the PostgreSQL 13-19 matrix. The remainder of this document is the
+original exploratory design sketch, retained for provenance.
 
 ## Design (sketch -- a project)
 


### PR DESCRIPTION
Documentation-only. Marks gap 27 as fully complete now that every slice has
shipped and merged (#39–#43 export/import + nesting, #44 memory bounding):

- **ROADMAP**: consolidated "Gap 27 complete" row; Remaining now states the gap
  is fully complete and links the spec.
- **gaps/27-arrow-parquet-interop.md**: Status "exploratory" → "complete";
  "Current state" rewritten from "None" to a summary of what shipped (export +
  import, scalar/array/composite, the Parquet reader's Dremel level assembly,
  per-row memory bounding) plus the covering suites. Design sketch retained for
  provenance.

No code change; not matrix-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)