### PR TITLE
Phase D5: SMA zone maps and data skipping (native)

### DIFF
--- a/design/PHASE_D5_PLAN.md
+++ b/design/PHASE_D5_PLAN.md
@@ -1,0 +1,226 @@
+# Phase D5 plan: Small Materialized Aggregate zone maps, and retiring the 1.0-dev format
+
+Status: plan, on the `re-origination` branch (a `phase-d/d5-zone-maps` branch off
+`re-origination` once approved). D5 gives the native (PGCN v1) format data
+skipping: per-vector and per-chunk Small Materialized Aggregates (minimum,
+maximum, sum, value count, null count) stored in `pgcolumnar.zone_map`, wired into
+scan skipping and into zone-map-only aggregates, with optional per-chunk bloom
+filters for equality skipping. It closes the last read-side gap between the native
+format and the 1.0-dev line for scan performance.
+
+This document also plans, at the end, the retirement of the legacy 1.0-dev (2.2)
+on-disk format, which the re-origination exists to reach. That removal is a late,
+prerequisite-gated capstone, not part of D5; it is planned here because it is the
+destination the sub-phases are walking toward.
+
+## What already exists (the base)
+
+- `pgcolumnar.zone_map` catalog (`pgcolumnar--1.0.sql:216-228`): storage_id,
+  group_number, column_index, vector_index (-1 for the whole column chunk),
+  minimum bytea, maximum bytea, sum numeric, value_count, null_count, with a
+  unique index on (storage_id, group_number, column_index, vector_index). It is
+  unused scaffolding: no C struct, Anum, insert, or read helper exists, nothing
+  writes it, and `ColumnarDeleteMetadata` (`columnar_metadata.c:945-952`) does not
+  clean it. D5 fills all of that in.
+- Min/max accumulation already runs for native inserts: `ColumnarWriteRow`
+  (`columnar_write_state.c:362-403`) maintains per-column min/max with the column's
+  btree compare proc and collation on every insert, native included. D5 adds sum
+  and counts and moves the granularity to per vector and per chunk.
+- The 2.2 mechanisms to mirror: skip-list build and evaluation
+  (`columnar_reader.c` `columnar_build_predicates` :329-399 and
+  `columnar_group_can_match` :408-500), scan-key construction shared with the
+  aggregate (`columnar_customscan.c` `ColumnarBuildScanKeys` :357-380), the
+  metadata `count(*)` path (`columnar_vector.c` `columnar_try_metadata_count`
+  :961-1002), and the bloom module (`columnar_bloom.c`
+  `ColumnarBloomBuild`/`ColumnarBloomProbe`, format-agnostic, currently wired only
+  to the 2.2 writer/reader).
+- Native currently uses only the base access-method scan: the vectorized custom
+  scan returns early for native (`columnar_customscan.c:538-546`) and the
+  vectorized aggregate returns early for native (`columnar_vector.c:645-651`), so
+  native scans run through `ColumnarReadNextRow` with no skip or metadata-aggregate
+  logic today.
+
+## Design
+
+The native write and read seams from D2b through D4 are the attach points, and the
+correctness contract is unchanged: zone maps only ever cause a scan to skip data
+that provably cannot match, or to answer an aggregate the catalog already holds
+exactly, so results are identical with or without them. The differential oracle
+stays the proof.
+
+### Compute and store (write)
+
+In `columnar_flush_row_group` (`columnar_write_state.c:744`), during the existing
+per-column, per-vector loop that D4 added, compute for each 1024-value vector:
+minimum and maximum (btree compare proc and collation, as `ColumnarWriteRow`
+already does), value count and null count (from the validity bitmap and the
+present count), and sum as a `numeric` accumulator for summable types (int2, int4,
+int8, float4, float8, numeric). Fold the per-vector results into the whole-chunk
+zone map (vector_index -1). Insert the rows through a new
+`ColumnarInsertZoneMapRow` helper (with a matching struct and Anum accessors, and
+a `ColumnarReadZoneMapList`), mirroring the column_chunk plumbing. Extend
+`ColumnarDeleteMetadata` to delete zone_map rows with the rest of a relation's
+catalog.
+
+Zone maps are stored only for types with a default btree ordering (min and max)
+and, for sum, a defined addition; other columns get value_count and null_count
+only. Minimum and maximum are serialized with `ColumnarEncodeValue`, the same codec
+the 2.2 skip list and the value stream use.
+
+### Skip (read)
+
+Extend the native read path to prune using zone maps:
+
+- Row-group skip: in `columnar_read_start` / `columnar_native_load_group`
+  (`columnar_reader.c:722`, `:845`), before loading a row group's bytes, evaluate
+  the pushed-down predicates against the whole-chunk zone map and skip the group
+  when its min and max prove no row can match, reusing `columnar_build_predicates`
+  and the strategy logic of `columnar_group_can_match`. The base scan already
+  receives the scan keys; no custom scan is required.
+- Vector skip: within a loaded group, use per-vector zone maps to skip the 1024-row
+  vectors of a column chunk that cannot match, decoding only surviving vectors
+  (late materialization at vector granularity, which the D4 per-vector descriptor
+  boundaries make addressable).
+
+Skipping respects collation exactly as the 2.2 path does: a predicate whose
+collation differs from the column's own collation is applied as a filter and does
+not drive skipping, so results never depend on pushdown.
+
+### Zone-map-only aggregates (read)
+
+Generalize the 1.0-dev metadata `count(*)` to native. For an ungrouped
+`count`, `sum`, `min`, or `max` with no residual filter, answer from the
+whole-chunk zone maps without decoding, mirroring `columnar_try_metadata_count`
+but reading `pgcolumnar.zone_map` and accounting for null counts. This requires a
+narrow native aggregate entry point, since the vectorized aggregate currently skips
+native; it is added for the zone-map-answerable cases only, falling back to the
+base scan otherwise.
+
+### Bloom filters (read, optional)
+
+Add the `pgcolumnar.bloom` catalog table from spec section 11 (storage_id,
+group_number, column_index, filter bytes) and wire the existing `columnar_bloom.c`
+into the native writer (build a per-column-chunk filter for hashable,
+deterministic-collation types) and the native reader (probe it in the equality
+case of the skip check). This carries the 2.2 bloom behavior to native.
+
+## Scope for D5, and a likely split
+
+D5 is larger than D1 through D4. It is cleanest as two matrix-gated PRs, mirroring
+the D2a/D2b split:
+
+- D5a: compute and store zone maps at native flush (per vector and per chunk),
+  add the catalog struct/Anum/insert/read helpers, and clean them up on delete. No
+  read behavior change; validated by reading back `pgcolumnar.zone_map` and by the
+  differential oracle staying green. Low risk.
+- D5b: use the zone maps: native row-group and vector skipping, zone-map-only
+  ungrouped aggregates, and the optional per-chunk bloom. Validated by result
+  parity with skipping on and off, and by skip-counter assertions.
+
+Deferred and correctness-neutral: multi-column and space-filling clustering (Phase
+F), compressed execution over encoded vectors (still deferred from D4), and the
+D4b cascade refinements.
+
+## Retiring the 1.0-dev (2.2) on-disk format
+
+Goal: remove the legacy 2.2 on-disk format so the engine carries one native format
+line, which is the purpose of the re-origination. This is a dedicated late phase,
+added to the roadmap as Phase H, not part of D5. It is planned here so the
+intervening sub-phases aim at it.
+
+### What is removed
+
+- 2.2 writer: `columnar_flush_stripe` and the 2.2 min/max and bloom encode block
+  (`columnar_write_state.c` ~520-728), and the `!isNative` branch of
+  `ColumnarWriteRow`.
+- 2.2 reader: the stripe/chunk sequential decode path in `columnar_reader.c` gated
+  by `!isNative`, `ColumnarReadRowByNumber`'s stripe path, and the 2.2 skip
+  predicates once native skipping (D5) subsumes them.
+- 2.2 catalog access and tables: `ColumnarInsertStripeRow`,
+  `ColumnarInsertChunkGroupRow`, `ColumnarInsertChunkRow`,
+  `ColumnarReadStripeList` and the chunk/chunk-group readers
+  (`columnar_metadata.c`), and the tables `pgcolumnar.stripe`,
+  `pgcolumnar.chunk`, `pgcolumnar.chunk_group` (inline skip lists live in `chunk`).
+- The per-table `format_version` option and `ColumnarTableFormatVersion` collapse
+  to a single format; `columnar_tableam.c` stays format-agnostic and simply always
+  drives the native reader and writer.
+
+Shared code is kept: the logical storage layer (`columnar_storage.c`), the value
+codec (`columnar_encoding.c`, `columnar_compression.c`), `ColumnarEncodeValue` /
+`ColumnarDecodeValue`, the options catalog, and the table-AM entry layer.
+
+### Hard prerequisites (why it cannot happen at D5)
+
+Removal is blocked until the native format has parity for everything the default
+path serves today, because the default for `CREATE TABLE ... USING pgcolumnar` is
+still the 2.2 format (`ColumnarTableFormatVersion` returns 2.2 when the option is
+unset, `columnar_metadata.c:1284-1292`) and the whole differential and feature
+suite runs on that default. Native gaps that must close first:
+
+1. Delete and update visibility. The row mask is keyed by 2.2 stripe and chunk ids
+   (`columnar_row_mask.c`), so native rows cannot be marked deleted. Phase F
+   (native delete vectors and merge-on-read) closes this.
+2. Index scan and index-only scan. `ColumnarReadRowByNumber`
+   (`columnar_reader.c:1659-1677`) walks only the 2.2 stripe list; a native
+   by-row-number fetch over row groups is required.
+3. Projections. The projection writer reuses the 2.2 stripe writer and the
+   projection scan lives in the custom scan, which skips native.
+4. Zone-map skipping and zone-map-only aggregates. Delivered by D5.
+5. Native default. Phase D6 flips the default to native.
+6. Arrow and Parquet import and export verified on native (no native-specific
+   coverage exists today).
+
+Compressed storage already has native parity (D4). Compressed execution over
+encoded vectors remains a performance follow-up, not a removal blocker, because the
+base scan reconstructs exact values.
+
+### Sequencing and migration
+
+Ordered: D5 (this phase) closes skipping. Phase D6 makes native the default and
+takes the full suite green on native. Phase F gives native delete and update
+parity and native index and projection parity land alongside. Only then, Phase H:
+
+1. Provide and verify a migration from 2.2 to native while the 2.2 reader still
+   exists: `COPY` or Arrow/Parquet export from a 2.2 table into a native table, and
+   `ALTER TABLE ... SET ACCESS METHOD` rewrite where it applies. This is the
+   migration path the spec already names (section 13); the `v1.0-dev` tag preserves
+   the old line permanently regardless.
+2. Remove the 2.2 writer, so no new 2.2 data is produced.
+3. Remove the 2.2 reader and catalog, and drop the format selector.
+
+### Decision required
+
+Whether Phase H keeps a transitional read-only 2.2 reader for one release (so
+existing 2.2 relations can still be read and migrated in place before the reader is
+also removed), or removes both writer and reader together and relies solely on
+export/import and the `v1.0-dev` tag for anyone still on 2.2. The read-only
+transitional reader is safer for users with 2.2 data on disk; the clean cut is
+simpler and is defensible given the tag and the Arrow/Parquet migration path. This
+is the owner's call and is recorded when Phase H is scheduled.
+
+## Validation
+
+- A native zone-map test (`test/native_zonemap.sh`, registered in the matrix):
+  populate a native table whose columns have known ranges, read back
+  `pgcolumnar.zone_map` and assert per-vector and per-chunk min/max/sum/counts;
+  then assert result parity for range and equality queries with skipping enabled
+  versus a heap mirror, and assert skip counters advance (a selective predicate
+  skips groups and vectors) with a row-count sanity check so a down cluster cannot
+  pass falsely.
+- Zone-map-only aggregate parity: ungrouped count/sum/min/max on native equal the
+  heap oracle, and are answered without decoding (assert via the read stats).
+- The differential oracle green on native tables with skipping on.
+- Full PostgreSQL 13-19 matrix (restored from the temporary 17-19 iteration set
+  before the final pass).
+
+## Risks
+
+- Skipping is the first native read-side optimization that changes what the scan
+  touches. It is correctness-neutral by construction (skip only provably
+  non-matching data; collation-gated), validated by parity with skipping on and
+  off and by the differential oracle.
+- Sum accumulation must not overflow: use a `numeric` accumulator, and omit sum
+  when the type has no defined addition, matching the catalog's nullable sum.
+- Retiring 2.2 is high-impact and is deliberately deferred behind explicit parity
+  prerequisites and a verified migration path, so it is a mechanical removal once
+  native is the sole, full-featured format, never a correctness risk to live data.

--- a/design/TODO_PIVOT.md
+++ b/design/TODO_PIVOT.md
@@ -82,7 +82,9 @@ directions". Both of those are also uncommitted.
     Deferred: multi-level cascade chaining and sample-based selection (D4b);
     compressed execution (needs a native vector path; correctness-neutral).
   - [ ] D5. SMA zone maps (min/max/sum/count/null per vector and chunk); skipping
-    and zone-map-only aggregates.
+    and zone-map-only aggregates; optional per-chunk bloom. Planned in
+    [PHASE_D5_PLAN.md](PHASE_D5_PLAN.md); likely split D5a (compute and store zone
+    maps, no read change) and D5b (skipping, zone-map-only aggregates, bloom).
   - [ ] D6. Default new tables to native; full suites green 13-19; Arrow/Parquet
     over native; user docs updated.
 - [ ] **Phase E. New codecs.** Add ALP (floats/decimals) and FSST (strings) as
@@ -93,6 +95,17 @@ directions". Both of those are also uncommitted.
 - [ ] **Phase G. Interop extension.** Extend Arrow/Parquet interop toward reading
   external Parquet and open-table-format (Iceberg/Delta) files with predicate and
   projection pushdown.
