### PR TITLE
Phase D3: native reader (sequential round-trip)

### DIFF
--- a/design/PHASE_D3_PLAN.md
+++ b/design/PHASE_D3_PLAN.md
@@ -1,0 +1,80 @@
+# Phase D3 plan: native reader
+
+Status: plan, on the `re-origination` branch (`phase-d/d3-native-reader`). D3 makes
+native-format (PGCN v1) tables round-trip: it reads the row groups and column
+chunks the D2b writer produced and feeds them to the executor, so a native table
+can be scanned. Once it works, the differential oracle runs its suites against
+native tables (heap as the correctness oracle), which is the real validation the
+writer has been waiting for.
+
+## What D2b wrote (the read contract)
+
+For a native table (storage id S):
+
+- `pgcolumnar.storage` has one row: format_version 1, vector_length 1024,
+  row_group_limit.
+- `pgcolumnar.row_group` has one row per group: group_number, file_offset,
+  row_count, byte_length.
+- `pgcolumnar.column_chunk` has one row per (group, column): value_count (= group
+  row count), encoding_descriptor (1 byte, 0 = uncompressed), block_codec (0),
+  page_offset (logical byte offset), page_length.
+- On disk at page_offset, each column chunk is `[validity bitmap][values]`:
+  - validity: `ceil(row_count / 8)` bytes, one bit per row, LSB-first; set = present.
+  - values: the present values only, serialized exactly as `ColumnarWriteRow`
+    buffers them (the same bytes `ColumnarDecodeValue` reads in the 2.2 fetch
+    path), concatenated in row order.
+
+## Design
+
+Extend the existing reader (`columnar_reader.c`) with a native mode rather than a
+separate scan object, so the AM scan callbacks and the row-mask visibility path
+are reused unchanged.
+
+- Add `bool isNative` to `ColumnarReadState`, plus native cursors: the row_group
+  list, the current group's per-column decoded state (a value cursor into the
+  chunk's values, a pointer to the chunk's validity bitmap, and a running present
+  index), the current group index, and row-in-group.
+- `ColumnarBeginRead` / `ColumnarBeginReadWithStorage`: detect native via
+  `ColumnarTableFormatVersion(relid) == COLUMNAR_NATIVE_VERSION_MAJOR` (or a
+  storage-row lookup). When native, load the row_group list and the
+  column_chunk map for S instead of the stripe list.
+- `ColumnarReadNextRow`: when native, iterate row groups; for the current group,
+  on first entry read each projected column's chunk bytes with
+  `ColumnarReadLogicalData` into the group context and split into
+  `[validity][values]`. For each row, for each column, read the validity bit; if
+  set, `ColumnarDecodeValue` from that column's value cursor; else NULL. Advance
+  to the next group at end.
+- `ColumnarEndRead` / `ColumnarRescanRead`: reset the native cursors alongside the
+  existing teardown.
+
+### Scope for D3 (kept minimal, symmetric with the D2b baseline)
+
+- Sequential scan only. Native tables bypass, for now: chunk-group skip predicates
+  (there are no native zone maps until D5), the vectorized fast paths, projection
+  pushdown (read all columns, project in the slot), and parallel scan. These are
+  correctness-neutral (the executor re-applies quals and projection) and are
+  optimized in later sub-phases.
+- Delete visibility: native tables still record deletes through the existing row
+  mask (D2b reused the 2.2 delete marking), so the reader applies the same
+  `groupMask` logic keyed by row number. If wiring the row mask into the native
+  group iteration proves intricate, D3 may first validate insert-only round-trips
+  and defer delete visibility to a follow-up, but the target is full DML parity.
+
+## Validation
+
+- A new `native_roundtrip.sh`: create a native table, insert scalar data with
+  nulls across several row groups, and compare `SELECT`s against a heap mirror
+  with the differential oracle (order-independent set hash). This is the first
+  time native data is read back.
+- Extend the differential oracle (`test/lib.sh` `make_pair`) so a columnar side
+  can be created native, and run a native pass of the core differential suite.
+- Full PostgreSQL 13-19 matrix.
+
+## Risks
+
+- The reader is intricate (MVCC snapshot, row mask, projection, skip, parallel).
+  The native branch deliberately bypasses the optimizations and reuses only the
+  visibility essentials, keeping the change surface small and correctness-first.
+- The values-stream decode must match the writer's buffering exactly; it reuses
+  `ColumnarDecodeValue`, the same decoder the 2.2 fetch-by-tid path uses, so the
+  encoding contract is shared and already exercised.

