### PR TITLE
Phase F3b: fully-online rewrite of partially-deleted groups

### DIFF
--- a/design/PHASE_F3B_PLAN.md
+++ b/design/PHASE_F3B_PLAN.md
@@ -1,0 +1,100 @@
+# Phase F3b plan: fully-online rewrite of partially-deleted groups
+
+Status: active, on `phase-f/f3b-online-rewrite`. F3b reclaims space from row
+groups that are only PARTIALLY deleted (F3a retires only fully-dead groups) by
+rewriting their live rows into a fresh group, ONLINE under
+ShareUpdateExclusiveLock: concurrent reads AND writes, like regular VACUUM. This
+is the hardest piece of the mutation story; correctness rests on the protocol
+below, verified against the MVCC model (see design/PHASE_F3_PLAN.md).
+
+## Mechanism (per group, bounded batch per call)
+
+For a group G whose deleted fraction exceeds a threshold:
+1. Acquire the per-chunk-group advisory ExclusiveLock for (storageId, G) -- the
+   SAME lock deleters take in ColumnarUpsertRowMask -- held to transaction end.
+2. Take a fresh snapshot AFTER the lock, so it reflects every delete committed
+   before the lock was granted.
+3. Read G's live rows (skip row_mask-deleted rows under that snapshot),
+   materializing their values.
+4. Write them as a new group G' through the write state: reserve fresh row
+   numbers, write column chunks to fresh append-only offsets, insert G's
+   replacement `row_group` / `column_chunk` / `zone_map` / `bloom` catalog rows.
+5. Insert index entries for each moved row's NEW row number into every index on
+   the relation (online index maintenance; the offline path instead reindexes).
+6. Delete G's catalog rows (row_group, column_chunk, zone_map, bloom, row_mask).
+7. Commit -- releasing the advisory lock. Data pages of G are not reclaimed here
+   (deferred; append-only offsets).
+
+Because data pages are append-only and the swap is a set of catalog inserts plus
+the old row_group delete in one transaction, heap MVCC makes it atomic: snapshots
+older than the commit keep G (and read its pages); newer snapshots see G'. No
+relfilenode swap, no AccessExclusiveLock.
+
+## The concurrent-DELETE conflict protocol (the crux)
+
+Hazard: a DELETE resolves a row's OLD number under its snapshot and buffers the
+mark (flushed at pre-commit). If F3b moves that row to a NEW number in G' and
+commits first, the delete would mark the now-gone G and the row would resurrect
+for post-swap snapshots. The deleter's snapshot hides F3b's retirement, so the
+deleter cannot detect the conflict from its own snapshot.
+
+Resolution -- advisory-lock serialization + deleter abort-on-conflict:
+- Both F3b and DELETE-flush take the per-chunk-group advisory lock, so they
+  serialize per group.
+- In ColumnarUpsertRowMask, AFTER acquiring the lock, check under the LATEST
+  snapshot (not the deleter's stale snapshot) whether G's `row_group` catalog row
+  still exists. If it is gone (F3b retired G), raise
+  ERRCODE_T_R_SERIALIZATION_FAILURE ("row group compacted concurrently; retry").
+  The deleter aborts and retries; on retry it re-resolves the row at G' and marks
+  it correctly.
+
+Case analysis (all correct):
+- Deleter commits before F3b takes the lock: F3b's post-lock snapshot sees the
+  delete, excludes the row from G'.
+- Deleter holds the lock, F3b waits: F3b proceeds after the deleter commits,
+  post-lock snapshot sees the delete, excludes the row.
+- F3b commits before the deleter flushes: deleter takes the lock, checks latest,
+  finds G gone, aborts and retries.
+- Deleter buffered but not flushed while F3b runs: same as above -- caught at
+  flush by the latest-state check.
+
+Cost: a DELETE/UPDATE that races a concurrent rewrite of exactly its group gets a
+serialization failure and retries. Rare, and standard for online reorg.
+
+## Index correctness during the old/new overlap window
+
+After commit both old-number (G) and new-number (G') index entries exist for the
+moved rows; the btree returns both and table-fetch filtering picks the right one
+per snapshot:
+- New snapshot: old-number fetch hits retired G (its row_group tuple invisible)
+  -> ColumnarReadRowByNumber returns not-live -> filtered; new-number fetch hits
+  G' -> live -> returned. Each row returned once.
+- Old snapshot: sees G, old-number fetch returns the row; new-number fetch hits
+  G' whose row_group tuple (xmin = F3b) is invisible to the old snapshot ->
+  not-live -> filtered. Each row returned once.
+- Unique index: two entries for a key during the window, but the old-number one
+  is not-live, so uniqueness holds (H4, via liveness filtering).
+
+Old-number entries age out via btree vacuum / columnar_index_delete_tuples, which
+already report deletability by actual liveness.
+
+## Deferred / follow-on
+
+- Physical page reclaim of rewritten groups (append-only offsets; eager vacuum
+  reclaims the file).
+- F3c incremental reclustering reuses this online-swap path with the F2 Morton
+  key to re-sort out-of-order neighbors.
+
+## Validation
+
+- `test/native_compact.sh` (extend) or a new `native_rewrite.sh`: a
+  partially-deleted group is rewritten (row group replaced, live rows preserved,
+  deleted rows gone), heap-mirror parity, `pg_locks` shows
+  ShareUpdateExclusiveLock and no AccessExclusiveLock, and index scans still
+  return each live row exactly once after the rewrite.
+- Concurrency stressor: run `pgcolumnar.compact_rewrite` on many connections
+  against ongoing INSERT/UPDATE/DELETE and diff the surviving rows against a heap
+  mirror; assert that DELETE conflicts surface as serialization failures (retried)
+  and never as lost or resurrected rows.
+- The differential oracle, `concurrent_diff`, and `unique_conc` stay green.
+- PG17 gate during the work; full 15-19 matrix at the end.

--- a/pgcolumnar--1.0.sql
+++ b/pgcolumnar--1.0.sql
@@ -452,6 +452,17 @@ CREATE FUNCTION pgcolumnar.compact(tablename regclass)
 COMMENT ON FUNCTION pgcolumnar.compact(regclass)
 	IS 'lazy online compaction: retire row groups that are fully deleted, dropping their metadata so scans skip them. Holds only ShareUpdateExclusiveLock (concurrent reads and writes). Returns the number of groups retired (Phase F3a)';
 
+CREATE FUNCTION pgcolumnar.compact_rewrite(
+	tablename regclass,
+	min_deleted_fraction float8 DEFAULT 0.2,
+	max_groups int DEFAULT 0)
+	RETURNS bigint
+	LANGUAGE C
+	AS 'MODULE_PATHNAME', 'columnar_compact_rewrite';
+
+COMMENT ON FUNCTION pgcolumnar.compact_rewrite(regclass, float8, int)
+	IS 'lazy online space reclaim: rewrite partially-deleted row groups (deleted fraction >= min_deleted_fraction) to drop their dead rows, under ShareUpdateExclusiveLock (concurrent reads and writes). Returns the number of groups rewritten (Phase F3b)';
+
 CREATE FUNCTION pgcolumnar.export_arrow(rel regclass, path text)
 	RETURNS bigint
 	LANGUAGE C

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -331,6 +331,7 @@ extern List *ColumnarComputeFullyDeletedGroups(uint64 storageId,
 											   TransactionId oldestXmin);
 extern void ColumnarRetireGroup(uint64 storageId, uint64 groupNumber);
 extern int64 ColumnarRetireFullyDeletedGroups(Relation rel);
+extern void ColumnarLockChunkGroup(uint64 storageId, uint64 groupNumber);
 extern List *ColumnarComputeAllVisibleGroups(uint64 storageId,
 											 TransactionId oldestXmin);
 

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -632,6 +632,39 @@ rowmask_lock_chunk_group(uint64 storageId, uint64 stripeId, int chunkId)
  *		the CatalogTupleUpdate cannot lose an update and the CatalogTupleInsert
  *		on the first-delete path cannot hit a duplicate-key race.
  */
+/* does a row_group row for (storageId, groupNumber) exist under `snapshot`? */
+static bool
+row_group_exists(uint64 storageId, uint64 groupNumber, Snapshot snapshot)
+{
+	Relation	rel = open_columnar_table("row_group", AccessShareLock);
+	ScanKeyData key[2];
+	SysScanDesc scan;
+	bool		found;
+
+	ScanKeyInit(&key[0], Anum_row_group_storage_id, BTEqualStrategyNumber,
+				F_INT8EQ, Int64GetDatum((int64) storageId));
+	ScanKeyInit(&key[1], Anum_row_group_group_number, BTEqualStrategyNumber,
+				F_INT8EQ, Int64GetDatum((int64) groupNumber));
+	scan = systable_beginscan(rel, InvalidOid, false, snapshot, 2, key);
+	found = HeapTupleIsValid(systable_getnext(scan));
+	systable_endscan(scan);
+	table_close(rel, AccessShareLock);
+	return found;
+}
+
+/*
+ * ColumnarLockChunkGroup
+ *		Take the transaction-scoped advisory lock for one chunk group (the whole
+ *		row group, chunk id 0), the same lock ColumnarUpsertRowMask takes. Used by
+ *		online compaction (Phase F3b) so a rewrite of a group serializes with
+ *		concurrent deletes to that group.
+ */
+void
+ColumnarLockChunkGroup(uint64 storageId, uint64 groupNumber)
+{
+	rowmask_lock_chunk_group(storageId, groupNumber, 0);
+}
+
 void
 ColumnarUpsertRowMask(uint64 storageId, RowMaskMetadata *rm)
 {
@@ -650,6 +683,37 @@ ColumnarUpsertRowMask(uint64 storageId, RowMaskMetadata *rm)
 	bool		haveReplace = false;
 
 	rowmask_lock_chunk_group(storageId, rm->stripeId, rm->chunkId);
+
+	/*
+	 * Phase F3b conflict detection. Having taken the chunk-group advisory lock,
+	 * we have serialized with any concurrent online rewrite of this group. If that
+	 * rewrite retired the group, its row_group row is gone in the latest committed
+	 * state (our own snapshot may still show it, but the row now lives at a new
+	 * number in the new group). Applying this delete to the retired group would
+	 * lose it, so abort with a serialization failure; the transaction retries and
+	 * re-resolves the row at its new location. A group that was never rewritten
+	 * still exists, so normal deletes are unaffected.
+	 */
+	{
+		Snapshot	latest;
+		bool		exists;
+
+		/*
+		 * Latest committed state, with curcid advanced (ColumnarCatalogSnapshot)
+		 * so a group this same transaction just flushed (pending writes flush
+		 * before row masks at pre-commit) is visible and does not look retired.
+		 * A group retired by a concurrent COMMITTED rewrite is gone here.
+		 */
+		PushActiveSnapshot(GetLatestSnapshot());
+		latest = ColumnarCatalogSnapshot(GetActiveSnapshot());
+		exists = row_group_exists(storageId, rm->stripeId, latest);
+		PopActiveSnapshot();
+		if (!exists)
+			ereport(ERROR,
+					(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
+					 errmsg("row group was compacted concurrently"),
+					 errhint("Retry the transaction.")));
+	}
 
 	rel = open_columnar_table("row_mask", RowExclusiveLock);
 	tupdesc = RelationGetDescr(rel);

--- a/src/columnar_vacuum.c
+++ b/src/columnar_vacuum.c
@@ -23,10 +23,12 @@
 #include "columnar.h"
 
 #include "fmgr.h"
+#include "access/genam.h"
 #include "access/relation.h"
 #include "access/table.h"
 #include "catalog/index.h"
 #include "catalog/pg_type.h"
+#include "executor/executor.h"
 #include "executor/tuptable.h"
 #include "miscadmin.h"
 #include "storage/lockdefs.h"
@@ -45,6 +47,287 @@ PG_FUNCTION_INFO_V1(columnar_vacuum);
 PG_FUNCTION_INFO_V1(columnar_vacuum_sorted);
 PG_FUNCTION_INFO_V1(columnar_cluster);
 PG_FUNCTION_INFO_V1(columnar_compact);
+PG_FUNCTION_INFO_V1(columnar_compact_rewrite);
+
+/* -------------------------------------------------------------------------
+ * Online rewrite of partially-deleted row groups (Phase F3b)
+ *
+ * Reclaims the space of deleted rows in a group that is only partially deleted
+ * (F3a retires only fully-dead groups) by rewriting the group's live rows into a
+ * new group with fresh row numbers, then retiring the old group -- all under
+ * ShareUpdateExclusiveLock, concurrent with readers and writers. Correctness
+ * rests on the protocol in design/PHASE_F3B_PLAN.md: the rewrite serializes with
+ * deleters on the per-chunk-group advisory lock, and a delete that races a
+ * rewrite of its group is aborted with a serialization failure by the
+ * conflict check in ColumnarUpsertRowMask.
+ * ------------------------------------------------------------------------- */
+
+/* the relation's ready+valid indexes, opened once for a rewrite pass */
+typedef struct RewriteIndexState
+{
+	int			n;
+	Relation   *rels;
+	IndexInfo **infos;
+	ExprState **predicates;		/* partial-index predicate, or NULL */
+	EState	   *estate;
+	TupleTableSlot *slot;
+} RewriteIndexState;
+
+static void
+rewrite_index_open(Relation rel, RewriteIndexState *ris)
+{
+	List	   *oids = RelationGetIndexList(rel);
+	int			cap = Max(list_length(oids), 1);
+	ListCell   *lc;
+
+	ris->n = 0;
+	ris->rels = palloc(cap * sizeof(Relation));
+	ris->infos = palloc(cap * sizeof(IndexInfo *));
+	ris->predicates = palloc(cap * sizeof(ExprState *));
+	ris->estate = CreateExecutorState();
+	ris->slot = MakeSingleTupleTableSlot(RelationGetDescr(rel), &TTSOpsVirtual);
+
+	foreach(lc, oids)
+	{
+		Oid			ioid = lfirst_oid(lc);
+		Relation	irel = index_open(ioid, RowExclusiveLock);
+		IndexInfo  *info;
+
+		if (!irel->rd_index->indisready || !irel->rd_index->indisvalid)
+		{
+			index_close(irel, RowExclusiveLock);
+			continue;
+		}
+		info = BuildIndexInfo(irel);
+		ris->rels[ris->n] = irel;
+		ris->infos[ris->n] = info;
+		ris->predicates[ris->n] = (info->ii_Predicate != NIL)
+			? ExecPrepareQual(info->ii_Predicate, ris->estate)
+			: NULL;
+		ris->n++;
+	}
+	list_free(oids);
+}
+
+static void
+rewrite_index_close(RewriteIndexState *ris)
+{
+	int			i;
+
+	for (i = 0; i < ris->n; i++)
+		index_close(ris->rels[i], RowExclusiveLock);
+	ExecDropSingleTupleTableSlot(ris->slot);
+	FreeExecutorState(ris->estate);
+}
+
+/* insert index entries for one rewritten row at its new row number */
+static void
+rewrite_index_insert_row(RewriteIndexState *ris, Relation rel,
+						 Datum *values, bool *isnull, uint64 rowNumber)
+{
+	int			natts = RelationGetDescr(rel)->natts;
+	ExprContext *econtext = GetPerTupleExprContext(ris->estate);
+	ItemPointerData tid;
+	int			i;
+
+	ColumnarRowNumberToItemPointer(rowNumber, &tid);
+
+	ExecClearTuple(ris->slot);
+	memcpy(ris->slot->tts_values, values, natts * sizeof(Datum));
+	memcpy(ris->slot->tts_isnull, isnull, natts * sizeof(bool));
+	ExecStoreVirtualTuple(ris->slot);
+	econtext->ecxt_scantuple = ris->slot;
+
+	for (i = 0; i < ris->n; i++)
+	{
+		Datum		ivalues[INDEX_MAX_KEYS];
+		bool		inulls[INDEX_MAX_KEYS];
+
+		/* skip rows a partial index does not cover */
+		if (ris->predicates[i] != NULL && !ExecQual(ris->predicates[i], econtext))
+			continue;
+
+		FormIndexDatum(ris->infos[i], ris->slot, ris->estate, ivalues, inulls);
+		index_insert(ris->rels[i], ivalues, inulls, &tid, rel,
+					 UNIQUE_CHECK_NO, false, ris->infos[i]);
+	}
+	ResetPerTupleExprContext(ris->estate);
+}
+
+/*
+ * Rewrite one group's live rows into a fresh group and retire the old group.
+ * Returns the number of live rows moved. Caller holds ShareUpdateExclusiveLock
+ * on rel and has opened the indexes in ris.
+ */
+static int64
+rewrite_one_group(Relation rel, RewriteIndexState *ris, uint64 storageId,
+				  uint64 groupNumber, uint64 firstRow, uint64 rowCount)
+{
+	Oid			relid = RelationGetRelid(rel);
+	int			natts = RelationGetDescr(rel)->natts;
+	Datum	   *values = palloc(natts * sizeof(Datum));
+	bool	   *isnull = palloc(natts * sizeof(bool));
+	ColumnarWriteState *ws;
+	Snapshot	snap;
+	uint64		r;
+	int64		moved = 0;
+
+	/* serialize with concurrent deleters to this group (see ColumnarUpsertRowMask) */
+	ColumnarLockChunkGroup(storageId, groupNumber);
+
+	/* read the group's live set under a snapshot taken after the lock, so every
+	 * delete committed before the lock is reflected */
+	snap = GetLatestSnapshot();
+	PushActiveSnapshot(snap);
+
+	ws = ColumnarGetWriteState(rel);
+	for (r = firstRow; r < firstRow + rowCount; r++)
+	{
+		uint64		newRn;
+
+		CHECK_FOR_INTERRUPTS();
+		if (!ColumnarReadRowByNumber(rel, snap, r, values, isnull))
+			continue;			/* deleted or absent: drop it */
+
+		newRn = ColumnarWriteRow(ws, rel, values, isnull);
+		ColumnarProjectionFanoutRow(rel, ws, newRn, values, isnull);
+		rewrite_index_insert_row(ris, rel, values, isnull, newRn);
+		moved++;
+	}
+	ColumnarFlushWriteStateForRelation(relid);
+
+	/* atomically (same transaction) the new group is now in the catalog; drop the
+	 * old one. Heap MVCC keeps the old group readable to older snapshots. */
+	ColumnarRetireGroup(storageId, groupNumber);
+
+	PopActiveSnapshot();
+	pfree(values);
+	pfree(isnull);
+	return moved;
+}
+
+/* one candidate group to rewrite */
+typedef struct RewriteCandidate
+{
+	uint64		groupNumber;
+	uint64		firstRow;
+	uint64		rowCount;
+} RewriteCandidate;
+
+/*
+ * columnar_rewrite_partial_groups
+ *		Rewrite up to maxGroups groups whose deleted fraction is at least
+ *		minDeletedFraction (and which are not fully dead -- F3a handles those).
+ *		maxGroups <= 0 means all. Returns the number of groups rewritten.
+ */
+static int64
+columnar_rewrite_partial_groups(Relation rel, double minDeletedFraction,
+								int maxGroups)
+{
+	uint64		storageId = ColumnarStorageId(rel);
+	Oid			relid = RelationGetRelid(rel);
+	Snapshot	snap;
+	List	   *rgList;
+	ListCell   *lc;
+	List	   *cands = NIL;
+	RewriteIndexState ris;
+	int64		rewritten = 0;
+
+	/* persist own pending work so the group list and deletes are current */
+	ColumnarFlushWriteStateForRelation(relid);
+	ColumnarFlushRowMaskForRelation(rel);
+
+	/* collect candidate groups first (do not mutate the catalog mid-scan) */
+	snap = RegisterSnapshot(GetLatestSnapshot());
+	rgList = ColumnarReadRowGroupList(storageId, snap);
+	foreach(lc, rgList)
+	{
+		NativeRowGroupMetadata *rg = (NativeRowGroupMetadata *) lfirst(lc);
+		List	   *rmList;
+		ListCell   *lc2;
+		int64		deleted = 0;
+
+		if (rg->rowCount == 0)
+			continue;
+		rmList = ColumnarReadRowMaskList(storageId, rg->groupNumber, snap);
+		foreach(lc2, rmList)
+			deleted += ((RowMaskMetadata *) lfirst(lc2))->deletedRows;
+
+		/* partially deleted and past the threshold; fully-dead is F3a's job */
+		if (deleted > 0 && deleted < (int64) rg->rowCount &&
+			(double) deleted / (double) rg->rowCount >= minDeletedFraction)
+		{
+			RewriteCandidate *c = palloc(sizeof(RewriteCandidate));
+
+			c->groupNumber = rg->groupNumber;
+			c->firstRow = rg->firstRowNumber;
+			c->rowCount = rg->rowCount;
+			cands = lappend(cands, c);
+		}
+	}
+	UnregisterSnapshot(snap);
+
+	if (cands == NIL)
+		return 0;
+
+	rewrite_index_open(rel, &ris);
+	foreach(lc, cands)
+	{
+		RewriteCandidate *c = (RewriteCandidate *) lfirst(lc);
+
+		if (maxGroups > 0 && rewritten >= maxGroups)
+			break;
+		rewrite_one_group(rel, &ris, storageId, c->groupNumber,
+						  c->firstRow, c->rowCount);
+		rewritten++;
+	}
+	rewrite_index_close(&ris);
+
+	return rewritten;
+}
+
+/*
+ * columnar_compact_rewrite
+ *		SQL: pgcolumnar.compact_rewrite(tablename regclass,
+ *			 min_deleted_fraction float8 default 0.2, max_groups int default 0).
+ *		The lazy online space-reclaiming path (Phase F3b): rewrite partially
+ *		deleted groups to drop their dead rows, under ShareUpdateExclusiveLock
+ *		(concurrent reads and writes). Returns the number of groups rewritten.
+ */
+Datum
+columnar_compact_rewrite(PG_FUNCTION_ARGS)
+{
+	Oid			relid = PG_GETARG_OID(0);
+	double		minFrac = PG_ARGISNULL(1) ? 0.2 : PG_GETARG_FLOAT8(1);
+	int			maxGroups = PG_ARGISNULL(2) ? 0 : PG_GETARG_INT32(2);
+	Relation	rel;
+	int64		rewritten;
+
+	if (PG_ARGISNULL(0))
+		ereport(ERROR,
+				(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+				 errmsg("table name cannot be null")));
+	if (minFrac < 0.0 || minFrac > 1.0)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("min_deleted_fraction must be between 0 and 1")));
+
+	rel = table_open(relid, ShareUpdateExclusiveLock);
+
+	if (!ColumnarIsColumnarRelation(relid))
+	{
+		table_close(rel, ShareUpdateExclusiveLock);
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+				 errmsg("relation \"%s\" is not a columnar table",
+						RelationGetRelationName(rel))));
+	}
+
+	rewritten = columnar_rewrite_partial_groups(rel, minFrac, maxGroups);
+
+	table_close(rel, NoLock);
+	PG_RETURN_INT64(rewritten);
+}
 
 /* -------------------------------------------------------------------------
  * Z-order (Morton) clustering (Phase F2)

--- a/test/native_rewrite.sh
+++ b/test/native_rewrite.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# pgColumnar online rewrite of partially-deleted groups (Phase F3b).
+# pgcolumnar.compact_rewrite() rewrites groups whose deleted fraction exceeds a
+# threshold into fresh groups (dropping the dead rows) with fresh row numbers,
+# ONLINE under ShareUpdateExclusiveLock. This suite proves: results match a heap
+# mirror; the dead rows' space is reclaimed (deletedrows drops); INDEX scans
+# return each live row exactly once despite the transient old/new row-number
+# overlap (unique constraint still holds, point lookups correct); and the lock is
+# ShareUpdateExclusiveLock, never AccessExclusiveLock. Concurrency is covered by
+# native_rewrite_conc.sh.
+#
+# Usage:  test/native_rewrite.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+GEN="SELECT g, (g % 1000) AS v, 'p' || (g % 100) AS payload
+  FROM generate_series(1, 8192) g"
+
+psql_run "CREATE TABLE h (id int, v int, payload text);"
+psql_run "CREATE TABLE n (id int, v int, payload text) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 1024, chunk_group_row_limit => 1024);"
+psql_run "INSERT INTO h $GEN;"
+psql_run "INSERT INTO n $GEN;"
+psql_run "CREATE UNIQUE INDEX n_id_uq ON n (id);"
+psql_run "CREATE INDEX n_v ON n (v);"
+
+deletedrows() { q "SELECT COALESCE(sum(deletedrows), 0) FROM pgcolumnar.stats('n'::regclass);"; }
+
+# Partially delete a third of the rows across every group (id % 3 = 0), commit.
+psql_run "DELETE FROM h WHERE id % 3 = 0;"
+psql_run "DELETE FROM n WHERE id % 3 = 0;"
+
+check "row count after delete" "$(q 'SELECT count(*) FROM n;')" "$(q 'SELECT count(*) FROM h;')"
+check "there are deleted rows to reclaim" "$([ "$(deletedrows)" -gt 0 ] && echo yes || echo no)" "yes"
+check "parity after delete" \
+	"$(pgc_set_hash 'SELECT id, v, payload FROM n ORDER BY id')" \
+	"$(pgc_set_hash 'SELECT id, v, payload FROM h ORDER BY id')"
+
+# Online rewrite of the partially-deleted groups.
+rew="$(q "SELECT pgcolumnar.compact_rewrite('n', 0.2);")"
+echo "  (compact_rewrite rewrote $rew groups; deletedrows now $(deletedrows))"
+check "rewrote some groups" "$([ "$rew" -gt 0 ] && echo yes || echo no)" "yes"
+check "dead-row space reclaimed" "$(deletedrows)" "0"
+
+# Results unchanged.
+check "parity after rewrite" \
+	"$(pgc_set_hash 'SELECT id, v, payload FROM n ORDER BY id')" \
+	"$(pgc_set_hash 'SELECT id, v, payload FROM h ORDER BY id')"
+check "row count after rewrite" \
+	"$(q 'SELECT count(*) FROM n;')" \
+	"$(q 'SELECT count(*) FROM h;')"
+
+# Index-scan correctness: force an index scan and confirm each live row is
+# returned exactly once (no duplicate from lingering old-number index entries).
+idxcount() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -At 2>/dev/null -c \
+		"SET enable_seqscan=off; SET pgcolumnar.enable_custom_scan=off;
+		 SELECT count(*) FROM n WHERE id BETWEEN 1 AND 8192;" | tail -1
+}
+check "index scan returns each live row once" "$(idxcount)" "$(q 'SELECT count(*) FROM h;')"
+# Point lookups via the unique index.
+check "live id present via index" "$(q 'SELECT count(*) FROM n WHERE id = 4097;')" "1"
+check "deleted id absent via index" "$(q 'SELECT count(*) FROM n WHERE id = 4098;')" "0"
+
+# Uniqueness still enforced after the rewrite (no stale live duplicate).
+dupfails() {
+	if env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -At -v ON_ERROR_STOP=1 -c "INSERT INTO n VALUES (4097, 0, 'x');" >/dev/null 2>&1; then
+		echo no
+	else
+		echo yes
+	fi
+}
+check "unique constraint still enforced" "$(dupfails)" "yes"
+
+# Lock level: ShareUpdateExclusiveLock, never AccessExclusiveLock.
+locks="$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+	-d "$PGC_DB" -At 2>/dev/null <<'SQL' | grep -E '^[0-9]+\|[0-9]+$'
+BEGIN;
+SELECT pgcolumnar.compact_rewrite('n', 0.0);
+SELECT count(*) FILTER (WHERE mode='ShareUpdateExclusiveLock')::text || '|' ||
+       count(*) FILTER (WHERE mode='AccessExclusiveLock')::text
+  FROM pg_locks WHERE relation='n'::regclass AND locktype='relation';
+ROLLBACK;
+SQL
+)"
+check "compact_rewrite holds ShareUpdateExclusiveLock" "${locks%%|*}" "1"
+check "compact_rewrite holds no AccessExclusiveLock" "${locks##*|}" "0"
+
+pgc_summary

--- a/test/native_rewrite_conc.sh
+++ b/test/native_rewrite_conc.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# pgColumnar online-rewrite concurrency stress (Phase F3b). While several backends
+# run INSERT/DELETE/UPDATE over disjoint id ranges, a compactor loop concurrently
+# runs pgcolumnar.compact_rewrite (online rewrite of partially-deleted groups) and
+# pgcolumnar.compact (retire fully-dead groups). A DELETE/UPDATE that races a
+# rewrite of its group is aborted with a serialization failure by the conflict
+# protocol; the worker retries. Because the id ranges are disjoint the final
+# logical state is deterministic, so t_col must end equal to the heap oracle --
+# proving the online rewrite never loses or resurrects a row under concurrent
+# writes. This is the decisive correctness test for F3b's ShareUpdateExclusiveLock
+# path.
+#
+# Usage:  test/native_rewrite_conc.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+make_pair "id int, cat int, v bigint, txt text"
+q "SELECT pgcolumnar.alter_columnar_table_set('t_col', chunk_group_row_limit => 500, stripe_row_limit => 1000);" >/dev/null
+
+WORKERS=6
+PER=3000
+
+# Run one autocommit statement, retrying on the serialization failures the rewrite
+# conflict protocol raises (each failed attempt rolls back fully, so a retry
+# reapplies exactly once). Returns non-zero only if it never succeeds.
+runsql() {
+	local sql="$1" errf="$2" t=0
+	until env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+			-d "$PGC_DB" -v ON_ERROR_STOP=1 -q -c "$sql" >/dev/null 2>>"$errf"; do
+		t=$((t + 1))
+		[ "$t" -ge 200 ] && return 1
+	done
+	return 0
+}
+
+# Compactor loop: hammer the online rewrite + fully-dead retirement concurrently.
+STOP="$PGC_WORKDIR/stop"
+rm -f "$STOP"
+(
+	while [ ! -f "$STOP" ]; do
+		env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+			-d "$PGC_DB" -q -c "SELECT pgcolumnar.compact_rewrite('t_col', 0.0);" \
+			>/dev/null 2>>"$PGC_WORKDIR/compactor.err" || true
+		env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+			-d "$PGC_DB" -q -c "SELECT pgcolumnar.compact('t_col');" \
+			>/dev/null 2>>"$PGC_WORKDIR/compactor.err" || true
+	done
+) &
+comp_pid=$!
+
+echo "-- launching $WORKERS workers against a concurrent compactor"
+pids=()
+for w in $(seq 0 $((WORKERS - 1))); do
+	lo=$((w * PER + 1))
+	hi=$(((w + 1) * PER))
+	errf="$PGC_WORKDIR/w.$w.err"
+	(
+		# inserts never conflict with the rewrite (only delete/update do)
+		runsql "INSERT INTO t_heap SELECT g, g%5, g*3, md5(g::text) FROM generate_series($lo,$hi) g;" "$errf" || exit 1
+		runsql "INSERT INTO t_col  SELECT g, g%5, g*3, md5(g::text) FROM generate_series($lo,$hi) g;" "$errf" || exit 1
+		runsql "DELETE FROM t_heap WHERE id BETWEEN $lo AND $hi AND id % 7 = 0;" "$errf" || exit 1
+		runsql "DELETE FROM t_col  WHERE id BETWEEN $lo AND $hi AND id % 7 = 0;" "$errf" || exit 1
+		runsql "UPDATE t_heap SET v = v + 1 WHERE id BETWEEN $lo AND $hi AND id % 5 = 0;" "$errf" || exit 1
+		runsql "UPDATE t_col  SET v = v + 1 WHERE id BETWEEN $lo AND $hi AND id % 5 = 0;" "$errf" || exit 1
+	) &
+	pids+=($!)
+done
+
+fail=0
+for pid in "${pids[@]}"; do
+	wait "$pid" || fail=1
+done
+touch "$STOP"
+wait "$comp_pid" 2>/dev/null || true
+check "all workers succeeded (retried past serialization failures)" "$fail" "0"
+
+# A final settling pass, then the columnar table must equal the heap oracle.
+q "SELECT pgcolumnar.compact_rewrite('t_col', 0.0);" >/dev/null
+q "SELECT pgcolumnar.compact('t_col');" >/dev/null
+
+diff_query "conc-rewrite whole-row" "SELECT * FROM %T"
+diff_query "conc-rewrite count/sum" "SELECT count(*), sum(v), count(distinct cat) FROM %T"
+diff_query "conc-rewrite range"     "SELECT count(*) FROM %T WHERE id BETWEEN 4000 AND 12000"
+check "row count sane" "$([ "$(q 'SELECT count(*) FROM t_col;')" -gt 0 ] && echo ok)" "ok"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -27,7 +27,7 @@ SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUITES=(smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
 	differential recovery fuzz hardening concurrent_diff parallel sorted_projection \
 	arrow_export parquet_export read_stream corruption \
-	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip native_index native_dml native_ios native_projection native_cluster native_compact)
+	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip native_index native_dml native_ios native_projection native_cluster native_compact native_rewrite native_rewrite_conc)
 
 # Default matrix: one assert-enabled pg_config per major, 15 through 19.
 DEFAULT_CONFIGS=(


### PR DESCRIPTION
Reclaims the space of deleted rows in **partially**-deleted groups (F3a retires only fully-dead ones) by rewriting a group's live rows into a fresh group with fresh row numbers, then retiring the old group — **fully online under `ShareUpdateExclusiveLock`**, concurrent with readers *and* writers. `pgcolumnar.compact_rewrite(table, min_deleted_fraction, max_groups)` returns the number of groups rewritten.

This is the hardest piece of the mutation story. Correctness rests on the MVCC survey (visibility is pure heap MVCC on the metadata catalog):
- **Atomic swap via catalog MVCC:** one transaction inserts the new group's catalog rows + index entries and deletes the old `row_group`. Old snapshots keep the old group (append-only data pages untouched); new snapshots see the new one. No relfilenode swap, no AccessExclusiveLock.
- **Concurrent-DELETE conflict protocol:** the rewrite serializes with deleters on the per-chunk-group advisory lock, and `ColumnarUpsertRowMask` now checks (after taking that lock, under a curcid-advanced latest snapshot) whether the group's `row_group` still exists. If a concurrent rewrite retired it, the delete raises a **serialization failure** and retries, re-resolving the row at its new location — so a racing delete can never be lost or resurrect a row.
- **Online index maintenance:** rewritten rows get new row numbers, so index entries are inserted for the new numbers (`UNIQUE_CHECK_NO`; partial-index predicates and expression indexes handled). Old-number entries filter as not-live and age out; each live row is returned exactly once and uniqueness holds.

## Validation
- `native_rewrite.sh` (13 checks): parity, dead-row space reclaimed, **index scan returns each live row exactly once**, unique still enforced, `ShareUpdateExclusiveLock` and no `AccessExclusiveLock`.
- `native_rewrite_conc.sh` — **the decisive test**: 6 workers running INSERT/DELETE/UPDATE over disjoint ranges against a concurrent compactor loop, retrying past serialization failures, ending **byte-for-byte equal to the heap oracle** (no lost or resurrected rows).
- **Full PG17 suite green** (46 suites, no warnings). `design/PHASE_F3B_PLAN.md` has the protocol and correctness argument.

Next: deterministic `isolationtester` MVCC specs pin these races repeatably; then F3c incremental reclustering reuses this online-swap path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)