### PR TITLE
Phase D4: cascade encoding and adaptive selection (native)

### DIFF
--- a/design/PHASE_D4_PLAN.md
+++ b/design/PHASE_D4_PLAN.md
@@ -1,0 +1,169 @@
+# Phase D4 plan: cascade encoding and adaptive selection
+
+Status: plan, on the `re-origination` branch (a `phase-d/d4-cascade` branch off
+`re-origination` once approved). D4 makes native-format (PGCN v1) column chunks
+compressed. D2b wrote raw `[validity bitmap][values]` chunks with the encoding
+descriptor hardcoded to a single zero byte and `block_codec` 0; D3 read them back
+value by value. D4 fills in the encoding: each column chunk is encoded per
+1024-value vector with the lightweight primitives, an optional block codec runs
+over the chunk bytes, and the chosen scheme is recorded in the
+`pgcolumnar.column_chunk` encoding descriptor so the reader reconstructs the exact
+raw bytes D3 expects. The differential oracle stays the correctness proof: a
+native table still returns the same rows as its heap mirror, now from compressed
+storage.
+
+## What already exists (the reuse base)
+
+The lightweight-encoding toolkit and the block-codec layer are already in the tree,
+clean-room and matrix-tested on the 1.0-dev (2.2) stripe path. D4 does not write a
+new codec library; it wires the existing one into the native flush and load
+functions.
+
+- `src/columnar_encoding.c`: the primitives NONE, RLE, FOR, DELTA, GORILLA, DOD,
+  and DICT, with bit-packing and zigzag helpers. FOR and DELTA already fold
+  bit-packing in (each primitive is itself a short internal cascade). The selector
+  `ColumnarEncodeChunk(raw, rawLen, att, valueCount, &out, &outLen)` returns the
+  winning encoding type and its encoded bytes; `ColumnarDecodeChunk(enc, encLen,
+  encodingType, att, valueCount, rawLen, cx)` is the exact inverse. A run iterator
+  (`ColumnarBlockReaderInit` / `ColumnarBlockNextRun`) already exists for later
+  run-stream aggregation.
+- `src/columnar_compression.c`: `ColumnarCompressValueStream` /
+  `ColumnarDecompressValueStream` for pglz, lz4, and zstd, each storing raw when the
+  codec does not shrink and reporting the codec actually used.
+- 2.2 wiring precedent to mirror: encode then compress at
+  `columnar_write_state.c:593-618`; decompress then decode at
+  `columnar_reader.c:1630-1638`.
+- Catalog: `pgcolumnar.column_chunk` already has `encoding_descriptor bytea` and
+  `block_codec smallint` (`pgcolumnar--1.0.sql:203-214`), with the C struct,
+  Anum accessors, and insert/read plumbing in place
+  (`NativeColumnChunkMetadata`, `ColumnarInsertColumnChunkRow`,
+  `ColumnarReadColumnChunkList`). D4 needs no SQL or catalog schema change.
+- A codec property harness exists at `test/pbt/test_encoding.c` (`test/pbt/run.sh`).
+
+## The write and read seams
+
+- Write: `columnar_flush_row_group` (`columnar_write_state.c:744`). The chunk is
+  laid out column-major as `[validity bitmap][values]`; the descriptor is set to a
+  single zero byte at lines 842-857. The flush currently concatenates every
+  1024-value chunk-group value stream into one flat column chunk, so the per-vector
+  boundary survives only in the in-memory `chunkGroups` list iterated at 786-807.
+- Read: `columnar_native_load_group` (`columnar_reader.c:745`) reads the row group
+  whole, points `nativeValidity[c]` at the chunk base and `nativeValueCursor[c]` at
+  `base + validityBytes`, and ignores the descriptor. Per-row reconstruction in
+  `columnar_native_next_row` (line 799) advances that cursor with
+  `ColumnarDecodeValue`.
+
+## Design
+
+The correctness-first seam keeps the `[validity bitmap][encoded values]` chunk
+layout and confines all D4 work to the flush and the group-load step.
+
+- Write: for each column chunk, encode each 1024-value vector with
+  `ColumnarEncodeChunk`, concatenate the encoded vectors, optionally run a block
+  codec over the concatenation with `ColumnarCompressValueStream`, and write
+  `[validity][encoded (maybe block-compressed) values]`. Record the recipe in the
+  encoding descriptor and set `block_codec` to the codec actually used.
+- Read: in `columnar_native_load_group`, when the descriptor is not the
+  uncompressed baseline, reverse the block codec with
+  `ColumnarDecompressValueStream`, then decode each vector with
+  `ColumnarDecodeChunk` back into the exact raw value stream D2b produced,
+  materialize it in the group context, and point `nativeValueCursor[c]` at it.
+  `columnar_native_next_row` is unchanged: it still walks the raw stream with
+  `ColumnarDecodeValue`. Because the decode reconstructs identical bytes, the
+  round-trip is byte-exact.
+
+### Encoding descriptor layout
+
+The `encoding_descriptor` bytea becomes a small self-describing header, versioned
+by a leading tag so a later minor can extend it:
+
+- descriptor version tag and the chunk's vector length,
+- vector count, then per vector: encoding type (the `int` from
+  `ColumnarEncodeChunk`), encoded byte length, raw byte length, and value count
+  (1024 for all but the last vector).
+
+Persisting per-vector encoded and raw lengths restores the vector boundary the
+native writer currently drops at flush, which is also what D5 needs to attach a
+zone map to each vector. The uncompressed baseline written by D2b (a single zero
+byte) is read as "one implicit vector, encoding NONE, no block codec" so existing
+native tables written before D4 still read without a rewrite.
+
+### Selector scope
+
+Decision (owner, 2026-07-21): Option A. D4 reuses the existing per-vector selector
+and block codec; the true multi-level cascade and sample-based selection are
+deferred to D4b (or folded into Phase E, whose ALP and FSST are new cascade
+primitives anyway).
+
+Section 5.1 of the native spec calls for a cascade to depth three chosen by
+sampling about one percent of a chunk's vectors. There were two ways to land that,
+differing in the size and novelty of this PR:
+
+- Option A, reuse first: use the existing per-vector selector
+  (`ColumnarEncodeChunk`) exhaustively over each 1024-value vector. Each primitive
+  is already an internal short cascade (FOR plus bit-packing, delta plus zigzag
+  plus bit-packing), so this delivers adaptive, per-vector, descriptor-recorded
+  encoding plus the block codec using only proven code. Exhaustive measurement over
+  1024 values is cheap, so sampling is not needed for cost. Arbitrary multi-level
+  chaining across primitives and sample-then-apply-chunk-wide selection become a
+  D4b refinement.
+- Option B, full spec now: implement true three-level chaining across the
+  primitives and a sample-based selector that measures about one percent of a
+  chunk's vectors and applies one cascade chunk-wide, per BtrBlocks. Higher ratio
+  potential, but a larger and more novel surface in a single matrix-gated PR.
+
+Option A was chosen: it is the matrix-gated foundation that gets real compression
+onto native tables with the least risk, and it matches the minimal-per-PR
+discipline of D1 through D3 and the PHASE_D_PLAN risk note that a wrong selector
+choice must only ever be a size or speed regression, never a correctness bug.
+Option B is tracked as D4b.
+
+## Scope for D4 (kept minimal, symmetric with D2b and D3)
+
+In scope:
+
+- Native column chunks encoded per 1024-value vector with the existing primitives,
+  chosen adaptively; an optional block codec over the chunk; the descriptor
+  persisted; the reader reconstructing exact bytes.
+- Property and round-trip validation and the full matrix.
+
+Deferred, and why it is correctness-neutral:
+
+- ALP and FSST float and string schemes are Phase E; D4 uses the current primitive
+  set (GORILLA remains the float primitive until ALP lands).
+- Zone maps, vector and chunk skipping, and zone-map-only aggregates are D5; D4
+  persists the per-vector boundaries D5 builds on but computes no aggregates.
+- Compressed execution (handing the executor still-encoded vectors) is deferred.
+  After D3 native tables use only the base access-method scan, so in D4 the
+  executor consumes fully reconstructed values. Operating on encoded vectors needs
+  a native vector path re-enabled and is a later optimization; it cannot change
+  results because the reader always reconstructs exact values.
+
+## Validation
+
+- Extend `test/pbt/test_encoding.c` (or add a native cascade case) to cover the
+  descriptor round-trip: encode then decode reproduces the input across the
+  supported types and null patterns, including empty and single-value vectors and
+  the last short vector.
+- Add `test/native_encoding.sh` (or extend `native_roundtrip.sh`): an encoded
+  native table matches its heap mirror by the order-independent set hash across
+  several row groups with nulls, and `pgcolumnar.column_chunk` shows non-baseline
+  descriptors and reduced `page_length` on compressible data (a low-cardinality
+  column, a monotonic column, a constant column), with a row-count sanity assertion
+  so a down cluster cannot make the check pass falsely. Register it in
+  `test/run_all_versions.sh`.
+- Full PostgreSQL 13 through 19 matrix; the differential oracle green on
+  native-format tables.
+
+## Risks
+
+- The selector choice is a size and speed tradeoff, never correctness: the reader
+  reconstructs exactly what the descriptor records, proven by the property tests
+  and the differential oracle.
+- Two format lines coexist through D5; native stays opt-in until D6, so D4 is
+  exercised only by tables that select the native format and by the new native
+  cases.
+- Reconstructing a column chunk to a full raw buffer at group-load raises native
+  scan memory to about one row group's decoded size. This is bounded by
+  `row_group_limit` and is the same order as the 2.2 path's per-stripe decode; it
+  is revisited if and when compressed execution removes the full materialization.