--- a/pgcolumnar--1.0.sql
+++ b/pgcolumnar--1.0.sql
@@ -194,6 +194,7 @@ CREATE TABLE pgcolumnar.row_group (
 	file_offset bigint NOT NULL,      -- logical byte offset of the group
 	row_count bigint NOT NULL,
 	byte_length bigint NOT NULL,
+	first_row_number bigint NOT NULL, -- row number of the group's first row
 	sort_key smallint[] NOT NULL DEFAULT '{}'  -- attnums the group is sorted on
 );
 CREATE UNIQUE INDEX row_group_pkey

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -194,6 +194,7 @@ typedef struct NativeRowGroupMetadata
 	uint64		fileOffset;
 	uint64		rowCount;
 	uint64		byteLength;
+	uint64		firstRowNumber;
 } NativeRowGroupMetadata;
 
 typedef struct NativeColumnChunkMetadata
@@ -351,6 +352,9 @@ extern void ColumnarInsertChunkRow(uint64 storageId, const ChunkMetadata *chunk)
 extern void ColumnarInsertNativeStorageRow(const NativeStorageMetadata *s);
 extern void ColumnarInsertRowGroupRow(const NativeRowGroupMetadata *rg);
 extern void ColumnarInsertColumnChunkRow(const NativeColumnChunkMetadata *cc);
