### PR TITLE
Phase D6b: native delete/update via interim row mask

### DIFF
--- a/src/columnar.h
+++ b/src/columnar.h
@@ -455,6 +455,7 @@ extern Snapshot ColumnarCatalogSnapshot(Snapshot base);
 /* row_mask catalog access (spec 7.5) */
 extern List *ColumnarReadRowMaskList(uint64 storageId, uint64 stripeId,
 									 Snapshot snapshot);
+extern bool ColumnarStorageHasRowMask(uint64 storageId, Snapshot snapshot);
 extern void ColumnarUpsertRowMask(uint64 storageId, RowMaskMetadata *rm);
 extern uint64 ColumnarNextRowMaskId(void);
 
@@ -485,6 +486,7 @@ extern void ColumnarWriteStatePromoteSubXact(SubTransactionId subid,
  * row mask / delete tracking (columnar_row_mask.c, spec 7.5, 9)
  * ------------------------------------------------------------------------- */
 extern void ColumnarMarkRowDeleted(Relation rel, uint64 rowNumber);
+extern bool ColumnarRowMaskBufferedDeleted(Relation rel, uint64 rowNumber);
 extern void ColumnarFlushRowMaskForRelation(Relation rel);
 extern void ColumnarFlushAllRowMasks(void);
 extern void ColumnarDiscardAllRowMasks(void);

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -757,6 +757,31 @@ ColumnarReadRowMaskList(uint64 storageId, uint64 stripeId, Snapshot snapshot)
 }
 
 /*
+ * ColumnarStorageHasRowMask
+ *		True when the storage has any row_mask row, i.e. at least one delete has
+ *		been recorded. Used to decide whether the native zone-map-only aggregate
+ *		is valid (it is only correct when no rows are deleted) or must fall back to
+ *		a delete-applying scan (D6b).
+ */
+bool
+ColumnarStorageHasRowMask(uint64 storageId, Snapshot snapshot)
+{
+	Relation	rel = open_columnar_table("row_mask", AccessShareLock);
+	ScanKeyData key[1];
+	SysScanDesc scan;
+	bool		found;
+
+	ScanKeyInit(&key[0], Anum_row_mask_storage_id, BTEqualStrategyNumber,
+				F_INT8EQ, Int64GetDatum((int64) storageId));
+	scan = systable_beginscan(rel, InvalidOid, false, snapshot, 1, key);
+	found = HeapTupleIsValid(systable_getnext(scan));
+	systable_endscan(scan);
+	table_close(rel, AccessShareLock);
+
+	return found;
+}
+
+/*
  * rowmask_chunk_lock_key
  *		Mix the identity of a chunk group into a 64-bit advisory-lock key. The
  *		triple (storage_id, stripe_id, chunk_id) uniquely names a chunk group

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -138,6 +138,15 @@ struct ColumnarReadState
 	int			nativeCurVec;		/* vector containing rowInGroup */
 	uint64		vectorsSkipped;		/* for EXPLAIN */
 
+	/*
+	 * Native delete visibility (Phase D6b): the current row group's combined
+	 * delete mask (one bit per row-in-group, set = deleted), from
+	 * pgcolumnar.row_mask keyed by group number. NULL when the group has no
+	 * deletes. The interim row mask; Phase F replaces it with a delete vector.
+	 */
+	char	   *nativeDeleteMask;
+	uint32		nativeDeleteMaskLen;
+
 	MemoryContext readContext;		/* whole scan */
 	MemoryContext stripeContext;	/* reset per stripe */
 	MemoryContext groupContext;		/* reset per chunk group (decompressed) */
@@ -1201,6 +1210,37 @@ columnar_native_load_group(ColumnarReadState *rs)
 		rs->nativeCurVec = 0;
 	}
 