--- a/design/TODO_PIVOT.md
+++ b/design/TODO_PIVOT.md
@@ -60,8 +60,15 @@ directions". Both of those are also uncommitted.
     stays 1.0-dev, no behavior change. Depends on Phase C merged.
   - [ ] D2. Native writer (row groups, column chunks, 1024-value vectors,
     validity) with a baseline encoding.
-  - [ ] D3. Native reader (sequential scan); differential oracle runs on native
-    tables.
+  - [x] D3. Native reader (sequential scan); differential oracle runs on native
+    tables. Done (commit 0086c52): native catalog read helpers,
+    row_group.first_row_number, native reader branch in columnar_reader.c
+    (per-group [validity][values] decode via ColumnarDecodeValue), native tables
+    use only the base scan (vectorized custom scan / metadata aggregate skip
+    native), test/native_roundtrip.sh registered in the matrix. Full PG 13-19
+    matrix green (all 32 suites incl. native_writer + native_roundtrip; no
+    warnings). Sequential scan only; index fetch and delete/update visibility on
+    native tables are later sub-phases (native_roundtrip is insert-only).
   - [ ] D4. Cascade encoding + sample-based adaptive selection; encoding
     descriptor; compressed execution where cheap.
   - [ ] D5. SMA zone maps (min/max/sum/count/null per vector and chunk); skipping

