### PR TITLE
Phase H2 + H3: remove the 2.2 format and finish the clean cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,15 +13,12 @@ unreleased. For the forward-looking plan see
 
 - Column-oriented table access method (`USING pgcolumnar`) with per-column
   compression, chunk-group minimum and maximum skipping, per-chunk bloom filters,
-  and a vectorized scan and aggregate path with late materialization.
-- Native on-disk format PGCN v1: the default for new tables, with row groups,
-  per-column chunks, an adaptive per-vector encoding cascade, zone maps for
-  skipping, and per-chunk bloom filters. Delete, update, index scan, index-only
-  scan, and projections all work on native tables. The instance default is set
-  by `pgcolumnar.default_format_version` (1 native, 0 the earlier line); a
-  table's `format_version` option overrides it, and a table that already holds
-  data keeps its on-disk format. The earlier line is still read and is pinned at
-  the `v1.0-dev` tag.
+  and a vectorized aggregate path.
+- Native on-disk format PGCN v1: row groups, per-column chunks, an adaptive
+  per-vector encoding cascade, zone maps for skipping, and per-chunk bloom
+  filters. Delete, update, index scan, index-only scan, and projections all work
+  on native tables. The earlier 1.0-dev format line has been removed; the
+  `v1.0-dev` git tag preserves it.
 - Compression codecs `none`, `pglz`, `lz4`, and `zstd`. `lz4` and `zstd` are
   compiled in when their system libraries are present.
 - `count(*)` answered from catalog metadata without scanning.

--- a/README.md
+++ b/README.md
@@ -7,16 +7,14 @@
 
 Column-oriented storage for PostgreSQL, implemented as a table access method. A
 table created `USING pgcolumnar` stores its data by column, with per-column
-compression, chunk-group skipping, and a vectorized scan and aggregate path. It
-is for analytic workloads: large scans, aggregates, and column projections over
+compression, chunk-group skipping, and a vectorized aggregate path. It is for
+analytic workloads: large scans, aggregates, and column projections over
 append-mostly data.
 
 pgColumnar builds from one source tree on PostgreSQL 15 through 19 and is
 licensed under the [MIT License](LICENSE). It is pre-release; the version marker
-is `1.0-dev`, recorded in `VERSION`. A bare `USING pgcolumnar` table is written
-in the native on-disk format, PGCN v1. The earlier 1.0-dev format is still read
-for tables that already hold it; it is pinned at the `v1.0-dev` tag and is
-retired in a later release.
+is `1.0-dev`, recorded in `VERSION`. A table `USING pgcolumnar` is stored in the
+native on-disk format, PGCN v1.
 
 ## Documentation
 

--- a/design/PHASE_H_PLAN.md
+++ b/design/PHASE_H_PLAN.md
@@ -1,11 +1,21 @@
 # Phase H plan: retire the 1.0-dev (2.2) on-disk format, clean cut
 
-Status: plan, on the `re-origination` branch (phase branches off `re-origination`).
-Phase H is the capstone of the re-origination: remove the legacy 2.2 writer,
-reader, catalog, and the per-table format selector, leaving one native format
-line (PGCN v1). Owner decision (2026-07-21): a clean cut, no Hydra or Citus style
-page format and no on-disk compatibility shim. The `v1.0-dev` git tag preserves
-the old line permanently.
+Status: DONE. Phase H is the capstone of the re-origination: remove the legacy
+2.2 writer, reader, catalog, and the per-table format selector, leaving one
+native format line (PGCN v1). Owner decision (2026-07-21): a clean cut, no Hydra
+or Citus style page format and no on-disk compatibility shim. The `v1.0-dev` git
+tag preserves the old line permanently.
+
+Completed on `phase-h/retire-2.2`: H1 (native-only tests) merged in PR #68 with
+the plan and the PostgreSQL 13/14 matrix drop; H2 (remove the 2.2 code, catalog,
+selector, and the 2.2-only vectorized scan path; ~2955 lines) and H3 (retire the
+two now-dead vectorized-scan GUCs and the full docs pass) follow on the branch.
+Two bugs surfaced during H2 and were fixed: a stale COMMENT ON FUNCTION arity on
+alter_columnar_table_reset that aborted CREATE EXTENSION, and an unconditional
+pre-commit flush that reused a stale row-group id (duplicate row_group_pkey), now
+guarded by an early return in columnar_flush_row_group. columnar_relation_estimate_size
+gained a native row-group path. Gate: the full PostgreSQL 15-19 matrix passed
+during H1; H2 and H3 each passed the PostgreSQL 17-19 iteration set.
 
 ## Prerequisites: satisfied
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,32 +2,27 @@
 
 This document is a module-by-module map of the pgColumnar source so a new
 developer can navigate the code. It is derived from the source in `src/` and
-from `design/FORMAT_AND_INTERFACE_SPEC.md`. Read the specification first for the
-on-disk layout and catalog schema; this document describes how the code is
-organized against it.
+from `design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md`. Read the specification first
+for the on-disk layout and catalog schema; this document describes how the code
+is organized against it.
 
-New tables are written in the native format, PGCN v1. The earlier 1.0-dev line
-is still read for tables that already hold it, pinned at the `v1.0-dev` tag and
-retired in a later phase. The writer, reader, and catalog modules carry both
-paths; the native path is the default and the descriptions below note where the
-earlier path differs.
+Data is stored in one format, the native format PGCN v1. (An earlier 1.0-dev
+format line has been removed; the `v1.0-dev` git tag preserves it.)
 
 ## On-disk model in one paragraph
 
 A columnar relation stores its data in its own main fork using standard
 PostgreSQL pages, so the buffer manager, WAL, and page checksums apply. Block 0
 is a metapage, block 1 is reserved, and block 2 onward is a logical byte area.
-In the native format, rows are grouped into row groups (a run of up to
-`stripe_row_limit` rows, the write unit). Within a row group one column's data
-is a chunk, holding a validity bitmap and a value stream encoded in fixed-size
-vectors. A separate set of ordinary heap tables in the `pgcolumnar` schema is
-the metadata catalog: `storage`, `row_group`, and `column_chunk` record the
-layout, `zone_map` records each chunk's and each vector's minimum and maximum
-for skipping, `bloom` records the per-chunk equality filters, and `row_mask`
-records the delete and update marks. A storage id links a relation's physical
-file to its catalog rows. The earlier line groups rows into stripes and chunk
-groups recorded in the `stripe`, `chunk_group`, and `chunk` catalogs; it shares
-`row_mask`.
+Rows are grouped into row groups (a run of up to `stripe_row_limit` rows, the
+write unit). Within a row group one column's data is a chunk, holding a validity
+bitmap and a value stream encoded in fixed-size vectors. A separate set of
+ordinary heap tables in the `pgcolumnar` schema is the metadata catalog:
+`storage`, `row_group`, and `column_chunk` record the layout, `zone_map` records
+each chunk's and each vector's minimum and maximum for skipping, `bloom` records
+the per-chunk equality filters, `row_mask` records the delete and update marks,
+and `options` holds per-table settings. A storage id links a relation's physical
+file to its catalog rows.
 
 ## Module map
 
@@ -37,11 +32,10 @@ with the callbacks PostgreSQL calls for a `USING pgcolumnar` table: create
 storage, bulk and single insert, sequential scan open/next/close, delete and
 update (through the row mask), fetch a row by item pointer, size estimation, and
 truncate. It also holds `_PG_init`, which registers every `pgcolumnar.*` GUC (the
-default format version, the compression codec and level, stripe and chunk-group
-row limits, and the qual pushdown, custom scan, vectorization, and column cache
-toggles), the pre-commit
-hook that flushes pending writes, and the object-access hook that removes a
-table's metadata rows when the table is dropped.
+compression codec and level, the row-group and vector row limits, and the qual
+pushdown, custom scan, vectorized aggregate, and column cache toggles), the
+pre-commit hook that flushes pending writes, and the object-access hook that
+removes a table's metadata rows when the table is dropped.
 
 ### columnar_compat.h
 Major-version compatibility shims. pgColumnar keeps one source tree that builds
@@ -64,34 +58,29 @@ independently. This module reads and writes the raw logical buffers through the
 buffer manager.
 
 ### columnar_metadata.c
-Access to the `pgcolumnar` catalog tables and the storage-id sequence. The
-native catalogs are `storage`, `row_group`, `column_chunk`, `zone_map`, and
-`bloom`; the earlier line uses `stripe`, `chunk_group`, and `chunk`; `options`
-and `row_mask` are shared. Metadata are ordinary heap tables keyed by storage
-id, read and written with direct catalog access (heap opens, index scans, and
-inserts) rather than SPI, so metadata access does not depend on SPI reentrancy
-from inside a scan or write. Catalog reads use a snapshot whose command id is
-advanced so a transaction sees its own just-written metadata (read-your-writes)
-while staying isolated from other transactions. `ColumnarTableFormatVersion`
-resolves a table's format from its `format_version` option, falling back to the
-`pgcolumnar.default_format_version` instance default; the native storage-row
-insert is serialized by a storage-id advisory lock so concurrent first-writers
-do not race.
+Access to the `pgcolumnar` catalog tables and the storage-id sequence: the
+`storage`, `row_group`, `column_chunk`, `zone_map`, `bloom`, `row_mask`, and
+`options` tables. Metadata are ordinary heap tables keyed by storage id, read and
+written with direct catalog access (heap opens, index scans, and inserts) rather
+than SPI, so metadata access does not depend on SPI reentrancy from inside a scan
+or write. Catalog reads use a snapshot whose command id is advanced so a
+transaction sees its own just-written metadata (read-your-writes) while staying
+isolated from other transactions. The storage-row insert is serialized by a
+storage-id advisory lock so concurrent first-writers do not race.
 
 ### columnar_write_state.c
-The writer. It batches incoming rows into per-column chunk buffers, closes a
-chunk group when it reaches `chunk_group_row_limit`, and flushes a stripe (its
-data pages plus its catalog rows) when the stripe fills or at transaction
-pre-commit. Row numbers and the stripe id are reserved up front when a stripe
+The writer. It batches incoming rows into per-column buffers, closes a vector
+when it reaches `chunk_group_row_limit`, and flushes a row group (its data pages
+plus its catalog rows) when the group fills or at transaction pre-commit. The row
+group number and the row-number range are reserved up front when a row group
 starts buffering, so every row has its stable row number and synthetic item
-pointer at insert time (needed for indexes and unique checks). Pending writes
-are held per relation and per subtransaction for the life of the transaction,
-promoted to the parent on subtransaction commit and discarded on rollback. Per
-chunk it computes and stores the min/max skip values for orderable types. The
-native path writes row groups, per-column chunks with a per-vector encoding
-cascade, zone maps, and per-chunk bloom filters, and it anchors to the format
-already on disk so a table that holds data keeps its format; the projection
-fan-out shares this writer. The earlier path writes stripes and chunk groups.
+pointer at insert time (needed for indexes and unique checks). Pending writes are
+held per relation and per subtransaction for the life of the transaction,
+promoted to the parent on subtransaction commit and discarded on rollback. At
+flush it encodes each column chunk with the per-vector encoding cascade, computes
+the zone maps and per-chunk bloom filters, and writes the `storage`, `row_group`,
+`column_chunk`, `zone_map`, and `bloom` rows. The projection fan-out shares this
+writer.
 
 ### columnar_compression.c
 The value-stream codecs: `none`, `pglz` (built into PostgreSQL), `lz4`, and
@@ -121,34 +110,29 @@ rule out, skipping the group when the value is provably absent. Never a false
 negative, so results are unaffected.
 
 ### columnar_reader.c
-The reader and the shared value-stream decode path. It walks a relation's
-stripes and chunk groups, decompresses each projected column's chunk into a
-per-chunk-group context, applies the stripe's row mask so deleted rows are
-skipped, and reconstructs rows. It has three entry shapes: the scalar
-sequential scan (one tuple at a time), a fetch-by-item-pointer path (used by
-index scans and by UPDATE to refill unchanged columns), and the vectorized
-batch reader (`ColumnarReadNextVector`) that returns one decoded chunk group as
-flat per-column value and null arrays. All three honor column projection,
-min/max chunk-group skipping, and the row mask, and all three yield a column's
-missing value (from `getmissingattr`) for a stripe written before an
-`ADD COLUMN`. Chunk-group skipping also consults the per-chunk bloom filter for
-equality predicates. For late materialization the reader splits positioning
-(`ColumnarAdvanceGroup`) from decoding a chosen column subset
-(`ColumnarDecodeGroupColumns`), and `ColumnarReadNextRawGroup` hands back raw
-value streams so the aggregate can fold runs without materializing Datums. The
-reader detects the native format from the storage catalog and walks row groups
-and per-vector encoded chunks, skipping by the zone maps and per-chunk blooms,
-claiming row groups from the shared counter under a parallel scan; the liveness
-cache and the fetch-by-row-number path have native branches. The scalar path
-serves the native format; the vectorized batch path serves the earlier line.
+The reader and the shared value-stream decode path. It walks a relation's row
+groups, decodes each projected column's per-vector encoded chunk into a per-group
+context, applies the row group's row mask so deleted rows are skipped, and
+reconstructs rows. It has two entry shapes: the scalar sequential scan
+(`ColumnarReadNextRow`, one tuple at a time) and a fetch-by-row-number path
+(`ColumnarReadRowByNumber`, used by index and bitmap scans and by UPDATE to
+refill unchanged columns and by unique enforcement). Both honor column
+projection, zone-map row-group and per-vector skipping, the per-chunk bloom
+filter for equality predicates, and the row mask, and both yield a column's
+missing value (from `getmissingattr`) for a row group written before an
+`ADD COLUMN`. Under a parallel scan each worker claims distinct row groups from
+the shared counter. The liveness cache (`ColumnarBuildLivenessCache`) reads the
+row-group list and row masks once so a projection scan can test each row's base
+row number cheaply.
 
 ### columnar_row_mask.c
 Delete and update marking. A delete, and the old side of an update, sets a bit
-in the `pgcolumnar.row_mask` entry for the row's chunk group rather than
-rewriting the stripe; an update inserts the new row with a fresh row number.
-Marks accumulate in a per-subtransaction in-memory buffer and are applied to
-the catalog in one upsert per chunk group at flush time. The reader loads a
-stripe's mask and skips masked rows.
+in the `pgcolumnar.row_mask` entry for the row's row group rather than rewriting
+the group; an update inserts the new row with a fresh row number. Marks
+accumulate in a per-subtransaction in-memory buffer and are applied to the
+catalog in one upsert per row group at flush time. The reader loads a row
+group's mask and skips masked rows. This interim mask is replaced by first-class
+delete vectors in a later phase.
 
 ### columnar_customscan.c
 Planner and executor integration. A `set_rel_pathlist_hook` replaces a columnar
@@ -156,32 +140,27 @@ base relation's sequential-scan path with a custom scan path (and removes the
 parallel paths, so plans are stable). The custom scan computes the referenced
 column set from the target list and restriction clauses and pushes it into the
 reader (projection pushdown), and translates simple `column op const` clauses
-into scan keys so the reader's min/max skip lists remove chunk groups that
+into scan keys so the reader's zone maps remove row groups and vectors that
 cannot match (qual pushdown). The executor always re-applies the full
-restriction clauses as a filter, so chunk-group skipping never changes results.
-This module also drives the vectorized scan mode -- including late
-materialization, where it decodes the predicate columns, builds the selection
-vector, and decodes the remaining output columns only for groups with surviving
-rows -- and, through a `create_upper_paths_hook`, adds the vectorized aggregate
-path for a supported `SELECT agg(col) FROM t [WHERE ...]`. EXPLAIN reporting
-(projected columns, and under ANALYZE the chunk groups read versus removed) lives
-here.
+restriction clauses as a filter, so skipping never changes results. The scan is
+the scalar per-row path (`ColumnarScanNext`). Through a `create_upper_paths_hook`
+the module adds the vectorized aggregate path for a supported
+`SELECT agg(col) FROM t [WHERE ...]`. EXPLAIN reporting (projected columns, and
+under ANALYZE the row groups and vectors read versus skipped) lives here.
 
 ### columnar_vector.c
-Vectorized execution kernels. A shared column-at-a-time filter (`ColumnarVecSelect`)
-turns a plan's simple strict `column op const` clauses into a selection vector
-over a decoded chunk group; for integer, float, and date/time columns it uses a
-typed, branch-free comparison loop (the btree strategy resolved from the type's
-opfamily), falling back to the operator function otherwise (a null value or a
-failed comparison excludes the row, matching SQL WHERE semantics). The vectorized
-aggregates compute `count`, `sum`, `avg`, `min`, and `max`, reproducing
-PostgreSQL's result types exactly (integer sum as int8, integer average as
-numeric, min/max by the column type's default ordering). With no predicates they
-fold each column run-at-a-time over the value stream (compressed execution,
-`pgcolumnar.enable_compressed_execution`); with predicates, or a chunk group that
-has deletes, they use the per-row path. These paths are chosen only when every
-aggregate, column type, and clause is supported; anything else falls back to the
-scalar plan.
+The vectorized aggregate path and its shared filter. A column-at-a-time filter
+(`ColumnarVecSelect`) turns a plan's simple strict `column op const` clauses into
+a selection vector over a decoded group; for integer, float, and date/time
+columns it uses a typed, branch-free comparison loop (the btree strategy resolved
+from the type's opfamily), falling back to the operator function otherwise (a
+null value or a failed comparison excludes the row, matching SQL WHERE
+semantics). The vectorized aggregate computes `count`, `sum`, `avg`, `min`, and
+`max`, reproducing PostgreSQL's result types exactly (integer sum as int8,
+integer average as numeric, min/max by the column type's default ordering). It is
+answered from the zone-map metadata, falling back to a scan-and-fold when the
+group has deletes. It is chosen only when every aggregate, column type, and
+clause is supported; anything else falls back to the scalar plan.
 
 ### columnar_cache.c
 The optional decompressed-chunk cache, off by default behind
@@ -282,19 +261,19 @@ projections aligned to the compacted base.
 
 Insert: executor calls the table-AM insert or multi-insert callback ->
 `columnar_unique` takes the per-key advisory lock for each applicable unique
