### PR TITLE
Phase D6e: native-mode suites green + format-dependent tests and fixes

### DIFF
--- a/src/columnar.h
+++ b/src/columnar.h
@@ -130,6 +130,7 @@ typedef struct ColumnarOptions
 /* GUC-backed instance defaults (spec 8.3) */
 extern int columnar_stripe_row_limit;
 extern int columnar_chunk_group_row_limit;
+extern int columnar_default_format_version;	/* 0=format 2.2, 1=native (D6e/f) */
 extern int columnar_compression;		/* one of COLUMNAR_COMPRESSION_* */
 extern int columnar_compression_level;	/* zstd level */
 extern bool columnar_enable_qual_pushdown;
@@ -406,6 +407,7 @@ extern void ColumnarInsertChunkGroupRow(uint64 storageId,
 extern void ColumnarInsertChunkRow(uint64 storageId, const ChunkMetadata *chunk);
 extern void ColumnarInsertNativeStorageRow(const NativeStorageMetadata *s);
 extern bool ColumnarStorageIsNative(uint64 storageId, Snapshot snapshot);
+extern bool ColumnarStorageHasStripes(uint64 storageId, Snapshot snapshot);
 extern void ColumnarInsertRowGroupRow(const NativeRowGroupMetadata *rg);
 extern void ColumnarInsertColumnChunkRow(const NativeColumnChunkMetadata *cc);
 extern void ColumnarInsertZoneMapRow(const NativeZoneMapMetadata *z);

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -1080,21 +1080,49 @@ ColumnarInsertNativeStorageRow(const NativeStorageMetadata *s)
 	Datum		values[Natts_native_storage];
 	bool		nulls[Natts_native_storage];
 	HeapTuple	tuple;
-	Snapshot	base;
 	Snapshot	snapshot;
 	ScanKeyData key[1];
 	SysScanDesc scan;
 	bool		exists;
+	LOCKTAG		tag;
 
-	/* idempotent: the storage row is written once per storage id, but the
-	 * native writer calls this on every row-group flush */
-	base = ActiveSnapshotSet() ? GetActiveSnapshot() : GetTransactionSnapshot();
-	snapshot = ColumnarCatalogSnapshot(base);
+	/*
+	 * The storage row is written once per storage id, but the native writer
+	 * calls this on every row-group flush, so it must be idempotent. Under
+	 * concurrent first-writes to the same table both backends' inserts are
+	 * invisible to each other's snapshot, so a plain check-then-insert would let
+	 * both insert and the second would fail on storage_pkey (issue seen by the
+	 * concurrent differential suite in native mode). Serialize creators with a
+	 * transaction-scoped advisory lock keyed by the storage id (discriminator 2,
+	 * distinct from the row_mask lock's 1), then re-check against the latest
+	 * committed state: the loser of the race sees the winner's committed row and
+	 * skips the insert. The lock is held to transaction end so the winner's row
+	 * is committed and visible before the loser proceeds.
+	 */
+	SET_LOCKTAG_ADVISORY(tag, MyDatabaseId,
+						 (uint32) (s->storageId >> 32),
+						 (uint32) (s->storageId & 0xFFFFFFFF), 2);
+	(void) LockAcquire(&tag, ExclusiveLock, false /* transaction lock */ ,
+					   false /* wait */ );
+
+	/*
+	 * Re-check under the lock against a fresh snapshot so the loser of a
+	 * cross-transaction race sees the winner's just-committed row (GetLatestSnapshot),
+	 * with curcid advanced (ColumnarCatalogSnapshot) so a second flush in this same
+	 * transaction still sees the row this transaction already inserted. The latest
+	 * snapshot must be pushed active before it drives a heap visibility check:
+	 * PostgreSQL 18 asserts a scan snapshot is registered or active
+	 * (heapam_visibility.c), and the catalog-snapshot copy inherits the active
+	 * count. Pop it once the existence scan is done.
+	 */
+	PushActiveSnapshot(GetLatestSnapshot());
+	snapshot = ColumnarCatalogSnapshot(GetActiveSnapshot());
 	ScanKeyInit(&key[0], Anum_native_storage_storage_id, BTEqualStrategyNumber,
 				F_INT8EQ, Int64GetDatum((int64) s->storageId));
 	scan = systable_beginscan(rel, InvalidOid, false, snapshot, 1, key);
 	exists = HeapTupleIsValid(systable_getnext(scan));
 	systable_endscan(scan);
+	PopActiveSnapshot();
 	if (exists)
 	{
 		table_close(rel, RowExclusiveLock);
@@ -1133,6 +1161,33 @@ ColumnarStorageIsNative(uint64 storageId, Snapshot snapshot)
 	bool		found;
 
 	ScanKeyInit(&key[0], Anum_native_storage_storage_id, BTEqualStrategyNumber,
+				F_INT8EQ, Int64GetDatum((int64) storageId));
+	scan = systable_beginscan(rel, InvalidOid, false, snapshot, 1, key);
+	found = HeapTupleIsValid(systable_getnext(scan));
+	systable_endscan(scan);
+	table_close(rel, AccessShareLock);
+
+	return found;
+}
+
+/*
+ * ColumnarStorageHasStripes
+ *		True when the storage id has at least one 2.2 stripe row, i.e. 2.2 data
+ *		has been written for it. This is the 2.2 counterpart of
+ *		ColumnarStorageIsNative. The writer uses the pair to anchor to the format
+ *		already on disk: once a storage has 2.2 stripes it keeps writing 2.2 even
+ *		if the default GUC now says native, so the D6 default flip never rewrites
+ *		an existing table in a different format.
+ */
+bool
+ColumnarStorageHasStripes(uint64 storageId, Snapshot snapshot)
+{
+	Relation	rel = open_columnar_table("stripe", AccessShareLock);
+	ScanKeyData key[1];
+	SysScanDesc scan;
+	bool		found;
+
+	ScanKeyInit(&key[0], Anum_stripe_storage_id, BTEqualStrategyNumber,
 				F_INT8EQ, Int64GetDatum((int64) storageId));
 	scan = systable_beginscan(rel, InvalidOid, false, snapshot, 1, key);
 	found = HeapTupleIsValid(systable_getnext(scan));
@@ -1707,10 +1762,11 @@ ColumnarReadOptions(Oid relid, ColumnarOptions *opts)
 
 /*
  * ColumnarTableFormatVersion
- *		The on-disk format a relation's writes use: 0 for the 1.0-dev line (the
- *		default, format 2.2), or the native major version (1) when the table's
- *		format_version option is set. The native writer consults this to choose
- *		the layout; until the native writer exists it is informational.
+ *		The on-disk format a relation's writes use: 0 for the 1.0-dev line
+ *		(format 2.2), or the native major version (1, PGCN v1). A table's own
+ *		format_version option wins; absent that, the instance default GUC
+ *		(pgcolumnar.default_format_version) decides. The native writer consults
+ *		this to choose the layout.
  */
 int
 ColumnarTableFormatVersion(Oid relid)
@@ -1719,7 +1775,7 @@ ColumnarTableFormatVersion(Oid relid)
 
 	if (ColumnarReadOptions(relid, &opts) && opts.formatVersionSet)
 		return opts.formatVersion;
-	return 0;
+	return columnar_default_format_version;
 }
 
 /*

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -164,6 +164,7 @@ static bool columnar_group_can_match(ColumnarReadState *readState, int groupInde
 static bool columnar_is_projected(ColumnarReadState *readState, int attidx);
 static void columnar_build_predicates(ColumnarReadState *readState,
 									  int nkeys, ScanKey keys);
+static int64 columnar_next_group_index(ColumnarReadState *readState);
 
 /* -------------------------------------------------------------------------
  * value stream codec (shared with the writer)
@@ -1112,13 +1113,24 @@ columnar_native_load_group(ColumnarReadState *rs)
 	int			maxVecCount;
 	bool		allDescriptor;
 
-	/* advance past row groups the zone maps rule out (native spec 7.1) */
-	while (rs->rowGroupIndex < list_length(rs->rowGroupList))
+	/*
+	 * Claim the next row group and advance past any the zone maps rule out
+	 * (native spec 7.1). Under a parallel custom scan each worker claims distinct
+	 * groups from the shared counter (columnar_next_group_index), so a group is
+	 * read by exactly one backend; serially it walks rowGroupIndex. Without the
+	 * counter every worker read every group and a parallel scan returned each row
+	 * once per participating backend (D6e).
+	 */
+	rg = NULL;
+	for (;;)
 	{
+		int64		gi = columnar_next_group_index(rs);
 		bool		match = true;
 
-		rg = (NativeRowGroupMetadata *) list_nth(rs->rowGroupList,
-												 rs->rowGroupIndex);
+		if (gi < 0)
+			return false;
+
+		rg = (NativeRowGroupMetadata *) list_nth(rs->rowGroupList, (int) gi);
 		if (rs->numPredicates > 0)
 		{
 			MemoryContext old = MemoryContextSwitchTo(rs->skipContext);
@@ -1131,18 +1143,12 @@ columnar_native_load_group(ColumnarReadState *rs)
 			break;
 
 		rs->groupsSkipped++;
-		rs->rowGroupIndex++;
 	}
-
-	if (rs->rowGroupIndex >= list_length(rs->rowGroupList))
-		return false;
 
 	rs->groupsRead++;
 
 	MemoryContextReset(rs->groupContext);
 	oldContext = MemoryContextSwitchTo(rs->groupContext);
-
-	rg = (NativeRowGroupMetadata *) list_nth(rs->rowGroupList, rs->rowGroupIndex);
 	rs->nativeGroup = rg;
 	rs->nativeBuffer = palloc(rg->byteLength > 0 ? rg->byteLength : 1);
 	if (rg->byteLength > 0)
@@ -1243,7 +1249,6 @@ columnar_native_load_group(ColumnarReadState *rs)
 
 	rs->groupRowCount = rg->rowCount;
 	rs->rowInGroup = 0;
-	rs->rowGroupIndex++;
 
 	MemoryContextSwitchTo(oldContext);
 	return true;
@@ -1656,6 +1661,27 @@ columnar_next_stripe_index(ColumnarReadState *readState)
 	return (si < (uint32) nstripes) ? (int) si : -1;
 }
 
+/*
+ * columnar_next_group_index
+ *		The next native row group to scan, or -1 when none remain. The native
+ *		counterpart of columnar_next_stripe_index: a parallel custom scan claims
+ *		it from the shared atomic so each worker reads distinct row groups (gap
+ *		23, D6e); a serial scan walks rowGroupIndex.
+ */
+static int64
+columnar_next_group_index(ColumnarReadState *readState)
+{
+	int			ngroups = list_length(readState->rowGroupList);
+	uint32		gi;
+
+	if (readState->parallelCounter != NULL)
+		gi = pg_atomic_fetch_add_u32(readState->parallelCounter, 1);
+	else
+		gi = (uint32) readState->rowGroupIndex++;
+
+	return (gi < (uint32) ngroups) ? (int64) gi : -1;
+}
+
 void
 ColumnarReadSetParallelCounter(ColumnarReadState *readState,
 							   pg_atomic_uint32 *counter)
@@ -1856,12 +1882,70 @@ ColumnarBuildLivenessCache(Relation rel, Snapshot snapshot)
 											  "columnar liveness cache",
 											  ALLOCSET_DEFAULT_SIZES);
 	MemoryContext oldContext = MemoryContextSwitchTo(ctx);
