### PR TITLE
Phase D2a: per-table native format selection

### DIFF
--- a/pgcolumnar--1.0.sql
+++ b/pgcolumnar--1.0.sql
@@ -128,7 +128,8 @@ CREATE TABLE pgcolumnar.options (
 	chunk_group_row_limit integer,
 	stripe_row_limit integer,
 	compression_level integer,
-	compression name
+	compression name,
+	format_version integer   -- NULL = 1.0-dev (2.2); 1 = native (PGCN v1)
 );
 
 CREATE UNIQUE INDEX options_pkey
@@ -311,7 +312,8 @@ CREATE FUNCTION pgcolumnar.alter_columnar_table_set(
 	chunk_group_row_limit int DEFAULT NULL,
 	stripe_row_limit int DEFAULT NULL,
 	compression name DEFAULT NULL,
-	compression_level int DEFAULT NULL)
+	compression_level int DEFAULT NULL,
+	format_version int DEFAULT NULL)
 	RETURNS void
 	LANGUAGE plpgsql
 	AS $alter_columnar_table_set$
@@ -319,6 +321,17 @@ BEGIN
 	IF compression IS NOT NULL AND
 	   compression NOT IN ('none', 'pglz', 'lz4', 'zstd') THEN
 		RAISE EXCEPTION 'unknown columnar compression "%"', compression;
+	END IF;
+
+	/*
+	 * format_version selects the on-disk format for this table's later writes.
+	 * NULL leaves it unchanged (the instance default, the 1.0-dev 2.2 format).
+	 * 1 is the native format (PGCN v1). The write path honors this starting in
+	 * the native writer phase; until then a value of 1 is recorded but writes
+	 * continue in the 2.2 format.
+	 */
+	IF format_version IS NOT NULL AND format_version <> 1 THEN
+		RAISE EXCEPTION 'unsupported format_version %, expected 1', format_version;
 	END IF;
 
 	/*
@@ -343,9 +356,9 @@ BEGIN
 
 	INSERT INTO pgcolumnar.options AS o
 		(regclass, chunk_group_row_limit, stripe_row_limit,
-		 compression, compression_level)
+		 compression, compression_level, format_version)
 	VALUES (table_name, chunk_group_row_limit, stripe_row_limit,
-			compression, compression_level)
+			compression, compression_level, format_version)
 	ON CONFLICT (regclass) DO UPDATE SET
 		chunk_group_row_limit =
 			COALESCE(EXCLUDED.chunk_group_row_limit, o.chunk_group_row_limit),
@@ -354,11 +367,13 @@ BEGIN
 		compression =
 			COALESCE(EXCLUDED.compression, o.compression),
 		compression_level =
-			COALESCE(EXCLUDED.compression_level, o.compression_level);
+			COALESCE(EXCLUDED.compression_level, o.compression_level),
+		format_version =
+			COALESCE(EXCLUDED.format_version, o.format_version);
 END;
 $alter_columnar_table_set$;
 
-COMMENT ON FUNCTION pgcolumnar.alter_columnar_table_set(regclass, int, int, name, int)
+COMMENT ON FUNCTION pgcolumnar.alter_columnar_table_set(regclass, int, int, name, int, int)
 	IS 'set per-table columnar options; NULL leaves a value unchanged';
 
 CREATE FUNCTION pgcolumnar.alter_columnar_table_reset(
@@ -366,7 +381,8 @@ CREATE FUNCTION pgcolumnar.alter_columnar_table_reset(
 	chunk_group_row_limit bool DEFAULT false,
 	stripe_row_limit bool DEFAULT false,
 	compression bool DEFAULT false,
-	compression_level bool DEFAULT false)
+	compression_level bool DEFAULT false,
+	format_version bool DEFAULT false)
 	RETURNS void
 	LANGUAGE plpgsql
 	AS $alter_columnar_table_reset$
@@ -383,12 +399,15 @@ BEGIN
 			THEN NULL ELSE o.compression END,
 		compression_level = CASE
 			WHEN alter_columnar_table_reset.compression_level
-			THEN NULL ELSE o.compression_level END
+			THEN NULL ELSE o.compression_level END,
+		format_version = CASE
+			WHEN alter_columnar_table_reset.format_version
+			THEN NULL ELSE o.format_version END
 	WHERE o.regclass = table_name;
 END;
 $alter_columnar_table_reset$;
 
-COMMENT ON FUNCTION pgcolumnar.alter_columnar_table_reset(regclass, bool, bool, bool, bool)
+COMMENT ON FUNCTION pgcolumnar.alter_columnar_table_reset(regclass, bool, bool, bool, bool, bool)
 	IS 'reset per-table columnar options to the instance defaults';
 
 /* ---------------------------------------------------------------------------

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -108,6 +108,8 @@ typedef struct ColumnarOptions
 	int			compressionType;	/* one of COLUMNAR_COMPRESSION_* */
 	bool		compressionLevelSet;
 	int			compressionLevel;