-index (issue #5) -> `columnar_write_state` buffers the row into per-column chunk
-buffers, assigning its reserved row number and item pointer -> a full chunk group
-is closed, a full stripe is compressed per column by `columnar_compression`,
-written to pages by `columnar_storage`, and recorded by `columnar_metadata` ->
-remaining buffers flush at statement end and pre-commit.
+index (issue #5) -> `columnar_write_state` buffers the row into per-column
+buffers, assigning its reserved row number and item pointer -> a full vector is
+closed, a full row group is encoded per column by `columnar_encoding` /
+`columnar_compression`, written to pages by `columnar_storage`, and recorded by
+`columnar_metadata` -> remaining buffers flush at statement end and pre-commit.
 
 Scan: the planner installs the custom scan (`columnar_customscan`) with a column
-projection and scan keys -> the reader (`columnar_reader`) walks stripes and
-chunk groups, uses the min/max in `columnar_metadata` to skip groups, decodes
-projected chunks through `columnar_compression` (optionally via
-`columnar_cache`), applies the row mask (`columnar_row_mask`), and returns rows
-or, in vectorized mode, decoded arrays that `columnar_vector` filters and
-aggregates -> the executor re-applies the full qual as a filter.
+projection and scan keys -> the reader (`columnar_reader`) walks row groups, uses
+the zone maps in `columnar_metadata` to skip groups and vectors, decodes
+projected chunks through `columnar_encoding` / `columnar_compression` (optionally
+via `columnar_cache`), applies the row mask (`columnar_row_mask`), and returns
+rows one at a time -> the executor re-applies the full qual as a filter. An
+ungrouped aggregate is answered by `columnar_vector` from the zone-map metadata.
 
 Delete or update: the custom scan supplies each row's item pointer ->
 `columnar_row_mask` marks the old row; an update also inserts the new row through

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,7 +14,6 @@ pgColumnar has two kinds of settings:
 
 | Setting | Type | Default | Description |
 | --- | --- | --- | --- |
-| `pgcolumnar.default_format_version` | integer | `1` | On-disk format for new tables with no explicit `format_version` option. `1` is the native format (PGCN v1); `0` is the earlier 1.0-dev line. A table's own option wins, and a table that already holds data keeps its format. |
 | `pgcolumnar.stripe_row_limit` | integer | `150000` | Maximum rows per row group. The row group is the unit of write and the granularity at which whole segments are appended. Range 1000 to INT_MAX. |
 | `pgcolumnar.chunk_group_row_limit` | integer | `10000` | Maximum rows per vector. The vector is the unit of encoding and of min/max skipping. Range 100 to INT_MAX. |
 
@@ -31,9 +30,7 @@ pgColumnar has two kinds of settings:
 | --- | --- | --- | --- |
 | `pgcolumnar.enable_custom_scan` | boolean | `on` | Use the columnar custom scan path for columnar tables. |
 | `pgcolumnar.enable_qual_pushdown` | boolean | `on` | Push scan qualifiers down so per-chunk min and max values can skip chunk groups. |
-| `pgcolumnar.enable_vectorization` | boolean | `on` | Use the vectorized scan and aggregate paths. |
-| `pgcolumnar.enable_compressed_execution` | boolean | `on` | Compute aggregates over runs of the encoded value stream without full decoding. |
-| `pgcolumnar.enable_late_materialization` | boolean | `on` | Decode output columns only after the filter has selected rows. |
+| `pgcolumnar.enable_vectorization` | boolean | `on` | Use the vectorized aggregate path for supported ungrouped aggregates. |
 | `pgcolumnar.enable_bloom_filter` | boolean | `on` | Skip chunk groups on equality filters using per-chunk bloom filters. |
 | `pgcolumnar.enable_metadata_count` | boolean | `on` | Answer `count(*)` from catalog metadata without scanning the table. |
 | `pgcolumnar.enable_read_stream` | boolean | `on` | Prefetch block reads with the read stream API. Effective on PostgreSQL 17 and later. |
@@ -81,7 +78,6 @@ SELECT pgcolumnar.alter_columnar_table_set(
 | `stripe_row_limit` | integer | Per-table override of `pgcolumnar.stripe_row_limit`. |
 | `compression` | name | One of `none`, `pglz`, `lz4`, `zstd`. |
 | `compression_level` | integer | Level for the `zstd` codec, 1 to 22. |
-| `format_version` | integer | On-disk format for this table: `1` native (PGCN v1), `0` the earlier line. Overrides `pgcolumnar.default_format_version`. Takes effect for a table with no data yet; a table that already holds data keeps its format. |
 
 Arguments left at their default (`NULL`) are not changed. A value outside the
 valid range for a limit or level is rejected.

--- a/docs/features.md
+++ b/docs/features.md
@@ -8,13 +8,9 @@ settings see the [configuration reference](configuration.md); for constraints se
 ## Storage and format
 
 - Column-oriented storage in the relation's main fork, so the buffer manager,
-  WAL, and page checksums apply. New tables are written in the native format,
-  PGCN v1, specified in
-  [../design/FORMAT_AND_INTERFACE_SPEC.md](../design/FORMAT_AND_INTERFACE_SPEC.md).
-  The earlier 1.0-dev line is still read for tables that already hold it; it is
-  pinned at the `v1.0-dev` tag and is retired in a later release. The instance
-  default is set by `pgcolumnar.default_format_version`, and a table's
-  `format_version` option overrides it.
+  WAL, and page checksums apply. Data is stored in the native format, PGCN v1,
+  specified in
+  [../design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md](../design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md).
 - Rows are grouped into row groups (the write unit). Within a row group each
   column is stored and compressed as its own chunk, and a chunk's values are
   encoded in fixed-size vectors. Zone maps hold each chunk's and each vector's
@@ -40,22 +36,18 @@ settings see the [configuration reference](configuration.md); for constraints se
   probe whose value is provably absent, for hashable, non-collatable columns such
   as ids and uuids. The executor always re-applies the full qualifier, so skipping
   never changes results.
-- Vectorized execution: a batch reader returns one decoded chunk group at a time
-  as flat per-column arrays. A column-at-a-time filter builds a selection vector
-  with typed comparison loops for integer, float, and date/time types, and a
-  vectorized aggregate computes `count`, `sum`, `avg`, `min`, and `max`. With no
-  predicates it folds each column over the value stream, so a value repeated N
-  times costs one operation rather than N.
-- Late materialization: a scan with a filter decodes the predicate columns first
-  and decodes the remaining output columns only for chunk groups with surviving
-  rows.
+- Vectorized aggregate: an ungrouped `count`, `sum`, `avg`, `min`, or `max` over
+  a supported column type is answered from the zone-map metadata, or by a
+  column-at-a-time fold over the decoded values when the group has deletes,
+  without the per-tuple executor path.
 - `count(*)` with no filter is answered from catalog metadata without scanning.
 - Parallel scan across a table's row groups.
 - Read stream prefetch of block reads on PostgreSQL 17 and later
   (`pgcolumnar.enable_read_stream`).
 
-Vectorization and skipping change how a result is computed, never the result. See
-[limitations](limitations.md) for the exact aggregate and type coverage.
+The vectorized aggregate and skipping change how a result is computed, never the
+result. See [limitations](limitations.md) for the exact aggregate and type
+coverage.
 
 ## Indexes and index-only scans
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,8 +2,8 @@
 
 pgColumnar is a column-oriented storage extension for PostgreSQL, implemented as
 a table access method. A table created `USING pgcolumnar` stores its data by
-column, with per-column compression, chunk-group skipping, and a vectorized scan
-and aggregate path. It targets analytic workloads: large scans, aggregates, and
+column, with per-column compression, chunk-group skipping, and a vectorized
+aggregate path. It targets analytic workloads: large scans, aggregates, and
 column projections over append-mostly data.
 
 pgColumnar builds from one source tree on PostgreSQL 15 through 19. It is

--- a/docs/sql-reference.md
+++ b/docs/sql-reference.md
@@ -24,7 +24,7 @@ SELECT pgcolumnar.alter_table_set_access_method('events', 'pgcolumnar');
 ### pgcolumnar.alter_columnar_table_set(...) and pgcolumnar.alter_columnar_table_reset(...)
 
 Set or reset per-table storage options (row group and vector row limits,
-compression codec and level, and `format_version`). See
+compression codec and level). See
 [Configuration reference](configuration.md#per-table-storage-options).
 
 ### pgcolumnar.get_storage_id(rel regclass) returns bigint
@@ -71,16 +71,15 @@ SELECT pgcolumnar.vacuum_full('public');
 
 ### pgcolumnar.stats(rel regclass)
 
-Returns one row per row group for a native table (one row per stripe for a table
-still on the earlier line), with these columns:
+Returns one row per row group, with these columns:
 
 | Column | Type | Meaning |
 | --- | --- | --- |
-| `stripeid` | bigint | Row group number within the table (stripe number on the earlier line). |
+| `stripeid` | bigint | Row group number within the table. |
 | `fileoffset` | bigint | Byte offset of the row group in the relation file. |
 | `rowcount` | bigint | Rows written into the row group. |
 | `deletedrows` | bigint | Rows in the row group marked deleted. |
-| `chunkcount` | integer | Vectors in the row group (chunk groups in the stripe on the earlier line). |
+| `chunkcount` | integer | Vectors in the row group. |
 | `datalength` | bigint | On-disk length of the row group in bytes. |
 
 ```sql

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -10,14 +10,14 @@ test/phase2.sh  /path/to/pg_config   # compression, projection, min/max skip, fi
 test/phase3.sh  /path/to/pg_config   # delete, update, MVCC, savepoints, temp tables
 test/phase4.sh  /path/to/pg_config   # btree/hash indexes, constraints, conversion
 test/phase5.sh  /path/to/pg_config   # custom scan, pushdown, options, vacuum
-test/phase6.sh  /path/to/pg_config   # vectorized scan and aggregates, column cache
+test/phase6.sh  /path/to/pg_config   # aggregate correctness and the column cache
 test/audit.sh   /path/to/pg_config   # regression tests for audited defects
 test/concurrency.sh      /path/to/pg_config  # concurrent same-chunk-group deletes
 test/unique_conc.sh      /path/to/pg_config  # concurrent same-unique-key inserts
 test/differential.sh     /path/to/pg_config  # heap-vs-columnar oracle
 test/recovery.sh         /path/to/pg_config  # crash recovery and atomicity
 test/fuzz.sh             /path/to/pg_config  # seeded randomized differential
-test/hardening.sh        /path/to/pg_config  # corrupt-input robustness (native and legacy catalogs)
+test/hardening.sh        /path/to/pg_config  # corrupt-input robustness (native catalogs)
 test/concurrent_diff.sh  /path/to/pg_config  # concurrent DML vs a heap oracle
 test/parallel.sh         /path/to/pg_config  # parallel scan plan and results vs a heap oracle
 test/sorted_projection.sh /path/to/pg_config # pgcolumnar.vacuum_sorted results and skipping
@@ -44,12 +44,6 @@ test/native_dml.sh       /path/to/pg_config  # native delete and update
 test/native_ios.sh       /path/to/pg_config  # native index-only scan
 test/native_projection.sh /path/to/pg_config # native projections
 ```
-
-Native (PGCN v1) is the default format, so the suites that create tables without
-an explicit format run native. Set `PGC_NATIVE=0` to run those suites against the
-earlier line instead; the `native_*` suites always exercise the native format,
-and the core mechanics suites (`smoke`, `phase2` through `phase6`, `audit`,
-`concurrency`, `unique_conc`) always exercise the earlier line.
 
 ## Differential oracle
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -90,8 +90,8 @@ controlled by a setting in the [Configuration reference](configuration.md):
 - Chunk-group skipping: per-chunk minimum and maximum values drop groups of rows
   that cannot satisfy a filter.
 - Bloom filters: per-chunk filters drop groups for equality filters.
-- Vectorized execution and late materialization: filters run first, then only the
-  output columns of matching rows are decoded.
+- Vectorized aggregate: an ungrouped count, sum, avg, min, or max over a
+  supported type is answered from the zone-map metadata.
 - `count(*)` answered from catalog metadata when there is no filter.
 
 ### Point lookups and indexes

--- a/pgcolumnar--1.0.sql
+++ b/pgcolumnar--1.0.sql
@@ -1,13 +1,14 @@
-/* pgColumnar 1.0 - format 2.0 metadata catalog and access method registration.
+/* pgColumnar 1.0 - native (PGCN v1) metadata catalog and access method
+ * registration.
  *
- * This script matches section 7 (metadata catalog) and section 8 (SQL
- * interface) of design/FORMAT_AND_INTERFACE_SPEC.md. Column order and index
- * definitions are part of the on-disk/interoperable format.
+ * The catalog matches section 11 of
+ * design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md. Column order and index
+ * definitions are part of the on-disk format.
  *
- * Phase 1 scope: stripe, chunk, chunk_group tables, the storageid_seq
- * sequence, the columnar_handler function, and the columnar access method.
- * Phase 3 adds the row_mask table and row_mask_seq for delete/update marking.
- * The remaining options table and management functions arrive in later phases.
+ * The catalog holds the native storage, row_group, column_chunk, zone_map,
+ * and bloom tables, the shared row_mask and options tables, the storageid_seq
+ * and row_mask_seq sequences, the columnar_handler function, and the columnar
+ * access method.
  */
 
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
@@ -22,70 +23,6 @@ CREATE SEQUENCE pgcolumnar.storageid_seq
 	NO CYCLE;
 
 CREATE SEQUENCE pgcolumnar.row_mask_seq;
-
-/* ---------------------------------------------------------------------------
- * pgcolumnar.stripe (spec 7.1)
- * ------------------------------------------------------------------------- */
-
-CREATE TABLE pgcolumnar.stripe (
-	storage_id bigint NOT NULL,
-	stripe_num bigint NOT NULL,
-	file_offset bigint NOT NULL,
-	data_length bigint NOT NULL,
-	column_count integer NOT NULL,
-	chunk_row_count integer NOT NULL,
-	row_count bigint NOT NULL,
-	chunk_group_count integer NOT NULL,
-	first_row_number bigint NOT NULL
-);
-
-CREATE UNIQUE INDEX stripe_pkey
-	ON pgcolumnar.stripe USING btree (storage_id, stripe_num);
-
-CREATE UNIQUE INDEX stripe_first_row_number_idx
-	ON pgcolumnar.stripe USING btree (storage_id, first_row_number);
-
-/* ---------------------------------------------------------------------------
- * pgcolumnar.chunk (spec 7.2)
- * ------------------------------------------------------------------------- */
-
-CREATE TABLE pgcolumnar.chunk (
-	storage_id bigint NOT NULL,
-	stripe_num bigint NOT NULL,
-	attr_num integer NOT NULL,
-	chunk_group_num integer NOT NULL,
-	minimum_value bytea,
-	maximum_value bytea,
-	value_stream_offset bigint NOT NULL,
-	value_stream_length bigint NOT NULL,
-	exists_stream_offset bigint NOT NULL,
-	exists_stream_length bigint NOT NULL,
-	value_compression_type integer NOT NULL,
-	value_compression_level integer NOT NULL,
-	value_decompressed_length bigint NOT NULL,
-	value_count bigint NOT NULL,
-	value_encoding_type integer,
-	value_raw_length bigint,
-	bloom_filter bytea
-);
-
-CREATE UNIQUE INDEX chunk_pkey
-	ON pgcolumnar.chunk USING btree (storage_id, stripe_num, attr_num, chunk_group_num);
-
-/* ---------------------------------------------------------------------------
- * pgcolumnar.chunk_group (spec 7.3)
- * ------------------------------------------------------------------------- */
-
-CREATE TABLE pgcolumnar.chunk_group (
-	storage_id bigint NOT NULL,
-	stripe_num bigint NOT NULL,
-	chunk_group_num integer NOT NULL,
-	row_count bigint NOT NULL,
-	deleted_rows bigint NOT NULL
-);
-
-CREATE UNIQUE INDEX chunk_group_pkey
-	ON pgcolumnar.chunk_group USING btree (storage_id, stripe_num, chunk_group_num);
 
 /* ---------------------------------------------------------------------------
  * pgcolumnar.row_mask (spec 7.5)
@@ -128,25 +65,21 @@ CREATE TABLE pgcolumnar.options (
 	chunk_group_row_limit integer,
 	stripe_row_limit integer,
 	compression_level integer,
-	compression name,
-	format_version integer   -- NULL = 1.0-dev (2.2); 1 = native (PGCN v1)
+	compression name
 );
 
 CREATE UNIQUE INDEX options_pkey
 	ON pgcolumnar.options USING btree (regclass);
 
 /* ---------------------------------------------------------------------------
- * pgcolumnar.projection (gap 26, format 2.2)
+ * pgcolumnar.projection (gap 26)
  *
  * Multiple physical projections per table (C-Store). Each projection is a named,
  * ordered subset of the table's columns stored as its own columnar storage
  * (proj_storage_id) sorted on sort_key, sharing the row-number identity space.
  * projection_id 0 is the implicit base projection (all columns, insert order);
- * a table with no rows here has a single implicit base projection, so 2.0/2.1
- * tables and tables with no declared projections behave exactly as before.
- *
- * Phase 1 records the catalog and DDL only; no rows are written to a
- * projection's storage yet (write fan-out arrives in phase 2).
+ * a table with no rows here has a single implicit base projection, so a table
+ * with no declared projections behaves as one with only its base.
  * ------------------------------------------------------------------------- */
 
 CREATE TABLE pgcolumnar.projection (
@@ -168,14 +101,11 @@ CREATE UNIQUE INDEX projection_storage_idx
 	ON pgcolumnar.projection USING btree (proj_storage_id);
 
 /* ---------------------------------------------------------------------------
- * Native format catalog (re-origination line, format PGCN v1).
+ * Native format catalog (format PGCN v1).
  *
- * Additive scaffolding for the native on-disk format
- * (design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md section 11). These tables are
- * empty until the native writer (Phase D2) populates them; the 2.2-line catalog
- * above is unaffected. Both format lines coexist per table until the native
- * format becomes the default (Phase D6). Dropped with the extension; per-table
- * row cleanup is wired into ColumnarDeleteMetadata when D2 begins writing them.
+ * The native on-disk format (design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md
+ * section 11). Dropped with the extension; per-table row cleanup is wired
+ * into ColumnarDeleteMetadata.
  * ------------------------------------------------------------------------- */
 
 CREATE TABLE pgcolumnar.storage (
@@ -324,8 +254,7 @@ CREATE FUNCTION pgcolumnar.alter_columnar_table_set(
 	chunk_group_row_limit int DEFAULT NULL,
 	stripe_row_limit int DEFAULT NULL,
 	compression name DEFAULT NULL,
-	compression_level int DEFAULT NULL,
-	format_version int DEFAULT NULL)
+	compression_level int DEFAULT NULL)
 	RETURNS void
 	LANGUAGE plpgsql
 	AS $alter_columnar_table_set$
@@ -333,17 +262,6 @@ BEGIN
 	IF compression IS NOT NULL AND
 	   compression NOT IN ('none', 'pglz', 'lz4', 'zstd') THEN
 		RAISE EXCEPTION 'unknown columnar compression "%"', compression;
-	END IF;
-
-	/*
-	 * format_version selects the on-disk format for this table's later writes.
-	 * NULL leaves it unchanged (the instance default, the 1.0-dev 2.2 format).
-	 * 1 is the native format (PGCN v1). The write path honors this starting in
-	 * the native writer phase; until then a value of 1 is recorded but writes
-	 * continue in the 2.2 format.
-	 */
-	IF format_version IS NOT NULL AND format_version <> 1 THEN
-		RAISE EXCEPTION 'unsupported format_version %, expected 1', format_version;
 	END IF;
 
 	/*
@@ -368,9 +286,9 @@ BEGIN
 
 	INSERT INTO pgcolumnar.options AS o
 		(regclass, chunk_group_row_limit, stripe_row_limit,
-		 compression, compression_level, format_version)
+		 compression, compression_level)
 	VALUES (table_name, chunk_group_row_limit, stripe_row_limit,
-			compression, compression_level, format_version)
+			compression, compression_level)
 	ON CONFLICT (regclass) DO UPDATE SET
 		chunk_group_row_limit =
 			COALESCE(EXCLUDED.chunk_group_row_limit, o.chunk_group_row_limit),
@@ -379,13 +297,11 @@ BEGIN
 		compression =
 			COALESCE(EXCLUDED.compression, o.compression),
 		compression_level =
-			COALESCE(EXCLUDED.compression_level, o.compression_level),
-		format_version =
-			COALESCE(EXCLUDED.format_version, o.format_version);
+			COALESCE(EXCLUDED.compression_level, o.compression_level);
 END;
 $alter_columnar_table_set$;
 
-COMMENT ON FUNCTION pgcolumnar.alter_columnar_table_set(regclass, int, int, name, int, int)
+COMMENT ON FUNCTION pgcolumnar.alter_columnar_table_set(regclass, int, int, name, int)
 	IS 'set per-table columnar options; NULL leaves a value unchanged';
 
 CREATE FUNCTION pgcolumnar.alter_columnar_table_reset(
@@ -393,8 +309,7 @@ CREATE FUNCTION pgcolumnar.alter_columnar_table_reset(
 	chunk_group_row_limit bool DEFAULT false,
 	stripe_row_limit bool DEFAULT false,
 	compression bool DEFAULT false,
-	compression_level bool DEFAULT false,
-	format_version bool DEFAULT false)
+	compression_level bool DEFAULT false)
 	RETURNS void
 	LANGUAGE plpgsql
 	AS $alter_columnar_table_reset$
@@ -411,15 +326,12 @@ BEGIN
 			THEN NULL ELSE o.compression END,
 		compression_level = CASE
 			WHEN alter_columnar_table_reset.compression_level
-			THEN NULL ELSE o.compression_level END,
-		format_version = CASE
-			WHEN alter_columnar_table_reset.format_version
-			THEN NULL ELSE o.format_version END
+			THEN NULL ELSE o.compression_level END
 	WHERE o.regclass = table_name;
 END;
 $alter_columnar_table_reset$;
 
-COMMENT ON FUNCTION pgcolumnar.alter_columnar_table_reset(regclass, bool, bool, bool, bool, bool)
+COMMENT ON FUNCTION pgcolumnar.alter_columnar_table_reset(regclass, bool, bool, bool, bool)
 	IS 'reset per-table columnar options to the instance defaults';
 
 /* ---------------------------------------------------------------------------
@@ -482,8 +394,7 @@ CREATE FUNCTION pgcolumnar.stats(
 	LANGUAGE sql STABLE
 	AS $stats$
 	-- Native (PGCN v1) tables report one row per row group from the native
-	-- catalog; earlier-line tables report one row per stripe. A table populates
-	-- exactly one of the two catalogs, so the union yields that table's rows.
+	-- catalog.
 	SELECT rg.group_number,
 		   rg.file_offset,
 		   rg.row_count,
@@ -499,23 +410,11 @@ CREATE FUNCTION pgcolumnar.stats(
 		   rg.byte_length
 	FROM pgcolumnar.row_group rg
 	WHERE rg.storage_id = pgcolumnar.get_storage_id(rel)
-	UNION ALL
-	SELECT s.stripe_num,
-		   s.file_offset,
-		   s.row_count,
-		   COALESCE((SELECT sum(rm.deleted_rows)::bigint
-					 FROM pgcolumnar.row_mask rm
-					 WHERE rm.storage_id = s.storage_id
-					   AND rm.stripe_id = s.stripe_num), 0::bigint),
-		   s.chunk_group_count,
-		   s.data_length
-	FROM pgcolumnar.stripe s
-	WHERE s.storage_id = pgcolumnar.get_storage_id(rel)
 	ORDER BY 1;
 $stats$;
 
 COMMENT ON FUNCTION pgcolumnar.stats(regclass)
-	IS 'per-row-group (native) or per-stripe statistics for a columnar table';
+	IS 'per-row-group statistics for a columnar table';
 
 CREATE FUNCTION pgcolumnar.vacuum(tablename regclass, stripe_count int DEFAULT 0)
 	RETURNS void

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -130,11 +130,9 @@ extern int columnar_compression_level;	/* zstd level */
 extern bool columnar_enable_qual_pushdown;
 extern bool columnar_enable_custom_scan;
 extern bool columnar_enable_bloom_filter;	/* bloom equality skipping (I7) */
-extern bool columnar_enable_late_materialization;	/* decode outputs after filter (I8) */
 
 /* Phase 6 GUCs (spec 8.3) */
-extern bool columnar_enable_vectorization;	/* vectorized scan/aggregate path */
-extern bool columnar_enable_compressed_execution;	/* run-based aggregate path (I3) */
+extern bool columnar_enable_vectorization;	/* vectorized aggregate path */
 extern bool columnar_enable_metadata_count;	/* count(*) from catalog metadata (gap 28) */
 extern bool columnar_enable_column_cache;	/* decompressed-chunk cache */
 extern bool columnar_enable_read_stream;	/* stream/prefetch block reads (PG17+) */

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -4,8 +4,8 @@
  *		Shared declarations for the pgColumnar table access method.
  *
  * pgColumnar is an independent MIT implementation built solely from
- * design/FORMAT_AND_INTERFACE_SPEC.md (format 2.0) and the public PostgreSQL
- * API. It reads and writes the format described in that specification.
+ * design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md and the public PostgreSQL API. It
+ * reads and writes the native format (PGCN v1) described in that specification.
  *
  *-------------------------------------------------------------------------
  */
@@ -27,24 +27,21 @@
 #include "utils/rel.h"
 #include "utils/snapshot.h"
 
-/* format version (spec 3). Minor 1 adds per-chunk value encodings (I1); minor 2
- * adds multiple projections (gap 26; the columnar.projection catalog, no
- * metapage layout change). 2.0/2.1 files still read: only the major version is
- * validated, a chunk with no encoding type is treated as NONE, and a table with
- * no columnar.projection rows has a single implicit base projection. */
+/* Physical storage-layer version stamped on the metapage (block 0). This is the
+ * shared logical-storage version, independent of the data format; the data
+ * format is the native format identified below and in pgcolumnar.storage. */
 #define COLUMNAR_VERSION_MAJOR 2
 #define COLUMNAR_VERSION_MINOR 2
 
 /*
- * Native format (re-origination line). A separate format line from the 2.2 line
- * above, designed from public research and the open Arrow/Parquet/ORC specs; see
- * design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md. It is identified by its own
- * metapage magic and major version and has no requirement to read the 2.2 line.
- * These are the Phase D1 scaffolding constants; the native metapage layout,
- * writer, and reader land in D2/D3, and the cascade encoding and zone maps in
- * D4/D5. Nothing writes the native format yet, so these are unused so far.
+ * Native format (PGCN v1). The on-disk data format, designed from public
+ * research and the open Arrow/Parquet/ORC specs; see
+ * design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md. It is identified by its own magic
+ * and major version, recorded in the pgcolumnar.storage catalog row. The row
+ * group holds per-column chunks encoded in fixed-length vectors, with zone maps
+ * and per-chunk bloom filters for skipping.
  */
-#define COLUMNAR_NATIVE_MAGIC "PGCN"		/* native metapage magic tag */
+#define COLUMNAR_NATIVE_MAGIC "PGCN"		/* native format magic tag */
 #define COLUMNAR_NATIVE_VERSION_MAJOR 1
 #define COLUMNAR_NATIVE_VECTOR_LENGTH 1024	/* values per vector (fixed) */
 
@@ -123,14 +120,11 @@ typedef struct ColumnarOptions
 	int			compressionType;	/* one of COLUMNAR_COMPRESSION_* */
 	bool		compressionLevelSet;
 	int			compressionLevel;
-	bool		formatVersionSet;
-	int			formatVersion;		/* native format major version, 1 = PGCN v1 */
 } ColumnarOptions;
 
 /* GUC-backed instance defaults (spec 8.3) */
 extern int columnar_stripe_row_limit;
 extern int columnar_chunk_group_row_limit;
-extern int columnar_default_format_version;	/* 0=format 2.2, 1=native (D6e/f) */
 extern int columnar_compression;		/* one of COLUMNAR_COMPRESSION_* */
 extern int columnar_compression_level;	/* zstd level */
 extern bool columnar_enable_qual_pushdown;
@@ -166,29 +160,7 @@ typedef struct ColumnarMetapage
 	bool		unloggedReset;
 } ColumnarMetapage;
 
-/* -------------------------------------------------------------------------
- * Catalog row shapes, as C structs (spec 7)
- * ------------------------------------------------------------------------- */
-typedef struct StripeMetadata
-{
-	uint64		storageId;
-	uint64		stripeNum;
-	uint64		fileOffset;
-	uint64		dataLength;
-	int			columnCount;
-	int			chunkRowCount;		/* chunk_group_row_limit at write time */
-	uint64		rowCount;
-	int			chunkGroupCount;
-	uint64		firstRowNumber;
-} StripeMetadata;
 
-typedef struct ChunkGroupMetadata
-{
-	uint64		stripeNum;
-	int			chunkGroupNum;
-	uint64		rowCount;
-	uint64		deletedRows;
-} ChunkGroupMetadata;
 
 /* -------------------------------------------------------------------------
  * Native format catalog row shapes (re-origination line, PGCN v1). These map
@@ -303,54 +275,6 @@ typedef struct ColumnarProjection
 	int			columnsLen;
 } ColumnarProjection;
 
-typedef struct ChunkMetadata
-{
-	uint64		stripeNum;
-	int			attrNum;			/* 1-based attribute number */
-	int			chunkGroupNum;
-	uint64		valueStreamOffset;	/* relative to stripe file_offset */
-	uint64		valueStreamLength;
-	uint64		existsStreamOffset;
-	uint64		existsStreamLength;
-	int			valueCompressionType;
-	int			valueCompressionLevel;
-	uint64		valueDecompressedLength;	/* length after decompression (= encoded
-										 * stream length; for NONE encoding this
-										 * equals the raw length) */
-	uint64		valueCount;
-
-	/*
-	 * Value-stream encoding (I1, format 2.1). valueEncodingType is one of
-	 * COLUMNAR_ENCODING_*; valueRawLength is the length of the fully decoded raw
-	 * value stream (what decode reconstructs). For format 2.0 chunks the catalog
-	 * columns are absent/NULL and the reader defaults to NONE with
-	 * valueRawLength == valueDecompressedLength.
-	 */
-	int			valueEncodingType;
-	uint64		valueRawLength;
-
-	/*
-	 * Per-chunk min/max skip list (spec 7.2). Stored only for orderable types;
-	 * minMaxValid is false when the column type is not orderable or the chunk
-	 * has no non-null values, in which case the catalog columns are SQL NULL.
-	 * The bytes are the single min/max value encoded with the value-stream
-	 * codec (ColumnarEncodeValue), so the reader can decode them back to
-	 * Datums for chunk-group skipping.
-	 */
-	bool		minMaxValid;
-	char	   *minEncoded;
-	uint32		minEncodedLen;
-	char	   *maxEncoded;
-	uint32		maxEncodedLen;
-
-	/*
-	 * Optional per-chunk bloom filter over the column's non-null values (I7),
-	 * for equality chunk-group skipping. NULL when absent (older chunks, or a
-	 * collatable/non-hashable column, or a chunk too small to be worth it).
-	 */
-	char	   *bloomFilter;
-	uint32		bloomLen;
-} ChunkMetadata;
 
 /* -------------------------------------------------------------------------
  * storage layer (columnar_storage.c)
@@ -401,13 +325,7 @@ extern List *ColumnarComputeAllVisibleGroups(uint64 storageId,
  * metadata layer (columnar_metadata.c)
  * ------------------------------------------------------------------------- */
 extern uint64 ColumnarNextStorageId(void);
-extern void ColumnarInsertStripeRow(const StripeMetadata *stripe);
-extern void ColumnarInsertChunkGroupRow(uint64 storageId,
-										const ChunkGroupMetadata *cg);
-extern void ColumnarInsertChunkRow(uint64 storageId, const ChunkMetadata *chunk);
 extern void ColumnarInsertNativeStorageRow(const NativeStorageMetadata *s);
-extern bool ColumnarStorageIsNative(uint64 storageId, Snapshot snapshot);
-extern bool ColumnarStorageHasStripes(uint64 storageId, Snapshot snapshot);
 extern void ColumnarInsertRowGroupRow(const NativeRowGroupMetadata *rg);
 extern void ColumnarInsertColumnChunkRow(const NativeColumnChunkMetadata *cc);
 extern void ColumnarInsertZoneMapRow(const NativeZoneMapMetadata *z);
@@ -421,16 +339,10 @@ extern List *ColumnarReadZoneMapVectors(uint64 storageId, uint64 groupNumber,
 										Snapshot snapshot);
 extern List *ColumnarReadBloomList(uint64 storageId, uint64 groupNumber,
 								   Snapshot snapshot);
-extern List *ColumnarReadStripeList(uint64 storageId, Snapshot snapshot);
-extern List *ColumnarReadChunkGroupList(uint64 storageId, uint64 stripeNum,
-										Snapshot snapshot);
-extern List *ColumnarReadChunkList(uint64 storageId, uint64 stripeNum,
-								   Snapshot snapshot);
 extern void ColumnarDeleteMetadata(uint64 storageId);
 
 /* per-table options catalog (spec 7.4) */
 extern bool ColumnarReadOptions(Oid relid, ColumnarOptions *opts);
-extern int	ColumnarTableFormatVersion(Oid relid);
 extern void ColumnarDeleteOptions(Oid relid);
 
 /* projection catalog (gap 26, format 2.2). List entries are ColumnarProjection*
@@ -544,8 +456,6 @@ extern uint64 ColumnarVectorsSkipped(ColumnarReadState *readState);
  * are allocated in the current memory context) and returns true when the row
  * exists and is not marked deleted in the row mask.
  */
-extern bool ColumnarRowIsLive(Relation rel, Snapshot snapshot,
-							  uint64 rowNumber);
 /* cached base-liveness for a projection scan (gap 26): build once per scan,
  * probe per row with a binary search instead of a per-row catalog scan */
 typedef struct ColumnarLivenessCache ColumnarLivenessCache;
@@ -558,16 +468,13 @@ extern bool ColumnarReadRowByNumber(Relation rel, Snapshot snapshot,
 									uint64 rowNumber, Datum *values, bool *nulls);
 
 /* -------------------------------------------------------------------------
- * vectorized batch reader (columnar_reader.c, spec 9 vectorized execution)
+ * Decoded chunk group (columnar_vector.c aggregate path)
  *
  * A ColumnarVector is one decoded chunk group: for each projected column, the
  * whole group's values and null flags as flat arrays, plus the per-row deleted
- * flag resolved from the row mask. ColumnarReadNextVector advances to the next
- * chunk group that survives min/max skipping (spec 9) and decodes it. The arrays
- * live in the read state's per-group context and stay valid only until the next
- * ColumnarReadNextVector call. A vectorized scan or aggregate applies its own
- * filter and row-mask handling on top of this, so it returns exactly what the
- * scalar per-row reader (ColumnarReadNextRow) would.
+ * flag resolved from the row mask. The vectorized aggregate builds a selection
+ * vector over it (ColumnarVecSelect); the scan itself is the scalar per-row
+ * reader (ColumnarReadNextRow).
  * ------------------------------------------------------------------------- */
 typedef struct ColumnarVector
 {
@@ -577,52 +484,6 @@ typedef struct ColumnarVector
 	bool	  **isnull;			/* [natts]; isnull[c] is bool[nrows] or NULL */
 	bool	   *deleted;		/* [nrows]; true when row-mask-deleted */
 } ColumnarVector;
-
-extern bool ColumnarReadNextVector(ColumnarReadState *readState,
-								   ColumnarVector *vec);
-
-/*
- * Late materialization (I8): position on the next readable chunk group without
- * decoding, then decode a chosen subset of columns into the vector. A scan
- * decodes only the predicate columns, builds the selection vector, and decodes
- * the remaining output columns only when the group has surviving rows. Pass
- * cols = NULL to decode every projected column; init = true on the first decode
- * of a group (allocates the vector and resolves the deleted flags).
- */
-extern bool ColumnarAdvanceGroup(ColumnarReadState *readState);
-extern void ColumnarDecodeGroupColumns(ColumnarReadState *readState,
-									   ColumnarVector *vec,
-									   Bitmapset *cols, bool init,
-									   const bool *sel);
-
-/* -------------------------------------------------------------------------
- * raw-group reader (columnar_reader.c, I3 compressed execution)
- *
- * Like ColumnarReadNextVector but hands back each projected column's raw value
- * stream (packed non-null values) instead of a decoded Datum array, so an
- * aggregate can run over runs (ColumnarBlockReader) without materializing
- * Datums. Only the non-null values are present in valueCursor; deletedCount
- * reports how many of the group's rows are row-mask-deleted. When deletedCount
- * is non-zero the caller falls back to ColumnarDecodeCurrentGroupVector, which
- * decodes the currently positioned group into a full vector (with per-row null
- * and deleted flags). The arrays live in the read state's per-group context and
- * are valid only until the next raw-group / vector call.
- * ------------------------------------------------------------------------- */
-typedef struct ColumnarRawGroup
-{
-	uint64		nrows;			/* rows in this chunk group */
-	uint64		firstRowNumber;
-	uint64		deletedCount;	/* rows in this group marked deleted */
-	int			natts;
-	char	  **valueCursor;	/* [natts]; raw value stream, or NULL */
-	uint64	   *groupValueCount;	/* [natts]; non-null values per column */
-	bool	   *columnAbsent;	/* [natts]; true if column predates the stripe */
-} ColumnarRawGroup;
-
-extern bool ColumnarReadNextRawGroup(ColumnarReadState *readState,
-									 ColumnarRawGroup *rg);
-extern void ColumnarDecodeCurrentGroupVector(ColumnarReadState *readState,
-											 ColumnarVector *vec);
 
 /* value stream encode/decode shared by writer and reader */
 extern void ColumnarEncodeValue(StringInfo buf, Form_pg_attribute att,

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -74,34 +74,17 @@ typedef struct ColumnarCustomScanState
 	int			nProjected;			/* for EXPLAIN */
 	int			nTotalColumns;
 
-	/*
-	 * Vectorized scan state (spec 9). When vectorized is true, rows are produced
-	 * a chunk group at a time: ColumnarReadNextVector decodes the whole group,
-	 * a column-at-a-time selection vector drops rows that fail the pushed-down
-	 * predicates and the row mask, and surviving rows are emitted one by one.
-	 * The executor still re-applies the full qual, so a dropped row is one that
-	 * would fail the qual anyway; results equal the scalar path exactly.
-	 */
-	bool		vectorized;
-	ColumnarVector vec;
-	bool		haveVec;
-	uint64		vecPos;
-	ColumnarVecPredicate *vecPreds;
-	int			nVecPreds;
-	bool	   *vecSel;			/* per-group selection vector (I6) */
-	uint64		vecSelCap;		/* allocated length of vecSel */
-	Bitmapset  *vecPredCols;	/* predicate columns, decoded first (I8) */
-	bool		lateMat;		/* two-phase decode enabled for this scan */
-	pg_atomic_uint32 *parallelCounter;	/* shared stripe claimer (gap 23) */
+	/* shared row-group claimer for a parallel scan (gap 23) */
+	pg_atomic_uint32 *parallelCounter;
 
 	/*
 	 * Projection scan (gap 26, phase 4). When projScan is true this scan reads a
 	 * projection's storage instead of the base: readState is opened on the
 	 * projection's storage id with a synthetic [rownumber, cols...] descriptor,
 	 * covered columns are mapped into the base-shaped output slot, and rows whose
-	 * stored base row number is deleted/invisible are filtered via
-	 * ColumnarRowIsLive. Selection requires the projection to cover every
-	 * referenced column, so no base reconstruction fetch is needed here.
+	 * stored base row number is deleted/invisible are filtered via the liveness
+	 * cache. Selection requires the projection to cover every referenced column,
+	 * so no base reconstruction fetch is needed here.
 	 */
 	char	   *projName;			/* chosen projection name (EXPLAIN), or NULL */
 	bool		projScan;
@@ -536,12 +519,10 @@ ColumnarSetRelPathlist(PlannerInfo *root, RelOptInfo *rel, Index rti,
 		return;
 
 	/*
-	 * Native-format tables (PGCN v1) take the custom scan too (Phase D5b), but
-	 * only its scalar per-row path (ColumnarReadNextRow, which is native-aware),
-	 * so pushed-down predicates drive zone-map row-group skipping (native spec
-	 * 7.1). The vectorized paths and metadata count(*) read the 2.2 stripe/chunk
-	 * catalog a native table does not populate; ColumnarBeginCustomScan forces the
-	 * scalar path for native, and the native aggregate path is a later sub-phase.
+	 * The custom scan is the scalar per-row path (ColumnarReadNextRow), so
+	 * pushed-down predicates drive zone-map row-group and per-vector skipping
+	 * (native spec 7.1). Ungrouped aggregates are answered from the zone maps by
+	 * the separate aggregate path (columnar_vector.c).
 	 */
 
 	/* find a non-parameterized seqscan path to inherit its costs from */
@@ -836,72 +817,17 @@ ColumnarBeginCustomScan(CustomScanState *node, EState *estate, int eflags)
 
 	if (cstate->projName != NULL)
 	{
-		/*
-		 * gap 26: read a covering projection instead of the base. The scalar
-		 * per-row path handles projection reconstruction and base liveness, so
-		 * vectorization is disabled for a projection scan.
-		 */
+		/* gap 26: read a covering projection instead of the base. */
 		columnar_setup_projection_scan(cstate, rel, estate->es_snapshot,
 									   cstate->projName);
 		if (!cstate->projScan)
 			cstate->projName = NULL;	/* projection vanished; base fallback */
-		cstate->vectorized = false;
 	}
 	else
 	{
 		cstate->readState = ColumnarBeginRead(rel, estate->es_snapshot, NULL,
 											  cstate->projectedColumns,
 											  cstate->nScanKeys, cstate->scanKeys);
-
-		/*
-		 * Choose the vectorized scan path when vectorization is enabled and every
-		 * needed column is decoded (projectedColumns != NULL). A NULL projection
-		 * means a whole-row or system column is referenced, as UPDATE/DELETE do
-		 * via ctid; those keep the scalar per-row path, which is simplest and
-		 * safest for TID-addressed rows. The predicates pre-filter rows
-		 * column-at-a-time; the executor re-applies the full qual, so results are
-		 * identical either way.
-		 */
-		cstate->vectorized = columnar_enable_vectorization &&
-			cstate->projectedColumns != NULL;
-
-		/*
-		 * Native tables (PGCN v1) have no vectorized path yet; the scalar per-row
-		 * reader is native-aware and applies zone-map row-group skipping from the
-		 * pushed-down scan keys (Phase D5b). The vectorized path reads the 2.2
-		 * chunk catalog, so it must not run for native.
-		 */
-		if (ColumnarTableFormatVersion(RelationGetRelid(rel)) ==
-			COLUMNAR_NATIVE_VERSION_MAJOR)
-			cstate->vectorized = false;
-	}
-	cstate->haveVec = false;
-	cstate->vecPos = 0;
-	cstate->vecSel = NULL;
-	cstate->vecSelCap = 0;
-	cstate->vecPredCols = NULL;
-	cstate->lateMat = false;
-	if (cstate->vectorized)
-	{
-		bool		allConvertible;
-		int			p;
-
-		cstate->vecPreds =
-			ColumnarBuildVecPredicates(cscan->scan.plan.qual,
-									   cscan->scan.scanrelid, tupdesc,
-									   &cstate->nVecPreds, &allConvertible);
-
-		/*
-		 * Late materialization (I8): decode the predicate columns first, then
-		 * decode the remaining output columns only for groups with survivors.
-		 * Worth it only when there are predicates but not every projected column
-		 * is a predicate column.
-		 */
-		for (p = 0; p < cstate->nVecPreds; p++)
-			cstate->vecPredCols = bms_add_member(cstate->vecPredCols,
-												 cstate->vecPreds[p].attidx);
-		cstate->lateMat = columnar_enable_late_materialization &&
-			cstate->nVecPreds > 0;
 	}
 }
 
@@ -911,120 +837,6 @@ ColumnarBeginCustomScan(CustomScanState *node, EState *estate, int eflags)
  *		The row's synthetic item pointer (spec 6) is stored on the slot so an
  *		UPDATE/DELETE above the scan can identify the row by its ctid.
  */
-/*
- * ColumnarScanNextVector
- *		Vectorized access method: decode a chunk group at a time and emit its
- *		surviving rows one by one. A row is skipped when the row mask marks it
- *		deleted or when it fails a pushed-down predicate (a conjunct of the
- *		WHERE, so skipping it is always correct); the executor re-applies the
- *		full qual to the rows we do emit.
- */
-static TupleTableSlot *
-ColumnarScanNextVector(ScanState *ss)
-{
-	ColumnarCustomScanState *cstate = (ColumnarCustomScanState *) ss;
-	TupleTableSlot *slot = ss->ss_ScanTupleSlot;
-	int			natts = cstate->nTotalColumns;
-
-	for (;;)
-	{
-		uint64		i;
-
-		if (!cstate->haveVec || cstate->vecPos >= cstate->vec.nrows)
-		{
-			uint64		r;
-			bool		anyPass = false;
-
-			if (cstate->lateMat)
-			{
-				/* phase 1: position and decode only the predicate columns (I8) */
-				if (!ColumnarAdvanceGroup(cstate->readState))
-					return NULL;
-				ColumnarDecodeGroupColumns(cstate->readState, &cstate->vec,
-										   cstate->vecPredCols, true, NULL);
-			}
-			else
-			{
-				if (!ColumnarReadNextVector(cstate->readState, &cstate->vec))
-					return NULL;
-			}
-			cstate->haveVec = true;
-			cstate->vecPos = 0;
-
-			/* build the group's selection vector once, column-at-a-time (I6) */
-			if (cstate->vec.nrows > cstate->vecSelCap)
-			{
-				if (cstate->vecSel)
-					pfree(cstate->vecSel);
-				cstate->vecSel = MemoryContextAlloc(
-					cstate->css.ss.ps.state->es_query_cxt,
-					sizeof(bool) * cstate->vec.nrows);
-				cstate->vecSelCap = cstate->vec.nrows;
-			}
-			ColumnarVecSelect(cstate->vecPreds, cstate->nVecPreds,
-							  &cstate->vec, cstate->vecSel);
-
-			/*
-			 * Late materialization (I8): decode the remaining output columns
-			 * only when some row in the group survived the filter; a group whose
-			 * rows all fail costs nothing beyond the predicate columns.
-			 */
-			if (cstate->lateMat)
-			{
-				uint64		survivors = 0;
-
-				for (r = 0; r < cstate->vec.nrows; r++)
-					if (cstate->vecSel[r])
-						survivors++;
-				anyPass = (survivors > 0);
-
-				/*
-				 * Decode the output columns only for surviving rows when the
-				 * filter is selective (position-list late materialization, gap
-				 * 22): passing the selection vector makes the decoder skip
-				 * copying unselected values. When most rows survive, a full
-				 * decode is simpler and more cache-friendly.
-				 */
-				if (anyPass)
-				{
-					const bool *gatherSel =
-						(survivors * 2 < cstate->vec.nrows) ? cstate->vecSel : NULL;
-
-					ColumnarDecodeGroupColumns(cstate->readState, &cstate->vec,
-											   NULL, false, gatherSel);
-				}
-			}
-			continue;			/* re-check bounds (handles an empty group) */
-		}
-
-		i = cstate->vecPos++;
-
-		if (!cstate->vecSel[i])
-			continue;
-
-		ExecClearTuple(slot);
-		for (int c = 0; c < natts; c++)
-		{
-			if (cstate->vec.values[c] == NULL)
-			{
-				/* not projected: return NULL, matching the scalar path */
-				slot->tts_values[c] = (Datum) 0;
-				slot->tts_isnull[c] = true;
-			}
-			else
-			{
-				slot->tts_values[c] = cstate->vec.values[c][i];
-				slot->tts_isnull[c] = cstate->vec.isnull[c][i];
-			}
-		}
-		ExecStoreVirtualTuple(slot);
-		ColumnarRowNumberToItemPointer(cstate->vec.firstRowNumber + i,
-									   &slot->tts_tid);
-		slot->tts_tableOid = RelationGetRelid(ss->ss_currentRelation);
-
-		return slot;
-	}
-}
 
 static TupleTableSlot *
 columnar_projection_scan_next(ScanState *ss)
@@ -1083,9 +895,6 @@ ColumnarScanNext(ScanState *ss)
 	if (cstate->projScan)
 		return columnar_projection_scan_next(ss);
 
-	if (cstate->vectorized)
-		return ColumnarScanNextVector(ss);
-
 	ExecClearTuple(slot);
 
 	if (!ColumnarReadNextRow(cstate->readState, slot->tts_values,
@@ -1126,9 +935,6 @@ ColumnarReScanCustomScan(CustomScanState *node)
 			ColumnarReadSetParallelCounter(cstate->readState,
 										   cstate->parallelCounter);
 	}
-
-	cstate->haveVec = false;
-	cstate->vecPos = 0;
 
 	ExecScanReScan(&node->ss);
 }

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -57,7 +57,6 @@
 
 /* GUC: use the columnar custom scan path (spec 8.3) */
 bool		columnar_enable_custom_scan = true;
-bool		columnar_enable_late_materialization = true;
 /* GUC: let the planner scan a covering projection instead of the base (gap 26) */
 bool		columnar_enable_projection_scan = true;
 

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -30,53 +30,12 @@
 #include "utils/rel.h"
 #include "utils/snapmgr.h"
 
-/* attribute numbers for columnar.stripe (spec 7.1) */
-#define Anum_stripe_storage_id 1
-#define Anum_stripe_stripe_num 2
-#define Anum_stripe_file_offset 3
-#define Anum_stripe_data_length 4
-#define Anum_stripe_column_count 5
-#define Anum_stripe_chunk_row_count 6
-#define Anum_stripe_row_count 7
-#define Anum_stripe_chunk_group_count 8
-#define Anum_stripe_first_row_number 9
-#define Natts_stripe 9
-
-/* attribute numbers for columnar.chunk (spec 7.2) */
-#define Anum_chunk_storage_id 1
-#define Anum_chunk_stripe_num 2
-#define Anum_chunk_attr_num 3
-#define Anum_chunk_chunk_group_num 4
-#define Anum_chunk_minimum_value 5
-#define Anum_chunk_maximum_value 6
-#define Anum_chunk_value_stream_offset 7
-#define Anum_chunk_value_stream_length 8
-#define Anum_chunk_exists_stream_offset 9
-#define Anum_chunk_exists_stream_length 10
-#define Anum_chunk_value_compression_type 11
-#define Anum_chunk_value_compression_level 12
-#define Anum_chunk_value_decompressed_length 13
-#define Anum_chunk_value_count 14
-#define Anum_chunk_value_encoding_type 15
-#define Anum_chunk_value_raw_length 16
-#define Anum_chunk_bloom_filter 17
-#define Natts_chunk 17
-
-/* attribute numbers for columnar.chunk_group (spec 7.3) */
-#define Anum_chunk_group_storage_id 1
-#define Anum_chunk_group_stripe_num 2
-#define Anum_chunk_group_chunk_group_num 3
-#define Anum_chunk_group_row_count 4
-#define Anum_chunk_group_deleted_rows 5
-#define Natts_chunk_group 5
-
 /* attribute numbers for columnar.options (spec 7.4) */
 #define Anum_options_regclass 1
 #define Anum_options_chunk_group_row_limit 2
 #define Anum_options_stripe_row_limit 3
 #define Anum_options_compression_level 4
 #define Anum_options_compression 5
-#define Anum_options_format_version 6
 
 /* attribute numbers for columnar.projection (gap 26, format 2.2) */
 #define Anum_projection_storage_id 1
@@ -240,199 +199,15 @@ ColumnarCatalogSnapshot(Snapshot base)
  * inserts
  * ------------------------------------------------------------------------- */
 
-void
-ColumnarInsertStripeRow(const StripeMetadata *stripe)
-{
-	Relation	rel = open_columnar_table("stripe", RowExclusiveLock);
-	TupleDesc	tupdesc = RelationGetDescr(rel);
-	Datum		values[Natts_stripe];
-	bool		nulls[Natts_stripe];
-	HeapTuple	tuple;
 
-	memset(nulls, false, sizeof(nulls));
-	values[Anum_stripe_storage_id - 1] = Int64GetDatum((int64) stripe->storageId);
-	values[Anum_stripe_stripe_num - 1] = Int64GetDatum((int64) stripe->stripeNum);
-	values[Anum_stripe_file_offset - 1] = Int64GetDatum((int64) stripe->fileOffset);
-	values[Anum_stripe_data_length - 1] = Int64GetDatum((int64) stripe->dataLength);
-	values[Anum_stripe_column_count - 1] = Int32GetDatum(stripe->columnCount);
-	values[Anum_stripe_chunk_row_count - 1] = Int32GetDatum(stripe->chunkRowCount);
-	values[Anum_stripe_row_count - 1] = Int64GetDatum((int64) stripe->rowCount);
-	values[Anum_stripe_chunk_group_count - 1] = Int32GetDatum(stripe->chunkGroupCount);
-	values[Anum_stripe_first_row_number - 1] = Int64GetDatum((int64) stripe->firstRowNumber);
 
-	tuple = heap_form_tuple(tupdesc, values, nulls);
-	CatalogTupleInsert(rel, tuple);
-	heap_freetuple(tuple);
-
-	table_close(rel, RowExclusiveLock);
-}
-
-void
-ColumnarInsertChunkGroupRow(uint64 storageId, const ChunkGroupMetadata *cg)
-{
-	Relation	rel = open_columnar_table("chunk_group", RowExclusiveLock);
-	TupleDesc	tupdesc = RelationGetDescr(rel);
-	Datum		values[Natts_chunk_group];
-	bool		nulls[Natts_chunk_group];
-	HeapTuple	tuple;
-
-	memset(nulls, false, sizeof(nulls));
-	values[Anum_chunk_group_storage_id - 1] = Int64GetDatum((int64) storageId);
-	values[Anum_chunk_group_stripe_num - 1] = Int64GetDatum((int64) cg->stripeNum);
-	values[Anum_chunk_group_chunk_group_num - 1] = Int32GetDatum(cg->chunkGroupNum);
-	values[Anum_chunk_group_row_count - 1] = Int64GetDatum((int64) cg->rowCount);
-	values[Anum_chunk_group_deleted_rows - 1] = Int64GetDatum((int64) cg->deletedRows);
-
-	tuple = heap_form_tuple(tupdesc, values, nulls);
-	CatalogTupleInsert(rel, tuple);
-	heap_freetuple(tuple);
-
-	table_close(rel, RowExclusiveLock);
-}
-
-void
-ColumnarInsertChunkRow(uint64 storageId, const ChunkMetadata *chunk)
-{
-	Relation	rel = open_columnar_table("chunk", RowExclusiveLock);
-	TupleDesc	tupdesc = RelationGetDescr(rel);
-	Datum		values[Natts_chunk];
-	bool		nulls[Natts_chunk];
-	HeapTuple	tuple;
-
-	memset(nulls, false, sizeof(nulls));
-	values[Anum_chunk_storage_id - 1] = Int64GetDatum((int64) storageId);
-	values[Anum_chunk_stripe_num - 1] = Int64GetDatum((int64) chunk->stripeNum);
-	values[Anum_chunk_attr_num - 1] = Int32GetDatum(chunk->attrNum);
-	values[Anum_chunk_chunk_group_num - 1] = Int32GetDatum(chunk->chunkGroupNum);
-
-	/* min/max skip list (spec 7.2); NULL for non-orderable/empty chunks */
-	if (chunk->minMaxValid)
-	{
-		bytea	   *minb = (bytea *) palloc(VARHDRSZ + chunk->minEncodedLen);
-		bytea	   *maxb = (bytea *) palloc(VARHDRSZ + chunk->maxEncodedLen);
-
-		SET_VARSIZE(minb, VARHDRSZ + chunk->minEncodedLen);
-		memcpy(VARDATA(minb), chunk->minEncoded, chunk->minEncodedLen);
-		values[Anum_chunk_minimum_value - 1] = PointerGetDatum(minb);
-
-		SET_VARSIZE(maxb, VARHDRSZ + chunk->maxEncodedLen);
-		memcpy(VARDATA(maxb), chunk->maxEncoded, chunk->maxEncodedLen);
-		values[Anum_chunk_maximum_value - 1] = PointerGetDatum(maxb);
-	}
-	else
-	{
-		nulls[Anum_chunk_minimum_value - 1] = true;
-		nulls[Anum_chunk_maximum_value - 1] = true;
-	}
-
-	values[Anum_chunk_value_stream_offset - 1] = Int64GetDatum((int64) chunk->valueStreamOffset);
-	values[Anum_chunk_value_stream_length - 1] = Int64GetDatum((int64) chunk->valueStreamLength);
-	values[Anum_chunk_exists_stream_offset - 1] = Int64GetDatum((int64) chunk->existsStreamOffset);
-	values[Anum_chunk_exists_stream_length - 1] = Int64GetDatum((int64) chunk->existsStreamLength);
-	values[Anum_chunk_value_compression_type - 1] = Int32GetDatum(chunk->valueCompressionType);
-	values[Anum_chunk_value_compression_level - 1] = Int32GetDatum(chunk->valueCompressionLevel);
-	values[Anum_chunk_value_decompressed_length - 1] = Int64GetDatum((int64) chunk->valueDecompressedLength);
-	values[Anum_chunk_value_count - 1] = Int64GetDatum((int64) chunk->valueCount);
-	values[Anum_chunk_value_encoding_type - 1] = Int32GetDatum(chunk->valueEncodingType);
-	values[Anum_chunk_value_raw_length - 1] = Int64GetDatum((int64) chunk->valueRawLength);
-
-	if (chunk->bloomFilter != NULL)
-	{
-		bytea	   *bl = (bytea *) palloc(VARHDRSZ + chunk->bloomLen);
-
-		SET_VARSIZE(bl, VARHDRSZ + chunk->bloomLen);
-		memcpy(VARDATA(bl), chunk->bloomFilter, chunk->bloomLen);
-		values[Anum_chunk_bloom_filter - 1] = PointerGetDatum(bl);
-	}
-	else
-		nulls[Anum_chunk_bloom_filter - 1] = true;
-
-	tuple = heap_form_tuple(tupdesc, values, nulls);
-	CatalogTupleInsert(rel, tuple);
-	heap_freetuple(tuple);
-
-	table_close(rel, RowExclusiveLock);
-}
 
 /* -------------------------------------------------------------------------
  * reads
  * ------------------------------------------------------------------------- */
 
-/*
- * stripe_cmp
- *		qsort comparator ordering StripeMetadata by stripe number.
- */
-static int
-stripe_cmp(const ListCell *a, const ListCell *b)
-{
-	const StripeMetadata *sa = (const StripeMetadata *) lfirst(a);
-	const StripeMetadata *sb = (const StripeMetadata *) lfirst(b);
 
-	if (sa->stripeNum < sb->stripeNum)
-		return -1;
-	if (sa->stripeNum > sb->stripeNum)
-		return 1;
-	return 0;
-}
 
-static int
-chunk_group_cmp(const ListCell *a, const ListCell *b)
-{
-	const ChunkGroupMetadata *ca = (const ChunkGroupMetadata *) lfirst(a);
-	const ChunkGroupMetadata *cb = (const ChunkGroupMetadata *) lfirst(b);
-
-	if (ca->chunkGroupNum < cb->chunkGroupNum)
-		return -1;
-	if (ca->chunkGroupNum > cb->chunkGroupNum)
-		return 1;
-	return 0;
-}
-
-List *
-ColumnarReadStripeList(uint64 storageId, Snapshot snapshot)
-{
-	Relation	rel = open_columnar_table("stripe", AccessShareLock);
-	TupleDesc	tupdesc = RelationGetDescr(rel);
-	ScanKeyData key[1];
-	SysScanDesc scan;
-	HeapTuple	tuple;
-	List	   *result = NIL;
-
-	ScanKeyInit(&key[0], Anum_stripe_storage_id, BTEqualStrategyNumber,
-				F_INT8EQ, Int64GetDatum((int64) storageId));
-
-	scan = systable_beginscan(rel, InvalidOid, false, snapshot, 1, key);
-	while (HeapTupleIsValid(tuple = systable_getnext(scan)))
-	{
-		StripeMetadata *stripe = palloc0(sizeof(StripeMetadata));
-		bool		isnull;
-
-		stripe->storageId = storageId;
-		stripe->stripeNum = (uint64) DatumGetInt64(
-			heap_getattr(tuple, Anum_stripe_stripe_num, tupdesc, &isnull));
-		stripe->fileOffset = (uint64) DatumGetInt64(
-			heap_getattr(tuple, Anum_stripe_file_offset, tupdesc, &isnull));
-		stripe->dataLength = (uint64) DatumGetInt64(
-			heap_getattr(tuple, Anum_stripe_data_length, tupdesc, &isnull));
-		stripe->columnCount = DatumGetInt32(
-			heap_getattr(tuple, Anum_stripe_column_count, tupdesc, &isnull));
-		stripe->chunkRowCount = DatumGetInt32(
-			heap_getattr(tuple, Anum_stripe_chunk_row_count, tupdesc, &isnull));
-		stripe->rowCount = (uint64) DatumGetInt64(
-			heap_getattr(tuple, Anum_stripe_row_count, tupdesc, &isnull));
-		stripe->chunkGroupCount = DatumGetInt32(
-			heap_getattr(tuple, Anum_stripe_chunk_group_count, tupdesc, &isnull));
-		stripe->firstRowNumber = (uint64) DatumGetInt64(
-			heap_getattr(tuple, Anum_stripe_first_row_number, tupdesc, &isnull));
-
-		result = lappend(result, stripe);
-	}
-	systable_endscan(scan);
-	table_close(rel, AccessShareLock);
-
-	list_sort(result, stripe_cmp);
-	return result;
-}
 
 /*
  * ColumnarComputeAllVisibleGroups
@@ -448,11 +223,11 @@ ColumnarReadStripeList(uint64 storageId, Snapshot snapshot)
 List *
 ColumnarComputeAllVisibleGroups(uint64 storageId, TransactionId oldestXmin)
 {
-	Relation	srel = open_columnar_table("stripe", AccessShareLock);
-	TupleDesc	stupdesc = RelationGetDescr(srel);
-	ScanKeyData skey[1];
-	SysScanDesc sscan;
-	HeapTuple	stuple;
+	Relation	grel = open_columnar_table("row_group", AccessShareLock);
+	TupleDesc	gtd = RelationGetDescr(grel);
+	ScanKeyData gkey[1];
+	SysScanDesc gscan;
+	HeapTuple	gtuple;
 	Snapshot	snap;
 	SnapshotData dirty;
 	List	   *ranges = NIL;
@@ -461,306 +236,69 @@ ColumnarComputeAllVisibleGroups(uint64 storageId, TransactionId oldestXmin)
 	 * Register the MVCC snapshot: PG18 asserts that a snapshot used for heap
 	 * visibility in a scan is registered or active (heapam_visibility.c). Called
 	 * from the vacuum path, there is no active snapshot to rely on.
+	 *
+	 * A row group is all-visible when its catalog row (inserted in the flushing
+	 * transaction) precedes oldestXmin and the group has no delete (committed or
+	 * in progress, checked under a dirty snapshot). The whole row group is one
+	 * all-visible range. Clear-on-write removes the bit for any later delete or
+	 * insert, so a set bit never covers a modified row.
 	 */
 	snap = RegisterSnapshot(GetLatestSnapshot());
 	InitDirtySnapshot(dirty);
 
-	/*
-	 * Native format (PGCN v1, D6c): a row group is all-visible when its catalog
-	 * row (inserted in the flushing transaction) precedes oldestXmin and the group
-	 * has no delete (committed or in progress, checked under a dirty snapshot). The
-	 * whole row group is one all-visible range. Clear-on-write removes the bit for
-	 * any later delete or insert, so a set bit never covers a modified row.
-	 */
-	if (ColumnarStorageIsNative(storageId, snap))
-	{
-		Relation	grel;
-		TupleDesc	gtd;
-		ScanKeyData gkey[1];
-		SysScanDesc gscan;
-		HeapTuple	gtuple;
-
-		table_close(srel, AccessShareLock);
-		grel = open_columnar_table("row_group", AccessShareLock);
-		gtd = RelationGetDescr(grel);
-		ScanKeyInit(&gkey[0], Anum_row_group_storage_id, BTEqualStrategyNumber,
-					F_INT8EQ, Int64GetDatum((int64) storageId));
-		gscan = systable_beginscan(grel, InvalidOid, false, snap, 1, gkey);
-		while (HeapTupleIsValid(gtuple = systable_getnext(gscan)))
-		{
-			TransactionId xmin = HeapTupleHeaderGetXmin(gtuple->t_data);
-			bool		isnull;
-			uint64		groupNumber,
-						firstRow,
-						rowCount;
-			List	   *rmList;
-			ListCell   *lc;
-			bool		hasDelete = false;
-			ColumnarRowRange *r;
-
-			if (TransactionIdIsNormal(xmin) &&
-				!TransactionIdPrecedes(xmin, oldestXmin))
-				continue;
-
-			groupNumber = (uint64) DatumGetInt64(
-				heap_getattr(gtuple, Anum_row_group_group_number, gtd, &isnull));
-			rowCount = (uint64) DatumGetInt64(
-				heap_getattr(gtuple, Anum_row_group_row_count, gtd, &isnull));
-			firstRow = (uint64) DatumGetInt64(
-				heap_getattr(gtuple, Anum_row_group_first_row_number, gtd, &isnull));
-			if (rowCount == 0)
-				continue;
-
-			rmList = ColumnarReadRowMaskList(storageId, groupNumber, &dirty);
-			foreach(lc, rmList)
-			{
-				if (((RowMaskMetadata *) lfirst(lc))->deletedRows > 0)
-				{
-					hasDelete = true;
-					break;
-				}
-			}
-			if (hasDelete)
-				continue;
-
-			r = palloc(sizeof(ColumnarRowRange));
-			r->firstRowNumber = firstRow;
-			r->rowCount = rowCount;
-			ranges = lappend(ranges, r);
-		}
-		systable_endscan(gscan);
-		table_close(grel, AccessShareLock);
-		UnregisterSnapshot(snap);
-		return ranges;
-	}
-
-	ScanKeyInit(&skey[0], Anum_stripe_storage_id, BTEqualStrategyNumber,
+	ScanKeyInit(&gkey[0], Anum_row_group_storage_id, BTEqualStrategyNumber,
 				F_INT8EQ, Int64GetDatum((int64) storageId));
-	sscan = systable_beginscan(srel, InvalidOid, false, snap, 1, skey);
-	while (HeapTupleIsValid(stuple = systable_getnext(sscan)))
+	gscan = systable_beginscan(grel, InvalidOid, false, snap, 1, gkey);
+	while (HeapTupleIsValid(gtuple = systable_getnext(gscan)))
 	{
-		TransactionId xmin = HeapTupleHeaderGetXmin(stuple->t_data);
+		TransactionId xmin = HeapTupleHeaderGetXmin(gtuple->t_data);
 		bool		isnull;
-		uint64		stripeNum,
+		uint64		groupNumber,
 					firstRow,
 					rowCount;
-		int			chunkRowCount,
-					chunkGroupCount,
-					g;
-		bool	   *deleted;
 		List	   *rmList;
 		ListCell   *lc;
+		bool		hasDelete = false;
+		ColumnarRowRange *r;
 
-		/* the stripe (hence all its rows) must be visible to every snapshot */
 		if (TransactionIdIsNormal(xmin) &&
 			!TransactionIdPrecedes(xmin, oldestXmin))
 			continue;
 
-		stripeNum = (uint64) DatumGetInt64(
-			heap_getattr(stuple, Anum_stripe_stripe_num, stupdesc, &isnull));
-		chunkRowCount = DatumGetInt32(
-			heap_getattr(stuple, Anum_stripe_chunk_row_count, stupdesc, &isnull));
+		groupNumber = (uint64) DatumGetInt64(
+			heap_getattr(gtuple, Anum_row_group_group_number, gtd, &isnull));
 		rowCount = (uint64) DatumGetInt64(
-			heap_getattr(stuple, Anum_stripe_row_count, stupdesc, &isnull));
-		chunkGroupCount = DatumGetInt32(
-			heap_getattr(stuple, Anum_stripe_chunk_group_count, stupdesc, &isnull));
+			heap_getattr(gtuple, Anum_row_group_row_count, gtd, &isnull));
 		firstRow = (uint64) DatumGetInt64(
-			heap_getattr(stuple, Anum_stripe_first_row_number, stupdesc, &isnull));
-
-		if (chunkGroupCount <= 0 || chunkRowCount <= 0)
+			heap_getattr(gtuple, Anum_row_group_first_row_number, gtd, &isnull));
+		if (rowCount == 0)
 			continue;
 
-		/* mark groups that have any delete (committed or in progress) */
-		deleted = palloc0(sizeof(bool) * chunkGroupCount);
-		rmList = ColumnarReadRowMaskList(storageId, stripeNum, &dirty);
+		rmList = ColumnarReadRowMaskList(storageId, groupNumber, &dirty);
 		foreach(lc, rmList)
 		{
-			RowMaskMetadata *rm = (RowMaskMetadata *) lfirst(lc);
-
-			if (rm->deletedRows > 0 &&
-				rm->chunkId >= 0 && rm->chunkId < chunkGroupCount)
-				deleted[rm->chunkId] = true;
+			if (((RowMaskMetadata *) lfirst(lc))->deletedRows > 0)
+			{
+				hasDelete = true;
+				break;
+			}
 		}
+		if (hasDelete)
+			continue;
 
-		for (g = 0; g < chunkGroupCount; g++)
-		{
-			uint64		gStart = firstRow + (uint64) g * (uint64) chunkRowCount;
-			uint64		gRows = rowCount - (uint64) g * (uint64) chunkRowCount;
-			ColumnarRowRange *r;
-
-			if (deleted[g])
-				continue;
-			if (gRows > (uint64) chunkRowCount)
-				gRows = (uint64) chunkRowCount;
-			if (gRows == 0)
-				continue;
-
-			r = palloc(sizeof(ColumnarRowRange));
-			r->firstRowNumber = gStart;
-			r->rowCount = gRows;
-			ranges = lappend(ranges, r);
-		}
-		pfree(deleted);
+		r = palloc(sizeof(ColumnarRowRange));
+		r->firstRowNumber = firstRow;
+		r->rowCount = rowCount;
+		ranges = lappend(ranges, r);
 	}
-	systable_endscan(sscan);
-	table_close(srel, AccessShareLock);
+	systable_endscan(gscan);
+	table_close(grel, AccessShareLock);
 	UnregisterSnapshot(snap);
 
 	return ranges;
 }
 
