### PR TITLE
Phase D6d: native projections inherit the base table's format

### DIFF
--- a/src/columnar_write_state.c
+++ b/src/columnar_write_state.c
@@ -1202,6 +1202,10 @@ columnar_build_write_state(Oid relid, TupleDesc srcTupdesc, uint64 storageId,
 	ws->compressionType = compType;
 	ws->compressionLevel = compLevel;
 	ws->storageId = storageId;
+	/* a projection inherits the base table's format: a native table's projections
+	 * are native too (D6d), written to their own storage id */
+	ws->isNative =
+		(ColumnarTableFormatVersion(relid) == COLUMNAR_NATIVE_VERSION_MAJOR);
 	columnar_init_col_defs(ws);	/* min/max + bloom skip metadata for projections */
 	ws->stripeContext = AllocSetContextCreate(ColumnarWriteContext,
 											  "columnar proj stripe",

--- a/test/native_projection.sh
+++ b/test/native_projection.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# pgColumnar native projections (Phase D6d): a projection of a native-format
+# (PGCN v1) table is itself written in the native format (to its own storage id)
+# and read back in that format. Before D6d the projection writer was hard-wired to
+# 2.2 while the reader took the base table's format, so a native base's projection
+# scan returned nothing. This suite checks the write fan-out reproduces the base's
+# live rows, the projection storage is native, deletes are reflected via the base
+# row mask, and fan-out spans multiple projection row groups.
+#
+# Usage:  test/native_projection.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+psql_run "CREATE TABLE fo (a int, b text, c int) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.alter_columnar_table_set('fo', stripe_row_limit => 1000, format_version => 1);"
+psql_run "SELECT pgcolumnar.add_projection('fo', 'fp', ARRAY['a','c'], ARRAY['c']);"
+psql_run "SELECT pgcolumnar.add_projection('fo', 'fq', ARRAY['b']);"
+psql_run "INSERT INTO fo SELECT g, 'r'||g, (g*7)%100 FROM generate_series(1,5000) g;"
+
+check "fp fan-out matches base (a,c)" \
+	"$(pgc_set_hash "SELECT pgcolumnar.read_projection('fo','fp')")" \
+	"$(pgc_set_hash "SELECT a::text || '|' || c::text FROM fo")"
+check "fq fan-out matches base (b)" \
+	"$(pgc_set_hash "SELECT pgcolumnar.read_projection('fo','fq')")" \
+	"$(pgc_set_hash "SELECT b FROM fo")"
+check "fp row count matches base" \
+	"$(q "SELECT count(*) FROM pgcolumnar.read_projection('fo','fp');")" \
+	"$(q 'SELECT count(*) FROM fo;')"
+
+# The projection storage is native (its own native storage catalog row exists) and
+# carries zone maps, not the 2.2 chunk catalog.
+check "fp storage is native" \
+	"$(q "SELECT count(*) FROM pgcolumnar.storage WHERE storage_id = (SELECT proj_storage_id FROM pgcolumnar.projection WHERE storage_id = pgcolumnar.get_storage_id('fo') AND name='fp');")" \
+	"1"
+check "fp has zone maps (native skip metadata)" \
+	"$([ "$(q "SELECT count(*) FROM pgcolumnar.zone_map WHERE storage_id = (SELECT proj_storage_id FROM pgcolumnar.projection WHERE storage_id = pgcolumnar.get_storage_id('fo') AND name='fp');")" -ge 1 ] && echo yes || echo no)" "yes"
+check "fp not in the 2.2 chunk catalog" \
+	"$(q "SELECT count(*) FROM pgcolumnar.chunk WHERE storage_id = (SELECT proj_storage_id FROM pgcolumnar.projection WHERE storage_id = pgcolumnar.get_storage_id('fo') AND name='fp');")" \
+	"0"
+
+# Deletes on the base are reflected in the projection (via the base row mask).
+psql_run "DELETE FROM fo WHERE a BETWEEN 1000 AND 2000;"
+check "fp reflects deletes (a,c)" \
+	"$(pgc_set_hash "SELECT pgcolumnar.read_projection('fo','fp')")" \
+	"$(pgc_set_hash "SELECT a::text || '|' || c::text FROM fo")"
+check "fp count after delete matches base" \
+	"$(q "SELECT count(*) FROM pgcolumnar.read_projection('fo','fp');")" \
+	"$(q 'SELECT count(*) FROM fo;')"
+
+# Fan-out spans multiple projection row groups (small stripe limit, 5000 rows).
+check "fp spans multiple projection row groups" \
+	"$([ "$(q "SELECT count(*) FROM pgcolumnar.row_group WHERE storage_id = (SELECT proj_storage_id FROM pgcolumnar.projection WHERE storage_id = pgcolumnar.get_storage_id('fo') AND name='fp');")" -ge 2 ] && echo yes || echo no)" "yes"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -26,7 +26,7 @@ SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUITES=(smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
 	differential recovery fuzz hardening concurrent_diff parallel sorted_projection \
 	arrow_export parquet_export read_stream corruption \
-	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip native_index native_dml native_ios)
+	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip native_index native_dml native_ios native_projection)
 
 # Default matrix: one assert-enabled pg_config per major, 13 through 19.
 DEFAULT_CONFIGS=(


### PR DESCRIPTION
## Phase D6d: native projections

A projection of a native (PGCN v1) table is now written in the native format to its own storage id, matching the reader which already took the base table's format.

### What this does
- `columnar_build_write_state` derives `isNative` from the base relation's `format_version`, the single source already used for base tables. Before this the projection writer left `isNative` at its default (2.2), while the reader expected native, so a native base's projection scan returned nothing.

### Testing
- New suite `test/native_projection.sh` (registered in the matrix): checks the write fan-out reproduces the base's live rows, the projection storage is native (its own storage catalog row and zone maps, not the 2.2 chunk catalog), base deletes are reflected via the row mask, and fan-out spans multiple projection row groups.
- Full 13-19 matrix (all suites, assert-enabled): ALL VERSIONS PASSED, no failures, no build warnings.

Part of the Phase D6 stacked series. D6e (native-mode suites) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)