--- a/design/TODO_PIVOT.md
+++ b/design/TODO_PIVOT.md
@@ -69,8 +69,18 @@ directions". Both of those are also uncommitted.
     matrix green (all 32 suites incl. native_writer + native_roundtrip; no
     warnings). Sequential scan only; index fetch and delete/update visibility on
     native tables are later sub-phases (native_roundtrip is insert-only).
-  - [ ] D4. Cascade encoding + sample-based adaptive selection; encoding
-    descriptor; compressed execution where cheap.
+  - [x] D4. Cascade encoding + adaptive selection; encoding descriptor. Done
+    (commit e76966c): the existing lightweight-encoding toolkit
+    (columnar_encoding.c) and block-codec layer (columnar_compression.c) are wired
+    into the native flush (columnar_flush_row_group) and load
+    (columnar_native_decode_chunk) seams. Each 1024-value vector is encoded
+    adaptively and the chunk optionally block-compressed; the choice is recorded
+    in the per-vector column_chunk.encoding_descriptor (no schema change) and the
+    reader reconstructs the exact raw bytes. test/native_encoding.sh registered in
+    the matrix. Full PG 13-19 matrix green (all 33 suites; no warnings). Scope per
+    the D4 plan (Option A): reuse the per-vector selector + block codec.
+    Deferred: multi-level cascade chaining and sample-based selection (D4b);
+    compressed execution (needs a native vector path; correctness-neutral).
   - [ ] D5. SMA zone maps (min/max/sum/count/null per vector and chunk); skipping
     and zone-map-only aggregates.
   - [ ] D6. Default new tables to native; full suites green 13-19; Arrow/Parquet

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -48,6 +48,21 @@
 #define COLUMNAR_NATIVE_VERSION_MAJOR 1
 #define COLUMNAR_NATIVE_VECTOR_LENGTH 1024	/* values per vector (fixed) */
 
