### PR TITLE
docs: user and DBA documentation, project logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="logo/pgcolumnar-logo-dark.svg">
+  <img src="logo/pgcolumnar-logo.svg" alt="pgColumnar" width="340">
+</picture>
+
 # pgColumnar
 
 **Release: 1.0-dev** (pre-release; on-disk format 2.2). The `VERSION` file is the
 source of truth for the release marker; a `-prod` build will be cut once the
 remaining gap work lands and the full matrix stays green.
+
+Documentation for users and administrators is in [docs/](docs/index.md):
+[installation](docs/installation.md), [user guide](docs/user-guide.md),
+[administration](docs/administration.md), [configuration reference](docs/configuration.md),
+[SQL reference](docs/sql-reference.md), and [limitations](docs/limitations.md).
 
 pgColumnar is a column-oriented storage extension for PostgreSQL, implemented as
 a table access method. A table created `USING columnar` stores its data by

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -1,0 +1,170 @@
+# Administration
+
+This guide is for database administrators operating columnar tables. It covers
+storage layout, compression, compaction, index-only scans, projections,
+monitoring, backup, and security.
+
+## Storage layout
+
+A columnar table is one PostgreSQL relation plus rows in the `columnar` catalog
+tables. Data is organized as follows:
+
+- A **stripe** is the unit of write. Each write transaction appends one or more
+  stripes of up to `columnar.stripe_row_limit` rows.
+- A **chunk group** is a horizontal slice of a stripe, up to
+  `columnar.chunk_group_row_limit` rows. It is the unit of decompression and of
+  minimum and maximum skipping.
+- Within a chunk group, each column is stored and compressed separately, with a
+  recorded minimum and maximum and an optional bloom filter.
+
+Deletes and updates do not rewrite data. They mark rows in a row mask. Space is
+reclaimed by compaction (see below).
+
+Inspect the layout with [`columnar.stats`](sql-reference.md#columnarstatsrel-regclass).
+
+## Compression
+
+The default codec is `zstd` at level 3. Set the default for new data with
+`columnar.compression` and `columnar.compression_level`, or per table with
+[`columnar.alter_columnar_table_set`](configuration.md#per-table-storage-options).
+
+| Codec | Notes |
+| --- | --- |
+| `none` | No compression. Lowest write cost, largest size. |
+| `pglz` | Built in, always available. |
+| `lz4` | Available when built with `liblz4`. Fast decompression. |
+| `zstd` | Available when built with `libzstd`. Higher compression at a given speed than `pglz`; the level trades size against write cost. |
+
+A codec change applies to data written after the change. To apply it to existing
+data, rewrite the table with [`columnar.vacuum`](sql-reference.md#columnarvacuumtablename-regclass-stripe_count-int-default-0).
+
+## Row-group sizing
+
+`columnar.chunk_group_row_limit` (default 10000) sets how many rows share one
+minimum and maximum. Smaller groups skip more precisely on selective range
+filters but hold less data per group. `columnar.stripe_row_limit` (default
+150000) sets the write unit. The defaults suit most workloads. Change them for a
+table with `columnar.alter_columnar_table_set` when a specific access pattern
+calls for it, and measure the result.
+
+## Compaction and vacuum
+
+There are two distinct operations, and the difference matters:
+
+- **Standard `VACUUM`** (manual or autovacuum) runs the columnar table's vacuum,
+  which sets visibility-map bits used by index-only scans and maintains
+  statistics. It does not rewrite data or reclaim space from deleted rows.
+- **`columnar.vacuum`** (a function) rewrites the table, combining stripes and
+  reclaiming space held by deleted and updated rows.
+
+Run `columnar.vacuum` after bulk deletes or updates, or after many small load
+transactions have produced many small stripes:
+
+```sql
+SELECT columnar.vacuum('events');
+```
+
+To store rows sorted on a column so range filters on it skip more chunk groups,
+use `columnar.vacuum_sorted`:
+
+```sql
+SELECT columnar.vacuum_sorted('events', 'customer_id');
+```
+
+To compact every columnar table in a schema, use `columnar.vacuum_full`.
+
+Leave autovacuum on. It maintains visibility-map bits and statistics for columnar
+tables. Schedule `columnar.vacuum` separately based on delete and update volume.
+
+## Index-only scans
+
+An index-only scan answers a query from the index without reading the table, when
+the index covers the query and the rows are marked all-visible. pgColumnar serves
+this through a columnar visibility-map fork:
+
+- `VACUUM` marks a chunk group all-visible when its inserting transaction is old
+  enough and the group has no deletes.
+- Any insert, update, or delete clears the bit for the affected group.
+
+Index-only scans are on by default (`columnar.enable_index_only_scan`). To make a
+covering query use one, ensure the table has been vacuumed since its last write.
+Check with `EXPLAIN (ANALYZE)`: an index-only scan reports `Heap Fetches: 0`.
+
+## Projections
+
+A projection stores a subset of a table's columns a second time, optionally
+sorted on a key. The planner scans a projection instead of the base table when it
+covers the query and serves it better, for example a range query on a key that is
+scattered in the base table but is the projection's sort key.
+
+Declare a projection:
+
+```sql
+SELECT columnar.add_projection(
+    'events', 'events_by_customer',
+    columns  => ARRAY['customer_id', 'amount', 'ts'],
+    sort_key => ARRAY['customer_id']);
+```
+
+Existing rows are back-filled when the projection is added. New inserts write to
+the base table and its projections. Projection scans are on by default
+(`columnar.enable_projection_scan`). Drop a projection with
+`columnar.drop_projection`.
+
+A projection adds write cost and storage, because inserts write it too. Add one
+for a query pattern that a covering, sorted column subset serves, and measure the
+result. Confirm the plan uses it with `EXPLAIN`, which names the chosen projection.
+
+## Monitoring
+
+`columnar.stats(rel)` reports per-stripe row counts, deleted-row counts, chunk
+counts, and byte sizes. Use it to see fragmentation and decide when to compact:
+
+```sql
+SELECT count(*)                         AS stripes,
+       sum(rowcount)                    AS rows,
+       sum(deletedrows)                 AS deleted,
+       round(100.0 * sum(deletedrows)
+             / nullif(sum(rowcount), 0), 1) AS pct_deleted,
+       pg_size_pretty(sum(datalength))  AS size
+FROM columnar.stats('events');
+```
+
+A high deleted-row percentage or a large number of small stripes indicates that
+`columnar.vacuum` would help.
+
+## Concurrent unique inserts
+
+When a columnar table has a unique index, `columnar.enable_unique_insert_lock`
+(on by default) serializes concurrent inserts of the same key with a
+transaction-scoped advisory lock, so overlapping same-key inserts conflict
+correctly. `columnar.unique_lock_buckets` (default 128) bounds how many advisory
+locks a transaction holds per unique index. Leave the lock on unless you have a
+specific reason to change it.
+
+## Column cache
+
+`columnar.enable_column_cache` (off by default) caches decompressed chunk groups
+so they can be reused across reads, sized by `columnar.column_cache_size` (default
+200 MB). Enable it for repeated scans over the same recently read data, and size
+the cache to the working set.
+
+## Backup and restore
+
+A columnar table is an ordinary WAL-logged relation.
+
+- **Physical backup** (`pg_basebackup`, file-system snapshots) and **physical
+  replication** include columnar tables and their WAL.
+- **Logical backup** (`pg_dump`) writes the table definition, including `USING
+  columnar`, and its data with `COPY`. Restore requires the `columnar` extension
+  installed and present in `shared_preload_libraries` on the target server.
+
+Install and preload the extension on any server that restores or replicates a
+columnar table, because reading the table requires the access method.
+
+## Security
+
+The Arrow and Parquet import and export functions read and write files on the
+server host and require superuser. Grant them only to roles you trust with
+server-side file access, and control the paths those roles can reach. All other
+`columnar.*` functions run with ordinary table privileges.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,96 @@
+# Configuration reference
+
+pgColumnar has two kinds of settings:
+
+- Server settings under the `columnar.` prefix, listed below. Each can be set in
+  `postgresql.conf`, per session with `SET`, per role, or per database. All of
+  them are `USERSET`, so a session may change them without special privileges.
+- Per-table storage options, set with `columnar.alter_columnar_table_set`. These
+  apply to one table and are used when that table writes new data.
+
+## Server settings
+
+### Storage layout
+
+| Setting | Type | Default | Description |
+| --- | --- | --- | --- |
+| `columnar.stripe_row_limit` | integer | `150000` | Maximum rows per stripe. A stripe is the unit of write and the granularity at which whole segments are appended. Range 1000 to INT_MAX. |
+| `columnar.chunk_group_row_limit` | integer | `10000` | Maximum rows per chunk group. A chunk group is the unit of min/max skipping and decompression. Range 100 to INT_MAX. |
+
+### Compression
+
+| Setting | Type | Default | Description |
+| --- | --- | --- | --- |
+| `columnar.compression` | enum | `zstd` | Default codec for new chunks. One of `none`, `pglz`, `lz4`, `zstd`. `lz4` and `zstd` are available only when the extension was built with those libraries. |
+| `columnar.compression_level` | integer | `3` | Level for the `zstd` codec. Range 1 to 22. Higher levels compress more and write more slowly. |
+
+### Scan and execution
+
+| Setting | Type | Default | Description |
+| --- | --- | --- | --- |
+| `columnar.enable_custom_scan` | boolean | `on` | Use the columnar custom scan path for columnar tables. |
+| `columnar.enable_qual_pushdown` | boolean | `on` | Push scan qualifiers down so per-chunk min and max values can skip chunk groups. |
+| `columnar.enable_vectorization` | boolean | `on` | Use the vectorized scan and aggregate paths. |
+| `columnar.enable_compressed_execution` | boolean | `on` | Compute aggregates over runs of the encoded value stream without full decoding. |
+| `columnar.enable_late_materialization` | boolean | `on` | Decode output columns only after the filter has selected rows. |
+| `columnar.enable_bloom_filter` | boolean | `on` | Skip chunk groups on equality filters using per-chunk bloom filters. |
+| `columnar.enable_metadata_count` | boolean | `on` | Answer `count(*)` from catalog metadata without scanning the table. |
+| `columnar.enable_read_stream` | boolean | `on` | Prefetch block reads with the read stream API. Effective on PostgreSQL 17 and later. |
+
+### Index-only scan and projections
+
+| Setting | Type | Default | Description |
+| --- | --- | --- | --- |
+| `columnar.enable_index_only_scan` | boolean | `on` | Allow index-only scans on columnar tables, served by the columnar visibility-map fork. Set to `off` to force a plain index scan. |
+| `columnar.enable_projection_scan` | boolean | `on` | Let the planner scan a covering projection instead of the base table when one serves the query better. |
+
+### Column cache
+
+| Setting | Type | Default | Description |
+| --- | --- | --- | --- |
+| `columnar.enable_column_cache` | boolean | `off` | Cache decompressed chunk groups so they can be reused across reads. |
+| `columnar.column_cache_size` | integer (MB) | `200` | Size of the decompressed-chunk cache. Applies when the column cache is enabled. Range 1 to INT_MAX. |
+
+### Concurrent unique inserts
+
+| Setting | Type | Default | Description |
+| --- | --- | --- | --- |
+| `columnar.enable_unique_insert_lock` | boolean | `on` | Serialize concurrent inserts of the same unique-index key with a transaction-scoped advisory lock, so overlapping same-key inserts conflict correctly. |
+| `columnar.unique_lock_buckets` | integer | `128` | Advisory-lock buckets per unique index. Bounds how many advisory locks a transaction holds per unique index. Equal keys always share a bucket; unrelated keys may share one, which only over-serializes. Range 1 to 1048576. |
+
+## Per-table storage options
+
+`columnar.alter_columnar_table_set` sets storage options on one table. New data
+written after the change uses the new values; data already written is unchanged
+until the table is rewritten (for example by `columnar.vacuum`).
+
+```sql
+SELECT columnar.alter_columnar_table_set(
+    'events',
+    chunk_group_row_limit => 20000,
+    stripe_row_limit      => 300000,
+    compression           => 'zstd',
+    compression_level     => 6);
+```
+
+| Argument | Type | Description |
+| --- | --- | --- |
+| `table_name` | regclass | The columnar table to change. |
+| `chunk_group_row_limit` | integer | Per-table override of `columnar.chunk_group_row_limit`. |
+| `stripe_row_limit` | integer | Per-table override of `columnar.stripe_row_limit`. |
+| `compression` | name | One of `none`, `pglz`, `lz4`, `zstd`. |
+| `compression_level` | integer | Level for the `zstd` codec, 1 to 22. |
+
+Arguments left at their default (`NULL`) are not changed. A value outside the
+valid range for a limit or level is rejected.
+
+`columnar.alter_columnar_table_reset` returns options to the server defaults:
+
+```sql
+SELECT columnar.alter_columnar_table_reset(
+    'events',
+    chunk_group_row_limit => true,
+    compression           => true);
+```
+
+Each boolean argument, when true, resets that option on the table.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,61 @@
+# pgColumnar documentation
+
+pgColumnar is a column-oriented storage extension for PostgreSQL, implemented as
+a table access method. A table created `USING columnar` stores its data by
+column, with per-column compression, chunk-group skipping, and a vectorized scan
+and aggregate path. It targets analytic workloads: large scans, aggregates, and
+column projections over append-mostly data.
+
+pgColumnar builds from one source tree on PostgreSQL 13 through 19. It is
+licensed under the MIT License.
+
+## Where to start
+
+| If you want to | Read |
+| --- | --- |
+| Install the extension and load it into a server | [Installation](installation.md) |
+| Create columnar tables, load data, and query them | [User guide](user-guide.md) |
+| Operate columnar tables in production | [Administration](administration.md) |
+| Look up a setting and its default | [Configuration reference](configuration.md) |
+| Look up a `columnar.*` function | [SQL reference](sql-reference.md) |
+| Check type coverage and known constraints | [Limitations and compatibility](limitations.md) |
+
+## When to use columnar storage
+
+A columnar table stores each column separately and compresses it. Reads that
+touch a subset of columns and scan many rows benefit, because only the requested
+columns are read and decompressed, and per-chunk minimum and maximum values let
+the scan skip groups of rows that cannot match a filter.
+
+Use pgColumnar for:
+
+- Fact tables and event logs that are appended to and read with aggregates or
+  wide scans.
+- Queries that select a few columns from a table with many columns.
+- Data that compresses well and is queried more often than it is updated.
+
+Row storage (the default heap) remains the better choice for high-rate single
+row updates and deletes, and for point lookups that return whole rows.
+pgColumnar supports updates, deletes, and indexes, but its storage layout is
+built for append-mostly data. See [Limitations and compatibility](limitations.md).
+
+## How it fits together
+
+A columnar table is an ordinary PostgreSQL relation. It works with transactions,
+WAL, replication, indexes, `COPY`, and `pg_dump`. The extension adds:
+
+- A table access method named `columnar`.
+- A set of catalog tables and functions in the `columnar` schema.
+- Planner and executor paths for columnar scans, aggregates, index-only scans,
+  and projections, controlled by settings under the `columnar.` prefix.
+
+## Design and internals
+
+The documents above are for users and administrators. The design and format
+specifications are separate:
+
+- [../design/FORMAT_AND_INTERFACE_SPEC.md](../design/FORMAT_AND_INTERFACE_SPEC.md):
+  on-disk format and SQL interface specification.
+- [ARCHITECTURE.md](ARCHITECTURE.md): source layout and how the pieces connect.
+- [../design/ROADMAP.md](../design/ROADMAP.md): completed work and remaining items.
+- [../PROVENANCE.md](../PROVENANCE.md): clean-room implementation method.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,90 @@
+# Installation
+
+pgColumnar builds with PGXS against an installed PostgreSQL server, versions 13
+through 19.
+
+## Requirements
+
+- A PostgreSQL server and its development headers, reachable through `pg_config`.
+- A C compiler and `make`.
+- `pkg-config`. It is used to detect the optional compression libraries.
+- Optional: `liblz4` and `libzstd` development libraries. When present, the `lz4`
+  and `zstd` codecs are compiled in. When absent, those codecs are compiled out
+  and a request for them falls back to a codec that is present.
+- A little-endian host is required for the Arrow and Parquet import and export
+  functions. The rest of the extension runs on any host PostgreSQL supports.
+
+## Build and install
+
+Point the build at the `pg_config` of the target server:
+
+```sh
+make PG_CONFIG=/path/to/pg_config
+make install PG_CONFIG=/path/to/pg_config
+```
+
+`make install` copies `columnar.so`, the control file, and the SQL script into
+the server's library and extension directories.
+
+## Load the library
+
+pgColumnar installs planner and executor hooks at library load time. Add it to
+`shared_preload_libraries` and restart the server:
+
+```
+shared_preload_libraries = 'columnar'
+```
+
+Set this in `postgresql.conf` (or with `ALTER SYSTEM SET shared_preload_libraries
+= 'columnar'`), then restart. If other libraries are already preloaded, add
+`columnar` to the comma-separated list.
+
+## Create the extension
+
+In each database that will hold columnar tables:
+
+```sql
+CREATE EXTENSION columnar;
+```
+
+This creates the `columnar` schema, the `columnar` table access method, the
+catalog tables, and the `columnar.*` functions. The extension is not
+relocatable; its objects stay in the `columnar` schema.
+
+## Verify
+
+```sql
+-- the access method is registered
+SELECT amname FROM pg_am WHERE amname = 'columnar';
+
+-- a columnar table can be created and read
+CREATE TABLE install_check (id int, v text) USING columnar;
+INSERT INTO install_check VALUES (1, 'ok');
+SELECT * FROM install_check;
+DROP TABLE install_check;
+```
+
+## Upgrade
+
+To install a new build of the extension:
+
+1. Run `make install` with the same `PG_CONFIG`.
+2. Restart the server so the new library is loaded.
+
+The on-disk format version is recorded in the source and in
+[../design/FORMAT_AND_INTERFACE_SPEC.md](../design/FORMAT_AND_INTERFACE_SPEC.md).
+A build that keeps the same format version reads tables written by earlier builds
+of that version without conversion.
+
+## Remove
+
+Drop the extension from a database, then remove the files if no database still
+uses it:
+
+```sql
+DROP EXTENSION columnar;   -- fails if columnar tables still exist; drop them first
+```
+
+Removing `columnar` from `shared_preload_libraries` and restarting unloads the
+library. Do this only after no database contains columnar tables, because reading
+a columnar table requires the access method to be present.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,0 +1,70 @@
+# Limitations and compatibility
+
+## PostgreSQL versions
+
+pgColumnar builds from one source tree on PostgreSQL 13, 14, 15, 16, 17, 18, and
+19. Every test suite runs on all seven majors.
+
+Two behaviors depend on the major:
+
+- `ALTER TABLE ... SET ACCESS METHOD` exists on PostgreSQL 15 and later. On 13 and
+  14, `columnar.alter_table_set_access_method` rebuilds the table instead and does
+  not preserve its OID or dependent objects (views, foreign keys). See the
+  [SQL reference](sql-reference.md#columnaralter_table_set_access_methodt-text-method-text).
+- The read stream prefetch path (`columnar.enable_read_stream`) is effective on
+  PostgreSQL 17 and later. On earlier majors the setting has no effect.
+
+## Host architecture
+
+The Arrow and Parquet import and export functions run on little-endian hosts
+only. The rest of the extension runs on any architecture PostgreSQL supports.
+
+## Workload
+
+Columnar storage is built for append-mostly data. Updates and deletes are
+supported, but they mark rows rather than rewriting data, and the space is
+reclaimed only by [`columnar.vacuum`](sql-reference.md#columnarvacuumtablename-regclass-stripe_count-int-default-0).
+For high-rate single-row updates and deletes, and for workloads that read whole
+rows by key, the default heap is the better fit.
+
+## Replication and backup
+
+- Physical replication and physical backups (`pg_basebackup`, snapshots) include
+  columnar tables, which are WAL-logged relations.
+- `pg_dump` and `pg_restore` handle columnar tables. The target server must have
+  the extension installed and preloaded.
+- Logical decoding reads heap-tuple WAL records. Changes to columnar tables are
+  not emitted through logical decoding, so logical replication does not carry
+  them. Use physical replication for columnar tables.
+
+## Import and export type coverage
+
+The import and export functions require superuser and run on little-endian hosts.
+They support one-dimensional arrays and composite types built from the scalar
+types below, with nulls at every level. Multi-dimensional arrays and types not
+listed are rejected.
+
+| Type | Arrow export | Parquet export | Arrow import | Parquet import |
+| --- | --- | --- | --- | --- |
+| `int2`, `int4`, `int8` | yes | yes | yes | yes |
+| `float4`, `float8` | yes | yes | yes | yes |
+| `bool` | yes | yes | yes | yes |
+| `text`, `varchar` | yes | yes | yes | yes |
+| `bytea` | yes | yes | yes | yes |
+| `date`, `time`, `timestamp`, `timestamptz` | yes | yes | yes | yes |
+| `uuid` | yes | yes | yes | no |
+| `numeric` | yes | yes | yes | no |
+| `json`, `jsonb` | yes | yes | yes | no |
+| one-dimensional array of the above | yes | yes | yes | yes |
+| composite of the above | yes | yes | yes | yes |
+
+`uuid`, `numeric`, and `json` can be exported to Parquet and read back with other
+tools, but pgColumnar does not currently import those three types from Parquet.
+They are supported end to end through Arrow.
+
+## Compression codecs
+
+`lz4` and `zstd` are available only when the extension was built with the
+corresponding system libraries. When a codec is not built in, a request for it
+falls back to a codec that is present. `pglz` and `none` are always available.
+See [Installation](installation.md#requirements).

--- a/docs/sql-reference.md
+++ b/docs/sql-reference.md
@@ -1,0 +1,174 @@
+# SQL reference
+
+Every function is in the `columnar` schema. Types are shown as in the function
+signature. For server settings, see [Configuration reference](configuration.md).
+
+## Table management
+
+### columnar.alter_table_set_access_method(t text, method text)
+
+Converts a table to another access method, for example from the default heap to
+`columnar` or back.
+
+On PostgreSQL 15 and later this runs `ALTER TABLE ... SET ACCESS METHOD`, which
+rewrites the table in place and preserves its identity and dependents. On
+PostgreSQL 13 and 14, which have no such command, it builds a sibling table with
+`LIKE ... INCLUDING ALL`, copies every row through the target method, and swaps
+names. On those two majors the conversion does not preserve the original table's
+OID or objects that depend on it, such as views and foreign keys.
+
+```sql
+SELECT columnar.alter_table_set_access_method('events', 'columnar');
+```
+
+### columnar.alter_columnar_table_set(...) and columnar.alter_columnar_table_reset(...)
+
+Set or reset per-table storage options (chunk group and stripe row limits,
+compression codec and level). See
+[Configuration reference](configuration.md#per-table-storage-options).
+
+### columnar.get_storage_id(rel regclass) returns bigint
+
+Returns the internal storage identifier of a columnar table. Used to join the
+`columnar` catalog tables. Most users read [`columnar.stats`](#columnarstatsrel-regclass)
+instead.
+
+## Maintenance
+
+### columnar.vacuum(tablename regclass, stripe_count int DEFAULT 0)
+
+Compacts a columnar table by combining stripes and reclaiming space held by rows
+that were deleted or updated. Use it after bulk deletes or updates, or after many
+small load transactions have produced many small stripes.
+
+`stripe_count` bounds how many stripes are combined in one call; `0` places no
+bound.
+
+```sql
+SELECT columnar.vacuum('events');
+```
+
+### columnar.vacuum_sorted(tablename regclass, VARIADIC sort_columns name[])
+
+Compacts a columnar table and stores its rows sorted ascending on the given
+columns. Sorted storage makes per-chunk minimum and maximum values tight and
+non-overlapping on the sort columns, so range filters on those columns skip more
+chunk groups. Use it for a column whose values are scattered in insertion order
+but are often queried by range.
+
+```sql
+SELECT columnar.vacuum_sorted('events', 'customer_id');
+```
+
+### columnar.vacuum_full(schema name DEFAULT 'public', sleep_time real DEFAULT 0.0, stripe_count int DEFAULT 0)
+
+Runs `columnar.vacuum` on every columnar table in a schema. `sleep_time` is a
+pause in seconds between tables. `stripe_count` is passed through to each call.
+
+```sql
+SELECT columnar.vacuum_full('public');
+```
+
+### columnar.stats(rel regclass)
+
+Returns one row per stripe with these columns:
+
+| Column | Type | Meaning |
+| --- | --- | --- |
+| `stripeid` | bigint | Stripe number within the table. |
+| `fileoffset` | bigint | Byte offset of the stripe in the relation file. |
+| `rowcount` | bigint | Rows written into the stripe. |
+| `deletedrows` | bigint | Rows in the stripe marked deleted. |
+| `chunkcount` | integer | Chunk groups in the stripe. |
+| `datalength` | bigint | On-disk length of the stripe in bytes. |
+
+```sql
+-- total live rows, deleted rows, and size
+SELECT sum(rowcount) AS rows,
+       sum(deletedrows) AS deleted,
+       pg_size_pretty(sum(datalength)) AS size
+FROM columnar.stats('events');
+```
+
+## Projections
+
+A projection is a named subset of a table's columns stored a second time,
+optionally sorted on a key. When a projection covers a query and serves it better
+than the base table, the planner scans the projection instead. See
+[Administration](administration.md#projections).
+
+### columnar.add_projection(rel regclass, name text, columns text[], sort_key text[] DEFAULT '{}')
+
+Declares a projection on `rel` named `name`, storing `columns`, sorted on
+`sort_key`. Existing rows are back-filled when the projection is added.
+
+```sql
+SELECT columnar.add_projection(
+    'events', 'events_by_customer',
+    columns  => ARRAY['customer_id', 'amount', 'ts'],
+    sort_key => ARRAY['customer_id']);
+```
+
+### columnar.drop_projection(rel regclass, name text)
+
+Drops a projection and frees its storage.
+
+```sql
+SELECT columnar.drop_projection('events', 'events_by_customer');
+```
+
+### columnar.read_projection(rel regclass, name text) and columnar.reconstruct_via_projection(rel regclass, name text)
+
+Return a projection's stored rows as text, for verification. They are for
+inspection and testing, not for query use.
+
+## Import and export
+
+These functions read and write Arrow IPC stream files and Parquet files. They
+require superuser, because they read and write files on the server host. They run
+on little-endian hosts only. They support scalar column types, one-dimensional
+arrays, and composite types, with nulls at every level. Multi-dimensional arrays
+and unsupported types are rejected. See
+[Limitations and compatibility](limitations.md).
+
+### columnar.export_arrow(rel regclass, path text) returns bigint
+
+Writes the live rows of `rel` to an Arrow IPC stream file at `path`. Returns the
+number of rows written.
+
+### columnar.export_parquet(rel regclass, path text) returns bigint
+
+Writes the live rows of `rel` to a Parquet file at `path`. Returns the number of
+rows written.
+
+### columnar.import_arrow(rel regclass, path text) returns bigint
+
+Inserts the rows of an Arrow IPC stream file at `path` into the existing table
+`rel`. The table's column types define what is expected. Returns the number of
+rows inserted.
+
+### columnar.import_parquet(rel regclass, path text) returns bigint
+
+Inserts the rows of a Parquet file at `path` into the existing table `rel`. The
+reader handles Snappy compression, PLAIN and dictionary encodings, and data-page
+versions 1 and 2. Returns the number of rows inserted.
+
+```sql
+-- round-trip a table through Parquet
+SELECT columnar.export_parquet('events', '/tmp/events.parquet');   -- returns row count
+CREATE TABLE events_copy (LIKE events) USING columnar;
+SELECT columnar.import_parquet('events_copy', '/tmp/events.parquet');
+```
+
+## Visibility map inspection
+
+These report the state of the columnar visibility-map fork that serves
+index-only scans. They are for diagnostics.
+
+### columnar.vm_is_visible(rel regclass, blk int)
+
+Returns whether the given block (chunk group) is marked all-visible.
+
+### columnar.vm_selftest(rel regclass, blk int)
+
+Runs a set and clear self-test against the visibility map for one block.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,136 @@
+# User guide
+
+This guide covers creating columnar tables, loading data, and querying them. It
+assumes the extension is installed and loaded (see [Installation](installation.md)).
+
+## Create a columnar table
+
+Add `USING columnar` to `CREATE TABLE`:
+
+```sql
+CREATE TABLE events (
+    id          bigint,
+    customer_id int,
+    amount      numeric,
+    kind        text,
+    ts          timestamptz
+) USING columnar;
+```
+
+The table behaves like any PostgreSQL table for SQL purposes. It supports
+transactions, constraints, indexes, `COPY`, and `pg_dump`.
+
+## Convert an existing table
+
+On PostgreSQL 15 and later:
+
+```sql
+ALTER TABLE events SET ACCESS METHOD columnar;
+```
+
+On any supported major, including 13 and 14, the extension provides a helper:
+
+```sql
+SELECT columnar.alter_table_set_access_method('events', 'columnar');
+```
+
+On PostgreSQL 13 and 14 the helper rebuilds the table and does not preserve its
+OID or dependent objects such as views and foreign keys. See the
+[SQL reference](sql-reference.md#columnaralter_table_set_access_methodt-text-method-text).
+
+To convert back to the default heap, use `heap` as the method.
+
+## Load data
+
+Columnar storage is built for append-mostly data. Rows are buffered and written
+in stripes of up to `columnar.stripe_row_limit` rows. Each transaction writes its
+own stripes, so a load's shape affects the result:
+
+- Prefer `COPY` or multi-row `INSERT` over many single-row `INSERT` statements. A
+  `COPY` of N rows writes about N divided by `stripe_row_limit` stripes.
+- Many small transactions produce many small stripes. If a table was loaded that
+  way, run [`columnar.vacuum`](sql-reference.md#columnarvacuumtablename-regclass-stripe_count-int-default-0)
+  to combine stripes.
+
+```sql
+COPY events FROM '/data/events.csv' WITH (FORMAT csv, HEADER);
+
+INSERT INTO events
+SELECT g, g % 1000, (random() * 100)::numeric(10,2), 'sale',
+       now() - (g || ' seconds')::interval
+FROM generate_series(1, 1000000) g;
+```
+
+## Query
+
+Queries need no special syntax. The planner adds columnar scan and aggregate
+paths for columnar tables. Reads that touch a subset of columns and scan many
+rows benefit most.
+
+```sql
+-- reads only amount and ts, skips chunk groups outside the time range
+SELECT date_trunc('day', ts) AS day, sum(amount)
+FROM events
+WHERE ts >= '2026-01-01' AND ts < '2026-02-01'
+GROUP BY 1
+ORDER BY 1;
+```
+
+### How the scan is chosen
+
+Read the plan with `EXPLAIN`:
+
+```sql
+EXPLAIN (ANALYZE, VERBOSE) SELECT sum(amount) FROM events WHERE customer_id = 42;
+```
+
+A columnar scan shows as a custom scan node. The scan uses the following, each
+controlled by a setting in the [Configuration reference](configuration.md):
+
+- Chunk-group skipping: per-chunk minimum and maximum values drop groups of rows
+  that cannot satisfy a filter.
+- Bloom filters: per-chunk filters drop groups for equality filters.
+- Vectorized execution and late materialization: filters run first, then only the
+  output columns of matching rows are decoded.
+- `count(*)` answered from catalog metadata when there is no filter.
+
+### Point lookups and indexes
+
+Create indexes on columnar tables as usual:
+
+```sql
+CREATE INDEX ON events (id);
+SELECT * FROM events WHERE id = 12345;
+```
+
+An index supports point lookups and range scans. When a query's columns are all
+in the index and the table's rows are marked all-visible, pgColumnar can answer
+from the index alone with an index-only scan, served by its visibility-map fork.
+Visibility bits are set by `VACUUM`. See
+[Administration](administration.md#index-only-scans).
+
+## Arrays and composite types
+
+Columnar tables store one-dimensional arrays and composite types. These are also
+covered by the Arrow and Parquet import and export functions.
+
+```sql
+CREATE TYPE addr AS (city text, zip text);
+
+CREATE TABLE people (
+    id    int,
+    tags  text[],
+    home  addr
+) USING columnar;
+
+INSERT INTO people VALUES (1, ARRAY['a','b'], ROW('Portland','97201')::addr);
+```
+
+## Next steps
+
+- Operate tables in production: [Administration](administration.md).
+- Improve range scans on a scattered key or serve a query from a column subset:
+  [projections](administration.md#projections) and
+  [`columnar.vacuum_sorted`](sql-reference.md#columnarvacuum_sortedtablename-regclass-variadic-sort_columns-namel).
+- Move data in and out of the Arrow and Parquet ecosystem:
+  [import and export](sql-reference.md#import-and-export).

--- a/logo/README.md
+++ b/logo/README.md
@@ -1,0 +1,36 @@
+# pgColumnar logo
+
+Brand assets for pgColumnar. The mark is four vertical bars of varying height
+that read as a column store; the tallest bar carries the amber accent. All files
+are self-contained SVG with no external fonts or images.
+
+| File | Use |
+| --- | --- |
+| `pgcolumnar-logo.svg` | Horizontal lockup (mark plus wordmark) for light backgrounds. |
+| `pgcolumnar-logo-dark.svg` | Horizontal lockup for dark backgrounds. |
+| `pgcolumnar-mark.svg` | Mark only, for favicons and avatars. Holds its shape down to 16 px. |
+
+## Palette
+
+| Role | Value |
+| --- | --- |
+| Bar blue | `#5B8DEF` to `#2B5FD0` (vertical gradient) |
+| Bar blue on dark | `#7AA2F7` to `#3B6FE0` |
+| Accent amber | `#F7B733` to `#F59E0B` |
+| Wordmark ink | `#1F2A44` (light background), `#F2F4F8` (dark background) |
+
+The wordmark is set in a system sans-serif stack (`Segoe UI`, `Roboto`,
+`Helvetica`, `Arial`). To lock the wordmark independent of installed fonts,
+convert its text to paths in a vector editor.
+
+## Theme-aware embedding
+
+Use the `<picture>` element to serve the light or dark lockup by the viewer's
+color scheme:
+
+```html
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="logo/pgcolumnar-logo-dark.svg">
+  <img src="logo/pgcolumnar-logo.svg" alt="pgColumnar" width="340">
+</picture>
+```

--- a/logo/pgcolumnar-logo-dark.svg
+++ b/logo/pgcolumnar-logo-dark.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 340 80" width="340" height="80" role="img" aria-label="pgColumnar">
+  <defs>
+    <linearGradient id="bar" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#7AA2F7"/>
+      <stop offset="1" stop-color="#3B6FE0"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#F7B733"/>
+      <stop offset="1" stop-color="#F59E0B"/>
+    </linearGradient>
+  </defs>
+  <g transform="translate(16,16)">
+    <rect x="5"  y="30" width="7" height="11" rx="2.5" fill="url(#bar)"/>
+    <rect x="15" y="22" width="7" height="19" rx="2.5" fill="url(#bar)"/>
+    <rect x="25" y="10" width="7" height="31" rx="2.5" fill="url(#accent)"/>
+    <rect x="35" y="16" width="7" height="25" rx="2.5" fill="url(#bar)"/>
+  </g>
+  <g font-family="'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+    <text x="82" y="46" font-size="34" font-weight="700" fill="#F2F4F8">
+      <tspan fill="#7AA2F7">pg</tspan><tspan>Columnar</tspan>
+    </text>
+    <text x="84" y="64" font-size="12.5" letter-spacing="0.5" fill="#9AA4B8">columnar storage for PostgreSQL</text>
+  </g>
+</svg>

--- a/logo/pgcolumnar-logo.svg
+++ b/logo/pgcolumnar-logo.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 340 80" width="340" height="80" role="img" aria-label="pgColumnar">
+  <defs>
+    <linearGradient id="bar" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#5B8DEF"/>
+      <stop offset="1" stop-color="#2B5FD0"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#F7B733"/>
+      <stop offset="1" stop-color="#F59E0B"/>
+    </linearGradient>
+  </defs>
+  <g transform="translate(16,16)">
+    <rect x="5"  y="30" width="7" height="11" rx="2.5" fill="url(#bar)"/>
+    <rect x="15" y="22" width="7" height="19" rx="2.5" fill="url(#bar)"/>
+    <rect x="25" y="10" width="7" height="31" rx="2.5" fill="url(#accent)"/>
+    <rect x="35" y="16" width="7" height="25" rx="2.5" fill="url(#bar)"/>
+  </g>
+  <g font-family="'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+    <text x="82" y="46" font-size="34" font-weight="700" fill="#1F2A44">
+      <tspan fill="#2B5FD0">pg</tspan><tspan>Columnar</tspan>
+    </text>
+    <text x="84" y="64" font-size="12.5" letter-spacing="0.5" fill="#5A6478">columnar storage for PostgreSQL</text>
+  </g>
+</svg>

--- a/logo/pgcolumnar-mark.svg
+++ b/logo/pgcolumnar-mark.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48" height="48" role="img" aria-label="pgColumnar">
+  <defs>
+    <linearGradient id="bar" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#5B8DEF"/>
+      <stop offset="1" stop-color="#2B5FD0"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#F7B733"/>
+      <stop offset="1" stop-color="#F59E0B"/>
+    </linearGradient>
+  </defs>
+  <rect x="5"  y="30" width="7" height="11" rx="2.5" fill="url(#bar)"/>
+  <rect x="15" y="22" width="7" height="19" rx="2.5" fill="url(#bar)"/>
+  <rect x="25" y="10" width="7" height="31" rx="2.5" fill="url(#accent)"/>
+  <rect x="35" y="16" width="7" height="25" rx="2.5" fill="url(#bar)"/>
+</svg>


### PR DESCRIPTION
Adds the user, administrator, and project documentation that the repository was
missing, plus a project logo. No code change.

## Documentation (docs/)
End-user and DBA facing, separate from the design and format specs:

- **index**: documentation home, when to use columnar storage.
- **installation**: requirements, build, `shared_preload_libraries`, `CREATE EXTENSION`, verify, upgrade, remove.
- **user-guide**: create and convert tables, load data, query, read `EXPLAIN`, indexes, arrays and composites.
- **administration**: storage layout, compression, row-group sizing, compaction vs `VACUUM`, index-only scans, projections, monitoring, concurrent unique inserts, column cache, backup and restore, security.
- **configuration**: all 18 `columnar.*` server settings with types, defaults, and ranges, plus per-table options.
- **sql-reference**: every `columnar.*` function with signature, description, example, and privileges.
- **limitations**: PostgreSQL 13-19 support, host architecture, workload fit, replication and backup, and a per-operation import/export type-coverage table.

Written factually, without em-dashes.

## Logo (logo/)
Column-bars mark plus wordmark, self-contained SVG: light lockup, dark lockup, and a favicon mark, with `logo/README.md` (palette, embedding). The top-level `README` shows a theme-aware lockup and links the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)