+	bool		formatVersionSet;
+	int			formatVersion;		/* native format major version, 1 = PGCN v1 */
 } ColumnarOptions;
 
 /* GUC-backed instance defaults (spec 8.3) */
@@ -320,6 +322,7 @@ extern void ColumnarDeleteMetadata(uint64 storageId);
 
 /* per-table options catalog (spec 7.4) */
 extern bool ColumnarReadOptions(Oid relid, ColumnarOptions *opts);
+extern int	ColumnarTableFormatVersion(Oid relid);
 extern void ColumnarDeleteOptions(Oid relid);
 
 /* projection catalog (gap 26, format 2.2). List entries are ColumnarProjection*

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -75,6 +75,7 @@
 #define Anum_options_stripe_row_limit 3
 #define Anum_options_compression_level 4
 #define Anum_options_compression 5
+#define Anum_options_format_version 6
 
 /* attribute numbers for columnar.projection (gap 26, format 2.2) */
 #define Anum_projection_storage_id 1
@@ -1011,11 +1012,35 @@ ColumnarReadOptions(Oid relid, ColumnarOptions *opts)
 				opts->compressionType = code;
 			}
 		}
+
+		d = heap_getattr(tuple, Anum_options_format_version, tupdesc, &isnull);
+		if (!isnull)
+		{
+			opts->formatVersionSet = true;
+			opts->formatVersion = DatumGetInt32(d);
+		}
 	}
 	systable_endscan(scan);
 	table_close(rel, AccessShareLock);
 
 	return found;
+}
+
+/*
+ * ColumnarTableFormatVersion
+ *		The on-disk format a relation's writes use: 0 for the 1.0-dev line (the
+ *		default, format 2.2), or the native major version (1) when the table's
+ *		format_version option is set. The native writer consults this to choose
+ *		the layout; until the native writer exists it is informational.
+ */
+int
+ColumnarTableFormatVersion(Oid relid)
+{
+	ColumnarOptions opts;
+
+	if (ColumnarReadOptions(relid, &opts) && opts.formatVersionSet)
+		return opts.formatVersion;
+	return 0;
 }
 
 /*

--- a/test/phase5.sh
+++ b/test/phase5.sh
@@ -212,6 +212,25 @@ q "INSERT INTO o_reset SELECT g FROM generate_series(1,5000) g;" >/dev/null
 check "reset restores default limit" \
 	"$(q "SELECT count(*) FROM pgcolumnar.chunk_group WHERE storage_id=pgcolumnar.get_storage_id('o_reset');")" "1"
 
+# Phase D2a: the format_version option round-trips (native writer honors it in a
+# later phase; here it is recorded and read back). An invalid value is rejected,
+# and the default is the 1.0-dev format (no row / NULL).
+echo "-- format_version option (native format selection)"
+q "CREATE TABLE o_fmt (a int) USING pgcolumnar;" >/dev/null
+check "format_version default legacy" \
+	"$(q "SELECT count(*) FROM pgcolumnar.options WHERE regclass='o_fmt'::regclass AND format_version IS NOT NULL;")" "0"
+q "SELECT pgcolumnar.alter_columnar_table_set('o_fmt', format_version => 1);" >/dev/null
+check "format_version set to native" \
+	"$(q "SELECT format_version FROM pgcolumnar.options WHERE regclass='o_fmt'::regclass;")" "1"
+if q "SELECT pgcolumnar.alter_columnar_table_set('o_fmt', format_version => 2);" >/dev/null 2>&1; then
+	echo "FAIL  format_version invalid rejected: expected error"; fail=1
+else
+	echo "PASS  format_version invalid rejected"
+fi
+q "SELECT pgcolumnar.alter_columnar_table_reset('o_fmt', format_version => true);" >/dev/null
+check "format_version reset to legacy" \
+	"$(q "SELECT format_version FROM pgcolumnar.options WHERE regclass='o_fmt'::regclass;")" ""
+
 # ---------------------------------------------------------------------------
 # Vacuum: combine small stripes and reclaim deleted rows, returning correct
 # data. stripe_row_limit=1000 makes 5 stripes; after deleting half and vacuum


### PR DESCRIPTION
Sub-phase of the native format core. Adds the per-table `format_version` option
the native writer (D2b) will branch on. Plumbing only: the write path still
produces the 1.0-dev (2.2) format, so behavior is unchanged. Targets
`re-origination`.

- `pgcolumnar.options` gains a `format_version` column (NULL = 1.0-dev 2.2; 1 =
  native PGCN v1). `alter_columnar_table_set` accepts `format_version` (validated
  to NULL or 1); `alter_columnar_table_reset` accepts a `format_version` flag.
- `ColumnarOptions` gains the field; `ColumnarReadOptions` reads it; new helper
  `ColumnarTableFormatVersion(relid)` returns 0 (1.0-dev) or the native major
  version. Unused by the write path until D2b.
- phase5.sh asserts default-legacy, set-to-native, invalid-rejected, and reset.

Builds and phase5 pass on PG17; full 13-19 matrix running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)