### PR TITLE
Phase D6c: native index-only scan (visibility map)

### DIFF
--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -465,6 +465,75 @@ ColumnarComputeAllVisibleGroups(uint64 storageId, TransactionId oldestXmin)
 	snap = RegisterSnapshot(GetLatestSnapshot());
 	InitDirtySnapshot(dirty);
 
+	/*
+	 * Native format (PGCN v1, D6c): a row group is all-visible when its catalog
+	 * row (inserted in the flushing transaction) precedes oldestXmin and the group
+	 * has no delete (committed or in progress, checked under a dirty snapshot). The
+	 * whole row group is one all-visible range. Clear-on-write removes the bit for
+	 * any later delete or insert, so a set bit never covers a modified row.
+	 */
+	if (ColumnarStorageIsNative(storageId, snap))
+	{
+		Relation	grel;
+		TupleDesc	gtd;
+		ScanKeyData gkey[1];
+		SysScanDesc gscan;
+		HeapTuple	gtuple;
+
+		table_close(srel, AccessShareLock);
+		grel = open_columnar_table("row_group", AccessShareLock);
+		gtd = RelationGetDescr(grel);
+		ScanKeyInit(&gkey[0], Anum_row_group_storage_id, BTEqualStrategyNumber,
+					F_INT8EQ, Int64GetDatum((int64) storageId));
+		gscan = systable_beginscan(grel, InvalidOid, false, snap, 1, gkey);
+		while (HeapTupleIsValid(gtuple = systable_getnext(gscan)))
+		{
+			TransactionId xmin = HeapTupleHeaderGetXmin(gtuple->t_data);
+			bool		isnull;
+			uint64		groupNumber,
+						firstRow,
+						rowCount;
+			List	   *rmList;
+			ListCell   *lc;
+			bool		hasDelete = false;
+			ColumnarRowRange *r;
+
+			if (TransactionIdIsNormal(xmin) &&
+				!TransactionIdPrecedes(xmin, oldestXmin))
+				continue;
+
+			groupNumber = (uint64) DatumGetInt64(
+				heap_getattr(gtuple, Anum_row_group_group_number, gtd, &isnull));
+			rowCount = (uint64) DatumGetInt64(
+				heap_getattr(gtuple, Anum_row_group_row_count, gtd, &isnull));
+			firstRow = (uint64) DatumGetInt64(
+				heap_getattr(gtuple, Anum_row_group_first_row_number, gtd, &isnull));
+			if (rowCount == 0)
+				continue;
+
+			rmList = ColumnarReadRowMaskList(storageId, groupNumber, &dirty);
+			foreach(lc, rmList)
+			{
+				if (((RowMaskMetadata *) lfirst(lc))->deletedRows > 0)
+				{
+					hasDelete = true;
+					break;
+				}
+			}
+			if (hasDelete)
+				continue;
+
+			r = palloc(sizeof(ColumnarRowRange));
+			r->firstRowNumber = firstRow;
+			r->rowCount = rowCount;
+			ranges = lappend(ranges, r);
+		}
+		systable_endscan(gscan);
+		table_close(grel, AccessShareLock);
+		UnregisterSnapshot(snap);
+		return ranges;
+	}
+
 	ScanKeyInit(&skey[0], Anum_stripe_storage_id, BTEqualStrategyNumber,
 				F_INT8EQ, Int64GetDatum((int64) storageId));
 	sscan = systable_beginscan(srel, InvalidOid, false, snap, 1, skey);