-	List	   *stripeList = ColumnarReadStripeList(storageId, metaSnapshot);
+	List	   *stripeList;
 	ColumnarLivenessCache *cache = palloc0(sizeof(ColumnarLivenessCache));
 	ListCell   *lc;
 	int			i = 0;
 
 	cache->ctx = ctx;
+
+	/*
+	 * Native base (PGCN v1): each row group is one liveness entry with a single
+	 * whole-group delete mask (D6b keys the row mask by group number, chunk id 0).
+	 * Modeling it as chunkGroupCount 1 with chunkRowCount == rowCount makes the
+	 * shared ColumnarLivenessCacheIsLive map every row to chunk 0. Without this a
+	 * native base's stripe list is empty and every projected row would read as not
+	 * visible, so a projection scan over a native table returned nothing (D6e).
+	 */
+	if (ColumnarStorageIsNative(storageId, metaSnapshot))
+	{
+		List	   *rgList = ColumnarReadRowGroupList(storageId, metaSnapshot);
+
+		cache->nstripes = list_length(rgList);
+		cache->stripes = palloc0(sizeof(LiveStripeEntry) * Max(cache->nstripes, 1));
+
+		foreach(lc, rgList)
+		{
+			NativeRowGroupMetadata *rg = (NativeRowGroupMetadata *) lfirst(lc);
+			LiveStripeEntry *e = &cache->stripes[i++];
+			List	   *rml;
+			ListCell   *mc;
+			uint32		want = (uint32) ((rg->rowCount + 7) / 8);
+
+			e->firstRowNumber = rg->firstRowNumber;
+			e->rowCount = rg->rowCount;
+			e->chunkRowCount = (int) rg->rowCount;
+			e->chunkGroupCount = 1;
+			e->masks = palloc0(sizeof(char *) * 1);
+			e->maskLens = palloc0(sizeof(uint32) * 1);
+
+			rml = ColumnarReadRowMaskList(storageId, rg->groupNumber, metaSnapshot);
+			foreach(mc, rml)
+			{
+				RowMaskMetadata *rm = (RowMaskMetadata *) lfirst(mc);
+				uint32		b;
+
+				if (rm->mask == NULL || rm->maskLen == 0)
+					continue;
+				if (e->masks[0] == NULL)
+				{
+					e->masks[0] = palloc0(want > 0 ? want : 1);
+					e->maskLens[0] = want;
+				}
+				for (b = 0; b < rm->maskLen && b < want; b++)
+					e->masks[0][b] |= rm->mask[b];
+			}
+		}
+
+		if (cache->nstripes > 1)
+			qsort(cache->stripes, cache->nstripes, sizeof(LiveStripeEntry),
+				  livestripe_cmp);
+
+		MemoryContextSwitchTo(oldContext);
+		return cache;
+	}
+
+	stripeList = ColumnarReadStripeList(storageId, metaSnapshot);
 	cache->nstripes = list_length(stripeList);
 	cache->stripes = palloc0(sizeof(LiveStripeEntry) * Max(cache->nstripes, 1));
 

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -45,6 +45,12 @@ PG_MODULE_MAGIC;
 /* GUC-backed instance defaults (spec 8.3) */
 int			columnar_stripe_row_limit = 150000;
 int			columnar_chunk_group_row_limit = 10000;