-List *
-ColumnarReadChunkGroupList(uint64 storageId, uint64 stripeNum, Snapshot snapshot)
-{
-	Relation	rel = open_columnar_table("chunk_group", AccessShareLock);
-	TupleDesc	tupdesc = RelationGetDescr(rel);
-	ScanKeyData key[2];
-	SysScanDesc scan;
-	HeapTuple	tuple;
-	List	   *result = NIL;
 
-	ScanKeyInit(&key[0], Anum_chunk_group_storage_id, BTEqualStrategyNumber,
-				F_INT8EQ, Int64GetDatum((int64) storageId));
-	ScanKeyInit(&key[1], Anum_chunk_group_stripe_num, BTEqualStrategyNumber,
-				F_INT8EQ, Int64GetDatum((int64) stripeNum));
-
-	scan = systable_beginscan(rel, InvalidOid, false, snapshot, 2, key);
-	while (HeapTupleIsValid(tuple = systable_getnext(scan)))
-	{
-		ChunkGroupMetadata *cg = palloc0(sizeof(ChunkGroupMetadata));
-		bool		isnull;
-
-		cg->stripeNum = stripeNum;
-		cg->chunkGroupNum = DatumGetInt32(
-			heap_getattr(tuple, Anum_chunk_group_chunk_group_num, tupdesc, &isnull));
-		cg->rowCount = (uint64) DatumGetInt64(
-			heap_getattr(tuple, Anum_chunk_group_row_count, tupdesc, &isnull));
-		cg->deletedRows = (uint64) DatumGetInt64(
-			heap_getattr(tuple, Anum_chunk_group_deleted_rows, tupdesc, &isnull));
-
-		result = lappend(result, cg);
-	}
-	systable_endscan(scan);
-	table_close(rel, AccessShareLock);
-
-	list_sort(result, chunk_group_cmp);
-	return result;
-}
-
-List *
-ColumnarReadChunkList(uint64 storageId, uint64 stripeNum, Snapshot snapshot)
-{
-	Relation	rel = open_columnar_table("chunk", AccessShareLock);
-	TupleDesc	tupdesc = RelationGetDescr(rel);
-	ScanKeyData key[2];
-	SysScanDesc scan;
-	HeapTuple	tuple;
-	List	   *result = NIL;
-
-	ScanKeyInit(&key[0], Anum_chunk_storage_id, BTEqualStrategyNumber,
-				F_INT8EQ, Int64GetDatum((int64) storageId));
-	ScanKeyInit(&key[1], Anum_chunk_stripe_num, BTEqualStrategyNumber,
-				F_INT8EQ, Int64GetDatum((int64) stripeNum));
-
-	scan = systable_beginscan(rel, InvalidOid, false, snapshot, 2, key);
-	while (HeapTupleIsValid(tuple = systable_getnext(scan)))
-	{
-		ChunkMetadata *chunk = palloc0(sizeof(ChunkMetadata));
-		bool		isnull;
-
-		chunk->stripeNum = stripeNum;
-		chunk->attrNum = DatumGetInt32(
-			heap_getattr(tuple, Anum_chunk_attr_num, tupdesc, &isnull));
-		chunk->chunkGroupNum = DatumGetInt32(
-			heap_getattr(tuple, Anum_chunk_chunk_group_num, tupdesc, &isnull));
-		chunk->valueStreamOffset = (uint64) DatumGetInt64(
-			heap_getattr(tuple, Anum_chunk_value_stream_offset, tupdesc, &isnull));
-		chunk->valueStreamLength = (uint64) DatumGetInt64(
-			heap_getattr(tuple, Anum_chunk_value_stream_length, tupdesc, &isnull));
-		chunk->existsStreamOffset = (uint64) DatumGetInt64(
-			heap_getattr(tuple, Anum_chunk_exists_stream_offset, tupdesc, &isnull));
-		chunk->existsStreamLength = (uint64) DatumGetInt64(
-			heap_getattr(tuple, Anum_chunk_exists_stream_length, tupdesc, &isnull));
-		chunk->valueCompressionType = DatumGetInt32(
-			heap_getattr(tuple, Anum_chunk_value_compression_type, tupdesc, &isnull));
-		chunk->valueCompressionLevel = DatumGetInt32(
-			heap_getattr(tuple, Anum_chunk_value_compression_level, tupdesc, &isnull));
-		chunk->valueDecompressedLength = (uint64) DatumGetInt64(
-			heap_getattr(tuple, Anum_chunk_value_decompressed_length, tupdesc, &isnull));
-		chunk->valueCount = (uint64) DatumGetInt64(
-			heap_getattr(tuple, Anum_chunk_value_count, tupdesc, &isnull));
-
-		/*
-		 * Value-stream encoding (I1, format 2.1). Format 2.0 chunks predate
-		 * these columns; a NULL encoding type means NONE, and the raw length
-		 * then equals the decompressed length.
-		 */
-		{
-			bool		encNull;
-			bool		rawNull;
-			Datum		encDatum = heap_getattr(tuple, Anum_chunk_value_encoding_type,
-												tupdesc, &encNull);
-			Datum		rawDatum = heap_getattr(tuple, Anum_chunk_value_raw_length,
-												tupdesc, &rawNull);
-
-			chunk->valueEncodingType = encNull ? COLUMNAR_ENCODING_NONE
-				: DatumGetInt32(encDatum);
-			chunk->valueRawLength = rawNull ? chunk->valueDecompressedLength
-				: (uint64) DatumGetInt64(rawDatum);
-		}
-
-		/* optional per-chunk bloom filter (I7) */
-		{
-			bool		bloomNull;
-			Datum		bloomDatum = heap_getattr(tuple, Anum_chunk_bloom_filter,
-												  tupdesc, &bloomNull);
-
-			if (!bloomNull)
-			{
-				bytea	   *bl = DatumGetByteaP(bloomDatum);
-
-				chunk->bloomLen = VARSIZE(bl) >= VARHDRSZ ?
-					(uint32) (VARSIZE(bl) - VARHDRSZ) : 0;
-				chunk->bloomFilter = palloc(chunk->bloomLen + 1);
-				memcpy(chunk->bloomFilter, VARDATA(bl), chunk->bloomLen);
-			}
-		}
-
-		/* min/max skip list (spec 7.2), decoded on demand by the reader */
-		{
-			bool		minNull;
-			bool		maxNull;
-			Datum		minDatum = heap_getattr(tuple, Anum_chunk_minimum_value,
-												tupdesc, &minNull);
-			Datum		maxDatum = heap_getattr(tuple, Anum_chunk_maximum_value,
-												tupdesc, &maxNull);
-
-			if (!minNull && !maxNull)
-			{
-				bytea	   *minb = DatumGetByteaP(minDatum);
-				bytea	   *maxb = DatumGetByteaP(maxDatum);
-
-				chunk->minEncodedLen = VARSIZE(minb) >= VARHDRSZ ?
-					(uint32) (VARSIZE(minb) - VARHDRSZ) : 0;
-				chunk->minEncoded = palloc(chunk->minEncodedLen + 1);
-				memcpy(chunk->minEncoded, VARDATA(minb), chunk->minEncodedLen);
-
-				chunk->maxEncodedLen = VARSIZE(maxb) >= VARHDRSZ ?
-					(uint32) (VARSIZE(maxb) - VARHDRSZ) : 0;
-				chunk->maxEncoded = palloc(chunk->maxEncodedLen + 1);
-				memcpy(chunk->maxEncoded, VARDATA(maxb), chunk->maxEncodedLen);
-
-				chunk->minMaxValid = true;
-			}
-		}
-
-		result = lappend(result, chunk);
-	}
-	systable_endscan(scan);
-	table_close(rel, AccessShareLock);
-
-	return result;
-}
 
 /*
  * ColumnarReadRowMaskList
@@ -1054,10 +592,7 @@ delete_rows_by_storage_id(const char *tableName, AttrNumber storageAttno,
 void
 ColumnarDeleteMetadata(uint64 storageId)
 {
-	delete_rows_by_storage_id("chunk", Anum_chunk_storage_id, storageId);
-	delete_rows_by_storage_id("chunk_group", Anum_chunk_group_storage_id, storageId);
 	delete_rows_by_storage_id("row_mask", Anum_row_mask_storage_id, storageId);
-	delete_rows_by_storage_id("stripe", Anum_stripe_storage_id, storageId);
 	/* native format catalog (PGCN v1); no-op rows for 2.2-line tables */
 	delete_rows_by_storage_id("column_chunk", Anum_column_chunk_storage_id, storageId);
 	delete_rows_by_storage_id("zone_map", Anum_zone_map_storage_id, storageId);