--- a/test/native_ios.sh
+++ b/test/native_ios.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# pgColumnar native index-only scan (Phase D6c): after VACUUM marks a native
+# (PGCN v1) table's all-visible row groups in the visibility map, an index-only
+# scan over an all-visible range skips the fetch (Heap Fetches: 0) and returns the
+# same rows as a heap mirror. A delete clears the VM bit (clear-on-write), so the
+# scan falls back to the fetch and never returns a deleted row.
+#
+# Usage:  test/native_ios.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+# One row group (large stripe limit) so an interior id range maps to blocks wholly
+# inside an all-visible group.
+psql_run "CREATE TABLE ioh (id int, v text);"
+psql_run "CREATE TABLE ios (id int, v text) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.alter_columnar_table_set('ios', stripe_row_limit => 16384, format_version => 1);"
+GEN="SELECT g, 'r'||g FROM generate_series(1, 8000) g"
+psql_run "INSERT INTO ioh $GEN;"
+psql_run "INSERT INTO ios $GEN;"
+psql_run "CREATE INDEX ios_id ON ios (id);"
+
+psql_run "ALTER DATABASE $PGC_DB SET pgcolumnar.enable_index_only_scan = on;"
+psql_run "ALTER DATABASE $PGC_DB SET pgcolumnar.enable_custom_scan = off;"
+psql_run "ALTER DATABASE $PGC_DB SET enable_seqscan = off;"
+psql_run "ALTER DATABASE $PGC_DB SET enable_bitmapscan = off;"
+
+psql_run "VACUUM ios;"   # mark all-visible row groups in the VM fork
+
+check "row count" "$(q 'SELECT count(*) FROM ios;')" "8000"
+
+planon="$(q 'EXPLAIN (COSTS OFF) SELECT id FROM ios WHERE id BETWEEN 1000 AND 5000;')"
+check "index-only scan chosen" "$(printf '%s' "$planon" | grep -c 'Index Only Scan')" "1"
+
+eaav="$(q 'EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT id FROM ios WHERE id BETWEEN 1000 AND 5000;')"
+check "all-visible interior: zero heap fetches" \
+	"$(printf '%s' "$eaav" | grep -oE 'Heap Fetches: [0-9]+' | grep -oE '[0-9]+' | head -1)" "0"
+
+check "index-only results match heap (all-visible)" \
+	"$(pgc_set_hash 'SELECT id FROM ios WHERE id BETWEEN 1000 AND 5000')" \
+	"$(pgc_set_hash 'SELECT id FROM ioh WHERE id BETWEEN 1000 AND 5000')"
+
+# A delete clears the VM bit for the affected blocks; the scan falls back to the
+# fetch there and must never return a deleted row.
+psql_run "DELETE FROM ios WHERE id BETWEEN 2000 AND 2200;"
+psql_run "DELETE FROM ioh WHERE id BETWEEN 2000 AND 2200;"
+check "index-only results match heap after delete" \
+	"$(pgc_set_hash 'SELECT id FROM ios WHERE id BETWEEN 1000 AND 5000')" \
+	"$(pgc_set_hash 'SELECT id FROM ioh WHERE id BETWEEN 1000 AND 5000')"
+eadel="$(q 'EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT id FROM ios WHERE id BETWEEN 1000 AND 5000;')"
+hf="$(printf '%s' "$eadel" | grep -oE 'Heap Fetches: [0-9]+' | grep -oE '[0-9]+' | head -1)"
+check "after delete: some heap fetches occur" "$([ "${hf:-0}" -gt 0 ] && echo yes || echo no)" "yes"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -26,7 +26,7 @@ SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUITES=(smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
 	differential recovery fuzz hardening concurrent_diff parallel sorted_projection \
 	arrow_export parquet_export read_stream corruption \
-	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip native_index native_dml)
+	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip native_index native_dml native_ios)
 
 # Default matrix: one assert-enabled pg_config per major, 13 through 19.
 DEFAULT_CONFIGS=(


### PR DESCRIPTION
## Phase D6c: native index-only scan / visibility map

Extends the native PGCN v1 path to support index-only scans backed by the visibility map.

### What this does
- `ColumnarComputeAllVisibleGroups` gains a native branch that scans `pgcolumnar.row_group`. A group is all-visible when its catalog xmin precedes `oldestXmin` (dirty snapshot) and it carries no delete, and the whole group maps to one `ColumnarRowRange`.
- VACUUM marks all-visible native row groups in the VM fork; an index-only scan over an all-visible interior range reports `Heap Fetches: 0`.
- A delete clears the affected VM bits (clear-on-write), so the scan falls back to the fetch there and never returns a deleted row.

### Testing
- New suite `test/native_ios.sh` (registered in the matrix): builds a single-group native table, VACUUMs, asserts an index-only scan is chosen, zero heap fetches on the all-visible interior, results match a heap mirror, and the VM bit clears after a delete.
- Full 13-19 matrix (all suites, assert-enabled): ALL VERSIONS PASSED, no failures, no build warnings.

Part of the Phase D6 stacked series. D6d (native projections) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)