+- [ ] **Phase H. Retire the 1.0-dev (2.2) on-disk format.** Remove the legacy 2.2
+  writer, reader, and catalog (`stripe`, `chunk`, `chunk_group`, inline skip
+  lists) and the per-table format selector, leaving one native format line. The
+  capstone of the re-origination. Prerequisite-gated (planned in
+  [PHASE_D5_PLAN.md](PHASE_D5_PLAN.md) "Retiring the 1.0-dev (2.2) on-disk
+  format"): native must have delete/update parity (Phase F), index and index-only
+  scan parity, projection parity, zone-map skipping (D5), be the default (D6), and
+  have Arrow/Parquet verified on native; then a verified 2.2-to-native migration
+  (COPY or Arrow/Parquet, `SET ACCESS METHOD` rewrite) with the `v1.0-dev` tag as
+  the permanent preservation. Open decision at scheduling: keep a transitional
+  read-only 2.2 reader for one release, or a clean cut relying on export/import.
 
 ## Independent later work (not gated on the format reset)
 

--- a/design/TODO_PIVOT.md
+++ b/design/TODO_PIVOT.md
@@ -81,10 +81,19 @@ directions". Both of those are also uncommitted.
     the D4 plan (Option A): reuse the per-vector selector + block codec.
     Deferred: multi-level cascade chaining and sample-based selection (D4b);
     compressed execution (needs a native vector path; correctness-neutral).
-  - [ ] D5. SMA zone maps (min/max/sum/count/null per vector and chunk); skipping
-    and zone-map-only aggregates; optional per-chunk bloom. Planned in
-    [PHASE_D5_PLAN.md](PHASE_D5_PLAN.md); likely split D5a (compute and store zone
-    maps, no read change) and D5b (skipping, zone-map-only aggregates, bloom).
+  - [x] D5. SMA zone maps (min/max/sum/count/null per vector and chunk); skipping
+    and zone-map-only aggregates; per-chunk bloom. Done, planned in
+    [PHASE_D5_PLAN.md](PHASE_D5_PLAN.md). D5a (d10a435): compute and store per-vector
+    and per-chunk zone maps in pgcolumnar.zone_map, no read change. D5b: native
+    tables take the custom scan's scalar path so pushed-down predicates drive
+    zone-map row-group skipping (f7433a4); zone-map-only ungrouped aggregates
+    count/sum/avg/min/max with the int2/int4 writer sum (85b6f29); per-chunk bloom
+    filters for equality skipping in a new pgcolumnar.bloom (82e5e9b); and
+    per-vector (1024-row) skipping within a group, decoding neither skipped
+    vectors nor their rows (0f800a8). Full PG 13-19 matrix green (all 37 suites
+    incl. native_zonemap/skip/agg/bloom/vecskip; no warnings). Design note: the
+    plan assumed the base scan receives scan keys, but a seqscan pushes none, so
+    the custom scan (scalar path) is the qual-pushdown mechanism for native.
   - [ ] D6. Default new tables to native; full suites green 13-19; Arrow/Parquet
     over native; user docs updated.
 - [ ] **Phase E. New codecs.** Add ALP (floats/decimals) and FSST (strings) as

--- a/pgcolumnar--1.0.sql
+++ b/pgcolumnar--1.0.sql
@@ -227,6 +227,17 @@ CREATE TABLE pgcolumnar.zone_map (
 CREATE UNIQUE INDEX zone_map_pkey
 	ON pgcolumnar.zone_map USING btree (storage_id, group_number, column_index, vector_index);
 
+-- Per-column-chunk bloom filter for equality skipping on hashable columns
+-- (native spec 7.2). One row per (storage_id, group_number, column_index).
+CREATE TABLE pgcolumnar.bloom (
+	storage_id bigint NOT NULL,
+	group_number bigint NOT NULL,
+	column_index smallint NOT NULL,
+	filter bytea NOT NULL
+);
+CREATE UNIQUE INDEX bloom_pkey
+	ON pgcolumnar.bloom USING btree (storage_id, group_number, column_index);
+
 /* ---------------------------------------------------------------------------
  * Access method (spec 8.1)
  * ------------------------------------------------------------------------- */

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -414,6 +414,8 @@ extern List *ColumnarReadColumnChunkList(uint64 storageId, uint64 groupNumber,
 										 Snapshot snapshot);
 extern List *ColumnarReadZoneMapList(uint64 storageId, uint64 groupNumber,
 									 Snapshot snapshot);
+extern List *ColumnarReadZoneMapVectors(uint64 storageId, uint64 groupNumber,
+										Snapshot snapshot);
 extern List *ColumnarReadBloomList(uint64 storageId, uint64 groupNumber,
 								   Snapshot snapshot);
 extern List *ColumnarReadStripeList(uint64 storageId, Snapshot snapshot);
@@ -529,6 +531,7 @@ extern void ColumnarReadSetParallelCounter(ColumnarReadState *readState,
 extern void ColumnarReadStats(ColumnarReadState *readState,
 							  uint64 *groupsRead, uint64 *groupsSkipped,
 							  uint64 *groupsTotal);
+extern uint64 ColumnarVectorsSkipped(ColumnarReadState *readState);
 
 /*
  * Fetch a single row by its 1-based row number (spec 6), for the table AM's

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -397,6 +397,8 @@ extern void ColumnarInsertZoneMapRow(const NativeZoneMapMetadata *z);
 extern List *ColumnarReadRowGroupList(uint64 storageId, Snapshot snapshot);
 extern List *ColumnarReadColumnChunkList(uint64 storageId, uint64 groupNumber,
 										 Snapshot snapshot);
+extern List *ColumnarReadZoneMapList(uint64 storageId, uint64 groupNumber,
+									 Snapshot snapshot);
 extern List *ColumnarReadStripeList(uint64 storageId, Snapshot snapshot);
 extern List *ColumnarReadChunkGroupList(uint64 storageId, uint64 stripeNum,
 										Snapshot snapshot);

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -226,6 +226,32 @@ typedef struct NativeColumnChunkMetadata
 } NativeColumnChunkMetadata;
 
 /*
+ * One pgcolumnar.zone_map row (native spec 7.1, Phase D5): a Small Materialized
+ * Aggregate for one vector of a column chunk (vectorIndex 0-based) or for the
+ * whole column chunk (vectorIndex -1). minimum and maximum are the column's
+ * value serialized with ColumnarEncodeValue (NULL when the type has no btree
+ * ordering); sum is a numeric Datum (D5a leaves it unset, hasSum false; the
+ * zone-map-only aggregate that consumes it lands in D5b). value_count and
+ * null_count are always present.
+ */
+typedef struct NativeZoneMapMetadata
+{
+	uint64		storageId;
+	uint64		groupNumber;
+	int			columnIndex;
+	int			vectorIndex;		/* 0-based vector; -1 for the whole chunk */
+	bool		hasMinMax;
+	const char *minimum;			/* ColumnarEncodeValue bytes, when hasMinMax */
+	uint32		minimumLen;
+	const char *maximum;
+	uint32		maximumLen;
+	bool		hasSum;				/* D5a: false; sum computed in D5b */
+	Datum		sum;				/* numeric Datum when hasSum */
+	uint64		valueCount;
+	uint64		nullCount;
+} NativeZoneMapMetadata;
+
+/*
  * One columnar.row_mask row (spec 7.5). Covers the row-number range
  * [startRowNumber, endRowNumber] of a single chunk group; a set bit in mask
  * marks a deleted row. Bit i (0-based) corresponds to row number
@@ -367,6 +393,7 @@ extern void ColumnarInsertChunkRow(uint64 storageId, const ChunkMetadata *chunk)
 extern void ColumnarInsertNativeStorageRow(const NativeStorageMetadata *s);
 extern void ColumnarInsertRowGroupRow(const NativeRowGroupMetadata *rg);
 extern void ColumnarInsertColumnChunkRow(const NativeColumnChunkMetadata *cc);
+extern void ColumnarInsertZoneMapRow(const NativeZoneMapMetadata *z);
 extern List *ColumnarReadRowGroupList(uint64 storageId, Snapshot snapshot);
 extern List *ColumnarReadColumnChunkList(uint64 storageId, uint64 groupNumber,
 										 Snapshot snapshot);

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -252,6 +252,20 @@ typedef struct NativeZoneMapMetadata
 } NativeZoneMapMetadata;
 
 /*
+ * One pgcolumnar.bloom row (native spec 7.2, Phase D5b): a per-column-chunk bloom
+ * filter over the chunk's hashable values, for equality skipping on unsorted
+ * columns. filter is the ColumnarBloomBuild byte image.
+ */
+typedef struct NativeBloomMetadata
+{
+	uint64		storageId;
+	uint64		groupNumber;
+	int			columnIndex;
+	const char *filter;
+	uint32		filterLen;
+} NativeBloomMetadata;
+
+/*
  * One columnar.row_mask row (spec 7.5). Covers the row-number range
  * [startRowNumber, endRowNumber] of a single chunk group; a set bit in mask
  * marks a deleted row. Bit i (0-based) corresponds to row number
@@ -394,11 +408,14 @@ extern void ColumnarInsertNativeStorageRow(const NativeStorageMetadata *s);
 extern void ColumnarInsertRowGroupRow(const NativeRowGroupMetadata *rg);
 extern void ColumnarInsertColumnChunkRow(const NativeColumnChunkMetadata *cc);
 extern void ColumnarInsertZoneMapRow(const NativeZoneMapMetadata *z);
+extern void ColumnarInsertBloomRow(const NativeBloomMetadata *b);
 extern List *ColumnarReadRowGroupList(uint64 storageId, Snapshot snapshot);
 extern List *ColumnarReadColumnChunkList(uint64 storageId, uint64 groupNumber,
 										 Snapshot snapshot);
 extern List *ColumnarReadZoneMapList(uint64 storageId, uint64 groupNumber,
 									 Snapshot snapshot);
+extern List *ColumnarReadBloomList(uint64 storageId, uint64 groupNumber,
+								   Snapshot snapshot);
 extern List *ColumnarReadStripeList(uint64 storageId, Snapshot snapshot);
 extern List *ColumnarReadChunkGroupList(uint64 storageId, uint64 stripeNum,
 										Snapshot snapshot);

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -536,14 +536,13 @@ ColumnarSetRelPathlist(PlannerInfo *root, RelOptInfo *rel, Index rti,
 		return;
 
 	/*
-	 * Native-format tables (PGCN v1) are read only through the base access-method
-	 * scan (ColumnarReadNextRow, which is native-aware) in Phase D3. The custom
-	 * scan's vectorized paths and metadata count(*) read the 2.2 stripe/chunk
-	 * catalog, which a native table does not populate, so skip them here; the
-	 * native vectorized path is a later sub-phase.
+	 * Native-format tables (PGCN v1) take the custom scan too (Phase D5b), but
+	 * only its scalar per-row path (ColumnarReadNextRow, which is native-aware),
+	 * so pushed-down predicates drive zone-map row-group skipping (native spec
+	 * 7.1). The vectorized paths and metadata count(*) read the 2.2 stripe/chunk
+	 * catalog a native table does not populate; ColumnarBeginCustomScan forces the
+	 * scalar path for native, and the native aggregate path is a later sub-phase.
 	 */
-	if (ColumnarTableFormatVersion(rte->relid) == COLUMNAR_NATIVE_VERSION_MAJOR)
-		return;
 
 	/* find a non-parameterized seqscan path to inherit its costs from */
 	foreach(lc, rel->pathlist)
@@ -865,6 +864,16 @@ ColumnarBeginCustomScan(CustomScanState *node, EState *estate, int eflags)
 		 */
 		cstate->vectorized = columnar_enable_vectorization &&
 			cstate->projectedColumns != NULL;
+
+		/*
+		 * Native tables (PGCN v1) have no vectorized path yet; the scalar per-row
+		 * reader is native-aware and applies zone-map row-group skipping from the
+		 * pushed-down scan keys (Phase D5b). The vectorized path reads the 2.2
+		 * chunk catalog, so it must not run for native.
+		 */
+		if (ColumnarTableFormatVersion(RelationGetRelid(rel)) ==
+			COLUMNAR_NATIVE_VERSION_MAJOR)
+			cstate->vectorized = false;
 	}
 	cstate->haveVec = false;
 	cstate->vecPos = 0;

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -1228,6 +1228,8 @@ ColumnarExplainCustomScan(CustomScanState *node, List *ancestors,
 							   (int64) groupsRead, es);
 		ExplainPropertyInteger("Columnar Chunk Groups Removed by Filter", NULL,
 							   (int64) groupsSkipped, es);
+		ExplainPropertyInteger("Columnar Vectors Skipped", NULL,
+							   (int64) ColumnarVectorsSkipped(cstate->readState), es);
 	}
 }
 

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -1237,6 +1237,80 @@ ColumnarReadColumnChunkList(uint64 storageId, uint64 groupNumber, Snapshot snaps
 	return result;
 }
 
+/*
+ * ColumnarReadZoneMapList
+ *		The whole-chunk zone maps (vector_index -1) of one row group, for group
+ *		skipping (native spec 7.1, Phase D5b). The caller indexes the result by
+ *		column_index; the minimum/maximum bytes are copied into the current memory
+ *		context. Per-vector rows (vector_index >= 0) are skipped by this reader.
+ */
+List *
+ColumnarReadZoneMapList(uint64 storageId, uint64 groupNumber, Snapshot snapshot)
+{
+	Relation	rel = open_columnar_table("zone_map", AccessShareLock);
+	TupleDesc	tupdesc = RelationGetDescr(rel);
+	ScanKeyData key[2];
+	SysScanDesc scan;
+	HeapTuple	tuple;
+	List	   *result = NIL;
+
+	ScanKeyInit(&key[0], Anum_zone_map_storage_id, BTEqualStrategyNumber,
+				F_INT8EQ, Int64GetDatum((int64) storageId));
+	ScanKeyInit(&key[1], Anum_zone_map_group_number, BTEqualStrategyNumber,
+				F_INT8EQ, Int64GetDatum((int64) groupNumber));
+	scan = systable_beginscan(rel, InvalidOid, false, snapshot, 2, key);
+	while (HeapTupleIsValid(tuple = systable_getnext(scan)))
+	{
+		NativeZoneMapMetadata *z;
+		bool		isnull;
+		int32		vecIndex;
+		Datum		d;
+
+		vecIndex = DatumGetInt32(
+			heap_getattr(tuple, Anum_zone_map_vector_index, tupdesc, &isnull));
+		if (vecIndex != -1)
+			continue;			/* whole-chunk rows only, for group skipping */
+
+		z = palloc0(sizeof(NativeZoneMapMetadata));
+		z->storageId = storageId;
+		z->groupNumber = groupNumber;
+		z->columnIndex = DatumGetInt16(
+			heap_getattr(tuple, Anum_zone_map_column_index, tupdesc, &isnull));
+		z->vectorIndex = vecIndex;
+
+		d = heap_getattr(tuple, Anum_zone_map_minimum, tupdesc, &isnull);
+		if (!isnull)
+		{
+			bytea	   *bmin = DatumGetByteaPP(d);
+			Datum		dmax = heap_getattr(tuple, Anum_zone_map_maximum,
+											tupdesc, &isnull);
+
+			if (!isnull)
+			{
+				bytea	   *bmax = DatumGetByteaPP(dmax);
+
+				z->minimumLen = VARSIZE_ANY_EXHDR(bmin);
+				z->minimum = (const char *) memcpy(palloc(z->minimumLen + 1),
+												   VARDATA_ANY(bmin), z->minimumLen);
+				z->maximumLen = VARSIZE_ANY_EXHDR(bmax);
+				z->maximum = (const char *) memcpy(palloc(z->maximumLen + 1),
+												   VARDATA_ANY(bmax), z->maximumLen);
+				z->hasMinMax = true;
+			}
+		}
+
+		z->valueCount = (uint64) DatumGetInt64(
+			heap_getattr(tuple, Anum_zone_map_value_count, tupdesc, &isnull));
+		z->nullCount = (uint64) DatumGetInt64(
+			heap_getattr(tuple, Anum_zone_map_null_count, tupdesc, &isnull));
+		result = lappend(result, z);
+	}
+	systable_endscan(scan);
+	table_close(rel, AccessShareLock);
+
+	return result;
+}
+
 /* -------------------------------------------------------------------------
  * per-table options (spec 7.4)
  * ------------------------------------------------------------------------- */

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -113,6 +113,17 @@
 #define Anum_column_chunk_page_length 8
 #define Natts_column_chunk 8
 