+/*
+ * Native column-chunk encoding descriptor (D4). A column chunk's
+ * pgcolumnar.column_chunk.encoding_descriptor is either the D2b baseline (a
+ * single 0 byte: raw present values, no per-vector encoding, block_codec 0) or a
+ * D4 descriptor with this leading version byte, recording the lightweight
+ * encoding chosen per 1024-value vector so the reader reconstructs the exact raw
+ * value stream. The layout is: uint8 version, uint8 reserved, uint32 vectorCount,
+ * then per vector { uint8 encodingType, uint32 valueCount, uint32 rawLen,
+ * uint32 encLen }. Integers are host-endian (little-endian hosts assumed, spec 3).
+ */
+#define COLUMNAR_NATIVE_ENCDESC_BASELINE 0
+#define COLUMNAR_NATIVE_ENCDESC_VERSION 1
+#define COLUMNAR_NATIVE_ENCDESC_HEADER_LEN 6	/* version + reserved + vectorCount */
+#define COLUMNAR_NATIVE_ENCDESC_ENTRY_LEN 13	/* encodingType + 3 * uint32 */
+
 /* first row number is 1 (spec 3) */
 #define COLUMNAR_FIRST_ROW_NUMBER 1
 

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -737,6 +737,106 @@ columnar_read_start(ColumnarReadState *readState)
 }
 
 /*
+ * columnar_native_decode_chunk
+ *		Reconstruct a native column chunk's raw present-value stream (D4) from its
+ *		encoding descriptor. The on-disk values region is the per-1024-value-vector
+ *		encoded streams concatenated, optionally block-compressed as a whole. This
+ *		reverses the block codec, then decodes each vector with ColumnarDecodeChunk
+ *		into one raw buffer byte-identical to what the writer buffered, so the
+ *		per-row producer walks it exactly as it walks the D2b baseline. Allocated
+ *		in the group context. The descriptor lengths are cross-checked so a corrupt
+ *		chunk cannot drive a decoder past its buffers.
+ */
+static char *
+columnar_native_decode_chunk(ColumnarReadState *rs, Form_pg_attribute att,
+							 char *values, uint32 valuesLen,
+							 const char *desc, uint32 descLen, int blockCodec)
+{
+	uint32		vectorCount;
+	uint32		v;
+	const char *dp;
+	uint64		encTotal = 0;
+	uint64		rawTotal = 0;
+	const char *encRegion;
+	const char *encCursor;
+	char	   *rawBuf;
+	char	   *rawCursor;
+
+	if (descLen < COLUMNAR_NATIVE_ENCDESC_HEADER_LEN ||
+		(uint8) desc[0] != COLUMNAR_NATIVE_ENCDESC_VERSION)
+		ereport(ERROR,
+				(errcode(ERRCODE_DATA_CORRUPTED),
+				 errmsg("pgcolumnar: unrecognized native encoding descriptor")));
+	memcpy(&vectorCount, desc + 2, sizeof(uint32));
+
+	if ((uint64) descLen != (uint64) COLUMNAR_NATIVE_ENCDESC_HEADER_LEN +
+		(uint64) vectorCount * COLUMNAR_NATIVE_ENCDESC_ENTRY_LEN)
+		ereport(ERROR,
+				(errcode(ERRCODE_DATA_CORRUPTED),
+				 errmsg("pgcolumnar: native encoding descriptor length mismatch")));
+
+	/* first pass: total encoded and raw lengths across the vectors */
+	dp = desc + COLUMNAR_NATIVE_ENCDESC_HEADER_LEN;
+	for (v = 0; v < vectorCount; v++)
+	{
+		uint32		rawLen;
+		uint32		encLen;
+
+		memcpy(&rawLen, dp + 1 + sizeof(uint32), sizeof(uint32));
+		memcpy(&encLen, dp + 1 + 2 * sizeof(uint32), sizeof(uint32));
+		encTotal += encLen;
+		rawTotal += rawLen;
+		dp += COLUMNAR_NATIVE_ENCDESC_ENTRY_LEN;
+	}
+
+	/* reverse the block codec to recover the concatenated encoded region */
+	if (blockCodec != COLUMNAR_COMPRESSION_NONE)
+		encRegion = ColumnarDecompressValueStream(values, valuesLen, blockCodec,
+												  (uint32) encTotal,
+												  rs->groupContext);
+	else
+	{
+		if ((uint64) valuesLen != encTotal)
+			ereport(ERROR,
+					(errcode(ERRCODE_DATA_CORRUPTED),
+					 errmsg("pgcolumnar: native chunk length does not match descriptor")));
+		encRegion = values;
+	}
+
+	/* second pass: decode each vector into one raw present-value buffer */
+	rawBuf = MemoryContextAlloc(rs->groupContext, rawTotal > 0 ? rawTotal : 1);
+	rawCursor = rawBuf;
+	encCursor = encRegion;
+	dp = desc + COLUMNAR_NATIVE_ENCDESC_HEADER_LEN;
+	for (v = 0; v < vectorCount; v++)
+	{
+		uint8		encType;
+		uint32		valueCount;
+		uint32		rawLen;
+		uint32		encLen;
+
+		encType = (uint8) dp[0];
+		memcpy(&valueCount, dp + 1, sizeof(uint32));
+		memcpy(&rawLen, dp + 1 + sizeof(uint32), sizeof(uint32));
+		memcpy(&encLen, dp + 1 + 2 * sizeof(uint32), sizeof(uint32));
+		dp += COLUMNAR_NATIVE_ENCDESC_ENTRY_LEN;
+
+		if (rawLen > 0)
+		{
+			char	   *rawVec = ColumnarDecodeChunk(encCursor, encLen, encType,
+													 att, valueCount, rawLen,
+													 rs->groupContext);
+
+			memcpy(rawCursor, rawVec, rawLen);
+			rawCursor += rawLen;
+		}
+		encCursor += encLen;
+	}
+
+	return rawBuf;
+}
+
+/*
  * columnar_native_load_group
  *		Load the next native row group (PGCN v1, Phase D3): read its bytes whole
  *		into the group context and set each column's validity-bitmap pointer and
@@ -779,7 +879,25 @@ columnar_native_load_group(ColumnarReadState *rs)
 			continue;
 		base = rs->nativeBuffer + (cc->pageOffset - rg->fileOffset);
 		rs->nativeValidity[cc->columnIndex] = base;
-		rs->nativeValueCursor[cc->columnIndex] = base + validityBytes;
+
+		if (cc->encodingDescriptorLen == 1 &&
+			(uint8) cc->encodingDescriptor[0] == COLUMNAR_NATIVE_ENCDESC_BASELINE)
+		{
+			/* D2b baseline: raw present values follow the validity bitmap */
+			rs->nativeValueCursor[cc->columnIndex] = base + validityBytes;
+		}
+		else
+		{
+			Form_pg_attribute att = TupleDescAttr(rs->tupdesc, cc->columnIndex);
+
+			/* D4: reconstruct the raw present-value stream from the descriptor */
+			rs->nativeValueCursor[cc->columnIndex] =
+				columnar_native_decode_chunk(rs, att, base + validityBytes,
+											 (uint32) (cc->pageLength - validityBytes),
+											 cc->encodingDescriptor,
+											 cc->encodingDescriptorLen,
+											 cc->blockCodec);
+		}
 	}
 
 	rs->groupRowCount = rg->rowCount;

