### PR TITLE
chore: add .mailmap to canonicalize author identity to jdatcmd

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,7 @@
+# Canonical author identity for pgColumnar.
+# Maps earlier commit identities to the jdatcmd account so git log, git shortlog,
+# and the GitHub contributor view show one author, without rewriting history.
+Joshua D. Drake <jd@commandprompt.com> <136637981+ChronicallyJD@users.noreply.github.com>
+Joshua D. Drake <jd@commandprompt.com> Joshua (D) Drake <136637981+ChronicallyJD@users.noreply.github.com>
+Joshua D. Drake <jd@commandprompt.com> <offgridwithjd@gmail.com>
+Joshua D. Drake <jd@commandprompt.com> Joshua (D) Drake <offgridwithjd@gmail.com>


### PR DESCRIPTION
Adds a `.mailmap` mapping the earlier commit identities (the ChronicallyJD
GitHub-noreply address and an `offgridwithjd@gmail.com` address) to the jdatcmd
account, `Joshua D. Drake <jd@commandprompt.com>`. `git log`, `git shortlog`, and
the GitHub contributor view then show one author, without rewriting merged
history. Future commits already use this identity through the repo-local git
config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)