### PR TITLE
Phase D6f: native format the default, and full docs pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 All notable changes to pgColumnar are recorded here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). pgColumnar is
-pre-release; the current marker is `1.0-dev` (on-disk format 2.2), recorded in
-`VERSION`. Everything below is unreleased. For the forward-looking plan see
+pre-release; the version marker is `1.0-dev`, recorded in `VERSION`. New tables
+are written in the native on-disk format, PGCN v1. Everything below is
+unreleased. For the forward-looking plan see
 [design/ROADMAP.md](design/ROADMAP.md); for full history see the git log.
 
 ## [Unreleased]
@@ -13,6 +14,14 @@ pre-release; the current marker is `1.0-dev` (on-disk format 2.2), recorded in
 - Column-oriented table access method (`USING pgcolumnar`) with per-column
   compression, chunk-group minimum and maximum skipping, per-chunk bloom filters,
   and a vectorized scan and aggregate path with late materialization.
+- Native on-disk format PGCN v1: the default for new tables, with row groups,
+  per-column chunks, an adaptive per-vector encoding cascade, zone maps for
+  skipping, and per-chunk bloom filters. Delete, update, index scan, index-only
+  scan, and projections all work on native tables. The instance default is set
+  by `pgcolumnar.default_format_version` (1 native, 0 the earlier line); a
+  table's `format_version` option overrides it, and a table that already holds
+  data keeps its on-disk format. The earlier line is still read and is pinned at
+  the `v1.0-dev` tag.
 - Compression codecs `none`, `pglz`, `lz4`, and `zstd`. `lz4` and `zstd` are
   compiled in when their system libraries are present.
 - `count(*)` answered from catalog metadata without scanning.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,11 @@ is for analytic workloads: large scans, aggregates, and column projections over
 append-mostly data.
 
 pgColumnar builds from one source tree on PostgreSQL 13 through 19 and is
-licensed under the [MIT License](LICENSE). It is pre-release; the current marker
-is `1.0-dev` (on-disk format 2.2), recorded in `VERSION`.
+licensed under the [MIT License](LICENSE). It is pre-release; the version marker
+is `1.0-dev`, recorded in `VERSION`. A bare `USING pgcolumnar` table is written
+in the native on-disk format, PGCN v1. The earlier 1.0-dev format is still read
+for tables that already hold it; it is pinned at the `v1.0-dev` tag and is
+retired in a later release.
 
 ## Documentation
 
@@ -24,7 +27,7 @@ is `1.0-dev` (on-disk format 2.2), recorded in `VERSION`.
 | [User guide](docs/user-guide.md) | Create tables, load data, and query |
 | [Administration](docs/administration.md) | Operate columnar tables in production |
 | [Configuration](docs/configuration.md) | Settings and per-table options |
-| [SQL reference](docs/sql-reference.md) | The `columnar.*` functions |
+| [SQL reference](docs/sql-reference.md) | The `pgcolumnar.*` functions |
 | [Limitations](docs/limitations.md) | Compatibility and known constraints |
 | [Benchmarks](docs/benchmarks.md) | Size and latency numbers |
 | [Testing](docs/testing.md) | The test suite and version matrix |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,22 +2,32 @@
 
 This document is a module-by-module map of the pgColumnar source so a new
 developer can navigate the code. It is derived from the source in `src/` and
-from `design/FORMAT_AND_INTERFACE_SPEC.md` (format version 2.0). Read the
-specification first for the on-disk layout and catalog schema; this document
-describes how the code is organized against it.
+from `design/FORMAT_AND_INTERFACE_SPEC.md`. Read the specification first for the
+on-disk layout and catalog schema; this document describes how the code is
+organized against it.
+
+New tables are written in the native format, PGCN v1. The earlier 1.0-dev line
+is still read for tables that already hold it, pinned at the `v1.0-dev` tag and
+retired in a later phase. The writer, reader, and catalog modules carry both
+paths; the native path is the default and the descriptions below note where the
+earlier path differs.
 
 ## On-disk model in one paragraph
 
 A columnar relation stores its data in its own main fork using standard
 PostgreSQL pages, so the buffer manager, WAL, and page checksums apply. Block 0
 is a metapage, block 1 is reserved, and block 2 onward is a logical byte area.
-Rows are grouped into stripes (a run of up to `stripe_row_limit` rows). A stripe
-is divided into chunk groups (up to `chunk_group_row_limit` rows each). Within a
-chunk group, one column's data is a chunk, holding a value stream and an exists
-(null bitmap) stream. A separate set of ordinary heap tables in the `pgcolumnar`
-schema is the metadata catalog: it records each stripe, chunk group, and chunk,
-the per-chunk compression and min/max, and the delete/update row mask. A storage
-id links a relation's physical file to its catalog rows.
+In the native format, rows are grouped into row groups (a run of up to
+`stripe_row_limit` rows, the write unit). Within a row group one column's data
+is a chunk, holding a validity bitmap and a value stream encoded in fixed-size
+vectors. A separate set of ordinary heap tables in the `pgcolumnar` schema is
+the metadata catalog: `storage`, `row_group`, and `column_chunk` record the
+layout, `zone_map` records each chunk's and each vector's minimum and maximum
+for skipping, `bloom` records the per-chunk equality filters, and `row_mask`
+records the delete and update marks. A storage id links a relation's physical
+file to its catalog rows. The earlier line groups rows into stripes and chunk
+groups recorded in the `stripe`, `chunk_group`, and `chunk` catalogs; it shares
+`row_mask`.
 
 ## Module map
 
@@ -26,9 +36,10 @@ The table access method handler and extension glue. It fills a `TableAmRoutine`
 with the callbacks PostgreSQL calls for a `USING pgcolumnar` table: create
 storage, bulk and single insert, sequential scan open/next/close, delete and
 update (through the row mask), fetch a row by item pointer, size estimation, and
-truncate. It also holds `_PG_init`, which registers every `columnar.*` GUC (the
-compression codec and level, stripe and chunk-group row limits, and the qual
-pushdown, custom scan, vectorization, and column cache toggles), the pre-commit
+truncate. It also holds `_PG_init`, which registers every `pgcolumnar.*` GUC (the
+default format version, the compression codec and level, stripe and chunk-group
+row limits, and the qual pushdown, custom scan, vectorization, and column cache
+toggles), the pre-commit
 hook that flushes pending writes, and the object-access hook that removes a
 table's metadata rows when the table is dropped.
 
