### PR TITLE
Phase F2: Z-order space-filling-curve clustering (eager reorg)

### DIFF
--- a/design/PHASE_F_PLAN.md
+++ b/design/PHASE_F_PLAN.md
@@ -1,0 +1,112 @@
+# Phase F plan: mutation and clustering
+
+Status: active, branched off `main` (post E3b). Phase F delivers the native
+format spec's mutation and clustering design: first-class delete vectors,
+space-filling-curve clustering, and incremental background compaction. Per the
+plan-before-code discipline this decomposes the work before touching code, from
+a full survey of the current (interim) machinery.
+
+## What already works (interim), from the code survey
+
+Much of the "delete vectors and merge-on-read" design is already functioning
+through interim mechanisms flagged in the code as Phase F's to replace:
+
+- **Delete/merge-on-read works.** `pgcolumnar.row_mask` (a catalog table) is a
+  per-row-group bitmap, one bit per row in the group. `columnar_tuple_delete`
+  marks a bit; `columnar_tuple_update` is delete-plus-insert; the reader ORs the
+  masks per row group and skips set rows while keeping vector cursors aligned.
+  Buffering, subtransaction discard/promote, deadlock-safe lock ordering, and
+  read-your-writes are all handled (`src/columnar_row_mask.c`, `columnar_reader.c`).
+  This IS a delete vector; it is just named `row_mask` and carries vestigial
+  columns (`stripe_id`, `chunk_id` always 0, `start_row_number`, `end_row_number`).
+- **MERGE already works** through the generic update/insert tableam path and is
+  tested (`test/native_dml.sh`). Phase F re-bases it on the native delete vector
+  but adds no new SQL capability there.
+- **Foreground compaction works** but coarsely: `pgcolumnar.vacuum` rewrites the
+  whole relation, reading only live rows (so deletes are physically dropped) into
+  fresh stripes. `pgcolumnar.vacuum_sorted` adds a one-shot single-key physical
+  sort. Neither is incremental, background, or multi-dimensional.
+
+What genuinely does NOT exist yet: a spec-named `delete_vector` catalog keyed by
+group number; space-filling-curve (Z-order/Hilbert) clustering; incremental /
+background / per-row-group compaction; `INSERT ... ON CONFLICT` (speculative
+insert is unsupported).
+
+## Decomposition
+
+Each sub-phase is its own PG17-gated PR into `main` (PG17-only during the work,
+full 15-19 matrix at the end per the standing directive).
+
+Ordering note: implementation leads with the genuinely-new functionality (F2
+clustering, then F3 compaction, optionally F4 ON CONFLICT), because those are the
+real functional gaps. F1 is behavior-preserving spec-alignment cleanup of a path
+that already works, so it is valuable but lower priority and is scheduled after
+the new features (or whenever a clean-catalog break is convenient); F3 wants the
+`delete_vector` naming, so F1 lands before or with F3.
+
+### F1. Native delete vector (catalog alignment) [deferred: cleanup, low priority]
+
+Replace the interim `row_mask` with the spec's `pgcolumnar.delete_vector` (spec
+section 11: `storage_id, group_number, bitmap, deleted_count`). Key it by
+`group_number` directly instead of by row-number ranges, and drop the vestigial
+`stripe_id` / `chunk_id` / `start_row_number` / `end_row_number` columns. The
+mechanism (mark, buffer, merge-on-read, subxact discard/promote, lock ordering)
+is preserved behaviorally; this is spec alignment plus cleanup, not a rewrite.
+Rename the C module `columnar_row_mask.c` accordingly and the metadata accessors.
+Low risk: existing DML/oracle suites (`native_dml`, `differential`, `unique_conc`,
+`concurrent_diff`) already exercise the mechanism and must stay green. Value:
+the catalog matches the published spec and sheds cruft, and group-keyed access is
+cleaner for F2/F3.
+
+### F2. Space-filling-curve clustering, eager path [start here]
+
+Implement multi-dimensional clustering ordering rows by a Z-order (Morton)
+interleaving over several columns, exposed as `pgcolumnar.cluster(table,
+columns)`, superseding the single-key `vacuum_sorted`. Compute a per-row Morton
+key from the chosen columns (normalize each to an unsigned ordinal, bit-interleave),
+`tuplesort` by it, and rewrite. Hilbert ordering is a follow-on refinement over
+the same plumbing. Value: dramatically tighter zone maps and skipping for
+multi-column range/point workloads.
+
+LOCK SCOPE (important). This F2 entry point is the EAGER / offline reorg: it
+rewrites the whole relation and swaps the relfilenode
+(RelationSetNewRelfilenumber), which inherently needs AccessExclusiveLock, exactly
+like PostgreSQL's own `CLUSTER` / `VACUUM FULL`. That blocks all reads and writes
+for the duration and is NOT acceptable as the routine maintenance path. It is
+useful only as an initial bulk reorg. The routine path is the LAZY one in F3.
+This constraint applies equally to the existing `vacuum` and `vacuum_sorted`.
+
+### F3. Incremental compaction and reclustering, LAZY path (required)
+
+The lazy counterpart to F2's eager reorg, and the primary production maintenance
+mechanism. Per-row-group, incremental, MVCC-safe rewrite that holds only
+ShareUpdateExclusiveLock (concurrent reads AND writes allowed), like PostgreSQL's
+regular VACUUM -- never a table-wide AccessExclusiveLock. It retires delete
+vectors (drops fully-deleted row groups, rewrites groups past a deleted-fraction
+threshold), and MAINTAINS clustering order incrementally rather than only via the
+one-shot eager reorg. Invocable per-group and hookable from autovacuum. This is
+also the MVCC-safe row-group-rewrite machinery the asynchronous-compaction
+wishlist (ROADMAP.md) depends on. REQUIRED, not optional: every maintenance op
+must offer a non-AccessExclusive lazy path (see the lazy-option requirement).
+Value: bounded compaction cost, space reclaimed and rows reclustered online, and
+the foundation for deferred compression.
+
+### F4 (optional). INSERT ... ON CONFLICT and first-class MERGE
+
+Speculative insert is currently unsupported, so `INSERT ... ON CONFLICT` fails.
+Implement speculative insert/complete over the delete-vector path and confirm
+`MERGE` remains robust. Value: closes a real DML gap. Scoped optional; ordered
+last because MERGE (the spec's named case) already works.
+
+## Validation (each sub-phase)
+
+- The differential oracle stays green on native tables (`differential.sh`,
+  `fuzz.sh`, `native_dml.sh`), plus the concurrency suites (`concurrent_diff`,
+  `unique_conc`) since mutation runs on many connections.
+- New coverage per sub-phase: F1 asserts the `delete_vector` catalog shape and
+  delete/update/MERGE round-trips; F2 asserts clustering tightens zone maps and
+  round-trips; F3 asserts incremental compaction retires delete vectors and
+  reclaims space while preserving results.
+- `corruption.sh` / `hardening.sh` confirm a corrupt delete vector or clustering
+  descriptor raises a clean error, not a crash.
+- PG17 gate during the work; full 15-19 matrix at the end.

--- a/pgcolumnar--1.0.sql
+++ b/pgcolumnar--1.0.sql
@@ -434,6 +434,16 @@ CREATE FUNCTION pgcolumnar.vacuum_sorted(
 COMMENT ON FUNCTION pgcolumnar.vacuum_sorted(regclass, name[])
 	IS 'compact a columnar table, storing rows sorted ascending on the given columns';
 
+CREATE FUNCTION pgcolumnar.cluster(
+	tablename regclass,
+	VARIADIC columns name[])
+	RETURNS void
+	LANGUAGE C
+	AS 'MODULE_PATHNAME', 'columnar_cluster';
+
+COMMENT ON FUNCTION pgcolumnar.cluster(regclass, name[])
+	IS 'eager reorg: rewrite a columnar table with rows ordered by the Z-order space-filling curve over the given columns. Holds AccessExclusiveLock like CLUSTER/VACUUM FULL; the online incremental path is Phase F3';
+
 CREATE FUNCTION pgcolumnar.export_arrow(rel regclass, path text)
 	RETURNS bigint
 	LANGUAGE C

--- a/src/columnar_vacuum.c
+++ b/src/columnar_vacuum.c
@@ -26,6 +26,7 @@
 #include "access/relation.h"
 #include "access/table.h"
 #include "catalog/index.h"
+#include "catalog/pg_type.h"
 #include "executor/tuptable.h"
 #include "miscadmin.h"
 #include "storage/lockdefs.h"
@@ -42,6 +43,137 @@
 PG_FUNCTION_INFO_V1(columnar_relation_storageid);
 PG_FUNCTION_INFO_V1(columnar_vacuum);
 PG_FUNCTION_INFO_V1(columnar_vacuum_sorted);
+PG_FUNCTION_INFO_V1(columnar_cluster);
+
+/* -------------------------------------------------------------------------
+ * Z-order (Morton) clustering (Phase F2)
+ *
+ * Space-filling-curve clustering orders rows so that rows close in a
+ * multi-column key space are close on disk, which tightens every clustered
+ * column's per-vector min/max zone maps at once (unlike a single-column sort,
+ * which only tightens the lead column). We map each clustered column value to
+ * an order-preserving unsigned 64-bit ordinal, then bit-interleave the ordinals
+ * most-significant-round-first into a byte string whose memcmp order is the
+ * Z-order. Rows are rewritten sorted by that key (spec 9). Clean-room from the
+ * public description of Morton/Z-order codes.
+ * ------------------------------------------------------------------------- */
+
+/*
+ * Map a value of a supported clustering type to an order-preserving uint64:
+ * a < b (in the type's default order) iff ordinal(a) < ordinal(b). Signed
+ * integers flip the sign bit; floats flip the sign bit when positive and all
+ * bits when negative (the standard radix-sort float transform). NULL is mapped
+ * by the caller to 0 (sorts first).
+ */
+static uint64
+cluster_type_ordinal(Datum value, Oid typid)
+{
+	switch (typid)
+	{
+		case BOOLOID:
+			return DatumGetBool(value) ? 1 : 0;
+		case INT2OID:
+			return (uint64) ((int64) DatumGetInt16(value)) ^ UINT64CONST(0x8000000000000000);
+		case INT4OID:
+		case DATEOID:
+			return (uint64) ((int64) DatumGetInt32(value)) ^ UINT64CONST(0x8000000000000000);
+		case INT8OID:
+		case TIMESTAMPOID:
+		case TIMESTAMPTZOID:
+			return (uint64) DatumGetInt64(value) ^ UINT64CONST(0x8000000000000000);
+		case FLOAT8OID:
+			{
+				uint64		b;
+				float8		f = DatumGetFloat8(value);
+
+				memcpy(&b, &f, sizeof(b));
+				return b ^ ((b >> 63) ? UINT64CONST(0xFFFFFFFFFFFFFFFF)
+							: UINT64CONST(0x8000000000000000));
+			}
+		case FLOAT4OID:
+			{
+				uint32		b;
+				float4		f = DatumGetFloat4(value);
+				uint32		o;
+
+				memcpy(&b, &f, sizeof(b));
+				o = b ^ ((b >> 31) ? 0xFFFFFFFFu : 0x80000000u);
+				return ((uint64) o) << 32;	/* keep the ordering in the high bits */
+			}
+		default:
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("column type %s cannot be used as a clustering key",
+							format_type_be(typid)),
+					 errhint("Z-order clustering supports integer, date/time, boolean, and floating-point columns.")));
+			return 0;				/* keep the compiler happy */
+	}
+}
+
+/* true when a type is usable as a Z-order clustering key */
+static bool
+cluster_type_supported(Oid typid)
+{
+	switch (typid)
+	{
+		case BOOLOID:
+		case INT2OID:
+		case INT4OID:
+		case DATEOID:
+		case INT8OID:
+		case TIMESTAMPOID:
+		case TIMESTAMPTZOID:
+		case FLOAT8OID:
+		case FLOAT4OID:
+			return true;
+		default:
+			return false;
+	}
+}
+
+/*
+ * Build the Z-order key for one row: interleave the ncols column ordinals
+ * MSB-first into an 8*ncols-byte string. Output bit stream is
+ * ord[0].bit63, ord[1].bit63, ..., ord[n-1].bit63, ord[0].bit62, ... packed
+ * MSB-first, so lexicographic (memcmp) order over the bytea equals Z-order.
+ */
+static bytea *
+cluster_zorder_key(Datum *values, bool *isnull, AttrNumber *atts, int ncols,
+				   TupleDesc tupdesc)
+{
+	int			keybytes = ncols * 8;
+	bytea	   *result = (bytea *) palloc(VARHDRSZ + keybytes);
+	unsigned char *out = (unsigned char *) VARDATA(result);
+	uint64	   *ord = (uint64 *) palloc(ncols * sizeof(uint64));
+	int			c;
+	int			r;
+	int			outbit = 0;
+
+	SET_VARSIZE(result, VARHDRSZ + keybytes);
+	memset(out, 0, keybytes);
+
+	for (c = 0; c < ncols; c++)
+	{
+		AttrNumber	a = atts[c];
+		Form_pg_attribute att = TupleDescAttr(tupdesc, a - 1);
+
+		ord[c] = isnull[a - 1] ? 0
+			: cluster_type_ordinal(values[a - 1], att->atttypid);
+	}
+
+	for (r = 63; r >= 0; r--)
+	{
+		for (c = 0; c < ncols; c++)
+		{
+			if ((ord[c] >> r) & 1)
+				out[outbit >> 3] |= (unsigned char) (0x80 >> (outbit & 7));
+			outbit++;
+		}
+	}
+
+	pfree(ord);
+	return result;
+}
 
 /*
  * columnar_relation_storageid
@@ -275,6 +407,136 @@ columnar_compact_relation(Relation rel, int nsortkeys, AttrNumber *sortAtts)
 }
 
 /*
+ * columnar_compact_relation_zorder
+ *		Rewrite every live row of a columnar relation ordered by the Z-order
+ *		(Morton) code over atts[0..ncols-1] (Phase F2). Mirrors
+ *		columnar_compact_relation, but sorts by a computed key carried as a
+ *		trailing bytea column of an augmented tuple, so the sort still spills to
+ *		disk through tuplesort. The relation is already open AccessExclusiveLock.
+ */
+static void
+columnar_compact_relation_zorder(Relation rel, int ncols, AttrNumber *atts)
+{
+	Oid			relid = RelationGetRelid(rel);
+	TupleDesc	tupdesc = RelationGetDescr(rel);
+	int			natts = tupdesc->natts;
+	AttrNumber	zAtt = (AttrNumber) (natts + 1);
+	uint64		oldStorageId;
+	Snapshot	snapshot;
+	ColumnarReadState *readState;
+	ColumnarWriteState *writeState;
+	Tuplesortstate *tsort;
+	TupleDesc	augdesc;
+	TupleTableSlot *readSlot;
+	TupleTableSlot *putSlot;
+	TupleTableSlot *augSlot;
+	TypeCacheEntry *tce;
+	Oid			byteaLt;
+	Oid			sortColl = InvalidOid;
+	bool		nullsFirst = false;
+	uint64		rowNumber;
+	List	   *oldProjs;
+	int			i;
+
+	/* persist pending work so the read below sees it (spec 9) */
+	ColumnarFlushWriteStateForRelation(relid);
+	ColumnarFlushRowMaskForRelation(rel);
+
+	oldStorageId = ColumnarStorageId(rel);
+	oldProjs = ColumnarListProjections(oldStorageId);
+	snapshot = ActiveSnapshotSet() ? GetActiveSnapshot() : GetTransactionSnapshot();
+
+	/* augmented descriptor: the table's columns plus a trailing bytea Z-order key */
+	augdesc = CreateTemplateTupleDesc(natts + 1);
+	for (i = 1; i <= natts; i++)
+		TupleDescCopyEntry(augdesc, (AttrNumber) i, tupdesc, (AttrNumber) i);
+	TupleDescInitEntry(augdesc, zAtt, "__zorder", BYTEAOID, -1, 0);
+
+	tce = lookup_type_cache(BYTEAOID, TYPECACHE_LT_OPR);
+	byteaLt = tce->lt_opr;
+	tsort = tuplesort_begin_heap(augdesc, 1, &zAtt, &byteaLt, &sortColl,
+								 &nullsFirst, maintenance_work_mem, NULL,
+								 COLUMNAR_TUPLESORT_NONACCESS);
+
+	readSlot = MakeSingleTupleTableSlot(tupdesc, &TTSOpsVirtual);
+	putSlot = MakeSingleTupleTableSlot(augdesc, &TTSOpsVirtual);
+	augSlot = MakeSingleTupleTableSlot(augdesc, &TTSOpsMinimalTuple);
+
+	readState = ColumnarBeginRead(rel, snapshot, NULL, NULL, 0, NULL);
+	while (ColumnarReadNextRow(readState, readSlot->tts_values,
+							   readSlot->tts_isnull, &rowNumber))
+	{
+		bytea	   *zkey;
+
+		CHECK_FOR_INTERRUPTS();
+		memcpy(putSlot->tts_values, readSlot->tts_values, natts * sizeof(Datum));
+		memcpy(putSlot->tts_isnull, readSlot->tts_isnull, natts * sizeof(bool));
+		zkey = cluster_zorder_key(readSlot->tts_values, readSlot->tts_isnull,
+								  atts, ncols, tupdesc);
+		putSlot->tts_values[natts] = PointerGetDatum(zkey);
+		putSlot->tts_isnull[natts] = false;
+		ExecStoreVirtualTuple(putSlot);
+		tuplesort_puttupleslot(tsort, putSlot);
+		ExecClearTuple(putSlot);
+	}
+	ColumnarEndRead(readState);
+	ExecDropSingleTupleTableSlot(readSlot);
+	ExecDropSingleTupleTableSlot(putSlot);
+	tuplesort_performsort(tsort);
+
+	/* swap to fresh storage and drop old metadata (as in compact_relation) */
+	RelationSetNewRelfilenumber(rel, rel->rd_rel->relpersistence);
+	ColumnarForgetWriteStateForRelation(relid);
+	ColumnarDeleteMetadata(oldStorageId);
+
+	/* realign projections to the compacted base (as in compact_relation) */
+	if (oldProjs != NIL)
+	{
+		uint64		newStorageId = ColumnarStorageId(rel);
+		ListCell   *lc;
+
+		foreach(lc, oldProjs)
+		{
+			ColumnarProjection *p = (ColumnarProjection *) lfirst(lc);
+
+			if (p->projStorageId != oldStorageId)
+				ColumnarDeleteMetadata(p->projStorageId);
+			ColumnarDeleteProjectionRow(oldStorageId, p->projectionId);
+		}
+		foreach(lc, oldProjs)
+		{
+			ColumnarProjection *p = (ColumnarProjection *) lfirst(lc);
+			ColumnarProjection np = *p;
+
+			np.storageId = newStorageId;
+			np.projStorageId = (p->projectionId == 0) ? newStorageId
+				: ColumnarNextStorageId();
+			ColumnarInsertProjectionRow(&np);
+		}
+	}
+
+	/* write the live rows back in Z-order; the trailing key column is ignored */
+	writeState = ColumnarGetWriteState(rel);
+	while (tuplesort_gettupleslot(tsort, true, false, augSlot, NULL))
+	{
+		uint64		newRowNumber;
+
+		CHECK_FOR_INTERRUPTS();
+		slot_getallattrs(augSlot);
+		newRowNumber = ColumnarWriteRow(writeState, rel, augSlot->tts_values,
+										augSlot->tts_isnull);
+		ColumnarProjectionFanoutRow(rel, writeState, newRowNumber,
+									augSlot->tts_values, augSlot->tts_isnull);
+		ExecClearTuple(augSlot);
+	}
+	ColumnarFlushWriteStateForRelation(relid);
+	tuplesort_end(tsort);
+	ExecDropSingleTupleTableSlot(augSlot);
+
+	ColumnarReindexRelation(relid, REINDEX_REL_PROCESS_TOAST);
+}
+
+/*
  * columnar_vacuum
  *		SQL: columnar.vacuum(tablename regclass, stripe_count int default 0).
  *		Compacts a columnar table by combining its stripes and reclaiming the
@@ -390,6 +652,119 @@ columnar_vacuum_sorted(PG_FUNCTION_ARGS)
 	}
 
 	columnar_compact_relation(rel, ncols, sortAtts);
+
+	/* keep the lock until end of transaction */
+	table_close(rel, NoLock);
+
+	PG_RETURN_VOID();
+}
+
+/*
+ * columnar_cluster
+ *		SQL: pgcolumnar.cluster(tablename regclass, VARIADIC columns name[]).
+ *		Physically reorders a columnar table by the Z-order (Morton) space-filling
+ *		curve over the named columns (Phase F2, spec 9). Unlike vacuum_sorted's
+ *		single lead-column sort, Z-order clustering tightens the min/max zone maps
+ *		of ALL clustered columns at once, so multi-column range and point
+ *		predicates skip far more vectors and chunks. Results are unchanged; this
+ *		only reorders physical storage.
+ *
+ *		This is the EAGER / offline reorg: it rewrites the whole relation and
+ *		swaps the relfilenode, so it holds AccessExclusiveLock for the duration
+ *		(like PostgreSQL's own CLUSTER / VACUUM FULL) and blocks concurrent reads
+ *		and writes. Use it for an initial bulk reorg. The routine, online path that
+ *		reclusters incrementally under ShareUpdateExclusiveLock (concurrent reads
+ *		and writes allowed) is Phase F3; every maintenance op must offer that lazy
+ *		path.
+ */
+Datum
+columnar_cluster(PG_FUNCTION_ARGS)
+{
+	Oid			relid = PG_GETARG_OID(0);
+	ArrayType  *colArray;
+	Datum	   *colDatums;
+	bool	   *colNulls;
+	int			ncols;
+	Relation	rel;
+	TupleDesc	tupdesc;
+	AttrNumber *atts;
+	int			i;
+
+	if (PG_ARGISNULL(0))
+		ereport(ERROR,
+				(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+				 errmsg("table name cannot be null")));
+	if (PG_ARGISNULL(1))
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("at least one clustering column is required")));
+
+	colArray = PG_GETARG_ARRAYTYPE_P(1);
+	deconstruct_array(colArray, NAMEOID, NAMEDATALEN, false, 'c',
+					  &colDatums, &colNulls, &ncols);
+	if (ncols < 1)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("at least one clustering column is required")));
+	if (ncols > 8)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("Z-order clustering supports at most 8 columns")));
+
+	rel = table_open(relid, AccessExclusiveLock);
+
+	if (!ColumnarIsColumnarRelation(relid))
+	{
+		table_close(rel, AccessExclusiveLock);
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+				 errmsg("relation \"%s\" is not a columnar table",
+						RelationGetRelationName(rel))));
+	}
+
+	tupdesc = RelationGetDescr(rel);
+	atts = palloc(ncols * sizeof(AttrNumber));
+
+	for (i = 0; i < ncols; i++)
+	{
+		char	   *colname;
+		AttrNumber	attno;
+		Form_pg_attribute att;
+
+		if (colNulls[i])
+		{
+			table_close(rel, AccessExclusiveLock);
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("clustering column name cannot be null")));
+		}
+
+		colname = NameStr(*DatumGetName(colDatums[i]));
+		attno = get_attnum(relid, colname);
+		if (attno == InvalidAttrNumber || attno <= 0 ||
+			TupleDescAttr(tupdesc, attno - 1)->attisdropped)
+		{
+			table_close(rel, AccessExclusiveLock);
+			ereport(ERROR,
+					(errcode(ERRCODE_UNDEFINED_COLUMN),
+					 errmsg("column \"%s\" does not exist in table \"%s\"",
+							colname, RelationGetRelationName(rel))));
+		}
+
+		att = TupleDescAttr(tupdesc, attno - 1);
+		if (!cluster_type_supported(att->atttypid))
+		{
+			table_close(rel, AccessExclusiveLock);
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("column \"%s\" of type %s cannot be used as a clustering key",
+							colname, format_type_be(att->atttypid)),
+					 errhint("Z-order clustering supports integer, date/time, boolean, and floating-point columns.")));
+		}
+		atts[i] = attno;
+	}
+
+	columnar_compact_relation_zorder(rel, ncols, atts);
 
 	/* keep the lock until end of transaction */
 	table_close(rel, NoLock);

