### PR TITLE
Phase E3b: chunk-shared FSST symbol table

### DIFF
--- a/bench/run_bench_fsst.sh
+++ b/bench/run_bench_fsst.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+#
+# pgColumnar FSST ingestion micro-benchmark (Phase E3 gate).
+#
+# The main benchmark (run_bench.sh) never exercises FSST: its text columns are
+# low cardinality, so dict wins and the FSST cost guard skips the symbol-table
+# build. This harness loads the case FSST is actually for -- a high-cardinality
+# column whose values are distinct but share frequent substrings (URL / log-line
+# shaped) -- and times ingestion, which is where the per-vector symbol-table
+# build lands. Its output is the number Phase E3 is gated on (design/PHASE_E3_PLAN.md).
+#
+# To isolate FSST's cost, run it twice against two builds of the same branch:
+#   1. as shipped (FSST enabled)
+#   2. with FSST disabled (a one-line `return false;` at the top of encode_fsst),
+#      rebuilt -- the column then falls to none/dict.
+# The ingestion-time delta is FSST's cost; the size delta is the ratio it buys.
+#
+# Written fresh for pgColumnar. Run against a NON-assert build (assertions
+# distort timing). Run as a user that may "runuser -u postgres" (e.g. root).
+#
+# Usage:   bench/run_bench_fsst.sh [PG_CONFIG]
+# Environment:
+#   BENCH_SCALE  rows to load (default 3000000)
+#   BENCH_PORT   cluster port (default 55462)
+
+set -euo pipefail
+
+PG_CONFIG="${1:-/usr/local/pg17_nc/bin/pg_config}"
+BINDIR="$("$PG_CONFIG" --bindir)"
+PORT="${BENCH_PORT:-55462}"
+SCALE="${BENCH_SCALE:-3000000}"
+SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+WORKDIR="$(mktemp -d /tmp/pgcolumnar-fsstbench.XXXXXX)"
+PGDATA="$WORKDIR/data"
+LOGFILE="$WORKDIR/server.log"
+
+echo "== pgColumnar FSST ingestion micro-benchmark =="
+echo "PG_CONFIG=$PG_CONFIG  ($("$PG_CONFIG" --version))"
+echo "scale=$SCALE rows  workdir=$WORKDIR"
+
+echo "-- building (non-assert expected)"
+make -C "$SRCDIR" PG_CONFIG="$PG_CONFIG" clean >/dev/null 2>&1 || true
+make -C "$SRCDIR" PG_CONFIG="$PG_CONFIG" >/dev/null
+make -C "$SRCDIR" install PG_CONFIG="$PG_CONFIG" >/dev/null
+
+if [ "$(id -u)" = "0" ]; then
+	RUNPG=(runuser -u postgres --)
+	chown -R postgres "$WORKDIR"
+else
+	RUNPG=(env)
+fi
+run_pg() { "${RUNPG[@]}" env PATH="$BINDIR:$PATH" bash -lc "$1"; }
+
+cleanup() {
+	run_pg "pg_ctl -D '$PGDATA' stop -m immediate -w" >/dev/null 2>&1 || true
+	rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+echo "-- initdb and start"
+run_pg "initdb -D '$PGDATA' -A trust" >/dev/null 2>&1
+{
+	echo "port=$PORT"
+	echo "shared_preload_libraries='pgcolumnar'"
+	echo "shared_buffers=512MB"
+	echo "work_mem=64MB"
+	echo "maintenance_work_mem=256MB"
+	echo "max_wal_size=8GB"
+	echo "checkpoint_timeout=30min"
+	echo "max_parallel_workers_per_gather=0"
+} | run_pg "cat >> '$PGDATA/postgresql.conf'"
+run_pg "pg_ctl -D '$PGDATA' -l '$LOGFILE' start -w" >/dev/null
+run_pg "createdb -p $PORT bench"
+
+PSQL="psql -p $PORT -d bench -v ON_ERROR_STOP=1"
+run_pg "$PSQL -q -c \"CREATE EXTENSION pgcolumnar;\""
+
+# High-cardinality, shared-substring text: every row distinct (g and an md5), but
+# heavy shared structure (scheme, host, path, query key) -- exactly what FSST
+# compresses and dict declines. compression=none so we measure the encoding, not
+# a block codec on top of it.
+echo "-- staging $SCALE rows of shared-substring text"
+run_pg "$PSQL -q -c \"
+CREATE UNLOGGED TABLE stage AS
+SELECT g::bigint AS id,
+       'https://www.example.com/user/' || g || '/profile?id=' ||
+         md5(g::text) || '&ref=columnar&lang=en-US' AS url
+FROM generate_series(1, $SCALE) g;\""
+
+# Server-side timing via clock_timestamp(), so no dependence on psql \timing
+# formatting; the elapsed milliseconds are RAISEd as a NOTICE and grepped out.
+time_insert() {  # $1 = target table, prints elapsed ms
+	run_pg "$PSQL -qtA -c \"
+DO \\\$\\\$
+DECLARE t0 timestamptz; ms numeric;
+BEGIN
+  t0 := clock_timestamp();
+  INSERT INTO $1 SELECT * FROM stage;
+  ms := extract(epoch from clock_timestamp() - t0) * 1000;
+  RAISE NOTICE 'INGEST_MS %', round(ms, 1);
+END \\\$\\\$;\" 2>&1" | grep -oE 'INGEST_MS [0-9.]+' | grep -oE '[0-9.]+' | tail -1
+}
+
+echo "-- timing heap ingestion (baseline)"
+run_pg "$PSQL -q -c \"CREATE TABLE h (LIKE stage);\""
+heap_ms=$(time_insert h)
+
+echo "-- timing columnar (compression=none) ingestion"
+run_pg "$PSQL -q \
+	-c \"CREATE TABLE c (LIKE stage) USING pgcolumnar;\" \
+	-c \"SELECT pgcolumnar.alter_columnar_table_set('c', compression => 'none');\""
+col_ms=$(time_insert c)
+
+# Order-independent fingerprint (no giant string_agg): count, total length, and
+# xor of per-row md5 hashes catch any byte-level corruption cheaply.
+echo "-- verify round-trip (heap vs columnar fingerprint)"
+FP="SELECT count(*), sum(length(url))::bigint, bit_xor(('x'||substr(md5(id||'|'||url),1,16))::bit(64)::bigint)"
+hh=$(run_pg "$PSQL -qtA -c \"$FP FROM h;\"")
+ch=$(run_pg "$PSQL -qtA -c \"$FP FROM c;\"")
+
+echo "-- sizes and FSST usage"
+hsize=$(run_pg "$PSQL -qtA -c \"SELECT pg_table_size('h');\"")
+csize=$(run_pg "$PSQL -qtA -c \"SELECT pg_table_size('c');\"")
+fsst_chunks=$(run_pg "$PSQL -qtA -c \"
+SELECT count(*) FROM pgcolumnar.column_chunk
+ WHERE storage_id = pgcolumnar.get_storage_id('c')
+   AND column_index = 1
+   AND get_byte(encoding_descriptor, 6) = 8;\"")
+total_chunks=$(run_pg "$PSQL -qtA -c \"
+SELECT count(*) FROM pgcolumnar.column_chunk
+ WHERE storage_id = pgcolumnar.get_storage_id('c')
+   AND column_index = 1;\"")
+
+echo
+echo "===================== FSST INGESTION GATE ======================"
+printf '  %-28s %s\n' "rows"                 "$SCALE"
+printf '  %-28s %s ms\n' "heap INSERT"       "${heap_ms:-?}"
+printf '  %-28s %s ms\n' "columnar INSERT"   "${col_ms:-?}"
+printf '  %-28s %s\n' "round-trip"           "$([ "$hh" = "$ch" ] && echo MATCH || echo MISMATCH)"
+printf '  %-28s %s bytes\n' "heap size"      "${hsize:-?}"
+printf '  %-28s %s bytes\n' "columnar size"  "${csize:-?}"
+printf '  %-28s %s / %s (first-vector = FSST)\n' "url chunks using FSST" "${fsst_chunks:-?}" "${total_chunks:-?}"
+echo "================================================================"
+echo "Run once as shipped and once with encode_fsst stubbed to return false;"
+echo "the columnar-INSERT delta is FSST's ingestion cost, the size delta its ratio."

--- a/design/PHASE_E3_PLAN.md
+++ b/design/PHASE_E3_PLAN.md
@@ -1,0 +1,172 @@
+# Phase E3 plan: selector cost and cascade refinement
+
+Status: active investigation, branched off `main` after E2 (FSST) merges. E3 is
+the refinement the Phase E plan tracked as "executed only if warranted" -- it is
+evidence-gated, not a scheduled deliverable. This document is written before any
+E3 code, per the plan-before-code discipline: it fixes the gate measurement and
+the design options that measurement chooses between.
+
+## The question E3 answers
+
+The per-vector cascade selector (`ColumnarEncodeChunk`, called once per chunk
+group from `columnar_write_state.c`) measures every applicable encoding on the
+full 1024-value vector and keeps the smallest. This is per-vector optimal for
+compression ratio, and cheap for the lightweight integer/float encoders. FSST
+(E2) changed the cost profile: building a symbol table per vector is by far the
+costliest encoder in the set. E2 already added two guards -- FSST is skipped when
+a cheaper encoding already compressed the vector below three quarters of raw, and
+its candidate-counting hash is sized to the sample -- but when FSST *is* the right
+encoding (high-cardinality varlena with shared substrings), the table is still
+rebuilt from scratch for every vector in the column chunk.
+
+E3 asks: **is that per-vector rebuild a measurable ingestion cost, and if so,
+what is the smallest change that removes it without losing ratio?**
+
+## Gate measurement (run first, before any E3 code)
+
+The existing 6M-row benchmark does not exercise FSST at all: its text columns are
+low cardinality (`c1` 1000 distinct, `c2` 20 distinct, `c3` constant), so dict
+wins and the cost guard skips FSST. The gate therefore needs a targeted load.
+
+Measurement: `bench/run_bench_fsst.sh` (new, non-assert build), loading N million
+rows of a **high-cardinality shared-substring** text column (URL / log-line
+shaped -- the case FSST is for) into a native columnar table, timing the INSERT
+(ingestion is where the per-vector build cost lands). Compare two builds of the
+same branch:
+
+- FSST enabled (as shipped).
+- FSST disabled (one-line local `return false` at the top of `encode_fsst`),
+  rebuilt -- the column then falls to `none`/`dict`, isolating FSST's cost.
+
+The delta is FSST's ingestion cost. Decision rule:
+
+- Delta is small (say < ~15% of total columnar ingestion time on that column, and
+  ingestion still comfortably faster than the value it delivers): E3 is **not
+  warranted**. Record the number here and stop; the per-vector selector stays.
+- Delta is large: implement the targeted fix below (E3b), then re-run the gate to
+  confirm the cost is removed and ratio is unchanged.
+
+Also record the compression ratio in both runs, so any E3 change can be shown to
+be ratio-neutral (its whole justification).
+
+## Gate result (2026-07-22): E3b warranted
+
+Ran `bench/run_bench_fsst.sh` at 3M rows of high-cardinality shared-substring URL
+text, `compression=none`, on `pg17_nc`, A/B against an FSST-stubbed build (both
+under concurrent matrix load, so absolute times are inflated but the relative
+delta is what matters and is robust):
+
+| build     | columnar INSERT | columnar size | chunks using FSST |
+| --------- | --------------- | ------------- | ----------------- |
+| FSST on   | 11792 ms        | 106.2 MB      | 20 / 20           |
+| FSST off  | 2615 ms         | 324.6 MB      | 0 / 20            |
+| heap base | ~1550 ms        | 439.3 MB      | --                |
+
+- **Cost:** FSST adds 9177 ms, 78% of columnar ingestion time and a 4.5x
+  slowdown, on an FSST-heavy column. Decisively past the gate threshold.
+- **Ratio:** FSST buys 3.06x (324.6 -> 106.2 MB), even with no block codec -- a
+  win worth keeping. Round-trip MATCH in both runs.
+- **Amortization headroom:** ~20 column chunks over 3M rows is ~150k rows/chunk,
+  ~146 vectors/chunk. The symbol table is rebuilt once per vector today; building
+  it once per chunk is ~146x fewer builds, which should return ingestion to near
+  the FSST-off baseline while keeping the 3x ratio.
+
+Decision: implement **E3b** (chunk-shared FSST symbol table). E3a is not pursued
+now; it does not remove the per-vector build, which is where the measured cost is.
+
+## Design options the measurement chooses between
+
+### E3a. Sample-based selection (general, BtrBlocks-style)
+
+Sample ~1% of a column chunk's vectors, run the full candidate measurement on the
+sample, pick the winning encoding, and apply it to every vector in the chunk --
+skipping the exhaustive measurement of the losing candidates per vector. This is
+a general selector speedup (it saves measuring encoders that were never going to
+win) and keeps per-vector encoding descriptors.
+
+For FSST specifically it is only a partial fix: even once FSST is chosen for the
+chunk, each vector still *builds its own table*, which is the dominant cost. E3a
+helps the mixed-column case (stop measuring dict/rle/for on every vector of a
+column FSST always wins) but does not remove the per-vector table build.
+
+### E3b. Chunk-shared FSST symbol table (targeted at the measured cost)
+
+Build one FSST symbol table per column chunk from a sample of the chunk's values,
+store it once at the chunk level in the encoding descriptor, and encode every
+vector's code stream against that shared table. The table build -- the dominant
+cost -- is then paid once per chunk instead of once per vector, while each vector
+keeps its own code stream (so per-vector skipping and random access are
+unchanged). Ratio is essentially unchanged or slightly better: one table trained
+on the whole chunk is at least as representative as many tables trained on 1024
+values each, and the per-vector table bytes are no longer repeated.
+
+Cost: a format touch. The per-column-chunk descriptor gains an optional
+chunk-level FSST table region that FSST vectors in that chunk reference, instead
+of each FSST vector embedding its own table inline. The decoder reads the shared
+table once per chunk. This is the invasive part and the reason E3b is gated on
+the measurement actually showing a cost worth a format change.
+
+As-built format (from reading the descriptor code). The encoding descriptor is
+`[version:1][reserved:1][vectorCount:uint32]` then `vectorCount` entries of
+`[encType:1][valueCount:uint32][rawLen:uint32][encLen:uint32]`, with the encoded
+value streams concatenated in a separate region (optionally block-compressed).
+E3b:
+- Bump `COLUMNAR_NATIVE_ENCDESC_VERSION` 1 -> 2 and **append** the shared table as
+  a trailing region `[sharedTableLen:uint32][table bytes]` after the per-vector
+  entries -- deliberately at the end so every existing per-vector `encType` offset
+  is unchanged and current descriptor assertions keep reading the right bytes.
+  `sharedTableLen` is 0 for non-varlena chunks and for varlena chunks where FSST
+  was not built.
+- The table serialization is the existing FSST symbol table `[uint8 nSym][ nSym x
+  (uint8 len, len bytes) ]`; an FSST vector's encoded bytes become just the bare
+  code stream (no inline table). Inline-table FSST (E2's on-disk form) is replaced
+  wholesale; the version bump makes any stray v1 descriptor fail cleanly rather
+  than misdecode. No persistent v1 data exists (pre-release, tests regenerate).
+- The table lives in `encoding_descriptor` (uncompressed, ~1-2 KB/chunk); the code
+  streams still get the block codec. Build once per chunk from a bounded (~64 KB)
+  sample gathered across the chunk's vectors.
+- Touch points: `ColumnarEncodeChunk`/`ColumnarDecodeChunk` gain shared-table
+  params; a new `ColumnarFsstBuildChunkTable` builds+serializes once per chunk;
+  the writer builds the table before its per-vector loop and appends it to the
+  descriptor; `columnar_native_decode_chunk` reads the trailing table and passes
+  it to each FSST vector decode. Only one decode call site exists. `test/pbt` and
+  its shim update to build+pass a shared table for the varlena round-trip.
+
+### Recommendation
+
+If the gate shows a real cost, **E3b is the fix** -- it removes the dominant
+per-vector build, which E3a does not. E3a is a separate, orthogonal selector
+speedup that can be considered on its own merits later; it is not a substitute
+for E3b on FSST-heavy ingestion. If the gate shows no meaningful cost, neither is
+warranted and the per-vector selector stays as is.
+
+## Tracked alternative: asynchronous / deferred compression
+
+A larger lever for the same ingestion-cost problem: commit the insert in a fast,
+lightly-encoded (or uncompressed) write-optimized form, return to the transaction
+immediately, and have a background worker rewrite the row groups with the full
+cascade afterward. This is the classic write-optimized-store to read-optimized-
+store split (Vertica WOS/ROS, SQL Server columnstore delta rowgroups) as prior
+art. It hides all encoder latency from the foreground, not just FSST's.
+
+It is not pursued in E3 because it is a substantial subsystem with real costs:
+write amplification (data written twice plus WAL), transient ~3x space and slower
+interim reads until compaction, and MVCC-safe atomic row-group rewrite -- the same
+machinery Phase F (mutation, clustering, MERGE) needs. E3b removes the measured
+FSST cost cheaply and synchronously and likely makes async compaction unnecessary
+for FSST specifically. If, after E3b, foreground encoding cost is still a problem
+(other encoders, larger scale), the async delta-store is the right next step and
+belongs with the Phase F compaction work. Tracked here; gated on a post-E3b
+measurement, exactly as E3b was gated on the E2 measurement.
+
+## Validation (if E3b is implemented)
+
+- The codec property test (`test/pbt`) stays byte-exact: E3b changes where the
+  FSST table lives, not the round-trip contract; a chunk-shared-table variant is
+  added to the harness.
+- `native_encoding.sh` still asserts FSST is chosen, round-trips text and bytea,
+  and shrinks the column; add an assertion that a chunk carries one shared table,
+  not one per vector.
+- The differential oracle stays green on native tables.
+- The gate benchmark re-run shows ingestion cost removed and ratio unchanged.
+- Full PostgreSQL 15-19 matrix, assert-enabled, no warnings, before merge.

--- a/design/PHASE_E3_PLAN.md
+++ b/design/PHASE_E3_PLAN.md
@@ -74,6 +74,37 @@ delta is what matters and is robust):
 Decision: implement **E3b** (chunk-shared FSST symbol table). E3a is not pursued
 now; it does not remove the per-vector build, which is where the measured cost is.
 
+## Post-implementation measurement (2026-07-22): correction
+
+Re-running the gate under clean, matched conditions (no concurrent matrix load)
+against E2, E3b, and an FSST-off build corrected the cost attribution the first
+gate got wrong. The first gate ran under matrix contention, which inflated the
+absolute times and, worse, led to attributing FSST's cost to the table build. The
+clean numbers (3M rows, high-cardinality URL text, compression=none, pg17_nc):
+
+| build (clean)        | columnar INSERT | size     |
+| -------------------- | --------------- | -------- |
+| FSST off (baseline)  | 2777 ms         | 324.6 MB |
+| E3b, 256 KB sample   | 10329 ms        | 105.8 MB |
+| E3b, 32 KB sample    | 9550 ms         | 111.2 MB |
+| E2 (per-vector table)| 11087 ms        | 106.2 MB |
+
+FSST's cost decomposes as roughly **82% per-vector greedy-match compression**
+(6773 ms, which E3b does NOT change) and only **18% table build** (1537 ms, which
+E3b amortizes). So E3b's ingestion win is real but modest, not the ~4x the first
+(confounded) gate implied. With the small 32 KB sample E3b was 14% faster but 4.7%
+larger (a less representative shared table gives looser codes). Training the shared
+table on a larger 256 KB sample -- affordable because the build is now amortized
+~146x per chunk -- makes E3b **strictly better than E2 on both axes**: ~7% faster
+ingestion and a slightly smaller result (105.8 vs 106.2 MB), so E3b ships with the
+256 KB sample. E3b also scales better than E2 as vectors-per-chunk grows (E2
+rebuilds per vector; E3b builds once per chunk).
+
+The real lever for FSST ingestion cost is the per-vector greedy-match compression,
+not the build. That is future work (faster matcher, or the asynchronous
+compaction lever below), and is why E3b is a refinement rather than a fix for the
+whole cost.
+
 ## Design options the measurement chooses between
 
 ### E3a. Sample-based selection (general, BtrBlocks-style)

--- a/design/PHASE_E3_PLAN.md
+++ b/design/PHASE_E3_PLAN.md
@@ -85,9 +85,10 @@ clean numbers (3M rows, high-cardinality URL text, compression=none, pg17_nc):
 | build (clean)        | columnar INSERT | size     |
 | -------------------- | --------------- | -------- |
 | FSST off (baseline)  | 2777 ms         | 324.6 MB |
-| E3b, 256 KB sample   | 10329 ms        | 105.8 MB |
 | E3b, 32 KB sample    | 9550 ms         | 111.2 MB |
+| E3b, 256 KB sample   | 10329 ms        | 105.8 MB |
 | E2 (per-vector table)| 11087 ms        | 106.2 MB |
+| E3b, 10 MB sample    | 40240 ms        | 98.1 MB  |
 
 FSST's cost decomposes as roughly **82% per-vector greedy-match compression**
 (6773 ms, which E3b does NOT change) and only **18% table build** (1537 ms, which
@@ -99,6 +100,17 @@ table on a larger 256 KB sample -- affordable because the build is now amortized
 ingestion and a slightly smaller result (105.8 vs 106.2 MB), so E3b ships with the
 256 KB sample. E3b also scales better than E2 as vectors-per-chunk grows (E2
 rebuilds per vector; E3b builds once per chunk).
+
+The sample size was chosen from the tradeoff curve above, not guessed. 32 KB is
+faster to build but its shared table is too loose (111.2 MB, a ratio regression).
+A 10 MB sample reaches the best ratio (98.1 MB) but the build cost explodes: it
+scans most of each ~13 MB chunk four times, driving ingestion to 40.2 s, a 3.9x
+slowdown over E2 for an 8% ratio gain -- not worth it. 256 KB sits at the knee: it
+is the only sample that is Pareto-better than E2 (faster and smaller), with the
+build cost still negligible next to the compression pass. Should a workload want
+the last few percent of ratio at the cost of ingestion, this is a single tunable
+constant (FSST_SAMPLE_CAP and the writer's matching corpus cap); a per-table option
+could expose it, but the default stays at the balanced 256 KB knee.
 
 The real lever for FSST ingestion cost is the per-vector greedy-match compression,
 not the build. That is future work (faster matcher, or the asynchronous

--- a/design/ROADMAP.md
+++ b/design/ROADMAP.md
@@ -119,6 +119,18 @@ is preserved.
   vectors and runs directly on them. Large effort (a new format generation) that
   targets the run-at-a-time compressed executor pgColumnar already has.
   Source: FastLanes, PVLDB vol.18, 2025, https://www.vldb.org/pvldb/vol18/p4629-afroozeh.pdf .
+- Asynchronous write and background compaction (wishlist). Commit inserts in a
+  fast, lightly encoded or uncompressed write-optimized form and return to the
+  transaction immediately, then have a background worker rewrite the row groups
+  with the full encoding cascade afterward. This hides encoder latency from the
+  foreground for the heaviest encoders at scale. The classic write-optimized to
+  read-optimized store split is the prior art. It must be toggleable on or off per
+  table or per storage tier, since it trades foreground latency for write
+  amplification, transient extra space, and slower interim reads until compaction.
+  It shares the MVCC-safe row-group rewrite machinery with the mutation and
+  clustering work, so it belongs with that phase. Gated on a measurement showing
+  synchronous encoding cost is still a problem after the per-chunk shared FSST
+  table (E3b) lands. Large effort.
 
 ### Interoperability and PostgreSQL integration
 

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -54,11 +54,20 @@
  * value stream. The layout is: uint8 version, uint8 reserved, uint32 vectorCount,
  * then per vector { uint8 encodingType, uint32 valueCount, uint32 rawLen,
  * uint32 encLen }. Integers are host-endian (little-endian hosts assumed, spec 3).
+ *
+ * Version 2 (E3b) appends one trailing region after the per-vector entries:
+ * { uint32 sharedTableLen, sharedTableLen bytes }. It holds a chunk-shared FSST
+ * symbol table (0 when the chunk has none); FSST vectors in a version-2 chunk
+ * store a bare code stream decoded against this one table instead of embedding
+ * their own, so the costly table build is paid once per chunk, not per vector.
+ * It is appended (not inserted after the header) so every per-vector entry offset
+ * is unchanged from version 1.
  */
 #define COLUMNAR_NATIVE_ENCDESC_BASELINE 0
-#define COLUMNAR_NATIVE_ENCDESC_VERSION 1
+#define COLUMNAR_NATIVE_ENCDESC_VERSION 2
 #define COLUMNAR_NATIVE_ENCDESC_HEADER_LEN 6	/* version + reserved + vectorCount */
 #define COLUMNAR_NATIVE_ENCDESC_ENTRY_LEN 13	/* encodingType + 3 * uint32 */
+#define COLUMNAR_NATIVE_ENCDESC_SHARED_LEN_BYTES 4	/* trailing uint32 sharedTableLen */
 
 /* first row number is 1 (spec 3) */
 #define COLUMNAR_FIRST_ROW_NUMBER 1
@@ -496,12 +505,26 @@ extern Datum ColumnarDecodeValue(Form_pg_attribute att, char **cursor,
  * ------------------------------------------------------------------------- */
 extern int ColumnarEncodeChunk(const char *raw, uint32 rawLen,
 							   Form_pg_attribute att, uint64 valueCount,
+							   const char *fsstTable, uint32 fsstTableLen,
 							   char **out, uint32 *outLen);
 extern char *ColumnarDecodeChunk(const char *enc, uint32 encLen,
 								 int encodingType, Form_pg_attribute att,
 								 uint64 valueCount, uint32 rawLen,
+								 const char *fsstTable, uint32 fsstTableLen,
 								 MemoryContext cx);
 extern const char *ColumnarEncodingName(int encodingType);
+
+/*
+ * Build one FSST symbol table for a whole column chunk from a sample of its
+ * concatenated varlena value streams (E3b). Returns true and sets *tableOut /
+ * *tableLenOut (palloc'd, serialized as [uint8 nSym][ nSym x (uint8 len, bytes)])
+ * when a table was built; false for non-varlena columns or when no useful table
+ * exists. The table is passed back into ColumnarEncodeChunk / ColumnarDecodeChunk
+ * as fsstTable so the per-vector build cost is paid once per chunk.
+ */
+extern bool ColumnarFsstBuildChunkTable(const char *corpus, uint32 corpusLen,
+										Form_pg_attribute att,
+										char **tableOut, uint32 *tableLenOut);
 
 /* -------------------------------------------------------------------------
  * per-chunk bloom filters (columnar_bloom.c, I7)

--- a/src/columnar_encoding.c
+++ b/src/columnar_encoding.c
@@ -1539,37 +1539,109 @@ build_fsst_table(const char *corpus, uint32 corpusLen, FsstTable *out)
 	*out = cur;
 }
 
-static bool
-encode_fsst(const char *raw, uint32 rawLen, Form_pg_attribute att, uint32 n,
-			char **out, uint32 *outLen)
+/* serialize a symbol table as [uint8 nSym][ nSym x (uint8 len, len bytes) ] */
+static void
+fsst_serialize_table(const FsstTable *t, StringInfo out)
+{
+	int			s;
+
+	appendStringInfoChar(out, (char) t->nSym);
+	for (s = 0; s < t->nSym; s++)
+	{
+		uint64		v = t->symVal[s];
+
+		appendStringInfoChar(out, (char) t->symLen[s]);
+		appendBinaryStringInfo(out, (char *) &v, t->symLen[s]);
+	}
+}
+
+/* parse a serialized symbol table; false (with a clean error) on corruption */
+static void
+fsst_deserialize_table(const char *p, uint32 len, FsstTable *t)
+{
+	const char *end = p + len;
+	uint32		nSym;
+	uint32		i;
+
+	if (len < 1)
+		DECODE_CORRUPT("FSST shared table truncated");
+	nSym = (unsigned char) *p++;
+	if (nSym > FSST_MAX_SYMBOLS)
+		DECODE_CORRUPT("FSST shared table symbol count out of range");
+	t->nSym = (int) nSym;
+	for (i = 0; i < nSym; i++)
+	{
+		uint8		L;
+		uint64		v = 0;
+
+		if (p >= end)
+			DECODE_CORRUPT("FSST shared table symbol length past end");
+		L = (unsigned char) *p++;
+		if (L < 1 || L > FSST_MAX_SYMLEN)
+			DECODE_CORRUPT("FSST shared table symbol length invalid");
+		if ((uint32) (end - p) < L)
+			DECODE_CORRUPT("FSST shared table symbol bytes past end");
+		memcpy(&v, p, L);
+		t->symVal[i] = v;
+		t->symLen[i] = L;
+		p += L;
+	}
+}
+
+/*
+ * ColumnarFsstBuildChunkTable
+ *		Build one FSST symbol table for a whole column chunk (E3b). The expensive
+ *		iterative table build runs once here; the serialized table is handed back
+ *		to be stored once per chunk and reused by every FSST vector.
+ */
+bool
+ColumnarFsstBuildChunkTable(const char *corpus, uint32 corpusLen,
+							Form_pg_attribute att, char **tableOut,
+							uint32 *tableLenOut)
 {
 	FsstTable	table;
-	FsstLookup	lk;
 	StringInfoData buf;
-	uint32		pos = 0;
-	int			s;
 
 	if (att->attlen != -1)
 		return false;			/* varlena only */
-	if (rawLen < FSST_MIN_RAWLEN || n == 0)
+	if (corpusLen < FSST_MIN_RAWLEN)
 		return false;
 
-	build_fsst_table(raw, rawLen, &table);
+	build_fsst_table(corpus, corpusLen, &table);
 	if (table.nSym == 0)
 		return false;
 
-	fsst_lookup_build(&lk, &table);
+	initStringInfo(&buf);
+	fsst_serialize_table(&table, &buf);
+	*tableOut = buf.data;
+	*tableLenOut = (uint32) buf.len;
+	return true;
+}
+
+/*
+ * Encode one vector against a chunk-shared table, producing a bare code stream
+ * (no inline table). The per-vector win test compares the code stream alone to
+ * the raw length: the shared table's bytes are amortized across the chunk and
+ * not charged here, so FSST wins per vector whenever the codes are smaller.
+ */
+static bool
+encode_fsst_shared(const char *raw, uint32 rawLen, const char *table,
+				   uint32 tableLen, char **out, uint32 *outLen)
+{
+	FsstTable	t;
+	FsstLookup	lk;
+	StringInfoData buf;
+	uint32		pos = 0;
+
+	if (rawLen < FSST_MIN_RAWLEN)
+		return false;
+
+	fsst_deserialize_table(table, tableLen, &t);
+	if (t.nSym == 0)
+		return false;
+	fsst_lookup_build(&lk, &t);
 
 	initStringInfo(&buf);
-	appendStringInfoChar(&buf, (char) table.nSym);
-	for (s = 0; s < table.nSym; s++)
-	{
-		uint64		v = table.symVal[s];
-
-		appendStringInfoChar(&buf, (char) table.symLen[s]);
-		appendBinaryStringInfo(&buf, (char *) &v, table.symLen[s]);
-	}
-
 	while (pos < rawLen)
 	{
 		int			L = 1;
@@ -1589,8 +1661,7 @@ encode_fsst(const char *raw, uint32 rawLen, Form_pg_attribute att, uint32 n,
 			pos += 1;
 		}
 
-		/* abandon as soon as we know FSST is not winning this chunk */
-		if ((uint32) buf.len >= rawLen)
+		if ((uint32) buf.len >= rawLen)	/* not winning this vector */
 		{
 			fsst_lookup_free(&lk);
 			pfree(buf.data);
@@ -1609,37 +1680,44 @@ encode_fsst(const char *raw, uint32 rawLen, Form_pg_attribute att, uint32 n,
 	return true;
 }
 
+/* decode a bare code stream against a chunk-shared serialized table (E3b) */
 static char *
-decode_fsst(const char *enc, uint32 encLen, uint32 n, uint32 rawLen,
-			MemoryContext cx)
+decode_fsst_shared(const char *enc, uint32 encLen, const char *table,
+				   uint32 tableLen, uint32 rawLen, MemoryContext cx)
 {
 	char	   *raw = MemoryContextAlloc(cx, rawLen > 0 ? rawLen : 1);
 	const char *p = enc;
 	const char *end = enc + encLen;
+	const char *tp;
+	const char *tend;
 	const char *symPtr[FSST_MAX_SYMBOLS];
 	uint8		symLen[FSST_MAX_SYMBOLS];
 	uint32		nSym;
 	uint32		outPos = 0;
 	uint32		i;
 
-	if (p >= end)
-		DECODE_CORRUPT("FSST header truncated");
-	nSym = (unsigned char) *p++;
-
+	/* parse the shared table (pointers reference the caller's descriptor bytes) */
+	if (tableLen < 1)
+		DECODE_CORRUPT("FSST shared table missing");
+	tp = table;
+	tend = table + tableLen;
+	nSym = (unsigned char) *tp++;
+	if (nSym > FSST_MAX_SYMBOLS)
+		DECODE_CORRUPT("FSST shared table symbol count out of range");
 	for (i = 0; i < nSym; i++)
 	{
 		uint8		L;
 
-		if (p >= end)
-			DECODE_CORRUPT("FSST symbol length past encoded length");
-		L = (unsigned char) *p++;
+		if (tp >= tend)
+			DECODE_CORRUPT("FSST shared table symbol length past end");
+		L = (unsigned char) *tp++;
 		if (L < 1 || L > FSST_MAX_SYMLEN)
-			DECODE_CORRUPT("FSST symbol length invalid");
-		if ((uint32) (end - p) < L)
-			DECODE_CORRUPT("FSST symbol bytes past encoded length");
+			DECODE_CORRUPT("FSST shared table symbol length invalid");
+		if ((uint32) (tend - tp) < L)
+			DECODE_CORRUPT("FSST shared table symbol bytes past end");
 		symLen[i] = L;
-		symPtr[i] = p;
-		p += L;
+		symPtr[i] = tp;
+		tp += L;
 	}
 
 	while (p < end)
@@ -1753,12 +1831,20 @@ ColumnarEncodingName(int encodingType)
  *		Selection is adaptive per chunk: each applicable encoding is measured and
  *		the smallest pre-compression result wins (each encoder bails cheaply when
  *		it cannot help). The candidate set spans the encoding axes -- runs (rle),
- *		range (for), sequences (delta, dod), cardinality (dict), and floats
- *		(gorilla) -- so the choice adapts to the column's data (I5).
+ *		range (for), sequences (delta, dod), cardinality (dict), floats (gorilla,
+ *		alp), and shared-substring strings (fsst) -- so the choice adapts to the
+ *		column's data (I5).
+ *
+ *		fsstTable/fsstTableLen, when non-NULL, is the chunk-shared FSST symbol
+ *		table (E3b): for a varlena column the FSST candidate encodes against it,
+ *		producing a bare code stream, so the table build is paid once per chunk by
+ *		the caller rather than once per vector here. When NULL, FSST is not a
+ *		candidate.
  */
 int
 ColumnarEncodeChunk(const char *raw, uint32 rawLen, Form_pg_attribute att,
-					uint64 valueCount, char **out, uint32 *outLen)
+					uint64 valueCount, const char *fsstTable, uint32 fsstTableLen,
+					char **out, uint32 *outLen)
 {
 	int			w = att->attlen;
 	uint32		n = (uint32) valueCount;
@@ -1859,14 +1945,15 @@ ColumnarEncodeChunk(const char *raw, uint32 rawLen, Form_pg_attribute att,
 	 * FSST (the substring axis) applies to varlena columns and captures shared
 	 * byte patterns that dictionary cannot -- high-cardinality text/bytea where
 	 * values differ but share frequent substrings. It competes with dict per
-	 * chunk and the smaller result wins (I5). Building the per-vector symbol
-	 * table is the costliest encoder, so it is skipped when a cheaper encoding
-	 * (dictionary on a low-cardinality column) already compressed the chunk
-	 * well; FSST is only worth its cost when nothing else has helped much.
+	 * vector and the smaller result wins (I5). The symbol table is built once per
+	 * chunk by the caller (E3b) and passed as fsstTable; here each vector only
+	 * encodes against it, so the dominant cost is not repeated per vector. It is
+	 * still skipped when a cheaper encoding already compressed the vector well.
 	 */
-	if (w == -1 && bestLen > rawLen - rawLen / 4)
+	if (w == -1 && fsstTable != NULL && bestLen > rawLen - rawLen / 4)
 	{
-		if (encode_fsst(raw, rawLen, att, n, &buf, &len) && len < bestLen)
+		if (encode_fsst_shared(raw, rawLen, fsstTable, fsstTableLen, &buf, &len) &&
+			len < bestLen)
 		{
 			if (bestBuf)
 				pfree(bestBuf);
@@ -1896,6 +1983,7 @@ ColumnarEncodeChunk(const char *raw, uint32 rawLen, Form_pg_attribute att,
 char *
 ColumnarDecodeChunk(const char *enc, uint32 encLen, int encodingType,
 					Form_pg_attribute att, uint64 valueCount, uint32 rawLen,
+					const char *fsstTable, uint32 fsstTableLen,
 					MemoryContext cx)
 {
 	uint32		n = (uint32) valueCount;
@@ -1956,7 +2044,10 @@ ColumnarDecodeChunk(const char *enc, uint32 encLen, int encodingType,
 		case COLUMNAR_ENCODING_DICT:
 			return decode_dict(enc, encLen, att, n, rawLen, cx);
 		case COLUMNAR_ENCODING_FSST:
-			return decode_fsst(enc, encLen, n, rawLen, cx);
+			if (fsstTable == NULL || fsstTableLen == 0)
+				DECODE_CORRUPT("FSST vector without a chunk-shared table");
+			return decode_fsst_shared(enc, encLen, fsstTable, fsstTableLen,
+									  rawLen, cx);
 		default:
 			ereport(ERROR,
 					(errcode(ERRCODE_DATA_CORRUPTED),

--- a/src/columnar_encoding.c
+++ b/src/columnar_encoding.c
@@ -1262,7 +1262,11 @@ decode_dict(const char *enc, uint32 encLen, Form_pg_attribute att, uint32 n,
 #define FSST_ESCAPE 255
 #define FSST_MAX_SYMLEN 8
 #define FSST_ROUNDS 4			/* enough to grow symbols to 8 bytes and refine */
-#define FSST_SAMPLE_CAP 32768	/* bytes of the corpus used to build the table */
+#define FSST_SAMPLE_CAP 262144	/* bytes of the corpus used to build the table.
+								 * Larger than a single vector on purpose: the table
+								 * is built once per column chunk (E3b), so a bigger
+								 * sample trains a more representative table (tighter
+								 * codes) at negligible amortized cost. */
 #define FSST_MIN_RAWLEN 64		/* below this, table overhead cannot pay off */
 #define FSST_COUNT_SLOTS (1u << 17)	/* candidate-counting hash capacity */
 

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -465,6 +465,9 @@ columnar_native_decode_chunk(MemoryContext cx, Form_pg_attribute att,
 	const char *dp;
 	uint64		encTotal = 0;
 	uint64		rawTotal = 0;
+	uint64		entriesEnd;
+	uint32		sharedTableLen = 0;
+	const char *sharedTable = NULL;
 	const char *encRegion;
 	const char *encCursor;
 	char	   *rawBuf;
@@ -478,11 +481,25 @@ columnar_native_decode_chunk(MemoryContext cx, Form_pg_attribute att,
 				 errmsg("pgcolumnar: unrecognized native encoding descriptor")));
 	memcpy(&vectorCount, desc + 2, sizeof(uint32));
 
-	if ((uint64) descLen != (uint64) COLUMNAR_NATIVE_ENCDESC_HEADER_LEN +
-		(uint64) vectorCount * COLUMNAR_NATIVE_ENCDESC_ENTRY_LEN)
+	/*
+	 * Version 2 (E3b) appends a trailing region { uint32 sharedTableLen, bytes }
+	 * after the per-vector entries: the chunk-shared FSST symbol table. Locate and
+	 * validate it, so FSST vectors can be decoded against it.
+	 */
+	entriesEnd = (uint64) COLUMNAR_NATIVE_ENCDESC_HEADER_LEN +
+		(uint64) vectorCount * COLUMNAR_NATIVE_ENCDESC_ENTRY_LEN;
+	if ((uint64) descLen < entriesEnd + COLUMNAR_NATIVE_ENCDESC_SHARED_LEN_BYTES)
 		ereport(ERROR,
 				(errcode(ERRCODE_DATA_CORRUPTED),
 				 errmsg("pgcolumnar: native encoding descriptor length mismatch")));
+	memcpy(&sharedTableLen, desc + entriesEnd, sizeof(uint32));
+	if ((uint64) descLen != entriesEnd + COLUMNAR_NATIVE_ENCDESC_SHARED_LEN_BYTES +
+		(uint64) sharedTableLen)
+		ereport(ERROR,
+				(errcode(ERRCODE_DATA_CORRUPTED),
+				 errmsg("pgcolumnar: native encoding descriptor length mismatch")));
+	if (sharedTableLen > 0)
+		sharedTable = desc + entriesEnd + COLUMNAR_NATIVE_ENCDESC_SHARED_LEN_BYTES;
 
 	/* first pass: total encoded and raw lengths across the vectors */
 	dp = desc + COLUMNAR_NATIVE_ENCDESC_HEADER_LEN;
@@ -537,6 +554,7 @@ columnar_native_decode_chunk(MemoryContext cx, Form_pg_attribute att,
 		{
 			char	   *rawVec = ColumnarDecodeChunk(encCursor, encLen, encType,
 													 att, valueCount, rawLen,
+													 sharedTable, sharedTableLen,
 													 cx);
 
 			memcpy(rawCursor, rawVec, rawLen);

--- a/src/columnar_write_state.c
+++ b/src/columnar_write_state.c
@@ -648,7 +648,8 @@ columnar_flush_row_group(ColumnarWriteState *writeState)
 				if (col->valueStream.len > 0)
 					appendBinaryStringInfo(&corpus, col->valueStream.data,
 										   col->valueStream.len);
-				if (corpus.len >= 65536)	/* enough to train a symbol table */
+				if (corpus.len >= 262144)	/* matches FSST_SAMPLE_CAP: train the
+											 * one per-chunk table on a broad sample */
 					break;
 			}
 			if (corpus.len > 0)

--- a/src/columnar_write_state.c
+++ b/src/columnar_write_state.c
@@ -595,6 +595,8 @@ columnar_flush_row_group(ColumnarWriteState *writeState)
 		uint8		descVersion = COLUMNAR_NATIVE_ENCDESC_VERSION;
 		uint8		descReserved = 0;
 		uint32		vectorCount = (uint32) list_length(writeState->chunkGroups);
+		char	   *fsstTable = NULL;	/* chunk-shared FSST table (E3b), or NULL */
+		uint32		fsstTableLen = 0;
 		char	   *finalData;
 		uint32		finalLen;
 		int			blockCodec = COLUMNAR_COMPRESSION_NONE;
@@ -626,6 +628,35 @@ columnar_flush_row_group(ColumnarWriteState *writeState)
 		appendBinaryStringInfo(desc, (char *) &descReserved, 1);
 		appendBinaryStringInfo(desc, (char *) &vectorCount, sizeof(uint32));
 
+		/*
+		 * E3b: build one FSST symbol table for the whole column chunk from a
+		 * bounded sample of its value streams, so the costly table build is paid
+		 * once here rather than once per vector. It is stored once as a trailing
+		 * descriptor region and reused by every FSST vector below. Non-varlena
+		 * columns and columns FSST cannot help leave it NULL.
+		 */
+		if (att->attlen == -1)
+		{
+			StringInfoData corpus;
+
+			initStringInfo(&corpus);
+			foreach(lc, writeState->chunkGroups)
+			{
+				ChunkGroupBuffer *group = (ChunkGroupBuffer *) lfirst(lc);
+				ColumnChunkBuffer *col = &group->columns[c];
+
+				if (col->valueStream.len > 0)
+					appendBinaryStringInfo(&corpus, col->valueStream.data,
+										   col->valueStream.len);
+				if (corpus.len >= 65536)	/* enough to train a symbol table */
+					break;
+			}
+			if (corpus.len > 0)
+				ColumnarFsstBuildChunkTable(corpus.data, (uint32) corpus.len, att,
+											&fsstTable, &fsstTableLen);
+			pfree(corpus.data);
+		}
+
 		/* encode each vector (chunk group) and record its descriptor entry */
 		foreach(lc, writeState->chunkGroups)
 		{
@@ -640,7 +671,8 @@ columnar_flush_row_group(ColumnarWriteState *writeState)
 
 			encType = ColumnarEncodeChunk(col->valueStream.data,
 										  col->valueStream.len, att,
-										  col->valueCount, &encData, &encLen);
+										  col->valueCount, fsstTable, fsstTableLen,
+										  &encData, &encLen);
 
 			if (encLen > 0)
 				appendBinaryStringInfo(encoded, encData, encLen);
@@ -714,6 +746,15 @@ columnar_flush_row_group(ColumnarWriteState *writeState)
 			}
 			vec++;
 		}
+
+		/*
+		 * E3b: trailing chunk-shared FSST table region (descriptor version 2).
+		 * sharedTableLen is 0 when the chunk has no shared table; FSST vectors
+		 * above reference this one table instead of embedding their own.
+		 */
+		appendBinaryStringInfo(desc, (char *) &fsstTableLen, sizeof(uint32));
+		if (fsstTableLen > 0)
+			appendBinaryStringInfo(desc, fsstTable, fsstTableLen);
 
 		/* whole-chunk zone map (vector_index -1) */
 		{

--- a/test/native_encoding.sh
+++ b/test/native_encoding.sh
@@ -161,4 +161,21 @@ check "fsst shrinks the url column" \
 	     "$(q "SELECT max(octet_length(url)) * 2048 FROM hf;")" ] && echo yes || echo no)" \
 	"yes"
 
+# E3b: the symbol table is stored once per chunk as a trailing descriptor region,
+# not once per vector. The descriptor is [6-byte header][vectorCount entries of 13
+# bytes][uint32 sharedTableLen][table]; assert the url column's descriptor carries
+# a non-empty shared table, i.e. octet_length exceeds header + entries + the length
+# word. vectorCount is the little-endian uint32 at descriptor offset 2.
+check "fsst stores one shared table per chunk (E3b)" \
+	"$([ "$(q "SELECT count(*) FROM pgcolumnar.column_chunk
+	           WHERE storage_id = pgcolumnar.get_storage_id('nf')
+	             AND column_index = 1
+	             AND octet_length(encoding_descriptor) >
+	                 6 + (get_byte(encoding_descriptor, 2)
+	                      + get_byte(encoding_descriptor, 3) * 256
+	                      + get_byte(encoding_descriptor, 4) * 65536
+	                      + get_byte(encoding_descriptor, 5) * 16777216) * 13 + 4;")" \
+	     -ge 1 ] && echo yes || echo no)" \
+	"yes"
+
 pgc_summary

--- a/test/pbt/columnar.h
+++ b/test/pbt/columnar.h
@@ -34,11 +34,16 @@ typedef struct ColumnarBlockReader
 
 extern int ColumnarEncodeChunk(const char *raw, uint32 rawLen,
 							   Form_pg_attribute att, uint64 valueCount,
+							   const char *fsstTable, uint32 fsstTableLen,
 							   char **out, uint32 *outLen);
 extern char *ColumnarDecodeChunk(const char *enc, uint32 encLen,
 								 int encodingType, Form_pg_attribute att,
 								 uint64 valueCount, uint32 rawLen,
+								 const char *fsstTable, uint32 fsstTableLen,
 								 MemoryContext cx);
+extern bool ColumnarFsstBuildChunkTable(const char *corpus, uint32 corpusLen,
+										Form_pg_attribute att,
+										char **tableOut, uint32 *tableLenOut);
 extern const char *ColumnarEncodingName(int encodingType);
 extern void ColumnarBlockReaderInit(ColumnarBlockReader *br, const char *raw,
 									uint64 valueCount, int width);

--- a/test/pbt/test_encoding.c
+++ b/test/pbt/test_encoding.c
@@ -64,8 +64,8 @@ check_fixed(int w, Oid typid, uint32 n, const char *raw)
 	att.attbyval = true;
 	att.atttypid = typid;
 
-	code = ColumnarEncodeChunk(raw, rawLen, &att, n, &enc, &encLen);
-	dec = ColumnarDecodeChunk(enc, encLen, code, &att, n, rawLen, NULL);
+	code = ColumnarEncodeChunk(raw, rawLen, &att, n, NULL, 0, &enc, &encLen);
+	dec = ColumnarDecodeChunk(enc, encLen, code, &att, n, rawLen, NULL, 0, NULL);
 	checks++;
 
 	if (rawLen > 0 && memcmp(dec, raw, rawLen) != 0)
@@ -264,14 +264,31 @@ gen_varlena(uint32 n, int shape)
 	att.attbyval = false;
 	att.atttypid = 25;			/* text */
 
-	code = ColumnarEncodeChunk(s.data, (uint32) s.len, &att, n, &enc, &encLen);
-	dec = ColumnarDecodeChunk(enc, encLen, code, &att, n, (uint32) s.len, NULL);
-	checks++;
-	if (s.len > 0 && memcmp(dec, s.data, s.len) != 0)
+	/*
+	 * E3b: FSST now encodes against a chunk-shared table built once. Build it from
+	 * this chunk's raw stream and pass it through; a NULL table (no useful symbols)
+	 * simply means FSST is not a candidate, which the round trip still covers.
+	 */
 	{
-		failures++;
-		fprintf(stderr, "FAIL varlena n=%u code=%s rawLen=%d\n",
-				n, ColumnarEncodingName(code), s.len);
+		char	   *tbl = NULL;
+		uint32		tblLen = 0;
+		bool		haveTbl = ColumnarFsstBuildChunkTable(s.data, (uint32) s.len,
+														  &att, &tbl, &tblLen);
+
+		code = ColumnarEncodeChunk(s.data, (uint32) s.len, &att, n,
+								   haveTbl ? tbl : NULL, haveTbl ? tblLen : 0,
+								   &enc, &encLen);
+		dec = ColumnarDecodeChunk(enc, encLen, code, &att, n, (uint32) s.len,
+								  haveTbl ? tbl : NULL, haveTbl ? tblLen : 0, NULL);
+		checks++;
+		if (s.len > 0 && memcmp(dec, s.data, s.len) != 0)
+		{
+			failures++;
+			fprintf(stderr, "FAIL varlena n=%u code=%s rawLen=%d\n",
+					n, ColumnarEncodingName(code), s.len);
+		}
+		if (haveTbl)
+			free(tbl);
 	}
 	free(s.data);
 }


### PR DESCRIPTION
Builds one FSST symbol table per column chunk and reuses it across the chunk's vectors, instead of rebuilding a table per 1024-value vector as E2 did.

## Why
The E2 gate benchmark suggested FSST's per-vector table build dominated ingestion. A clean, matched-condition re-measurement (E2 vs E3b vs FSST-off, no matrix contention) **corrected that**: FSST's cost is ~82% per-vector greedy-match compression (unchanged by E3b) and only ~18% table build (what E3b amortizes). So E3b is a modest, honest win, not the large one the contention-confounded first gate implied.

## Result (3M-row high-cardinality URL text, clean, pg17_nc)
| build | columnar INSERT | size |
| --- | --- | --- |
| FSST off | 2777 ms | 324.6 MB |
| E3b (256 KB sample) | **10329 ms** | **105.8 MB** |
| E2 (per-vector) | 11087 ms | 106.2 MB |
| E3b (10 MB sample) | 40240 ms | 98.1 MB |

E3b with a 256 KB training sample is **Pareto-better than E2**: ~7% faster ingestion *and* slightly smaller. The sample size was chosen from the tradeoff curve (32 KB regresses ratio to 111 MB; 10 MB reaches 98 MB but a 3.9x ingestion slowdown), with 256 KB at the knee. It also scales better than E2 as vectors-per-chunk grows.

## How
- Descriptor version 1 -> 2: the shared table is a trailing region `[uint32 sharedTableLen][table]` **appended** after the per-vector entries, so every existing entry offset is unchanged. FSST vectors store a bare code stream decoded against the one shared table.
- `ColumnarFsstBuildChunkTable` builds and serializes the table once; the writer builds it before its per-vector loop from a bounded (256 KB) cross-vector sample; `columnar_native_decode_chunk` reads the trailing table and passes it to each FSST vector decode. `ColumnarEncodeChunk`/`ColumnarDecodeChunk` take the shared table. The inline-table form (E2's layout) is replaced; the version bump makes any stray v1 descriptor fail cleanly (no persistent v1 data, pre-release).

## Validation
- Codec property test byte-exact over 30k iterations (build-once/encode-against-shared-table).
- `native_encoding.sh` asserts the url column carries one trailing shared table and round-trips text and bytea.
- **Full PostgreSQL 17 suite green** (42 suites, assert-enabled, no warnings), including corruption/hardening/fuzz on the new descriptor path. Full 15-19 matrix runs at the end-of-work gate per the current directive.

## Follow-on
The real ingestion lever is the per-vector greedy-match compression, not the build. Tracked as future work (faster matcher, or the async write + background compaction wishlist item now in ROADMAP.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)