@@ -53,13 +64,19 @@ independently. This module reads and writes the raw logical buffers through the
 buffer manager.
 
 ### columnar_metadata.c
-Access to the `pgcolumnar` catalog tables (stripe, chunk_group, chunk, options,
-row_mask) and the storage-id sequence. Metadata are ordinary heap tables keyed
-by storage id, read and written with direct catalog access (heap opens, index
-scans, and inserts) rather than SPI, so metadata access does not depend on SPI
-reentrancy from inside a scan or write. Catalog reads use a snapshot whose
-command id is advanced so a transaction sees its own just-written metadata
-(read-your-writes) while staying isolated from other transactions.
+Access to the `pgcolumnar` catalog tables and the storage-id sequence. The
+native catalogs are `storage`, `row_group`, `column_chunk`, `zone_map`, and
+`bloom`; the earlier line uses `stripe`, `chunk_group`, and `chunk`; `options`
+and `row_mask` are shared. Metadata are ordinary heap tables keyed by storage
+id, read and written with direct catalog access (heap opens, index scans, and
+inserts) rather than SPI, so metadata access does not depend on SPI reentrancy
+from inside a scan or write. Catalog reads use a snapshot whose command id is
+advanced so a transaction sees its own just-written metadata (read-your-writes)
+while staying isolated from other transactions. `ColumnarTableFormatVersion`
+resolves a table's format from its `format_version` option, falling back to the
+`pgcolumnar.default_format_version` instance default; the native storage-row
+insert is serialized by a storage-id advisory lock so concurrent first-writers
+do not race.
 
 ### columnar_write_state.c
 The writer. It batches incoming rows into per-column chunk buffers, closes a
@@ -70,7 +87,11 @@ starts buffering, so every row has its stable row number and synthetic item
 pointer at insert time (needed for indexes and unique checks). Pending writes
 are held per relation and per subtransaction for the life of the transaction,
 promoted to the parent on subtransaction commit and discarded on rollback. Per
-chunk it computes and stores the min/max skip values for orderable types.
+chunk it computes and stores the min/max skip values for orderable types. The
+native path writes row groups, per-column chunks with a per-vector encoding
+cascade, zone maps, and per-chunk bloom filters, and it anchors to the format
+already on disk so a table that holds data keeps its format; the projection
+fan-out shares this writer. The earlier path writes stripes and chunk groups.
 
 ### columnar_compression.c
 The value-stream codecs: `none`, `pglz` (built into PostgreSQL), `lz4`, and
@@ -114,7 +135,12 @@ missing value (from `getmissingattr`) for a stripe written before an
 equality predicates. For late materialization the reader splits positioning
 (`ColumnarAdvanceGroup`) from decoding a chosen column subset
 (`ColumnarDecodeGroupColumns`), and `ColumnarReadNextRawGroup` hands back raw
-value streams so the aggregate can fold runs without materializing Datums.
+value streams so the aggregate can fold runs without materializing Datums. The
+reader detects the native format from the storage catalog and walks row groups
+and per-vector encoded chunks, skipping by the zone maps and per-chunk blooms,
+claiming row groups from the shared counter under a parallel scan; the liveness
+cache and the fetch-by-row-number path have native branches. The scalar path
+serves the native format; the vectorized batch path serves the earlier line.
 
 ### columnar_row_mask.c
 Delete and update marking. A delete, and the old side of an update, sets a bit
@@ -224,7 +250,7 @@ levels and dictionary indices, PLAIN and dictionary value decoding, and both
 DATA_PAGE v1 and v2 (what pyarrow writes). The schema tree is walked to derive
 each leaf column's Dremel level bounds; nested columns are reconstructed by
 decoding each leaf's full entry sequence (defs/reps/dense values) and grouping
-repeated runs — LIST → array, group → composite — the inverse of the nested
+repeated runs (LIST to array, group to composite), the inverse of the nested
 Parquet exporter. Scalars remain byte-for-byte the flat path. Rows are inserted
 into an existing target table via `table_tuple_insert`, mirroring the Arrow
 importer. No libparquet dependency.
@@ -241,7 +267,7 @@ answered from the index tuple and any other block falls back to the
 snapshot-checked fetch. Gated by `pgcolumnar.enable_index_only_scan` (default on).
 
 ### columnar_projection.c
-Multiple projections DDL and reader (gap 26, format 2.2). `add_projection` /
+Multiple projections DDL and reader (gap 26). `add_projection` /
 `drop_projection` manage the `pgcolumnar.projection` catalog; `add_projection`
 back-fills the projection from existing rows under ShareLock. The catalog CRUD
 lives in `columnar_metadata.c`; write fan-out and the sorted per-stripe encoder

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -9,13 +9,14 @@ monitoring, backup, and security.
 A columnar table is one PostgreSQL relation plus rows in the `pgcolumnar` catalog
 tables. Data is organized as follows:
 
-- A **stripe** is the unit of write. Each write transaction appends one or more
-  stripes of up to `pgcolumnar.stripe_row_limit` rows.
-- A **chunk group** is a horizontal slice of a stripe, up to
-  `pgcolumnar.chunk_group_row_limit` rows. It is the unit of decompression and of
-  minimum and maximum skipping.
-- Within a chunk group, each column is stored and compressed separately, with a
-  recorded minimum and maximum and an optional bloom filter.
+- A **row group** is the unit of write. Each write transaction appends one or
+  more row groups of up to `pgcolumnar.stripe_row_limit` rows.
+- Within a row group, each column is stored and compressed separately as a
+  chunk. A chunk's values are encoded in **vectors** of up to
+  `pgcolumnar.chunk_group_row_limit` rows, the unit of the encoding cascade and
+  of minimum and maximum skipping.
+- Each chunk records its minimum and maximum and an optional bloom filter, and a
+  per-vector zone map records the finer minimum and maximum ranges.
 
 Deletes and updates do not rewrite data. They mark rows in a row mask. Space is
 reclaimed by compaction (see below).