--- a/src/columnar_write_state.c
+++ b/src/columnar_write_state.c
@@ -751,6 +751,9 @@ columnar_flush_row_group(ColumnarWriteState *writeState)
 	StringInfo	data;
 	uint64	   *chunkOffset;
 	uint64	   *chunkLength;
+	char	  **chunkDescriptor;
+	uint32	   *chunkDescriptorLen;
+	int		   *chunkBlockCodec;
 	uint64		rowCount = writeState->stripeRowCount;
 	uint64		groupNumber = writeState->nativeNextGroup;
 	uint64		fileOffset;
@@ -774,12 +777,33 @@ columnar_flush_row_group(ColumnarWriteState *writeState)
 	data = makeStringInfo();
 	chunkOffset = palloc0(sizeof(uint64) * natts);
 	chunkLength = palloc0(sizeof(uint64) * natts);
+	chunkDescriptor = palloc0(sizeof(char *) * natts);
+	chunkDescriptorLen = palloc0(sizeof(uint32) * natts);
+	chunkBlockCodec = palloc0(sizeof(int) * natts);
 
-	/* build the row group column-major: each column chunk is validity + values */
+	/*
+	 * Build the row group column-major: each column chunk is
+	 * [validity bitmap][values]. The values region is encoded per 1024-value
+	 * vector (one chunk group) with the lightweight adaptive selector (D4), then
+	 * an optional block codec runs over the whole encoded region. The chosen
+	 * scheme is recorded in the encoding descriptor so the reader reconstructs
+	 * the exact raw bytes. A vector whose selector returns NONE is stored raw,
+	 * so an incompressible column stays byte-for-byte the D2b baseline plus the
+	 * descriptor.
+	 */
 	for (c = 0; c < natts; c++)
 	{
+		Form_pg_attribute att = TupleDescAttr(writeState->tupdesc, c);
 		uint8	   *validity = (uint8 *) palloc0(validityBytes);
 		uint64		rowIdx = 0;
+		StringInfo	encoded = makeStringInfo();
+		StringInfo	desc = makeStringInfo();
+		uint8		descVersion = COLUMNAR_NATIVE_ENCDESC_VERSION;
+		uint8		descReserved = 0;
+		uint32		vectorCount = (uint32) list_length(writeState->chunkGroups);
+		char	   *finalData;
+		uint32		finalLen;
+		int			blockCodec = COLUMNAR_COMPRESSION_NONE;
 
 		chunkOffset[c] = data->len;
 
@@ -796,17 +820,70 @@ columnar_flush_row_group(ColumnarWriteState *writeState)
 		}
 		appendBinaryStringInfo(data, (char *) validity, validityBytes);
 
