### PR TITLE
Phase D1: native format identity and catalog scaffolding

### DIFF
--- a/pgcolumnar--1.0.sql
+++ b/pgcolumnar--1.0.sql
@@ -167,6 +167,65 @@ CREATE UNIQUE INDEX projection_storage_idx
 	ON pgcolumnar.projection USING btree (proj_storage_id);
 
 /* ---------------------------------------------------------------------------
+ * Native format catalog (re-origination line, format PGCN v1).
+ *
+ * Additive scaffolding for the native on-disk format
+ * (design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md section 11). These tables are
+ * empty until the native writer (Phase D2) populates them; the 2.2-line catalog
+ * above is unaffected. Both format lines coexist per table until the native
+ * format becomes the default (Phase D6). Dropped with the extension; per-table
+ * row cleanup is wired into ColumnarDeleteMetadata when D2 begins writing them.
+ * ------------------------------------------------------------------------- */
+
+CREATE TABLE pgcolumnar.storage (
+	storage_id bigint NOT NULL,       -- native relation storage id
+	relation_oid oid NOT NULL,
+	format_version integer NOT NULL,  -- native format major version (1)
+	vector_length integer NOT NULL,   -- values per vector (1024)
+	row_group_limit integer NOT NULL  -- max rows per row group
+);
+CREATE UNIQUE INDEX storage_pkey
+	ON pgcolumnar.storage USING btree (storage_id);
+
+CREATE TABLE pgcolumnar.row_group (
+	storage_id bigint NOT NULL,
+	group_number bigint NOT NULL,     -- 0-based row group ordinal
+	file_offset bigint NOT NULL,      -- logical byte offset of the group
+	row_count bigint NOT NULL,
+	byte_length bigint NOT NULL,
+	sort_key smallint[] NOT NULL DEFAULT '{}'  -- attnums the group is sorted on
+);
+CREATE UNIQUE INDEX row_group_pkey
+	ON pgcolumnar.row_group USING btree (storage_id, group_number);
+
+CREATE TABLE pgcolumnar.column_chunk (
+	storage_id bigint NOT NULL,
+	group_number bigint NOT NULL,
+	column_index smallint NOT NULL,   -- 0-based attribute position
+	value_count bigint NOT NULL,
+	encoding_descriptor bytea NOT NULL, -- the chosen cascade (Phase D4)
+	block_codec smallint NOT NULL,    -- optional final block codec (0 = none)
+	page_offset bigint NOT NULL,      -- logical byte offset of the chunk's page
+	page_length bigint NOT NULL
+);
+CREATE UNIQUE INDEX column_chunk_pkey
+	ON pgcolumnar.column_chunk USING btree (storage_id, group_number, column_index);
+
+CREATE TABLE pgcolumnar.zone_map (
+	storage_id bigint NOT NULL,
+	group_number bigint NOT NULL,
+	column_index smallint NOT NULL,
+	vector_index integer NOT NULL,    -- -1 for the whole-chunk aggregate
+	minimum bytea,                    -- encoded per the column type
+	maximum bytea,
+	sum numeric,                      -- NULL when the type has no sum
+	value_count bigint NOT NULL,
+	null_count bigint NOT NULL
+);
+CREATE UNIQUE INDEX zone_map_pkey
+	ON pgcolumnar.zone_map USING btree (storage_id, group_number, column_index, vector_index);
+
+/* ---------------------------------------------------------------------------
  * Access method (spec 8.1)
  * ------------------------------------------------------------------------- */
 

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -35,6 +35,19 @@
 #define COLUMNAR_VERSION_MAJOR 2
 #define COLUMNAR_VERSION_MINOR 2
 
+/*
+ * Native format (re-origination line). A separate format line from the 2.2 line
+ * above, designed from public research and the open Arrow/Parquet/ORC specs; see
+ * design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md. It is identified by its own
+ * metapage magic and major version and has no requirement to read the 2.2 line.
+ * These are the Phase D1 scaffolding constants; the native metapage layout,
+ * writer, and reader land in D2/D3, and the cascade encoding and zone maps in
+ * D4/D5. Nothing writes the native format yet, so these are unused so far.
+ */
+#define COLUMNAR_NATIVE_MAGIC "PGCN"		/* native metapage magic tag */
+#define COLUMNAR_NATIVE_VERSION_MAJOR 1
+#define COLUMNAR_NATIVE_VECTOR_LENGTH 1024	/* values per vector (fixed) */
+
 /* first row number is 1 (spec 3) */
 #define COLUMNAR_FIRST_ROW_NUMBER 1
 

--- a/test/smoke.sh
+++ b/test/smoke.sh
@@ -111,6 +111,11 @@ check "null table nulls"   "$NNULL"    "1"
 check "null table value"   "$NVAL"     "z"
 check "orphan stripes"     "$ORPHANS"  "0"
 
+# Phase D1: the native format catalog tables exist (empty until the native
+# writer, Phase D2). Confirms CREATE EXTENSION created the additive catalog.
+NATIVE_TABLES="$(run_pg "$PSQL -c \"SELECT count(*) FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='pgcolumnar' AND c.relkind='r' AND c.relname IN ('storage','row_group','column_chunk','zone_map');\"")"
+check "native catalog tables" "$NATIVE_TABLES" "4"
+
 echo
 if [ "$fail" = "0" ]; then
 	echo "SMOKE TEST PASSED"


### PR DESCRIPTION
First sub-phase of the native format core (Phase D). Additive and
behavior-preserving: it adds the native format identity constants and the new
catalog tables, but nothing writes the native format yet (writer is D2), so
existing tables and every suite are unaffected. Targets `re-origination`.

- **src/columnar.h**: native format constants, separate from the 2.2 line:
  metapage magic tag `PGCN`, major version 1, fixed 1024-value vector length.
- **pgcolumnar--1.0.sql**: native catalog tables from the native spec section 11,
  alongside the 2.2 catalog: `pgcolumnar.storage`, `row_group`, `column_chunk`,
  `zone_map`, each with a unique index. Empty until D2; dropped with the extension.
- **test/smoke.sh**: asserts the four native catalog tables exist after
  `CREATE EXTENSION`, so the matrix validates the D1 deliverable.

Refinement to the plan: per-table format selection moves to D2 (where the writer
consumes it), keeping D1 pure additive scaffolding.

Builds and smoke pass on PG17; full PostgreSQL 13-19 matrix running, will confirm
green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)