+#define Anum_zone_map_storage_id 1
+#define Anum_zone_map_group_number 2
+#define Anum_zone_map_column_index 3
+#define Anum_zone_map_vector_index 4
+#define Anum_zone_map_minimum 5
+#define Anum_zone_map_maximum 6
+#define Anum_zone_map_sum 7
+#define Anum_zone_map_value_count 8
+#define Anum_zone_map_null_count 9
+#define Natts_zone_map 9
+
 /* attribute numbers for columnar.row_mask (spec 7.5) */
 #define Anum_row_mask_id 1
 #define Anum_row_mask_storage_id 2
@@ -948,6 +959,7 @@ ColumnarDeleteMetadata(uint64 storageId)
 	delete_rows_by_storage_id("stripe", Anum_stripe_storage_id, storageId);
 	/* native format catalog (PGCN v1); no-op rows for 2.2-line tables */
 	delete_rows_by_storage_id("column_chunk", Anum_column_chunk_storage_id, storageId);
+	delete_rows_by_storage_id("zone_map", Anum_zone_map_storage_id, storageId);
 	delete_rows_by_storage_id("row_group", Anum_row_group_storage_id, storageId);
 	delete_rows_by_storage_id("storage", Anum_native_storage_storage_id, storageId);
 }
@@ -1049,6 +1061,62 @@ ColumnarInsertColumnChunkRow(const NativeColumnChunkMetadata *cc)
 	values[Anum_column_chunk_block_codec - 1] = Int16GetDatum((int16) cc->blockCodec);
 	values[Anum_column_chunk_page_offset - 1] = Int64GetDatum((int64) cc->pageOffset);
 	values[Anum_column_chunk_page_length - 1] = Int64GetDatum((int64) cc->pageLength);
+
+	tuple = heap_form_tuple(tupdesc, values, nulls);
+	CatalogTupleInsert(rel, tuple);
+	heap_freetuple(tuple);
+	table_close(rel, RowExclusiveLock);
+}
+
+/*
+ * ColumnarInsertZoneMapRow
+ *		Record one native zone-map row (Small Materialized Aggregate) for a vector
+ *		or for a whole column chunk (native spec 7.1, Phase D5). Called by the
+ *		native writer's flush.
+ */
+void
+ColumnarInsertZoneMapRow(const NativeZoneMapMetadata *z)
+{
+	Relation	rel = open_columnar_table("zone_map", RowExclusiveLock);
+	TupleDesc	tupdesc = RelationGetDescr(rel);
+	Datum		values[Natts_zone_map];
+	bool		nulls[Natts_zone_map];
+	HeapTuple	tuple;
+
+	memset(nulls, false, sizeof(nulls));
+
+	values[Anum_zone_map_storage_id - 1] = Int64GetDatum((int64) z->storageId);
+	values[Anum_zone_map_group_number - 1] = Int64GetDatum((int64) z->groupNumber);
+	values[Anum_zone_map_column_index - 1] = Int16GetDatum((int16) z->columnIndex);
+	values[Anum_zone_map_vector_index - 1] = Int32GetDatum((int32) z->vectorIndex);
+
+	if (z->hasMinMax)
+	{
+		bytea	   *mn = (bytea *) palloc(VARHDRSZ + z->minimumLen);
+		bytea	   *mx = (bytea *) palloc(VARHDRSZ + z->maximumLen);
+
+		SET_VARSIZE(mn, VARHDRSZ + z->minimumLen);
+		SET_VARSIZE(mx, VARHDRSZ + z->maximumLen);
+		if (z->minimumLen > 0)
+			memcpy(VARDATA(mn), z->minimum, z->minimumLen);
+		if (z->maximumLen > 0)
+			memcpy(VARDATA(mx), z->maximum, z->maximumLen);
+		values[Anum_zone_map_minimum - 1] = PointerGetDatum(mn);
+		values[Anum_zone_map_maximum - 1] = PointerGetDatum(mx);
+	}
+	else
+	{
+		nulls[Anum_zone_map_minimum - 1] = true;
+		nulls[Anum_zone_map_maximum - 1] = true;
+	}
+
+	if (z->hasSum)
+		values[Anum_zone_map_sum - 1] = z->sum;
+	else
+		nulls[Anum_zone_map_sum - 1] = true;
+
+	values[Anum_zone_map_value_count - 1] = Int64GetDatum((int64) z->valueCount);
+	values[Anum_zone_map_null_count - 1] = Int64GetDatum((int64) z->nullCount);
 
 	tuple = heap_form_tuple(tupdesc, values, nulls);
 	CatalogTupleInsert(rel, tuple);

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -1211,6 +1211,79 @@ ColumnarReadBloomList(uint64 storageId, uint64 groupNumber, Snapshot snapshot)
 	return result;
 }
 
+/*
+ * ColumnarReadZoneMapVectors
+ *		The per-vector zone maps (vector_index >= 0) of one row group, for
+ *		per-vector skipping (native spec 7.1, Phase D5b). Only min/max and the
+ *		vector/column indices are needed by the caller. The min/max bytes are
+ *		copied into the current memory context.
+ */
+List *
+ColumnarReadZoneMapVectors(uint64 storageId, uint64 groupNumber, Snapshot snapshot)
+{
+	Relation	rel = open_columnar_table("zone_map", AccessShareLock);
+	TupleDesc	tupdesc = RelationGetDescr(rel);
+	ScanKeyData key[2];
+	SysScanDesc scan;
+	HeapTuple	tuple;
+	List	   *result = NIL;
+
+	ScanKeyInit(&key[0], Anum_zone_map_storage_id, BTEqualStrategyNumber,
+				F_INT8EQ, Int64GetDatum((int64) storageId));
+	ScanKeyInit(&key[1], Anum_zone_map_group_number, BTEqualStrategyNumber,
+				F_INT8EQ, Int64GetDatum((int64) groupNumber));
+	scan = systable_beginscan(rel, InvalidOid, false, snapshot, 2, key);
+	while (HeapTupleIsValid(tuple = systable_getnext(scan)))
+	{
+		NativeZoneMapMetadata *z;
+		bool		isnull;
+		int32		vecIndex;
+		Datum		d;
+
+		vecIndex = DatumGetInt32(
+			heap_getattr(tuple, Anum_zone_map_vector_index, tupdesc, &isnull));
+		if (vecIndex < 0)
+			continue;			/* per-vector rows only */
+
+		z = palloc0(sizeof(NativeZoneMapMetadata));
+		z->storageId = storageId;
+		z->groupNumber = groupNumber;
+		z->columnIndex = DatumGetInt16(
+			heap_getattr(tuple, Anum_zone_map_column_index, tupdesc, &isnull));
+		z->vectorIndex = vecIndex;
+
+		d = heap_getattr(tuple, Anum_zone_map_minimum, tupdesc, &isnull);
+		if (!isnull)
+		{
+			bytea	   *bmin = DatumGetByteaPP(d);
+			Datum		dmax = heap_getattr(tuple, Anum_zone_map_maximum,
+											tupdesc, &isnull);
+
+			if (!isnull)
+			{
+				bytea	   *bmax = DatumGetByteaPP(dmax);
+
+				z->minimumLen = VARSIZE_ANY_EXHDR(bmin);
+				z->minimum = (const char *) memcpy(palloc(z->minimumLen + 1),
+												   VARDATA_ANY(bmin), z->minimumLen);
+				z->maximumLen = VARSIZE_ANY_EXHDR(bmax);
+				z->maximum = (const char *) memcpy(palloc(z->maximumLen + 1),
+												   VARDATA_ANY(bmax), z->maximumLen);
+				z->hasMinMax = true;
+			}
+		}
+		z->valueCount = (uint64) DatumGetInt64(
+			heap_getattr(tuple, Anum_zone_map_value_count, tupdesc, &isnull));
+		z->nullCount = (uint64) DatumGetInt64(
+			heap_getattr(tuple, Anum_zone_map_null_count, tupdesc, &isnull));
+		result = lappend(result, z);
+	}
+	systable_endscan(scan);
+	table_close(rel, AccessShareLock);
+
+	return result;
+}
+
 /* order native row groups by group_number */
 static int
 row_group_cmp(const ListCell *a, const ListCell *b)

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -24,6 +24,7 @@
 #include "storage/lock.h"
 #include "utils/array.h"
 #include "utils/builtins.h"
+#include "utils/datum.h"
 #include "utils/fmgroids.h"
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
@@ -1297,6 +1298,13 @@ ColumnarReadZoneMapList(uint64 storageId, uint64 groupNumber, Snapshot snapshot)
 												   VARDATA_ANY(bmax), z->maximumLen);
 				z->hasMinMax = true;
 			}
+		}
+
+		d = heap_getattr(tuple, Anum_zone_map_sum, tupdesc, &isnull);
+		if (!isnull)
+		{
+			z->sum = datumCopy(d, false, -1);	/* numeric is varlena */
+			z->hasSum = true;
 		}
 
 		z->valueCount = (uint64) DatumGetInt64(

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -125,6 +125,12 @@
 #define Anum_zone_map_null_count 9
 #define Natts_zone_map 9
 
+#define Anum_bloom_storage_id 1
+#define Anum_bloom_group_number 2
+#define Anum_bloom_column_index 3
+#define Anum_bloom_filter 4
+#define Natts_bloom 4
+
 /* attribute numbers for columnar.row_mask (spec 7.5) */
 #define Anum_row_mask_id 1
 #define Anum_row_mask_storage_id 2
@@ -961,6 +967,7 @@ ColumnarDeleteMetadata(uint64 storageId)
 	/* native format catalog (PGCN v1); no-op rows for 2.2-line tables */
 	delete_rows_by_storage_id("column_chunk", Anum_column_chunk_storage_id, storageId);
 	delete_rows_by_storage_id("zone_map", Anum_zone_map_storage_id, storageId);
+	delete_rows_by_storage_id("bloom", Anum_bloom_storage_id, storageId);
 	delete_rows_by_storage_id("row_group", Anum_row_group_storage_id, storageId);
 	delete_rows_by_storage_id("storage", Anum_native_storage_storage_id, storageId);
 }
@@ -1123,6 +1130,85 @@ ColumnarInsertZoneMapRow(const NativeZoneMapMetadata *z)
 	CatalogTupleInsert(rel, tuple);
 	heap_freetuple(tuple);
 	table_close(rel, RowExclusiveLock);
+}
+
+/*
+ * ColumnarInsertBloomRow
+ *		Record one per-column-chunk bloom filter (native spec 7.2, Phase D5b).
+ */
+void
+ColumnarInsertBloomRow(const NativeBloomMetadata *b)
+{
+	Relation	rel = open_columnar_table("bloom", RowExclusiveLock);
+	TupleDesc	tupdesc = RelationGetDescr(rel);
+	Datum		values[Natts_bloom];
+	bool		nulls[Natts_bloom];
+	HeapTuple	tuple;
+	bytea	   *filt;
+
+	memset(nulls, false, sizeof(nulls));
+	filt = (bytea *) palloc(VARHDRSZ + b->filterLen);
+	SET_VARSIZE(filt, VARHDRSZ + b->filterLen);
+	if (b->filterLen > 0)
+		memcpy(VARDATA(filt), b->filter, b->filterLen);
+
+	values[Anum_bloom_storage_id - 1] = Int64GetDatum((int64) b->storageId);
+	values[Anum_bloom_group_number - 1] = Int64GetDatum((int64) b->groupNumber);
+	values[Anum_bloom_column_index - 1] = Int16GetDatum((int16) b->columnIndex);
+	values[Anum_bloom_filter - 1] = PointerGetDatum(filt);
+
+	tuple = heap_form_tuple(tupdesc, values, nulls);
+	CatalogTupleInsert(rel, tuple);
+	heap_freetuple(tuple);
+	table_close(rel, RowExclusiveLock);
+}
+
+/*
+ * ColumnarReadBloomList
+ *		The per-column-chunk bloom filters of one row group (native spec 7.2,
+ *		Phase D5b). The caller indexes the result by column_index; the filter
+ *		bytes are copied into the current memory context.
+ */
+List *
+ColumnarReadBloomList(uint64 storageId, uint64 groupNumber, Snapshot snapshot)
+{
+	Relation	rel = open_columnar_table("bloom", AccessShareLock);
+	TupleDesc	tupdesc = RelationGetDescr(rel);
+	ScanKeyData key[2];
+	SysScanDesc scan;
+	HeapTuple	tuple;
+	List	   *result = NIL;
+
+	ScanKeyInit(&key[0], Anum_bloom_storage_id, BTEqualStrategyNumber,
+				F_INT8EQ, Int64GetDatum((int64) storageId));
+	ScanKeyInit(&key[1], Anum_bloom_group_number, BTEqualStrategyNumber,
+				F_INT8EQ, Int64GetDatum((int64) groupNumber));
+	scan = systable_beginscan(rel, InvalidOid, false, snapshot, 2, key);
+	while (HeapTupleIsValid(tuple = systable_getnext(scan)))
+	{
+		NativeBloomMetadata *b = palloc0(sizeof(NativeBloomMetadata));
+		bool		isnull;
+		Datum		d;
+
+		b->storageId = storageId;
+		b->groupNumber = groupNumber;
+		b->columnIndex = DatumGetInt16(
+			heap_getattr(tuple, Anum_bloom_column_index, tupdesc, &isnull));
+		d = heap_getattr(tuple, Anum_bloom_filter, tupdesc, &isnull);
+		if (!isnull)
+		{
+			bytea	   *bf = DatumGetByteaPP(d);
+
+			b->filterLen = VARSIZE_ANY_EXHDR(bf);
+			b->filter = (const char *) memcpy(palloc(b->filterLen + 1),
+											  VARDATA_ANY(bf), b->filterLen);
+		}
+		result = lappend(result, b);
+	}
+	systable_endscan(scan);
+	table_close(rel, AccessShareLock);
+
+	return result;
 }
 
 /* order native row groups by group_number */

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -123,6 +123,21 @@ struct ColumnarReadState
 	char	  **nativeValidity;		/* [natts]; NULL if the column is absent */
 	char	  **nativeValueCursor;	/* [natts]; advancing values cursor */
 