@@ -1140,61 +675,6 @@ ColumnarInsertNativeStorageRow(const NativeStorageMetadata *s)
 	CatalogTupleInsert(rel, tuple);
 	heap_freetuple(tuple);
 	table_close(rel, RowExclusiveLock);
-}
-
-/*
- * ColumnarStorageIsNative
- *		True when the storage id has a native (PGCN v1) storage catalog row, i.e.
- *		native data has been written for it. This is the ground truth of a
- *		storage's on-disk format: the native writer records a storage row, the 2.2
- *		writer does not. The reader derives isNative from this (so a native base
- *		table's 2.2 projection storage is read as 2.2, and the D6 default flip needs
- *		no reader change). Callers must have flushed pending writes first, as the
- *		read paths do, so a just-written native storage is visible.
- */
-bool
-ColumnarStorageIsNative(uint64 storageId, Snapshot snapshot)
-{
-	Relation	rel = open_columnar_table("storage", AccessShareLock);
-	ScanKeyData key[1];
-	SysScanDesc scan;
-	bool		found;
-
-	ScanKeyInit(&key[0], Anum_native_storage_storage_id, BTEqualStrategyNumber,
-				F_INT8EQ, Int64GetDatum((int64) storageId));
-	scan = systable_beginscan(rel, InvalidOid, false, snapshot, 1, key);
-	found = HeapTupleIsValid(systable_getnext(scan));
-	systable_endscan(scan);
-	table_close(rel, AccessShareLock);
-
-	return found;
-}
-
-/*
- * ColumnarStorageHasStripes
- *		True when the storage id has at least one 2.2 stripe row, i.e. 2.2 data
- *		has been written for it. This is the 2.2 counterpart of
- *		ColumnarStorageIsNative. The writer uses the pair to anchor to the format
- *		already on disk: once a storage has 2.2 stripes it keeps writing 2.2 even
- *		if the default GUC now says native, so the D6 default flip never rewrites
- *		an existing table in a different format.
- */
-bool
-ColumnarStorageHasStripes(uint64 storageId, Snapshot snapshot)
-{
-	Relation	rel = open_columnar_table("stripe", AccessShareLock);
-	ScanKeyData key[1];
-	SysScanDesc scan;
-	bool		found;
-
-	ScanKeyInit(&key[0], Anum_stripe_storage_id, BTEqualStrategyNumber,
-				F_INT8EQ, Int64GetDatum((int64) storageId));
-	scan = systable_beginscan(rel, InvalidOid, false, snapshot, 1, key);
-	found = HeapTupleIsValid(systable_getnext(scan));
-	systable_endscan(scan);
-	table_close(rel, AccessShareLock);
-
-	return found;
 }
 
 void
@@ -1747,12 +1227,6 @@ ColumnarReadOptions(Oid relid, ColumnarOptions *opts)
 			}
 		}
 
-		d = heap_getattr(tuple, Anum_options_format_version, tupdesc, &isnull);
-		if (!isnull)
-		{
-			opts->formatVersionSet = true;
-			opts->formatVersion = DatumGetInt32(d);
-		}
 	}
 	systable_endscan(scan);
 	table_close(rel, AccessShareLock);
@@ -1760,23 +1234,6 @@ ColumnarReadOptions(Oid relid, ColumnarOptions *opts)
 	return found;
 }
 
-/*
- * ColumnarTableFormatVersion
- *		The on-disk format a relation's writes use: 0 for the 1.0-dev line
- *		(format 2.2), or the native major version (1, PGCN v1). A table's own
- *		format_version option wins; absent that, the instance default GUC
- *		(pgcolumnar.default_format_version) decides. The native writer consults
- *		this to choose the layout.
- */
-int
-ColumnarTableFormatVersion(Oid relid)
-{
-	ColumnarOptions opts;
-
-	if (ColumnarReadOptions(relid, &opts) && opts.formatVersionSet)
-		return opts.formatVersion;
-	return columnar_default_format_version;
-}
 
 /*
  * ColumnarDeleteOptions

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -68,8 +68,6 @@ struct ColumnarReadState
 	SkipPredicate *predicates;		/* [numPredicates], in readContext */
 	int			numPredicates;
 
-	List	   *stripeList;			/* list of StripeMetadata* */
-	int			stripeIndex;		/* next stripe to load */
 	bool		started;
 	bool		exhausted;
 
@@ -77,45 +75,26 @@ struct ColumnarReadState
 
 	/*
 	 * Parallel scan work claiming (gap 23). When non-NULL, this shared atomic
-	 * hands out the next stripe index across all workers; each worker scans the
-	 * whole stripes it claims. NULL for a serial scan, which walks stripeIndex.
+	 * hands out the next row group across all workers; each worker scans the row
+	 * groups it claims. NULL for a serial scan, which walks rowGroupIndex.
 	 */
 	pg_atomic_uint32 *parallelCounter;
 
-	/* current stripe decode state (in stripeContext) */
-	StripeMetadata *stripe;
-	char	   *stripeBuffer;
-	List	   *chunkGroupList;		/* ChunkGroupMetadata* */
-	ChunkMetadata ***chunkMap;		/* [natts][chunkGroupCount] */
-	int			chunkGroupCount;
-	int			groupIndex;
+	/* current group row count and position, shared by the native producer */
 	uint64		groupRowCount;
 	uint64		rowInGroup;
-	uint64		rowOffsetInStripe;	/* rows before the current group */
-	char	  **valueCursor;		/* [natts]; decompressed value stream */
-	char	  **existsBase;			/* [natts]; into the raw stripe buffer */
-
-	/* row mask (spec 7.5): per chunk group, the delete bitmap or NULL */
-	char	  **groupMask;			/* [chunkGroupCount] */
-	uint32	   *groupMaskLen;		/* [chunkGroupCount] */
-	char	   *currentMask;		/* mask of the current group, or NULL */
-	uint32		currentMaskLen;
 
 	/* chunk-group skip counters over the groups reached so far (spec 9) */
 	uint64		groupsRead;
 	uint64		groupsSkipped;
 
 	/*
-	 * Native format (re-origination line, PGCN v1) read state (Phase D3). When
-	 * isNative, the scan reads row groups and column chunks from the native
-	 * catalog instead of stripes/chunks. The current row group's bytes are read
+	 * Native format (PGCN v1) read state. The scan reads row groups and column
+	 * chunks from the native catalog. The current row group's bytes are read
 	 * whole into nativeBuffer (in groupContext); nativeValidity[c] points at each
 	 * column chunk's validity bitmap and nativeValueCursor[c] advances through its
-	 * uncompressed values. Sequential scan only: skip predicates, the vectorized
-	 * path, projection pushdown, and parallel scan are bypassed for native tables
-	 * in D3 (correctness-neutral optimizations for later).
+	 * uncompressed values.
 	 */
-	bool		isNative;
 	List	   *rowGroupList;		/* NativeRowGroupMetadata* */
 	int			rowGroupIndex;		/* next row group to load */
 	NativeRowGroupMetadata *nativeGroup;
@@ -154,14 +133,6 @@ struct ColumnarReadState
 	MemoryContext skipContext;		/* scratch for skip-list evaluation */
 };
 
-static void columnar_load_stripe(ColumnarReadState *readState,
-								 StripeMetadata *stripe);
-static bool columnar_advance_group(ColumnarReadState *readState);
-static int	columnar_next_stripe_index(ColumnarReadState *readState);
-static void columnar_setup_group(ColumnarReadState *readState, int groupIndex);
-static bool columnar_position_group(ColumnarReadState *readState);
-static bool columnar_group_can_match(ColumnarReadState *readState, int groupIndex);
-static bool columnar_is_projected(ColumnarReadState *readState, int attidx);
 static void columnar_build_predicates(ColumnarReadState *readState,
 									  int nkeys, ScanKey keys);
 static int64 columnar_next_group_index(ColumnarReadState *readState);
@@ -301,22 +272,10 @@ ColumnarBeginReadWithStorage(Relation rel, Snapshot snapshot,
 							   &readState->missingIsnull[mc]);
 	}
 
-	/*
-	 * The storage being read is native iff it has a native storage catalog row
-	 * (D6a). This is the storage's own format, not the base table's option, so a
-	 * native base table's 2.2 projection storage is correctly read as 2.2, and the
-	 * D6 default flip needs no change here (the reader follows the data). Read
-	 * paths flush pending writes first, so a just-written native storage is seen.
-	 */
-	readState->isNative =
-		ColumnarStorageIsNative(storageId, readState->metaSnapshot);
 	readState->projectedColumns = bms_copy(projectedColumns);
-	readState->stripeList = NIL;
-	readState->stripeIndex = 0;
 	readState->started = false;
 	readState->exhausted = false;
 	readState->parallelScan = parallelScan;