+
+/* GUC: on-disk format for new columnar tables that set no explicit
+ * format_version option. 0 is the 1.0-dev line (format 2.2); 1 is native
+ * (PGCN v1). ColumnarTableFormatVersion falls back to this. D6f flips the
+ * boot default to native; D6e uses it to run the whole suite in native mode. */
+int			columnar_default_format_version = 0;
 int			columnar_compression = COLUMNAR_COMPRESSION_ZSTD;
 int			columnar_compression_level = 3;
 bool		columnar_enable_qual_pushdown = true;
@@ -1101,6 +1107,19 @@ _PG_init(void)
 							&columnar_stripe_row_limit,
 							150000,
 							1000, INT_MAX,
+							PGC_USERSET,
+							0,
+							NULL, NULL, NULL);
+
+	DefineCustomIntVariable("pgcolumnar.default_format_version",
+							"On-disk format for new columnar tables with no "
+							"explicit format_version option.",
+							"0 is the 1.0-dev line (format 2.2); 1 is the native "
+							"PGCN v1 format. A table's own format_version option "
+							"always wins over this default.",
+							&columnar_default_format_version,
+							0,
+							0, 1,
 							PGC_USERSET,
 							0,
 							NULL, NULL, NULL);

--- a/src/columnar_write_state.c
+++ b/src/columnar_write_state.c
@@ -265,9 +265,26 @@ ColumnarGetWriteState(Relation rel)
 	 * defaulting via ColumnarTableFormatVersion. Flipping that default (D6f) flips
 	 * writer and reader together. The reader derives its own native flag from the
 	 * storage catalog, which follows what the writer produced.