--- a/test/native_cluster.sh
+++ b/test/native_cluster.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# pgColumnar Z-order clustering (Phase F2). pgcolumnar.cluster(table, cols)
+# physically reorders rows by the Z-order (Morton) space-filling curve over
+# several columns, so the per-group min/max zone maps of ALL clustered columns
+# tighten at once. A multi-column box predicate then skips far more row groups
+# than in insert order, where the columns are scattered. Clustering only reorders
+# storage, so results are identical to a heap mirror. This suite proves parity,
+# the skipping improvement, single-column clustering, and a clean error on an
+# unsupported clustering type. It is the EAGER reorg (AccessExclusiveLock); the
+# online incremental path is Phase F3.
+#
+# Usage:  test/native_cluster.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+# 40960 rows in 20 row groups (2048 each). x and y are scattered in insert order
+# via coprime multiplicative hashes, so before clustering each group's x and y
+# ranges span most of [0,200) and a small 2D box skips nothing. Z-order
+# clustering co-locates nearby (x,y).
+GEN="SELECT g,
+       ((g::bigint * 7919) % 200)::int   AS x,
+       ((g::bigint * 104729) % 200)::int AS y,
+       'p' || (g % 97)                    AS payload
+  FROM generate_series(1, 40960) g"
+
+psql_run "CREATE TABLE h (id int, x int, y int, payload text);"
+psql_run "CREATE TABLE n (id int, x int, y int, payload text) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 2048, chunk_group_row_limit => 1024);"
+psql_run "INSERT INTO h $GEN;"
+psql_run "INSERT INTO n $GEN;"
+
+# Count of row groups skipped by the zone maps for a query, from EXPLAIN ANALYZE.
+skipped() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -At -c "EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) $1" 2>/dev/null \
+		| grep 'Columnar Chunk Groups Removed by Filter' | grep -oE '[0-9]+' | head -1
+}
+# Does a statement fail (for the unsupported-type check)?
+fails() {
+	if env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -At -v ON_ERROR_STOP=1 -c "$1" >/dev/null 2>&1; then
+		echo no
+	else
+		echo yes
+	fi
+}
+
+BOX="x BETWEEN 20 AND 40 AND y BETWEEN 20 AND 40"
+
+check "row count" "$(q 'SELECT count(*) FROM n;')" "40960"
+check "box parity (pre-cluster)" \
+	"$(pgc_set_hash "SELECT id, x, y, payload FROM n WHERE $BOX")" \
+	"$(pgc_set_hash "SELECT id, x, y, payload FROM h WHERE $BOX")"
+
+before="$(skipped "SELECT id FROM n WHERE $BOX")"; before="${before:-0}"
+
+# Cluster by (x, y) -- the eager Z-order reorg.
+psql_run "SELECT pgcolumnar.cluster('n', 'x', 'y');"
+
+check "row count after cluster" "$(q 'SELECT count(*) FROM n;')" "40960"
+check "box parity (post-cluster)" \
+	"$(pgc_set_hash "SELECT id, x, y, payload FROM n WHERE $BOX")" \
+	"$(pgc_set_hash "SELECT id, x, y, payload FROM h WHERE $BOX")"
+check "full-table parity after cluster" \
+	"$(pgc_set_hash 'SELECT id, x, y, payload FROM n ORDER BY id')" \
+	"$(pgc_set_hash 'SELECT id, x, y, payload FROM h ORDER BY id')"
+
+after="$(skipped "SELECT id FROM n WHERE $BOX")"; after="${after:-0}"
+
+echo "  (chunk groups skipped for the box: before=$before after=$after of 20)"
+# Z-order tightens both columns' zone maps, so the box skips strictly more groups
+# after clustering, and skips most of the 20 groups.
+check "clustering increases 2D skipping" "$([ "$after" -gt "$before" ] && echo yes || echo no)" "yes"
+check "clustering skips most groups" "$([ "$after" -ge 10 ] && echo yes || echo no)" "yes"
+
+# Single-column clustering works and preserves results.
+psql_run "SELECT pgcolumnar.cluster('n', 'id');"
+check "single-column cluster parity" \
+	"$(pgc_set_hash 'SELECT id, x, y, payload FROM n ORDER BY id')" \
+	"$(pgc_set_hash 'SELECT id, x, y, payload FROM h ORDER BY id')"
+
+# An unsupported clustering type (text) must error cleanly, not crash.
+check "unsupported type errors cleanly" "$(fails "SELECT pgcolumnar.cluster('n', 'payload')")" "yes"
+# A non-existent column errors cleanly too.
+check "missing column errors cleanly" "$(fails "SELECT pgcolumnar.cluster('n', 'nope')")" "yes"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -27,7 +27,7 @@ SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUITES=(smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
 	differential recovery fuzz hardening concurrent_diff parallel sorted_projection \
 	arrow_export parquet_export read_stream corruption \
-	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip native_index native_dml native_ios native_projection)
+	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip native_index native_dml native_ios native_projection native_cluster)
 
 # Default matrix: one assert-enabled pg_config per major, 15 through 19.
 DEFAULT_CONFIGS=(


### PR DESCRIPTION
Adds `pgcolumnar.cluster(table, VARIADIC columns)` — physically reorders a columnar table by the **Z-order (Morton)** space-filling curve over several columns. Unlike `vacuum_sorted`'s single lead-column sort, Z-order tightens the min/max zone maps of **all** clustered columns at once, so multi-column range/point predicates skip far more vectors and row groups.

## Result
On the test (40960 rows, 20 row groups, columns scattered in insert order), a 2D box predicate skips **0 groups before clustering and 17 of 20 after** — with full heap-mirror parity.

## How
Each column value maps to an order-preserving unsigned 64-bit ordinal (signed integers flip the sign bit; floats use the radix-sort transform), then the ordinals are bit-interleaved MSB-round-first into a byte key whose memcmp order is the Z-order. Rows are rewritten sorted by that key, carried as a trailing bytea column of an augmented tuple so the sort still spills to disk. Supports integer, date/time, boolean, and floating-point columns (1–8 of them); other types and missing columns error cleanly. Clean-room from the public description of Morton/Z-order codes.

## Lock scope (important)
This is the **eager / offline** reorg: it rewrites the whole relation and swaps the relfilenode, so it holds **AccessExclusiveLock** (like PostgreSQL's own `CLUSTER` / `VACUUM FULL`) and blocks concurrent reads/writes. It is for an initial bulk reorg. The routine **online** path that reclusters and compacts incrementally under `ShareUpdateExclusiveLock` (concurrent reads and writes) is **Phase F3**, which is required — every maintenance op must offer a lazy path. The MVCC survey confirms F3 is achievable via atomic catalog-MVCC swaps with no relfilenode swap; `design/PHASE_F3_PLAN.md` has the design.

## Validation
`test/native_cluster.sh` proves parity before/after clustering, the 2D skipping improvement, single-column clustering, and clean errors; added to the matrix. **Full PG17 suite green** (43 suites, no warnings). `design/PHASE_F_PLAN.md` decomposes Phase F and frames the eager/lazy split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)