-	readState->stripe = NULL;
 	readState->readContext = readContext;
 	readState->stripeContext = AllocSetContextCreate(readContext,
 													 "columnar read stripe",
@@ -338,17 +297,6 @@ ColumnarBeginReadWithStorage(Relation rel, Snapshot snapshot,
 	return readState;
 }
 
-/*
- * columnar_is_projected
- *		Whether a 0-based column should be decoded. A NULL projection set means
- *		all columns are projected (the plain sequential-scan default).
- */
-static bool
-columnar_is_projected(ColumnarReadState *readState, int attidx)
-{
-	return readState->projectedColumns == NULL ||
-		bms_is_member(attidx, readState->projectedColumns);
-}
 
 /*
  * columnar_build_predicates
@@ -436,98 +384,6 @@ columnar_build_predicates(ColumnarReadState *readState, int nkeys, ScanKey keys)
  *		return of false means the group can be skipped. Missing min/max, or a
  *		non-orderable column, is treated conservatively as "may match".
  */
-static bool
-columnar_group_can_match(ColumnarReadState *readState, int groupIndex)
-{
-	int			p;
-
-	if (readState->numPredicates == 0)
-		return true;
-
-	MemoryContextReset(readState->skipContext);
-
-	for (p = 0; p < readState->numPredicates; p++)
-	{
-		SkipPredicate *pred = &readState->predicates[p];
-		ChunkMetadata *m = readState->chunkMap[pred->attidx][groupIndex];
-		Form_pg_attribute att = TupleDescAttr(readState->tupdesc, pred->attidx);
-		char	   *cur;
-		Datum		minv;
-		Datum		maxv;
-		int32		c1;
-		int32		c2;
-
-		if (m == NULL || !m->minMaxValid)
-			continue;			/* cannot prove empty; keep the group */
-
-		cur = m->minEncoded;
-		minv = ColumnarDecodeValue(att, &cur, readState->skipContext);
-		cur = m->maxEncoded;
-		maxv = ColumnarDecodeValue(att, &cur, readState->skipContext);
-
-		switch (pred->strategy)
-		{
-			case BTLessStrategyNumber:	/* col < const : skip if min >= const */
-				c1 = DatumGetInt32(FunctionCall2Coll(&pred->cmpFn,
-													 pred->collation,
-													 minv, pred->compareValue));
-				if (c1 >= 0)
-					return false;
-				break;
-			case BTLessEqualStrategyNumber: /* col <= const : skip if min > const */
-				c1 = DatumGetInt32(FunctionCall2Coll(&pred->cmpFn,
-													 pred->collation,
-													 minv, pred->compareValue));
-				if (c1 > 0)
-					return false;
-				break;
-			case BTEqualStrategyNumber: /* col = const : skip if const<min or >max */
-				c1 = DatumGetInt32(FunctionCall2Coll(&pred->cmpFn,
-													 pred->collation,
-													 pred->compareValue, minv));
-				c2 = DatumGetInt32(FunctionCall2Coll(&pred->cmpFn,
-													 pred->collation,
-													 pred->compareValue, maxv));
-				if (c1 < 0 || c2 > 0)
-					return false;
-
-				/*
-				 * min/max did not rule the group out; consult the bloom filter
-				 * (I7). If the value is provably absent, skip the group -- this
-				 * is what prunes equality probes on unsorted columns.
-				 */
-				if (columnar_enable_bloom_filter && pred->hasHash &&
-					m->bloomFilter != NULL)
-				{
-					uint32		h = DatumGetUInt32(
-						FunctionCall1Coll(&pred->hashFn, pred->hashCollation,
-										  pred->compareValue));
-
-					if (!ColumnarBloomProbe(m->bloomFilter, m->bloomLen, h))
-						return false;
-				}
-				break;
-			case BTGreaterEqualStrategyNumber:	/* col >= const : skip if max<const */
-				c2 = DatumGetInt32(FunctionCall2Coll(&pred->cmpFn,
-													 pred->collation,
-													 maxv, pred->compareValue));
-				if (c2 < 0)
-					return false;
-				break;
-			case BTGreaterStrategyNumber:	/* col > const : skip if max<=const */
-				c2 = DatumGetInt32(FunctionCall2Coll(&pred->cmpFn,
-													 pred->collation,
-													 maxv, pred->compareValue));
-				if (c2 <= 0)
-					return false;
-				break;
-			default:
-				break;
-		}
-	}
-
-	return true;
-}
 
 /*
  * columnar_setup_group
@@ -536,73 +392,6 @@ columnar_group_can_match(ColumnarReadState *readState, int groupIndex)
  *		decompressed bytes and the (uncompressed) exists bytes. Non-projected
  *		columns are left un-decoded (column projection, spec 9).
  */
-static void
-columnar_setup_group(ColumnarReadState *readState, int groupIndex)
-{
-	ChunkGroupMetadata *cg = list_nth(readState->chunkGroupList, groupIndex);
-	int			c;
-
-	readState->groupRowCount = cg->rowCount;
-	readState->rowInGroup = 0;
-
-	/* the delete bitmap for this chunk group, if any (spec 7.5) */
-	readState->currentMask = readState->groupMask[groupIndex];
-	readState->currentMaskLen = readState->groupMaskLen[groupIndex];
-
-	MemoryContextReset(readState->groupContext);
-
-	for (c = 0; c < readState->natts; c++)
-	{
-		ChunkMetadata *m = readState->chunkMap[c][groupIndex];
-
-		/*
-		 * A NULL chunk means this column did not exist when the stripe was
-		 * written (ALTER TABLE ADD COLUMN, spec 6). Mark the column absent for
-		 * this group; the row/vector producers substitute the missing value.
-		 */
-		if (m == NULL)
-		{
-			readState->existsBase[c] = NULL;
-			readState->valueCursor[c] = NULL;
-			continue;
-		}
-
-		/* the stream offsets come from the catalog; reject any that fall outside
-		 * the stripe buffer before they are used to index it */
-		if ((uint64) m->existsStreamOffset + readState->groupRowCount >
-			readState->stripe->dataLength ||
-			(uint64) m->valueStreamOffset + m->valueStreamLength >
-			readState->stripe->dataLength)
-			ereport(ERROR,
-					(errcode(ERRCODE_DATA_CORRUPTED),
-					 errmsg("columnar: corrupt chunk stream offset in stripe")));
-
-		readState->existsBase[c] = readState->stripeBuffer + m->existsStreamOffset;
-
-		if (columnar_is_projected(readState, c))
-		{
-			Form_pg_attribute att = TupleDescAttr(readState->tupdesc, c);
-			char	   *decompressed =
-				ColumnarGetDecompressedStream(readState->storageId,
-											  readState->stripe->fileOffset +
-											  m->valueStreamOffset,
-											  readState->stripeBuffer +
-											  m->valueStreamOffset,
-											  m->valueStreamLength,
-											  m->valueCompressionType,
-											  m->valueDecompressedLength,
-											  readState->groupContext);
-
-			/* reverse the lightweight encoding to the raw value stream (I1) */
-			readState->valueCursor[c] =
-				ColumnarDecodeChunk(decompressed, m->valueDecompressedLength,
-									m->valueEncodingType, att, m->valueCount,
-									m->valueRawLength, readState->groupContext);
-		}
-		else
-			readState->valueCursor[c] = NULL;
-	}
-}
 
 /*
  * columnar_position_group
@@ -611,116 +400,12 @@ columnar_setup_group(ColumnarReadState *readState, int groupIndex)
  *		them out (spec 9). Returns true when positioned on a readable group,
  *		false when the stripe has no more matching groups.
  */
-static bool
-columnar_position_group(ColumnarReadState *readState)
-{
-	while (readState->groupIndex < readState->chunkGroupCount)
-	{
-		int			g = readState->groupIndex;
-
-		if (columnar_group_can_match(readState, g))
-		{
-			readState->groupsRead++;
-			columnar_setup_group(readState, g);
-			return true;
-		}
-
-		/* skip this group: account for its rows and move on */
-		{
-			ChunkGroupMetadata *cg = list_nth(readState->chunkGroupList, g);
-
-			readState->rowOffsetInStripe += cg->rowCount;
-		}
-		readState->groupsSkipped++;
-		readState->groupIndex++;
-	}
-
-	return false;
-}
 
 /*
  * columnar_load_stripe
  *		Read a stripe's metadata and data into memory and position at its
  *		first chunk group.
  */
-static void
-columnar_load_stripe(ColumnarReadState *readState, StripeMetadata *stripe)
-{
-	MemoryContext oldContext;
-	List	   *chunkList;
-	ListCell   *lc;
-	int			natts = readState->natts;
-	int			c;
-
-	MemoryContextReset(readState->stripeContext);
-	oldContext = MemoryContextSwitchTo(readState->stripeContext);
-
-	readState->stripe = stripe;
-	readState->chunkGroupCount = stripe->chunkGroupCount;
-	readState->groupIndex = 0;
-	readState->rowOffsetInStripe = 0;
-
-	readState->chunkGroupList = ColumnarReadChunkGroupList(readState->storageId,
-														   stripe->stripeNum,
-														   readState->metaSnapshot);
-	chunkList = ColumnarReadChunkList(readState->storageId, stripe->stripeNum,
-									  readState->metaSnapshot);
-
-	/* index chunks by (attr, chunk group) */
-	readState->chunkMap = palloc0(sizeof(ChunkMetadata **) * natts);
-	for (c = 0; c < natts; c++)
-		readState->chunkMap[c] = palloc0(sizeof(ChunkMetadata *) *
-										 readState->chunkGroupCount);
-
-	foreach(lc, chunkList)
-	{
-		ChunkMetadata *m = (ChunkMetadata *) lfirst(lc);
-
-		/* reject corrupt catalog attr/group numbers before indexing */
-		if (m->attrNum >= 1 && m->attrNum <= natts &&
-			m->chunkGroupNum >= 0 &&
-			m->chunkGroupNum < readState->chunkGroupCount)
-			readState->chunkMap[m->attrNum - 1][m->chunkGroupNum] = m;
-	}
-
-	readState->valueCursor = palloc0(sizeof(char *) * natts);
-	readState->existsBase = palloc0(sizeof(char *) * natts);
-
-	/*
-	 * Load the row mask for this stripe (spec 7.5) and index it by chunk-group
-	 * number, so deleted rows can be skipped during the scan. A NULL entry
-	 * means the chunk group has no deletes.
-	 */
-	readState->groupMask = palloc0(sizeof(char *) * readState->chunkGroupCount);
-	readState->groupMaskLen = palloc0(sizeof(uint32) * readState->chunkGroupCount);
-	{
-		List	   *rowMaskList = ColumnarReadRowMaskList(readState->storageId,
-														  stripe->stripeNum,
-														  readState->metaSnapshot);
-		ListCell   *mlc;
-
-		foreach(mlc, rowMaskList)
-		{
-			RowMaskMetadata *rm = (RowMaskMetadata *) lfirst(mlc);
-
-			if (rm->chunkId >= 0 && rm->chunkId < readState->chunkGroupCount &&
-				rm->mask != NULL)
-			{
-				readState->groupMask[rm->chunkId] = rm->mask;
-				readState->groupMaskLen[rm->chunkId] = rm->maskLen;
-			}
-		}
-	}
-
-	/* read the stripe's data area into a contiguous buffer */
-	readState->stripeBuffer = palloc(stripe->dataLength);
-	ColumnarReadLogicalData(readState->rel, stripe->fileOffset,
-							readState->stripeBuffer, stripe->dataLength);
-
-	/* the caller positions on the first matching group via columnar_position_group */
-
-	MemoryContextSwitchTo(oldContext);
-}
 
 /*
  * columnar_read_start
@@ -750,19 +435,10 @@ columnar_read_start(ColumnarReadState *readState)
 	{
 		MemoryContext oldContext = MemoryContextSwitchTo(readState->readContext);
 
-		if (readState->isNative)
-		{
-			readState->rowGroupList =
-				ColumnarReadRowGroupList(readState->storageId,
-										 readState->metaSnapshot);
-			readState->rowGroupIndex = 0;
-		}
-		else
-		{
-			readState->stripeList = ColumnarReadStripeList(readState->storageId,
-														   readState->metaSnapshot);
-			readState->stripeIndex = 0;
-		}
+		readState->rowGroupList =
+			ColumnarReadRowGroupList(readState->storageId,
+									 readState->metaSnapshot);
+		readState->rowGroupIndex = 0;
 		MemoryContextSwitchTo(oldContext);
 	}
 }
@@ -1377,288 +1053,7 @@ ColumnarReadNextRow(ColumnarReadState *readState, Datum *values, bool *nulls,
 					uint64 *rowNumber)
 {
 	columnar_read_start(readState);
-
-	if (readState->isNative)
-		return columnar_native_next_row(readState, values, nulls, rowNumber);
-
-	for (;;)
-	{
-		if (readState->exhausted)
-			return false;
-
-		if (readState->stripe == NULL)
-		{
-			int			si = columnar_next_stripe_index(readState);
-
-			if (si < 0)
-			{
-				readState->exhausted = true;
-				return false;
-			}
-
-			columnar_load_stripe(readState,
-								 list_nth(readState->stripeList, si));
-
-			readState->groupIndex = 0;
-			if (!columnar_position_group(readState))
-			{
-				readState->stripe = NULL;
-				continue;
-			}
-		}
-
-		if (readState->rowInGroup >= readState->groupRowCount)
-		{
-			readState->rowOffsetInStripe += readState->groupRowCount;
-			readState->groupIndex++;
-
-			if (!columnar_position_group(readState))
-			{
-				readState->stripe = NULL;
-				continue;
-			}
-		}
-
-		/* produce the current row */
-		MemoryContextReset(readState->rowContext);
-
-		{
-			int			c;
-
-			for (c = 0; c < readState->natts; c++)
-			{
-				char		exists;
-
-				/*
-				 * A value still has to be consumed from the stream even for a
-				 * present row so the cursor stays aligned; but for a column
-				 * that is not projected we never decoded it, so return NULL.
-				 */
-				if (!columnar_is_projected(readState, c))
-				{
-					values[c] = (Datum) 0;
-					nulls[c] = true;
-					continue;
-				}
-
-				/*
-				 * Column absent from this stripe (added by ALTER TABLE ADD
-				 * COLUMN after it was written): produce the missing value
-				 * (spec 6).
-				 */
-				if (readState->existsBase[c] == NULL)
-				{
-					values[c] = readState->missingValues[c];
-					nulls[c] = readState->missingIsnull[c];
-					continue;
-				}
-
-				exists = readState->existsBase[c][readState->rowInGroup];
-
-				if (exists)
-				{
-					Form_pg_attribute att = TupleDescAttr(readState->tupdesc, c);
-
-					values[c] = ColumnarDecodeValue(att, &readState->valueCursor[c],
-													readState->rowContext);
-					nulls[c] = false;
-				}
-				else
-				{
-					values[c] = (Datum) 0;
-					nulls[c] = true;
-				}
-			}
-		}
-
-		*rowNumber = readState->stripe->firstRowNumber +
-			readState->rowOffsetInStripe + readState->rowInGroup;
-
-		/*
-		 * If this row is marked deleted in the row mask (spec 7.5), skip it.
-		 * The value cursors were already advanced above, so the stream stays
-		 * aligned for the following rows.
-		 */
-		{
-			uint64		bitIndex = readState->rowInGroup;
-			bool		deleted = false;
-
-			if (readState->currentMask != NULL &&
-				(bitIndex >> 3) < readState->currentMaskLen)
-				deleted = (readState->currentMask[bitIndex >> 3] &
-						   (1 << (bitIndex & 7))) != 0;
-
-			readState->rowInGroup++;
-
-			if (deleted)
-				continue;
-		}
-
-		return true;
-	}
-}
-
-/*
- * columnar_decode_group_to_vector
- *		Decode the chunk group the read state is currently positioned on into
- *		flat per-column arrays, plus the per-row deleted flag from the row mask.
- *		Each projected column is decoded in a tight loop over the whole group;
- *		non-projected columns are left as NULL arrays. Everything is allocated in
- *		the group context, which the next group's setup resets, so the batch is
- *		valid only until the following ColumnarReadNextVector call.
- */
-static void
-columnar_decode_group_columns(ColumnarReadState *readState, ColumnarVector *vec,
-							  Bitmapset *cols, bool init, const bool *sel)
-{
-	MemoryContext oldContext = MemoryContextSwitchTo(readState->groupContext);
-	int			natts = readState->natts;
-	uint64		nrows = readState->groupRowCount;
-	int			c;
-	uint64		i;
-
-	/*
-	 * On the first call for a group, allocate the vector and resolve the
-	 * per-row deleted flags; later calls decode more columns into the same
-	 * vector (late materialization, I8). Only columns in `cols` are decoded
-	 * (all projected columns when cols is NULL), and a column already decoded
-	 * is skipped.
-	 */
-	if (init)
-	{
-		vec->nrows = nrows;
-		vec->firstRowNumber = readState->stripe->firstRowNumber +
-			readState->rowOffsetInStripe;
-		vec->values = palloc0(sizeof(Datum *) * natts);
-		vec->isnull = palloc0(sizeof(bool *) * natts);
-		vec->deleted = palloc0(sizeof(bool) * (nrows == 0 ? 1 : nrows));
-
-		for (i = 0; i < nrows; i++)
-		{
-			bool		deleted = false;
-
-			if (readState->currentMask != NULL &&
-				(i >> 3) < readState->currentMaskLen)
-				deleted = (readState->currentMask[i >> 3] & (1 << (i & 7))) != 0;
-
-			vec->deleted[i] = deleted;
-		}
-	}
-
-	for (c = 0; c < natts; c++)
-	{
-		Datum	   *vals;
-		bool	   *nulls;
-		char	   *cursor;
-		char	   *existsBase;
-		Form_pg_attribute att;
-
-		if (!columnar_is_projected(readState, c))
-			continue;
-		if (cols != NULL && !bms_is_member(c, cols))
-			continue;
-		if (vec->values[c] != NULL)
-			continue;			/* already decoded for this group */
-
-		vals = palloc(sizeof(Datum) * (nrows == 0 ? 1 : nrows));
-		nulls = palloc(sizeof(bool) * (nrows == 0 ? 1 : nrows));
-		cursor = readState->valueCursor[c];
-		existsBase = readState->existsBase[c];
-		att = TupleDescAttr(readState->tupdesc, c);
-
-		/*
-		 * Column absent from this stripe (added by ALTER TABLE ADD COLUMN
-		 * after it was written): fill the whole group with the missing value
-		 * (spec 6).
-		 */
-		if (existsBase == NULL)
-		{
-			for (i = 0; i < nrows; i++)
-			{
-				vals[i] = readState->missingValues[c];
-				nulls[i] = readState->missingIsnull[c];
-			}
-			vec->values[c] = vals;
-			vec->isnull[c] = nulls;
-			continue;
-		}
-
-		for (i = 0; i < nrows; i++)
-		{
-			if (existsBase[i])
-			{
-				if (sel == NULL || sel[i])
-				{
-					vals[i] = ColumnarDecodeValue(att, &cursor,
-												  readState->groupContext);
-					nulls[i] = false;
-				}
-				else
-				{
-					/*
-					 * Position-list late materialization (gap 22): a present but
-					 * unselected value is skipped -- advance the cursor past it
-					 * without copying it (the win for by-ref/varlena output
-					 * columns). The slot is never read (sel[i] is false).
-					 */
-					cursor += (att->attlen > 0) ? att->attlen
-						: (int) VARSIZE_ANY(cursor);
-					vals[i] = (Datum) 0;
-					nulls[i] = true;
-				}
-			}
-			else
-			{
-				vals[i] = (Datum) 0;
-				nulls[i] = true;
-			}
-		}
-
-		vec->values[c] = vals;
-		vec->isnull[c] = nulls;
-	}
-
-	MemoryContextSwitchTo(oldContext);
-}
-
-/* decode all projected columns of the current group (the common path) */
-static void
-columnar_decode_group_to_vector(ColumnarReadState *readState, ColumnarVector *vec)
-{
-	columnar_decode_group_columns(readState, vec, NULL, true, NULL);
-}
-
-/*
- * ColumnarAdvanceGroup / ColumnarDecodeGroupColumns
- *		Public split of "position on the next group" from "decode its columns",
- *		so a scan can decode only the predicate columns, filter, and decode the
- *		remaining output columns only when the group has surviving rows (late
- *		materialization, I8). Pass cols = NULL to decode every projected column.
- */
-bool
-ColumnarAdvanceGroup(ColumnarReadState *readState)
-{
-	return columnar_advance_group(readState);
-}
-
-/*
- * columnar_next_stripe_index
- *		The next stripe to scan, or -1 when none remain. A parallel scan claims
- *		it from the shared atomic (each worker gets distinct stripes); a serial
- *		scan walks stripeIndex (gap 23).
- */
-static int
-columnar_next_stripe_index(ColumnarReadState *readState)
-{
-	int			nstripes = list_length(readState->stripeList);
-	uint32		si;
-
-	if (readState->parallelCounter != NULL)
-		si = pg_atomic_fetch_add_u32(readState->parallelCounter, 1);
-	else
-		si = (uint32) readState->stripeIndex++;
-
-	return (si < (uint32) nstripes) ? (int) si : -1;
+	return columnar_native_next_row(readState, values, nulls, rowNumber);
 }
 
 /*
@@ -1689,159 +1084,13 @@ ColumnarReadSetParallelCounter(ColumnarReadState *readState,
 	readState->parallelCounter = counter;
 }
 
-void
-ColumnarDecodeGroupColumns(ColumnarReadState *readState, ColumnarVector *vec,
-						   Bitmapset *cols, bool init, const bool *sel)
-{
-	columnar_decode_group_columns(readState, vec, cols, init, sel);
-}
-
-/*
- * ColumnarReadNextVector
- *		Advance to the next chunk group that survives min/max skipping and decode
- *		it into a ColumnarVector (spec 9). Returns false at end of scan. This
- *		drives the same stripe/group state machine as ColumnarReadNextRow, so it
- *		reads exactly the same groups (including chunk-group skipping and the row
- *		mask) but hands back a whole group at a time for vectorized processing.
- */
-/*
- * columnar_advance_group
- *		Drive the stripe/group state machine to the next chunk group that
- *		survives min/max skipping (spec 9), loading stripes as needed. Returns
- *		true when positioned on a readable group (readState->groupIndex), false
- *		when the scan is exhausted. Shared by the vector and raw-group readers.
- */
-static bool
-columnar_advance_group(ColumnarReadState *readState)
-{
-	columnar_read_start(readState);
-
-	for (;;)
-	{
-		if (readState->exhausted)
-			return false;
-
-		if (readState->stripe == NULL)
-		{
-			int			si = columnar_next_stripe_index(readState);
-
-			if (si < 0)
-			{
-				readState->exhausted = true;
-				return false;
-			}
-
-			columnar_load_stripe(readState,
-								 list_nth(readState->stripeList, si));
-			readState->groupIndex = 0;
-
-			if (!columnar_position_group(readState))
-			{
-				readState->stripe = NULL;
-				continue;
-			}
-		}
-		else
-		{
-			/* the previous call delivered this group; advance to the next */
-			readState->rowOffsetInStripe += readState->groupRowCount;
-			readState->groupIndex++;
-
-			if (!columnar_position_group(readState))
-			{
-				readState->stripe = NULL;
-				continue;
-			}
-		}
-
-		return true;
-	}
-}
-
-bool
-ColumnarReadNextVector(ColumnarReadState *readState, ColumnarVector *vec)
-{
-	if (!columnar_advance_group(readState))
-		return false;
-
-	columnar_decode_group_to_vector(readState, vec);
-	return true;
-}
-
-/*
- * ColumnarReadNextRawGroup
- *		Advance to the next readable chunk group and expose each projected
- *		column's raw value stream (packed non-null values) without decoding to
- *		Datums, for the aggregate's compressed-execution run path (I3).
- */
-bool
-ColumnarReadNextRawGroup(ColumnarReadState *readState, ColumnarRawGroup *rg)
-{
-	MemoryContext oldContext;
-	int			natts = readState->natts;
-	int			c;
-	uint64		i;
-
-	if (!columnar_advance_group(readState))
-		return false;
-
-	oldContext = MemoryContextSwitchTo(readState->groupContext);
-
-	rg->nrows = readState->groupRowCount;
-	rg->firstRowNumber = readState->stripe->firstRowNumber +
-		readState->rowOffsetInStripe;
-	rg->natts = natts;
-	rg->valueCursor = palloc0(sizeof(char *) * natts);
-	rg->groupValueCount = palloc0(sizeof(uint64) * natts);
-	rg->columnAbsent = palloc0(sizeof(bool) * natts);
-
-	for (c = 0; c < natts; c++)
-	{
-		ChunkMetadata *m = readState->chunkMap[c][readState->groupIndex];
-
-		if (m == NULL)
-		{
-			rg->columnAbsent[c] = true;
-			continue;
-		}
-		rg->valueCursor[c] = readState->valueCursor[c];
-		rg->groupValueCount[c] = m->valueCount;
-	}
-
-	/* how many of this group's rows are row-mask-deleted (spec 7.5) */
-	rg->deletedCount = 0;
-	if (readState->currentMask != NULL)
-	{
-		for (i = 0; i < rg->nrows; i++)
-			if ((i >> 3) < readState->currentMaskLen &&
-				(readState->currentMask[i >> 3] & (1 << (i & 7))) != 0)
-				rg->deletedCount++;
-	}
-
-	MemoryContextSwitchTo(oldContext);
-	return true;
-}
-
-/*
- * ColumnarDecodeCurrentGroupVector
- *		Decode the currently positioned chunk group into a full vector, used by
- *		the aggregate to fall back from the run path when the group has deletes.
- */
-void
-ColumnarDecodeCurrentGroupVector(ColumnarReadState *readState,
-								 ColumnarVector *vec)
-{
-	columnar_decode_group_to_vector(readState, vec);
-}
-
 /* -------------------------------------------------------------------------
  * Liveness cache (gap 26, phase 4): a projection scan must test each row's base
- * row number for deletion/visibility. Doing that per row via ColumnarRowIsLive
- * re-scans the stripe and row-mask catalogs every call -- O(rows x stripes).
- * The cache reads the base stripe list and row masks once (at the scan's
- * snapshot) into memory, then answers each test with a binary search over
- * stripes plus a bitmap probe. Consistent with the scan's fixed snapshot, the
- * same way ColumnarBeginRead reads those lists once at begin.
+ * row number for deletion/visibility. The cache reads the base row-group list
+ * and row masks once (at the scan's snapshot) into memory, then answers each
+ * test with a binary search over row groups plus a bitmap probe. Consistent
+ * with the scan's fixed snapshot, the same way ColumnarBeginRead reads those
+ * lists once at begin.
  * ------------------------------------------------------------------------- */
 typedef struct LiveStripeEntry
 {
@@ -1882,99 +1131,51 @@ ColumnarBuildLivenessCache(Relation rel, Snapshot snapshot)
 											  "columnar liveness cache",
 											  ALLOCSET_DEFAULT_SIZES);
 	MemoryContext oldContext = MemoryContextSwitchTo(ctx);
-	List	   *stripeList;
+	List	   *rgList = ColumnarReadRowGroupList(storageId, metaSnapshot);
 	ColumnarLivenessCache *cache = palloc0(sizeof(ColumnarLivenessCache));
 	ListCell   *lc;
 	int			i = 0;
 
-	cache->ctx = ctx;
-
 	/*
-	 * Native base (PGCN v1): each row group is one liveness entry with a single
-	 * whole-group delete mask (D6b keys the row mask by group number, chunk id 0).
-	 * Modeling it as chunkGroupCount 1 with chunkRowCount == rowCount makes the
-	 * shared ColumnarLivenessCacheIsLive map every row to chunk 0. Without this a
-	 * native base's stripe list is empty and every projected row would read as not
-	 * visible, so a projection scan over a native table returned nothing (D6e).
+	 * Each native row group is one liveness entry with a single whole-group
+	 * delete mask (the row mask is keyed by group number, chunk id 0). Modeling
+	 * it as chunkGroupCount 1 with chunkRowCount == rowCount makes the shared
+	 * ColumnarLivenessCacheIsLive map every row to chunk 0.
 	 */