+	 *
+	 * A storage that already holds data anchors to the format on disk, ignoring
+	 * the default: a table written 2.2 stays 2.2 and a native table stays native
+	 * even after the default GUC flips (D6f). Only an empty storage follows the
+	 * per-table option or the instance default. This keeps a single table from
+	 * ever mixing 2.2 stripes and native row groups.
 	 */
-	writeState->isNative =
-		(ColumnarTableFormatVersion(relid) == COLUMNAR_NATIVE_VERSION_MAJOR);
+	{
+		Snapshot	base = ActiveSnapshotSet() ? GetActiveSnapshot() :
+			GetTransactionSnapshot();
+		Snapshot	snap = ColumnarCatalogSnapshot(base);
+
+		if (ColumnarStorageIsNative(writeState->storageId, snap))
+			writeState->isNative = true;
+		else if (ColumnarStorageHasStripes(writeState->storageId, snap))
+			writeState->isNative = false;
+		else
+			writeState->isNative =
+				(ColumnarTableFormatVersion(relid) == COLUMNAR_NATIVE_VERSION_MAJOR);
+	}
 
 	columnar_init_col_defs(writeState);
 

--- a/test/corruption.sh
+++ b/test/corruption.sh
@@ -33,6 +33,64 @@ mkc() {
 	          FROM generate_series(1,20000) g;"
 }
 
+if native_mode; then
+	# Native (PGCN v1) catalog: the reader trusts the row_group and column_chunk
+	# lengths/counts and the encoding descriptor. Corrupt each and require a clean
+	# error (or safe degradation) with the backend surviving (D6e). The native
+	# equivalents of the 2.2 chunk fields are the row_group byte_length/row_count
+	# and the column_chunk page_length/value_count/encoding_descriptor.
+	echo "-- row_group.byte_length corruption must error, not crash"
+	mkc
+	psql_run "UPDATE pgcolumnar.row_group SET byte_length = byte_length + 123456
+	          WHERE storage_id = $(sid);"
+	check "byte_length corruption errors"   "$(errors 'SELECT count(*), sum(r) FROM c;')" "yes"
+	check "alive after byte_length"         "$(alive)" "yes"
+
+	echo "-- row_group.row_count corruption must error, not crash"
+	mkc
+	psql_run "UPDATE pgcolumnar.row_group SET row_count = row_count + 100000
+	          WHERE storage_id = $(sid);"
+	check "row_count corruption errors"     "$(errors 'SELECT sum(r) FROM c;')" "yes"
+	check "alive after row_count"           "$(alive)" "yes"
+
+	echo "-- column_chunk.page_length corruption must error, not crash"
+	mkc
+	psql_run "UPDATE pgcolumnar.column_chunk SET page_length = page_length + 123456
+	          WHERE storage_id = $(sid);"
+	check "page_length corruption errors"   "$(errors 'SELECT sum(r) FROM c;')" "yes"
+	check "alive after page_length"         "$(alive)" "yes"
+
+	echo "-- column_chunk.value_count corruption must not crash (degrades safely)"
+	mkc
+	psql_run "UPDATE pgcolumnar.column_chunk SET value_count = value_count + 100000
+	          WHERE storage_id = $(sid);"
+	q "SELECT sum(r) FROM c;" >/dev/null 2>&1
+	check "alive after value_count"         "$(alive)" "yes"
+
+	echo "-- corrupt encoding descriptor must error, not crash"
+	mkc
+	psql_run "UPDATE pgcolumnar.column_chunk SET encoding_descriptor = '\\xffffffff'::bytea
+	          WHERE storage_id = $(sid) AND column_index = 1;"
+	check "bad descriptor errors"           "$(errors 'SELECT * FROM c;')" "yes"
+	check "alive after bad descriptor"      "$(alive)" "yes"
+
+	echo "-- column_index = -1 (negative index guard) must not crash"
+	mkc
+	psql_run "UPDATE pgcolumnar.column_chunk SET column_index = -1
+	          WHERE storage_id = $(sid) AND column_index = 1;"
+	q "SELECT count(*) FROM c;" >/dev/null 2>&1
+	check "alive after column_index=-1"     "$(alive)" "yes"
+
+	echo "-- corrupt bloom header (huge nbits, short buffer) is treated as no filter"
+	mkc
+	psql_run "UPDATE pgcolumnar.bloom SET filter = '\\x0000004006'::bytea
+	          WHERE storage_id = $(sid);"
+	check "corrupt bloom equality still correct" "$(q 'SELECT count(*) FROM c WHERE r = -999;')" "0"
+	check "alive after bloom corruption"         "$(alive)" "yes"
+
+	pgc_summary
+fi
+
 echo "-- value_raw_length corruption must error, not crash"
 mkc
 psql_run "UPDATE pgcolumnar.chunk SET value_raw_length = value_raw_length + 123456

--- a/test/differential.sh
+++ b/test/differential.sh
@@ -231,15 +231,21 @@ diff_query "enc lowcard eq" "SELECT id FROM %T WHERE lowcard = 2"
 diff_query "enc const scan" "SELECT id FROM %T WHERE constv = 42"
 diff_query "enc aggregate"  "SELECT sum(seqv), min(lowcard), max(lowcard), count(constv), sum(rnd) FROM %T"
 