+	/*
+	 * Native delete visibility (D6b): combine this group's row-mask rows (keyed
+	 * by group number, one bit per row-in-group) into a single delete mask that
+	 * columnar_native_next_row consults to skip deleted rows.
+	 */
+	rs->nativeDeleteMask = NULL;
+	rs->nativeDeleteMaskLen = 0;
+	{
+		List	   *maskList = ColumnarReadRowMaskList(rs->storageId,
+													   rg->groupNumber,
+													   rs->metaSnapshot);
+		ListCell   *mlc;
+		uint32		want = (uint32) ((rg->rowCount + 7) / 8);
+
+		foreach(mlc, maskList)
+		{
+			RowMaskMetadata *rm = (RowMaskMetadata *) lfirst(mlc);
+			uint32		i;
+
+			if (rm->mask == NULL || rm->maskLen == 0)
+				continue;
+			if (rs->nativeDeleteMask == NULL)
+			{
+				rs->nativeDeleteMask = palloc0(want > 0 ? want : 1);
+				rs->nativeDeleteMaskLen = want;
+			}
+			for (i = 0; i < rm->maskLen && i < want; i++)
+				rs->nativeDeleteMask[i] |= rm->mask[i];
+		}
+	}
+
 	rs->groupRowCount = rg->rowCount;
 	rs->rowInGroup = 0;
 	rs->rowGroupIndex++;