-	if (ColumnarStorageIsNative(storageId, metaSnapshot))
-	{
-		List	   *rgList = ColumnarReadRowGroupList(storageId, metaSnapshot);
-
-		cache->nstripes = list_length(rgList);
-		cache->stripes = palloc0(sizeof(LiveStripeEntry) * Max(cache->nstripes, 1));
-
-		foreach(lc, rgList)
-		{
-			NativeRowGroupMetadata *rg = (NativeRowGroupMetadata *) lfirst(lc);
-			LiveStripeEntry *e = &cache->stripes[i++];
-			List	   *rml;
-			ListCell   *mc;
-			uint32		want = (uint32) ((rg->rowCount + 7) / 8);
-
-			e->firstRowNumber = rg->firstRowNumber;
-			e->rowCount = rg->rowCount;
-			e->chunkRowCount = (int) rg->rowCount;
-			e->chunkGroupCount = 1;
-			e->masks = palloc0(sizeof(char *) * 1);
-			e->maskLens = palloc0(sizeof(uint32) * 1);
-
-			rml = ColumnarReadRowMaskList(storageId, rg->groupNumber, metaSnapshot);
-			foreach(mc, rml)
-			{
-				RowMaskMetadata *rm = (RowMaskMetadata *) lfirst(mc);
-				uint32		b;
-
-				if (rm->mask == NULL || rm->maskLen == 0)
-					continue;
-				if (e->masks[0] == NULL)
-				{
-					e->masks[0] = palloc0(want > 0 ? want : 1);
-					e->maskLens[0] = want;
-				}
-				for (b = 0; b < rm->maskLen && b < want; b++)
-					e->masks[0][b] |= rm->mask[b];
-			}
-		}
-
-		if (cache->nstripes > 1)
-			qsort(cache->stripes, cache->nstripes, sizeof(LiveStripeEntry),
-				  livestripe_cmp);
-
-		MemoryContextSwitchTo(oldContext);
-		return cache;
-	}
-
-	stripeList = ColumnarReadStripeList(storageId, metaSnapshot);
-	cache->nstripes = list_length(stripeList);
+	cache->ctx = ctx;
+	cache->nstripes = list_length(rgList);
 	cache->stripes = palloc0(sizeof(LiveStripeEntry) * Max(cache->nstripes, 1));
 
-	foreach(lc, stripeList)
+	foreach(lc, rgList)
 	{
-		StripeMetadata *s = (StripeMetadata *) lfirst(lc);
+		NativeRowGroupMetadata *rg = (NativeRowGroupMetadata *) lfirst(lc);
 		LiveStripeEntry *e = &cache->stripes[i++];
 		List	   *rml;
 		ListCell   *mc;
+		uint32		want = (uint32) ((rg->rowCount + 7) / 8);
 
-		e->firstRowNumber = s->firstRowNumber;
-		e->rowCount = s->rowCount;
-		e->chunkRowCount = s->chunkRowCount;
-		e->chunkGroupCount = s->chunkGroupCount;
-		e->masks = palloc0(sizeof(char *) * Max(s->chunkGroupCount, 1));
-		e->maskLens = palloc0(sizeof(uint32) * Max(s->chunkGroupCount, 1));
+		e->firstRowNumber = rg->firstRowNumber;
+		e->rowCount = rg->rowCount;
+		e->chunkRowCount = (int) rg->rowCount;
+		e->chunkGroupCount = 1;
+		e->masks = palloc0(sizeof(char *) * 1);
+		e->maskLens = palloc0(sizeof(uint32) * 1);
 
-		rml = ColumnarReadRowMaskList(storageId, s->stripeNum, metaSnapshot);
+		rml = ColumnarReadRowMaskList(storageId, rg->groupNumber, metaSnapshot);
 		foreach(mc, rml)
 		{
 			RowMaskMetadata *rm = (RowMaskMetadata *) lfirst(mc);
+			uint32		b;
 
-			if (rm->chunkId >= 0 && rm->chunkId < s->chunkGroupCount &&
-				rm->mask != NULL && rm->maskLen > 0)
+			if (rm->mask == NULL || rm->maskLen == 0)
+				continue;
+			if (e->masks[0] == NULL)
 			{
-				e->masks[rm->chunkId] = palloc(rm->maskLen);
-				memcpy(e->masks[rm->chunkId], rm->mask, rm->maskLen);
-				e->maskLens[rm->chunkId] = rm->maskLen;
+				e->masks[0] = palloc0(want > 0 ? want : 1);
+				e->maskLens[0] = want;
 			}
+			for (b = 0; b < rm->maskLen && b < want; b++)
+				e->masks[0][b] |= rm->mask[b];
 		}
 	}
 
@@ -2027,80 +1228,6 @@ ColumnarFreeLivenessCache(ColumnarLivenessCache *cache)
 }
 
 /*
- * ColumnarRowIsLive
- *		Whether the base row addressed by rowNumber is visible to snapshot: a
- *		stripe covers it (its catalog row is visible) and it is not marked
- *		deleted in the row mask. Unlike ColumnarReadRowByNumber this decodes no
- *		column data, so a projection scan can filter deleted/invisible rows
- *		cheaply by their stored base row number (gap 26, phase 4). Uses the same
- *		catalog snapshot rule as the reader.
- */
-bool
-ColumnarRowIsLive(Relation rel, Snapshot snapshot, uint64 rowNumber)
-{
-	uint64		storageId = ColumnarStorageId(rel);
-	MemoryContext tmp;
-	MemoryContext oldContext;
-	Snapshot	metaSnapshot;
-	List	   *stripeList;
-	ListCell   *lc;
-	StripeMetadata *stripe = NULL;
-	List	   *rowMaskList;
-	uint64		offsetInStripe;
-	int			chunkId;
-	uint64		rowInGroup;
-	bool		live = true;
-
-	tmp = AllocSetContextCreate(CurrentMemoryContext, "columnar liveness",
-								ALLOCSET_SMALL_SIZES);
-	oldContext = MemoryContextSwitchTo(tmp);
-
-	metaSnapshot = ColumnarCatalogSnapshot(snapshot);
-	stripeList = ColumnarReadStripeList(storageId, metaSnapshot);
-	foreach(lc, stripeList)
-	{
-		StripeMetadata *s = (StripeMetadata *) lfirst(lc);
-
-		if (rowNumber >= s->firstRowNumber &&
-			rowNumber < s->firstRowNumber + s->rowCount)
-		{
-			stripe = s;
-			break;
-		}
-	}
-
-	if (stripe == NULL || stripe->chunkRowCount <= 0)
-	{
-		MemoryContextSwitchTo(oldContext);
-		MemoryContextDelete(tmp);
-		return false;
-	}
-
-	offsetInStripe = rowNumber - stripe->firstRowNumber;
-	chunkId = (int) (offsetInStripe / (uint64) stripe->chunkRowCount);
-	rowInGroup = offsetInStripe - (uint64) chunkId * (uint64) stripe->chunkRowCount;
-
-	rowMaskList = ColumnarReadRowMaskList(storageId, stripe->stripeNum,
-										  metaSnapshot);
-	foreach(lc, rowMaskList)
-	{
-		RowMaskMetadata *rm = (RowMaskMetadata *) lfirst(lc);
-
-		if (rm->chunkId == chunkId && rm->mask != NULL &&
-			(rowInGroup >> 3) < rm->maskLen &&
-			(rm->mask[rowInGroup >> 3] & (1 << (rowInGroup & 7))) != 0)
-		{
-			live = false;
-			break;
-		}
-	}
-
-	MemoryContextSwitchTo(oldContext);
-	MemoryContextDelete(tmp);
-	return live;
-}
-
-/*
  * ColumnarReadRowByNumber
  *		Fetch a single row addressed by its row number (spec 6). Used by the
  *		table AM's fetch-by-tid callback (UPDATE re-fetches the old row). Reads
@@ -2119,18 +1246,15 @@ ColumnarReadRowByNumber(Relation rel, Snapshot snapshot, uint64 rowNumber,
 	MemoryContext tmp;
 	MemoryContext oldContext;
 	Snapshot	metaSnapshot;
-	List	   *stripeList;
-	ListCell   *lc;
-	StripeMetadata *stripe = NULL;
-	List	   *chunkList;
-	List	   *rowMaskList;
-	ChunkMetadata **chunkForGroup;
-	char	   *stripeBuffer;
-	uint64		offsetInStripe;
-	int			chunkId;
-	uint64		rowInGroup;
+	List	   *rgList;
+	NativeRowGroupMetadata *rg = NULL;
+	List	   *nchunks;
+	NativeColumnChunkMetadata **ccForCol;
+	char	   *groupBuffer;
+	int			validityBytes;
+	uint64		rowInGrp;
+	ListCell   *nlc;
 	int			c;
-	bool		found = true;
 
 	tmp = AllocSetContextCreate(CurrentMemoryContext, "columnar fetch",
 								ALLOCSET_SMALL_SIZES);
@@ -2139,185 +1263,47 @@ ColumnarReadRowByNumber(Relation rel, Snapshot snapshot, uint64 rowNumber,
 	metaSnapshot = ColumnarCatalogSnapshot(snapshot);
 
 	/*
-	 * Native (PGCN v1) fetch-by-row-number (D6a): find the row group covering the
-	 * row, reconstruct each column's value at its position. This is what index and
-	 * bitmap scans and unique enforcement call, so it unblocks them on native.
-	 * (D6b adds the native row-mask delete-visibility check here.)
+	 * Native (PGCN v1) fetch-by-row-number: find the row group covering the row
+	 * and reconstruct each column's value at its position. Index and bitmap scans
+	 * and unique enforcement call this. A deleted row (in the group's row mask or
+	 * a not-yet-flushed buffered delete) is not visible.
 	 */
-	if (ColumnarStorageIsNative(storageId, metaSnapshot))
+	rgList = ColumnarReadRowGroupList(storageId, metaSnapshot);
+	foreach(nlc, rgList)
 	{
-		List	   *rgList = ColumnarReadRowGroupList(storageId, metaSnapshot);
-		NativeRowGroupMetadata *rg = NULL;
-		List	   *nchunks;
-		NativeColumnChunkMetadata **ccForCol;
-		char	   *groupBuffer;
-		int			validityBytes;
-		uint64		rowInGrp;
-		ListCell   *nlc;
+		NativeRowGroupMetadata *g = (NativeRowGroupMetadata *) lfirst(nlc);
 
-		foreach(nlc, rgList)
+		if (rowNumber >= g->firstRowNumber &&
+			rowNumber < g->firstRowNumber + g->rowCount)
 		{
-			NativeRowGroupMetadata *g = (NativeRowGroupMetadata *) lfirst(nlc);
-
-			if (rowNumber >= g->firstRowNumber &&
-				rowNumber < g->firstRowNumber + g->rowCount)
-			{
-				rg = g;
-				break;
-			}
-		}
-		if (rg == NULL)
-		{
-			MemoryContextSwitchTo(oldContext);
-			MemoryContextDelete(tmp);
-			return false;
-		}
-		rowInGrp = rowNumber - rg->firstRowNumber;
-
-		/* deleted rows are not visible (D6b): check the group's row mask, plus any
-		 * not-yet-flushed buffered delete (so a same-key UPDATE's unique check sees
-		 * the old row as gone) */
-		{
-			List	   *maskList = ColumnarReadRowMaskList(storageId,
-													   rg->groupNumber,
-													   metaSnapshot);
-			ListCell   *mlc;
-			bool		deleted = ColumnarRowMaskBufferedDeleted(rel, rowNumber);
-
-			foreach(mlc, maskList)
-			{
-				RowMaskMetadata *rm = (RowMaskMetadata *) lfirst(mlc);
-
-				if (rm->mask != NULL && (rowInGrp >> 3) < rm->maskLen &&
-					(rm->mask[rowInGrp >> 3] & (1 << (rowInGrp & 7))) != 0)
-					deleted = true;
-			}
-			if (deleted)
-			{
-				MemoryContextSwitchTo(oldContext);
-				MemoryContextDelete(tmp);
-				return false;
-			}
-		}
-
-		groupBuffer = palloc(rg->byteLength > 0 ? rg->byteLength : 1);
-		if (rg->byteLength > 0)
-			ColumnarReadLogicalData(rel, rg->fileOffset, groupBuffer,
-									rg->byteLength);
-		nchunks = ColumnarReadColumnChunkList(storageId, rg->groupNumber,
-											  metaSnapshot);
-		validityBytes = (int) ((rg->rowCount + 7) / 8);
-
-		ccForCol = palloc0(sizeof(NativeColumnChunkMetadata *) * natts);
-		foreach(nlc, nchunks)
-		{
-			NativeColumnChunkMetadata *cc = (NativeColumnChunkMetadata *) lfirst(nlc);
-
-			if (cc->columnIndex >= 0 && cc->columnIndex < natts)
-				ccForCol[cc->columnIndex] = cc;
-		}
-
-		for (c = 0; c < natts; c++)
-		{
-			Form_pg_attribute att = TupleDescAttr(tupdesc, c);
-			NativeColumnChunkMetadata *cc = ccForCol[c];
-			char	   *base;
-			char	   *vbits;
-			char	   *rawBuf;
-			char	   *cursor;
-			uint64		present;
-			uint64		i;
-
-			/* column added after this row group was written: missing value */
-			if (cc == NULL)
-			{
-				values[c] = getmissingattr(tupdesc, c + 1, &nulls[c]);
-				continue;
-			}
-
-			base = groupBuffer + (cc->pageOffset - rg->fileOffset);
-			vbits = base;
-			if (((vbits[rowInGrp >> 3] >> (rowInGrp & 7)) & 1) == 0)
-			{
-				values[c] = (Datum) 0;
-				nulls[c] = true;
-				continue;
-			}
-
-			/* present-index of this row = number of present rows before it */
-			present = 0;
-			for (i = 0; i < rowInGrp; i++)
-				if ((vbits[i >> 3] >> (i & 7)) & 1)
-					present++;
-
-			if (cc->encodingDescriptorLen == 1 &&
-				(uint8) cc->encodingDescriptor[0] == COLUMNAR_NATIVE_ENCDESC_BASELINE)
-				rawBuf = base + validityBytes;
-			else
-				rawBuf = columnar_native_decode_chunk(tmp, att, base + validityBytes,
-													  (uint32) (cc->pageLength - validityBytes),
-													  cc->encodingDescriptor,
-													  cc->encodingDescriptorLen,
-													  cc->blockCodec, NULL, NULL);
-
-			cursor = rawBuf;
-			for (i = 0; i < present; i++)
-				(void) ColumnarDecodeValue(att, &cursor, tmp);
-			values[c] = ColumnarDecodeValue(att, &cursor, target);
-			nulls[c] = false;
-		}
-
-		MemoryContextSwitchTo(oldContext);
-		MemoryContextDelete(tmp);
-		return true;
-	}
-
-	stripeList = ColumnarReadStripeList(storageId, metaSnapshot);
-	foreach(lc, stripeList)
-	{
-		StripeMetadata *s = (StripeMetadata *) lfirst(lc);
-
-		if (rowNumber >= s->firstRowNumber &&
-			rowNumber < s->firstRowNumber + s->rowCount)
-		{
-			stripe = s;
+			rg = g;
 			break;
 		}
 	}
-
-	if (stripe == NULL)
+	if (rg == NULL)
 	{
 		MemoryContextSwitchTo(oldContext);
 		MemoryContextDelete(tmp);
 		return false;
 	}
+	rowInGrp = rowNumber - rg->firstRowNumber;
 
-	if (stripe->chunkRowCount <= 0)
-		ereport(ERROR,
-				(errcode(ERRCODE_DATA_CORRUPTED),
-				 errmsg("columnar: corrupt stripe chunk row count")));
-
-	offsetInStripe = rowNumber - stripe->firstRowNumber;
-	chunkId = (int) (offsetInStripe / (uint64) stripe->chunkRowCount);
-	rowInGroup = offsetInStripe - (uint64) chunkId * (uint64) stripe->chunkRowCount;
-
-	/* deleted rows are not visible (spec 7.5), including a not-yet-flushed
-	 * buffered delete so a same-key UPDATE's unique check sees the old row gone */
-	if (ColumnarRowMaskBufferedDeleted(rel, rowNumber))
 	{
-		MemoryContextSwitchTo(oldContext);
-		MemoryContextDelete(tmp);
-		return false;
-	}
-	rowMaskList = ColumnarReadRowMaskList(storageId, stripe->stripeNum,
-										  metaSnapshot);
-	foreach(lc, rowMaskList)
-	{
-		RowMaskMetadata *rm = (RowMaskMetadata *) lfirst(lc);
+		List	   *maskList = ColumnarReadRowMaskList(storageId,
+													   rg->groupNumber,
+													   metaSnapshot);
+		ListCell   *mlc;
+		bool		deleted = ColumnarRowMaskBufferedDeleted(rel, rowNumber);
 
-		if (rm->chunkId == chunkId && rm->mask != NULL &&
-			(rowInGroup >> 3) < rm->maskLen &&
-			(rm->mask[rowInGroup >> 3] & (1 << (rowInGroup & 7))) != 0)
+		foreach(mlc, maskList)
+		{
+			RowMaskMetadata *rm = (RowMaskMetadata *) lfirst(mlc);
+
+			if (rm->mask != NULL && (rowInGrp >> 3) < rm->maskLen &&
+				(rm->mask[rowInGrp >> 3] & (1 << (rowInGrp & 7))) != 0)
+				deleted = true;
+		}
+		if (deleted)
 		{
 			MemoryContextSwitchTo(oldContext);
 			MemoryContextDelete(tmp);
@@ -2325,101 +1311,84 @@ ColumnarReadRowByNumber(Relation rel, Snapshot snapshot, uint64 rowNumber,
 		}
 	}
 
-	/* index this chunk group's chunks by attribute */
-	chunkList = ColumnarReadChunkList(storageId, stripe->stripeNum, metaSnapshot);
-	chunkForGroup = palloc0(sizeof(ChunkMetadata *) * natts);
-	foreach(lc, chunkList)
+	groupBuffer = palloc(rg->byteLength > 0 ? rg->byteLength : 1);
+	if (rg->byteLength > 0)
+		ColumnarReadLogicalData(rel, rg->fileOffset, groupBuffer,
+								rg->byteLength);
+	nchunks = ColumnarReadColumnChunkList(storageId, rg->groupNumber,
+										  metaSnapshot);
+	validityBytes = (int) ((rg->rowCount + 7) / 8);
+
+	ccForCol = palloc0(sizeof(NativeColumnChunkMetadata *) * natts);
+	foreach(nlc, nchunks)
 	{
-		ChunkMetadata *m = (ChunkMetadata *) lfirst(lc);
+		NativeColumnChunkMetadata *cc = (NativeColumnChunkMetadata *) lfirst(nlc);
 
-		if (m->chunkGroupNum == chunkId &&
-			m->attrNum >= 1 && m->attrNum <= natts)
-			chunkForGroup[m->attrNum - 1] = m;
+		if (cc->columnIndex >= 0 && cc->columnIndex < natts)
+			ccForCol[cc->columnIndex] = cc;
 	}
-
-	stripeBuffer = palloc(stripe->dataLength);
-	ColumnarReadLogicalData(rel, stripe->fileOffset, stripeBuffer,
-							stripe->dataLength);
 
 	for (c = 0; c < natts; c++)
 	{
-		ChunkMetadata *m = chunkForGroup[c];
 		Form_pg_attribute att = TupleDescAttr(tupdesc, c);
-		char	   *existsBase;
+		NativeColumnChunkMetadata *cc = ccForCol[c];
+		char	   *base;
+		char	   *vbits;
+		char	   *rawBuf;
 		char	   *cursor;
+		uint64		present;
 		uint64		i;
 
-		/*
-		 * Column absent from this stripe (added by ALTER TABLE ADD COLUMN
-		 * after it was written): produce the attribute's missing value, the
-		 * same value a sequential scan yields for this row (spec 6).
-		 */
-		if (m == NULL)
+		if (cc == NULL)
 		{
 			values[c] = getmissingattr(tupdesc, c + 1, &nulls[c]);
 			continue;
 		}
 
-		if ((uint64) m->existsStreamOffset + rowInGroup + 1 > stripe->dataLength ||
-			(uint64) m->valueStreamOffset + m->valueStreamLength >
-			stripe->dataLength)
-			ereport(ERROR,
-					(errcode(ERRCODE_DATA_CORRUPTED),
-					 errmsg("columnar: corrupt chunk stream offset in stripe")));
-
-		existsBase = stripeBuffer + m->existsStreamOffset;
-		cursor = ColumnarDecompressValueStream(stripeBuffer + m->valueStreamOffset,
-											   m->valueStreamLength,
-											   m->valueCompressionType,
-											   m->valueDecompressedLength,
-											   tmp);
-		/* reverse the lightweight encoding to the raw value stream (I1) */
-		cursor = ColumnarDecodeChunk(cursor, m->valueDecompressedLength,
-									 m->valueEncodingType, att, m->valueCount,
-									 m->valueRawLength, tmp);
-
-		for (i = 0; i <= rowInGroup; i++)
+		base = groupBuffer + (cc->pageOffset - rg->fileOffset);
+		vbits = base;
+		if (((vbits[rowInGrp >> 3] >> (rowInGrp & 7)) & 1) == 0)
 		{
-			char		exists = existsBase[i];
-
-			if (i == rowInGroup)
-			{
-				if (exists)
-				{
-					values[c] = ColumnarDecodeValue(att, &cursor, target);
-					nulls[c] = false;
-				}
-				else
-				{
-					values[c] = (Datum) 0;
-					nulls[c] = true;
-				}
-			}
-			else if (exists)
-			{
-				/* advance the cursor past earlier present values */
-				(void) ColumnarDecodeValue(att, &cursor, tmp);
-			}
+			values[c] = (Datum) 0;
+			nulls[c] = true;
+			continue;
 		}
+
+		present = 0;
+		for (i = 0; i < rowInGrp; i++)
+			if ((vbits[i >> 3] >> (i & 7)) & 1)
+				present++;
+
+		if (cc->encodingDescriptorLen == 1 &&
+			(uint8) cc->encodingDescriptor[0] == COLUMNAR_NATIVE_ENCDESC_BASELINE)
+			rawBuf = base + validityBytes;
+		else
+			rawBuf = columnar_native_decode_chunk(tmp, att, base + validityBytes,
+												  (uint32) (cc->pageLength - validityBytes),
+												  cc->encodingDescriptor,
+												  cc->encodingDescriptorLen,
+												  cc->blockCodec, NULL, NULL);
+
+		cursor = rawBuf;
+		for (i = 0; i < present; i++)
+			(void) ColumnarDecodeValue(att, &cursor, tmp);
+		values[c] = ColumnarDecodeValue(att, &cursor, target);
+		nulls[c] = false;
 	}
 
 	MemoryContextSwitchTo(oldContext);
 	MemoryContextDelete(tmp);
-
-	return found;
+	return true;
 }
 
 void
 ColumnarRescanRead(ColumnarReadState *readState)
 {
 	MemoryContextReset(readState->stripeContext);
-	readState->stripe = NULL;
-	readState->stripeIndex = 0;
 	readState->started = false;
 	readState->exhausted = false;
-	readState->stripeList = NIL;
 
-	/* native format cursors (Phase D3) */
+	/* native format cursors */
 	readState->rowGroupList = NIL;
 	readState->rowGroupIndex = 0;
 	readState->nativeGroup = NULL;

--- a/src/columnar_row_mask.c
+++ b/src/columnar_row_mask.c
@@ -45,15 +45,13 @@ typedef struct RowMaskBuffer
 	uint64		storageId;
 	SubTransactionId subid;
 	List	   *chunks;			/* list of RowMaskChunkBuffer* */
-	List	   *stripeCache;	/* cached StripeMetadata* for resolution (2.2) */
-	List	   *rowGroupCache;	/* cached NativeRowGroupMetadata* (native) */
+	List	   *rowGroupCache;	/* cached NativeRowGroupMetadata* for resolution */
 } RowMaskBuffer;
 
 static MemoryContext ColumnarRowMaskContext = NULL;
 static List *ColumnarRowMaskBuffers = NIL;
 
 static RowMaskBuffer *rowmask_get_buffer(Relation rel, uint64 storageId);
-static StripeMetadata *rowmask_find_stripe(RowMaskBuffer *buf, uint64 rowNumber);
 static NativeRowGroupMetadata *rowmask_find_row_group(RowMaskBuffer *buf,
 													  uint64 rowNumber);
 static RowMaskChunkBuffer *rowmask_get_chunk(RowMaskBuffer *buf,
@@ -116,7 +114,6 @@ rowmask_get_buffer(Relation rel, uint64 storageId)
 	buf->storageId = storageId;
 	buf->subid = subid;
 	buf->chunks = NIL;
-	buf->stripeCache = NIL;
 	buf->rowGroupCache = NIL;
 	ColumnarRowMaskBuffers = lappend(ColumnarRowMaskBuffers, buf);
 	MemoryContextSwitchTo(oldContext);
@@ -124,44 +121,6 @@ rowmask_get_buffer(Relation rel, uint64 storageId)
 	return buf;
 }
 
-/*
- * rowmask_find_stripe
- *		Return the stripe metadata for the stripe that contains rowNumber,
- *		rebuilding the buffer's cached stripe list from the catalog when the
- *		cache is empty or does not cover the row (e.g. after a stripe was
- *		flushed later in this same transaction).
- */
-static StripeMetadata *
-rowmask_find_stripe(RowMaskBuffer *buf, uint64 rowNumber)
-{
-	ListCell   *lc;
-	int			attempt;
-
-	for (attempt = 0; attempt < 2; attempt++)
-	{
-		foreach(lc, buf->stripeCache)
-		{
-			StripeMetadata *s = (StripeMetadata *) lfirst(lc);
-
-			if (rowNumber >= s->firstRowNumber &&
-				rowNumber < s->firstRowNumber + s->rowCount)
-				return s;
-		}
-
-		/* miss: rebuild the cache once with an up-to-date catalog snapshot */
-		if (attempt == 0)
-		{
-			MemoryContext oldContext =
-				MemoryContextSwitchTo(ColumnarRowMaskContext);
-			Snapshot	snap = ColumnarCatalogSnapshot(GetActiveSnapshot());
-
-			buf->stripeCache = ColumnarReadStripeList(buf->storageId, snap);
-			MemoryContextSwitchTo(oldContext);
-		}
-	}
-
-	return NULL;
-}
 
 /*
  * rowmask_find_row_group
@@ -248,67 +207,32 @@ ColumnarMarkRowDeleted(Relation rel, uint64 rowNumber)
 {
 	uint64		storageId = ColumnarStorageId(rel);
 	RowMaskBuffer *buf = rowmask_get_buffer(rel, storageId);
-	StripeMetadata *stripe;
-	uint64		offsetInStripe;
-	int			chunkId;
 	uint64		startRowNumber;
-	uint64		groupRowCount;
 	uint64		endRowNumber;
 	uint64		bitIndex;
 	RowMaskChunkBuffer *chunk;
+	NativeRowGroupMetadata *rg = rowmask_find_row_group(buf, rowNumber);
 
 	/*
-	 * Native (PGCN v1) delete marking (D6b, interim row mask keyed by row group).
 	 * The whole row group is one mask (chunk id 0), sized to its row count. Phase
-	 * F replaces this with a first-class delete vector.
+	 * F replaces this interim row mask with a first-class delete vector.
 	 */