+	/*
+	 * Per-vector (1024-row) skipping within a loaded group (Phase D5b). When any
+	 * predicate's per-vector zone map rules a vector out, its rows are neither
+	 * decoded nor emitted. nativeSkipVec[v] flags a ruled-out vector;
+	 * nativeVecRawLen[c][v] is column c's decoded byte length for vector v, used to
+	 * step the value cursor past a skipped vector. Both NULL when per-vector
+	 * skipping is inactive (no predicates or no per-vector zone maps).
+	 */
+	bool	   *nativeSkipVec;		/* [nativeVectorCount] or NULL */
+	int			nativeVectorCount;
+	uint32	  **nativeVecRawLen;	/* [natts][nativeVectorCount] or NULL */
+	uint32	   *nativeVecStart;		/* [nativeVectorCount+1] cumulative row spans */
+	int			nativeCurVec;		/* vector containing rowInGroup */
+	uint64		vectorsSkipped;		/* for EXPLAIN */
+
 	MemoryContext readContext;		/* whole scan */
 	MemoryContext stripeContext;	/* reset per stripe */
 	MemoryContext groupContext;		/* reset per chunk group (decompressed) */
@@ -750,7 +765,8 @@ columnar_read_start(ColumnarReadState *readState)
 static char *
 columnar_native_decode_chunk(ColumnarReadState *rs, Form_pg_attribute att,
 							 char *values, uint32 valuesLen,
-							 const char *desc, uint32 descLen, int blockCodec)
+							 const char *desc, uint32 descLen, int blockCodec,
+							 uint32 **outVecRawLen, int *outVecCount)
 {
 	uint32		vectorCount;
 	uint32		v;
@@ -761,6 +777,7 @@ columnar_native_decode_chunk(ColumnarReadState *rs, Form_pg_attribute att,
 	const char *encCursor;
 	char	   *rawBuf;
 	char	   *rawCursor;
+	uint32	   *vecRawLen;
 
 	if (descLen < COLUMNAR_NATIVE_ENCDESC_HEADER_LEN ||
 		(uint8) desc[0] != COLUMNAR_NATIVE_ENCDESC_VERSION)
@@ -805,6 +822,8 @@ columnar_native_decode_chunk(ColumnarReadState *rs, Form_pg_attribute att,
 
 	/* second pass: decode each vector into one raw present-value buffer */
 	rawBuf = MemoryContextAlloc(rs->groupContext, rawTotal > 0 ? rawTotal : 1);
+	vecRawLen = (uint32 *) MemoryContextAlloc(rs->groupContext,
+											  sizeof(uint32) * (vectorCount > 0 ? vectorCount : 1));
 	rawCursor = rawBuf;
 	encCursor = encRegion;
 	dp = desc + COLUMNAR_NATIVE_ENCDESC_HEADER_LEN;
@@ -821,6 +840,7 @@ columnar_native_decode_chunk(ColumnarReadState *rs, Form_pg_attribute att,
 		memcpy(&encLen, dp + 1 + 2 * sizeof(uint32), sizeof(uint32));
 		dp += COLUMNAR_NATIVE_ENCDESC_ENTRY_LEN;
 
+		vecRawLen[v] = rawLen;
 		if (rawLen > 0)
 		{
 			char	   *rawVec = ColumnarDecodeChunk(encCursor, encLen, encType,
@@ -833,7 +853,67 @@ columnar_native_decode_chunk(ColumnarReadState *rs, Form_pg_attribute att,
 		encCursor += encLen;
 	}
 
+	if (outVecRawLen != NULL)
+		*outVecRawLen = vecRawLen;
+	if (outVecCount != NULL)
+		*outVecCount = (int) vectorCount;
+
 	return rawBuf;
+}
+
+/*
+ * native_zone_excludes
+ *		Return true when a zone map's min/max prove that no value in its range can
+ *		satisfy the predicate (so the vector or chunk can be skipped). A missing or
+ *		non-orderable zone map returns false (cannot prove empty). Shared by
+ *		whole-chunk (group) and per-vector skipping (native spec 7.1). Decodes the
+ *		stored min/max in cx.
+ */
+static bool
+native_zone_excludes(SkipPredicate *pred, Form_pg_attribute att,
+					 NativeZoneMapMetadata *z, MemoryContext cx)
+{
+	char	   *cur;
+	Datum		minv;
+	Datum		maxv;
+	int32		c1;
+	int32		c2;
+
+	if (z == NULL || !z->hasMinMax)
+		return false;
+
+	cur = (char *) z->minimum;
+	minv = ColumnarDecodeValue(att, &cur, cx);
+	cur = (char *) z->maximum;
+	maxv = ColumnarDecodeValue(att, &cur, cx);
+
+	switch (pred->strategy)
+	{
+		case BTLessStrategyNumber:	/* col < const : skip if min >= const */
+			c1 = DatumGetInt32(FunctionCall2Coll(&pred->cmpFn, pred->collation,
+												 minv, pred->compareValue));
+			return (c1 >= 0);
+		case BTLessEqualStrategyNumber: /* col <= const : skip if min > const */
+			c1 = DatumGetInt32(FunctionCall2Coll(&pred->cmpFn, pred->collation,
+												 minv, pred->compareValue));
+			return (c1 > 0);
+		case BTEqualStrategyNumber: /* col = const : skip if const<min or const>max */
+			c1 = DatumGetInt32(FunctionCall2Coll(&pred->cmpFn, pred->collation,
+												 pred->compareValue, minv));
+			c2 = DatumGetInt32(FunctionCall2Coll(&pred->cmpFn, pred->collation,
+												 pred->compareValue, maxv));
+			return (c1 < 0 || c2 > 0);
+		case BTGreaterEqualStrategyNumber:	/* col >= const : skip if max < const */
+			c2 = DatumGetInt32(FunctionCall2Coll(&pred->cmpFn, pred->collation,
+												 maxv, pred->compareValue));
+			return (c2 < 0);
+		case BTGreaterStrategyNumber:	/* col > const : skip if max <= const */
+			c2 = DatumGetInt32(FunctionCall2Coll(&pred->cmpFn, pred->collation,
+												 maxv, pred->compareValue));
+			return (c2 <= 0);
+		default:
+			return false;
+	}
 }
 
 /*
@@ -881,82 +961,122 @@ columnar_native_group_can_match(ColumnarReadState *rs, uint64 groupNumber)
 	for (p = 0; p < rs->numPredicates; p++)
 	{
 		SkipPredicate *pred = &rs->predicates[p];
-		NativeZoneMapMetadata *z = byCol[pred->attidx];
 		Form_pg_attribute att = TupleDescAttr(rs->tupdesc, pred->attidx);
-		char	   *cur;
-		Datum		minv;
-		Datum		maxv;
-		int32		c1;
-		int32		c2;
 
-		if (z == NULL || !z->hasMinMax)
-			continue;			/* cannot prove empty; keep the group */
+		if (native_zone_excludes(pred, att, byCol[pred->attidx], rs->skipContext))
+			return false;
 
-		cur = (char *) z->minimum;
-		minv = ColumnarDecodeValue(att, &cur, rs->skipContext);
-		cur = (char *) z->maximum;
-		maxv = ColumnarDecodeValue(att, &cur, rs->skipContext);
-
-		switch (pred->strategy)
+		/*
+		 * min/max did not rule the group out; for equality consult the per-chunk
+		 * bloom filter (native spec 7.2), which prunes equality probes on unsorted
+		 * columns that min/max cannot.
+		 */
+		if (pred->strategy == BTEqualStrategyNumber &&
+			columnar_enable_bloom_filter && pred->hasHash)
 		{
-			case BTLessStrategyNumber:	/* col < const : skip if min >= const */
-				c1 = DatumGetInt32(FunctionCall2Coll(&pred->cmpFn, pred->collation,
-													 minv, pred->compareValue));
-				if (c1 >= 0)
-					return false;
-				break;
-			case BTLessEqualStrategyNumber: /* col <= const : skip if min > const */
-				c1 = DatumGetInt32(FunctionCall2Coll(&pred->cmpFn, pred->collation,
-													 minv, pred->compareValue));
-				if (c1 > 0)
-					return false;
-				break;
-			case BTEqualStrategyNumber: /* col = const : skip if const<min or >max */
-				c1 = DatumGetInt32(FunctionCall2Coll(&pred->cmpFn, pred->collation,
-													 pred->compareValue, minv));
-				c2 = DatumGetInt32(FunctionCall2Coll(&pred->cmpFn, pred->collation,
-													 pred->compareValue, maxv));
-				if (c1 < 0 || c2 > 0)
-					return false;
+			NativeBloomMetadata *b = byColBloom[pred->attidx];
 
-				/*
-				 * min/max did not rule the group out; consult the bloom filter
-				 * (native spec 7.2). A provably-absent value skips the group,
-				 * which prunes equality probes on unsorted columns.
-				 */
-				if (columnar_enable_bloom_filter && pred->hasHash)
-				{
-					NativeBloomMetadata *b = byColBloom[pred->attidx];
+			if (b != NULL && b->filter != NULL)
+			{
+				uint32		h = DatumGetUInt32(
+					FunctionCall1Coll(&pred->hashFn, pred->hashCollation,
+									  pred->compareValue));
 
-					if (b != NULL && b->filter != NULL)
-					{
-						uint32		h = DatumGetUInt32(
-							FunctionCall1Coll(&pred->hashFn, pred->hashCollation,
-											  pred->compareValue));
-
-						if (!ColumnarBloomProbe(b->filter, b->filterLen, h))
-							return false;
-					}
-				}
-				break;
-			case BTGreaterEqualStrategyNumber:	/* col >= const : skip if max<const */
-				c2 = DatumGetInt32(FunctionCall2Coll(&pred->cmpFn, pred->collation,
-													 maxv, pred->compareValue));
-				if (c2 < 0)
+				if (!ColumnarBloomProbe(b->filter, b->filterLen, h))
 					return false;
-				break;
-			case BTGreaterStrategyNumber:	/* col > const : skip if max<=const */
-				c2 = DatumGetInt32(FunctionCall2Coll(&pred->cmpFn, pred->collation,
-													 maxv, pred->compareValue));
-				if (c2 <= 0)
-					return false;
-				break;
-			default:
-				break;
+			}
 		}
 	}
 
 	return true;
+}
+
+/*
+ * columnar_native_build_skipvec
+ *		Build the per-vector skip flags for a loaded row group (native spec 7.1,
+ *		Phase D5b): vector v is skipped when any predicate's per-vector zone map
+ *		proves no row in it can match. Also fills rs->nativeVecStart with the
+ *		cumulative row spans (from the zone maps' value+null counts, so it is
+ *		correct for any chunk-group size). Sets rs->nativeSkipVec (or NULL when
+ *		nothing is skippable or no per-vector zone maps exist) and
+ *		rs->nativeVectorCount. Runs in the group context (caller-switched); decodes
+ *		min/max in rs->skipContext.
+ */
+static void
+columnar_native_build_skipvec(ColumnarReadState *rs, uint64 groupNumber, int vecCount)
+{
+	List	   *zones;
+	NativeZoneMapMetadata ***byColVec;
+	uint32	   *span;
+	bool	   *skip;
+	bool		any = false;
+	ListCell   *lc;
+	int			v;
+	int			p;
+
+	rs->nativeSkipVec = NULL;
+	rs->nativeVecStart = NULL;
+	rs->nativeVectorCount = vecCount;
+	rs->nativeCurVec = 0;
+
+	if (rs->numPredicates == 0 || vecCount <= 0)
+		return;
+
+	zones = ColumnarReadZoneMapVectors(rs->storageId, groupNumber, rs->metaSnapshot);
+	if (zones == NIL)
+		return;					/* legacy: no per-vector zone maps */
+
+	/* per-predicate-column lookup [column][vector] */
+	byColVec = (NativeZoneMapMetadata ***)
+		palloc0(sizeof(NativeZoneMapMetadata **) * rs->natts);
+	for (p = 0; p < rs->numPredicates; p++)
+	{
+		int			col = rs->predicates[p].attidx;
+
+		if (col >= 0 && col < rs->natts && byColVec[col] == NULL)
+			byColVec[col] = (NativeZoneMapMetadata **)
+				palloc0(sizeof(NativeZoneMapMetadata *) * vecCount);
+	}
+
+	span = (uint32 *) palloc0(sizeof(uint32) * vecCount);
+	foreach(lc, zones)
+	{
+		NativeZoneMapMetadata *z = (NativeZoneMapMetadata *) lfirst(lc);
+
+		if (z->vectorIndex < 0 || z->vectorIndex >= vecCount)
+			continue;
+		span[z->vectorIndex] = (uint32) (z->valueCount + z->nullCount);
+		if (z->columnIndex >= 0 && z->columnIndex < rs->natts &&
+			byColVec[z->columnIndex] != NULL)
+			byColVec[z->columnIndex][z->vectorIndex] = z;
+	}
+
+	MemoryContextReset(rs->skipContext);
+	skip = (bool *) palloc0(sizeof(bool) * vecCount);
+	for (v = 0; v < vecCount; v++)
+	{
+		for (p = 0; p < rs->numPredicates; p++)
+		{
+			SkipPredicate *pred = &rs->predicates[p];
+			Form_pg_attribute att = TupleDescAttr(rs->tupdesc, pred->attidx);
+			NativeZoneMapMetadata *z = byColVec[pred->attidx]
+				? byColVec[pred->attidx][v] : NULL;
+
+			if (native_zone_excludes(pred, att, z, rs->skipContext))
+			{
+				skip[v] = true;
+				any = true;
+				break;
+			}
+		}
+	}
+
+	/* cumulative row spans, for mapping a row to its vector */
+	rs->nativeVecStart = (uint32 *) palloc0(sizeof(uint32) * (vecCount + 1));
+	for (v = 0; v < vecCount; v++)
+		rs->nativeVecStart[v + 1] = rs->nativeVecStart[v] + span[v];
+
+	rs->nativeSkipVec = any ? skip : NULL;
 }
 
 /*
@@ -974,6 +1094,8 @@ columnar_native_load_group(ColumnarReadState *rs)
 	List	   *chunks;
 	ListCell   *lc;
 	int			validityBytes;
+	int			maxVecCount;
+	bool		allDescriptor;
 
 	/* advance past row groups the zone maps rule out (native spec 7.1) */
 	while (rs->rowGroupIndex < list_length(rs->rowGroupList))
@@ -1016,7 +1138,10 @@ columnar_native_load_group(ColumnarReadState *rs)
 										 rs->metaSnapshot);
 	rs->nativeValidity = palloc0(sizeof(char *) * rs->natts);
 	rs->nativeValueCursor = palloc0(sizeof(char *) * rs->natts);
+	rs->nativeVecRawLen = (uint32 **) palloc0(sizeof(uint32 *) * rs->natts);
 	validityBytes = (int) ((rg->rowCount + 7) / 8);
+	maxVecCount = 0;
+	allDescriptor = (chunks != NIL);
 
 	foreach(lc, chunks)
 	{
@@ -1031,12 +1156,16 @@ columnar_native_load_group(ColumnarReadState *rs)
 		if (cc->encodingDescriptorLen == 1 &&
 			(uint8) cc->encodingDescriptor[0] == COLUMNAR_NATIVE_ENCDESC_BASELINE)
 		{
-			/* D2b baseline: raw present values follow the validity bitmap */
+			/* D2b baseline: raw present values follow the validity bitmap; no
+			 * per-vector structure, so per-vector skipping is disabled below */
 			rs->nativeValueCursor[cc->columnIndex] = base + validityBytes;
+			allDescriptor = false;
 		}
 		else
 		{
 			Form_pg_attribute att = TupleDescAttr(rs->tupdesc, cc->columnIndex);
+			uint32	   *vraw = NULL;
+			int			vcount = 0;
 
 			/* D4: reconstruct the raw present-value stream from the descriptor */
 			rs->nativeValueCursor[cc->columnIndex] =
@@ -1044,8 +1173,26 @@ columnar_native_load_group(ColumnarReadState *rs)
 											 (uint32) (cc->pageLength - validityBytes),
 											 cc->encodingDescriptor,
 											 cc->encodingDescriptorLen,
-											 cc->blockCodec);
+											 cc->blockCodec, &vraw, &vcount);
+			rs->nativeVecRawLen[cc->columnIndex] = vraw;
+			if (vcount > maxVecCount)
+				maxVecCount = vcount;
 		}
+	}
+
+	/*
+	 * Per-vector skipping (native spec 7.1, D5b): build the skip vector from the
+	 * per-vector zone maps. Only when every column carries a descriptor (so the
+	 * vector boundaries line up); a legacy baseline chunk disables it.
+	 */
+	if (allDescriptor)
+		columnar_native_build_skipvec(rs, rg->groupNumber, maxVecCount);
+	else
+	{
+		rs->nativeSkipVec = NULL;
+		rs->nativeVecStart = NULL;
+		rs->nativeVectorCount = maxVecCount;
+		rs->nativeCurVec = 0;
 	}
 
 	rs->groupRowCount = rg->rowCount;