-# the encoding was actually applied for the shaped columns
+# the encoding was actually applied for the shaped columns. These inspect the
+# 2.2 chunk catalog's encoding-type code; the native format records encodings in
+# the column-chunk descriptor instead, proven by the native_encoding suite, so
+# these run only in 2.2 mode (D6e). The oracle checks above cover correctness in
+# both modes.
 enc_applied() {
 	q "SELECT bool_and(value_encoding_type <> 0) FROM pgcolumnar.chunk
 	   WHERE storage_id = pgcolumnar.get_storage_id('t_col') AND attr_num = $1;"
 }
-check "enc id encoded"      "$(enc_applied 1)" "t"
-check "enc seqv encoded"    "$(enc_applied 2)" "t"
-check "enc lowcard encoded" "$(enc_applied 3)" "t"
-check "enc constv encoded"  "$(enc_applied 4)" "t"
+if ! native_mode; then
+	check "enc id encoded"      "$(enc_applied 1)" "t"
+	check "enc seqv encoded"    "$(enc_applied 2)" "t"
+	check "enc lowcard encoded" "$(enc_applied 3)" "t"
+	check "enc constv encoded"  "$(enc_applied 4)" "t"
+fi
 
 # Gorilla (float XOR) and delta-of-delta (regular-interval timestamp), I4.
 # alt: a random walk -> many distinct (dict bails), irregular bit deltas (for/
@@ -260,8 +266,10 @@ enc_has() {
 	q "SELECT bool_or(value_encoding_type = $2) FROM pgcolumnar.chunk
 	   WHERE storage_id = pgcolumnar.get_storage_id('t_col') AND attr_num = $1;"
 }
-check "i4 alt uses gorilla" "$(enc_has 2 4)" "t"
-check "i4 tsreg uses dod"   "$(enc_has 3 5)" "t"
+if ! native_mode; then
+	check "i4 alt uses gorilla" "$(enc_has 2 4)" "t"
+	check "i4 tsreg uses dod"   "$(enc_has 3 5)" "t"
+fi
 
 # Dictionary (I5) for low-cardinality columns, including varlena/text which had
 # no lightweight encoding before. cat/tag repeat a few distinct values.
@@ -277,11 +285,13 @@ diff_query "dict whole-row"   "SELECT * FROM %T"
 diff_query "dict text eq"     "SELECT id FROM %T WHERE cat = 'east'"
 diff_query "dict text agg"    "SELECT count(cat), min(cat), max(cat), count(distinct tag) FROM %T"
 diff_query "dict text group"  "SELECT cat, count(*) FROM %T GROUP BY cat"
-check "dict cat uses dict"    "$(enc_has 2 6)" "t"
-check "dict tag uses dict"    "$(enc_has 3 6)" "t"
-check "dict code encoded"     "$(enc_applied 4)" "t"
-# a high-cardinality text column stays unencoded (dict bails)
-check "dict hicard none"      "$(enc_has 5 0)" "t"
+if ! native_mode; then
+	check "dict cat uses dict"    "$(enc_has 2 6)" "t"
+	check "dict tag uses dict"    "$(enc_has 3 6)" "t"
+	check "dict code encoded"     "$(enc_applied 4)" "t"
+	# a high-cardinality text column stays unencoded (dict bails)
+	check "dict hicard none"      "$(enc_has 5 0)" "t"
+fi
 
 # a NONE-compression table still round-trips (encoding independent of codec)
 make_pair "id int, v bigint"
@@ -340,12 +350,18 @@ diff_query "bloom k present" "SELECT id FROM %T WHERE k = ((7*2654435761)%100000
 diff_query "bloom u eq"      "SELECT count(*) FROM %T WHERE u = md5('123')::uuid"
 diff_query "bloom k range"   "SELECT count(*) FROM %T WHERE k < 50000"
 
+# The bloom is confirmed built by inspecting the 2.2 chunk catalog; the native
+# per-chunk bloom lives in its own bloom catalog, proven by the native_bloom
+# suite, so the catalog-introspection and the 2.2 chunk-group removal count run
+# only in 2.2 mode (D6e). Correctness (below) is checked in both modes.
 bloom_built() {
 	q "SELECT bool_or(bloom_filter IS NOT NULL) FROM pgcolumnar.chunk
 	   WHERE storage_id = pgcolumnar.get_storage_id('t_col') AND attr_num = $1;"
 }
-check "bloom built for k" "$(bloom_built 2)" "t"
-check "bloom built for u" "$(bloom_built 3)" "t"
+if ! native_mode; then
+	check "bloom built for k" "$(bloom_built 2)" "t"
+	check "bloom built for u" "$(bloom_built 3)" "t"
+fi
 
 # an absent value strictly inside the global min/max, so min/max alone cannot
 # skip it (every hash-spread chunk's range contains it) -- only bloom can.
@@ -357,10 +373,12 @@ removed() {
 	   EXPLAIN (ANALYZE, TIMING off, SUMMARY off) SELECT id FROM t_col WHERE k = ${absent}::bigint;" \
 		| grep -oiE 'Removed by Filter: [0-9]+' | grep -oE '[0-9]+$'
 }
-on=$(removed on)
-off=$(removed off)
 check "bloom absent correct"   "$(q "SELECT count(*) FROM t_col WHERE k = ${absent}::bigint;")" "0"
