### PR TITLE
Phase F3a: online retirement of fully-dead row groups (lazy path)

### DIFF
--- a/design/PHASE_F3_PLAN.md
+++ b/design/PHASE_F3_PLAN.md
@@ -1,0 +1,100 @@
+# Phase F3 plan: online incremental compaction and reclustering (lazy path)
+
+Status: active, on `phase-f/delete-vectors` (after F2). F3 is the REQUIRED lazy
+counterpart to F2's eager reorg: incremental, per-row-group, MVCC-safe compaction
+and reclustering that holds only ShareUpdateExclusiveLock (concurrent reads AND
+writes), never a table-wide AccessExclusiveLock. Every maintenance op must offer
+this non-blocking path (see the lazy-option requirement). Written before code,
+from a full survey of the MVCC / visibility model.
+
+## The MVCC model F3 builds on (survey result)
+
+pgColumnar has no columnar-specific visibility machinery. Visibility is ORDINARY
+heap MVCC applied to the metadata catalog tuples; data pages are append-only,
+unversioned raw bytes at monotonic file offsets. Concretely, a snapshot S sees
+row r iff:
+1. the `row_group` catalog tuple covering r is MVCC-visible to S, AND
+2. no `row_mask` tuple visible to S has r's bit set, AND
+3. r's validity bit is set (NULL handling, orthogonal to MVCC).
+
+Consequences that make an online swap possible WITHOUT AccessExclusiveLock:
+- Row numbers come from a monotone metapage counter; compaction can reserve a
+  fresh disjoint range for rewritten rows, coexisting with concurrent inserters.
+- Data offsets are append-only and never reused, so writing a rewritten group to
+  fresh offsets does not disturb old-snapshot readers still reading old offsets.
+- The reader loads the row-group list once at scan begin under the scan snapshot,
+  then reads raw bytes; old snapshots keep reading the old group.
+- Therefore a group can be replaced by: in ONE transaction, insert the new
+  `row_group` / `column_chunk` / `zone_map` / `bloom` rows AND delete the old
+  `row_group` tuple. Heap MVCC makes the swap atomic exactly as an INSERT becomes
+  visible: old snapshots keep the old group, new snapshots see the new one.
+
+## Hazards (from the survey) and how F3 handles them
+
+- H1 concurrent DELETE racing a rewrite. A delete resolves a row's OLD number
+  under its snapshot and buffers it; if compaction rewrites that row to a NEW
+  number and commits, the delete lands on the now-gone old group and the row is
+  resurrected for post-swap snapshots. ShareUpdateExclusiveLock does not block
+  deletes. This is the crux and is why F3 is decomposed with the safe case first.
+- H2 concurrent INSERT: no hazard; disjoint row-number ranges.
+- H3 old pages pinned by old snapshots: reclamation of an old group's offsets must
+  be DEFERRED until oldestXmin passes the swap, mirroring
+  ColumnarComputeAllVisibleGroups. Append-only offsets make deferral trivial.
+- H4 index bloat: after a rewrite both old- and new-number index entries exist;
+  the old ones are filtered as not-live (their group tuple is gone) via
+  ColumnarReadRowByNumber / columnar_index_delete_tuples.
+- H5 curcid self-visibility: the rewrite must read the source under the pre-swap
+  snapshot, not a self-including catalog snapshot.
+
+## Decomposition (each PG17-gated PR)
+
+### F3a. Online retirement of fully-dead row groups [start here]
+
+The safe, race-free first slice. Retire (drop the catalog rows for, and defer
+page reclaim of) any row group ALL of whose rows are deleted as-of `oldestXmin` --
+i.e. every live snapshot agrees the group is dead. No rewrite, no row-number
+remap, no index change (the rows are already dead to everyone), so H1/H4 do not
+arise, and gating on oldestXmin closes H3. This directly retires delete vectors
+and reclaims space for the common delete-heavy pattern (drop old partitions,
+bulk deletes), all under ShareUpdateExclusiveLock, concurrent with reads/writes.
+Invocable as `pgcolumnar.compact(table)` and hookable from
+`columnar_relation_vacuum` (autovacuum), which today only sets all-visible bits.
+
+Design: extend the oldestXmin all-visible computation to also report groups whose
+visible row_mask marks every row deleted with all deleting xids < oldestXmin.
+For each such group, in one transaction delete its `row_group` + `column_chunk` +
+`zone_map` + `bloom` + `row_mask` catalog rows; record the freed offset range for
+deferred physical reclaim. Never touch a group any snapshot still sees as live.
+
+### F3b. Online rewrite of partially-deleted groups
+
+Rewrite a group past a deleted-fraction threshold: read its live rows under a
+captured snapshot, write them to fresh offsets as a new group with fresh row
+numbers, insert the new catalog rows and delete the old `row_group` tuple in one
+transaction, and insert index entries for the new row numbers. Handle H1 by
+serializing with deleters on the per-chunk-group advisory lock AND detecting
+conflict at commit: hold the group's advisory lock across capture..commit so no
+delete commits to the group meanwhile; a delete that resolved an old row number
+before the lock and blocks on it must, on unblock, find the old group gone and
+re-resolve (or its transaction conflicts and retries). The exact conflict
+protocol (redirect the buffered delete to the new number vs. abort-and-retry the
+losing transaction) is the key design decision and is settled in F3b, not F3a.
+
+### F3c. Incremental reclustering
+
+Maintain F2's Z-order online: pick groups whose keys interleave (out-of-order
+neighbors), merge-and-resplit them in Z-order via the F3b rewrite path, bounded
+per invocation. Reuses F2's Morton-key code and F3b's online-swap machinery.
+
+## Validation
+
+- The differential oracle and the concurrency suites (`concurrent_diff`,
+  `unique_conc`) stay green while compaction runs concurrently with DML -- add a
+  concurrent-compaction stressor that runs `pgcolumnar.compact` on many
+  connections against ongoing insert/update/delete and diffs against the heap.
+- F3a: assert a fully-deleted group is retired (row group count drops, space
+  reclaimed) only after its deleting txns pass oldestXmin, and that a concurrent
+  old snapshot still sees the rows until then.
+- Lock assertion: compaction runs under ShareUpdateExclusiveLock and does NOT
+  block a concurrent reader or writer (verify via a second session).
+- PG17 gate during the work; full 15-19 matrix at the end.

