### PR TITLE
Phase D2b: native writer (baseline uncompressed row groups)

### DIFF
--- a/src/columnar.h
+++ b/src/columnar.h
@@ -174,6 +174,41 @@ typedef struct ChunkGroupMetadata
 	uint64		deletedRows;
 } ChunkGroupMetadata;
 
+/* -------------------------------------------------------------------------
+ * Native format catalog row shapes (re-origination line, PGCN v1). These map
+ * to pgcolumnar.storage / row_group / column_chunk (native spec section 11).
+ * ------------------------------------------------------------------------- */
+typedef struct NativeStorageMetadata
+{
+	uint64		storageId;
+	Oid			relationOid;
+	int			formatVersion;
+	int			vectorLength;
+	int			rowGroupLimit;
+} NativeStorageMetadata;
+
+typedef struct NativeRowGroupMetadata
+{
+	uint64		storageId;
+	uint64		groupNumber;
+	uint64		fileOffset;
+	uint64		rowCount;
+	uint64		byteLength;
+} NativeRowGroupMetadata;
+
+typedef struct NativeColumnChunkMetadata
+{
+	uint64		storageId;
+	uint64		groupNumber;
+	int			columnIndex;
+	uint64		valueCount;
+	const char *encodingDescriptor;	/* bytea payload */
+	uint32		encodingDescriptorLen;
+	int			blockCodec;			/* 0 = none */
+	uint64		pageOffset;
+	uint64		pageLength;
+} NativeColumnChunkMetadata;
+
 /*
  * One columnar.row_mask row (spec 7.5). Covers the row-number range
  * [startRowNumber, endRowNumber] of a single chunk group; a set bit in mask
@@ -313,6 +348,9 @@ extern void ColumnarInsertStripeRow(const StripeMetadata *stripe);
 extern void ColumnarInsertChunkGroupRow(uint64 storageId,
 										const ChunkGroupMetadata *cg);
 extern void ColumnarInsertChunkRow(uint64 storageId, const ChunkMetadata *chunk);
+extern void ColumnarInsertNativeStorageRow(const NativeStorageMetadata *s);
+extern void ColumnarInsertRowGroupRow(const NativeRowGroupMetadata *rg);
+extern void ColumnarInsertColumnChunkRow(const NativeColumnChunkMetadata *cc);
 extern List *ColumnarReadStripeList(uint64 storageId, Snapshot snapshot);
 extern List *ColumnarReadChunkGroupList(uint64 storageId, uint64 stripeNum,
 										Snapshot snapshot);

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -86,6 +86,32 @@
 #define Anum_projection_columns 6
 #define Natts_projection 6
 
+/* attribute numbers for the native format catalog (PGCN v1, native spec 11) */
+#define Anum_native_storage_storage_id 1
+#define Anum_native_storage_relation_oid 2
+#define Anum_native_storage_format_version 3
+#define Anum_native_storage_vector_length 4
+#define Anum_native_storage_row_group_limit 5
+#define Natts_native_storage 5
+
+#define Anum_row_group_storage_id 1
+#define Anum_row_group_group_number 2
+#define Anum_row_group_file_offset 3
+#define Anum_row_group_row_count 4
+#define Anum_row_group_byte_length 5
+#define Anum_row_group_sort_key 6
+#define Natts_row_group 6
+
+#define Anum_column_chunk_storage_id 1
+#define Anum_column_chunk_group_number 2
+#define Anum_column_chunk_column_index 3
+#define Anum_column_chunk_value_count 4
+#define Anum_column_chunk_encoding_descriptor 5
+#define Anum_column_chunk_block_codec 6
+#define Anum_column_chunk_page_offset 7
+#define Anum_column_chunk_page_length 8
+#define Natts_column_chunk 8
+
 /* attribute numbers for columnar.row_mask (spec 7.5) */
 #define Anum_row_mask_id 1
 #define Anum_row_mask_storage_id 2
