### PR TITLE
Record the re-origination cutover to main

### DIFF
--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -549,3 +549,13 @@ oracle, so none changes query results.
   record) and points the build source at the new specification to be written in
   Phase B. No upstream source consulted. See
   design/DESIGN_PIVOT_ORIGINAL_ENGINE.md and design/TODO_PIVOT.md.
+- 2026-07-22. Re-origination cutover: merged `re-origination` into `main` (owner
+  approved). The core pivot is complete: Phases A through D and H landed, so the
+  native format (PGCN v1) is the sole on-disk format, built clean-room from
+  design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md and the open Arrow/Parquet/ORC specs,
+  and the legacy 1.0-dev (2.2) writer, reader, catalog, and format selector are
+  removed. The `v1.0-dev` tag permanently preserves the 1.0-dev practice-round
+  snapshot. `main` now carries the native engine. Going forward, feature phases
+  (E2 FSST, F mutation and clustering, G interop) branch off `main` directly and
+  land as matrix-gated PRs into `main`; the `re-origination` integration branch is
+  retired. No upstream source consulted at any point.

--- a/design/TODO_PIVOT.md
+++ b/design/TODO_PIVOT.md
@@ -32,6 +32,13 @@ directions". Both of those are also uncommitted.
 - Commits and pushes to `re-origination` and its phase branches are fine. Do NOT
   merge to `main` until the end.
 
+**Done (2026-07-22): the cutover happened.** The core pivot (Phases A-D, H) is
+complete, so `re-origination` was merged into `main` with owner approval. `main`
+now carries the native engine; the legacy 1.0-dev line is preserved only by the
+`v1.0-dev` tag. Going forward, the remaining feature phases (E2, F, G) branch off
+`main` directly and land as matrix-gated PRs into `main`; the `re-origination`
+integration branch is retired.
+
 ## Phases (each matrix-gated; none reads upstream source)
 
 - [x] **Phase A. Provenance reset (docs only).** Done (PR #51 into


### PR DESCRIPTION
Bookkeeping ahead of the cutover: logs the re-origination -> main merge in PROVENANCE.md and marks it in TODO_PIVOT.md. The core pivot (Phases A-D, H) is complete; the remaining feature phases (E2, F, G) branch off main directly, retiring the re-origination integration branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)