@@ -1057,10 +1204,44 @@ columnar_native_load_group(ColumnarReadState *rs)
 }
 
 /*
+ * columnar_native_skip_current_vector
+ *		Per-vector skipping (native spec 7.1, D5b): when rowInGroup sits at the
+ *		start of a vector the zone maps rule out, step each column's value cursor
+ *		past that vector's decoded bytes and jump rowInGroup to the next vector,
+ *		neither decoding nor emitting its rows. Returns true when it advanced (the
+ *		caller re-checks bounds), false when the current row must be emitted.
+ */
+static bool
+columnar_native_skip_current_vector(ColumnarReadState *rs)
+{
+	int			v = rs->nativeCurVec;
+	int			V = rs->nativeVectorCount;
+	int			c;
+
+	while (v < V && rs->rowInGroup >= rs->nativeVecStart[v + 1])
+		v++;
+	rs->nativeCurVec = v;
+
+	if (v >= V || !rs->nativeSkipVec[v] ||
+		rs->rowInGroup != rs->nativeVecStart[v])
+		return false;
+
+	for (c = 0; c < rs->natts; c++)
+		if (rs->nativeValueCursor[c] != NULL && rs->nativeVecRawLen[c] != NULL)
+			rs->nativeValueCursor[c] += rs->nativeVecRawLen[c][v];
+
+	rs->rowInGroup = rs->nativeVecStart[v + 1];
+	rs->nativeCurVec = v + 1;
+	rs->vectorsSkipped++;
+	return true;
+}
+
+/*
  * columnar_native_next_row
  *		Native-format sequential row production (Phase D3). Decodes one row from
  *		the current row group, reconstructing each column from its validity bit
- *		and, when present, the next value on its cursor.
+ *		and, when present, the next value on its cursor. Vectors the zone maps rule
+ *		out are stepped over without decoding (Phase D5b).
  */
 static bool
 columnar_native_next_row(ColumnarReadState *rs, Datum *values, bool *nulls,
@@ -1072,13 +1253,22 @@ columnar_native_next_row(ColumnarReadState *rs, Datum *values, bool *nulls,
 	if (rs->exhausted)
 		return false;
 
-	if (rs->nativeGroup == NULL || rs->rowInGroup >= rs->groupRowCount)
+	for (;;)
 	{
-		if (!columnar_native_load_group(rs))
+		if (rs->nativeGroup == NULL || rs->rowInGroup >= rs->groupRowCount)
 		{
-			rs->exhausted = true;
-			return false;
+			if (!columnar_native_load_group(rs))
+			{
+				rs->exhausted = true;
+				return false;
+			}
 		}
+
+		if (rs->nativeSkipVec != NULL &&
+			columnar_native_skip_current_vector(rs))
+			continue;			/* stepped past a ruled-out vector; re-check */
+
+		break;
 	}
 
 	MemoryContextReset(rs->rowContext);
@@ -1951,6 +2141,11 @@ ColumnarRescanRead(ColumnarReadState *readState)
 	readState->nativeBuffer = NULL;
 	readState->nativeValidity = NULL;
 	readState->nativeValueCursor = NULL;
+	readState->nativeSkipVec = NULL;
+	readState->nativeVecStart = NULL;
+	readState->nativeVecRawLen = NULL;
+	readState->nativeVectorCount = 0;
+	readState->nativeCurVec = 0;
 }
 
 void
@@ -1971,4 +2166,15 @@ ColumnarReadStats(ColumnarReadState *readState, uint64 *groupsRead,
 	*groupsRead = readState->groupsRead;
 	*groupsSkipped = readState->groupsSkipped;
 	*groupsTotal = readState->groupsRead + readState->groupsSkipped;
+}
+
+/*
+ * ColumnarVectorsSkipped
+ *		How many 1024-value vectors the native scan skipped within read row groups
+ *		via per-vector zone maps (native spec 7.1, D5b). Used by EXPLAIN.
+ */
+uint64
+ColumnarVectorsSkipped(ColumnarReadState *readState)
+{
+	return readState->vectorsSkipped;
 }

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -837,10 +837,102 @@ columnar_native_decode_chunk(ColumnarReadState *rs, Form_pg_attribute att,
 }
 
 /*
+ * columnar_native_group_can_match
+ *		Decide whether a native row group could hold a row satisfying every
+ *		pushed-down predicate, using its whole-chunk zone maps (native spec 7.1,
+ *		Phase D5b). Returns false when the group can be skipped. Mirrors the 2.2
+ *		columnar_group_can_match, reading min/max from pgcolumnar.zone_map instead
+ *		of the 2.2 chunk catalog. A missing or non-orderable zone map is treated
+ *		conservatively as "may match". Runs in rs->skipContext (caller-reset).
+ */
+static bool
+columnar_native_group_can_match(ColumnarReadState *rs, uint64 groupNumber)
+{
+	List	   *zones;
+	NativeZoneMapMetadata **byCol;
+	ListCell   *lc;
+	int			p;
+
+	if (rs->numPredicates == 0)
+		return true;
+
+	zones = ColumnarReadZoneMapList(rs->storageId, groupNumber, rs->metaSnapshot);
+	byCol = palloc0(sizeof(NativeZoneMapMetadata *) * rs->natts);
+	foreach(lc, zones)
+	{
+		NativeZoneMapMetadata *z = (NativeZoneMapMetadata *) lfirst(lc);
+
+		if (z->columnIndex >= 0 && z->columnIndex < rs->natts)
+			byCol[z->columnIndex] = z;
+	}
+
+	for (p = 0; p < rs->numPredicates; p++)
+	{
+		SkipPredicate *pred = &rs->predicates[p];
+		NativeZoneMapMetadata *z = byCol[pred->attidx];
+		Form_pg_attribute att = TupleDescAttr(rs->tupdesc, pred->attidx);
+		char	   *cur;
+		Datum		minv;
+		Datum		maxv;
+		int32		c1;
+		int32		c2;
+
+		if (z == NULL || !z->hasMinMax)
+			continue;			/* cannot prove empty; keep the group */
+
+		cur = (char *) z->minimum;
+		minv = ColumnarDecodeValue(att, &cur, rs->skipContext);
+		cur = (char *) z->maximum;
+		maxv = ColumnarDecodeValue(att, &cur, rs->skipContext);
+
+		switch (pred->strategy)
+		{
+			case BTLessStrategyNumber:	/* col < const : skip if min >= const */
+				c1 = DatumGetInt32(FunctionCall2Coll(&pred->cmpFn, pred->collation,
+													 minv, pred->compareValue));
+				if (c1 >= 0)
+					return false;
+				break;
+			case BTLessEqualStrategyNumber: /* col <= const : skip if min > const */
+				c1 = DatumGetInt32(FunctionCall2Coll(&pred->cmpFn, pred->collation,
+													 minv, pred->compareValue));
+				if (c1 > 0)
+					return false;
+				break;
+			case BTEqualStrategyNumber: /* col = const : skip if const<min or >max */
+				c1 = DatumGetInt32(FunctionCall2Coll(&pred->cmpFn, pred->collation,
+													 pred->compareValue, minv));
+				c2 = DatumGetInt32(FunctionCall2Coll(&pred->cmpFn, pred->collation,
+													 pred->compareValue, maxv));
+				if (c1 < 0 || c2 > 0)
+					return false;
+				break;
+			case BTGreaterEqualStrategyNumber:	/* col >= const : skip if max<const */
+				c2 = DatumGetInt32(FunctionCall2Coll(&pred->cmpFn, pred->collation,
+													 maxv, pred->compareValue));
+				if (c2 < 0)
+					return false;
+				break;
+			case BTGreaterStrategyNumber:	/* col > const : skip if max<=const */
+				c2 = DatumGetInt32(FunctionCall2Coll(&pred->cmpFn, pred->collation,
+													 maxv, pred->compareValue));
+				if (c2 <= 0)
+					return false;
+				break;
+			default:
+				break;
+		}
+	}
+
+	return true;
+}
+
+/*
  * columnar_native_load_group
  *		Load the next native row group (PGCN v1, Phase D3): read its bytes whole
  *		into the group context and set each column's validity-bitmap pointer and
- *		values cursor. Returns false when no more row groups remain.
+ *		values cursor. Row groups the zone maps prove cannot match are skipped
+ *		(Phase D5b). Returns false when no more row groups remain.
  */
 static bool
 columnar_native_load_group(ColumnarReadState *rs)
@@ -851,8 +943,32 @@ columnar_native_load_group(ColumnarReadState *rs)
 	ListCell   *lc;
 	int			validityBytes;
 
+	/* advance past row groups the zone maps rule out (native spec 7.1) */
+	while (rs->rowGroupIndex < list_length(rs->rowGroupList))
+	{
+		bool		match = true;
+
+		rg = (NativeRowGroupMetadata *) list_nth(rs->rowGroupList,
+												 rs->rowGroupIndex);
+		if (rs->numPredicates > 0)
+		{
+			MemoryContext old = MemoryContextSwitchTo(rs->skipContext);
+
+			MemoryContextReset(rs->skipContext);
+			match = columnar_native_group_can_match(rs, rg->groupNumber);
+			MemoryContextSwitchTo(old);
+		}
+		if (match)
+			break;
+
+		rs->groupsSkipped++;
+		rs->rowGroupIndex++;
+	}
+
 	if (rs->rowGroupIndex >= list_length(rs->rowGroupList))
 		return false;
+
+	rs->groupsRead++;
 
 	MemoryContextReset(rs->groupContext);
 	oldContext = MemoryContextSwitchTo(rs->groupContext);

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -849,7 +849,9 @@ static bool
 columnar_native_group_can_match(ColumnarReadState *rs, uint64 groupNumber)
 {
 	List	   *zones;
+	List	   *blooms;
 	NativeZoneMapMetadata **byCol;
+	NativeBloomMetadata **byColBloom;
 	ListCell   *lc;
 	int			p;
 
@@ -864,6 +866,16 @@ columnar_native_group_can_match(ColumnarReadState *rs, uint64 groupNumber)
 
 		if (z->columnIndex >= 0 && z->columnIndex < rs->natts)
 			byCol[z->columnIndex] = z;
+	}
+
+	blooms = ColumnarReadBloomList(rs->storageId, groupNumber, rs->metaSnapshot);
+	byColBloom = palloc0(sizeof(NativeBloomMetadata *) * rs->natts);
+	foreach(lc, blooms)
+	{
+		NativeBloomMetadata *b = (NativeBloomMetadata *) lfirst(lc);
+
+		if (b->columnIndex >= 0 && b->columnIndex < rs->natts)
+			byColBloom[b->columnIndex] = b;
 	}
 
 	for (p = 0; p < rs->numPredicates; p++)
@@ -906,6 +918,26 @@ columnar_native_group_can_match(ColumnarReadState *rs, uint64 groupNumber)
 													 pred->compareValue, maxv));
 				if (c1 < 0 || c2 > 0)
 					return false;
