### PR TITLE
Skip storage for virtual generated columns (roadmap Remaining #1)

### DIFF
--- a/design/PHASE_F_RECLAIM_PLAN.md
+++ b/design/PHASE_F_RECLAIM_PLAN.md
@@ -58,6 +58,26 @@ gated on that horizon exactly like the all-visible and F3a computations.
 - Aborted compaction rolls back both the retirement and the free record.
 - The differential oracle stays byte-exact through delete+compact+reuse cycles.
 
+## Follow-ups (status)
+
+- DONE (PR #81): free-list record-on-retire + oldest-xmin-gated reuse (whole-range
+  best-fit), gated on the compaction SUEL lock; the file plateaus instead of
+  bloating. PG18/19 fixes in PR #82.
+- NEXT (safe): make the free-list a proper allocator -- page-aligned spans, split
+  a larger range and re-insert the remainder, and coalesce adjacent same-xid
+  ranges -- so reuse wastes less and packs tighter across varied-size cycles.
+- DEFERRED for owner review (corruption-critical): end-truncation to return disk
+  to the OS. It must lower the metapage reservedOffset and truncate the main fork
+  only for the contiguous free tail that is above every live group AND every
+  not-yet-oldest-xmin-safe retired group, under a conditional AccessExclusiveLock
+  (PG lazy-vacuum pattern). Open hazards to design carefully: RelationTruncate also
+  truncates the FSM/VM forks by main-block count, but pgColumnar's VM fork is
+  indexed by SYNTHETIC (row-number) blocks, not physical -- truncating it by
+  physical block count would corrupt index-only-scan visibility; so truncation
+  must touch only the MAIN fork with correct WAL. To make the tail actually vacate,
+  reuse should also prefer LOW offsets. High value, but the file-truncation + VM
+  interaction warrants review before merge.
+
 ## Validation
 
 - `native_reclaim.sh`: repeated delete + compact_rewrite / recluster cycles keep

--- a/src/columnar_write_state.c
+++ b/src/columnar_write_state.c
@@ -221,7 +221,10 @@ ColumnarGetWriteState(Relation rel)
 	writeState = palloc0(sizeof(ColumnarWriteState));
 	writeState->relid = relid;
 	writeState->subid = subid;
-	writeState->tupdesc = CreateTupleDescCopy(RelationGetDescr(rel));
+	/* CopyConstr (not CopyEntry) so attgenerated is preserved: the flush skips
+	 * writing a chunk for virtual generated columns (attgenerated 'v'), which
+	 * CreateTupleDescCopy would clear. */
+	writeState->tupdesc = CreateTupleDescCopyConstr(RelationGetDescr(rel));
 	writeState->natts = writeState->tupdesc->natts;
 	writeState->stripeRowLimit = columnar_stripe_row_limit;
 	writeState->chunkGroupRowLimit = columnar_chunk_group_row_limit;
@@ -613,6 +616,25 @@ columnar_flush_row_group(ColumnarWriteState *writeState)
 
 		chunkOffset[c] = data->len;
 
+		/*
+		 * Virtual generated columns (attgenerated 'v', PostgreSQL 18+) are computed
+		 * on read from their base columns and never stored, so writing an all-null
+		 * chunk for them wastes space. Skip the chunk entirely: the reader finds no
+		 * column_chunk for this column, treats it as absent, and returns its missing
+		 * value (NULL via getmissingattr), while the executor expands the generated
+		 * expression regardless. A NULL descriptor marks the column skipped for the
+		 * column_chunk insertion pass below. ('v' is never set on PG15-17.)
+		 */
+		if (att->attgenerated == 'v')
+		{
+			chunkLength[c] = 0;
+			chunkDescriptor[c] = NULL;
+			chunkDescriptorLen[c] = 0;
+			chunkBlockCodec[c] = COLUMNAR_COMPRESSION_NONE;
+			pfree(validity);
+			continue;
+		}
+
 		foreach(lc, writeState->chunkGroups)
 		{
 			ChunkGroupBuffer *group = (ChunkGroupBuffer *) lfirst(lc);
@@ -913,6 +935,10 @@ columnar_flush_row_group(ColumnarWriteState *writeState)
 	for (c = 0; c < natts; c++)
 	{
 		NativeColumnChunkMetadata cc;
+
+		/* skipped virtual generated column (no chunk written) */
+		if (chunkDescriptor[c] == NULL)
+			continue;
 
 		cc.storageId = writeState->storageId;
 		cc.groupNumber = groupNumber;

--- a/test/generated_columns.sh
+++ b/test/generated_columns.sh
@@ -79,10 +79,22 @@ if [ "$major" -ge 18 ]; then
 	# generation expression applied to the base column.
 	mism="$(q "SELECT count(*) FROM gv_col WHERE b <> a * 2 OR c <> 'r' || a;")"
 	check "virtual generated: recomputed correctly" "$mism" "0"
-	# Note: pgColumnar currently materializes an all-null chunk for a virtual
-	# column rather than skipping its storage; the read-time value overrides it, so
-	# this is a storage inefficiency, not a correctness issue. Skipping the storage
-	# is a future write-path optimization (design/PG18_19_OPPORTUNITIES.md item 2).
+
+	# Write-path optimization (PG18_19_OPPORTUNITIES.md item 2): a virtual generated
+	# column is computed on read and never stored, so pgColumnar writes NO column
+	# chunk for it (b, c = column_index 1, 2), while the base column a (index 0) is
+	# stored. The reader returns the column's missing value (NULL) for the absent
+	# chunk and the executor expands the generation expression, so reads stay
+	# correct (asserted above) with no wasted storage.
+	vchunks="$(q "SELECT count(*) FROM pgcolumnar.column_chunk
+	              WHERE storage_id = pgcolumnar.get_storage_id('gv_col')
+	                AND column_index IN (1, 2);")"
+	check "virtual generated: no chunk stored for the virtual columns" "$vchunks" "0"
+	achunks="$(q "SELECT count(*) FROM pgcolumnar.column_chunk
+	              WHERE storage_id = pgcolumnar.get_storage_id('gv_col')
+	                AND column_index = 0;")"
+	check "virtual generated: base column still stored" \
+		"$([ "$achunks" -gt 0 ] && echo yes || echo no)" "yes"
 else
 	echo "-- virtual generated column: skipped (PostgreSQL < 18)"
 fi


### PR DESCRIPTION
A virtual generated column (`attgenerated 'v'`, PostgreSQL 18+) is computed on read from its base columns and never stored, yet pgColumnar was writing an all-null column chunk for it in every row group. This skips that write.

## How
- The flush skips building/inserting the chunk (and its validity, encoding, zone map, and bloom) for a virtual generated column, marked by a NULL descriptor for the column-chunk insertion pass.
- Required switching the write state's descriptor from `CreateTupleDescCopy` (which clears `attgenerated`) to `CreateTupleDescCopyConstr`.
- **No reader change**: the reader already handles an absent column chunk (the ALTER TABLE ADD COLUMN "missing value" path) and returns the column's missing value (NULL via `getmissingattr`); the executor expands the generation expression regardless, so reads stay correct.

STORED generated columns and base columns are unaffected.

## Validation
`generated_columns.sh` asserts (PG18+) that **no column chunk is stored for the virtual columns** while the base column is, and that reads recompute correctly. It and `native_dml` pass on PG15-19; **full 15-19 matrix green**. Also records the deferral of end-truncation (corruption-critical) for review in `design/PHASE_F_RECLAIM_PLAN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)