### PR TITLE
Fix PG18/19 regressions in online compaction/clustering

### DIFF
--- a/src/columnar_vacuum.c
+++ b/src/columnar_vacuum.c
@@ -193,9 +193,12 @@ rewrite_one_group(Relation rel, RewriteIndexState *ris, uint64 storageId,
 	/* serialize with concurrent deleters to this group (see ColumnarUpsertRowMask) */
 	ColumnarLockChunkGroup(storageId, groupNumber);
 
-	/* read the group's live set under a snapshot taken after the lock, so every
-	 * delete committed before the lock is reflected */
-	snap = GetLatestSnapshot();
+	/* Read the group's live set under a snapshot taken after the lock, so every
+	 * delete committed before the lock is reflected. Register it (not just push
+	 * active): ColumnarReadRowByNumber derives a catalog snapshot copy that must
+	 * inherit a nonzero regd_count for PG18's heap-visibility assertion, which a
+	 * merely-active GetLatestSnapshot does not provide. */
+	snap = RegisterSnapshot(GetLatestSnapshot());
 	PushActiveSnapshot(snap);
 
 	ws = ColumnarGetWriteState(rel);
@@ -219,6 +222,7 @@ rewrite_one_group(Relation rel, RewriteIndexState *ris, uint64 storageId,
 	ColumnarRetireGroup(storageId, groupNumber);
 
 	PopActiveSnapshot();
+	UnregisterSnapshot(snap);
 	pfree(values);
 	pfree(isnull);
 	return moved;
@@ -381,14 +385,22 @@ columnar_recluster_online(Relation rel, int ncols, AttrNumber *atts)
 	for (i = 0; i < nGroups; i++)
 		ColumnarLockChunkGroup(storageId, oldGroups[i]);
 
-	/* read all live rows into a Morton-keyed tuplesort (as in eager cluster) */
-	snap = GetLatestSnapshot();
+	/* read all live rows into a Morton-keyed tuplesort (as in eager cluster).
+	 * Register the snapshot (not just push active) so the catalog snapshot copies
+	 * the reader derives satisfy PG18's heap-visibility assertion. */
+	snap = RegisterSnapshot(GetLatestSnapshot());
 	PushActiveSnapshot(snap);
 
 	augdesc = CreateTemplateTupleDesc(natts + 1);
 	for (i = 1; i <= natts; i++)
 		TupleDescCopyEntry(augdesc, (AttrNumber) i, tupdesc, (AttrNumber) i);
 	TupleDescInitEntry(augdesc, zAtt, "__zorder", BYTEAOID, -1, 0);
+#if PG_VERSION_NUM >= 190000
+	/* PG19 requires a manually-built TupleDesc to be finalized before use, which
+	 * computes firstNonCachedOffsetAttr (asserted by the tuple routines) after the
+	 * TupleDescCopyEntry calls filled the FormData array directly. */
+	TupleDescFinalize(augdesc);
+#endif
 
 	tce = lookup_type_cache(BYTEAOID, TYPECACHE_LT_OPR);
 	byteaLt = tce->lt_opr;
@@ -448,6 +460,7 @@ columnar_recluster_online(Relation rel, int ncols, AttrNumber *atts)
 		ColumnarRetireGroup(storageId, oldGroups[i]);
 
 	PopActiveSnapshot();
+	UnregisterSnapshot(snap);
 	pfree(oldGroups);
 	return nGroups;
 }
@@ -993,6 +1006,12 @@ columnar_compact_relation_zorder(Relation rel, int ncols, AttrNumber *atts)
 	for (i = 1; i <= natts; i++)
 		TupleDescCopyEntry(augdesc, (AttrNumber) i, tupdesc, (AttrNumber) i);
 	TupleDescInitEntry(augdesc, zAtt, "__zorder", BYTEAOID, -1, 0);
+#if PG_VERSION_NUM >= 190000
+	/* PG19 requires a manually-built TupleDesc to be finalized before use, which
+	 * computes firstNonCachedOffsetAttr (asserted by the tuple routines) after the
+	 * TupleDescCopyEntry calls filled the FormData array directly. */
+	TupleDescFinalize(augdesc);
+#endif
 
 	tce = lookup_type_cache(BYTEAOID, TYPECACHE_LT_OPR);
 	byteaLt = tce->lt_opr;

--- a/test/isolation.sh
+++ b/test/isolation.sh
@@ -29,7 +29,7 @@ if [ ! -x "$ISO" ]; then
 	exit 0
 fi
 
-SPECS="delete_vs_rewrite old_snapshot_compact"
+SPECS="delete_vs_rewrite old_snapshot_compact compact_vs_reader recluster_vs_delete"
 OUTDIR="$PGC_WORKDIR/iso_out"
 mkdir -p "$OUTDIR"
 

--- a/test/isolation/expected/compact_vs_reader.out
+++ b/test/isolation/expected/compact_vs_reader.out
@@ -1,0 +1,24 @@
+Parsed test spec with 2 sessions
+
+starting permutation: r_begin r_read1 w_delete_all w_compact r_read2 r_commit
+step r_begin: BEGIN ISOLATION LEVEL REPEATABLE READ;
+step r_read1: SELECT count(*) FROM iso;
+count
+-----
+   50
+(1 row)
+
+step w_delete_all: DELETE FROM iso;
+step w_compact: SELECT pgcolumnar.compact('iso');
+compact
+-------
+      0
+(1 row)
+
+step r_read2: SELECT count(*) FROM iso;
+count
+-----
+   50
+(1 row)
+
+step r_commit: COMMIT;

--- a/test/isolation/expected/recluster_vs_delete.out
+++ b/test/isolation/expected/recluster_vs_delete.out
@@ -1,0 +1,19 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1_begin s1_touch s2_recluster s1_delete s1_commit
+step s1_begin: BEGIN ISOLATION LEVEL REPEATABLE READ;
+step s1_touch: SELECT count(*) FROM iso;
+count
+-----
+   50
+(1 row)
+
+step s2_recluster: SELECT pgcolumnar.recluster('iso', 'id');
+recluster
+---------
+        1
+(1 row)
+
+step s1_delete: DELETE FROM iso WHERE id = 25;
+ERROR:  row group was compacted concurrently
+step s1_commit: COMMIT;

--- a/test/isolation/specs/compact_vs_reader.spec
+++ b/test/isolation/specs/compact_vs_reader.spec
@@ -1,0 +1,31 @@
+# Phase F3a gate, pinned deterministically: pgcolumnar.compact() must NOT retire a
+# fully-deleted row group while an older snapshot can still see its rows. A
+# REPEATABLE READ reader fixes a snapshot, then a writer deletes every row and
+# runs compact(); because the reader's snapshot precedes the delete, its
+# oldest-xmin horizon holds the group back, so compact retires 0 groups and the
+# reader still sees all its rows. (Once the reader ends, a later compact could
+# retire the group; that horizon advance is not exercised here.)
+
+setup
+{
+	CREATE TABLE iso (id int, v int) USING pgcolumnar;
+	SELECT pgcolumnar.alter_columnar_table_set('iso', stripe_row_limit => 1000);
+	INSERT INTO iso SELECT g, g FROM generate_series(1, 50) g;
+}
+
+teardown { DROP TABLE iso; }
+
+session reader
+step r_begin  { BEGIN ISOLATION LEVEL REPEATABLE READ; }
+step r_read1  { SELECT count(*) FROM iso; }
+step r_read2  { SELECT count(*) FROM iso; }
+step r_commit { COMMIT; }
+
+session writer
+step w_delete_all { DELETE FROM iso; }
+step w_compact    { SELECT pgcolumnar.compact('iso'); }
+
+# reader pins its snapshot at 50 rows; the writer deletes all and compacts, but
+# compact retires 0 (the reader's horizon holds the group), and the reader still
+# sees all 50 rows.
+permutation "r_begin" "r_read1" "w_delete_all" "w_compact" "r_read2" "r_commit"

--- a/test/isolation/specs/recluster_vs_delete.spec
+++ b/test/isolation/specs/recluster_vs_delete.spec
@@ -1,0 +1,28 @@
+# Phase F3c hazard, pinned deterministically: a DELETE whose snapshot predates a
+# concurrent online recluster of its group must be aborted with a serialization
+# failure, never lost. Same conflict protocol as delete_vs_rewrite, exercised
+# through pgcolumnar.recluster (which retires and rewrites every group). s1 fixes a
+# REPEATABLE READ snapshot that still sees the old group, s2 reclusters (retiring
+# it), then s1 deletes a row it still sees; s1's delete flush detects the
+# retirement and raises a serialization failure. s1 would retry against the new
+# group; the abort is the point.
+
+setup
+{
+	CREATE TABLE iso (id int, v int) USING pgcolumnar;
+	SELECT pgcolumnar.alter_columnar_table_set('iso', stripe_row_limit => 1000);
+	INSERT INTO iso SELECT g, g FROM generate_series(1, 50) g;
+}
+
+teardown { DROP TABLE iso; }
+
+session s1
+step s1_begin  { BEGIN ISOLATION LEVEL REPEATABLE READ; }
+step s1_touch  { SELECT count(*) FROM iso; }
+step s1_delete { DELETE FROM iso WHERE id = 25; }
+step s1_commit { COMMIT; }
+
+session s2
+step s2_recluster { SELECT pgcolumnar.recluster('iso', 'id'); }
+
+permutation "s1_begin" "s1_touch" "s2_recluster" "s1_delete" "s1_commit"


### PR DESCRIPTION
The end-of-work full 15-19 matrix (PG17-only gating had masked these) surfaced two PostgreSQL-18/19-specific crashes in the Phase F online rewrite/cluster/reclaim code. Both root-caused via `-O0` backtraces and fixed; **full 15-19 matrix now ALL GREEN**.

1. **PG18+ snapshot registration.** `rewrite_one_group` / `columnar_recluster_online` read under `GetLatestSnapshot()` pushed active only. `ColumnarReadRowByNumber` derives a catalog-snapshot copy that must inherit a nonzero `regd_count` for PG18's `heapam_visibility` assertion (`regd_count > 0 || active_count > 0`). Fixed with `RegisterSnapshot()` (kept active), matching the eager paths.
2. **PG19 `TupleDescFinalize`.** The Z-order sort builds an augmented TupleDesc via `TupleDescCopyEntry`; PG19 requires `TupleDescFinalize()` before use (computes `firstNonCachedOffsetAttr`, asserted in `heaptuple.c`). Added, guarded PG19+.

Also adds two deterministic isolation specs (blessed, stable across 15-19): `compact_vs_reader` (F3a oldest-xmin retirement gate) and `recluster_vs_delete` (F3c delete-conflict serialization failure).

Verified: native_cluster/recluster/reclaim/rewrite and isolation pass on PG15-19; full matrix green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)