### PR TITLE
Phase D6a: unify format switch, native fetch-by-row-number, resumable groups

### DIFF
--- a/design/PHASE_D5_PLAN.md
+++ b/design/PHASE_D5_PLAN.md
@@ -188,15 +188,14 @@ parity and native index and projection parity land alongside. Only then, Phase H
 2. Remove the 2.2 writer, so no new 2.2 data is produced.
 3. Remove the 2.2 reader and catalog, and drop the format selector.
 
-### Decision required
+### Decision (owner, 2026-07-21): clean cut, no compatibility
 
-Whether Phase H keeps a transitional read-only 2.2 reader for one release (so
-existing 2.2 relations can still be read and migrated in place before the reader is
-also removed), or removes both writer and reader together and relies solely on
-export/import and the `v1.0-dev` tag for anyone still on 2.2. The read-only
-transitional reader is safer for users with 2.2 data on disk; the clean cut is
-simpler and is defensible given the tag and the Arrow/Parquet migration path. This
-is the owner's call and is recorded when Phase H is scheduled.
+The project keeps no Hydra or Citus style page format and no storage-format
+compatibility. Phase H is a required clean cut: the 2.2 writer and reader are
+removed together, not kept as a transitional read-only reader. Migration off 2.2
+is by COPY or Arrow/Parquet export/import while the 2.2 reader still exists at the
+start of H, and the `v1.0-dev` tag permanently preserves the old line for anyone
+who needs it. No on-disk compatibility shim is carried forward.
 
 ## Validation
 

--- a/design/PHASE_D6_PLAN.md
+++ b/design/PHASE_D6_PLAN.md
@@ -120,9 +120,15 @@ default changes and the silent-wrong-results gaps cannot hide.
 - Full differential, fuzz, hardening, recovery, and concurrency suites green
   13-19 with native as the default.
 - Confirm Arrow and Parquet import and export over native default tables.
-- Update the user-facing documentation (features, configuration, limitations,
-  benchmarks) for the native format and the `pgcolumnar` namespace, in the
-  project's professional docs style.
+- Update the user-facing documentation in full. Every file under `docs/`
+  (index, installation, administration, configuration, features, limitations,
+  sql-reference, user-guide, benchmarks, testing, ARCHITECTURE), plus README.md
+  and CHANGELOG.md, describes the native (PGCN v1) format as the format and the
+  `pgcolumnar` namespace. Remove any Hydra or Citus framing and any description of
+  the 1.0-dev (2.2) format as current; the project keeps no such compatibility
+  (a pointer to the `v1.0-dev` tag is the only mention the 2.2 line needs). Style:
+  professional, no em-dashes, no extra adjectives (matches the existing user-docs
+  style). This is a full pass, not a diff over the old text.
 
 ## Sequencing decision (for the owner)
 