@@ -41,8 +42,8 @@ data, rewrite the table with [`pgcolumnar.vacuum`](sql-reference.md#pgcolumnarva
 ## Row-group sizing
 
 `pgcolumnar.chunk_group_row_limit` (default 10000) sets how many rows share one
-minimum and maximum. Smaller groups skip more precisely on selective range
-filters but hold less data per group. `pgcolumnar.stripe_row_limit` (default
+minimum and maximum in a vector. Smaller vectors skip more precisely on selective
+range filters but hold less data per vector. `pgcolumnar.stripe_row_limit` (default
 150000) sets the write unit. The defaults suit most workloads. Change them for a
 table with `pgcolumnar.alter_columnar_table_set` when a specific access pattern
 calls for it, and measure the result.
@@ -54,17 +55,17 @@ There are two distinct operations, and the difference matters:
 - **Standard `VACUUM`** (manual or autovacuum) runs the columnar table's vacuum,
   which sets visibility-map bits used by index-only scans and maintains
   statistics. It does not rewrite data or reclaim space from deleted rows.
-- **`pgcolumnar.vacuum`** (a function) rewrites the table, combining stripes and
+- **`pgcolumnar.vacuum`** (a function) rewrites the table, combining row groups and
   reclaiming space held by deleted and updated rows.
 
 Run `pgcolumnar.vacuum` after bulk deletes or updates, or after many small load
-transactions have produced many small stripes:
+transactions have produced many small row groups:
 
 ```sql
 SELECT pgcolumnar.vacuum('events');
 ```
 
-To store rows sorted on a column so range filters on it skip more chunk groups,
+To store rows sorted on a column so range filters on it skip more row groups,
 use `pgcolumnar.vacuum_sorted`:
 
 ```sql
@@ -82,7 +83,7 @@ An index-only scan answers a query from the index without reading the table, whe
 the index covers the query and the rows are marked all-visible. pgColumnar serves
 this through a columnar visibility-map fork:
 
-- `VACUUM` marks a chunk group all-visible when its inserting transaction is old
+- `VACUUM` marks a row group all-visible when its inserting transaction is old
   enough and the group has no deletes.
 - Any insert, update, or delete clears the bit for the affected group.
 
@@ -117,11 +118,11 @@ result. Confirm the plan uses it with `EXPLAIN`, which names the chosen projecti
 
 ## Monitoring
 
-`pgcolumnar.stats(rel)` reports per-stripe row counts, deleted-row counts, chunk
+`pgcolumnar.stats(rel)` reports per-row-group row counts, deleted-row counts, chunk
 counts, and byte sizes. Use it to see fragmentation and decide when to compact:
 
 ```sql
-SELECT count(*)                         AS stripes,
+SELECT count(*)                         AS row_groups,
        sum(rowcount)                    AS rows,
        sum(deletedrows)                 AS deleted,
        round(100.0 * sum(deletedrows)
@@ -130,7 +131,7 @@ SELECT count(*)                         AS stripes,
 FROM pgcolumnar.stats('events');
 ```
 
-A high deleted-row percentage or a large number of small stripes indicates that
+A high deleted-row percentage or a large number of small row groups indicates that
 `pgcolumnar.vacuum` would help.
 
 ## Concurrent unique inserts
@@ -167,4 +168,4 @@ columnar table, because reading the table requires the access method.
 The Arrow and Parquet import and export functions read and write files on the
 server host and require superuser. Grant them only to roles you trust with
 server-side file access, and control the paths those roles can reach. All other
-`columnar.*` functions run with ordinary table privileges.
+`pgcolumnar.*` functions run with ordinary table privileges.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,7 @@
 
 pgColumnar has two kinds of settings:
 
-- Server settings under the `columnar.` prefix, listed below. Each can be set in
+- Server settings under the `pgcolumnar.` prefix, listed below. Each can be set in
   `postgresql.conf`, per session with `SET`, per role, or per database. All of
   them are `USERSET`, so a session may change them without special privileges.
 - Per-table storage options, set with `pgcolumnar.alter_columnar_table_set`. These
@@ -14,8 +14,9 @@ pgColumnar has two kinds of settings:
 
 | Setting | Type | Default | Description |
 | --- | --- | --- | --- |
-| `pgcolumnar.stripe_row_limit` | integer | `150000` | Maximum rows per stripe. A stripe is the unit of write and the granularity at which whole segments are appended. Range 1000 to INT_MAX. |
-| `pgcolumnar.chunk_group_row_limit` | integer | `10000` | Maximum rows per chunk group. A chunk group is the unit of min/max skipping and decompression. Range 100 to INT_MAX. |
+| `pgcolumnar.default_format_version` | integer | `1` | On-disk format for new tables with no explicit `format_version` option. `1` is the native format (PGCN v1); `0` is the earlier 1.0-dev line. A table's own option wins, and a table that already holds data keeps its format. |
+| `pgcolumnar.stripe_row_limit` | integer | `150000` | Maximum rows per row group. The row group is the unit of write and the granularity at which whole segments are appended. Range 1000 to INT_MAX. |
+| `pgcolumnar.chunk_group_row_limit` | integer | `10000` | Maximum rows per vector. The vector is the unit of encoding and of min/max skipping. Range 100 to INT_MAX. |
 
 ### Compression
 
@@ -80,6 +81,7 @@ SELECT pgcolumnar.alter_columnar_table_set(
 | `stripe_row_limit` | integer | Per-table override of `pgcolumnar.stripe_row_limit`. |
 | `compression` | name | One of `none`, `pglz`, `lz4`, `zstd`. |
 | `compression_level` | integer | Level for the `zstd` codec, 1 to 22. |
+| `format_version` | integer | On-disk format for this table: `1` native (PGCN v1), `0` the earlier line. Overrides `pgcolumnar.default_format_version`. Takes effect for a table with no data yet; a table that already holds data keeps its format. |
 
 Arguments left at their default (`NULL`) are not changed. A value outside the
 valid range for a limit or level is rejected.

--- a/docs/features.md
+++ b/docs/features.md
@@ -8,12 +8,17 @@ settings see the [configuration reference](configuration.md); for constraints se
 ## Storage and format
 
 - Column-oriented storage in the relation's main fork, so the buffer manager,
-  WAL, and page checksums apply. The on-disk format is version 2.2, specified in
+  WAL, and page checksums apply. New tables are written in the native format,
+  PGCN v1, specified in
   [../design/FORMAT_AND_INTERFACE_SPEC.md](../design/FORMAT_AND_INTERFACE_SPEC.md).
-  Format 2.0 and 2.1 files still read.
-- Rows are grouped into stripes (the write unit) and chunk groups (the unit of
-  decompression and of minimum and maximum skipping). Each column in a chunk
-  group is stored and compressed separately.
+  The earlier 1.0-dev line is still read for tables that already hold it; it is
+  pinned at the `v1.0-dev` tag and is retired in a later release. The instance
+  default is set by `pgcolumnar.default_format_version`, and a table's
+  `format_version` option overrides it.
+- Rows are grouped into row groups (the write unit). Within a row group each
+  column is stored and compressed as its own chunk, and a chunk's values are
+  encoded in fixed-size vectors. Zone maps hold each chunk's and each vector's
+  minimum and maximum for skipping.
 
 ## Encodings and compression
 
@@ -45,7 +50,7 @@ settings see the [configuration reference](configuration.md); for constraints se
   and decodes the remaining output columns only for chunk groups with surviving
   rows.
 - `count(*)` with no filter is answered from catalog metadata without scanning.
-- Parallel scan across a table's stripes.
+- Parallel scan across a table's row groups.
 - Read stream prefetch of block reads on PostgreSQL 17 and later
   (`pgcolumnar.enable_read_stream`).
 
@@ -77,13 +82,13 @@ Vectorization and skipping change how a result is computed, never the result. Se
   `Columnar Projection: <name>`. Deletes and MVCC visibility come from the base,
   and `pgcolumnar.vacuum` keeps projections aligned.
   `pgcolumnar.drop_projection(table, name)` frees one. On by default
-  (`pgcolumnar.enable_projection_scan`); format 2.2.
+  (`pgcolumnar.enable_projection_scan`).
 
 ## Transactions, MVCC, and DML
 
 - Reads see the transaction's own inserts and deletes while staying isolated from
   other transactions. Deletes and the old side of updates are marked in a row mask
-  without rewriting stripes. Pending work is discarded on transaction and
+  without rewriting row groups. Pending work is discarded on transaction and
   savepoint rollback, with correct attribution across `ROLLBACK TO`.
 - Unique and primary-key constraints are enforced on insert and at index build
   time. NOT NULL and CHECK constraints are enforced through the insert path.
@@ -93,7 +98,7 @@ Vectorization and skipping change how a result is computed, never the result. Se
 
 ## Schema changes
 
-- `ALTER TABLE ... ADD COLUMN` on a populated table without a rewrite: a stripe
+- `ALTER TABLE ... ADD COLUMN` on a populated table without a rewrite: a row group
   written before the column existed carries no chunk for it, and the reader
   produces the column's missing value (NULL, or the constant default the column
   was added with), matching heap fast-default behavior.
@@ -103,8 +108,8 @@ Vectorization and skipping change how a result is computed, never the result. Se
 
 ## Maintenance
 
-- `pgcolumnar.vacuum(table)` rewrites a table's live rows into full stripes,
-  combining small stripes, reclaiming deleted-row space, and rebuilding indexes.
+- `pgcolumnar.vacuum(table)` rewrites a table's live rows into full row groups,
+  combining small row groups, reclaiming deleted-row space, and rebuilding indexes.
   `pgcolumnar.vacuum_full(schema)` does the same across a schema.
 - `pgcolumnar.vacuum_sorted(table, col [, col ...])` rewrites a table stored sorted
   on the given columns, ascending with nulls last. A sorted key gives tight,
@@ -112,7 +117,7 @@ Vectorization and skipping change how a result is computed, never the result. Se
   more chunk groups, and the sort key compresses better under RLE and delta
   encodings. It is a one-time reorder, like `CLUSTER`: rows inserted afterward
   append in insert order until the next call.
-- `pgcolumnar.stats(table)` reports per-stripe row counts, deleted-row counts,
+- `pgcolumnar.stats(table)` reports per-row-group row counts, deleted-row counts,
   chunk counts, and byte sizes.
 
 ## Interoperability

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ licensed under the MIT License.
 | Create columnar tables, load data, and query them | [User guide](user-guide.md) |
 | Operate columnar tables in production | [Administration](administration.md) |
 | Look up a setting and its default | [Configuration reference](configuration.md) |
-| Look up a `columnar.*` function | [SQL reference](sql-reference.md) |
+| Look up a `pgcolumnar.*` function | [SQL reference](sql-reference.md) |
 | Check type coverage and known constraints | [Limitations and compatibility](limitations.md) |
 | See size and latency numbers | [Benchmarks](benchmarks.md) |
 | Run the test suite | [Testing](testing.md) |
@@ -47,10 +47,11 @@ built for append-mostly data. See [Limitations and compatibility](limitations.md
 A columnar table is an ordinary PostgreSQL relation. It works with transactions,
 WAL, replication, indexes, `COPY`, and `pg_dump`. The extension adds:
 
-- A table access method named `pgcolumnar`.
+- A table access method named `pgcolumnar`. New tables are written in the native
+  on-disk format, PGCN v1.
 - A set of catalog tables and functions in the `pgcolumnar` schema.
 - Planner and executor paths for columnar scans, aggregates, index-only scans,
-  and projections, controlled by settings under the `columnar.` prefix.
+  and projections, controlled by settings under the `pgcolumnar.` prefix.
 
 ## Design and internals
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -48,7 +48,7 @@ CREATE EXTENSION pgcolumnar;
 ```
 
 This creates the `pgcolumnar` schema, the `pgcolumnar` table access method, the
-catalog tables, and the `columnar.*` functions. The extension is not
+catalog tables, and the `pgcolumnar.*` functions. The extension is not
 relocatable; its objects stay in the `pgcolumnar` schema.
 
 ## Verify

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -26,11 +26,11 @@ only. The rest of the extension runs on any architecture PostgreSQL supports.
   supported, but they mark rows rather than rewriting data, and the space is
   reclaimed only by `pgcolumnar.vacuum`.
 - Point lookups are slow relative to heap. A single-row fetch by item pointer must
-  read and decode the chunk group that contains the row. Bloom filters speed up an
-  equality scan by skipping chunk groups, but do not help an index fetch by item
+  read and decode the row group that contains the row. Bloom filters speed up an
+  equality scan by skipping row groups, but do not help an index fetch by item
   pointer.
 - A bulk `UPDATE` re-fetches each old row by item pointer to fill unchanged
-  columns, which is proportional to rows times stripe size and is not yet
+  columns, which is proportional to rows times row group size and is not yet
   optimized.
 
 ## Vacuum and compaction
@@ -38,17 +38,17 @@ only. The rest of the extension runs on any architecture PostgreSQL supports.
 - `VACUUM FULL` and `CLUSTER` are not supported on a columnar table; the
   copy-for-cluster path raises an error. Use `pgcolumnar.vacuum` or
   `pgcolumnar.vacuum_full` instead.
-- `pgcolumnar.vacuum` always rewrites the whole relation into full stripes. It
+- `pgcolumnar.vacuum` always rewrites the whole relation into full row groups. It
   accepts a `stripe_count` argument for interface compatibility but performs the
   full rewrite. Because it renumbers rows, it rebuilds the table's indexes.
-- Row numbers are reserved a whole stripe at a time, so a stripe flushed with
-  fewer than `stripe_row_limit` rows leaves a gap in the row-number space. Row
+- Row numbers are reserved a whole row group at a time, so a row group flushed
+  with fewer than `stripe_row_limit` rows leaves a gap in the row-number space. Row
   numbers need only be unique and stable, so the gap is harmless.
 
 ## Index-only scans
 
 An index-only scan uses the columnar visibility-map fork, which lazy `VACUUM`
-populates. A chunk group is reported all-visible only once its inserting
+populates. A row group is reported all-visible only once its inserting
 transaction precedes the oldest snapshot horizon and it has no deletes, and any
 later write clears the bit. Recently loaded data is served by a snapshot-checked
 fetch until autovacuum or an explicit `VACUUM` marks it. Turn the feature off with
@@ -67,10 +67,10 @@ for the build, like non-concurrent `CREATE INDEX`. Turn projection scans off wit
 
 ## Concurrency
 
-- Concurrent deletes or updates to rows in the same chunk group serialize on that
-  chunk group's row-mask entry: a second writer waits for the first to commit,
+- Concurrent deletes or updates to rows in the same row group serialize on that
+  row group's row-mask entry: a second writer waits for the first to commit,
   re-reads the committed mask, and merges its bits, so both sets of delete marks
-  survive. Writes to different chunk groups proceed concurrently.
+  survive. Writes to different row groups proceed concurrently.
 - Concurrent inserts of the same unique key are serialized so the conflict is
   always caught. Before a freshly inserted row reaches the uniqueness check, the
   access method takes a transaction-scoped advisory lock keyed by the row's unique

--- a/docs/sql-reference.md
+++ b/docs/sql-reference.md
@@ -23,8 +23,8 @@ SELECT pgcolumnar.alter_table_set_access_method('events', 'pgcolumnar');
 
 ### pgcolumnar.alter_columnar_table_set(...) and pgcolumnar.alter_columnar_table_reset(...)
 
-Set or reset per-table storage options (chunk group and stripe row limits,
-compression codec and level). See
+Set or reset per-table storage options (row group and vector row limits,
+compression codec and level, and `format_version`). See
 [Configuration reference](configuration.md#per-table-storage-options).
 
 ### pgcolumnar.get_storage_id(rel regclass) returns bigint
@@ -37,11 +37,11 @@ instead.
 
 ### pgcolumnar.vacuum(tablename regclass, stripe_count int DEFAULT 0)
 
-Compacts a columnar table by combining stripes and reclaiming space held by rows
-that were deleted or updated. Use it after bulk deletes or updates, or after many
-small load transactions have produced many small stripes.
+Compacts a columnar table by combining small row groups and reclaiming space held
+by rows that were deleted or updated. Use it after bulk deletes or updates, or
+after many small load transactions have produced many small row groups.
 
-`stripe_count` bounds how many stripes are combined in one call; `0` places no
+`stripe_count` bounds how many row groups are combined in one call; `0` places no
 bound.
 
 ```sql
@@ -71,16 +71,17 @@ SELECT pgcolumnar.vacuum_full('public');
 
 ### pgcolumnar.stats(rel regclass)
 
-Returns one row per stripe with these columns:
+Returns one row per row group for a native table (one row per stripe for a table
+still on the earlier line), with these columns:
 
 | Column | Type | Meaning |
 | --- | --- | --- |
-| `stripeid` | bigint | Stripe number within the table. |
-| `fileoffset` | bigint | Byte offset of the stripe in the relation file. |
-| `rowcount` | bigint | Rows written into the stripe. |
-| `deletedrows` | bigint | Rows in the stripe marked deleted. |
-| `chunkcount` | integer | Chunk groups in the stripe. |
-| `datalength` | bigint | On-disk length of the stripe in bytes. |
+| `stripeid` | bigint | Row group number within the table (stripe number on the earlier line). |
+| `fileoffset` | bigint | Byte offset of the row group in the relation file. |
+| `rowcount` | bigint | Rows written into the row group. |
+| `deletedrows` | bigint | Rows in the row group marked deleted. |
+| `chunkcount` | integer | Vectors in the row group (chunk groups in the stripe on the earlier line). |
+| `datalength` | bigint | On-disk length of the row group in bytes. |
 
 ```sql
 -- total live rows, deleted rows, and size

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -17,7 +17,7 @@ test/unique_conc.sh      /path/to/pg_config  # concurrent same-unique-key insert
 test/differential.sh     /path/to/pg_config  # heap-vs-columnar oracle
 test/recovery.sh         /path/to/pg_config  # crash recovery and atomicity
 test/fuzz.sh             /path/to/pg_config  # seeded randomized differential
-test/hardening.sh        /path/to/pg_config  # format 2.0 compat and corrupt-input robustness
+test/hardening.sh        /path/to/pg_config  # corrupt-input robustness (native and legacy catalogs)
 test/concurrent_diff.sh  /path/to/pg_config  # concurrent DML vs a heap oracle
 test/parallel.sh         /path/to/pg_config  # parallel scan plan and results vs a heap oracle
 test/sorted_projection.sh /path/to/pg_config # pgcolumnar.vacuum_sorted results and skipping
@@ -31,7 +31,25 @@ test/arrow_nested.sh     /path/to/pg_config  # nested Arrow export
 test/parquet_nested.sh   /path/to/pg_config  # nested Parquet export
 test/arrow_nested_import.sh   /path/to/pg_config  # nested Arrow import
 test/parquet_nested_import.sh /path/to/pg_config  # nested Parquet import
+test/native_writer.sh    /path/to/pg_config  # native format catalog output
+test/native_roundtrip.sh /path/to/pg_config  # native write then read round-trip
+test/native_encoding.sh  /path/to/pg_config  # native per-vector encoding cascade
+test/native_zonemap.sh   /path/to/pg_config  # native zone maps
+test/native_skip.sh      /path/to/pg_config  # native chunk and vector skipping
+test/native_agg.sh       /path/to/pg_config  # native aggregate paths
+test/native_bloom.sh     /path/to/pg_config  # native per-chunk bloom filters
+test/native_vecskip.sh   /path/to/pg_config  # native per-vector skipping
+test/native_index.sh     /path/to/pg_config  # native index and index scan
+test/native_dml.sh       /path/to/pg_config  # native delete and update
+test/native_ios.sh       /path/to/pg_config  # native index-only scan
+test/native_projection.sh /path/to/pg_config # native projections
 ```
+
+Native (PGCN v1) is the default format, so the suites that create tables without
+an explicit format run native. Set `PGC_NATIVE=0` to run those suites against the
+earlier line instead; the `native_*` suites always exercise the native format,
+and the core mechanics suites (`smoke`, `phase2` through `phase6`, `audit`,
+`concurrency`, `unique_conc`) always exercise the earlier line.
 
 ## Differential oracle
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -25,7 +25,7 @@ transactions, constraints, indexes, `COPY`, and `pg_dump`.
 On PostgreSQL 15 and later:
 
 ```sql
-ALTER TABLE events SET ACCESS METHOD columnar;
+ALTER TABLE events SET ACCESS METHOD pgcolumnar;
 ```
 
 On any supported major, including 13 and 14, the extension provides a helper:
@@ -43,14 +43,14 @@ To convert back to the default heap, use `heap` as the method.
 ## Load data
 
 Columnar storage is built for append-mostly data. Rows are buffered and written
-in stripes of up to `pgcolumnar.stripe_row_limit` rows. Each transaction writes its
-own stripes, so a load's shape affects the result:
+in row groups of up to `pgcolumnar.stripe_row_limit` rows. Each transaction writes
+its own row groups, so a load's shape affects the result:
 
 - Prefer `COPY` or multi-row `INSERT` over many single-row `INSERT` statements. A
-  `COPY` of N rows writes about N divided by `stripe_row_limit` stripes.
-- Many small transactions produce many small stripes. If a table was loaded that
+  `COPY` of N rows writes about N divided by `stripe_row_limit` row groups.
+- Many small transactions produce many small row groups. If a table was loaded that
   way, run [`pgcolumnar.vacuum`](sql-reference.md#pgcolumnarvacuumtablename-regclass-stripe_count-int-default-0)
-  to combine stripes.
+  to combine row groups.
 
 ```sql
 COPY events FROM '/data/events.csv' WITH (FORMAT csv, HEADER);

--- a/pgcolumnar--1.0.sql
+++ b/pgcolumnar--1.0.sql
@@ -481,6 +481,25 @@ CREATE FUNCTION pgcolumnar.stats(
 	RETURNS SETOF record
 	LANGUAGE sql STABLE
 	AS $stats$
+	-- Native (PGCN v1) tables report one row per row group from the native
+	-- catalog; earlier-line tables report one row per stripe. A table populates
+	-- exactly one of the two catalogs, so the union yields that table's rows.
+	SELECT rg.group_number,
+		   rg.file_offset,
+		   rg.row_count,
+		   COALESCE((SELECT sum(rm.deleted_rows)::bigint
+					 FROM pgcolumnar.row_mask rm
+					 WHERE rm.storage_id = rg.storage_id
+					   AND rm.stripe_id = rg.group_number), 0::bigint),
+		   (SELECT count(DISTINCT zm.vector_index)::int
+			FROM pgcolumnar.zone_map zm
+			WHERE zm.storage_id = rg.storage_id
+			  AND zm.group_number = rg.group_number
+			  AND zm.vector_index >= 0),
+		   rg.byte_length
+	FROM pgcolumnar.row_group rg
+	WHERE rg.storage_id = pgcolumnar.get_storage_id(rel)
+	UNION ALL
 	SELECT s.stripe_num,
 		   s.file_offset,
 		   s.row_count,
@@ -492,11 +511,11 @@ CREATE FUNCTION pgcolumnar.stats(
 		   s.data_length
 	FROM pgcolumnar.stripe s
 	WHERE s.storage_id = pgcolumnar.get_storage_id(rel)
-	ORDER BY s.stripe_num;
+	ORDER BY 1;
 $stats$;
 
 COMMENT ON FUNCTION pgcolumnar.stats(regclass)
-	IS 'per-stripe statistics for a columnar table';
+	IS 'per-row-group (native) or per-stripe statistics for a columnar table';
 
 CREATE FUNCTION pgcolumnar.vacuum(tablename regclass, stripe_count int DEFAULT 0)
 	RETURNS void

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -48,9 +48,12 @@ int			columnar_chunk_group_row_limit = 10000;
 
 /* GUC: on-disk format for new columnar tables that set no explicit
  * format_version option. 0 is the 1.0-dev line (format 2.2); 1 is native
- * (PGCN v1). ColumnarTableFormatVersion falls back to this. D6f flips the
- * boot default to native; D6e uses it to run the whole suite in native mode. */
-int			columnar_default_format_version = 0;
+ * (PGCN v1). ColumnarTableFormatVersion falls back to this. The boot default is
+ * native (D6f): a bare USING pgcolumnar writes PGCN v1. The 2.2 reader is kept
+ * so pre-existing 2.2 tables still read (retirement is the later Phase H), and
+ * the writer anchors to the format already on disk so an existing table is never
+ * rewritten in a different format. Set this to 0 to write 2.2 for new tables. */
+int			columnar_default_format_version = 1;
 int			columnar_compression = COLUMNAR_COMPRESSION_ZSTD;
 int			columnar_compression_level = 3;
 bool		columnar_enable_qual_pushdown = true;
@@ -1114,11 +1117,13 @@ _PG_init(void)
 	DefineCustomIntVariable("pgcolumnar.default_format_version",
 							"On-disk format for new columnar tables with no "
 							"explicit format_version option.",
-							"0 is the 1.0-dev line (format 2.2); 1 is the native "
-							"PGCN v1 format. A table's own format_version option "
-							"always wins over this default.",
+							"1 is the native PGCN v1 format (the default); 0 is "
+							"the 1.0-dev line (format 2.2). A table's own "
+							"format_version option always wins over this default, "
+							"and a table that already holds data keeps its "
+							"on-disk format regardless of this setting.",
 							&columnar_default_format_version,
-							0,
+							1,
 							0, 1,
 							PGC_USERSET,
 							0,

--- a/test/audit.sh
+++ b/test/audit.sh
@@ -75,6 +75,10 @@ echo "-- initdb"
 run_pg "initdb -D '$PGDATA' -A trust" >/dev/null 2>&1
 run_pg "echo \"port=$PORT\" >> '$PGDATA/postgresql.conf'"
 run_pg "echo \"shared_preload_libraries='pgcolumnar'\" >> '$PGDATA/postgresql.conf'"
+# This suite exercises the 2.2-line mechanics (chunk / stripe catalogs); pin
+# the instance default to 2.2 so the D6f native default does not change what it
+# writes. The 2.2 line is retired in the later Phase H.
+run_pg "echo \"pgcolumnar.default_format_version=0\" >> '$PGDATA/postgresql.conf'"
 echo "-- start"
 run_pg "pg_ctl -D '$PGDATA' -l '$LOGFILE' start -w" >/dev/null
 run_pg "createdb -p $PORT audit"

--- a/test/concurrency.sh
+++ b/test/concurrency.sh
@@ -130,6 +130,10 @@ echo "-- initdb"
 run_pg "initdb -D '$PGDATA' -A trust" >/dev/null 2>&1
 run_pg "echo \"port=$PORT\" >> '$PGDATA/postgresql.conf'"
 run_pg "echo \"shared_preload_libraries='pgcolumnar'\" >> '$PGDATA/postgresql.conf'"
+# This suite exercises the 2.2-line mechanics (chunk / stripe catalogs); pin
+# the instance default to 2.2 so the D6f native default does not change what it
+# writes. The 2.2 line is retired in the later Phase H.
+run_pg "echo \"pgcolumnar.default_format_version=0\" >> '$PGDATA/postgresql.conf'"
 # Listen only on a private unix socket in the run's workdir, no TCP. This makes
 # two runs fully independent: no shared /tmp/.s.PGSQL.PORT socket file and no TCP
 # port to bind, so a leaked postmaster from an earlier run cannot poison this one.

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -81,12 +81,15 @@ pgc_setup() {
 		echo "bytea_output='hex'"
 		# Keep planner honest but let small tables use the custom scan.
 		echo "max_parallel_workers_per_gather=0"
-		# Native-mode runs (D6e): make the native (PGCN v1) format the instance
-		# default so every columnar table created without an explicit
-		# format_version option is written native. A table's own option still
-		# wins, and a storage that already holds data keeps its on-disk format.
-		if [ "${PGC_NATIVE:-0}" = "1" ]; then
+		# The native (PGCN v1) format is the instance default (D6f): a bare
+		# columnar table with no explicit format_version option is written
+		# native. A run selects the legacy 2.2 line for the lib.sh-sourcing
+		# suites with PGC_NATIVE=0. A table's own option still wins, and a
+		# storage that already holds data keeps its on-disk format.
+		if native_mode; then
 			echo "pgcolumnar.default_format_version=1"
+		else
+			echo "pgcolumnar.default_format_version=0"
 		fi
 	} | pgc_pg "cat >> '$PGC_PGDATA/postgresql.conf'"
 
@@ -240,8 +243,9 @@ storage_id_of() {
 	q "SELECT pgcolumnar.get_storage_id('$1');"
 }
 
-# True when the harness is running in native-format mode (D6e).
-native_mode() { [ "${PGC_NATIVE:-0}" = "1" ]; }
+# True when the harness is running in native-format mode. Native (PGCN v1) is
+# the default (D6f); a run selects the legacy 2.2 line with PGC_NATIVE=0.
+native_mode() { [ "${PGC_NATIVE:-1}" != "0" ]; }
 
 # Number of stripes physically written for a columnar relation (default t_col).
 # The native (PGCN v1) row group is the stripe's counterpart and honors the same

--- a/test/phase2.sh
+++ b/test/phase2.sh
@@ -52,6 +52,10 @@ echo "-- initdb"
 run_pg "initdb -D '$PGDATA' -A trust" >/dev/null 2>&1
 run_pg "echo \"port=$PORT\" >> '$PGDATA/postgresql.conf'"
 run_pg "echo \"shared_preload_libraries='pgcolumnar'\" >> '$PGDATA/postgresql.conf'"
+# This suite exercises the 2.2-line mechanics (chunk / stripe catalogs); pin
+# the instance default to 2.2 so the D6f native default does not change what it
+# writes. The 2.2 line is retired in the later Phase H.
+run_pg "echo \"pgcolumnar.default_format_version=0\" >> '$PGDATA/postgresql.conf'"
 echo "-- start"
 run_pg "pg_ctl -D '$PGDATA' -l '$LOGFILE' start -w" >/dev/null
 run_pg "createdb -p $PORT p2"

--- a/test/phase3.sh
+++ b/test/phase3.sh
@@ -54,6 +54,10 @@ echo "-- initdb"
 run_pg "initdb -D '$PGDATA' -A trust" >/dev/null 2>&1
 run_pg "echo \"port=$PORT\" >> '$PGDATA/postgresql.conf'"
 run_pg "echo \"shared_preload_libraries='pgcolumnar'\" >> '$PGDATA/postgresql.conf'"
+# This suite exercises the 2.2-line mechanics (chunk / stripe catalogs); pin
+# the instance default to 2.2 so the D6f native default does not change what it
+# writes. The 2.2 line is retired in the later Phase H.
+run_pg "echo \"pgcolumnar.default_format_version=0\" >> '$PGDATA/postgresql.conf'"
 echo "-- start"
 run_pg "pg_ctl -D '$PGDATA' -l '$LOGFILE' start -w" >/dev/null
 run_pg "createdb -p $PORT p3"

--- a/test/phase4.sh
+++ b/test/phase4.sh
@@ -57,6 +57,10 @@ echo "-- initdb"
 run_pg "initdb -D '$PGDATA' -A trust" >/dev/null 2>&1
 run_pg "echo \"port=$PORT\" >> '$PGDATA/postgresql.conf'"
 run_pg "echo \"shared_preload_libraries='pgcolumnar'\" >> '$PGDATA/postgresql.conf'"
+# This suite exercises the 2.2-line mechanics (chunk / stripe catalogs); pin
+# the instance default to 2.2 so the D6f native default does not change what it
+# writes. The 2.2 line is retired in the later Phase H.
+run_pg "echo \"pgcolumnar.default_format_version=0\" >> '$PGDATA/postgresql.conf'"
 echo "-- start"
 run_pg "pg_ctl -D '$PGDATA' -l '$LOGFILE' start -w" >/dev/null
 run_pg "createdb -p $PORT p4"

--- a/test/phase5.sh
+++ b/test/phase5.sh
@@ -60,6 +60,10 @@ echo "-- initdb"
 run_pg "initdb -D '$PGDATA' -A trust" >/dev/null 2>&1
 run_pg "echo \"port=$PORT\" >> '$PGDATA/postgresql.conf'"
 run_pg "echo \"shared_preload_libraries='pgcolumnar'\" >> '$PGDATA/postgresql.conf'"
+# This suite exercises the 2.2-line mechanics (chunk / stripe catalogs); pin
+# the instance default to 2.2 so the D6f native default does not change what it
+# writes. The 2.2 line is retired in the later Phase H.
+run_pg "echo \"pgcolumnar.default_format_version=0\" >> '$PGDATA/postgresql.conf'"
 echo "-- start"
 run_pg "pg_ctl -D '$PGDATA' -l '$LOGFILE' start -w" >/dev/null
 run_pg "createdb -p $PORT p5"

--- a/test/phase6.sh
+++ b/test/phase6.sh
@@ -64,6 +64,10 @@ echo "-- initdb"
 run_pg "initdb -D '$PGDATA' -A trust" >/dev/null 2>&1
 run_pg "echo \"port=$PORT\" >> '$PGDATA/postgresql.conf'"
 run_pg "echo \"shared_preload_libraries='pgcolumnar'\" >> '$PGDATA/postgresql.conf'"
+# This suite exercises the 2.2-line mechanics (chunk / stripe catalogs); pin
+# the instance default to 2.2 so the D6f native default does not change what it
+# writes. The 2.2 line is retired in the later Phase H.
+run_pg "echo \"pgcolumnar.default_format_version=0\" >> '$PGDATA/postgresql.conf'"
 echo "-- start"
 run_pg "pg_ctl -D '$PGDATA' -l '$LOGFILE' start -w" >/dev/null
 run_pg "createdb -p $PORT p6"

--- a/test/smoke.sh
+++ b/test/smoke.sh
@@ -60,6 +60,10 @@ run_pg "echo \"port=$PORT\" >> '$PGDATA/postgresql.conf'"
 # Preload the library so the drop-time metadata cleanup hook is installed in
 # every backend (the canonical deployment for a table-AM extension).
 run_pg "echo \"shared_preload_libraries='pgcolumnar'\" >> '$PGDATA/postgresql.conf'"
+# This suite exercises the 2.2-line mechanics (chunk / stripe catalogs); pin
+# the instance default to 2.2 so the D6f native default does not change what it
+# writes. The 2.2 line is retired in the later Phase H.
+run_pg "echo \"pgcolumnar.default_format_version=0\" >> '$PGDATA/postgresql.conf'"
 echo "-- start"
 run_pg "pg_ctl -D '$PGDATA' -l '$LOGFILE' start -w" >/dev/null
 run_pg "createdb -p $PORT smoke"

--- a/test/unique_conc.sh
+++ b/test/unique_conc.sh
@@ -119,6 +119,10 @@ echo "-- initdb"
 run_pg "initdb -D '$PGDATA' -A trust" >/dev/null 2>&1
 run_pg "echo \"port=$PORT\" >> '$PGDATA/postgresql.conf'"
 run_pg "echo \"shared_preload_libraries='pgcolumnar'\" >> '$PGDATA/postgresql.conf'"
+# This suite exercises the 2.2-line mechanics (chunk / stripe catalogs); pin
+# the instance default to 2.2 so the D6f native default does not change what it
+# writes. The 2.2 line is retired in the later Phase H.
+run_pg "echo \"pgcolumnar.default_format_version=0\" >> '$PGDATA/postgresql.conf'"
 run_pg "echo \"listen_addresses=''\" >> '$PGDATA/postgresql.conf'"
 run_pg "echo \"unix_socket_directories='$WORKDIR'\" >> '$PGDATA/postgresql.conf'"
 # Cap any real hang so a bug cannot masquerade as a pass by blocking forever.


### PR DESCRIPTION
## Phase D6f: flip the default to native, and full docs pass

The capstone of Phase D6. A bare `USING pgcolumnar` table is now written in the native format, PGCN v1.

### Flip
- `pgcolumnar.default_format_version` boots at `1` (native). A table's `format_version` option and an on-disk storage that already holds data both override it, so existing 2.2 tables are never rewritten in a different format. The 2.2 reader stays; retirement is the later Phase H.

### Tests
- `lib.sh`: native is the default; a run selects the 2.2 line with `PGC_NATIVE=0`. The core-mechanics suites (`smoke`, `phase2`-`phase6`, `audit`, `concurrency`, `unique_conc`) pin the default to 2.2 since they exercise the 2.2 catalogs until Phase H.
- Full PostgreSQL 13-19 matrix, assert-enabled, in **both** modes: **ALL VERSIONS PASSED** with native as the default, and **ALL VERSIONS PASSED** with `PGC_NATIVE=0`. Arrow and Parquet import and export run over native default tables in the default matrix.

### pgcolumnar.stats
- Made native-aware (one row per row group for a native table, one per stripe for a 2.2 table). It previously read only the 2.2 stripe catalog and returned nothing for a native table, which is now the default. Verified on both.

### Documentation (full pass)
- README, CHANGELOG, and every file under `docs/` present the native (PGCN v1) format as the format and the `pgcolumnar` namespace. The configuration reference documents `pgcolumnar.default_format_version` and the `format_version` option. Storage vocabulary is native (row groups, chunks, vectors, zone maps). No em-dashes, no Hydra or Citus framing; the 2.2 line appears only as the retired line pinned at the `v1.0-dev` tag.

This completes Phase D6. Retiring the 2.2 line is the later Phase H.

🤖 Generated with [Claude Code](https://claude.com/claude-code)