@@ -919,6 +945,113 @@ ColumnarDeleteMetadata(uint64 storageId)
 	delete_rows_by_storage_id("chunk_group", Anum_chunk_group_storage_id, storageId);
 	delete_rows_by_storage_id("row_mask", Anum_row_mask_storage_id, storageId);
 	delete_rows_by_storage_id("stripe", Anum_stripe_storage_id, storageId);
+	/* native format catalog (PGCN v1); no-op rows for 2.2-line tables */
+	delete_rows_by_storage_id("column_chunk", Anum_column_chunk_storage_id, storageId);
+	delete_rows_by_storage_id("row_group", Anum_row_group_storage_id, storageId);
+	delete_rows_by_storage_id("storage", Anum_native_storage_storage_id, storageId);
+}
+
+/*
+ * ColumnarInsertNativeStorageRow, ColumnarInsertRowGroupRow,
+ * ColumnarInsertColumnChunkRow
+ *		Record the native-format catalog rows (PGCN v1, native spec 11). Called
+ *		by the native writer's flush. The 2.2-line writer does not use these.
+ */
+void
+ColumnarInsertNativeStorageRow(const NativeStorageMetadata *s)
+{
+	Relation	rel = open_columnar_table("storage", RowExclusiveLock);
+	TupleDesc	tupdesc = RelationGetDescr(rel);
+	Datum		values[Natts_native_storage];
+	bool		nulls[Natts_native_storage];
+	HeapTuple	tuple;
+	Snapshot	base;
+	Snapshot	snapshot;
+	ScanKeyData key[1];
+	SysScanDesc scan;
+	bool		exists;
+
+	/* idempotent: the storage row is written once per storage id, but the
+	 * native writer calls this on every row-group flush */
+	base = ActiveSnapshotSet() ? GetActiveSnapshot() : GetTransactionSnapshot();
+	snapshot = ColumnarCatalogSnapshot(base);
+	ScanKeyInit(&key[0], Anum_native_storage_storage_id, BTEqualStrategyNumber,
+				F_INT8EQ, Int64GetDatum((int64) s->storageId));
+	scan = systable_beginscan(rel, InvalidOid, false, snapshot, 1, key);
+	exists = HeapTupleIsValid(systable_getnext(scan));
+	systable_endscan(scan);
+	if (exists)
+	{
+		table_close(rel, RowExclusiveLock);
+		return;
+	}
+
+	memset(nulls, false, sizeof(nulls));
+	values[Anum_native_storage_storage_id - 1] = Int64GetDatum((int64) s->storageId);
+	values[Anum_native_storage_relation_oid - 1] = ObjectIdGetDatum(s->relationOid);
+	values[Anum_native_storage_format_version - 1] = Int32GetDatum(s->formatVersion);
+	values[Anum_native_storage_vector_length - 1] = Int32GetDatum(s->vectorLength);
+	values[Anum_native_storage_row_group_limit - 1] = Int32GetDatum(s->rowGroupLimit);
+
+	tuple = heap_form_tuple(tupdesc, values, nulls);
+	CatalogTupleInsert(rel, tuple);
+	heap_freetuple(tuple);
+	table_close(rel, RowExclusiveLock);
+}
+
+void
+ColumnarInsertRowGroupRow(const NativeRowGroupMetadata *rg)
+{
+	Relation	rel = open_columnar_table("row_group", RowExclusiveLock);
+	TupleDesc	tupdesc = RelationGetDescr(rel);
+	Datum		values[Natts_row_group];
+	bool		nulls[Natts_row_group];
+	HeapTuple	tuple;
+
+	memset(nulls, false, sizeof(nulls));
+	values[Anum_row_group_storage_id - 1] = Int64GetDatum((int64) rg->storageId);
+	values[Anum_row_group_group_number - 1] = Int64GetDatum((int64) rg->groupNumber);
+	values[Anum_row_group_file_offset - 1] = Int64GetDatum((int64) rg->fileOffset);
+	values[Anum_row_group_row_count - 1] = Int64GetDatum((int64) rg->rowCount);
+	values[Anum_row_group_byte_length - 1] = Int64GetDatum((int64) rg->byteLength);
+	values[Anum_row_group_sort_key - 1] =
+		PointerGetDatum(construct_empty_array(INT2OID));
+
+	tuple = heap_form_tuple(tupdesc, values, nulls);
+	CatalogTupleInsert(rel, tuple);
+	heap_freetuple(tuple);
+	table_close(rel, RowExclusiveLock);
+}
+
+void
+ColumnarInsertColumnChunkRow(const NativeColumnChunkMetadata *cc)
+{
+	Relation	rel = open_columnar_table("column_chunk", RowExclusiveLock);
+	TupleDesc	tupdesc = RelationGetDescr(rel);
+	Datum		values[Natts_column_chunk];
+	bool		nulls[Natts_column_chunk];
+	HeapTuple	tuple;
+	bytea	   *desc;
+
+	memset(nulls, false, sizeof(nulls));
+	desc = (bytea *) palloc(VARHDRSZ + cc->encodingDescriptorLen);
+	SET_VARSIZE(desc, VARHDRSZ + cc->encodingDescriptorLen);
+	if (cc->encodingDescriptorLen > 0)
+		memcpy(VARDATA(desc), cc->encodingDescriptor, cc->encodingDescriptorLen);
+
+	values[Anum_column_chunk_storage_id - 1] = Int64GetDatum((int64) cc->storageId);
+	values[Anum_column_chunk_group_number - 1] = Int64GetDatum((int64) cc->groupNumber);
+	values[Anum_column_chunk_column_index - 1] = Int16GetDatum((int16) cc->columnIndex);
+	values[Anum_column_chunk_value_count - 1] = Int64GetDatum((int64) cc->valueCount);
+	values[Anum_column_chunk_encoding_descriptor - 1] = PointerGetDatum(desc);
+	values[Anum_column_chunk_block_codec - 1] = Int16GetDatum((int16) cc->blockCodec);
+	values[Anum_column_chunk_page_offset - 1] = Int64GetDatum((int64) cc->pageOffset);
+	values[Anum_column_chunk_page_length - 1] = Int64GetDatum((int64) cc->pageLength);
+
+	tuple = heap_form_tuple(tupdesc, values, nulls);
+	CatalogTupleInsert(rel, tuple);
+	heap_freetuple(tuple);
+	table_close(rel, RowExclusiveLock);
 }
 
 /* -------------------------------------------------------------------------

--- a/src/columnar_write_state.c
+++ b/src/columnar_write_state.c
@@ -108,6 +108,15 @@ struct ColumnarWriteState
 	 */
 	bool		projInited;
 	List	   *projWriters;	/* list of ColumnarProjWriter * */