+		/* descriptor header */
+		appendBinaryStringInfo(desc, (char *) &descVersion, 1);
+		appendBinaryStringInfo(desc, (char *) &descReserved, 1);
+		appendBinaryStringInfo(desc, (char *) &vectorCount, sizeof(uint32));
+
+		/* encode each vector (chunk group) and record its descriptor entry */
 		foreach(lc, writeState->chunkGroups)
 		{
 			ChunkGroupBuffer *group = (ChunkGroupBuffer *) lfirst(lc);
 			ColumnChunkBuffer *col = &group->columns[c];
+			char	   *encData;
+			uint32		encLen;
+			int			encType;
+			uint8		entryType;
+			uint32		entryValueCount;
+			uint32		entryRawLen;
 
-			if (col->valueStream.len > 0)
-				appendBinaryStringInfo(data, col->valueStream.data,
-									   col->valueStream.len);
+			encType = ColumnarEncodeChunk(col->valueStream.data,
+										  col->valueStream.len, att,
+										  col->valueCount, &encData, &encLen);
+
+			if (encLen > 0)
+				appendBinaryStringInfo(encoded, encData, encLen);
+
+			entryType = (uint8) encType;
+			entryValueCount = (uint32) col->valueCount;
+			entryRawLen = (uint32) col->valueStream.len;
+			appendBinaryStringInfo(desc, (char *) &entryType, 1);
+			appendBinaryStringInfo(desc, (char *) &entryValueCount, sizeof(uint32));
+			appendBinaryStringInfo(desc, (char *) &entryRawLen, sizeof(uint32));
+			appendBinaryStringInfo(desc, (char *) &encLen, sizeof(uint32));
 		}
 