-check "bloom removes >= minmax" "$([ "${on:-0}" -gt "${off:-0}" ] && echo yes)" "yes"
+if ! native_mode; then
+	on=$(removed on)
+	off=$(removed off)
+	check "bloom removes >= minmax" "$([ "${on:-0}" -gt "${off:-0}" ] && echo yes)" "yes"
+fi
 
 # Text bloom (gap 25): deterministic-collation text/varchar columns are bloomed;
 # equality skipping works and results stay correct, including under a mismatched
@@ -373,8 +391,10 @@ diff_query "textbloom present"  "SELECT id FROM %T WHERE tk = 'k' || ((7*2654435
 diff_query "textbloom absent"   "SELECT count(*) FROM %T WHERE tk = 'zzzzzzzz'"
 diff_query "textbloom C absent" "SELECT count(*) FROM %T WHERE tc = 'zzzzzzzz'"
 diff_query "textbloom C eq"     "SELECT count(*) FROM %T WHERE tc = 'c123'"
-check "textbloom built for tk" "$(bloom_built 2)" "t"
-check "textbloom built for tc" "$(bloom_built 3)" "t"
+if ! native_mode; then
+	check "textbloom built for tk" "$(bloom_built 2)" "t"
+	check "textbloom built for tc" "$(bloom_built 3)" "t"
+fi
 # mismatched explicit COLLATE must still return correct results (not pushed)
 diff_query "textbloom collate-mismatch" "SELECT count(*) FROM %T WHERE tk = 'k100' COLLATE \"C\""
 
@@ -426,12 +446,18 @@ done
 q "ALTER DATABASE $PGC_DB RESET pgcolumnar.enable_metadata_count;" >/dev/null
 
 # with the metadata path on, count(*) must read no chunk groups; off, it scans.
+# The EXPLAIN counters are the 2.2 scan's "Columnar Chunk Groups" lines; the
+# native count path reports differently and is covered by the native_agg suite,
+# so this introspection runs only in 2.2 mode (D6e). The oracle checks above
+# prove the count is correct in both modes and both GUC settings.
 meta_lines() {
 	q "SET pgcolumnar.enable_metadata_count=$1;
 	   EXPLAIN (ANALYZE, TIMING off, SUMMARY off) SELECT count(*) FROM t_col;" \
 		| grep -c 'Columnar Chunk Groups'
 }
-check "count meta-on skips scan" "$(meta_lines on)" "0"
-check "count meta-off scans"     "$([ "$(meta_lines off)" -gt 0 ] && echo yes)" "yes"
+if ! native_mode; then
+	check "count meta-on skips scan" "$(meta_lines on)" "0"
+	check "count meta-off scans"     "$([ "$(meta_lines off)" -gt 0 ] && echo yes)" "yes"
+fi
 
 pgc_summary

--- a/test/generated_columns.sh
+++ b/test/generated_columns.sh
@@ -48,9 +48,16 @@ as_h="$(q "SELECT sum(b), count(c) FROM gs_heap")"
 as_c="$(q "SELECT sum(b), count(c) FROM gs_col")"
 check "stored generated: aggregate matches" "$as_c" "$as_h"
 
-# a STORED column is materialized, so a chunk is written for attr_num 2
-sc="$(q "SELECT count(*) FROM pgcolumnar.chunk
-         WHERE storage_id = pgcolumnar.get_storage_id('gs_col') AND attr_num = 2;")"
+# a STORED column is materialized, so a chunk is written for attr_num 2. In the
+# native format the counterpart is a column_chunk for the 0-based column_index 1
+# (D6e).
+if native_mode; then
+	sc="$(q "SELECT count(*) FROM pgcolumnar.column_chunk
+	         WHERE storage_id = pgcolumnar.get_storage_id('gs_col') AND column_index = 1;")"
+else
+	sc="$(q "SELECT count(*) FROM pgcolumnar.chunk
+	         WHERE storage_id = pgcolumnar.get_storage_id('gs_col') AND attr_num = 2;")"
+fi
 check "stored generated: chunk present for attr 2" "$([ "$sc" -gt 0 ] && echo yes)" "yes"
 
 # --- VIRTUAL generated column (PostgreSQL 18+) -----------------------------

--- a/test/hardening.sh
+++ b/test/hardening.sh
@@ -25,6 +25,35 @@ set -uo pipefail
 pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
 
 # ---------------------------------------------------------------------------