+
+	/*
+	 * Native format (re-origination line, PGCN v1). When isNative, a stripe
+	 * flush is laid out as a native row group and recorded in the native catalog
+	 * (Phase D2b) instead of the 2.2 stripe/chunk catalog. nativeNextGroup is the
+	 * 0-based row group ordinal assigned at each flush.
+	 */
+	bool		isNative;
+	uint64		nativeNextGroup;
 };
 
 /* per-backend registry of pending write states, in ColumnarWriteContext */
@@ -115,6 +124,7 @@ static MemoryContext ColumnarWriteContext = NULL;
 static List *ColumnarWriteStates = NIL;
 
 static void columnar_flush_stripe(ColumnarWriteState *writeState);
+static void columnar_flush_row_group(ColumnarWriteState *writeState);
 static ChunkGroupBuffer *columnar_start_chunk_group(ColumnarWriteState *writeState);
 static void columnar_init_col_defs(ColumnarWriteState *writeState);
 
@@ -231,6 +241,9 @@ ColumnarGetWriteState(Relation rel)
 				writeState->compressionType = opts.compressionType;
 			if (opts.compressionLevelSet)
 				writeState->compressionLevel = opts.compressionLevel;
+			if (opts.formatVersionSet &&
+				opts.formatVersion == COLUMNAR_NATIVE_VERSION_MAJOR)
+				writeState->isNative = true;
 		}
 	}
 