+
+				/*
+				 * min/max did not rule the group out; consult the bloom filter
+				 * (native spec 7.2). A provably-absent value skips the group,
+				 * which prunes equality probes on unsorted columns.
+				 */
+				if (columnar_enable_bloom_filter && pred->hasHash)
+				{
+					NativeBloomMetadata *b = byColBloom[pred->attidx];
+
+					if (b != NULL && b->filter != NULL)
+					{
+						uint32		h = DatumGetUInt32(
+							FunctionCall1Coll(&pred->hashFn, pred->hashCollation,
+											  pred->compareValue));
+
+						if (!ColumnarBloomProbe(b->filter, b->filterLen, h))
+							return false;
+					}
+				}
 				break;
 			case BTGreaterEqualStrategyNumber:	/* col >= const : skip if max<const */
 				c2 = DatumGetInt32(FunctionCall2Coll(&pred->cmpFn, pred->collation,

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -641,14 +641,6 @@ ColumnarCreateUpperPaths(PlannerInfo *root, UpperRelationKind stage,
 		return;
 	if (!OidIsValid(rte->relid) || !ColumnarIsColumnarRelation(rte->relid))
 		return;
-	/*
-	 * Native-format tables (PGCN v1) do not populate the 2.2 stripe/chunk
-	 * metadata this vectorized aggregate (and its count(*)-from-metadata) reads,
-	 * so skip them in Phase D3; the aggregate runs over the native base scan
-	 * instead. The native vectorized aggregate is a later sub-phase.
-	 */
-	if (ColumnarTableFormatVersion(rte->relid) == COLUMNAR_NATIVE_VERSION_MAJOR)
-		return;
 	relid = rte->relid;
 
 	/* every target entry must be a bare, supported aggregate */
@@ -674,6 +666,18 @@ ColumnarCreateUpperPaths(PlannerInfo *root, UpperRelationKind stage,
 	 * so the vectorized filter is the complete WHERE. Otherwise fall back.
 	 */
 	quals = extract_actual_clauses(input_rel->baserestrictinfo, false);
+
+	/*
+	 * A native-format table (PGCN v1) answers an ungrouped aggregate from its
+	 * zone maps without a data scan (native spec 7.1, D5b), but only when there
+	 * is no residual filter; with a filter, fall back to the ordinary Agg over
+	 * the (skipping-enabled) custom scan. The 2.2 vectorized scan-and-fold path
+	 * reads the 2.2 chunk catalog, which a native table does not populate.
+	 */
+	if (ColumnarTableFormatVersion(relid) == COLUMNAR_NATIVE_VERSION_MAJOR &&
+		quals != NIL)
+		return;
+
 	{
 		Relation	rel = table_open(relid, AccessShareLock);
 		TupleDesc	tupdesc = RelationGetDescr(rel);
@@ -1221,6 +1225,122 @@ columnar_agg_finalize(ColumnarAggSpec *spec, bool *isnull)
 	return (Datum) 0;
 }
 
+/*
+ * columnar_fill_native_metadata_agg
+ *		Answer an ungrouped, unfiltered aggregate over a native (PGCN v1) table
+ *		entirely from its whole-chunk zone maps (native spec 7.1, D5b): count(*)
+ *		from row-group row counts, count(col) and the avg count from value_count,
+ *		sum and the avg sum from the zone int sum (int2/int4), and min/max from the
+ *		zone min/max. The upper-path hook adds this path only when every aggregate
+ *		is so answerable and there is no filter, so no data pages are read.
+ */
+static void
+columnar_fill_native_metadata_agg(ColumnarAggScanState *state)
+{
+	EState	   *estate = state->css.ss.ps.state;
+	Relation	rel;
+	TupleDesc	tupdesc;
+	Snapshot	snap;
+	uint64		storageId;
+	List	   *groups;
+	ListCell   *lc;
+
+	ColumnarFlushWriteStateForRelation(state->relid);
+	rel = table_open(state->relid, AccessShareLock);
+	tupdesc = RelationGetDescr(rel);
+	snap = ColumnarCatalogSnapshot(estate->es_snapshot);
+	storageId = ColumnarStorageId(rel);
+
+	groups = ColumnarReadRowGroupList(storageId, snap);
+	foreach(lc, groups)
+	{
+		NativeRowGroupMetadata *rg = (NativeRowGroupMetadata *) lfirst(lc);
+		List	   *zones = ColumnarReadZoneMapList(storageId, rg->groupNumber,
+												   snap);
+		NativeZoneMapMetadata **byCol =
+			palloc0(sizeof(NativeZoneMapMetadata *) * tupdesc->natts);
+		ListCell   *zc;
+		int			a;
+
+		foreach(zc, zones)
+		{
+			NativeZoneMapMetadata *z = (NativeZoneMapMetadata *) lfirst(zc);
+
+			if (z->columnIndex >= 0 && z->columnIndex < tupdesc->natts)
+				byCol[z->columnIndex] = z;
+		}
+
+		for (a = 0; a < state->naggs; a++)
+		{
+			ColumnarAggSpec *spec = &state->specs[a];
+			NativeZoneMapMetadata *z =
+				(spec->attidx >= 0 && spec->attidx < tupdesc->natts)
+				? byCol[spec->attidx] : NULL;
+
+			switch (spec->kind)
+			{
+				case COLUMNAR_AGG_COUNT_STAR:
+					spec->count += (int64) rg->rowCount;
+					break;
+				case COLUMNAR_AGG_COUNT_COL:
+					if (z != NULL)
+						spec->count += (int64) z->valueCount;
+					break;
+				case COLUMNAR_AGG_SUM_INT:
+					if (z != NULL && z->hasSum)
+					{
+						spec->sum += DatumGetInt64(
+							DirectFunctionCall1(numeric_int8, z->sum));
+						if (z->valueCount > 0)
+							spec->sawValue = true;
+					}
+					break;
+				case COLUMNAR_AGG_AVG_INT:
+					if (z != NULL)
+					{
+						if (z->hasSum)
+							spec->sum += DatumGetInt64(
+								DirectFunctionCall1(numeric_int8, z->sum));
+						spec->count += (int64) z->valueCount;
+					}
+					break;
+				case COLUMNAR_AGG_MIN:
+				case COLUMNAR_AGG_MAX:
+					if (z != NULL && z->hasMinMax)
+					{
+						Form_pg_attribute att = TupleDescAttr(tupdesc, spec->attidx);
+						MemoryContext oldcx =
+							MemoryContextSwitchTo(state->resultContext);
+						char	   *cur = (spec->kind == COLUMNAR_AGG_MIN)
+							? (char *) z->minimum : (char *) z->maximum;
+						Datum		v = ColumnarDecodeValue(att, &cur,
+														state->resultContext);
+
+						if (!spec->sawValue)
+						{
+							spec->extreme = v;
+							spec->sawValue = true;
+						}
+						else
+						{
+							int32		c = DatumGetInt32(
+								FunctionCall2Coll(&spec->cmpFn, spec->collation,
+												  v, spec->extreme));
+
+							if ((spec->kind == COLUMNAR_AGG_MIN && c < 0) ||
+								(spec->kind == COLUMNAR_AGG_MAX && c > 0))
+								spec->extreme = v;
+						}
+						MemoryContextSwitchTo(oldcx);
+					}
+					break;
+			}
+		}
+	}
+
+	table_close(rel, AccessShareLock);
+}
+
 static TupleTableSlot *
 ColumnarExecAggScan(CustomScanState *node)
 {
@@ -1236,9 +1356,20 @@ ColumnarExecAggScan(CustomScanState *node)
 	state->done = true;
 
 	/*
+	 * Native tables answer entirely from zone maps (native spec 7.1, D5b): the
+	 * upper-path hook added this path only when every aggregate is zone-map
+	 * answerable and there is no filter, so no data pages are read.
+	 */
+	if (ColumnarTableFormatVersion(state->relid) == COLUMNAR_NATIVE_VERSION_MAJOR)
+	{
+		columnar_fill_native_metadata_agg(state);
+		state->haveStats = false;
+	}
+	/*
 	 * Covering count(*) (gap 28): answer a pure count(*) with no filter from the
 	 * catalog, skipping the data scan entirely. Otherwise scan and fold.
 	 */
+	else
 	{
 		int64		mcount;
 

--- a/src/columnar_write_state.c
+++ b/src/columnar_write_state.c
@@ -784,6 +784,7 @@ columnar_flush_row_group(ColumnarWriteState *writeState)
 	int			c;
 	bool		pushedSnapshot = false;
 	List	   *zoneRows = NIL;		/* NativeZoneMapMetadata * to insert (D5) */
+	List	   *bloomRows = NIL;		/* NativeBloomMetadata * to insert (D5b) */
 
 	if (!ActiveSnapshotSet())
 	{
@@ -980,6 +981,39 @@ columnar_flush_row_group(ColumnarWriteState *writeState)
 			zoneRows = lappend(zoneRows, z);
 		}
 
+		/* per-column-chunk bloom over hashable values (native spec 7.2, D5b) */
+		if (def->bloomable)
+		{
+			StringInfoData hashes;
+			char	   *bloom;
+			uint32		bloomLen;
+
+			initStringInfo(&hashes);
+			foreach(lc, writeState->chunkGroups)
+			{
+				ChunkGroupBuffer *group = (ChunkGroupBuffer *) lfirst(lc);
+				ColumnChunkBuffer *col = &group->columns[c];
+
+				if (col->hashBuf.len > 0)
+					appendBinaryStringInfo(&hashes, col->hashBuf.data,
+										   col->hashBuf.len);
+			}
+			if (hashes.len > 0 &&
+				ColumnarBloomBuild((const uint32 *) hashes.data,
+								   hashes.len / sizeof(uint32),
+								   &bloom, &bloomLen))
+			{
+				NativeBloomMetadata *b = palloc0(sizeof(NativeBloomMetadata));
+
+				b->storageId = writeState->storageId;
+				b->groupNumber = groupNumber;
+				b->columnIndex = c;
+				b->filter = bloom;
+				b->filterLen = bloomLen;
+				bloomRows = lappend(bloomRows, b);
+			}
+		}
+
 		/* optional block codec over the whole encoded region (spec 6) */
 		finalData = encoded->data;
 		finalLen = encoded->len;
@@ -1060,6 +1094,8 @@ columnar_flush_row_group(ColumnarWriteState *writeState)
 	}
 	foreach(lc, zoneRows)
 		ColumnarInsertZoneMapRow((NativeZoneMapMetadata *) lfirst(lc));
+	foreach(lc, bloomRows)
+		ColumnarInsertBloomRow((NativeBloomMetadata *) lfirst(lc));
 
 	table_close(rel, RowExclusiveLock);
 

--- a/src/columnar_write_state.c
+++ b/src/columnar_write_state.c
@@ -762,6 +762,7 @@ columnar_flush_row_group(ColumnarWriteState *writeState)
 	ListCell   *lc;
 	int			c;
 	bool		pushedSnapshot = false;
+	List	   *zoneRows = NIL;		/* NativeZoneMapMetadata * to insert (D5) */
 
 	if (!ActiveSnapshotSet())
 	{
@@ -804,6 +805,12 @@ columnar_flush_row_group(ColumnarWriteState *writeState)
 		char	   *finalData;
 		uint32		finalLen;
 		int			blockCodec = COLUMNAR_COMPRESSION_NONE;
+		ColumnarColumnDef *def = &writeState->colDefs[c];
+		int			vec = 0;
+		bool		chunkHasMinMax = false;
+		Datum		chunkMin = (Datum) 0;
+		Datum		chunkMax = (Datum) 0;
+		uint64		chunkValueCount = 0;
 
 		chunkOffset[c] = data->len;
 
@@ -851,6 +858,89 @@ columnar_flush_row_group(ColumnarWriteState *writeState)
 			appendBinaryStringInfo(desc, (char *) &entryValueCount, sizeof(uint32));
 			appendBinaryStringInfo(desc, (char *) &entryRawLen, sizeof(uint32));
 			appendBinaryStringInfo(desc, (char *) &encLen, sizeof(uint32));
+
+			/* per-vector zone map (native spec 7.1, D5) */
+			{
+				NativeZoneMapMetadata *z = palloc0(sizeof(NativeZoneMapMetadata));
+
+				z->storageId = writeState->storageId;
+				z->groupNumber = groupNumber;
+				z->columnIndex = c;
+				z->vectorIndex = vec;
+				z->valueCount = col->valueCount;
+				z->nullCount = group->rowCount - col->valueCount;
+
+				if (col->hasMinMax)
+				{
+					StringInfoData mn;
+					StringInfoData mx;
+
+					initStringInfo(&mn);
+					initStringInfo(&mx);
+					ColumnarEncodeValue(&mn, att, col->minValue);
+					ColumnarEncodeValue(&mx, att, col->maxValue);
+					z->hasMinMax = true;
+					z->minimum = mn.data;
+					z->minimumLen = (uint32) mn.len;
+					z->maximum = mx.data;
+					z->maximumLen = (uint32) mx.len;
+
+					/* fold into the whole-chunk min/max via the btree cmp proc */
+					if (!chunkHasMinMax)
+					{
+						chunkMin = col->minValue;
+						chunkMax = col->maxValue;
+						chunkHasMinMax = true;
+					}
+					else
+					{
+						if (DatumGetInt32(FunctionCall2Coll(&def->cmpFn,
+															def->collation,
+															col->minValue,
+															chunkMin)) < 0)
+							chunkMin = col->minValue;
+						if (DatumGetInt32(FunctionCall2Coll(&def->cmpFn,
+															def->collation,
+															col->maxValue,
+															chunkMax)) > 0)
+							chunkMax = col->maxValue;
+					}
+				}
+
+				chunkValueCount += col->valueCount;
+				zoneRows = lappend(zoneRows, z);
+			}
+			vec++;
+		}
+
+		/* whole-chunk zone map (vector_index -1) */
+		{
+			NativeZoneMapMetadata *z = palloc0(sizeof(NativeZoneMapMetadata));
+
+			z->storageId = writeState->storageId;
+			z->groupNumber = groupNumber;
+			z->columnIndex = c;
+			z->vectorIndex = -1;
+			z->valueCount = chunkValueCount;
+			z->nullCount = rowCount - chunkValueCount;
+
+			if (chunkHasMinMax)
+			{
+				StringInfoData mn;
+				StringInfoData mx;
+
+				initStringInfo(&mn);
+				initStringInfo(&mx);
+				ColumnarEncodeValue(&mn, att, chunkMin);
+				ColumnarEncodeValue(&mx, att, chunkMax);
+				z->hasMinMax = true;
+				z->minimum = mn.data;
+				z->minimumLen = (uint32) mn.len;
+				z->maximum = mx.data;
+				z->maximumLen = (uint32) mx.len;
+			}
+
+			zoneRows = lappend(zoneRows, z);
 		}
 
 		/* optional block codec over the whole encoded region (spec 6) */
@@ -931,6 +1021,8 @@ columnar_flush_row_group(ColumnarWriteState *writeState)
 		cc.pageLength = chunkLength[c];
 		ColumnarInsertColumnChunkRow(&cc);
 	}
+	foreach(lc, zoneRows)
+		ColumnarInsertZoneMapRow((NativeZoneMapMetadata *) lfirst(lc));
 
 	table_close(rel, RowExclusiveLock);
 

--- a/src/columnar_write_state.c
+++ b/src/columnar_write_state.c
@@ -22,6 +22,7 @@
 #include "utils/builtins.h"
 #include "utils/datum.h"
 #include "utils/fmgroids.h"
+#include "utils/fmgrprotos.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
 #include "utils/rel.h"
@@ -34,6 +35,13 @@ typedef struct ColumnarColumnDef
 	bool		orderable;		/* type has a default btree comparison proc */
 	FmgrInfo	cmpFn;			/* the comparison proc, when orderable */
 	Oid			collation;		/* collation to compare under */
+
+	/*
+	 * int2/int4 column: its exact sum fits an int64 accumulator, so the zone map
+	 * carries a per-vector and per-chunk sum for the zone-map-only aggregate (D5).
+	 * Other summable types (int8, numeric, float) are left with a null zone sum.
+	 */
+	bool		summableInt;
 
 	/*
 	 * Bloom-filter support (I7): hashable and non-collatable, so a value's hash
@@ -56,6 +64,9 @@ typedef struct ColumnChunkBuffer
 	bool		hasMinMax;
 	Datum		minValue;		/* held in the stripe context */
 	Datum		maxValue;
+
+	/* running exact sum of non-null int2/int4 values (zone map, D5) */
+	int64		sum;
 
 	/* accumulated 4-byte value hashes for the per-chunk bloom filter (I7) */
 	StringInfoData hashBuf;
@@ -160,6 +171,10 @@ columnar_init_col_defs(ColumnarWriteState *writeState)
 						   &tce->cmp_proc_finfo, ColumnarWriteContext);
 			writeState->colDefs[c].collation = att->attcollation;
 		}
+
+		/* int2/int4: exact sum fits int64, carried in the zone map (D5) */
+		writeState->colDefs[c].summableInt =
+			(att->atttypid == INT2OID || att->atttypid == INT4OID);
 
 		/*
 		 * Bloom filter for hashable columns whose collation is safe (I7, gap
@@ -358,6 +373,12 @@ ColumnarWriteRow(ColumnarWriteState *writeState, Relation rel,
 
 				appendBinaryStringInfo(&col->hashBuf, (char *) &h, sizeof(uint32));
 			}
+
+			/* maintain the per-chunk exact int sum for the zone map (D5) */
+			if (writeState->colDefs[c].summableInt)
+				col->sum += (att->atttypid == INT2OID)
+					? (int64) DatumGetInt16(values[c])
+					: (int64) DatumGetInt32(values[c]);
 
 			/* maintain the per-chunk min/max for orderable types */
 			if (writeState->colDefs[c].orderable)
@@ -811,6 +832,7 @@ columnar_flush_row_group(ColumnarWriteState *writeState)
 		Datum		chunkMin = (Datum) 0;
 		Datum		chunkMax = (Datum) 0;
 		uint64		chunkValueCount = 0;
+		int64		chunkSum = 0;
 
 		chunkOffset[c] = data->len;
 
@@ -870,6 +892,13 @@ columnar_flush_row_group(ColumnarWriteState *writeState)
 				z->valueCount = col->valueCount;
 				z->nullCount = group->rowCount - col->valueCount;
 
+				if (def->summableInt && col->valueCount > 0)
+				{
+					z->hasSum = true;
+					z->sum = DirectFunctionCall1(int8_numeric,
+												 Int64GetDatum(col->sum));
+				}
+
 				if (col->hasMinMax)
 				{
 					StringInfoData mn;
@@ -908,6 +937,7 @@ columnar_flush_row_group(ColumnarWriteState *writeState)
 				}
 
 				chunkValueCount += col->valueCount;
+				chunkSum += col->sum;
 				zoneRows = lappend(zoneRows, z);
 			}
 			vec++;
@@ -923,6 +953,13 @@ columnar_flush_row_group(ColumnarWriteState *writeState)
 			z->vectorIndex = -1;
 			z->valueCount = chunkValueCount;
 			z->nullCount = rowCount - chunkValueCount;
+
+			if (def->summableInt && chunkValueCount > 0)
+			{
+				z->hasSum = true;
+				z->sum = DirectFunctionCall1(int8_numeric,
+											 Int64GetDatum(chunkSum));
+			}
 
 			if (chunkHasMinMax)
 			{

--- a/test/native_agg.sh
+++ b/test/native_agg.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# pgColumnar native zone-map-only aggregates (Phase D5b): an ungrouped, unfiltered
+# aggregate over a native-format (PGCN v1) table is answered from the whole-chunk
+# zone maps without reading any data pages (native spec 7.1): count(*) from row
+# counts, count(col) from value_count, sum/avg(int2,int4) from the zone sum, and
+# min/max from the zone min/max. This suite proves the answers equal a heap oracle
+# across the supported aggregates, nulls and an empty table; that the metadata path
+# is actually taken (EXPLAIN shows the ColumnarAgg node with no data scan); and
+# that a filtered or unsupported aggregate falls back and is still correct.
+#
+# Usage:  test/native_agg.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+# id int4 monotonic no nulls; s int4 with nulls; k bigint; label text. Several row
+# groups so the aggregate folds across many whole-chunk zone maps.
+GEN="SELECT g,
+       CASE WHEN g % 5 = 0 THEN NULL ELSE g % 1000 END,
+       (g * 7)::bigint,
+       'lbl-' || (g % 40)
+  FROM generate_series(1, 10000) g"
+
+psql_run "CREATE TABLE h (id int, s int, k bigint, label text);"
+psql_run "CREATE TABLE n (id int, s int, k bigint, label text) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 2048, chunk_group_row_limit => 1024, format_version => 1);"
+psql_run "INSERT INTO h $GEN;"
+psql_run "INSERT INTO n $GEN;"
+
+# EXPLAIN plan text for a query.
+plan() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -At -c "EXPLAIN (COSTS OFF) $1" 2>/dev/null
+}
+# The metadata aggregate path reports "Columnar Vectorized Aggregates: N" and has
+# no separate Aggregate node above a scan; a fallback plan has an Aggregate node
+# and no such line.
+has_aggnode() { echo "$1" | grep -q 'Columnar Vectorized Aggregates' && echo yes || echo no; }
+
+# Supported aggregates answered from zone maps must equal the heap oracle.
+check "count(*)"          "$(q 'SELECT count(*) FROM n;')"        "$(q 'SELECT count(*) FROM h;')"
+check "count(col,nulls)"  "$(q 'SELECT count(s) FROM n;')"       "$(q 'SELECT count(s) FROM h;')"
+check "sum(int4)"         "$(q 'SELECT sum(id) FROM n;')"        "$(q 'SELECT sum(id) FROM h;')"
+check "sum(int4,nulls)"   "$(q 'SELECT sum(s) FROM n;')"         "$(q 'SELECT sum(s) FROM h;')"
+check "avg(int4,nulls)"   "$(q 'SELECT avg(s) FROM n;')"         "$(q 'SELECT avg(s) FROM h;')"
+check "min(int4)"         "$(q 'SELECT min(id) FROM n;')"        "$(q 'SELECT min(id) FROM h;')"
+check "max(int4)"         "$(q 'SELECT max(id) FROM n;')"        "$(q 'SELECT max(id) FROM h;')"
+check "min(int4,nulls)"   "$(q 'SELECT min(s) FROM n;')"         "$(q 'SELECT min(s) FROM h;')"
+check "min(text)"         "$(q 'SELECT min(label) FROM n;')"     "$(q 'SELECT min(label) FROM h;')"
+check "max(text)"         "$(q 'SELECT max(label) FROM n;')"     "$(q 'SELECT max(label) FROM h;')"
+check "multi-agg"         "$(q 'SELECT count(*), sum(id), min(id), max(id) FROM n;')" \
+                          "$(q 'SELECT count(*), sum(id), min(id), max(id) FROM h;')"
+
+# The metadata path is actually taken (ColumnarAgg node, no underlying scan).
+check "count(*) uses metadata agg node" "$(has_aggnode "$(plan 'SELECT count(*) FROM n')")" "yes"
+check "sum/min/max uses metadata agg node" \
+	"$(has_aggnode "$(plan 'SELECT sum(id), min(id), max(id) FROM n')")" "yes"
+
+# A filtered aggregate falls back (no zone-map answer) but is still correct.
+check "filtered aggregate parity" \
+	"$(q 'SELECT count(*), sum(id) FROM n WHERE id > 5000;')" \
+	"$(q 'SELECT count(*), sum(id) FROM h WHERE id > 5000;')"
+check "filtered aggregate not metadata node" \
+	"$(has_aggnode "$(plan 'SELECT count(*), sum(id) FROM n WHERE id > 5000')")" "no"
+
+# An unsupported aggregate (sum on bigint) falls back and is still correct.
+check "sum(bigint) fallback parity" "$(q 'SELECT sum(k) FROM n;')" "$(q 'SELECT sum(k) FROM h;')"
+
+# Empty native table: count 0, sum/min/max NULL, exactly as SQL.
+psql_run "CREATE TABLE e (id int, label text) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.alter_columnar_table_set('e', format_version => 1);"
+check "empty count(*)"  "$(q 'SELECT count(*) FROM e;')"                 "0"
+check "empty sum NULL"  "$(q 'SELECT sum(id) IS NULL FROM e;')"          "t"
+check "empty min NULL"  "$(q 'SELECT min(label) IS NULL FROM e;')"       "t"
+
+pgc_summary

--- a/test/native_bloom.sh
+++ b/test/native_bloom.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# pgColumnar native per-chunk bloom filters (Phase D5b): a native-format (PGCN v1)
+# table carries a per-column-chunk bloom filter over hashable columns, so an
+# equality probe on an unsorted column skips row groups that provably lack the
+# value (native spec 7.2), even when the min/max zone map cannot (overlapping
+# ranges). This suite proves result parity with a heap mirror and isolates the
+# bloom's effect: with values spread so every group's min/max spans the domain,
+# an equality probe skips groups only when the bloom is enabled.
+#
+# Usage:  test/native_bloom.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+# tag is a well-spread pseudo-random int over a large domain, so each 2048-row
+# group's [min,max] spans almost the whole domain and min/max skipping cannot
+# prune an in-range probe; the bloom can. 20480 rows -> 10 row groups.
+GEN="SELECT g, ((g * 104729) % 1000000) AS tag FROM generate_series(1, 20480) g"
+
+psql_run "CREATE TABLE h (id int, tag int);"
+psql_run "CREATE TABLE n (id int, tag int) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 2048, chunk_group_row_limit => 1024, format_version => 1);"
+psql_run "INSERT INTO h $GEN;"
+psql_run "INSERT INTO n $GEN;"
+
+# A tag value that really occurs (so the answer is non-empty and present in only
+# a few groups), taken from the heap mirror.
+PROBE="$(q 'SELECT tag FROM h WHERE id = 7777;')"
+
+skipped() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -At -c "SET pgcolumnar.enable_bloom_filter = $2; EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) $1" 2>/dev/null \
+		| grep 'Columnar Chunk Groups Removed by Filter' | grep -oE '[0-9]+' | head -1
+}
+gt0() { [ "${1:-0}" -gt 0 ] && echo yes || echo no; }
+
+check "row count" "$(q 'SELECT count(*) FROM n;')" "20480"
+
+# The bloom catalog is populated for the hashable tag column (10 groups) and the
+# id column; a non-hashable case would be absent, but both int4 here are bloomed.
+check "bloom rows written" \
+	"$(q "SELECT count(*) FROM pgcolumnar.bloom WHERE storage_id = pgcolumnar.get_storage_id('n') AND column_index = 1;")" \
+	"10"
+
+# Equality probe result parity.
+check "equality probe parity" \
+	"$(pgc_set_hash "SELECT id, tag FROM n WHERE tag = $PROBE")" \
+	"$(pgc_set_hash "SELECT id, tag FROM h WHERE tag = $PROBE")"
+
+# The bloom, not min/max, is what prunes: groups are skipped with the bloom on and
+# (nearly) none with it off, because the spread values make min/max ranges overlap.
+check "bloom on skips groups" "$(gt0 "$(skipped "SELECT id FROM n WHERE tag = $PROBE" on)")" "yes"
+check "bloom off skips nothing (min/max cannot)" "$(skipped "SELECT id FROM n WHERE tag = $PROBE" off)" "0"
+
+# A value that never occurs is pruned everywhere and returns nothing.
+check "absent value parity" \
+	"$(q 'SELECT count(*) FROM n WHERE tag = 999999999;')" \
+	"$(q 'SELECT count(*) FROM h WHERE tag = 999999999;')"
+
+pgc_summary