+# Native mode (D6e): the format 2.0 compatibility path (part 1) is 2.2-only and
+# does not apply. Cover the corrupted-input intent against the native catalogs:
+# an invalid encoding descriptor must raise a clean error (not crash), and a
+# malformed native bloom must be ignored so results stay correct.
+# ---------------------------------------------------------------------------
+if native_mode; then
+	echo "-- native: corrupted input robustness"
+
+	make_pair "id int, v bigint"
+	load_pair "SELECT g, g*2 FROM generate_series(1,3000) g"
+	psql_run "UPDATE pgcolumnar.column_chunk SET encoding_descriptor = '\\\\xffffffff'::bytea
+			  WHERE storage_id = pgcolumnar.get_storage_id('t_col') AND column_index = 1;"
+	badresult="$(q "SELECT * FROM t_col;")"
+	check "invalid descriptor raises error" "$([ -z "$badresult" ] && echo errored)" "errored"
+	check "backend alive after invalid descriptor" "$(q "SELECT 1;")" "1"
+
+	make_pair "id int, k bigint"
+	q "SELECT pgcolumnar.alter_columnar_table_set('t_col', chunk_group_row_limit => 1000, stripe_row_limit => 20000);" >/dev/null
+	load_pair "SELECT g, ((g*2654435761)%100000)::bigint FROM generate_series(1,8000) g"
+	psql_run "UPDATE pgcolumnar.bloom SET filter = '\\\\x00'::bytea
+			  WHERE storage_id = pgcolumnar.get_storage_id('t_col') AND column_index = 1;"
+	diff_query "corrupt bloom present" "SELECT id FROM %T WHERE k = ((7*2654435761)%100000)::bigint"
+	diff_query "corrupt bloom absent"  "SELECT count(*) FROM %T WHERE k = 424242424"
+	check "backend alive after corrupt bloom" "$(q "SELECT 1;")" "1"
+
+	pgc_summary
+fi
+
+# ---------------------------------------------------------------------------
 # Part 1: format 2.0 compatibility (NULL-default reader path)
 # ---------------------------------------------------------------------------
 echo "-- part 1: format 2.0 compatibility"

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -81,6 +81,13 @@ pgc_setup() {
 		echo "bytea_output='hex'"
 		# Keep planner honest but let small tables use the custom scan.
 		echo "max_parallel_workers_per_gather=0"
+		# Native-mode runs (D6e): make the native (PGCN v1) format the instance
+		# default so every columnar table created without an explicit
+		# format_version option is written native. A table's own option still
+		# wins, and a storage that already holds data keeps its on-disk format.
+		if [ "${PGC_NATIVE:-0}" = "1" ]; then
+			echo "pgcolumnar.default_format_version=1"
+		fi
 	} | pgc_pg "cat >> '$PGC_PGDATA/postgresql.conf'"
 
 	# Start, retrying a few times: under rapid cluster churn (the version matrix
@@ -233,18 +240,37 @@ storage_id_of() {
 	q "SELECT pgcolumnar.get_storage_id('$1');"
 }
 
+# True when the harness is running in native-format mode (D6e).
+native_mode() { [ "${PGC_NATIVE:-0}" = "1" ]; }
+
 # Number of stripes physically written for a columnar relation (default t_col).
+# The native (PGCN v1) row group is the stripe's counterpart and honors the same
+# stripe_row_limit, so in native mode this counts row groups (D6e).
 stripe_count() {
 	local rel="${1:-t_col}"
-	q "SELECT count(*) FROM pgcolumnar.stripe
-	   WHERE storage_id = pgcolumnar.get_storage_id('$rel');"
+	if native_mode; then
+		q "SELECT count(*) FROM pgcolumnar.row_group
+		   WHERE storage_id = pgcolumnar.get_storage_id('$rel');"
+	else
+		q "SELECT count(*) FROM pgcolumnar.stripe
+		   WHERE storage_id = pgcolumnar.get_storage_id('$rel');"
+	fi
 }
 
-# Number of chunk groups written for a columnar relation (default t_col).
+# Number of chunk groups written for a columnar relation (default t_col). The
+# native vector is the chunk group's counterpart and honors the same
+# chunk_group_row_limit, so in native mode this counts vectors, one per column 0
+# per-vector zone map, across all row groups (D6e).
 chunk_group_count() {
 	local rel="${1:-t_col}"
-	q "SELECT count(*) FROM pgcolumnar.chunk_group
-	   WHERE storage_id = pgcolumnar.get_storage_id('$rel');"
+	if native_mode; then
+		q "SELECT count(*) FROM pgcolumnar.zone_map
+		   WHERE storage_id = pgcolumnar.get_storage_id('$rel')
+		     AND vector_index >= 0 AND column_index = 0;"
+	else
+		q "SELECT count(*) FROM pgcolumnar.chunk_group
+		   WHERE storage_id = pgcolumnar.get_storage_id('$rel');"
+	fi
 }
 
 # ---- summary ---------------------------------------------------------------

--- a/test/native_writer.sh
+++ b/test/native_writer.sh
@@ -14,6 +14,12 @@ set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
 
+# This suite exercises format selection: a native table (format_version = 1) and
+# a default (legacy) table must land in different catalogs. Pin the instance
+# default to legacy so the per-table option alone drives the choice, regardless
+# of the harness's native-mode default (PGC_NATIVE sets it to native) (D6e).
+psql_run "ALTER DATABASE $PGC_DB SET pgcolumnar.default_format_version = 0;"
+
 # A native table with a small row-group limit so several row groups are written.
 psql_run "CREATE TABLE nw (id int, v text) USING pgcolumnar;"
 psql_run "SELECT pgcolumnar.alter_columnar_table_set('nw', stripe_row_limit => 1000, format_version => 1);"

--- a/test/projections.sh
+++ b/test/projections.sh
@@ -109,9 +109,16 @@ check "fp row count matches base" \
 	"$(q 'SELECT count(*) FROM fo;')"
 
 # Phase 4a: projection chunks carry per-chunk min/max skip metadata, so a sorted