@@ -516,6 +529,13 @@ columnar_flush_stripe(ColumnarWriteState *writeState)
 	if (writeState->stripeRowCount == 0)
 		return;
 
+	/* native format (PGCN v1) uses a separate row-group flush and catalog */
+	if (writeState->isNative)
+	{
+		columnar_flush_row_group(writeState);
+		return;
+	}
+
 	/*
 	 * Catalog inserts need an active snapshot. At transaction pre-commit the
 	 * executor snapshot has already been popped, so push a transaction
@@ -701,6 +721,148 @@ columnar_flush_stripe(ColumnarWriteState *writeState)
 	MemoryContextDelete(flushContext);
 
 	/* reset stripe accumulation; the next row reserves a fresh stripe */
+	MemoryContextReset(writeState->stripeContext);
+	writeState->chunkGroups = NIL;
+	writeState->currentGroup = NULL;
+	writeState->stripeRowCount = 0;
+	writeState->haveReservation = false;
+
+	if (pushedSnapshot)
+		PopActiveSnapshot();
+}
+
+/*
+ * columnar_flush_row_group
+ *		Native-format (PGCN v1) flush. Lay out the accumulated rows as one row
+ *		group: each column is a column chunk of [validity bitmap][uncompressed
+ *		values], where the validity bitmap is one bit per row (LSB-first) and the
+ *		values are the concatenated present-value streams. Write the bytes to the
+ *		relation file and record the native catalog rows (storage, row_group,
+ *		column_chunk). Phase D2b baseline: the encoding is uncompressed; the
+ *		cascade and zone maps arrive in D4/D5 and the native reader in D3.
+ */
+static void
+columnar_flush_row_group(ColumnarWriteState *writeState)
+{
+	MemoryContext flushContext;
+	MemoryContext oldContext;
+	Relation	rel;
+	int			natts = writeState->natts;
+	StringInfo	data;
+	uint64	   *chunkOffset;
+	uint64	   *chunkLength;
+	uint64		rowCount = writeState->stripeRowCount;
+	uint64		groupNumber = writeState->nativeNextGroup;
+	uint64		fileOffset;
+	uint64		dataLength;
+	int			validityBytes = (int) ((rowCount + 7) / 8);
+	ListCell   *lc;
+	int			c;
+	bool		pushedSnapshot = false;
+
+	if (!ActiveSnapshotSet())
+	{
+		PushActiveSnapshot(GetTransactionSnapshot());
+		pushedSnapshot = true;
+	}
+
+	flushContext = AllocSetContextCreate(CurrentMemoryContext,
+										 "columnar native flush",
+										 ALLOCSET_DEFAULT_SIZES);
+	oldContext = MemoryContextSwitchTo(flushContext);
+
+	data = makeStringInfo();
+	chunkOffset = palloc0(sizeof(uint64) * natts);
+	chunkLength = palloc0(sizeof(uint64) * natts);
+
+	/* build the row group column-major: each column chunk is validity + values */
+	for (c = 0; c < natts; c++)
+	{
+		uint8	   *validity = (uint8 *) palloc0(validityBytes);
+		uint64		rowIdx = 0;
+
+		chunkOffset[c] = data->len;
+
+		foreach(lc, writeState->chunkGroups)
+		{
+			ChunkGroupBuffer *group = (ChunkGroupBuffer *) lfirst(lc);
+			ColumnChunkBuffer *col = &group->columns[c];
+			char	   *existsBytes = col->existsStream.data;
+			uint64		i;
+
+			for (i = 0; i < group->rowCount; i++, rowIdx++)
+				if (existsBytes[i])
+					validity[rowIdx >> 3] |= (uint8) (1 << (rowIdx & 7));
+		}
+		appendBinaryStringInfo(data, (char *) validity, validityBytes);
+
+		foreach(lc, writeState->chunkGroups)
+		{
+			ChunkGroupBuffer *group = (ChunkGroupBuffer *) lfirst(lc);
+			ColumnChunkBuffer *col = &group->columns[c];
+
+			if (col->valueStream.len > 0)
+				appendBinaryStringInfo(data, col->valueStream.data,
+									   col->valueStream.len);
+		}
+
+		chunkLength[c] = data->len - chunkOffset[c];
+	}
+
+	dataLength = data->len;
+
+	rel = table_open(writeState->relid, RowExclusiveLock);
+	LockRelationForExtension(rel, ExclusiveLock);
+	ColumnarReserveOffset(rel, dataLength, &fileOffset);
+	if (dataLength > 0)
+		ColumnarWriteLogicalData(rel, fileOffset, data->data, dataLength);
+	UnlockRelationForExtension(rel, ExclusiveLock);
+
+	{
+		NativeStorageMetadata s;
+
+		s.storageId = writeState->storageId;
+		s.relationOid = writeState->relid;
+		s.formatVersion = COLUMNAR_NATIVE_VERSION_MAJOR;
+		s.vectorLength = COLUMNAR_NATIVE_VECTOR_LENGTH;
+		s.rowGroupLimit = writeState->stripeRowLimit;
+		ColumnarInsertNativeStorageRow(&s);
+	}
+	{
+		NativeRowGroupMetadata rg;
+
+		rg.storageId = writeState->storageId;
+		rg.groupNumber = groupNumber;
+		rg.fileOffset = fileOffset;
+		rg.rowCount = rowCount;
+		rg.byteLength = dataLength;
+		ColumnarInsertRowGroupRow(&rg);
+	}
+	for (c = 0; c < natts; c++)
+	{
+		NativeColumnChunkMetadata cc;
+		uint8		desc = 0;		/* 0 = uncompressed baseline (D2b) */
+
+		cc.storageId = writeState->storageId;
+		cc.groupNumber = groupNumber;
+		cc.columnIndex = c;
+		cc.valueCount = rowCount;
+		cc.encodingDescriptor = (const char *) &desc;
+		cc.encodingDescriptorLen = 1;
+		cc.blockCodec = 0;
+		cc.pageOffset = fileOffset + chunkOffset[c];
+		cc.pageLength = chunkLength[c];
+		ColumnarInsertColumnChunkRow(&cc);
+	}
+
+	table_close(rel, RowExclusiveLock);
+
+	MemoryContextSwitchTo(oldContext);
+	MemoryContextDelete(flushContext);
+
+	writeState->nativeNextGroup = groupNumber + 1;
+
+	/* reset accumulation; the next row reserves a fresh row group */
 	MemoryContextReset(writeState->stripeContext);
 	writeState->chunkGroups = NIL;
 	writeState->currentGroup = NULL;

--- a/test/native_writer.sh
+++ b/test/native_writer.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# pgColumnar native writer (Phase D2b): a table with format_version = 1 writes
+# the native format (PGCN v1) instead of the 1.0-dev 2.2 format. There is no
+# native reader yet (Phase D3), so this validates the writer by its catalog
+# output: the pgcolumnar.storage / row_group / column_chunk rows it produces, and
+# that a default (legacy) table does not touch the native catalog. It does not
+# SELECT data from a native table.
+#
+# Usage:  test/native_writer.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+# A native table with a small row-group limit so several row groups are written.
+psql_run "CREATE TABLE nw (id int, v text) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.alter_columnar_table_set('nw', stripe_row_limit => 1000, format_version => 1);"
+psql_run "INSERT INTO nw SELECT g, CASE WHEN g % 4 = 0 THEN NULL ELSE 'v'||g END FROM generate_series(1, 5000) g;"
+
+SID="$(q "SELECT pgcolumnar.get_storage_id('nw');")"
+check "native storage row written" \
+	"$(q "SELECT count(*) FROM pgcolumnar.storage WHERE storage_id = $SID;")" "1"
+check "native format version recorded" \
+	"$(q "SELECT format_version FROM pgcolumnar.storage WHERE storage_id = $SID;")" "1"
+check "native vector length recorded" \
+	"$(q "SELECT vector_length FROM pgcolumnar.storage WHERE storage_id = $SID;")" "1024"
+check "native row groups (5000 rows / 1000 limit)" \
+	"$(q "SELECT count(*) FROM pgcolumnar.row_group WHERE storage_id = $SID;")" "5"
+check "native row-group row total" \
+	"$(q "SELECT sum(row_count) FROM pgcolumnar.row_group WHERE storage_id = $SID;")" "5000"
+check "native column chunks (5 groups x 2 cols)" \
+	"$(q "SELECT count(*) FROM pgcolumnar.column_chunk WHERE storage_id = $SID;")" "10"
+check "native column-chunk value total" \
+	"$(q "SELECT sum(value_count) FROM pgcolumnar.column_chunk WHERE storage_id = $SID;")" "10000"
+# native writes bypass the 2.2 stripe catalog
+check "native writes no 2.2 stripes" \
+	"$(q "SELECT count(*) FROM pgcolumnar.stripe WHERE storage_id = $SID;")" "0"
+
+# A default (legacy) table writes the 2.2 catalog and NOT the native catalog.
+psql_run "CREATE TABLE leg (id int) USING pgcolumnar;"
+psql_run "INSERT INTO leg SELECT g FROM generate_series(1, 2000) g;"
+LID="$(q "SELECT pgcolumnar.get_storage_id('leg');")"
+check "legacy writes 2.2 stripes" \
+	"$(q "SELECT count(*) > 0 FROM pgcolumnar.stripe WHERE storage_id = $LID;")" "t"
+check "legacy writes no native storage row" \
+	"$(q "SELECT count(*) FROM pgcolumnar.storage WHERE storage_id = $LID;")" "0"
+
+# Drop cleanup removes the native catalog rows for the storage.
+psql_run "DROP TABLE nw;"
+check "drop clears native storage row" \
+	"$(q "SELECT count(*) FROM pgcolumnar.storage WHERE storage_id = $SID;")" "0"
+check "drop clears native row groups" \
+	"$(q "SELECT count(*) FROM pgcolumnar.row_group WHERE storage_id = $SID;")" "0"
+check "drop clears native column chunks" \
+	"$(q "SELECT count(*) FROM pgcolumnar.column_chunk WHERE storage_id = $SID;")" "0"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -26,7 +26,7 @@ SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUITES=(smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
 	differential recovery fuzz hardening concurrent_diff parallel sorted_projection \
 	arrow_export parquet_export read_stream corruption \
-	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import)
+	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer)
 
 # Default matrix: one assert-enabled pg_config per major, 13 through 19.
 DEFAULT_CONFIGS=(


### PR DESCRIPTION
Implements the native-format (PGCN v1) write path. A table with `format_version =
1` writes the native layout and catalog instead of the 1.0-dev 2.2 format;
default tables are unchanged. No native reader yet (D3), so this is validated by
the catalog it produces. Targets `re-origination`.

- **Native catalog write helpers** (columnar_metadata.c):
  `ColumnarInsertNativeStorageRow` (idempotent per storage id),
  `ColumnarInsertRowGroupRow`, `ColumnarInsertColumnChunkRow`, with Anum defines and
  row-shape structs. `ColumnarDeleteMetadata` clears native rows on drop.
- **Write state** (columnar_write_state.c): `isNative` from the `format_version`
  option; `columnar_flush_row_group` lays out each column as a column chunk of
  `[validity bitmap][uncompressed values]`, reserves/writes bytes with the
  existing offset machinery, and records storage/row_group/column_chunk. A stripe
  flush routes here when native. Baseline encoding uncompressed; cascade (D4) and
  zone maps (D5) follow, reader is D3.
- **test/native_writer.sh** (in the matrix): asserts the native catalog rows,
  legacy isolation, and drop cleanup.

Known D2b simplification: a native table still carries the 2.2 metapage version;
the format is selected by the option and catalog, not the metapage yet. Builds
and native_writer pass on PG17; full PostgreSQL 13-19 matrix running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)