--- a/pgcolumnar--1.0.sql
+++ b/pgcolumnar--1.0.sql
@@ -444,6 +444,14 @@ CREATE FUNCTION pgcolumnar.cluster(
 COMMENT ON FUNCTION pgcolumnar.cluster(regclass, name[])
 	IS 'eager reorg: rewrite a columnar table with rows ordered by the Z-order space-filling curve over the given columns. Holds AccessExclusiveLock like CLUSTER/VACUUM FULL; the online incremental path is Phase F3';
 
+CREATE FUNCTION pgcolumnar.compact(tablename regclass)
+	RETURNS bigint
+	LANGUAGE C
+	AS 'MODULE_PATHNAME', 'columnar_compact';
+
+COMMENT ON FUNCTION pgcolumnar.compact(regclass)
+	IS 'lazy online compaction: retire row groups that are fully deleted, dropping their metadata so scans skip them. Holds only ShareUpdateExclusiveLock (concurrent reads and writes). Returns the number of groups retired (Phase F3a)';
+
 CREATE FUNCTION pgcolumnar.export_arrow(rel regclass, path text)
 	RETURNS bigint
 	LANGUAGE C

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -327,6 +327,10 @@ typedef struct ColumnarRowRange
 
 /* all-visible chunk-group row ranges: stripe committed past the horizon and no
  * deletes (committed or in-progress). Returns a List of ColumnarRowRange *. */
+extern List *ColumnarComputeFullyDeletedGroups(uint64 storageId,
+											   TransactionId oldestXmin);
+extern void ColumnarRetireGroup(uint64 storageId, uint64 groupNumber);
+extern int64 ColumnarRetireFullyDeletedGroups(Relation rel);
 extern List *ColumnarComputeAllVisibleGroups(uint64 storageId,
 											 TransactionId oldestXmin);
 

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -10,6 +10,8 @@
  */
 #include "columnar.h"
 
+#include "fmgr.h"
+#include "columnar_compat.h"
 #include "access/genam.h"
 #include "access/htup_details.h"
 #include "access/table.h"
@@ -22,6 +24,7 @@
 #include "commands/sequence.h"
 #include "miscadmin.h"
 #include "storage/lock.h"
+#include "storage/procarray.h"
 #include "utils/array.h"
 #include "utils/builtins.h"
 #include "utils/datum.h"
@@ -296,6 +299,167 @@ ColumnarComputeAllVisibleGroups(uint64 storageId, TransactionId oldestXmin)
 	UnregisterSnapshot(snap);
 
 	return ranges;
+}
+
+/*
+ * ColumnarComputeFullyDeletedGroups
+ *		Return the group numbers of row groups every one of whose rows is deleted
+ *		as-of oldestXmin -- i.e. the group's catalog row and every delete on it
+ *		committed before oldestXmin, so every live snapshot agrees the group is
+ *		dead (Phase F3a). Such a group can be retired online (its catalog rows
+ *		dropped) with no rewrite and no row-number remap, and the retirement is
+ *		race-free: a fully-dead-to-all group has no visible rows for any writer to
+ *		delete or any inserter to target, and old-snapshot readers keep the old
+ *		catalog version via heap MVCC. Returns a List of palloc'd uint64.
+ */
+List *
+ColumnarComputeFullyDeletedGroups(uint64 storageId, TransactionId oldestXmin)
+{
+	Relation	grel = open_columnar_table("row_group", AccessShareLock);
+	TupleDesc	gtd = RelationGetDescr(grel);
+	Relation	mrel = open_columnar_table("row_mask", AccessShareLock);
+	TupleDesc	mtd = RelationGetDescr(mrel);
+	ScanKeyData gkey[1];
+	SysScanDesc gscan;
+	HeapTuple	gtuple;
+	Snapshot	snap;
+	List	   *groups = NIL;
+
+	snap = RegisterSnapshot(GetLatestSnapshot());
+
+	ScanKeyInit(&gkey[0], Anum_row_group_storage_id, BTEqualStrategyNumber,
+				F_INT8EQ, Int64GetDatum((int64) storageId));
+	gscan = systable_beginscan(grel, InvalidOid, false, snap, 1, gkey);
+	while (HeapTupleIsValid(gtuple = systable_getnext(gscan)))
+	{
+		TransactionId xmin = HeapTupleHeaderGetXmin(gtuple->t_data);
+		bool		isnull;
+		uint64		groupNumber;
+		uint64		rowCount;
+		int64		deletedSeen = 0;
+		ScanKeyData mkey[2];
+		SysScanDesc mscan;
+		HeapTuple	mtuple;
+
+		/* only settled groups: created and committed before oldestXmin */
+		if (TransactionIdIsNormal(xmin) &&
+			!TransactionIdPrecedes(xmin, oldestXmin))
+			continue;
+
+		groupNumber = (uint64) DatumGetInt64(
+			heap_getattr(gtuple, Anum_row_group_group_number, gtd, &isnull));
+		rowCount = (uint64) DatumGetInt64(
+			heap_getattr(gtuple, Anum_row_group_row_count, gtd, &isnull));
+		if (rowCount == 0)
+			continue;
+
+		/*
+		 * Sum the deleted-row counts of this group's row_mask rows, counting only
+		 * masks whose own xmin precedes oldestXmin -- those are visible to every
+		 * live snapshot. A more recent delete (xmin >= oldestXmin) is not yet
+		 * visible to all, so the group is not retired this pass.
+		 */
+		ScanKeyInit(&mkey[0], Anum_row_mask_storage_id, BTEqualStrategyNumber,
+					F_INT8EQ, Int64GetDatum((int64) storageId));
+		ScanKeyInit(&mkey[1], Anum_row_mask_stripe_id, BTEqualStrategyNumber,
+					F_INT8EQ, Int64GetDatum((int64) groupNumber));
+		mscan = systable_beginscan(mrel, InvalidOid, false, snap, 2, mkey);
+		while (HeapTupleIsValid(mtuple = systable_getnext(mscan)))
+		{
+			TransactionId mxmin = HeapTupleHeaderGetXmin(mtuple->t_data);
+
+			if (TransactionIdIsNormal(mxmin) &&
+				!TransactionIdPrecedes(mxmin, oldestXmin))
+				continue;
+			deletedSeen += DatumGetInt32(
+				heap_getattr(mtuple, Anum_row_mask_deleted_rows, mtd, &isnull));
+		}
+		systable_endscan(mscan);
+
+		if (deletedSeen >= (int64) rowCount)
+		{
+			uint64	   *g = palloc(sizeof(uint64));
+
+			*g = groupNumber;
+			groups = lappend(groups, g);
+		}
+	}
+	systable_endscan(gscan);
+	table_close(mrel, AccessShareLock);
+	table_close(grel, AccessShareLock);
+	UnregisterSnapshot(snap);
+
+	return groups;
+}
+
+/* delete every row of a metadata table matching (storageAttno, groupAttno) */
+static void
+delete_group_rows(const char *tableName, AttrNumber storageAttno,
+				  AttrNumber groupAttno, uint64 storageId, uint64 groupNumber)
+{
+	Relation	rel = open_columnar_table(tableName, RowExclusiveLock);
+	ScanKeyData key[2];
+	SysScanDesc scan;
+	HeapTuple	tuple;
+
+	ScanKeyInit(&key[0], storageAttno, BTEqualStrategyNumber,
+				F_INT8EQ, Int64GetDatum((int64) storageId));
+	ScanKeyInit(&key[1], groupAttno, BTEqualStrategyNumber,
+				F_INT8EQ, Int64GetDatum((int64) groupNumber));
+
+	scan = systable_beginscan(rel, InvalidOid, false, NULL, 2, key);
+	while (HeapTupleIsValid(tuple = systable_getnext(scan)))
+		CatalogTupleDelete(rel, &tuple->t_self);
+	systable_endscan(scan);
+
+	table_close(rel, RowExclusiveLock);
+}
+
+/*
+ * ColumnarRetireGroup
+ *		Drop all catalog rows for one row group (row_group, column_chunk,
+ *		zone_map, bloom, row_mask) in the current transaction (Phase F3a). The
+ *		storage row is left intact. Heap MVCC on these deletes keeps the group
+ *		readable to older snapshots; the group's data pages are not reclaimed here
+ *		(deferred physical reclaim). The caller must have verified the group is
+ *		fully deleted as-of oldestXmin.
+ */
+void
+ColumnarRetireGroup(uint64 storageId, uint64 groupNumber)
+{
+	delete_group_rows("row_mask", Anum_row_mask_storage_id,
+					  Anum_row_mask_stripe_id, storageId, groupNumber);
+	delete_group_rows("column_chunk", Anum_column_chunk_storage_id,
+					  Anum_column_chunk_group_number, storageId, groupNumber);
+	delete_group_rows("zone_map", Anum_zone_map_storage_id,
+					  Anum_zone_map_group_number, storageId, groupNumber);
+	delete_group_rows("bloom", Anum_bloom_storage_id,
+					  Anum_bloom_group_number, storageId, groupNumber);
+	delete_group_rows("row_group", Anum_row_group_storage_id,
+					  Anum_row_group_group_number, storageId, groupNumber);
+}
+
+/*
+ * ColumnarRetireFullyDeletedGroups
+ *		Online compaction (Phase F3a, lazy path): retire every row group that is
+ *		fully deleted as-of oldestXmin. Safe under ShareUpdateExclusiveLock,
+ *		concurrent with readers and writers. Returns the number of groups retired.
+ */
+int64
+ColumnarRetireFullyDeletedGroups(Relation rel)
+{
+	uint64		storageId = ColumnarStorageId(rel);
+	TransactionId oldestXmin = ColumnarOldestXmin(rel);
+	List	   *groups = ColumnarComputeFullyDeletedGroups(storageId, oldestXmin);
+	ListCell   *lc;
+	int64		retired = 0;
+
+	foreach(lc, groups)
+	{
+		ColumnarRetireGroup(storageId, *(uint64 *) lfirst(lc));
+		retired++;
+	}
+	return retired;
 }
 
 

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -407,6 +407,16 @@ columnar_relation_vacuum(Relation rel, COLUMNAR_VACUUM_PARAMS params,
 	 * columnar.vacuum (AccessExclusiveLock, the VACUUM-FULL analog).
 	 */
 	ColumnarVMSetVisibleForRelation(rel);
+
+	/*
+	 * Online compaction (Phase F3a): retire row groups that are fully deleted
+	 * as-of the oldest-xmin horizon, dropping their metadata so scans skip them.
+	 * This is also read-mostly on data (it only deletes catalog rows for groups
+	 * every snapshot agrees are dead) and is safe under ShareUpdateExclusiveLock,
+	 * so a plain VACUUM / autovacuum reclaims fully-deleted groups online without
+	 * the AccessExclusiveLock rewrite.
+	 */
+	ColumnarRetireFullyDeletedGroups(rel);
 }
 
 /* -------------------------------------------------------------------------

--- a/src/columnar_vacuum.c
+++ b/src/columnar_vacuum.c
@@ -44,6 +44,7 @@ PG_FUNCTION_INFO_V1(columnar_relation_storageid);
 PG_FUNCTION_INFO_V1(columnar_vacuum);
 PG_FUNCTION_INFO_V1(columnar_vacuum_sorted);
 PG_FUNCTION_INFO_V1(columnar_cluster);
+PG_FUNCTION_INFO_V1(columnar_compact);
 
 /* -------------------------------------------------------------------------
  * Z-order (Morton) clustering (Phase F2)
@@ -770,4 +771,48 @@ columnar_cluster(PG_FUNCTION_ARGS)
 	table_close(rel, NoLock);
 
 	PG_RETURN_VOID();
+}
+
+/*
+ * columnar_compact
+ *		SQL: pgcolumnar.compact(tablename regclass) -> bigint. The LAZY / online
+ *		maintenance path (Phase F3a): retire every row group that is fully deleted
+ *		as-of the oldest-xmin horizon, dropping its catalog rows so scans no longer
+ *		read it. Runs under ShareUpdateExclusiveLock, so it is concurrent with
+ *		readers and writers -- unlike vacuum / cluster, it never takes
+ *		AccessExclusiveLock. Returns the number of groups retired. Physical page
+ *		reclaim of retired groups is deferred; run the eager vacuum to reclaim the
+ *		file, or a later F3 pass. Rewriting partially-deleted groups online is
+ *		Phase F3b.
+ */
+Datum
+columnar_compact(PG_FUNCTION_ARGS)
+{
+	Oid			relid = PG_GETARG_OID(0);
+	Relation	rel;
+	int64		retired;
+
+	if (PG_ARGISNULL(0))
+		ereport(ERROR,
+				(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+				 errmsg("table name cannot be null")));
+
+	/* the lazy lock: concurrent reads and writes are allowed during compaction */
+	rel = table_open(relid, ShareUpdateExclusiveLock);
+
+	if (!ColumnarIsColumnarRelation(relid))
+	{
+		table_close(rel, ShareUpdateExclusiveLock);
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+				 errmsg("relation \"%s\" is not a columnar table",
+						RelationGetRelationName(rel))));
+	}
+
+	retired = ColumnarRetireFullyDeletedGroups(rel);
+
+	/* keep the lock until end of transaction */
+	table_close(rel, NoLock);
+
+	PG_RETURN_INT64(retired);
 }