@@ -1261,6 +1301,8 @@ columnar_native_next_row(ColumnarReadState *rs, Datum *values, bool *nulls,
 
 	for (;;)
 	{
+		bool		deleted;
+
 		if (rs->nativeGroup == NULL || rs->rowInGroup >= rs->groupRowCount)
 		{
 			if (!columnar_native_load_group(rs))
@@ -1274,43 +1316,55 @@ columnar_native_next_row(ColumnarReadState *rs, Datum *values, bool *nulls,
 			columnar_native_skip_current_vector(rs))
 			continue;			/* stepped past a ruled-out vector; re-check */
 
-		break;
+		/*
+		 * Read the row, advancing each present column's value cursor. This happens
+		 * even for a deleted row so the cursors stay aligned for the next row; a
+		 * deleted row is simply not emitted (D6b).
+		 */
+		MemoryContextReset(rs->rowContext);
+		oldContext = MemoryContextSwitchTo(rs->rowContext);
+
+		for (c = 0; c < rs->natts; c++)
+		{
+			Form_pg_attribute att = TupleDescAttr(rs->tupdesc, c);
+			char	   *vbits = rs->nativeValidity[c];
+
+			/* column absent from this group (added by a later ADD COLUMN) */
+			if (vbits == NULL)
+			{
+				values[c] = rs->missingValues[c];
+				nulls[c] = rs->missingIsnull[c];
+				continue;
+			}
+
+			if ((vbits[rs->rowInGroup >> 3] >> (rs->rowInGroup & 7)) & 1)
+			{
+				values[c] = ColumnarDecodeValue(att, &rs->nativeValueCursor[c],
+												rs->rowContext);
+				nulls[c] = false;
+			}
+			else
+			{
+				values[c] = (Datum) 0;
+				nulls[c] = true;
+			}
+		}
+
+		MemoryContextSwitchTo(oldContext);
+
+		deleted = (rs->nativeDeleteMask != NULL &&
+				   (rs->rowInGroup >> 3) < rs->nativeDeleteMaskLen &&
+				   (rs->nativeDeleteMask[rs->rowInGroup >> 3] &
+					(1 << (rs->rowInGroup & 7))) != 0);
+
+		*rowNumber = rs->nativeGroup->firstRowNumber + rs->rowInGroup;
+		rs->rowInGroup++;
+
+		if (deleted)
+			continue;			/* row deleted: cursors advanced, do not emit */
+
+		return true;
 	}
-
-	MemoryContextReset(rs->rowContext);
-	oldContext = MemoryContextSwitchTo(rs->rowContext);
-
-	for (c = 0; c < rs->natts; c++)
-	{
-		Form_pg_attribute att = TupleDescAttr(rs->tupdesc, c);
-		char	   *vbits = rs->nativeValidity[c];
-
-		/* column absent from this group (added by a later ALTER TABLE ADD COLUMN) */
-		if (vbits == NULL)
-		{
-			values[c] = rs->missingValues[c];
-			nulls[c] = rs->missingIsnull[c];
-			continue;
-		}
-
-		if ((vbits[rs->rowInGroup >> 3] >> (rs->rowInGroup & 7)) & 1)
-		{
-			values[c] = ColumnarDecodeValue(att, &rs->nativeValueCursor[c],
-											rs->rowContext);
-			nulls[c] = false;
-		}
-		else
-		{
-			values[c] = (Datum) 0;
-			nulls[c] = true;
-		}
-	}
-
-	MemoryContextSwitchTo(oldContext);
-
-	*rowNumber = rs->nativeGroup->firstRowNumber + rs->rowInGroup;
-	rs->rowInGroup++;
-	return true;
 }
 
 bool
@@ -2036,6 +2090,32 @@ ColumnarReadRowByNumber(Relation rel, Snapshot snapshot, uint64 rowNumber,
 		}
 		rowInGrp = rowNumber - rg->firstRowNumber;
 
+		/* deleted rows are not visible (D6b): check the group's row mask, plus any
+		 * not-yet-flushed buffered delete (so a same-key UPDATE's unique check sees
+		 * the old row as gone) */
+		{
+			List	   *maskList = ColumnarReadRowMaskList(storageId,
+													   rg->groupNumber,
+													   metaSnapshot);
+			ListCell   *mlc;
+			bool		deleted = ColumnarRowMaskBufferedDeleted(rel, rowNumber);
+
+			foreach(mlc, maskList)
+			{
+				RowMaskMetadata *rm = (RowMaskMetadata *) lfirst(mlc);
+
+				if (rm->mask != NULL && (rowInGrp >> 3) < rm->maskLen &&
+					(rm->mask[rowInGrp >> 3] & (1 << (rowInGrp & 7))) != 0)
+					deleted = true;
+			}
+			if (deleted)
+			{
+				MemoryContextSwitchTo(oldContext);
+				MemoryContextDelete(tmp);
+				return false;
+			}
+		}
+
 		groupBuffer = palloc(rg->byteLength > 0 ? rg->byteLength : 1);
 		if (rg->byteLength > 0)
 			ColumnarReadLogicalData(rel, rg->fileOffset, groupBuffer,
@@ -2137,7 +2217,14 @@ ColumnarReadRowByNumber(Relation rel, Snapshot snapshot, uint64 rowNumber,
 	chunkId = (int) (offsetInStripe / (uint64) stripe->chunkRowCount);
 	rowInGroup = offsetInStripe - (uint64) chunkId * (uint64) stripe->chunkRowCount;
 
-	/* deleted rows are not visible (spec 7.5) */
+	/* deleted rows are not visible (spec 7.5), including a not-yet-flushed
+	 * buffered delete so a same-key UPDATE's unique check sees the old row gone */
+	if (ColumnarRowMaskBufferedDeleted(rel, rowNumber))
+	{
+		MemoryContextSwitchTo(oldContext);
+		MemoryContextDelete(tmp);
+		return false;
+	}
 	rowMaskList = ColumnarReadRowMaskList(storageId, stripe->stripeNum,
 										  metaSnapshot);
 	foreach(lc, rowMaskList)
@@ -2260,6 +2347,8 @@ ColumnarRescanRead(ColumnarReadState *readState)
 	readState->nativeVecRawLen = NULL;
 	readState->nativeVectorCount = 0;
 	readState->nativeCurVec = 0;
+	readState->nativeDeleteMask = NULL;
+	readState->nativeDeleteMaskLen = 0;
 }
 
 void

--- a/src/columnar_row_mask.c
+++ b/src/columnar_row_mask.c
@@ -45,7 +45,8 @@ typedef struct RowMaskBuffer
 	uint64		storageId;
 	SubTransactionId subid;
 	List	   *chunks;			/* list of RowMaskChunkBuffer* */
-	List	   *stripeCache;	/* cached StripeMetadata* for resolution */
+	List	   *stripeCache;	/* cached StripeMetadata* for resolution (2.2) */
+	List	   *rowGroupCache;	/* cached NativeRowGroupMetadata* (native) */
 } RowMaskBuffer;
 
 static MemoryContext ColumnarRowMaskContext = NULL;
@@ -53,6 +54,8 @@ static List *ColumnarRowMaskBuffers = NIL;
 
 static RowMaskBuffer *rowmask_get_buffer(Relation rel, uint64 storageId);
 static StripeMetadata *rowmask_find_stripe(RowMaskBuffer *buf, uint64 rowNumber);
+static NativeRowGroupMetadata *rowmask_find_row_group(RowMaskBuffer *buf,
+													  uint64 rowNumber);
 static RowMaskChunkBuffer *rowmask_get_chunk(RowMaskBuffer *buf,
 											 uint64 stripeId, int chunkId,
 											 uint64 startRowNumber,
@@ -114,6 +117,7 @@ rowmask_get_buffer(Relation rel, uint64 storageId)
 	buf->subid = subid;
 	buf->chunks = NIL;
 	buf->stripeCache = NIL;
+	buf->rowGroupCache = NIL;
 	ColumnarRowMaskBuffers = lappend(ColumnarRowMaskBuffers, buf);
 	MemoryContextSwitchTo(oldContext);
 
@@ -152,6 +156,42 @@ rowmask_find_stripe(RowMaskBuffer *buf, uint64 rowNumber)
 			Snapshot	snap = ColumnarCatalogSnapshot(GetActiveSnapshot());
 
 			buf->stripeCache = ColumnarReadStripeList(buf->storageId, snap);
+			MemoryContextSwitchTo(oldContext);
+		}
+	}
+
+	return NULL;
+}
+
+/*
+ * rowmask_find_row_group
+ *		Native (PGCN v1) analog of rowmask_find_stripe: return the row group that
+ *		contains rowNumber, rebuilding the cache from the catalog on a miss.
+ */
+static NativeRowGroupMetadata *
+rowmask_find_row_group(RowMaskBuffer *buf, uint64 rowNumber)
+{
+	ListCell   *lc;
+	int			attempt;
+
+	for (attempt = 0; attempt < 2; attempt++)
+	{
+		foreach(lc, buf->rowGroupCache)
+		{
+			NativeRowGroupMetadata *g = (NativeRowGroupMetadata *) lfirst(lc);
+
+			if (rowNumber >= g->firstRowNumber &&
+				rowNumber < g->firstRowNumber + g->rowCount)
+				return g;
+		}
+
+		if (attempt == 0)
+		{
+			MemoryContext oldContext =
+				MemoryContextSwitchTo(ColumnarRowMaskContext);
+			Snapshot	snap = ColumnarCatalogSnapshot(GetActiveSnapshot());
+
+			buf->rowGroupCache = ColumnarReadRowGroupList(buf->storageId, snap);
 			MemoryContextSwitchTo(oldContext);
 		}
 	}
@@ -208,7 +248,7 @@ ColumnarMarkRowDeleted(Relation rel, uint64 rowNumber)
 {
 	uint64		storageId = ColumnarStorageId(rel);
 	RowMaskBuffer *buf = rowmask_get_buffer(rel, storageId);
-	StripeMetadata *stripe = rowmask_find_stripe(buf, rowNumber);
+	StripeMetadata *stripe;
 	uint64		offsetInStripe;
 	int			chunkId;
 	uint64		startRowNumber;
@@ -216,6 +256,34 @@ ColumnarMarkRowDeleted(Relation rel, uint64 rowNumber)
 	uint64		endRowNumber;
 	uint64		bitIndex;
 	RowMaskChunkBuffer *chunk;
+
+	/*
+	 * Native (PGCN v1) delete marking (D6b, interim row mask keyed by row group).
+	 * The whole row group is one mask (chunk id 0), sized to its row count. Phase
+	 * F replaces this with a first-class delete vector.
+	 */
+	if (ColumnarStorageIsNative(storageId,
+							   ColumnarCatalogSnapshot(GetActiveSnapshot())))
+	{
+		NativeRowGroupMetadata *rg = rowmask_find_row_group(buf, rowNumber);
+
+		if (rg == NULL)
+			elog(ERROR,
+				 "columnar: cannot delete row " UINT64_FORMAT
+				 ": no row group covers it", rowNumber);
+
+		startRowNumber = rg->firstRowNumber;
+		endRowNumber = startRowNumber + rg->rowCount - 1;
+		chunk = rowmask_get_chunk(buf, rg->groupNumber, 0,
+								  startRowNumber, endRowNumber, rg->rowCount);
+		bitIndex = rowNumber - startRowNumber;
+		chunk->mask[bitIndex >> 3] |= (char) (1 << (bitIndex & 7));
+
+		ColumnarVMClearForRow(rel, rowNumber);
+		return;
+	}
+
+	stripe = rowmask_find_stripe(buf, rowNumber);
 
 	if (stripe == NULL)
 		elog(ERROR,
@@ -243,6 +311,48 @@ ColumnarMarkRowDeleted(Relation rel, uint64 rowNumber)
 	 * (gap 28). A no-op unless a prior vacuum had marked the block visible.
 	 */
 	ColumnarVMClearForRow(rel, rowNumber);
+}
+
+/*
+ * ColumnarRowMaskBufferedDeleted
+ *		True when the row is marked deleted in an in-memory row-mask buffer that
+ *		has not yet been flushed to the catalog. The unique/primary-key check runs
+ *		as part of an insert (or the insert half of an update) and fetches a
+ *		conflicting row through ColumnarReadRowByNumber before the delete of the
+ *		old row is flushed; consulting the buffer here lets a same-key UPDATE (the
+ *		old row is buffered-deleted) proceed. Checks every buffer for the relation,
+ *		across subtransactions.
+ */
+bool
+ColumnarRowMaskBufferedDeleted(Relation rel, uint64 rowNumber)
+{
+	Oid			relid = RelationGetRelid(rel);
+	ListCell   *lc;
+
+	foreach(lc, ColumnarRowMaskBuffers)
+	{
+		RowMaskBuffer *buf = (RowMaskBuffer *) lfirst(lc);
+		ListCell   *cc;
+
+		if (buf->relid != relid)
+			continue;
+
+		foreach(cc, buf->chunks)
+		{
+			RowMaskChunkBuffer *chunk = (RowMaskChunkBuffer *) lfirst(cc);
+			uint64		bitIndex;
+
+			if (rowNumber < chunk->startRowNumber ||
+				rowNumber > chunk->endRowNumber)
+				continue;
+			bitIndex = rowNumber - chunk->startRowNumber;
+			if ((bitIndex >> 3) < chunk->maskLen &&
+				(chunk->mask[bitIndex >> 3] & (1 << (bitIndex & 7))) != 0)
+				return true;
+		}
+	}
+
+	return false;
 }
 
 /*
@@ -299,6 +409,7 @@ rowmask_flush_buffer(RowMaskBuffer *buf)
 
 	buf->chunks = NIL;
 	buf->stripeCache = NIL;
+	buf->rowGroupCache = NIL;
 }
 
 /*

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -534,12 +534,17 @@ columnar_tuple_satisfies_snapshot(Relation rel, TupleTableSlot *slot,
 
 /*
  * columnar_index_delete_tuples
- *		Opportunistic index tuple deletion. Columnar never removes index entries
- *		here: entries that point to deleted rows are filtered on fetch (the fetch
- *		returns false for a row-mask-deleted row), so leaving them is correct,
- *		and space is reclaimed by REINDEX or a rebuild. We therefore confirm that
- *		no entry is deletable and report no snapshot conflict horizon, which is
- *		always safe (spec 9).
+ *		Opportunistic index tuple deletion. An index entry is deletable exactly
+ *		when its row is no longer visible, i.e. ColumnarReadRowByNumber cannot
+ *		return it (deleted via the row mask). Reporting deletability by actual
+ *		liveness is required for correctness: nbtree's deletion pass (including
+ *		bottom-up deletion of duplicate keys, which a same-key UPDATE produces)
+ *		marks candidate items and calls this callback as the authority; leaving a
+ *		genuinely dead item marked non-deletable would make nbtree assert
+ *		(ndeletable > 0 || nupdatable > 0). Entries left in place are still
+ *		filtered on fetch, so either way is correct. The snapshot conflict horizon
+ *		is reported as invalid (no conflict), matching the row mask's own MVCC on
+ *		the catalog.
  */
 #if PG_VERSION_NUM < 140000
 /*
@@ -559,11 +564,25 @@ columnar_compute_xid_horizon_for_tuples(Relation rel, ItemPointerData *tids,
 static TransactionId
 columnar_index_delete_tuples(Relation rel, TM_IndexDeleteOp *delstate)
 {
+	Snapshot	snapshot = ActiveSnapshotSet() ? GetActiveSnapshot()
+		: GetTransactionSnapshot();
+	TupleDesc	tupdesc = RelationGetDescr(rel);
+	Datum	   *values = (Datum *) palloc(sizeof(Datum) * tupdesc->natts);
+	bool	   *nulls = (bool *) palloc(sizeof(bool) * tupdesc->natts);
 	int			i;
 
 	for (i = 0; i < delstate->ndeltids; i++)
-		delstate->status[delstate->deltids[i].id].knowndeletable = false;
+	{
+		uint64		rowNumber =
+			ColumnarItemPointerToRowNumber(&delstate->deltids[i].tid);
+		bool		live = ColumnarReadRowByNumber(rel, snapshot, rowNumber,
+												   values, nulls);
 
+		delstate->status[delstate->deltids[i].id].knowndeletable = !live;
+	}
+
+	pfree(values);
+	pfree(nulls);
 	return InvalidTransactionId;
 }
 #endif

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -1341,6 +1341,54 @@ columnar_fill_native_metadata_agg(ColumnarAggScanState *state)
 	table_close(rel, AccessShareLock);
 }
 
+/*
+ * columnar_native_scan_agg
+ *		Fold an ungrouped, unfiltered aggregate over a native table by scanning it
+ *		one row at a time (ColumnarReadNextRow applies the delete mask), for the
+ *		case where the zone-map-only path cannot be used because the storage has
+ *		deletes (D6b). No quals: the upper-path hook only adds the native agg path
+ *		when there is no filter.
+ */
+static void
+columnar_native_scan_agg(ColumnarAggScanState *state)
+{
+	EState	   *estate = state->css.ss.ps.state;
+	Relation	rel = table_open(state->relid, AccessShareLock);
+	TupleDesc	tupdesc = RelationGetDescr(rel);
+	Bitmapset  *projected = NULL;
+	ColumnarReadState *rs;
+	Datum	   *values = (Datum *) palloc(sizeof(Datum) * tupdesc->natts);
+	bool	   *nulls = (bool *) palloc(sizeof(bool) * tupdesc->natts);
+	uint64		rowNumber;
+	int			a;
+
+	for (a = 0; a < state->naggs; a++)
+		if (state->specs[a].attidx >= 0)
+			projected = bms_add_member(projected, state->specs[a].attidx);
+	if (projected == NULL)
+		projected = bms_make_singleton(0);	/* count(*) only: one column */
+
+	ColumnarFlushWriteStateForRelation(state->relid);
+	ColumnarFlushRowMaskForRelation(rel);
+
+	rs = ColumnarBeginRead(rel, estate->es_snapshot, NULL, projected, 0, NULL);
+	while (ColumnarReadNextRow(rs, values, nulls, &rowNumber))
+	{
+		for (a = 0; a < state->naggs; a++)
+		{
+			ColumnarAggSpec *spec = &state->specs[a];
+
+			if (spec->attidx >= 0)
+				columnar_apply_one(state, spec, values[spec->attidx],
+								   nulls[spec->attidx]);
+			else
+				columnar_apply_one(state, spec, (Datum) 0, true);
+		}
+	}
+	ColumnarEndRead(rs);
+	table_close(rel, AccessShareLock);
+}
+
 static TupleTableSlot *
 ColumnarExecAggScan(CustomScanState *node)
 {
@@ -1356,13 +1404,28 @@ ColumnarExecAggScan(CustomScanState *node)
 	state->done = true;
 
 	/*
-	 * Native tables answer entirely from zone maps (native spec 7.1, D5b): the
-	 * upper-path hook added this path only when every aggregate is zone-map
-	 * answerable and there is no filter, so no data pages are read.
+	 * Native tables answer from zone maps when no rows are deleted (native spec
+	 * 7.1, D5b): the upper-path hook added this path only when every aggregate is
+	 * zone-map answerable and there is no filter, so no data pages are read. When
+	 * the storage has deletes the zone maps include deleted rows, so fall back to a
+	 * scan that applies the delete mask (D6b).
 	 */
 	if (ColumnarTableFormatVersion(state->relid) == COLUMNAR_NATIVE_VERSION_MAJOR)
 	{
-		columnar_fill_native_metadata_agg(state);
+		EState	   *estate = node->ss.ps.state;
+		Relation	frel = table_open(state->relid, AccessShareLock);
+		bool		hasDeletes;
+
+		ColumnarFlushWriteStateForRelation(state->relid);
+		ColumnarFlushRowMaskForRelation(frel);
+		hasDeletes = ColumnarStorageHasRowMask(ColumnarStorageId(frel),
+											   ColumnarCatalogSnapshot(estate->es_snapshot));
+		table_close(frel, AccessShareLock);
+
+		if (hasDeletes)
+			columnar_native_scan_agg(state);
+		else
+			columnar_fill_native_metadata_agg(state);
 		state->haveStats = false;
 	}
 	/*

--- a/test/native_dml.sh
+++ b/test/native_dml.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# pgColumnar native delete and update (Phase D6b): DELETE, UPDATE and MERGE on a
+# native-format (PGCN v1) table, via the interim row mask keyed by row group. Every
+# result is compared to a heap mirror: the surviving rows, counts, aggregates after
+# deletes (which fall back from the zone-map path to a delete-applying scan), and
+# index lookups of deleted vs live rows. The interim row mask; Phase F replaces it
+# with a first-class delete vector.
+#
+# Usage:  test/native_dml.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+psql_run "CREATE TABLE h (id int PRIMARY KEY, k bigint, v text);"
+psql_run "CREATE TABLE n (id int PRIMARY KEY, k bigint, v text) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 1000, format_version => 1);"
+GEN="SELECT g, (g * 10)::bigint, 'row-' || g FROM generate_series(1, 5000) g"
+psql_run "INSERT INTO h $GEN;"
+psql_run "INSERT INTO n $GEN;"
+
+# DELETE across several row groups.
+psql_run "DELETE FROM h WHERE id % 7 = 0;"
+psql_run "DELETE FROM n WHERE id % 7 = 0;"
+
+check "count after delete" "$(q 'SELECT count(*) FROM n;')" "$(q 'SELECT count(*) FROM h;')"
+check "rows after delete match heap" \
+	"$(pgc_set_hash 'SELECT id, k, v FROM n')" \
+	"$(pgc_set_hash 'SELECT id, k, v FROM h')"
+# Aggregates after delete: the zone-map path is bypassed (deletes present), so this
+# exercises the delete-applying scan fold.
+check "sum(k) after delete" "$(q 'SELECT sum(k) FROM n;')" "$(q 'SELECT sum(k) FROM h;')"
+check "min/max after delete" \
+	"$(q 'SELECT min(id), max(id) FROM n;')" \
+	"$(q 'SELECT min(id), max(id) FROM h;')"
+check "deleted rows gone" "$(q 'SELECT count(*) FROM n WHERE id % 7 = 0;')" "0"
+
+# Index lookup of a deleted row returns nothing; a live row still resolves.
+idx() { env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" -q -At -c "SET enable_seqscan=off" -c "$1" 2>/dev/null; }
+# id 4444 is live (4444 % 7 = 6); id 4445 was deleted (4445 % 7 = 0).
+check "index finds live row"    "$(idx 'SELECT v FROM n WHERE id = 4444;')" "$(q 'SELECT v FROM h WHERE id = 4444;')"
+check "index skips deleted row" "$(idx 'SELECT count(*) FROM n WHERE id = 4445;')" "0"
+
+# UPDATE (delete old + insert new), including a plain column and a re-scan.
+psql_run "UPDATE h SET k = k + 1 WHERE id % 5 = 0;"
+psql_run "UPDATE n SET k = k + 1 WHERE id % 5 = 0;"
+check "count after update" "$(q 'SELECT count(*) FROM n;')" "$(q 'SELECT count(*) FROM h;')"
+check "rows after update match heap" \
+	"$(pgc_set_hash 'SELECT id, k, v FROM n')" \
+	"$(pgc_set_hash 'SELECT id, k, v FROM h')"
+check "sum(k) after update" "$(q 'SELECT sum(k) FROM n;')" "$(q 'SELECT sum(k) FROM h;')"
+
+# The primary key still rejects a duplicate of a surviving row and admits a new id.
+check "PK still enforced after DML" \
+	"$(psql_run 'INSERT INTO n VALUES (4444, 0, '"'"'x'"'"');' 2>&1 | grep -c -i 'duplicate key\|unique')" \
+	"1"
+
+# MERGE (PostgreSQL 15+): update matched, insert not-matched.
+if [ "$(q 'SELECT current_setting('"'"'server_version_num'"'"')::int >= 150000;')" = "t" ]; then
+	psql_run "CREATE TABLE src (id int, k bigint);"
+	psql_run "INSERT INTO src VALUES (1, 999), (999001, 5), (999002, 6);"
+	MERGE="MERGE INTO %T t USING src s ON t.id = s.id
+	       WHEN MATCHED THEN UPDATE SET k = s.k
+	       WHEN NOT MATCHED THEN INSERT (id, k, v) VALUES (s.id, s.k, 'm');"
+	psql_run "${MERGE//%T/h}"
+	psql_run "${MERGE//%T/n}"
+	check "count after merge" "$(q 'SELECT count(*) FROM n;')" "$(q 'SELECT count(*) FROM h;')"
+	check "rows after merge match heap" \
+		"$(pgc_set_hash 'SELECT id, k, v FROM n')" \
+		"$(pgc_set_hash 'SELECT id, k, v FROM h')"
+fi
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -26,7 +26,7 @@ SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUITES=(smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
 	differential recovery fuzz hardening concurrent_diff parallel sorted_projection \
 	arrow_export parquet_export read_stream corruption \
-	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip native_index)
+	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip native_index native_dml)
 
 # Default matrix: one assert-enabled pg_config per major, 13 through 19.
 DEFAULT_CONFIGS=(


### PR DESCRIPTION
DELETE, UPDATE and MERGE on native (PGCN v1) tables, via the row mask keyed by row group (interim per the Phase D constraint; Phase F replaces it with a delete vector). Default stays 2.2; native still opt-in.

- Row mask keyed by row group for native (`ColumnarMarkRowDeleted`, `rowmask_find_row_group`); the native scan and `ColumnarReadRowByNumber` apply it.
- `ColumnarRowMaskBufferedDeleted`: reads see a not-yet-flushed buffered delete, so a same-key UPDATE's unique check sees the old row gone.
- Native zone-map-only aggregate falls back to a delete-applying scan fold when the storage has any deletes (zone maps include deleted rows).
- **Latent bug fixed (2.2 and native):** `columnar_index_delete_tuples` reported deletability by actual row liveness instead of always-false; the always-false policy clobbered nbtree's LP_DEAD/duplicate deletability and crashed a same-key UPDATE on the nbtree assert `ndeletable > 0 || nupdatable > 0`.
- New `test/native_dml.sh`: DELETE/UPDATE/MERGE parity with a heap mirror, aggregates and index lookups after delete, PK enforcement after DML.

Full PG 13-19 matrix: ALL VERSIONS PASSED (38 suites, no warnings). This PR also carries the D6a commit (already reviewed at #61's branch tip) since it stacks on the same branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)