-# projection gives tight ranges the planner can use (gap 26).
+# projection gives tight ranges the planner can use (gap 26). Native projections
+# carry the same skip metadata in the zone map (D6e).
+fp_sid="(SELECT proj_storage_id FROM pgcolumnar.projection WHERE storage_id = pgcolumnar.get_storage_id('fo') AND name='fp')"
+if native_mode; then
+	fp_minmax="$(q "SELECT count(*) FROM pgcolumnar.zone_map WHERE storage_id = $fp_sid AND minimum IS NOT NULL;")"
+else
+	fp_minmax="$(q "SELECT count(*) FROM pgcolumnar.chunk WHERE storage_id = $fp_sid AND minimum_value IS NOT NULL;")"
+fi
 check "fp chunks carry min/max skip metadata" \
-	"$([ "$(q "SELECT count(*) FROM pgcolumnar.chunk WHERE storage_id = (SELECT proj_storage_id FROM pgcolumnar.projection WHERE storage_id = pgcolumnar.get_storage_id('fo') AND name='fp') AND minimum_value IS NOT NULL;")" -ge 1 ] && echo yes || echo no)" "yes"
+	"$([ "$fp_minmax" -ge 1 ] && echo yes || echo no)" "yes"
 
 echo "-- phase 2: deletes reflected via the base row_mask"
 psql_run "DELETE FROM fo WHERE a BETWEEN 1000 AND 2000;"
@@ -131,8 +138,14 @@ psql_run "INSERT INTO fo2 SELECT g, (g*13)%1000 FROM generate_series(1,7000) g;"
 check "fp2 multi-stripe fan-out matches base" \
 	"$(pgc_set_hash "SELECT pgcolumnar.read_projection('fo2','fp2')")" \
 	"$(pgc_set_hash "SELECT a::text || '|' || c::text FROM fo2")"
+fp2_sid="(SELECT proj_storage_id FROM pgcolumnar.projection WHERE storage_id = pgcolumnar.get_storage_id('fo2') AND name='fp2')"
+if native_mode; then
+	fp2_stripes="$(q "SELECT count(*) FROM pgcolumnar.row_group WHERE storage_id = $fp2_sid;")"
+else
+	fp2_stripes="$(q "SELECT count(*) FROM pgcolumnar.stripe WHERE storage_id = $fp2_sid;")"
+fi
 check "fp2 spans multiple projection stripes" \
-	"$([ "$(q "SELECT count(*) FROM pgcolumnar.stripe WHERE storage_id = (SELECT proj_storage_id FROM pgcolumnar.projection WHERE storage_id = pgcolumnar.get_storage_id('fo2') AND name='fp2');")" -ge 2 ] && echo yes || echo no)" "yes"
+	"$([ "$fp2_stripes" -ge 2 ] && echo yes || echo no)" "yes"
 
 echo "-- phase 2: reading the base projection by name is rejected"
 expect_fail "read_projection base rejected" "SELECT pgcolumnar.read_projection('fo', 'base');"

--- a/test/sorted_projection.sh
+++ b/test/sorted_projection.sh
@@ -22,9 +22,14 @@ pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
 # Number of chunk groups a filtered aggregate removes via min/max skipping.
 # sum() (not count(*)) is used so the scan actually runs -- an unfiltered
 # count(*) is answered from metadata and never scans (see test/phase5.sh).
+# The native format keeps one row group here and prunes at the per-vector level,
+# reported as "Columnar Vectors Skipped"; that is the counterpart of the 2.2
+# whole-chunk-group removal, so the metric is mode-aware (D6e).
 groups_removed() {
+	local field='Chunk Groups Removed by Filter'
+	native_mode && field='Vectors Skipped'
 	q "EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) $1" \
-		| grep -F 'Chunk Groups Removed by Filter' | grep -oE '[0-9]+$' | head -1
+		| grep -F "$field" | grep -oE '[0-9]+$' | head -1
 }
 
 expect_error() {


### PR DESCRIPTION
## Phase D6e: native-mode green across PostgreSQL 13-19

Runs the full suite in native mode and closes the gaps it surfaced.

### Mechanism
- New `pgcolumnar.default_format_version` GUC (0 = format 2.2, 1 = native). `ColumnarTableFormatVersion` falls back to it when a table sets no explicit `format_version`. This is the single flip point D6f will change; D6e drives it from the harness (`PGC_NATIVE=1`) to run every suite native.
- The writer anchors to the on-disk format: a storage with 2.2 stripes stays 2.2 and a native storage stays native even after the default flips, so no table is ever rewritten in a mixed format.

### Correctness fixes exposed by native-mode runs
- **Projection scan over a native base returned nothing** — the liveness cache was 2.2-only. `ColumnarBuildLivenessCache` now has a native branch (row groups + whole-group row mask).
- **Concurrent first-inserts raced on `storage_pkey`** — native storage-row creation is now serialized by a transaction advisory lock, re-checking against a fresh pushed-active snapshot (which also satisfies PostgreSQL 18's registered-or-active heap-visibility assertion).
- **Parallel scan double-counted native rows** — the native row-group loop now claims groups from the shared parallel counter, the counterpart of the 2.2 stripe claim, so each group is read by exactly one worker.

### Format-dependent tests
Made mode-aware: layout introspection runs against native catalogs where a clean equivalent exists, otherwise only in 2.2 mode (native layout is covered by the `native_*` suites). `corruption`/`hardening` gained native-catalog tamper equivalents; the native reader was verified robust to every case.

### Testing
Full PostgreSQL 13-19 matrix, assert-enabled, in **both** modes: ALL VERSIONS PASSED in default (2.2) mode and in native mode.

Part of the Phase D6 stacked series. D6f (flip the default + docs) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)