-	if (ColumnarStorageIsNative(storageId,
-							   ColumnarCatalogSnapshot(GetActiveSnapshot())))
-	{
-		NativeRowGroupMetadata *rg = rowmask_find_row_group(buf, rowNumber);
-
-		if (rg == NULL)
-			elog(ERROR,
-				 "columnar: cannot delete row " UINT64_FORMAT
-				 ": no row group covers it", rowNumber);
-
-		startRowNumber = rg->firstRowNumber;
-		endRowNumber = startRowNumber + rg->rowCount - 1;
-		chunk = rowmask_get_chunk(buf, rg->groupNumber, 0,
-								  startRowNumber, endRowNumber, rg->rowCount);
-		bitIndex = rowNumber - startRowNumber;
-		chunk->mask[bitIndex >> 3] |= (char) (1 << (bitIndex & 7));
-
-		ColumnarVMClearForRow(rel, rowNumber);
-		return;
-	}
-
-	stripe = rowmask_find_stripe(buf, rowNumber);
-
-	if (stripe == NULL)
+	if (rg == NULL)
 		elog(ERROR,
 			 "columnar: cannot delete row " UINT64_FORMAT
-			 ": no stripe covers it", rowNumber);
+			 ": no row group covers it", rowNumber);
 
-	offsetInStripe = rowNumber - stripe->firstRowNumber;
-	chunkId = (int) (offsetInStripe / (uint64) stripe->chunkRowCount);
-	startRowNumber = stripe->firstRowNumber +
-		(uint64) chunkId * (uint64) stripe->chunkRowCount;
-	groupRowCount = stripe->rowCount - (uint64) chunkId * (uint64) stripe->chunkRowCount;
-	if (groupRowCount > (uint64) stripe->chunkRowCount)
-		groupRowCount = (uint64) stripe->chunkRowCount;
-	endRowNumber = startRowNumber + groupRowCount - 1;
-
-	chunk = rowmask_get_chunk(buf, stripe->stripeNum, chunkId,
-							  startRowNumber, endRowNumber, groupRowCount);
-
+	startRowNumber = rg->firstRowNumber;
+	endRowNumber = startRowNumber + rg->rowCount - 1;
+	chunk = rowmask_get_chunk(buf, rg->groupNumber, 0,
+							  startRowNumber, endRowNumber, rg->rowCount);
 	bitIndex = rowNumber - startRowNumber;
 	chunk->mask[bitIndex >> 3] |= (char) (1 << (bitIndex & 7));
 
 	/*
 	 * The deleted row makes its block not all-visible; clear any VM bit so an
-	 * index-only scan never skips the fetch for a block with a dead row
-	 * (gap 28). A no-op unless a prior vacuum had marked the block visible.
+	 * index-only scan never skips the fetch for a block with a dead row (gap 28).
+	 * A no-op unless a prior vacuum had marked the block visible.
 	 */
 	ColumnarVMClearForRow(rel, rowNumber);
 }
@@ -408,7 +332,6 @@ rowmask_flush_buffer(RowMaskBuffer *buf)
 		PopActiveSnapshot();
 
 	buf->chunks = NIL;
-	buf->stripeCache = NIL;
 	buf->rowGroupCache = NIL;
 }
 

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -1155,18 +1155,9 @@ _PG_init(void)
 							 NULL, NULL, NULL);
 
 	DefineCustomBoolVariable("pgcolumnar.enable_vectorization",
-							 "Use the vectorized scan and aggregate fast paths.",
+							 "Use the vectorized aggregate fast path.",
 							 NULL,
 							 &columnar_enable_vectorization,
-							 true,
-							 PGC_USERSET,
-							 0,
-							 NULL, NULL, NULL);
-
-	DefineCustomBoolVariable("pgcolumnar.enable_compressed_execution",
-							 "Compute aggregates over runs of the encoded value stream.",
-							 NULL,
-							 &columnar_enable_compressed_execution,
 							 true,
 							 PGC_USERSET,
 							 0,
@@ -1185,15 +1176,6 @@ _PG_init(void)
 							 "Skip chunk groups on equality using per-chunk bloom filters.",
 							 NULL,
 							 &columnar_enable_bloom_filter,
-							 true,
-							 PGC_USERSET,
-							 0,
-							 NULL, NULL, NULL);
-
-	DefineCustomBoolVariable("pgcolumnar.enable_late_materialization",
-							 "Decode output columns only after the filter selects rows.",
-							 NULL,
-							 &columnar_enable_late_materialization,
 							 true,
 							 PGC_USERSET,
 							 0,

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -46,14 +46,6 @@ PG_MODULE_MAGIC;
 int			columnar_stripe_row_limit = 150000;
 int			columnar_chunk_group_row_limit = 10000;
 
-/* GUC: on-disk format for new columnar tables that set no explicit
- * format_version option. 0 is the 1.0-dev line (format 2.2); 1 is native
- * (PGCN v1). ColumnarTableFormatVersion falls back to this. The boot default is
- * native (D6f): a bare USING pgcolumnar writes PGCN v1. The 2.2 reader is kept
- * so pre-existing 2.2 tables still read (retirement is the later Phase H), and
- * the writer anchors to the format already on disk so an existing table is never
- * rewritten in a different format. Set this to 0 to write 2.2 for new tables. */
-int			columnar_default_format_version = 1;
 int			columnar_compression = COLUMNAR_COMPRESSION_ZSTD;
 int			columnar_compression_level = 3;
 bool		columnar_enable_qual_pushdown = true;
@@ -367,21 +359,21 @@ columnar_relation_estimate_size(Relation rel, int32 *attr_widths,
 	BlockNumber nblocks = RelationGetNumberOfBlocks(rel);
 	uint64		storageId = ColumnarStorageId(rel);
 	Snapshot	snapshot;
-	List	   *stripeList;
+	List	   *rowGroupList;
 	ListCell   *lc;
 	double		liveRows = 0;
 
 	/*
-	 * Estimate the row count from stripe metadata, not from the metapage
-	 * reservation high-water mark: row numbers are reserved a whole stripe at a
-	 * time, so the reservation overcounts. An accurate estimate keeps the
+	 * Estimate the row count from row-group metadata, not from the metapage
+	 * reservation high-water mark: row numbers are reserved a whole row group at
+	 * a time, so the reservation overcounts. An accurate estimate keeps the
 	 * planner from mis-costing scans (spec 6, 9).
 	 */
 	snapshot = ActiveSnapshotSet() ? GetActiveSnapshot() : GetTransactionSnapshot();
-	stripeList = ColumnarReadStripeList(storageId, ColumnarCatalogSnapshot(snapshot));
+	rowGroupList = ColumnarReadRowGroupList(storageId, ColumnarCatalogSnapshot(snapshot));
 
-	foreach(lc, stripeList)
-		liveRows += (double) ((StripeMetadata *) lfirst(lc))->rowCount;
+	foreach(lc, rowGroupList)
+		liveRows += (double) ((NativeRowGroupMetadata *) lfirst(lc))->rowCount;
 
 	*pages = Max(nblocks, 1);
 	*tuples = Max(liveRows, 0);
@@ -1110,21 +1102,6 @@ _PG_init(void)
 							&columnar_stripe_row_limit,
 							150000,
 							1000, INT_MAX,
-							PGC_USERSET,
-							0,
-							NULL, NULL, NULL);
-
-	DefineCustomIntVariable("pgcolumnar.default_format_version",
-							"On-disk format for new columnar tables with no "
-							"explicit format_version option.",
-							"1 is the native PGCN v1 format (the default); 0 is "
-							"the 1.0-dev line (format 2.2). A table's own "
-							"format_version option always wins over this default, "
-							"and a table that already holds data keeps its "
-							"on-disk format regardless of this setting.",
-							&columnar_default_format_version,
-							1,
-							0, 1,
 							PGC_USERSET,
 							0,
 							NULL, NULL, NULL);

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -27,10 +27,10 @@
  * create-state callback in columnar_customscan.c dispatches to the aggregate
  * variant when the plan is a scanrelid==0 upper node.
  *
- * Independent MIT implementation built from design/FORMAT_AND_INTERFACE_SPEC.md
- * (format 2.0), design/REWRITE_PLAN.md section 6, and the public PostgreSQL 17
- * API (the custom-scan provider contract, create_upper_paths_hook, and the
- * documented aggregate result types) only.
+ * Independent MIT implementation built from
+ * design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md and the public PostgreSQL API (the
+ * custom-scan provider contract, create_upper_paths_hook, and the documented
+ * aggregate result types) only.
  *
  *-------------------------------------------------------------------------
  */
@@ -67,12 +67,8 @@
 #include "utils/rel.h"
 #include "utils/typcache.h"
 
-/* GUC: use the vectorized scan/aggregate path (spec 8.3 scan control) */
+/* GUC: use the vectorized aggregate path (spec 8.3 scan control) */
 bool		columnar_enable_vectorization = true;
-
-/* GUC: run aggregates over runs of the encoded value stream (I3). Off falls
- * back to the per-row vectorized path; both must return identical results. */
-bool		columnar_enable_compressed_execution = true;
 
 /* GUC: answer count(*) from catalog metadata without scanning data (gap 28) */
 bool		columnar_enable_metadata_count = true;

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -6,11 +6,12 @@
  *
  * Two things live here. First, a shared filter: a plan's simple "column op
  * const" restriction clauses are turned into predicates that are evaluated
- * column-at-a-time over a decoded chunk group (ColumnarReadNextVector) to build
- * a selection vector. Second, a vectorized aggregate custom scan: for the common
- * shape SELECT agg(col) FROM t [WHERE ...] with no GROUP BY or HAVING, a custom
- * path on the grouping upper relation computes count, sum, avg, min and max
- * directly over the decoded arrays, skipping the per-tuple executor path.
+ * column-at-a-time over a decoded chunk group to build a selection vector.
+ * Second, a vectorized aggregate custom scan: for the common shape
+ * SELECT agg(col) FROM t [WHERE ...] with no GROUP BY or HAVING, a custom path
+ * on the grouping upper relation computes count, sum, avg, min and max from the
+ * zone-map metadata, or by scanning when the group has deletes, skipping the
+ * per-tuple executor path.
  *
  * Correctness is the invariant. The vectorized aggregate is only chosen when
  * every aggregate, every column type, and every filter clause is one this module
@@ -668,14 +669,12 @@ ColumnarCreateUpperPaths(PlannerInfo *root, UpperRelationKind stage,
 	quals = extract_actual_clauses(input_rel->baserestrictinfo, false);
 
 	/*
-	 * A native-format table (PGCN v1) answers an ungrouped aggregate from its
-	 * zone maps without a data scan (native spec 7.1, D5b), but only when there
-	 * is no residual filter; with a filter, fall back to the ordinary Agg over
-	 * the (skipping-enabled) custom scan. The 2.2 vectorized scan-and-fold path
-	 * reads the 2.2 chunk catalog, which a native table does not populate.
+	 * A native table answers an ungrouped aggregate from its zone maps without a
+	 * data scan (native spec 7.1), but only when there is no residual filter; with
+	 * a filter, fall back to the ordinary Agg over the skipping-enabled custom
+	 * scan.
 	 */
-	if (ColumnarTableFormatVersion(relid) == COLUMNAR_NATIVE_VERSION_MAJOR &&
-		quals != NIL)
+	if (quals != NIL)
 		return;
 
 	{
@@ -887,60 +886,6 @@ columnar_apply_one(ColumnarAggScanState *state, ColumnarAggSpec *spec,
 	}
 }
 
-/*
- * columnar_apply_run
- *		Fold a run of `runLen` copies of one non-null value into an accumulator,
- *		processing the whole run in O(1) for count/sum/avg (I3). The value's raw
- *		bytes come straight from the value stream. count(*) is handled by the
- *		caller at the group level.
- */
-static void
-columnar_apply_run(ColumnarAggScanState *state, ColumnarAggSpec *spec,
-				   const char *valBytes, Form_pg_attribute att, uint64 runLen)
-{
-	switch (spec->kind)
-	{
-		case COLUMNAR_AGG_COUNT_STAR:
-			break;				/* group-level */
-
-		case COLUMNAR_AGG_COUNT_COL:
-			/* the value stream holds only non-null values */
-			spec->count += (int64) runLen;
-			break;
-
-		case COLUMNAR_AGG_SUM_INT:
-			{
-				Datum		d = fetch_att(valBytes, true, att->attlen);
-				int64		v = (spec->inputType == INT2OID)
-					? (int64) DatumGetInt16(d) : (int64) DatumGetInt32(d);
-
-				spec->sum += v * (int64) runLen;
-				spec->sawValue = true;
-			}
-			break;
-
-		case COLUMNAR_AGG_AVG_INT:
-			{
-				Datum		d = fetch_att(valBytes, true, att->attlen);
-				int64		v = (spec->inputType == INT2OID)
-					? (int64) DatumGetInt16(d) : (int64) DatumGetInt32(d);
-
-				spec->sum += v * (int64) runLen;
-				spec->count += (int64) runLen;
-			}
-			break;
-
-		case COLUMNAR_AGG_MIN:
-		case COLUMNAR_AGG_MAX:
-			{
-				/* the extreme of a repeated value is the value itself */
-				Datum		d = fetch_att(valBytes, spec->byval, spec->typlen);
-
-				columnar_apply_one(state, spec, d, false);
-			}
-			break;
-	}
-}
 
 /*
  * columnar_run_agg
@@ -952,223 +897,7 @@ columnar_apply_run(ColumnarAggScanState *state, ColumnarAggSpec *spec,
  *		per-row vectorized path is used. Returns the read state so the caller can
  *		read skip counters for EXPLAIN before ending it.
  */
-/*
- * columnar_try_metadata_count
- *		Covering count(*) (gap 28): when every aggregate is count(*) and there is
- *		no filter, compute the answer from the catalog -- the sum of visible
- *		stripes' row counts minus the visible row-mask deletes -- without reading
- *		any data pages. Returns true and sets *countOut when it applies. Uses the
- *		same flush + catalog snapshot as a scan, so it respects MVCC and
- *		read-your-writes exactly (a stripe or delete not visible to the snapshot
- *		is not counted / not subtracted).
- */
-static bool
-columnar_try_metadata_count(ColumnarAggScanState *state, int64 *countOut)
-{
-	EState	   *estate = state->css.ss.ps.state;
-	Relation	rel;
-	Snapshot	snap;
-	uint64		storageId;
-	List	   *stripes;
-	ListCell   *lc;
-	int64		total = 0;
-	int			a;
 
-	if (!columnar_enable_metadata_count)
-		return false;
-	if (state->naggs == 0 || state->quals != NIL)
-		return false;
-	for (a = 0; a < state->naggs; a++)
-		if (state->specs[a].kind != COLUMNAR_AGG_COUNT_STAR)
-			return false;
-
-	ColumnarFlushWriteStateForRelation(state->relid);
-	rel = table_open(state->relid, AccessShareLock);
-	ColumnarFlushRowMaskForRelation(rel);
-	snap = ColumnarCatalogSnapshot(estate->es_snapshot);
-	storageId = ColumnarStorageId(rel);
-
-	stripes = ColumnarReadStripeList(storageId, snap);
-	foreach(lc, stripes)
-	{
-		StripeMetadata *s = (StripeMetadata *) lfirst(lc);
-		List	   *masks = ColumnarReadRowMaskList(storageId, s->stripeNum, snap);
-		ListCell   *mc;
-
-		total += (int64) s->rowCount;
-		foreach(mc, masks)
-			total -= ((RowMaskMetadata *) lfirst(mc))->deletedRows;
-	}
-
-	table_close(rel, AccessShareLock);
-	*countOut = total;
-	return true;
-}
-
-static ColumnarReadState *
-columnar_run_agg(ColumnarAggScanState *state)
-{
-	EState	   *estate = state->css.ss.ps.state;
-	Relation	rel;
-	TupleDesc	tupdesc;
-	Bitmapset  *projected = NULL;
-	ScanKey		scanKeys;
-	int			nScanKeys;
-	ColumnarReadState *readState;
-	ColumnarVector vec;
-	bool		useRuns;
-	int			a;
-	int			p;
-
-	rel = table_open(state->relid, AccessShareLock);
-	tupdesc = RelationGetDescr(rel);
-
-	/* project the columns the aggregates and filter need */
-	for (a = 0; a < state->naggs; a++)
-		if (state->specs[a].attidx >= 0)
-			projected = bms_add_member(projected, state->specs[a].attidx);
-	for (p = 0; p < state->npreds; p++)
-		projected = bms_add_member(projected, state->preds[p].attidx);
-	if (projected == NULL)
-		projected = bms_make_singleton(0);	/* count(*) only: decode one column */
-
-	/* persist our own writes so the scan sees them (read-your-writes, spec 9) */
-	ColumnarFlushWriteStateForRelation(state->relid);
-	ColumnarFlushRowMaskForRelation(rel);
-
-	scanKeys = ColumnarBuildScanKeys(state->quals, state->scanrelid, tupdesc,
-									 &nScanKeys);
-
-	readState = ColumnarBeginRead(rel, estate->es_snapshot, NULL, projected,
-								  nScanKeys, scanKeys);
-
-	/*
-	 * Decide the fold strategy. The run path needs no per-row predicate work
-	 * (npreds == 0) and fixed-width aggregate columns; otherwise use the per-row
-	 * vectorized path, which handles predicates, nulls, and deletes uniformly.
-	 */
-	useRuns = columnar_enable_compressed_execution && state->npreds == 0;
-	if (useRuns)
-	{
-		for (a = 0; a < state->naggs; a++)
-		{
-			int			c = state->specs[a].attidx;
-
-			if (c >= 0 && TupleDescAttr(tupdesc, c)->attlen <= 0)
-			{
-				useRuns = false;
-				break;
-			}
-		}
-	}
-
-	if (useRuns)
-	{
-		ColumnarRawGroup rg;
-
-		while (ColumnarReadNextRawGroup(readState, &rg))
-		{
-			bool		fallback = (rg.deletedCount > 0);
-
-			/* an absent column (post-ADD COLUMN stripe) needs its missing value */
-			for (a = 0; !fallback && a < state->naggs; a++)
-			{
-				int			c = state->specs[a].attidx;
-
-				if (c >= 0 && rg.columnAbsent[c])
-					fallback = true;
-			}
-
-			if (fallback)
-			{
-				uint64		i;
-
-				ColumnarDecodeCurrentGroupVector(readState, &vec);
-				for (i = 0; i < vec.nrows; i++)
-				{
-					if (vec.deleted[i])
-						continue;
-					for (a = 0; a < state->naggs; a++)
-					{
-						ColumnarAggSpec *spec = &state->specs[a];
-						int			c = spec->attidx;
-						bool		isnull = (c >= 0) ? vec.isnull[c][i] : true;
-						Datum		val = (c >= 0 && !isnull) ? vec.values[c][i]
-							: (Datum) 0;
-
-						columnar_apply_one(state, spec, val, isnull);
-					}
-				}
-				continue;
-			}
-
-			/* run path: no deletes, all aggregate columns present */
-			for (a = 0; a < state->naggs; a++)
-			{
-				ColumnarAggSpec *spec = &state->specs[a];
-				int			c = spec->attidx;
-				Form_pg_attribute att;
-				ColumnarBlockReader br;
-				const char *vb;
-				uint64		runLen;
-
-				if (spec->kind == COLUMNAR_AGG_COUNT_STAR)
-				{
-					spec->count += (int64) rg.nrows;
-					continue;
-				}
-
-				att = TupleDescAttr(tupdesc, c);
-				ColumnarBlockReaderInit(&br, rg.valueCursor[c],
-										rg.groupValueCount[c], att->attlen);
-				while (ColumnarBlockNextRun(&br, &vb, &runLen))
-					columnar_apply_run(state, spec, vb, att, runLen);
-			}
-		}
-	}
-	else
-	{
-		bool	   *sel = NULL;
-		uint64		selCap = 0;
-
-		while (ColumnarReadNextVector(readState, &vec))
-		{
-			uint64		i;
-
-			/* build the selection vector for the whole group once (I6) */
-			if (vec.nrows > selCap)
-			{
-				if (sel)
-					pfree(sel);
-				sel = palloc(sizeof(bool) * vec.nrows);
-				selCap = vec.nrows;
-			}
-			ColumnarVecSelect(state->preds, state->npreds, &vec, sel);
-
-			for (i = 0; i < vec.nrows; i++)
-			{
-				if (!sel[i])
-					continue;
-
-				for (a = 0; a < state->naggs; a++)
-				{
-					ColumnarAggSpec *spec = &state->specs[a];
-					int			c = spec->attidx;
-					bool		isnull = (c >= 0) ? vec.isnull[c][i] : true;
-					Datum		val = (c >= 0 && !isnull) ? vec.values[c][i]
-						: (Datum) 0;
-
-					columnar_apply_one(state, spec, val, isnull);
-				}
-			}
-		}
-		if (sel)
-			pfree(sel);
-	}
-
-	table_close(rel, AccessShareLock);
-	return readState;
-}
 
 /*
  * columnar_agg_finalize
@@ -1395,62 +1124,35 @@ ColumnarExecAggScan(CustomScanState *node)
 	ColumnarAggScanState *state = (ColumnarAggScanState *) node;
 	TupleTableSlot *scanSlot = node->ss.ss_ScanTupleSlot;
 	ExprContext *econtext = node->ss.ps.ps_ExprContext;
-	ColumnarReadState *readState;
 	TupleTableSlot *result;
 	int			a;
+	EState	   *estate = node->ss.ps.state;
+	Relation	frel;
+	bool		hasDeletes;
 
 	if (state->done)
 		return NULL;
 	state->done = true;
 
 	/*
-	 * Native tables answer from zone maps when no rows are deleted (native spec
-	 * 7.1, D5b): the upper-path hook added this path only when every aggregate is
+	 * A native table answers from zone maps when no rows are deleted (native spec
+	 * 7.1): the upper-path hook added this path only when every aggregate is
 	 * zone-map answerable and there is no filter, so no data pages are read. When
 	 * the storage has deletes the zone maps include deleted rows, so fall back to a
-	 * scan that applies the delete mask (D6b).
+	 * scan that applies the delete mask.
 	 */
-	if (ColumnarTableFormatVersion(state->relid) == COLUMNAR_NATIVE_VERSION_MAJOR)
-	{
-		EState	   *estate = node->ss.ps.state;
-		Relation	frel = table_open(state->relid, AccessShareLock);
-		bool		hasDeletes;
+	frel = table_open(state->relid, AccessShareLock);
+	ColumnarFlushWriteStateForRelation(state->relid);
+	ColumnarFlushRowMaskForRelation(frel);
+	hasDeletes = ColumnarStorageHasRowMask(ColumnarStorageId(frel),
+										   ColumnarCatalogSnapshot(estate->es_snapshot));
+	table_close(frel, AccessShareLock);
 
-		ColumnarFlushWriteStateForRelation(state->relid);
-		ColumnarFlushRowMaskForRelation(frel);
-		hasDeletes = ColumnarStorageHasRowMask(ColumnarStorageId(frel),
-											   ColumnarCatalogSnapshot(estate->es_snapshot));
-		table_close(frel, AccessShareLock);
-
-		if (hasDeletes)
-			columnar_native_scan_agg(state);
-		else
-			columnar_fill_native_metadata_agg(state);
-		state->haveStats = false;
-	}
-	/*
-	 * Covering count(*) (gap 28): answer a pure count(*) with no filter from the
-	 * catalog, skipping the data scan entirely. Otherwise scan and fold.
-	 */
+	if (hasDeletes)
+		columnar_native_scan_agg(state);
 	else
-	{
-		int64		mcount;
-
-		if (columnar_try_metadata_count(state, &mcount))
-		{
-			for (a = 0; a < state->naggs; a++)
-				state->specs[a].count = mcount;
-			state->haveStats = false;	/* no scan; no chunk-group counters */
-		}
-		else
-		{
-			readState = columnar_run_agg(state);
-			ColumnarReadStats(readState, &state->groupsRead,
-							  &state->groupsSkipped, &state->groupsTotal);
-			state->haveStats = true;
-			ColumnarEndRead(readState);
-		}
-	}
+		columnar_fill_native_metadata_agg(state);
+	state->haveStats = false;
 
 	/* build the single result row from the finalized aggregates */
 	ExecClearTuple(scanSlot);

--- a/src/columnar_write_state.c
+++ b/src/columnar_write_state.c
@@ -119,22 +119,12 @@ struct ColumnarWriteState
 	 */
 	bool		projInited;
 	List	   *projWriters;	/* list of ColumnarProjWriter * */
-
-	/*
-	 * Native format (re-origination line, PGCN v1). When isNative, a stripe
-	 * flush is laid out as a native row group and recorded in the native catalog
-	 * (Phase D2b) instead of the 2.2 stripe/chunk catalog. The row group's number
-	 * is the stripe id reserved from the metapage (persistent per storage), so
-	 * incremental inserts across transactions do not collide.
-	 */
-	bool		isNative;
 };
 
 /* per-backend registry of pending write states, in ColumnarWriteContext */
 static MemoryContext ColumnarWriteContext = NULL;
 static List *ColumnarWriteStates = NIL;
 
-static void columnar_flush_stripe(ColumnarWriteState *writeState);
 static void columnar_flush_row_group(ColumnarWriteState *writeState);
 static ChunkGroupBuffer *columnar_start_chunk_group(ColumnarWriteState *writeState);
 static void columnar_init_col_defs(ColumnarWriteState *writeState);
@@ -257,33 +247,6 @@ ColumnarGetWriteState(Relation rel)
 			if (opts.compressionLevelSet)
 				writeState->compressionLevel = opts.compressionLevel;
 		}
-	}
-
-	/*
-	 * The format is the single source of truth for both writer and reader: the
-	 * writer emits native when the table's format version is the native major,
-	 * defaulting via ColumnarTableFormatVersion. Flipping that default (D6f) flips
-	 * writer and reader together. The reader derives its own native flag from the
-	 * storage catalog, which follows what the writer produced.
-	 *
-	 * A storage that already holds data anchors to the format on disk, ignoring
-	 * the default: a table written 2.2 stays 2.2 and a native table stays native
-	 * even after the default GUC flips (D6f). Only an empty storage follows the
-	 * per-table option or the instance default. This keeps a single table from
-	 * ever mixing 2.2 stripes and native row groups.
-	 */
-	{
-		Snapshot	base = ActiveSnapshotSet() ? GetActiveSnapshot() :
-			GetTransactionSnapshot();
-		Snapshot	snap = ColumnarCatalogSnapshot(base);
-
-		if (ColumnarStorageIsNative(writeState->storageId, snap))
-			writeState->isNative = true;
-		else if (ColumnarStorageHasStripes(writeState->storageId, snap))
-			writeState->isNative = false;
-		else
-			writeState->isNative =
-				(ColumnarTableFormatVersion(relid) == COLUMNAR_NATIVE_VERSION_MAJOR);
 	}
 
 	columnar_init_col_defs(writeState);