--- a/test/native_compact.sh
+++ b/test/native_compact.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# pgColumnar online compaction (Phase F3a, the lazy path). pgcolumnar.compact()
+# retires row groups that are fully deleted as-of the oldest-xmin horizon,
+# dropping their catalog rows so scans skip them, WITHOUT rewriting data and
+# WITHOUT AccessExclusiveLock -- it holds only ShareUpdateExclusiveLock, so it is
+# concurrent with readers and writers. This suite proves: results match a heap
+# mirror after deletes + compact; a fully-deleted group is retired (row_group
+# count drops); a partially-deleted group is NOT retired; and the lock taken is
+# ShareUpdateExclusiveLock, never AccessExclusiveLock.
+#
+# Usage:  test/native_compact.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+# 8192 rows in 8 row groups of 1024 (group k covers ids k*1024+1 .. (k+1)*1024).
+GEN="SELECT g, (g % 100) AS v, 'p' || (g % 50) AS payload
+  FROM generate_series(1, 8192) g"
+
+psql_run "CREATE TABLE h (id int, v int, payload text);"
+psql_run "CREATE TABLE n (id int, v int, payload text) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 1024, chunk_group_row_limit => 1024);"
+psql_run "INSERT INTO h $GEN;"
+psql_run "INSERT INTO n $GEN;"
+
+groups() { q "SELECT count(*) FROM pgcolumnar.row_group WHERE storage_id = pgcolumnar.get_storage_id('n');"; }
+
+check "row count" "$(q 'SELECT count(*) FROM n;')" "8192"
+check "initial group count" "$(groups)" "8"
+
+# Delete two whole groups (ids 2049..4096 = groups 2 and 3) in both tables, commit.
+psql_run "DELETE FROM h WHERE id BETWEEN 2049 AND 4096;"
+psql_run "DELETE FROM n WHERE id BETWEEN 2049 AND 4096;"
+# Partially delete one group (half of group 5: ids 5121..5632).
+psql_run "DELETE FROM h WHERE id BETWEEN 5121 AND 5632;"
+psql_run "DELETE FROM n WHERE id BETWEEN 5121 AND 5632;"
+
+check "parity after deletes" \
+	"$(pgc_set_hash 'SELECT id, v, payload FROM n ORDER BY id')" \
+	"$(pgc_set_hash 'SELECT id, v, payload FROM h ORDER BY id')"
+
+# Online compaction: the two fully-deleted groups are retired, the partially
+# deleted one is kept. Returns the number retired.
+retired="$(q "SELECT pgcolumnar.compact('n');")"
+echo "  (compact retired $retired groups; group count now $(groups))"
+check "compact retired the two fully-deleted groups" "$retired" "2"
+check "group count dropped by two" "$(groups)" "6"
+
+# Results are unchanged by compaction (deleted rows already gone; live rows stay).
+check "parity after compact" \
+	"$(pgc_set_hash 'SELECT id, v, payload FROM n ORDER BY id')" \
+	"$(pgc_set_hash 'SELECT id, v, payload FROM h ORDER BY id')"
+check "live row count after compact" \
+	"$(q 'SELECT count(*) FROM n;')" \
+	"$(q 'SELECT count(*) FROM h;')"
+
+# The partially-deleted group's live rows are still readable.
+check "partial-group rows still present" \
+	"$(q 'SELECT count(*) FROM n WHERE id BETWEEN 4097 AND 6144;')" \
+	"$(q 'SELECT count(*) FROM h WHERE id BETWEEN 4097 AND 6144;')"
+
+# A second compact with nothing newly dead retires nothing.
+check "second compact retires nothing" "$(q "SELECT pgcolumnar.compact('n');")" "0"
+
+# Lock level: compact must hold ShareUpdateExclusiveLock, never AccessExclusiveLock.
+locks="$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+	-d "$PGC_DB" -At 2>/dev/null <<'SQL' | grep -E '^[0-9]+\|[0-9]+$'
+BEGIN;
+SELECT pgcolumnar.compact('n');
+SELECT count(*) FILTER (WHERE mode='ShareUpdateExclusiveLock')::text || '|' ||
+       count(*) FILTER (WHERE mode='AccessExclusiveLock')::text
+  FROM pg_locks WHERE relation='n'::regclass AND locktype='relation';
+ROLLBACK;
+SQL
+)"
+check "compact holds ShareUpdateExclusiveLock" "${locks%%|*}" "1"
+check "compact holds no AccessExclusiveLock" "${locks##*|}" "0"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -27,7 +27,7 @@ SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUITES=(smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
 	differential recovery fuzz hardening concurrent_diff parallel sorted_projection \
 	arrow_export parquet_export read_stream corruption \
-	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip native_index native_dml native_ios native_projection native_cluster)
+	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip native_index native_dml native_ios native_projection native_cluster native_compact)
 
 # Default matrix: one assert-enabled pg_config per major, 15 through 19.
 DEFAULT_CONFIGS=(


### PR DESCRIPTION
The **required lazy** counterpart to F2's eager reorg. `pgcolumnar.compact(table)` retires every row group all of whose rows are deleted as-of the oldest-xmin horizon, dropping its catalog rows so scans no longer read it — **online, under `ShareUpdateExclusiveLock`** (concurrent reads *and* writes), never the `AccessExclusiveLock` the eager vacuum/cluster rewrite takes. Also wired into `columnar_relation_vacuum`, so plain `VACUUM`/autovacuum reclaims fully-dead groups online.

This directly answers the requirement that every maintenance op offer a non-blocking lazy path ("AccessExclusive is a killer").

## Why it's correct (and race-free)
From the MVCC survey: pgColumnar visibility is pure heap MVCC on the metadata catalog tuples. Retirement only touches groups **every live snapshot agrees are dead** (the group's xmin and all delete xids precede `oldestXmin`), so:
- no rewrite, no row-number remap, no index change (rows already dead to everyone);
- race-free: a fully-dead-to-all group has no visible rows for any writer to delete or inserter to target;
- old-snapshot readers keep the old catalog version via heap MVCC.

Physical page reclaim is deferred (append-only offsets; the eager vacuum still reclaims the file). Rewriting *partially*-deleted groups online is F3b.

## Validation
`test/native_compact.sh` (11 checks): retirement of the two fully-deleted groups, a partially-deleted group kept, heap-mirror parity across delete+compact, second compact retires nothing, and — asserted via `pg_locks` — compact holds **ShareUpdateExclusiveLock and no AccessExclusiveLock**. **Full PG17 suite green** (44 suites, no warnings), including the concurrency and index-only/IOS suites that exercise the autovacuum hook. `design/PHASE_F3_PLAN.md` has the design and the F3b/F3c roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)