+extern List *ColumnarReadRowGroupList(uint64 storageId, Snapshot snapshot);
+extern List *ColumnarReadColumnChunkList(uint64 storageId, uint64 groupNumber,
+										 Snapshot snapshot);
 extern List *ColumnarReadStripeList(uint64 storageId, Snapshot snapshot);
 extern List *ColumnarReadChunkGroupList(uint64 storageId, uint64 stripeNum,
 										Snapshot snapshot);

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -535,6 +535,16 @@ ColumnarSetRelPathlist(PlannerInfo *root, RelOptInfo *rel, Index rti,
 	if (!OidIsValid(rte->relid) || !ColumnarIsColumnarRelation(rte->relid))
 		return;
 
+	/*
+	 * Native-format tables (PGCN v1) are read only through the base access-method
+	 * scan (ColumnarReadNextRow, which is native-aware) in Phase D3. The custom
+	 * scan's vectorized paths and metadata count(*) read the 2.2 stripe/chunk
+	 * catalog, which a native table does not populate, so skip them here; the
+	 * native vectorized path is a later sub-phase.
+	 */
+	if (ColumnarTableFormatVersion(rte->relid) == COLUMNAR_NATIVE_VERSION_MAJOR)
+		return;
+
 	/* find a non-parameterized seqscan path to inherit its costs from */
 	foreach(lc, rel->pathlist)
 	{

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -99,8 +99,9 @@
 #define Anum_row_group_file_offset 3
 #define Anum_row_group_row_count 4
 #define Anum_row_group_byte_length 5
-#define Anum_row_group_sort_key 6
-#define Natts_row_group 6
+#define Anum_row_group_first_row_number 6
+#define Anum_row_group_sort_key 7
+#define Natts_row_group 7
 
 #define Anum_column_chunk_storage_id 1
 #define Anum_column_chunk_group_number 2
@@ -1014,6 +1015,7 @@ ColumnarInsertRowGroupRow(const NativeRowGroupMetadata *rg)
 	values[Anum_row_group_file_offset - 1] = Int64GetDatum((int64) rg->fileOffset);
 	values[Anum_row_group_row_count - 1] = Int64GetDatum((int64) rg->rowCount);
 	values[Anum_row_group_byte_length - 1] = Int64GetDatum((int64) rg->byteLength);
+	values[Anum_row_group_first_row_number - 1] = Int64GetDatum((int64) rg->firstRowNumber);
 	values[Anum_row_group_sort_key - 1] =
 		PointerGetDatum(construct_empty_array(INT2OID));
 
@@ -1052,6 +1054,119 @@ ColumnarInsertColumnChunkRow(const NativeColumnChunkMetadata *cc)
 	CatalogTupleInsert(rel, tuple);
 	heap_freetuple(tuple);
 	table_close(rel, RowExclusiveLock);
+}
+
+/* order native row groups by group_number */
+static int
+row_group_cmp(const ListCell *a, const ListCell *b)
+{
+	const NativeRowGroupMetadata *ra = lfirst(a);
+	const NativeRowGroupMetadata *rb = lfirst(b);
+
+	if (ra->groupNumber < rb->groupNumber)
+		return -1;
+	if (ra->groupNumber > rb->groupNumber)
+		return 1;
+	return 0;
+}
+
+/*
+ * ColumnarReadRowGroupList
+ *		The native row groups of a storage, ordered by group number.
+ */
+List *
+ColumnarReadRowGroupList(uint64 storageId, Snapshot snapshot)
+{
+	Relation	rel = open_columnar_table("row_group", AccessShareLock);
+	TupleDesc	tupdesc = RelationGetDescr(rel);
+	ScanKeyData key[1];
+	SysScanDesc scan;
+	HeapTuple	tuple;
+	List	   *result = NIL;
+
+	ScanKeyInit(&key[0], Anum_row_group_storage_id, BTEqualStrategyNumber,
+				F_INT8EQ, Int64GetDatum((int64) storageId));
+	scan = systable_beginscan(rel, InvalidOid, false, snapshot, 1, key);
+	while (HeapTupleIsValid(tuple = systable_getnext(scan)))
+	{
+		NativeRowGroupMetadata *rg = palloc0(sizeof(NativeRowGroupMetadata));
+		bool		isnull;
+
+		rg->storageId = storageId;
+		rg->groupNumber = (uint64) DatumGetInt64(
+			heap_getattr(tuple, Anum_row_group_group_number, tupdesc, &isnull));
+		rg->fileOffset = (uint64) DatumGetInt64(
+			heap_getattr(tuple, Anum_row_group_file_offset, tupdesc, &isnull));
+		rg->rowCount = (uint64) DatumGetInt64(
+			heap_getattr(tuple, Anum_row_group_row_count, tupdesc, &isnull));
+		rg->byteLength = (uint64) DatumGetInt64(
+			heap_getattr(tuple, Anum_row_group_byte_length, tupdesc, &isnull));
+		rg->firstRowNumber = (uint64) DatumGetInt64(
+			heap_getattr(tuple, Anum_row_group_first_row_number, tupdesc, &isnull));
+		result = lappend(result, rg);
+	}
+	systable_endscan(scan);
+	table_close(rel, AccessShareLock);
+
+	list_sort(result, row_group_cmp);
+	return result;
+}
+
+/*
+ * ColumnarReadColumnChunkList
+ *		The native column chunks of one row group. The caller indexes the result
+ *		by column_index; the encoding descriptor bytes are copied into the
+ *		current memory context.
+ */
+List *
+ColumnarReadColumnChunkList(uint64 storageId, uint64 groupNumber, Snapshot snapshot)
+{
+	Relation	rel = open_columnar_table("column_chunk", AccessShareLock);
+	TupleDesc	tupdesc = RelationGetDescr(rel);
+	ScanKeyData key[2];
+	SysScanDesc scan;
+	HeapTuple	tuple;
+	List	   *result = NIL;
+
+	ScanKeyInit(&key[0], Anum_column_chunk_storage_id, BTEqualStrategyNumber,
+				F_INT8EQ, Int64GetDatum((int64) storageId));
+	ScanKeyInit(&key[1], Anum_column_chunk_group_number, BTEqualStrategyNumber,
+				F_INT8EQ, Int64GetDatum((int64) groupNumber));
+	scan = systable_beginscan(rel, InvalidOid, false, snapshot, 2, key);
+	while (HeapTupleIsValid(tuple = systable_getnext(scan)))
+	{
+		NativeColumnChunkMetadata *cc = palloc0(sizeof(NativeColumnChunkMetadata));
+		bool		isnull;
+		Datum		d;
+
+		cc->storageId = storageId;
+		cc->groupNumber = groupNumber;
+		cc->columnIndex = DatumGetInt16(
+			heap_getattr(tuple, Anum_column_chunk_column_index, tupdesc, &isnull));
+		cc->valueCount = (uint64) DatumGetInt64(
+			heap_getattr(tuple, Anum_column_chunk_value_count, tupdesc, &isnull));
+		d = heap_getattr(tuple, Anum_column_chunk_encoding_descriptor, tupdesc, &isnull);
+		if (!isnull)
+		{
+			bytea	   *b = DatumGetByteaPP(d);
+
+			cc->encodingDescriptorLen = VARSIZE_ANY_EXHDR(b);
+			cc->encodingDescriptor = (const char *)
+				memcpy(palloc(cc->encodingDescriptorLen + 1),
+					   VARDATA_ANY(b), cc->encodingDescriptorLen);
+		}
+		cc->blockCodec = DatumGetInt16(
+			heap_getattr(tuple, Anum_column_chunk_block_codec, tupdesc, &isnull));
+		cc->pageOffset = (uint64) DatumGetInt64(
+			heap_getattr(tuple, Anum_column_chunk_page_offset, tupdesc, &isnull));
+		cc->pageLength = (uint64) DatumGetInt64(
+			heap_getattr(tuple, Anum_column_chunk_page_length, tupdesc, &isnull));
+		result = lappend(result, cc);
+	}
+	systable_endscan(scan);
+	table_close(rel, AccessShareLock);
+
+	return result;
 }
 
 /* -------------------------------------------------------------------------

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -105,6 +105,24 @@ struct ColumnarReadState
 	uint64		groupsRead;
 	uint64		groupsSkipped;
 
+	/*
+	 * Native format (re-origination line, PGCN v1) read state (Phase D3). When
+	 * isNative, the scan reads row groups and column chunks from the native
+	 * catalog instead of stripes/chunks. The current row group's bytes are read
+	 * whole into nativeBuffer (in groupContext); nativeValidity[c] points at each
+	 * column chunk's validity bitmap and nativeValueCursor[c] advances through its
+	 * uncompressed values. Sequential scan only: skip predicates, the vectorized
+	 * path, projection pushdown, and parallel scan are bypassed for native tables
+	 * in D3 (correctness-neutral optimizations for later).
+	 */
+	bool		isNative;
+	List	   *rowGroupList;		/* NativeRowGroupMetadata* */
+	int			rowGroupIndex;		/* next row group to load */
+	NativeRowGroupMetadata *nativeGroup;
+	char	   *nativeBuffer;		/* whole current row group, in groupContext */
+	char	  **nativeValidity;		/* [natts]; NULL if the column is absent */
+	char	  **nativeValueCursor;	/* [natts]; advancing values cursor */
+
 	MemoryContext readContext;		/* whole scan */
 	MemoryContext stripeContext;	/* reset per stripe */
 	MemoryContext groupContext;		/* reset per chunk group (decompressed) */
@@ -258,6 +276,9 @@ ColumnarBeginReadWithStorage(Relation rel, Snapshot snapshot,
 							   &readState->missingIsnull[mc]);
 	}
 