--- a/design/PHASE_D6_PLAN.md
+++ b/design/PHASE_D6_PLAN.md
@@ -1,0 +1,164 @@
+# Phase D6 plan: make native the default and finalize
+
+Status: plan, on the `re-origination` branch (phase branches off `re-origination`
+once approved). D6 is the finalize sub-phase of Phase D: default new
+`CREATE TABLE ... USING pgcolumnar` to the native (PGCN v1) format, take the full
+suites green on native across PostgreSQL 13-19, validate Arrow and Parquet over
+native, and update the user documentation. It is the last sub-phase before the
+native format is the engine's normal path.
+
+D6 is larger than D1 through D5, because flipping the default routes every existing
+suite onto native, and native does not yet support several things the default path
+leans on. It is decomposed into matrix-gated sub-PRs D6a through D6f, with the
+default flip sequenced last, after native has parity.
+
+## What native already supports (D1-D5)
+
+Sequential scan, cascade encoding and block compression, zone-map row-group and
+per-vector skipping, zone-map-only aggregates, per-chunk bloom filters, and
+`INSERT` / `COPY`. Arrow and Parquet import and export already work on native,
+because they go through the format-agnostic scan and insert layer
+(`columnar_arrow.c`, `columnar_parquet.c`, `columnar_parquet_reader.c` have no
+2.2-specific catalog reads).
+
+## The gaps that block the default flip
+
+Each is confirmed in the code. The two "silent wrong results" gaps are the
+dangerous ones: they do not error, they return zero rows, so only a differential
+run on native catches them.
+
+1. DELETE / UPDATE / MERGE: hard error. The row mask is keyed by 2.2 stripe and
+   chunk ids, which native never populates. `ColumnarMarkRowDeleted`
+   (`columnar_row_mask.c`) resolves the row via `rowmask_find_stripe`, which reads
+   the empty native stripe list and raises "cannot delete row: no stripe covers
+   it". `columnar_tuple_delete` / `columnar_tuple_update` (`columnar_tableam.c`)
+   both hit this.
+2. Index scan and index-only scan: silent 0 rows. `ColumnarReadRowByNumber`
+   (`columnar_reader.c`) has only a 2.2 stripe path and returns false for a native
+   row, so `columnar_index_fetch_tuple` finds nothing. The visibility map is
+   computed from the stripe catalog only (`ColumnarComputeAllVisibleGroups`,
+   `columnar_metadata.c`), so index-only scans never set VM bits either.
+3. Unique and primary-key enforcement: silently not enforced. The uniqueness
+   decision rides on the same `ColumnarReadRowByNumber` (via `_bt_check_unique`),
+   which returns false on native, so a conflicting row looks absent and the
+   duplicate commits. `columnar_unique.c` itself is format-agnostic.
+4. Projections (covering, gap 26): silent 0 rows. The projection writer is hard
+   wired to 2.2 (`columnar_build_write_state` never sets `isNative`), but the
+   projection reader takes `isNative` from the base table's format, so on a native
+   base it reads native row-groups from a storage that holds only 2.2 stripes.
+5. The default selector is split. `ColumnarTableFormatVersion`
+   (`columnar_metadata.c`) returns 2.2 by default and only the reader consults it;
+   the writer decides native from the raw option directly
+   (`columnar_write_state.c`). Flipping only the reader default would make the
+   reader expect native while the writer still emits 2.2, breaking even plain
+   scans. Both sites must flip together.
+6. Format-dependent tests: `hardening.sh` and `corruption.sh` inject corruption by
+   `UPDATE pgcolumnar.chunk ...`, which does not exist for native (native uses
+   `column_chunk`); `phase5.sh` asserts the default is 2.2. These need native
+   equivalents or updates.
+
+## Design and decomposition
+
+The high-leverage observation: index scan, index-only scan, and unique
+enforcement all collapse onto one function, `ColumnarReadRowByNumber`. Giving it a
+native row-group path unlocks three gaps at once. Native delete uses the interim
+row-mask adapted to row groups, per the Phase D design constraint (the first-class
+delete vector replaces it in Phase F); this keeps D6 to a mechanical re-keying
+rather than the novel merge-on-read work.
+
+The default flip is the last step. Until then native stays opt-in, and each parity
+fix is validated by running the existing suites against native tables through a
+harness native mode (a `PGC_NATIVE=1` switch that makes `make_pair` and the suite
+tables select `format_version => 1`), so parity is proven before the global
+default changes and the silent-wrong-results gaps cannot hide.
+
+### D6a. Unify the format switch, and native fetch-by-row-number
+
+- Make the writer consult the same default as the reader: both
+  `columnar_build_write_state` / `ColumnarGetWriteState` and the reader derive
+  native from `ColumnarTableFormatVersion`, and the projection reader derives
+  `isNative` from the storage being read, not the base relid.
+- Add a native row-group branch to `ColumnarReadRowByNumber`: map a row number to
+  its row group (via `first_row_number` / `row_count` in `pgcolumnar.row_group`),
+  load the group, and reconstruct the row, reusing the D3/D4 decode. This unlocks
+  index scan, bitmap scan, and unique / primary-key enforcement on native.
+- No default change yet. Validated by the native-mode index and unique suites.
+
+### D6b. Native delete and update (interim row mask by row group)
+
+- Add a native-aware row mask keyed by `row_group` (group number and row-in-group)
+  instead of stripe and chunk. `ColumnarMarkRowDeleted` resolves a native row to
+  its row group; the native scan and `ReadRowByNumber` apply the mask.
+- `columnar_tuple_delete` / `columnar_tuple_update` / `MERGE` then work on native.
+  This is the interim marking; Phase F replaces it with the delete vector and
+  merge-on-read.
+
+### D6c. Native index-only scan (visibility map)
+
+- Compute all-visible groups from the native `row_group` catalog
+  (`ColumnarComputeAllVisibleGroups` native path) and set the VM bits, so
+  index-only scans skip the heap fetch on native.
+
+### D6d. Native projections
+
+- Write projection storage in the native format (the projection writer selects
+  native like the base), and read it via its own storage format. Covering
+  projection scans and back-fill then work on native.
+
+### D6e. Native-mode green, and format-dependent tests
+
+- Run the full suite in native mode (`PGC_NATIVE=1`) across 13-19 and close any
+  residual gaps. Give `hardening.sh` and `corruption.sh` native-catalog
+  equivalents (poke `pgcolumnar.column_chunk` / `row_group`), and update the
+  `phase5.sh` default assertion.
+
+### D6f. Flip the default, finalize, and document
+
+- Flip `ColumnarTableFormatVersion` and the writer default to native together, so
+  a bare `USING pgcolumnar` is native. Keep the 2.2 reader so existing 2.2 tables
+  still read (retirement is the later Phase H).
+- Full differential, fuzz, hardening, recovery, and concurrency suites green
+  13-19 with native as the default.
+- Confirm Arrow and Parquet import and export over native default tables.
+- Update the user-facing documentation (features, configuration, limitations,
+  benchmarks) for the native format and the `pgcolumnar` namespace, in the
+  project's professional docs style.
+
+## Sequencing decision (for the owner)
+
+Two choices to record when D6 is scheduled:
+
+- Interim row mask vs. delete vectors now. This plan follows the Phase D design
+  constraint: native delete/update uses the interim row mask in D6b, and Phase F
+  replaces it with the first-class delete vector and merge-on-read. The
+  alternative is to pull Phase F's delete-vector work into D6b and skip the
+  interim. Recommendation: keep the interim (lower risk, smaller D6, defers the
+  novel merge-on-read to its own phase).
+- Whether D6a-e land as separate PRs into `re-origination` with native opt-in
+  (default stays 2.2 until D6f), or whether the default flip rides in the same PR
+  as the last parity fix. Recommendation: separate PRs, flip last, so any
+  regression is isolated to the parity fix that caused it and the default is never
+  flipped while a gap remains.
+
+## Validation
+
+- A harness native mode (`PGC_NATIVE=1`) so `make_pair` and the suites create
+  native tables; run the differential oracle and the feature suites on native for
+  each of D6a-e, proving parity before the flip.
+- Full PostgreSQL 13-19 matrix, first in native mode (D6e), then with the default
+  flipped (D6f).
+- The differential oracle stays the correctness proof throughout: native results
+  equal the heap oracle for scans, deletes, updates, index scans, unique
+  enforcement, and projections.
+
+## Risks
+
+- Largest behavior change of Phase D: after D6f every new columnar table is
+  native, so the whole suite exercises native. Mitigated by proving parity in
+  native mode before the flip and by flipping last.
+- Two gaps return wrong results rather than erroring (index and projection scans
+  yield 0 rows on native today). The native-mode differential run is the guard;
+  without it a flip could pass smoke tests yet be silently wrong.
+- The interim row mask is throwaway work replaced in Phase F. Accepted, per the
+  Phase D design constraint, to keep the novel delete-vector and merge-on-read
+  design in its own phase.