@@ -453,7 +416,7 @@ ColumnarWriteRow(ColumnarWriteState *writeState, Relation rel,
 	writeState->stripeRowCount++;
 
 	if (writeState->stripeRowCount >= (uint64) writeState->stripeRowLimit)
-		columnar_flush_stripe(writeState);
+		columnar_flush_row_group(writeState);
 
 	return rowNumber;
 }
@@ -545,238 +508,6 @@ ColumnarBufferedRowByNumber(Relation rel, uint64 rowNumber,
 }
 
 /*
- * columnar_flush_stripe
- *		Lay out the accumulated stripe as a single contiguous byte buffer,
- *		reserve space, write the data pages, and record the stripe, chunk
- *		group, and chunk rows in the catalog (spec 4, 7). Then reset the
- *		stripe accumulator.
- */
-static void
-columnar_flush_stripe(ColumnarWriteState *writeState)
-{
-	MemoryContext flushContext;
-	MemoryContext oldContext;
-	Relation	rel;
-	int			natts = writeState->natts;
-	int			numGroups;
-	StringInfo	data;
-	ChunkMetadata *chunkMeta;
-	uint64		stripeId;
-	uint64		firstRowNumber;
-	uint64		fileOffset;
-	uint64		dataLength;
-	StripeMetadata stripe;
-	ListCell   *lc;
-	int			c;
-	int			g;
-	bool		pushedSnapshot = false;
-
-	if (writeState->stripeRowCount == 0)
-		return;
-
-	/* native format (PGCN v1) uses a separate row-group flush and catalog */
-	if (writeState->isNative)
-	{
-		columnar_flush_row_group(writeState);
-		return;
-	}
-
-	/*
-	 * Catalog inserts need an active snapshot. At transaction pre-commit the
-	 * executor snapshot has already been popped, so push a transaction
-	 * snapshot for the duration of the flush.
-	 */
-	if (!ActiveSnapshotSet())
-	{
-		PushActiveSnapshot(GetTransactionSnapshot());
-		pushedSnapshot = true;
-	}
-
-	numGroups = list_length(writeState->chunkGroups);
-
-	flushContext = AllocSetContextCreate(CurrentMemoryContext,
-										 "columnar flush",
-										 ALLOCSET_DEFAULT_SIZES);
-	oldContext = MemoryContextSwitchTo(flushContext);
-
-	/*
-	 * Build the stripe buffer column-major: for each column, the
-	 * concatenation of that column's chunks across all chunk groups, each
-	 * chunk laid out as [value stream][exists stream] (spec 4). Offsets and
-	 * lengths are recorded relative to the stripe start.
-	 */
-	data = makeStringInfo();
-	chunkMeta = palloc0(sizeof(ChunkMetadata) * natts * numGroups);
-
-	for (c = 0; c < natts; c++)
-	{
-		Form_pg_attribute att = TupleDescAttr(writeState->tupdesc, c);
-
-		g = 0;
-		foreach(lc, writeState->chunkGroups)
-		{
-			ChunkGroupBuffer *group = (ChunkGroupBuffer *) lfirst(lc);
-			ColumnChunkBuffer *col = &group->columns[c];
-			ChunkMetadata *m = &chunkMeta[c * numGroups + g];
-			char	   *encData;
-			uint32		encLen;
-			int			encType;
-			char	   *compData;
-			uint32		compLen;
-			int			usedType;
-			int			usedLevel;
-
-			m->attrNum = c + 1;
-			m->chunkGroupNum = g;
-
-			/*
-			 * Apply a lightweight, type-aware encoding to the raw value stream
-			 * (I1), then block-compress the encoded form (spec 5). Both steps
-			 * fall back to "none" when they do not shrink the data. The exists
-			 * stream is neither encoded nor compressed.
-			 */
-			encType = ColumnarEncodeChunk(col->valueStream.data,
-										  col->valueStream.len, att,
-										  col->valueCount, &encData, &encLen);
-
-			ColumnarCompressValueStream(encData, encLen,
-										writeState->compressionType,
-										writeState->compressionLevel,
-										&compData, &compLen,
-										&usedType, &usedLevel);
-
-			m->valueStreamOffset = data->len;
-			if (compLen > 0)
-				appendBinaryStringInfo(data, compData, compLen);
-			m->valueStreamLength = compLen;
-
-			m->existsStreamOffset = data->len;
-			appendBinaryStringInfo(data, col->existsStream.data,
-								   col->existsStream.len);
-			m->existsStreamLength = col->existsStream.len;
-
-			m->valueCompressionType = usedType;
-			m->valueCompressionLevel = usedLevel;
-			m->valueDecompressedLength = encLen;
-			m->valueCount = col->valueCount;
-			m->valueEncodingType = encType;
-			m->valueRawLength = col->valueStream.len;
-
-			/* encode the min/max skip list for orderable types (spec 7.2) */
-			if (col->hasMinMax)
-			{
-				StringInfoData minBuf;
-				StringInfoData maxBuf;
-
-				initStringInfo(&minBuf);
-				initStringInfo(&maxBuf);
-				ColumnarEncodeValue(&minBuf, att, col->minValue);
-				ColumnarEncodeValue(&maxBuf, att, col->maxValue);
-
-				m->minMaxValid = true;
-				m->minEncoded = minBuf.data;
-				m->minEncodedLen = minBuf.len;
-				m->maxEncoded = maxBuf.data;
-				m->maxEncodedLen = maxBuf.len;
-			}
-			else
-			{
-				m->minMaxValid = false;
-			}
-
-			/* build the per-chunk bloom filter from accumulated hashes (I7) */
-			if (col->hashBuf.len > 0)
-			{
-				char	   *bloom;
-				uint32		bloomLen;
-
-				if (ColumnarBloomBuild((const uint32 *) col->hashBuf.data,
-									   col->hashBuf.len / sizeof(uint32),
-									   &bloom, &bloomLen))
-				{
-					m->bloomFilter = bloom;
-					m->bloomLen = bloomLen;
-				}
-			}
-
-			g++;
-		}
-	}
-
-	dataLength = data->len;
-
-	/*
-	 * The stripe id and first row number were reserved eagerly when the first
-	 * row was buffered (spec 6). Reserve only the data byte range now, once its
-	 * size is known, under the relation extension lock, and write the pages.
-	 */
-	stripeId = writeState->stripeId;
-	firstRowNumber = writeState->stripeFirstRowNumber;
-
-	rel = table_open(writeState->relid, RowExclusiveLock);
-
-	LockRelationForExtension(rel, ExclusiveLock);
-	ColumnarReserveOffset(rel, dataLength, &fileOffset);
-	if (dataLength > 0)
-		ColumnarWriteLogicalData(rel, fileOffset, data->data, dataLength);
-	UnlockRelationForExtension(rel, ExclusiveLock);
-
-	/* record the stripe */
-	stripe.storageId = writeState->storageId;
-	stripe.stripeNum = stripeId;
-	stripe.fileOffset = fileOffset;
-	stripe.dataLength = dataLength;
-	stripe.columnCount = natts;
-	stripe.chunkRowCount = writeState->chunkGroupRowLimit;
-	stripe.rowCount = writeState->stripeRowCount;
-	stripe.chunkGroupCount = numGroups;
-	stripe.firstRowNumber = firstRowNumber;
-	ColumnarInsertStripeRow(&stripe);
-
-	/* record chunk groups */
-	g = 0;
-	foreach(lc, writeState->chunkGroups)
-	{
-		ChunkGroupBuffer *group = (ChunkGroupBuffer *) lfirst(lc);
-		ChunkGroupMetadata cg;
-
-		cg.stripeNum = stripeId;
-		cg.chunkGroupNum = g;
-		cg.rowCount = group->rowCount;
-		cg.deletedRows = 0;
-		ColumnarInsertChunkGroupRow(writeState->storageId, &cg);
-		g++;
-	}
-
-	/* record chunks */
-	for (c = 0; c < natts; c++)
-	{
-		for (g = 0; g < numGroups; g++)
-		{
-			ChunkMetadata *m = &chunkMeta[c * numGroups + g];
-
-			m->stripeNum = stripeId;
-			ColumnarInsertChunkRow(writeState->storageId, m);
-		}
-	}
-
-	table_close(rel, RowExclusiveLock);
-
-	MemoryContextSwitchTo(oldContext);
-	MemoryContextDelete(flushContext);
-
-	/* reset stripe accumulation; the next row reserves a fresh stripe */
-	MemoryContextReset(writeState->stripeContext);
-	writeState->chunkGroups = NIL;
-	writeState->currentGroup = NULL;
-	writeState->stripeRowCount = 0;
-	writeState->haveReservation = false;
-
-	if (pushedSnapshot)
-		PopActiveSnapshot();
-}
-
-/*
  * columnar_flush_row_group
  *		Native-format (PGCN v1) flush. Lay out the accumulated rows as one row
  *		group: each column is a column chunk of [validity bitmap][uncompressed
@@ -815,6 +546,16 @@ columnar_flush_row_group(ColumnarWriteState *writeState)
 	bool		pushedSnapshot = false;
 	List	   *zoneRows = NIL;		/* NativeZoneMapMetadata * to insert (D5) */
 	List	   *bloomRows = NIL;		/* NativeBloomMetadata * to insert (D5b) */
+
+	/*
+	 * Nothing buffered: a flush of an empty write state must be a no-op. The
+	 * stripe id is only consumed by a group that actually holds rows, so writing
+	 * a zero-row group here would reuse a stale stripe id and collide with the
+	 * group already written for it (duplicate row_group_pkey). This guards every
+	 * caller, including the unconditional pre-commit flush.
+	 */
+	if (rowCount == 0)
+		return;
 
 	if (!ActiveSnapshotSet())
 	{
@@ -1150,7 +891,7 @@ columnar_flush_row_group(ColumnarWriteState *writeState)
  * table's relation file and row-number space. On insert, the projected columns
  * plus the base row number are buffered; at flush the batch is sorted on the
  * projection's sort key and written as a stripe to the projection's storage,
- * reusing the base stripe encoder (ColumnarWriteRow + columnar_flush_stripe).
+ * reusing the base stripe encoder (ColumnarWriteRow + columnar_flush_row_group).
  * The base row number is stored as a leading int8 column so the projection can
  * be joined back to the base; deletes/visibility come from the base row_mask, so
  * only INSERT fans out (see design/gaps/26-IMPL-projections-phase2-plan.md).
@@ -1219,10 +960,6 @@ columnar_build_write_state(Oid relid, TupleDesc srcTupdesc, uint64 storageId,
 	ws->compressionType = compType;
 	ws->compressionLevel = compLevel;
 	ws->storageId = storageId;
-	/* a projection inherits the base table's format: a native table's projections
-	 * are native too (D6d), written to their own storage id */
-	ws->isNative =
-		(ColumnarTableFormatVersion(relid) == COLUMNAR_NATIVE_VERSION_MAJOR);
 	columnar_init_col_defs(ws);	/* min/max + bloom skip metadata for projections */
 	ws->stripeContext = AllocSetContextCreate(ColumnarWriteContext,
 											  "columnar proj stripe",
@@ -1294,7 +1031,7 @@ flush_proj_writer(ColumnarProjWriter *w, Relation tableRel)
 		ColumnarWriteRow(w->innerWs, tableRel, w->rows[i].values, w->rows[i].nulls);
 
 	if (w->innerWs->stripeRowCount > 0)
-		columnar_flush_stripe(w->innerWs);
+		columnar_flush_row_group(w->innerWs);
 
 	MemoryContextReset(w->rowCtx);
 	w->nrows = 0;
@@ -1568,7 +1305,7 @@ ColumnarFlushWriteStateForRelation(Oid relid)
 		if (writeState->relid != relid)
 			continue;
 		if (writeState->stripeRowCount > 0)
-			columnar_flush_stripe(writeState);
+			columnar_flush_row_group(writeState);
 		flush_ws_projections(writeState);
 	}
 }
@@ -1617,7 +1354,7 @@ ColumnarFlushAllPendingWrites(void)
 	{
 		ColumnarWriteState *writeState = (ColumnarWriteState *) lfirst(lc);
 
-		columnar_flush_stripe(writeState);
+		columnar_flush_row_group(writeState);
 		flush_ws_projections(writeState);
 	}
 }

--- a/test/differential.sh
+++ b/test/differential.sh
@@ -281,9 +281,13 @@ diff_query "enc+nocompress agg"  "SELECT count(*), sum(v), min(v), max(v) FROM %
 # both the run path and its fallback are exercised. Setting the GUC per database
 # makes it apply to the fresh session each query opens.
 # ---------------------------------------------------------------------------
-echo "-- part 4: compressed execution"
-
-set_guc() { q "ALTER DATABASE $PGC_DB SET $1 = $2;" >/dev/null; }
+# Part 4: aggregates over data with nulls and deletes
+#
+# The vectorized aggregate path answers ungrouped count/sum/avg/min/max; with
+# deletes present a group falls back to scanning. Results must equal the heap
+# oracle.
+# ---------------------------------------------------------------------------
+echo "-- part 4: aggregates with nulls and deletes"
 
 make_pair "id int, k int, big int, s smallint, nv int"
 q "SELECT pgcolumnar.alter_columnar_table_set('t_col', chunk_group_row_limit => 1000, stripe_row_limit => 5000);" >/dev/null
@@ -293,14 +297,10 @@ load_pair "SELECT g, g%6, g*2, ((g%100)-50)::smallint,
 psql_run "DELETE FROM t_heap WHERE id % 50 = 0;"
 psql_run "DELETE FROM t_col  WHERE id % 50 = 0;"
 
-for mode in on off; do
-	set_guc pgcolumnar.enable_compressed_execution "$mode"
-	diff_query "cexec=$mode count"  "SELECT count(*), count(k), count(nv) FROM %T"
-	diff_query "cexec=$mode sum"    "SELECT sum(big), sum(k), sum(nv) FROM %T"
-	diff_query "cexec=$mode avg"    "SELECT avg(k), avg(nv) FROM %T"
-	diff_query "cexec=$mode minmax" "SELECT min(k), max(k), min(big), max(big), min(s), max(s), min(nv), max(nv) FROM %T"
-done
-q "ALTER DATABASE $PGC_DB RESET pgcolumnar.enable_compressed_execution;" >/dev/null
+diff_query "agg count"  "SELECT count(*), count(k), count(nv) FROM %T"
+diff_query "agg sum"    "SELECT sum(big), sum(k), sum(nv) FROM %T"
+diff_query "agg avg"    "SELECT avg(k), avg(nv) FROM %T"
+diff_query "agg minmax" "SELECT min(k), max(k), min(big), max(big), min(s), max(s), min(nv), max(nv) FROM %T"
 
 # ---------------------------------------------------------------------------
 # Part 5: bloom-filter equality skipping (I7)
@@ -346,27 +346,21 @@ diff_query "textbloom C eq"     "SELECT count(*) FROM %T WHERE tc = 'c123'"
 diff_query "textbloom collate-mismatch" "SELECT count(*) FROM %T WHERE tk = 'k100' COLLATE \"C\""
 
 # ---------------------------------------------------------------------------
-# Part 6: late materialization (I8)
+# Part 6: selective filter with several wide output columns
 #
-# A selective filter on one column with several wide output columns: with late
-# materialization the output columns are decoded only for groups that survive
-# the filter. Results must be identical whether it is on or off (and equal to
-# the heap oracle), including a filter that matches nothing.
+# A selective filter on one column projecting several wide output columns must
+# match the heap oracle, including a filter that matches nothing.
 # ---------------------------------------------------------------------------
-echo "-- part 6: late materialization"
+echo "-- part 6: selective filter with wide projection"
 
 make_pair "id int, sel int, a text, b bigint, c numeric"
 q "SELECT pgcolumnar.alter_columnar_table_set('t_col', chunk_group_row_limit => 1000, stripe_row_limit => 20000);" >/dev/null
 load_pair "SELECT g, g, 'a'||g, g::bigint*2, g::numeric*1.5 FROM generate_series(1,20000) g"
 
-for mode in on off; do
-	q "ALTER DATABASE $PGC_DB SET pgcolumnar.enable_late_materialization=$mode;" >/dev/null
-	diff_query "lm=$mode point"    "SELECT id, a, b, c FROM %T WHERE sel = 12345"
-	diff_query "lm=$mode range"    "SELECT id, a, b FROM %T WHERE sel BETWEEN 5000 AND 5100"
-	diff_query "lm=$mode nomatch"  "SELECT id, a, b, c FROM %T WHERE sel = 999999"
-	diff_query "lm=$mode most"     "SELECT id, a FROM %T WHERE sel > 100"
-done
-q "ALTER DATABASE $PGC_DB RESET pgcolumnar.enable_late_materialization;" >/dev/null
+diff_query "wide point"    "SELECT id, a, b, c FROM %T WHERE sel = 12345"
+diff_query "wide range"    "SELECT id, a, b FROM %T WHERE sel BETWEEN 5000 AND 5100"
+diff_query "wide nomatch"  "SELECT id, a, b, c FROM %T WHERE sel = 999999"
+diff_query "wide most"     "SELECT id, a FROM %T WHERE sel > 100"
 
 # ---------------------------------------------------------------------------
 # Part 7: covering count(*) from metadata (gap 28)

--- a/test/native_agg.sh
+++ b/test/native_agg.sh
@@ -26,7 +26,7 @@ GEN="SELECT g,
 
 psql_run "CREATE TABLE h (id int, s int, k bigint, label text);"
 psql_run "CREATE TABLE n (id int, s int, k bigint, label text) USING pgcolumnar;"
-psql_run "SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 2048, chunk_group_row_limit => 1024, format_version => 1);"
+psql_run "SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 2048, chunk_group_row_limit => 1024);"
 psql_run "INSERT INTO h $GEN;"
 psql_run "INSERT INTO n $GEN;"
 
@@ -71,7 +71,6 @@ check "sum(bigint) fallback parity" "$(q 'SELECT sum(k) FROM n;')" "$(q 'SELECT 
 
 # Empty native table: count 0, sum/min/max NULL, exactly as SQL.
 psql_run "CREATE TABLE e (id int, label text) USING pgcolumnar;"
-psql_run "SELECT pgcolumnar.alter_columnar_table_set('e', format_version => 1);"
 check "empty count(*)"  "$(q 'SELECT count(*) FROM e;')"                 "0"
 check "empty sum NULL"  "$(q 'SELECT sum(id) IS NULL FROM e;')"          "t"
 check "empty min NULL"  "$(q 'SELECT min(label) IS NULL FROM e;')"       "t"

--- a/test/native_bloom.sh
+++ b/test/native_bloom.sh
@@ -22,7 +22,7 @@ GEN="SELECT g, ((g * 104729) % 1000000) AS tag FROM generate_series(1, 20480) g"
 
 psql_run "CREATE TABLE h (id int, tag int);"
 psql_run "CREATE TABLE n (id int, tag int) USING pgcolumnar;"
-psql_run "SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 2048, chunk_group_row_limit => 1024, format_version => 1);"
+psql_run "SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 2048, chunk_group_row_limit => 1024);"
 psql_run "INSERT INTO h $GEN;"
 psql_run "INSERT INTO n $GEN;"
 

--- a/test/native_dml.sh
+++ b/test/native_dml.sh
@@ -16,7 +16,7 @@ pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
 
 psql_run "CREATE TABLE h (id int PRIMARY KEY, k bigint, v text);"
 psql_run "CREATE TABLE n (id int PRIMARY KEY, k bigint, v text) USING pgcolumnar;"
-psql_run "SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 1000, format_version => 1);"
+psql_run "SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 1000);"
 GEN="SELECT g, (g * 10)::bigint, 'row-' || g FROM generate_series(1, 5000) g"
 psql_run "INSERT INTO h $GEN;"
 psql_run "INSERT INTO n $GEN;"

--- a/test/native_index.sh
+++ b/test/native_index.sh
@@ -16,7 +16,7 @@ pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
 
 psql_run "CREATE TABLE h (id int PRIMARY KEY, k bigint, v text);"
 psql_run "CREATE TABLE n (id int PRIMARY KEY, k bigint, v text) USING pgcolumnar;"
-psql_run "SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 2048, format_version => 1);"
+psql_run "SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 2048);"
 GEN="SELECT g, (g * 10)::bigint, 'row-' || g FROM generate_series(1, 8000) g"
 psql_run "INSERT INTO h $GEN;"
 psql_run "INSERT INTO n $GEN;"
@@ -52,7 +52,6 @@ check "row count unchanged after rejected dup" "$(q 'SELECT count(*) FROM n;')" 
 
 # A standalone UNIQUE index enforces too.
 psql_run "CREATE TABLE nu (id int, k bigint) USING pgcolumnar;"
-psql_run "SELECT pgcolumnar.alter_columnar_table_set('nu', format_version => 1);"
 psql_run "CREATE UNIQUE INDEX nu_k ON nu (k);"
 psql_run "INSERT INTO nu SELECT g, g FROM generate_series(1,1000) g;"
 check "unique index rejects duplicate" \

--- a/test/native_ios.sh
+++ b/test/native_ios.sh
@@ -17,7 +17,7 @@ pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
 # inside an all-visible group.
 psql_run "CREATE TABLE ioh (id int, v text);"
 psql_run "CREATE TABLE ios (id int, v text) USING pgcolumnar;"
-psql_run "SELECT pgcolumnar.alter_columnar_table_set('ios', stripe_row_limit => 16384, format_version => 1);"
+psql_run "SELECT pgcolumnar.alter_columnar_table_set('ios', stripe_row_limit => 16384);"
 GEN="SELECT g, 'r'||g FROM generate_series(1, 8000) g"
 psql_run "INSERT INTO ioh $GEN;"
 psql_run "INSERT INTO ios $GEN;"

--- a/test/native_projection.sh
+++ b/test/native_projection.sh
@@ -16,7 +16,7 @@ set -uo pipefail
 pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
 
 psql_run "CREATE TABLE fo (a int, b text, c int) USING pgcolumnar;"
-psql_run "SELECT pgcolumnar.alter_columnar_table_set('fo', stripe_row_limit => 1000, format_version => 1);"
+psql_run "SELECT pgcolumnar.alter_columnar_table_set('fo', stripe_row_limit => 1000);"
 psql_run "SELECT pgcolumnar.add_projection('fo', 'fp', ARRAY['a','c'], ARRAY['c']);"
 psql_run "SELECT pgcolumnar.add_projection('fo', 'fq', ARRAY['b']);"
 psql_run "INSERT INTO fo SELECT g, 'r'||g, (g*7)%100 FROM generate_series(1,5000) g;"

--- a/test/native_roundtrip.sh
+++ b/test/native_roundtrip.sh
@@ -18,7 +18,7 @@ pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
 # limit so the read crosses several row groups.
 psql_run "CREATE TABLE h (id int, k bigint, v text, f float8, b bool);"
 psql_run "CREATE TABLE n (id int, k bigint, v text, f float8, b bool) USING pgcolumnar;"
-psql_run "SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 1000, format_version => 1);"
+psql_run "SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 1000);"
 GEN="SELECT g,
        (g * 100000)::bigint,
        CASE WHEN g % 9 = 0 THEN NULL ELSE 'row-' || g END,

--- a/test/native_skip.sh
+++ b/test/native_skip.sh
@@ -25,7 +25,7 @@ GEN="SELECT g, (g * 10)::bigint, 'lbl-' || (g % 100)
 
 psql_run "CREATE TABLE h (id int, k bigint, label text);"
 psql_run "CREATE TABLE n (id int, k bigint, label text) USING pgcolumnar;"
-psql_run "SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 2048, chunk_group_row_limit => 1024, format_version => 1);"
+psql_run "SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 2048, chunk_group_row_limit => 1024);"
 psql_run "INSERT INTO h $GEN;"
 psql_run "INSERT INTO n $GEN;"
 

--- a/test/native_vecskip.sh
+++ b/test/native_vecskip.sh
@@ -22,7 +22,7 @@ GEN="SELECT g AS id, (g % 97) AS v FROM generate_series(1, 8192) g"
 
 psql_run "CREATE TABLE h (id int, v int);"
 psql_run "CREATE TABLE n (id int, v int) USING pgcolumnar;"
-psql_run "SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 16384, chunk_group_row_limit => 1024, format_version => 1);"
+psql_run "SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 16384, chunk_group_row_limit => 1024);"
 psql_run "INSERT INTO h $GEN;"
 psql_run "INSERT INTO n $GEN;"
 

--- a/test/native_zonemap.sh
+++ b/test/native_zonemap.sh
@@ -27,7 +27,7 @@ GEN="SELECT g,
 
 psql_run "CREATE TABLE h (id int, k bigint, label text, v int);"
 psql_run "CREATE TABLE n (id int, k bigint, label text, v int) USING pgcolumnar;"
-psql_run "SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 2048, chunk_group_row_limit => 1024, format_version => 1);"
+psql_run "SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 2048, chunk_group_row_limit => 1024);"
 psql_run "INSERT INTO h $GEN;"
 psql_run "INSERT INTO n $GEN;"
 


### PR DESCRIPTION
Completes Phase H, the clean-cut removal of the legacy 1.0-dev (2.2) on-disk format. Builds on PR #68 (plan + H1 native-only tests + PostgreSQL 13/14 matrix drop).

### H2: remove the 2.2 code, catalog, and format selector (~2955 lines removed)
- 2.2 writer, reader, catalog (`stripe` / `chunk` / `chunk_group`), the per-table format selector, and the 2.2-only vectorized scan path are gone; one native (PGCN v1) format line remains. The scan is the scalar per-row path; the native vectorized aggregate answers ungrouped count/sum/avg/min/max from the zone maps.
- `columnar_relation_estimate_size` now reads the native row groups (it previously estimated zero rows for a native table).
- Two bugs surfaced and fixed: a stale `COMMENT ON FUNCTION` arity on `alter_columnar_table_reset` that aborted `CREATE EXTENSION`, and an unconditional pre-commit flush that reused a stale row-group id (`duplicate row_group_pkey`), now guarded by an early return in `columnar_flush_row_group`.

### H3: retire the dead vectorized-scan GUCs and full docs pass
- Remove `pgcolumnar.enable_compressed_execution` and `pgcolumnar.enable_late_materialization` (both drove the removed scan path). `enable_vectorization` stays, gating the aggregate path.
- `differential.sh` no longer toggles the removed GUCs; the oracle checks run once.
- README, CHANGELOG, and all `docs/` describe a single native format: no `format_version` option, no `default_format_version`, no "earlier line still read / retired later" language. The `v1.0-dev` tag is the historical pointer. Execution and ARCHITECTURE descriptions are corrected to native-only. No em-dashes.

### Gate
Full PostgreSQL 15-19 matrix, assert-enabled, native-only: **ALL VERSIONS PASSED**, no warnings.

This is the capstone of the re-origination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)