--- a/test/native_skip.sh
+++ b/test/native_skip.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# pgColumnar native zone-map row-group skipping (Phase D5b): a native-format
+# (PGCN v1) table now takes the custom scan's scalar path, so pushed-down
+# predicates drive zone-map skipping of whole row groups whose min/max prove no
+# row can match (native spec 7.1). Skipping is a performance optimization only:
+# the executor re-applies the full qual, so results are identical whether a group
+# is skipped or not. This suite proves both halves: result parity with a heap
+# mirror across range and equality predicates, and that groups are actually
+# skipped (via the EXPLAIN ANALYZE "Columnar Chunk Groups Removed by Filter"
+# counter), including that a non-selective scan skips nothing.
+#
+# Usage:  test/native_skip.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+# 20480 rows, 2048-row groups -> 10 row groups with contiguous, non-overlapping
+# id ranges (group k holds ids k*2048+1 .. (k+1)*2048), so range and equality
+# predicates on id are highly skippable.
+GEN="SELECT g, (g * 10)::bigint, 'lbl-' || (g % 100)
+  FROM generate_series(1, 20480) g"
+
+psql_run "CREATE TABLE h (id int, k bigint, label text);"
+psql_run "CREATE TABLE n (id int, k bigint, label text) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 2048, chunk_group_row_limit => 1024, format_version => 1);"
+psql_run "INSERT INTO h $GEN;"
+psql_run "INSERT INTO n $GEN;"
+
+# Count of row groups skipped by the zone maps for a query, from EXPLAIN ANALYZE.
+skipped() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -At -c "EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) $1" 2>/dev/null \
+		| grep 'Columnar Chunk Groups Removed by Filter' | grep -oE '[0-9]+' | head -1
+}
+gt0() { [ "${1:-0}" -gt 0 ] && echo yes || echo no; }
+
+check "row count" "$(q 'SELECT count(*) FROM n;')" "20480"
+check "no-predicate scan returns all rows" "$(q 'SELECT count(*) FROM n;')" "$(q 'SELECT count(*) FROM h;')"
+
+# Range predicate confined to one group: correct, and skips the other groups.
+check "range result parity" \
+	"$(pgc_set_hash 'SELECT id, k, label FROM n WHERE id BETWEEN 5000 AND 5100')" \
+	"$(pgc_set_hash 'SELECT id, k, label FROM h WHERE id BETWEEN 5000 AND 5100')"
+check "range skips groups" "$(gt0 "$(skipped 'SELECT id FROM n WHERE id BETWEEN 5000 AND 5100')")" "yes"
+
+# Equality on the monotonic column skips groups too.
+check "equality result parity" \
+	"$(q 'SELECT count(*) FROM n WHERE id = 12345;')" \
+	"$(q 'SELECT count(*) FROM h WHERE id = 12345;')"
+check "equality skips groups" "$(gt0 "$(skipped 'SELECT id FROM n WHERE id = 12345')")" "yes"
+
+# Predicate on the bigint column (k = id*10) is equally skippable. The literals
+# are cast to bigint so the comparison is same-type: cross-type operators (int8
+# column vs int4 const) are deliberately not pushed down, on native as on 2.2.
+check "bigint range parity" \
+	"$(pgc_set_hash 'SELECT id FROM n WHERE k BETWEEN 100000::bigint AND 101000::bigint')" \
+	"$(pgc_set_hash 'SELECT id FROM h WHERE k BETWEEN 100000::bigint AND 101000::bigint')"
+check "bigint range skips groups" "$(gt0 "$(skipped 'SELECT id FROM n WHERE k BETWEEN 100000::bigint AND 101000::bigint')")" "yes"
+
+# A predicate every group satisfies must skip nothing (correctness of the bound).
+check "non-selective scan skips nothing" "$(skipped 'SELECT id FROM n WHERE id > 0')" "0"
+check "non-selective parity" \
+	"$(q 'SELECT count(*) FROM n WHERE id > 0;')" \
+	"$(q 'SELECT count(*) FROM h WHERE id > 0;')"
+
+# A predicate no group satisfies is fully skipped and returns nothing.
+check "out-of-range returns nothing" "$(q 'SELECT count(*) FROM n WHERE id > 1000000;')" "0"
+
+pgc_summary