--- a/design/TODO_PIVOT.md
+++ b/design/TODO_PIVOT.md
@@ -116,17 +116,20 @@ directions". Both of those are also uncommitted.
 - [ ] **Phase G. Interop extension.** Extend Arrow/Parquet interop toward reading
   external Parquet and open-table-format (Iceberg/Delta) files with predicate and
   projection pushdown.
-- [ ] **Phase H. Retire the 1.0-dev (2.2) on-disk format.** Remove the legacy 2.2
-  writer, reader, and catalog (`stripe`, `chunk`, `chunk_group`, inline skip
-  lists) and the per-table format selector, leaving one native format line. The
-  capstone of the re-origination. Prerequisite-gated (planned in
+- [ ] **Phase H. Retire the 1.0-dev (2.2) on-disk format (REQUIRED, clean cut).**
+  Remove the legacy 2.2 writer, reader, and catalog (`stripe`, `chunk`,
+  `chunk_group`, inline skip lists) and the per-table format selector, leaving one
+  native format line. The capstone of the re-origination and a firm requirement:
+  the project keeps no Hydra or Citus style page format and no storage-format
+  compatibility (owner, 2026-07-21). Decision recorded: a clean cut, not a
+  transitional read-only 2.2 reader. Migration off 2.2 is by COPY or Arrow/Parquet
+  export/import (spec 13) while the 2.2 reader still exists at the start of H, and
+  the `v1.0-dev` tag permanently preserves the old line; then both 2.2 writer and
+  reader are removed together. Prerequisite-gated (planned in
   [PHASE_D5_PLAN.md](PHASE_D5_PLAN.md) "Retiring the 1.0-dev (2.2) on-disk
   format"): native must have delete/update parity (Phase F), index and index-only
   scan parity, projection parity, zone-map skipping (D5), be the default (D6), and
-  have Arrow/Parquet verified on native; then a verified 2.2-to-native migration
-  (COPY or Arrow/Parquet, `SET ACCESS METHOD` rewrite) with the `v1.0-dev` tag as
-  the permanent preservation. Open decision at scheduling: keep a transitional
-  read-only 2.2 reader for one release, or a clean cut relying on export/import.
+  have Arrow/Parquet verified on native.
 
 ## Independent later work (not gated on the format reset)
 

--- a/design/TODO_PIVOT.md
+++ b/design/TODO_PIVOT.md
@@ -95,7 +95,19 @@ directions". Both of those are also uncommitted.
     plan assumed the base scan receives scan keys, but a seqscan pushes none, so
     the custom scan (scalar path) is the qual-pushdown mechanism for native.
   - [ ] D6. Default new tables to native; full suites green 13-19; Arrow/Parquet
-    over native; user docs updated.
+    over native; user docs updated. Planned in
+    [PHASE_D6_PLAN.md](PHASE_D6_PLAN.md). Larger than D1-D5: flipping the default
+    routes every suite onto native, which still lacks delete/update (row mask is
+    2.2-keyed), index and index-only scan and unique enforcement (all ride on
+    ColumnarReadRowByNumber, 2.2-only), and native projection storage; the reader
+    and writer default switches are also split and must flip together. Decomposed
+    with the flip last: D6a unify the switch + native ReadRowByNumber (unlocks
+    index/unique), D6b native delete/update via the interim row mask by row group
+    (Phase D constraint; delete vectors replace it in F), D6c native index-only
+    scan (visibility map), D6d native projections, D6e native-mode suites green +
+    fix format-dependent tests (hardening/corruption/phase5), D6f flip the default
+    + Arrow/Parquet over native + user docs. Validated via a PGC_NATIVE harness
+    mode before the flip.
 - [ ] **Phase E. New codecs.** Add ALP (floats/decimals) and FSST (strings) as
   cascade primitives; adaptive selector chooses among the full set.
 - [ ] **Phase F. Mutation and clustering.** Replace the row_mask with native

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -405,6 +405,7 @@ extern void ColumnarInsertChunkGroupRow(uint64 storageId,
 										const ChunkGroupMetadata *cg);
 extern void ColumnarInsertChunkRow(uint64 storageId, const ChunkMetadata *chunk);
 extern void ColumnarInsertNativeStorageRow(const NativeStorageMetadata *s);
+extern bool ColumnarStorageIsNative(uint64 storageId, Snapshot snapshot);
 extern void ColumnarInsertRowGroupRow(const NativeRowGroupMetadata *rg);
 extern void ColumnarInsertColumnChunkRow(const NativeColumnChunkMetadata *cc);
 extern void ColumnarInsertZoneMapRow(const NativeZoneMapMetadata *z);

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -1020,6 +1020,34 @@ ColumnarInsertNativeStorageRow(const NativeStorageMetadata *s)
 	table_close(rel, RowExclusiveLock);
 }
 
+/*
+ * ColumnarStorageIsNative
+ *		True when the storage id has a native (PGCN v1) storage catalog row, i.e.
+ *		native data has been written for it. This is the ground truth of a
+ *		storage's on-disk format: the native writer records a storage row, the 2.2
+ *		writer does not. The reader derives isNative from this (so a native base
+ *		table's 2.2 projection storage is read as 2.2, and the D6 default flip needs
+ *		no reader change). Callers must have flushed pending writes first, as the
+ *		read paths do, so a just-written native storage is visible.
+ */
+bool
+ColumnarStorageIsNative(uint64 storageId, Snapshot snapshot)
+{
+	Relation	rel = open_columnar_table("storage", AccessShareLock);
+	ScanKeyData key[1];
+	SysScanDesc scan;
+	bool		found;
+
+	ScanKeyInit(&key[0], Anum_native_storage_storage_id, BTEqualStrategyNumber,
+				F_INT8EQ, Int64GetDatum((int64) storageId));
+	scan = systable_beginscan(rel, InvalidOid, false, snapshot, 1, key);
+	found = HeapTupleIsValid(systable_getnext(scan));
+	systable_endscan(scan);
+	table_close(rel, AccessShareLock);
+
+	return found;
+}
+
 void
 ColumnarInsertRowGroupRow(const NativeRowGroupMetadata *rg)
 {

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -291,9 +291,15 @@ ColumnarBeginReadWithStorage(Relation rel, Snapshot snapshot,
 							   &readState->missingIsnull[mc]);
 	}
 
+	/*
+	 * The storage being read is native iff it has a native storage catalog row
+	 * (D6a). This is the storage's own format, not the base table's option, so a
+	 * native base table's 2.2 projection storage is correctly read as 2.2, and the
+	 * D6 default flip needs no change here (the reader follows the data). Read
+	 * paths flush pending writes first, so a just-written native storage is seen.
+	 */
 	readState->isNative =
-		(ColumnarTableFormatVersion(RelationGetRelid(rel)) ==
-		 COLUMNAR_NATIVE_VERSION_MAJOR);
+		ColumnarStorageIsNative(storageId, readState->metaSnapshot);
 	readState->projectedColumns = bms_copy(projectedColumns);
 	readState->stripeList = NIL;
 	readState->stripeIndex = 0;
@@ -763,7 +769,7 @@ columnar_read_start(ColumnarReadState *readState)
  *		chunk cannot drive a decoder past its buffers.
  */
 static char *
-columnar_native_decode_chunk(ColumnarReadState *rs, Form_pg_attribute att,
+columnar_native_decode_chunk(MemoryContext cx, Form_pg_attribute att,
 							 char *values, uint32 valuesLen,
 							 const char *desc, uint32 descLen, int blockCodec,
 							 uint32 **outVecRawLen, int *outVecCount)
@@ -810,7 +816,7 @@ columnar_native_decode_chunk(ColumnarReadState *rs, Form_pg_attribute att,
 	if (blockCodec != COLUMNAR_COMPRESSION_NONE)
 		encRegion = ColumnarDecompressValueStream(values, valuesLen, blockCodec,
 												  (uint32) encTotal,
-												  rs->groupContext);
+												  cx);
 	else
 	{
 		if ((uint64) valuesLen != encTotal)
@@ -821,8 +827,8 @@ columnar_native_decode_chunk(ColumnarReadState *rs, Form_pg_attribute att,
 	}
 
 	/* second pass: decode each vector into one raw present-value buffer */
-	rawBuf = MemoryContextAlloc(rs->groupContext, rawTotal > 0 ? rawTotal : 1);
-	vecRawLen = (uint32 *) MemoryContextAlloc(rs->groupContext,
+	rawBuf = MemoryContextAlloc(cx, rawTotal > 0 ? rawTotal : 1);
+	vecRawLen = (uint32 *) MemoryContextAlloc(cx,
 											  sizeof(uint32) * (vectorCount > 0 ? vectorCount : 1));
 	rawCursor = rawBuf;
 	encCursor = encRegion;
@@ -845,7 +851,7 @@ columnar_native_decode_chunk(ColumnarReadState *rs, Form_pg_attribute att,
 		{
 			char	   *rawVec = ColumnarDecodeChunk(encCursor, encLen, encType,
 													 att, valueCount, rawLen,
-													 rs->groupContext);
+													 cx);
 
 			memcpy(rawCursor, rawVec, rawLen);
 			rawCursor += rawLen;
@@ -1169,7 +1175,7 @@ columnar_native_load_group(ColumnarReadState *rs)
 
 			/* D4: reconstruct the raw present-value stream from the descriptor */
 			rs->nativeValueCursor[cc->columnIndex] =
-				columnar_native_decode_chunk(rs, att, base + validityBytes,
+				columnar_native_decode_chunk(rs->groupContext, att, base + validityBytes,
 											 (uint32) (cc->pageLength - validityBytes),
 											 cc->encodingDescriptor,
 											 cc->encodingDescriptorLen,
@@ -1993,6 +1999,114 @@ ColumnarReadRowByNumber(Relation rel, Snapshot snapshot, uint64 rowNumber,
 	oldContext = MemoryContextSwitchTo(tmp);
 
 	metaSnapshot = ColumnarCatalogSnapshot(snapshot);
+
+	/*
+	 * Native (PGCN v1) fetch-by-row-number (D6a): find the row group covering the
+	 * row, reconstruct each column's value at its position. This is what index and
+	 * bitmap scans and unique enforcement call, so it unblocks them on native.
+	 * (D6b adds the native row-mask delete-visibility check here.)
+	 */
+	if (ColumnarStorageIsNative(storageId, metaSnapshot))
+	{
+		List	   *rgList = ColumnarReadRowGroupList(storageId, metaSnapshot);
+		NativeRowGroupMetadata *rg = NULL;
+		List	   *nchunks;
+		NativeColumnChunkMetadata **ccForCol;
+		char	   *groupBuffer;
+		int			validityBytes;
+		uint64		rowInGrp;
+		ListCell   *nlc;
+
+		foreach(nlc, rgList)
+		{
+			NativeRowGroupMetadata *g = (NativeRowGroupMetadata *) lfirst(nlc);
+
+			if (rowNumber >= g->firstRowNumber &&
+				rowNumber < g->firstRowNumber + g->rowCount)
+			{
+				rg = g;
+				break;
+			}
+		}
+		if (rg == NULL)
+		{
+			MemoryContextSwitchTo(oldContext);
+			MemoryContextDelete(tmp);
+			return false;
+		}
+		rowInGrp = rowNumber - rg->firstRowNumber;
+
+		groupBuffer = palloc(rg->byteLength > 0 ? rg->byteLength : 1);
+		if (rg->byteLength > 0)
+			ColumnarReadLogicalData(rel, rg->fileOffset, groupBuffer,
+									rg->byteLength);
+		nchunks = ColumnarReadColumnChunkList(storageId, rg->groupNumber,
+											  metaSnapshot);
+		validityBytes = (int) ((rg->rowCount + 7) / 8);
+
+		ccForCol = palloc0(sizeof(NativeColumnChunkMetadata *) * natts);
+		foreach(nlc, nchunks)
+		{
+			NativeColumnChunkMetadata *cc = (NativeColumnChunkMetadata *) lfirst(nlc);
+
+			if (cc->columnIndex >= 0 && cc->columnIndex < natts)
+				ccForCol[cc->columnIndex] = cc;
+		}
+
+		for (c = 0; c < natts; c++)
+		{
+			Form_pg_attribute att = TupleDescAttr(tupdesc, c);
+			NativeColumnChunkMetadata *cc = ccForCol[c];
+			char	   *base;
+			char	   *vbits;
+			char	   *rawBuf;
+			char	   *cursor;
+			uint64		present;
+			uint64		i;
+
+			/* column added after this row group was written: missing value */
+			if (cc == NULL)
+			{
+				values[c] = getmissingattr(tupdesc, c + 1, &nulls[c]);
+				continue;
+			}
+
+			base = groupBuffer + (cc->pageOffset - rg->fileOffset);
+			vbits = base;
+			if (((vbits[rowInGrp >> 3] >> (rowInGrp & 7)) & 1) == 0)
+			{
+				values[c] = (Datum) 0;
+				nulls[c] = true;
+				continue;
+			}
+
+			/* present-index of this row = number of present rows before it */
+			present = 0;
+			for (i = 0; i < rowInGrp; i++)
+				if ((vbits[i >> 3] >> (i & 7)) & 1)
+					present++;
+
+			if (cc->encodingDescriptorLen == 1 &&
+				(uint8) cc->encodingDescriptor[0] == COLUMNAR_NATIVE_ENCDESC_BASELINE)
+				rawBuf = base + validityBytes;
+			else
+				rawBuf = columnar_native_decode_chunk(tmp, att, base + validityBytes,
+													  (uint32) (cc->pageLength - validityBytes),
+													  cc->encodingDescriptor,
+													  cc->encodingDescriptorLen,
+													  cc->blockCodec, NULL, NULL);
+
+			cursor = rawBuf;
+			for (i = 0; i < present; i++)
+				(void) ColumnarDecodeValue(att, &cursor, tmp);
+			values[c] = ColumnarDecodeValue(att, &cursor, target);
+			nulls[c] = false;
+		}
+
+		MemoryContextSwitchTo(oldContext);
+		MemoryContextDelete(tmp);
+		return true;
+	}
 
 	stripeList = ColumnarReadStripeList(storageId, metaSnapshot);
 	foreach(lc, stripeList)

--- a/src/columnar_write_state.c
+++ b/src/columnar_write_state.c
@@ -123,11 +123,11 @@ struct ColumnarWriteState
 	/*
 	 * Native format (re-origination line, PGCN v1). When isNative, a stripe
 	 * flush is laid out as a native row group and recorded in the native catalog
-	 * (Phase D2b) instead of the 2.2 stripe/chunk catalog. nativeNextGroup is the
-	 * 0-based row group ordinal assigned at each flush.
+	 * (Phase D2b) instead of the 2.2 stripe/chunk catalog. The row group's number
+	 * is the stripe id reserved from the metapage (persistent per storage), so
+	 * incremental inserts across transactions do not collide.
 	 */
 	bool		isNative;
-	uint64		nativeNextGroup;
 };
 
 /* per-backend registry of pending write states, in ColumnarWriteContext */
@@ -256,11 +256,18 @@ ColumnarGetWriteState(Relation rel)
 				writeState->compressionType = opts.compressionType;
 			if (opts.compressionLevelSet)
 				writeState->compressionLevel = opts.compressionLevel;
-			if (opts.formatVersionSet &&
-				opts.formatVersion == COLUMNAR_NATIVE_VERSION_MAJOR)
-				writeState->isNative = true;
 		}
 	}
+
+	/*
+	 * The format is the single source of truth for both writer and reader: the
+	 * writer emits native when the table's format version is the native major,
+	 * defaulting via ColumnarTableFormatVersion. Flipping that default (D6f) flips
+	 * writer and reader together. The reader derives its own native flag from the
+	 * storage catalog, which follows what the writer produced.
+	 */
+	writeState->isNative =
+		(ColumnarTableFormatVersion(relid) == COLUMNAR_NATIVE_VERSION_MAJOR);
 
 	columnar_init_col_defs(writeState);
 
@@ -776,7 +783,13 @@ columnar_flush_row_group(ColumnarWriteState *writeState)
 	uint32	   *chunkDescriptorLen;
 	int		   *chunkBlockCodec;
 	uint64		rowCount = writeState->stripeRowCount;
-	uint64		groupNumber = writeState->nativeNextGroup;
+	/*
+	 * The row group number is the stripe id reserved from the metapage when this
+	 * stripe began buffering (persistent and unique per storage), so incremental
+	 * inserts across transactions never collide on (storage_id, group_number).
+	 * A per-write-state counter would restart at 0 and clash with existing groups.
+	 */
+	uint64		groupNumber = writeState->stripeId;
 	uint64		fileOffset;
 	uint64		dataLength;
 	int			validityBytes = (int) ((rowCount + 7) / 8);
@@ -1102,9 +1115,7 @@ columnar_flush_row_group(ColumnarWriteState *writeState)
 	MemoryContextSwitchTo(oldContext);
 	MemoryContextDelete(flushContext);
 
-	writeState->nativeNextGroup = groupNumber + 1;
-
-	/* reset accumulation; the next row reserves a fresh row group */
+	/* reset accumulation; the next row reserves a fresh stripe id (row group) */
 	MemoryContextReset(writeState->stripeContext);
 	writeState->chunkGroups = NIL;
 	writeState->currentGroup = NULL;

--- a/test/native_index.sh
+++ b/test/native_index.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# pgColumnar native fetch-by-row-number (Phase D6a): index scan, bitmap scan and
+# unique/primary-key enforcement on a native-format (PGCN v1) table. All route
+# through ColumnarReadRowByNumber, which before D6a had only a 2.2 path (index
+# scans returned 0 rows, unique was silently unenforced). This suite proves parity
+# with a heap mirror under a forced index path. Index-only scan (visibility map)
+# is D6c; native projection storage is D6d; delete/update is D6b.
+#
+# Usage:  test/native_index.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+psql_run "CREATE TABLE h (id int PRIMARY KEY, k bigint, v text);"
+psql_run "CREATE TABLE n (id int PRIMARY KEY, k bigint, v text) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 2048, format_version => 1);"
+GEN="SELECT g, (g * 10)::bigint, 'row-' || g FROM generate_series(1, 8000) g"
+psql_run "INSERT INTO h $GEN;"
+psql_run "INSERT INTO n $GEN;"
+
+check "row count" "$(q 'SELECT count(*) FROM n;')" "8000"
+
+# Force the index path (seqscan off) in a single session (two -c, quiet so the SET
+# tag is not printed), and confirm scalar results match the heap oracle. Filtered
+# aggregates fall back from the zone-map path to an index scan that fetches each
+# row via ColumnarReadRowByNumber.
+iscan() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -q -At -c "SET enable_seqscan=off" -c "$1" 2>/dev/null
+}
+
+check "index point lookup" \
+	"$(iscan 'SELECT v FROM n WHERE id = 4242;')" \
+	"$(q     'SELECT v FROM h WHERE id = 4242;')"
+check "index range aggregate" \
+	"$(iscan 'SELECT count(*), sum(k), min(v), max(v) FROM n WHERE id BETWEEN 100 AND 400;')" \
+	"$(q     'SELECT count(*), sum(k), min(v), max(v) FROM h WHERE id BETWEEN 100 AND 400;')"
+check "index IN lookup" \
+	"$(iscan 'SELECT count(*), sum(k) FROM n WHERE id IN (1,2000,4000,6000,8000);')" \
+	"$(q     'SELECT count(*), sum(k) FROM h WHERE id IN (1,2000,4000,6000,8000);')"
+check "index lookup miss returns nothing" "$(iscan 'SELECT count(*) FROM n WHERE id = 999999;')" "0"
+
+# Primary-key / unique enforcement: a duplicate must be rejected. Before D6a the
+# native index fetch found nothing, so duplicates were silently admitted.
+check "duplicate id rejected" \
+	"$(psql_run 'INSERT INTO n VALUES (4242, 1, '"'"'dup'"'"');' 2>&1 | grep -c -i 'duplicate key\|unique')" \
+	"1"
+check "row count unchanged after rejected dup" "$(q 'SELECT count(*) FROM n;')" "8000"
+
+# A standalone UNIQUE index enforces too.
+psql_run "CREATE TABLE nu (id int, k bigint) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.alter_columnar_table_set('nu', format_version => 1);"
+psql_run "CREATE UNIQUE INDEX nu_k ON nu (k);"
+psql_run "INSERT INTO nu SELECT g, g FROM generate_series(1,1000) g;"
+check "unique index rejects duplicate" \
+	"$(psql_run 'INSERT INTO nu VALUES (99999, 500);' 2>&1 | grep -c -i 'duplicate key\|unique')" \
+	"1"
+check "unique index admits a new key" \
+	"$(psql_run 'INSERT INTO nu VALUES (99999, 100000);' 2>&1 | grep -c -iE 'error|duplicate')" \
+	"0"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -26,7 +26,7 @@ SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUITES=(smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
 	differential recovery fuzz hardening concurrent_diff parallel sorted_projection \
 	arrow_export parquet_export read_stream corruption \
-	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip)
+	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip native_index)
 
 # Default matrix: one assert-enabled pg_config per major, 13 through 19.
 DEFAULT_CONFIGS=(


### PR DESCRIPTION
First step of Phase D6 (make native the default). Includes the D6 plan and the owner decisions (clean 2.2 removal, full docs pass) plus the D6a implementation. No default flip: native stays opt-in until D6f.

**D6a implementation**
- **Unify the format switch.** Writer decides native from \`ColumnarTableFormatVersion\` (one place for the default); reader derives \`isNative\` from the storage catalog (\`ColumnarStorageIsNative\`), i.e. the storage's own on-disk format. This fixes the projection reader (it took the base table's format and read 2.2 projection storage as native) and makes the D6f flip a one-line change.
- **Native \`ColumnarReadRowByNumber\`.** New row-group fetch path, reusing the D4 decode. Unlocks index scan, bitmap scan, and unique/primary-key enforcement on native.
- **Resumable row group numbers.** Number a native row group by the metapage-reserved stripe id (persistent, unique per storage) instead of a per-write-state counter that restarted at 0. Fixes a collision on \`(storage_id, group_number)\` when a second insert transaction appended to an already-flushed native table.

**Validation**
- New \`test/native_index.sh\`: index point/range/IN and unique/PK enforcement on native vs a heap mirror under a forced index path; incremental insert.
- Full PG 13-19 matrix: ALL VERSIONS PASSED (38 suites, no warnings).

Planning docs included: \`design/PHASE_D6_PLAN.md\` (D6a-f decomposition, flip last), the D5-plan/TODO Phase H update recording the clean 2.2 removal, and the full-docs directive for D6f.

Base \`re-origination\`. Subsequent D6 sub-phases (D6b delete/update, D6c index-only, D6d projections, D6e native-mode suites, D6f flip + docs) follow as their own PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)