+	readState->isNative =
+		(ColumnarTableFormatVersion(RelationGetRelid(rel)) ==
+		 COLUMNAR_NATIVE_VERSION_MAJOR);
 	readState->projectedColumns = bms_copy(projectedColumns);
 	readState->stripeList = NIL;
 	readState->stripeIndex = 0;
@@ -698,11 +719,136 @@ columnar_read_start(ColumnarReadState *readState)
 	{
 		MemoryContext oldContext = MemoryContextSwitchTo(readState->readContext);
 
-		readState->stripeList = ColumnarReadStripeList(readState->storageId,
-													   readState->metaSnapshot);
-		readState->stripeIndex = 0;
+		if (readState->isNative)
+		{
+			readState->rowGroupList =
+				ColumnarReadRowGroupList(readState->storageId,
+										 readState->metaSnapshot);
+			readState->rowGroupIndex = 0;
+		}
+		else
+		{
+			readState->stripeList = ColumnarReadStripeList(readState->storageId,
+														   readState->metaSnapshot);
+			readState->stripeIndex = 0;
+		}
 		MemoryContextSwitchTo(oldContext);
 	}
+}
+
+/*
+ * columnar_native_load_group
+ *		Load the next native row group (PGCN v1, Phase D3): read its bytes whole
+ *		into the group context and set each column's validity-bitmap pointer and
+ *		values cursor. Returns false when no more row groups remain.
+ */
+static bool
+columnar_native_load_group(ColumnarReadState *rs)
+{
+	MemoryContext oldContext;
+	NativeRowGroupMetadata *rg;
+	List	   *chunks;
+	ListCell   *lc;
+	int			validityBytes;
+
+	if (rs->rowGroupIndex >= list_length(rs->rowGroupList))
+		return false;
+
+	MemoryContextReset(rs->groupContext);
+	oldContext = MemoryContextSwitchTo(rs->groupContext);
+
+	rg = (NativeRowGroupMetadata *) list_nth(rs->rowGroupList, rs->rowGroupIndex);
+	rs->nativeGroup = rg;
+	rs->nativeBuffer = palloc(rg->byteLength > 0 ? rg->byteLength : 1);
+	if (rg->byteLength > 0)
+		ColumnarReadLogicalData(rs->rel, rg->fileOffset, rs->nativeBuffer,
+								rg->byteLength);
+
+	chunks = ColumnarReadColumnChunkList(rs->storageId, rg->groupNumber,
+										 rs->metaSnapshot);
+	rs->nativeValidity = palloc0(sizeof(char *) * rs->natts);
+	rs->nativeValueCursor = palloc0(sizeof(char *) * rs->natts);
+	validityBytes = (int) ((rg->rowCount + 7) / 8);
+
+	foreach(lc, chunks)
+	{
+		NativeColumnChunkMetadata *cc = (NativeColumnChunkMetadata *) lfirst(lc);
+		char	   *base;
+
+		if (cc->columnIndex < 0 || cc->columnIndex >= rs->natts)
+			continue;
+		base = rs->nativeBuffer + (cc->pageOffset - rg->fileOffset);
+		rs->nativeValidity[cc->columnIndex] = base;
+		rs->nativeValueCursor[cc->columnIndex] = base + validityBytes;
+	}
+
+	rs->groupRowCount = rg->rowCount;
+	rs->rowInGroup = 0;
+	rs->rowGroupIndex++;
+
+	MemoryContextSwitchTo(oldContext);
+	return true;
+}
+
+/*
+ * columnar_native_next_row
+ *		Native-format sequential row production (Phase D3). Decodes one row from
+ *		the current row group, reconstructing each column from its validity bit
+ *		and, when present, the next value on its cursor.
+ */
+static bool
+columnar_native_next_row(ColumnarReadState *rs, Datum *values, bool *nulls,
+						 uint64 *rowNumber)
+{
+	MemoryContext oldContext;
+	int			c;
+
+	if (rs->exhausted)
+		return false;
+
+	if (rs->nativeGroup == NULL || rs->rowInGroup >= rs->groupRowCount)
+	{
+		if (!columnar_native_load_group(rs))
+		{
+			rs->exhausted = true;
+			return false;
+		}
+	}
+
+	MemoryContextReset(rs->rowContext);
+	oldContext = MemoryContextSwitchTo(rs->rowContext);
+
+	for (c = 0; c < rs->natts; c++)
+	{
+		Form_pg_attribute att = TupleDescAttr(rs->tupdesc, c);
+		char	   *vbits = rs->nativeValidity[c];
+
+		/* column absent from this group (added by a later ALTER TABLE ADD COLUMN) */
+		if (vbits == NULL)
+		{
+			values[c] = rs->missingValues[c];
+			nulls[c] = rs->missingIsnull[c];
+			continue;
+		}
+
+		if ((vbits[rs->rowInGroup >> 3] >> (rs->rowInGroup & 7)) & 1)
+		{
+			values[c] = ColumnarDecodeValue(att, &rs->nativeValueCursor[c],
+											rs->rowContext);
+			nulls[c] = false;
+		}
+		else
+		{
+			values[c] = (Datum) 0;
+			nulls[c] = true;
+		}
+	}
+
+	MemoryContextSwitchTo(oldContext);
+
+	*rowNumber = rs->nativeGroup->firstRowNumber + rs->rowInGroup;
+	rs->rowInGroup++;
+	return true;
 }
 
 bool