+		/* optional block codec over the whole encoded region (spec 6) */
+		finalData = encoded->data;
+		finalLen = encoded->len;
+		if (writeState->compressionType != COLUMNAR_COMPRESSION_NONE &&
+			encoded->len > 0)
+		{
+			char	   *compData;
+			uint32		compLen;
+			int			usedType;
+			int			usedLevel;
+
+			ColumnarCompressValueStream(encoded->data, encoded->len,
+										writeState->compressionType,
+										writeState->compressionLevel,
+										&compData, &compLen,
+										&usedType, &usedLevel);
+			if (usedType != COLUMNAR_COMPRESSION_NONE)
+			{
+				finalData = compData;
+				finalLen = compLen;
+				blockCodec = usedType;
+			}
+		}
+
+		if (finalLen > 0)
+			appendBinaryStringInfo(data, finalData, finalLen);
+
 		chunkLength[c] = data->len - chunkOffset[c];
+		chunkDescriptor[c] = desc->data;
+		chunkDescriptorLen[c] = (uint32) desc->len;
+		chunkBlockCodec[c] = blockCodec;
 	}
 
 	dataLength = data->len;
@@ -842,15 +919,14 @@ columnar_flush_row_group(ColumnarWriteState *writeState)
 	for (c = 0; c < natts; c++)
 	{
 		NativeColumnChunkMetadata cc;
-		uint8		desc = 0;		/* 0 = uncompressed baseline (D2b) */
 
 		cc.storageId = writeState->storageId;
 		cc.groupNumber = groupNumber;
 		cc.columnIndex = c;
 		cc.valueCount = rowCount;
-		cc.encodingDescriptor = (const char *) &desc;
-		cc.encodingDescriptorLen = 1;
-		cc.blockCodec = 0;
+		cc.encodingDescriptor = chunkDescriptor[c];
+		cc.encodingDescriptorLen = chunkDescriptorLen[c];
+		cc.blockCodec = chunkBlockCodec[c];
 		cc.pageOffset = fileOffset + chunkOffset[c];
 		cc.pageLength = chunkLength[c];
 		ColumnarInsertColumnChunkRow(&cc);

--- a/test/native_encoding.sh
+++ b/test/native_encoding.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# pgColumnar native cascade encoding (Phase D4): a native-format (PGCN v1) table
+# now encodes each 1024-value vector with the lightweight adaptive selector and,
+# when a block codec is set, block-compresses the encoded region. The reader
+# reconstructs the exact raw values, so an encoded native table must still match a
+# heap mirror. This suite proves round-trip parity across the block codecs
+# (including compression=none, the encoded-but-not-block-compressed path that
+# native_roundtrip does not exercise) and asserts that the encoding actually
+# engages: a constant column's chunk shrinks far below its raw size, and every
+# native chunk now carries a real (non-baseline) encoding descriptor.
+#
+# Usage:  test/native_encoding.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+# Data with a distinct compressibility per column so the selector has something to
+# choose: a monotonic id (delta/for), a constant bigint (rle/for/dict), a
+# low-cardinality label (dict), a genuinely random-ish text (likely none per
+# vector, still block-compressible), some nulls throughout. Small row-group limit
+# so the write crosses several row groups and each column chunk spans several
+# 1024-value vectors.
+GEN="SELECT g,
+       42::bigint,
+       (ARRAY['cat','dog','bird'])[1 + g % 3],
+       md5(g::text),
+       CASE WHEN g % 7 = 0 THEN NULL ELSE g * 3 END
+  FROM generate_series(1, 6000) g"
+
+psql_run "CREATE TABLE h (id int, k bigint, label text, rnd text, v int);"
+psql_run "INSERT INTO h $GEN;"
+
+for codec in none pglz lz4 zstd; do
+	tbl="n_$codec"
+	psql_run "CREATE TABLE $tbl (id int, k bigint, label text, rnd text, v int) USING pgcolumnar;"
+	psql_run "SELECT pgcolumnar.alter_columnar_table_set('$tbl', stripe_row_limit => 1500, compression => '$codec');"
+	psql_run "INSERT INTO $tbl $GEN;"
+
+	check "[$codec] row count" "$(q "SELECT count(*) FROM $tbl;")" "6000"
+	check "[$codec] all columns round-trip" \
+		"$(pgc_set_hash "SELECT id, k, label, rnd, v FROM $tbl")" \
+		"$(pgc_set_hash 'SELECT id, k, label, rnd, v FROM h')"
+	check "[$codec] nulls round-trip" \
+		"$(q "SELECT count(*) FROM $tbl WHERE v IS NULL;")" \
+		"$(q 'SELECT count(*) FROM h WHERE v IS NULL;')"
+	check "[$codec] filtered scan" \
+		"$(pgc_set_hash "SELECT id, label FROM $tbl WHERE k = 42 AND id BETWEEN 2000 AND 4000")" \
+		"$(pgc_set_hash 'SELECT id, label FROM h WHERE k = 42 AND id BETWEEN 2000 AND 4000')"
+	check "[$codec] aggregate over encoded column" \
+		"$(q "SELECT sum(v) FROM $tbl;")" \
+		"$(q 'SELECT sum(v) FROM h;')"
+
+	# Every native column chunk now carries a real encoding descriptor (>= 6-byte
+	# header), never the single-byte D2b baseline.
+	check "[$codec] no baseline descriptors remain" \
+		"$(q "SELECT count(*) FROM pgcolumnar.column_chunk
+		      WHERE storage_id = pgcolumnar.get_storage_id('$tbl')
+		        AND octet_length(encoding_descriptor) < 6;")" \
+		"0"
+
+	# The constant bigint column (column_index 1) must shrink far below its raw
+	# size (6000 * 8 = 48000 bytes of values plus 750 validity per row group);
+	# encoding engaging drives every chunk's page_length well under 4000.
+	check "[$codec] constant column encoded small" \
+		"$(q "SELECT count(*) FROM pgcolumnar.column_chunk
+		      WHERE storage_id = pgcolumnar.get_storage_id('$tbl')
+		        AND column_index = 1 AND page_length > 4000;")" \
+		"0"
+
+	# compression=none must leave block_codec unset on every chunk; the encoding
+	# is independent of the block codec.
+	if [ "$codec" = "none" ]; then
+		check "[none] no block codec used" \
+			"$(q "SELECT count(*) FROM pgcolumnar.column_chunk
+			      WHERE storage_id = pgcolumnar.get_storage_id('$tbl')
+			        AND block_codec <> 0;")" \
+			"0"
+	fi
+done
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -26,7 +26,7 @@ SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUITES=(smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
 	differential recovery fuzz hardening concurrent_diff parallel sorted_projection \
 	arrow_export parquet_export read_stream corruption \
-	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip)
+	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding)
 
 # Default matrix: one assert-enabled pg_config per major, 13 through 19.
 DEFAULT_CONFIGS=(


### PR DESCRIPTION
Adds native-format (PGCN v1) compression: each 1024-value vector is encoded with the existing lightweight adaptive selector and the chunk optionally block-compressed, recorded in the per-vector \`column_chunk.encoding_descriptor\` (no schema change). The reader reconstructs the exact raw bytes, so round-trips stay byte-identical and the differential oracle is the proof.

Scope (D4 plan, Option A): reuse the existing per-vector selector + block codec. Multi-level cascade chaining and sample-based selection are deferred to D4b.

- Descriptor format + write seam (\`columnar_flush_row_group\`) and read seam (\`columnar_native_decode_chunk\`).
- \`test/native_encoding.sh\` (in the matrix): round-trip parity across none/pglz/lz4/zstd, encoding-engaged and compression=none assertions.

Full PG 13-19 matrix green (validated again on the stacked D5 branch: 37/37 suites, no warnings).

Base: \`re-origination\`. First of a stacked pair; **#D5 stacks on this** and must merge after it (merge commits, no rebase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)