--- a/test/native_vecskip.sh
+++ b/test/native_vecskip.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# pgColumnar native per-vector skipping (Phase D5b): within a row group that a
+# predicate does not prune wholesale, individual 1024-value vectors whose per-
+# vector zone map rules them out are neither decoded nor emitted (native spec
+# 7.1). This suite forces a single large row group (so nothing is pruned at the
+# row-group level) with many vectors, and shows a selective range prunes vectors:
+# "Columnar Vectors Skipped" > 0 while "Chunk Groups Removed by Filter"
+# stays 0. Results always match a heap mirror, since skipping is a pure
+# optimization the executor's re-check makes correctness-neutral.
+#
+# Usage:  test/native_vecskip.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+# One row group (stripe limit above the row count) of 8 vectors x 1024 rows.
+# id is monotonic, so each vector's min/max is tight and non-overlapping.
+GEN="SELECT g AS id, (g % 97) AS v FROM generate_series(1, 8192) g"
+
+psql_run "CREATE TABLE h (id int, v int);"
+psql_run "CREATE TABLE n (id int, v int) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 16384, chunk_group_row_limit => 1024, format_version => 1);"
+psql_run "INSERT INTO h $GEN;"
+psql_run "INSERT INTO n $GEN;"
+
+# EXPLAIN ANALYZE counters for a query.
+counter() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -At -c "EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) $2" 2>/dev/null \
+		| grep "$1" | grep -oE '[0-9]+' | head -1
+}
+gt0() { [ "${1:-0}" -gt 0 ] && echo yes || echo no; }
+
+check "row count" "$(q 'SELECT count(*) FROM n;')" "8192"
+check "single row group" \
+	"$(q "SELECT count(*) FROM pgcolumnar.row_group WHERE storage_id = pgcolumnar.get_storage_id('n');")" \
+	"1"
+
+# A range confined to one vector: correct, prunes vectors, prunes no whole group.
+Q="SELECT id, v FROM n WHERE id BETWEEN 100 AND 200"
+check "range parity" \
+	"$(pgc_set_hash "$Q")" \
+	"$(pgc_set_hash 'SELECT id, v FROM h WHERE id BETWEEN 100 AND 200')"
+check "vectors removed > 0" "$(gt0 "$(counter 'Columnar Vectors Skipped' "SELECT id FROM n WHERE id BETWEEN 100 AND 200")")" "yes"
+check "no whole group removed" "$(counter 'Columnar Chunk Groups Removed by Filter' "SELECT id FROM n WHERE id BETWEEN 100 AND 200")" "0"
+
+# A predicate matching every vector prunes none.
+check "non-selective removes no vectors" \
+	"$(counter 'Columnar Vectors Skipped' 'SELECT id FROM n WHERE id > 0')" "0"
+
+# Boundary and cross-vector ranges still return exactly the heap rows.
+check "cross-vector range parity" \
+	"$(pgc_set_hash 'SELECT id, v FROM n WHERE id BETWEEN 2000 AND 5000')" \
+	"$(pgc_set_hash 'SELECT id, v FROM h WHERE id BETWEEN 2000 AND 5000')"
+check "last-vector range parity" \
+	"$(pgc_set_hash 'SELECT id, v FROM n WHERE id BETWEEN 8000 AND 9000')" \
+	"$(pgc_set_hash 'SELECT id, v FROM h WHERE id BETWEEN 8000 AND 9000')"
+check "empty range parity" \
+	"$(q 'SELECT count(*) FROM n WHERE id BETWEEN 100000 AND 200000;')" \
+	"0"
+
+pgc_summary

--- a/test/native_zonemap.sh
+++ b/test/native_zonemap.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# pgColumnar native zone maps, storage side (Phase D5a): a native-format (PGCN v1)
+# table now records a Small Materialized Aggregate per 1024-value vector and per
+# column chunk in pgcolumnar.zone_map (min, max, value_count, null_count; sum
+# lands in D5b). D5a computes and stores them but does not yet read them, so this
+# suite validates the catalog contents directly: the row structure, the exact
+# value/null counts against the heap oracle, min/max presence and width, per-vector
+# bounds, that the rows are removed when the table is dropped, and that adding zone
+# maps did not perturb the read path (set-hash parity with a heap mirror).
+#
+# Usage:  test/native_zonemap.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+# 6144 rows, a 2048-row group limit and the fixed 1024 vector length give a clean
+# 3 groups x 2 vectors per column chunk. Four orderable columns with distinct null
+# patterns exercise value_count/null_count and min/max.
+GEN="SELECT g,
+       (g * 10)::bigint,
+       'lbl-' || (g % 50),
+       CASE WHEN g % 7 = 0 THEN NULL ELSE g END
+  FROM generate_series(1, 6144) g"
+
+psql_run "CREATE TABLE h (id int, k bigint, label text, v int);"
+psql_run "CREATE TABLE n (id int, k bigint, label text, v int) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 2048, chunk_group_row_limit => 1024, format_version => 1);"
+psql_run "INSERT INTO h $GEN;"
+psql_run "INSERT INTO n $GEN;"
+
+SID="$(q "SELECT pgcolumnar.get_storage_id('n');")"
+zq() { q "SELECT $1 FROM pgcolumnar.zone_map WHERE storage_id = $SID;"; }
+
+check "row count" "$(q 'SELECT count(*) FROM n;')" "6144"
+check "read parity (no regression)" \
+	"$(pgc_set_hash 'SELECT id, k, label, v FROM n')" \
+	"$(pgc_set_hash 'SELECT id, k, label, v FROM h')"
+
+# 3 groups x 4 columns whole-chunk rows (vector_index = -1).
+check "whole-chunk zone rows" "$(zq 'count(*) FILTER (WHERE vector_index = -1)')" "12"
+# 3 groups x 2 vectors x 4 columns per-vector rows.
+check "per-vector zone rows" "$(zq 'count(*) FILTER (WHERE vector_index >= 0)')" "24"
+
+# Every whole-chunk row covers its row group's rows; every vector covers 1024.
+check "whole-chunk value+null = group rows" \
+	"$(zq 'count(*) FILTER (WHERE vector_index = -1 AND value_count + null_count <> 2048)')" \
+	"0"
+check "per-vector value+null = 1024" \
+	"$(zq 'count(*) FILTER (WHERE vector_index >= 0 AND value_count + null_count <> 1024)')" \
+	"0"
+
+# Counts must match the heap oracle exactly, summed over the whole-chunk rows.
+# column_index is 0-based: id=0, k=1, label=2, v=3.
+check "value_count sums (v, nullable)" \
+	"$(zq 'sum(value_count) FILTER (WHERE vector_index = -1 AND column_index = 3)')" \
+	"$(q 'SELECT count(v) FROM h;')"
+check "null_count sums (v, nullable)" \
+	"$(zq 'sum(null_count) FILTER (WHERE vector_index = -1 AND column_index = 3)')" \
+	"$(q 'SELECT count(*) - count(v) FROM h;')"
+check "value_count sums (id, no nulls)" \
+	"$(zq 'sum(value_count) FILTER (WHERE vector_index = -1 AND column_index = 0)')" \
+	"6144"
+check "null_count zero (id, no nulls)" \
+	"$(zq 'sum(null_count) FILTER (WHERE vector_index = -1 AND column_index = 0)')" \
+	"0"
+
+# Per-vector value counts of a column sum to its whole-chunk value count, per group.
+check "per-vector value_count folds into chunk (k)" \
+	"$(zq 'count(*) FILTER (WHERE column_index = 1 AND vector_index = -1
+	        AND value_count <> (SELECT sum(z2.value_count)
+	                            FROM pgcolumnar.zone_map z2
+	                            WHERE z2.storage_id = pgcolumnar.zone_map.storage_id
+	                              AND z2.group_number = pgcolumnar.zone_map.group_number
+	                              AND z2.column_index = 1 AND z2.vector_index >= 0))')" \
+	"0"
+
+# Orderable columns carry min/max; fixed-width widths are exact.
+check "min/max present for all columns" "$(zq 'count(*) FILTER (WHERE minimum IS NULL OR maximum IS NULL)')" "0"
+check "id (int4) min width = 4 bytes" \
+	"$(zq 'count(*) FILTER (WHERE column_index = 0 AND octet_length(minimum) <> 4)')" "0"
+check "k (int8) max width = 8 bytes" \
+	"$(zq 'count(*) FILTER (WHERE column_index = 1 AND octet_length(maximum) <> 8)')" "0"
+
+# sum is deferred to D5b, so it is NULL for now.
+check "sum unset in D5a" "$(zq 'count(*) FILTER (WHERE sum IS NOT NULL)')" "0"
+
+# Zone maps are removed with the relation.
+psql_run "DROP TABLE n;"
+check "zone maps cleaned on drop" \
+	"$(q "SELECT count(*) FROM pgcolumnar.zone_map WHERE storage_id = $SID;")" "0"
+
+pgc_summary

--- a/test/native_zonemap.sh
+++ b/test/native_zonemap.sh
@@ -84,8 +84,17 @@ check "id (int4) min width = 4 bytes" \
 check "k (int8) max width = 8 bytes" \
 	"$(zq 'count(*) FILTER (WHERE column_index = 1 AND octet_length(maximum) <> 8)')" "0"
 
-# sum is deferred to D5b, so it is NULL for now.
-check "sum unset in D5a" "$(zq 'count(*) FILTER (WHERE sum IS NOT NULL)')" "0"
+# D5b populates sum for int2/int4 columns (id, v) as an exact numeric; other
+# types (k bigint, label text) keep a null sum. column_index: id=0, v=3, k=1, label=2.
+check "sum present for int4 columns" \
+	"$(zq 'count(*) FILTER (WHERE column_index IN (0,3) AND value_count > 0 AND sum IS NULL)')" \
+	"0"
+check "sum null for non-int4 columns" \
+	"$(zq 'count(*) FILTER (WHERE column_index IN (1,2) AND sum IS NOT NULL)')" \
+	"0"
+check "whole-chunk sum(id) matches heap" \
+	"$(zq 'sum(sum) FILTER (WHERE column_index = 0 AND vector_index = -1)')" \
+	"$(q 'SELECT sum(id) FROM h;')"
 
 # Zone maps are removed with the relation.
 psql_run "DROP TABLE n;"

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -26,7 +26,7 @@ SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUITES=(smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
 	differential recovery fuzz hardening concurrent_diff parallel sorted_projection \
 	arrow_export parquet_export read_stream corruption \
-	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding)
+	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap)
 
 # Default matrix: one assert-enabled pg_config per major, 13 through 19.
 DEFAULT_CONFIGS=(

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -26,7 +26,7 @@ SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUITES=(smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
 	differential recovery fuzz hardening concurrent_diff parallel sorted_projection \
 	arrow_export parquet_export read_stream corruption \
-	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip)
+	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg)
 
 # Default matrix: one assert-enabled pg_config per major, 13 through 19.
 DEFAULT_CONFIGS=(

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -26,7 +26,7 @@ SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUITES=(smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
 	differential recovery fuzz hardening concurrent_diff parallel sorted_projection \
 	arrow_export parquet_export read_stream corruption \
-	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg)
+	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom)
 
 # Default matrix: one assert-enabled pg_config per major, 13 through 19.
 DEFAULT_CONFIGS=(

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -26,7 +26,7 @@ SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUITES=(smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
 	differential recovery fuzz hardening concurrent_diff parallel sorted_projection \
 	arrow_export parquet_export read_stream corruption \
-	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom)
+	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip)
 
 # Default matrix: one assert-enabled pg_config per major, 13 through 19.
 DEFAULT_CONFIGS=(

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -26,7 +26,7 @@ SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUITES=(smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
 	differential recovery fuzz hardening concurrent_diff parallel sorted_projection \
 	arrow_export parquet_export read_stream corruption \
-	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap)
+	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip)
 
 # Default matrix: one assert-enabled pg_config per major, 13 through 19.
 DEFAULT_CONFIGS=(


### PR DESCRIPTION
Gives the native format (PGCN v1) data skipping. **Stacked on #59 (Phase D4)** — merge #59 first, then this (merge commits, no rebase). GitHub will retarget this PR's base to \`re-origination\` once #59 merges.

- **D5a** (\`d10a435\`): compute and store per-vector and per-chunk Small Materialized Aggregates (min/max/value_count/null_count) in \`pgcolumnar.zone_map\`; no read change.
- **D5b — row-group skipping** (\`f7433a4\`): native tables take the custom scan's scalar path so pushed-down predicates drive zone-map row-group skipping (collation-safe).
- **D5b — zone-map-only aggregates + writer sum** (\`85b6f29\`): ungrouped count/sum/avg/min/max answered from zone maps with no data scan; exact int2/int4 sum stored.
- **D5b — bloom filters** (\`82e5e9b\`): new \`pgcolumnar.bloom\`; equality skipping on unsorted columns.
- **D5b — per-vector skipping** (\`0f800a8\`): within a read group, ruled-out 1024-value vectors are neither decoded nor emitted.

Also plans the eventual retirement of the legacy 2.2 on-disk format (new roadmap Phase H), prerequisite-gated.

**Design note:** the D5 plan assumed the base scan receives scan keys; a plain seqscan pushes none, so the custom scan (scalar path) is the qual-pushdown mechanism for native. Corrected in the implementation.

Full PG 13-19 matrix green: 37/37 suites incl. native_zonemap/skip/agg/bloom/vecskip, no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)