@@ -710,6 +856,9 @@ ColumnarReadNextRow(ColumnarReadState *readState, Datum *values, bool *nulls,
 					uint64 *rowNumber)
 {
 	columnar_read_start(readState);
+
+	if (readState->isNative)
+		return columnar_native_next_row(readState, values, nulls, rowNumber);
 
 	for (;;)
 	{
@@ -1528,6 +1677,14 @@ ColumnarRescanRead(ColumnarReadState *readState)
 	readState->started = false;
 	readState->exhausted = false;
 	readState->stripeList = NIL;
+
+	/* native format cursors (Phase D3) */
+	readState->rowGroupList = NIL;
+	readState->rowGroupIndex = 0;
+	readState->nativeGroup = NULL;
+	readState->nativeBuffer = NULL;
+	readState->nativeValidity = NULL;
+	readState->nativeValueCursor = NULL;
 }
 
 void

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -641,6 +641,14 @@ ColumnarCreateUpperPaths(PlannerInfo *root, UpperRelationKind stage,
 		return;
 	if (!OidIsValid(rte->relid) || !ColumnarIsColumnarRelation(rte->relid))
 		return;
+	/*
+	 * Native-format tables (PGCN v1) do not populate the 2.2 stripe/chunk
+	 * metadata this vectorized aggregate (and its count(*)-from-metadata) reads,
+	 * so skip them in Phase D3; the aggregate runs over the native base scan
+	 * instead. The native vectorized aggregate is a later sub-phase.
+	 */
+	if (ColumnarTableFormatVersion(rte->relid) == COLUMNAR_NATIVE_VERSION_MAJOR)
+		return;
 	relid = rte->relid;
 
 	/* every target entry must be a bare, supported aggregate */

--- a/src/columnar_write_state.c
+++ b/src/columnar_write_state.c
@@ -836,6 +836,7 @@ columnar_flush_row_group(ColumnarWriteState *writeState)
 		rg.fileOffset = fileOffset;
 		rg.rowCount = rowCount;
 		rg.byteLength = dataLength;
+		rg.firstRowNumber = writeState->stripeFirstRowNumber;
 		ColumnarInsertRowGroupRow(&rg);
 	}
 	for (c = 0; c < natts; c++)

--- a/test/native_roundtrip.sh
+++ b/test/native_roundtrip.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# pgColumnar native round-trip (Phase D3): a native-format (PGCN v1) table is
+# read back through the native reader and must match a heap mirror. This is the
+# first read of native data. Insert-only (delete/update visibility on native
+# tables is a later sub-phase). Scalars with nulls across several row groups,
+# with a filter and a projection, compared by an order-independent set hash so
+# heap is the correctness oracle.
+#
+# Usage:  test/native_roundtrip.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+# heap mirror and a native columnar table with the same rows; small row-group
+# limit so the read crosses several row groups.
+psql_run "CREATE TABLE h (id int, k bigint, v text, f float8, b bool);"
+psql_run "CREATE TABLE n (id int, k bigint, v text, f float8, b bool) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 1000, format_version => 1);"
+GEN="SELECT g,
+       (g * 100000)::bigint,
+       CASE WHEN g % 9 = 0 THEN NULL ELSE 'row-' || g END,
+       CASE WHEN g % 6 = 0 THEN NULL ELSE (g::float8 / 7) END,
+       (g % 2 = 0)
+  FROM generate_series(1, 5000) g"
+psql_run "INSERT INTO h $GEN;"
+psql_run "INSERT INTO n $GEN;"
+
+check "native row count" "$(q 'SELECT count(*) FROM n;')" "5000"
+check "native reads back all columns" \
+	"$(pgc_set_hash 'SELECT id, k, v, f, b FROM n')" \
+	"$(pgc_set_hash 'SELECT id, k, v, f, b FROM h')"
+check "native null handling (v)" \
+	"$(q 'SELECT count(*) FROM n WHERE v IS NULL;')" \
+	"$(q 'SELECT count(*) FROM h WHERE v IS NULL;')"
+check "native null handling (f)" \
+	"$(q 'SELECT count(*) FROM n WHERE f IS NULL;')" \
+	"$(q 'SELECT count(*) FROM h WHERE f IS NULL;')"
+check "native filtered scan" \
+	"$(pgc_set_hash 'SELECT id, v FROM n WHERE k BETWEEN 100000000 AND 200000000')" \
+	"$(pgc_set_hash 'SELECT id, v FROM h WHERE k BETWEEN 100000000 AND 200000000')"
+check "native projection (subset of columns)" \
+	"$(pgc_set_hash 'SELECT v, b FROM n')" \
+	"$(pgc_set_hash 'SELECT v, b FROM h')"
+check "native aggregate (sum over a scanned column)" \
+	"$(q 'SELECT sum(k) FROM n;')" \
+	"$(q 'SELECT sum(k) FROM h;')"
+check "native count with filter" \
+	"$(q 'SELECT count(*) FROM n WHERE b;')" \
+	"$(q 'SELECT count(*) FROM h WHERE b;')"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -26,7 +26,7 @@ SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUITES=(smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
 	differential recovery fuzz hardening concurrent_diff parallel sorted_projection \
 	arrow_export parquet_export read_stream corruption \
-	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer)
+	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip)
 
 # Default matrix: one assert-enabled pg_config per major, 13 through 19.
 DEFAULT_CONFIGS=(


### PR DESCRIPTION
Implements the native-format (PGCN v1) read path, so native tables round-trip.
Native data is now read back and validated against a heap oracle. Targets
`re-origination`.

- **Native catalog read helpers** (columnar_metadata.c): `ColumnarReadRowGroupList`,
  `ColumnarReadColumnChunkList`.
- **row_group gains `first_row_number`** (SQL, Anum/struct, writer) so native rows
  keep the row numbers reserved at insert time (correct item pointers).
- **Reader** (columnar_reader.c): `ColumnarReadState.isNative` + native cursors;
  `columnar_read_start` loads the row_group list; `ColumnarReadNextRow` branches to
  a native producer that reads each row group whole, splits each column chunk into
  `[validity bitmap][values]`, and decodes present values with `ColumnarDecodeValue`.
- **Native uses the base AM scan only in D3**: the vectorized custom scan
  (columnar_customscan.c) and the vectorized aggregate incl. `count(*)`-from-metadata
  (columnar_vector.c) read the 2.2 catalog a native table does not populate, so
  both skip native relations; aggregates run over the native base scan.
- **test/native_roundtrip.sh** (in the matrix): first read of native data vs a
  heap mirror, across several row groups with nulls, a filter, a projection, and
  aggregates. 8/8 pass on PG17.

Scope/known limitations: sequential scan only (skip/vector/projection-pushdown/
parallel bypassed, correctness-neutral); index fetch and delete/update visibility
on native tables are later sub-phases; the test is insert-only. Full PostgreSQL
13-19 matrix running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)