### PR TITLE
Phase F reclaim: fix free-space allocator self-conflict on repeated compaction

### DIFF
--- a/design/ROADMAP.md
+++ b/design/ROADMAP.md
@@ -37,11 +37,18 @@ export and import, flat and nested, for both Arrow and Parquet, all self-contain
 (no libarrow/libparquet dependency) and matrix-gated. See
 [gaps/27-arrow-parquet-interop.md](gaps/27-arrow-parquet-interop.md).
 
-1. Skip virtual generated-column storage. pgColumnar currently writes an all-null
-   chunk for a virtual generated column (PostgreSQL 18+); reads are correct but
-   the bytes are wasted. Skip the write for `attgenerated = 'v'` columns and have
-   the reader return NULL for them. Small-to-medium write/read/vacuum change with
-   its own coverage. See [PG18_19_OPPORTUNITIES.md](PG18_19_OPPORTUNITIES.md) item 2.
+The concrete remaining list is complete as of 2026-07-23. The former item, skip
+virtual generated-column storage, is DONE (the flush skips the chunk for
+`attgenerated = 'v'` columns and the reader returns their missing value; see
+`generated_columns.sh`). Phases E (ALP, FSST, chunk-shared FSST) and F (Z-order
+cluster, online compaction/rewrite/recluster, physical page reclaim) also landed
+on the native PGCN v1 engine, all matrix-gated on PostgreSQL 15-19. What follows
+is Future directions (larger, and some deferred for review).
+
+Deferred (documented, not yet built): end-truncation for lazy disk reclaim
+(corruption-critical VM-fork/WAL hazards, see PHASE_F_RECLAIM_PLAN.md); the F1
+delete-vector catalog rename (PHASE_F_PLAN.md); reclaim free-list splitting and
+coalescing.
 
 ## Future directions
 

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -572,6 +572,13 @@ ColumnarAllocateFreeSpace(uint64 storageId, uint64 dataLength,
 	{
 		CatalogTupleDelete(rel, &bestTid);
 		*fileOffset = bestOff;
+		/*
+		 * A single compaction command can allocate many blocks in a row. Make
+		 * this consumption visible to the next allocation's scan within the same
+		 * command; otherwise it would still see this row as free, re-select it,
+		 * and fail with "tuple already updated by self" on the second delete.
+		 */
+		CommandCounterIncrement();
 	}
 	UnregisterSnapshot(snap);
 	table_close(rel, RowExclusiveLock);

--- a/test/native_scale.sh
+++ b/test/native_scale.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# pgColumnar Phase F scale validation (OPT-IN; not in the default matrix -- run it
+# manually or nightly). Exercises online compaction, rewrite, reclustering, and
+# physical page reclaim at a large row count and asserts correctness against a
+# heap mirror plus a bounded, steady-state file under repeated compaction. The
+# small matrix suites prove logic on a handful of groups; this proves the
+# mutation/clustering/reclaim machinery holds at scale and across many cycles
+# (no O(rows) blowups, and reclaim actually reaches a plateau rather than
+# growing without bound). Uses order-independent aggregates for parity (a full
+# set-hash of half a million rows is needless here).
+#
+# It was this suite (at SCALE_N=200000, repeated compaction) that surfaced the
+# free-space allocator's missing CommandCounterIncrement: without it a second
+# allocation in one compaction command re-selected the just-consumed free_space
+# row and failed with "tuple already updated by self". The steady-state plateau
+# check below is the regression guard.
+#
+# Usage:  SCALE_N=500000 test/native_scale.sh [PG_CONFIG]
+#         (SCALE_N=6000000 for a full-scale run; expect the recluster to be slow.)
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+N="${SCALE_N:-500000}"
+# compute the products in bigint so large g does not overflow int32
+GEN="SELECT g AS id, (g % 1000)::int AS a, (g::bigint * 7) AS b,
+       ((g::bigint * 7919) % 100000)::int AS c
+  FROM generate_series(1, $N) g"
+
+# order-independent fingerprint of the live set (same query on both tables)
+FP="SELECT count(*), sum(a)::bigint, sum(b)::bigint, min(c), max(c),
+           bit_xor(('x' || substr(md5(id||'|'||a||'|'||b||'|'||c), 1, 16))::bit(64)::bigint)"
+fp_n() { q "$FP FROM n;"; }
+fp_h() { q "$FP FROM h;"; }
+fsize() { q "SELECT pg_relation_size('n');"; }
+
+echo "-- loading $N rows into heap + columnar"
+psql_run "CREATE TABLE h (id int, a int, b bigint, c int);"
+psql_run "CREATE TABLE n (id int, a int, b bigint, c int) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 50000, chunk_group_row_limit => 10000);"
+psql_run "INSERT INTO h $GEN;"
+psql_run "INSERT INTO n $GEN;"
+psql_run "CREATE INDEX n_id ON n (id);"
+
+check "bulk load count" "$(q 'SELECT count(*) FROM n;')" "$N"
+check "bulk load parity" "$(fp_n)" "$(fp_h)"
+
+# ---- correctness under mutation / clustering -------------------------------
+# Delete ~25%, then online rewrite of the partially-deleted groups.
+psql_run "DELETE FROM h WHERE id % 4 = 0;"
+psql_run "DELETE FROM n WHERE id % 4 = 0;"
+check "parity after delete" "$(fp_n)" "$(fp_h)"
+rew="$(q "SELECT pgcolumnar.compact_rewrite('n', 0.1);")"
+echo "  (compact_rewrite rewrote $rew groups)"
+check "parity after compact_rewrite" "$(fp_n)" "$(fp_h)"
+# online index maintenance: rewritten rows carry new row numbers and must have
+# fresh index entries; an indexed range lookup must match the heap exactly.
+check "indexed lookup after rewrite" \
+	"$(q "SELECT count(*) FROM n WHERE id BETWEEN 1 AND $((N/2));")" \
+	"$(q "SELECT count(*) FROM h WHERE id BETWEEN 1 AND $((N/2));")"
+
+# Online recluster by c; results unchanged. (This is the slow step at scale.)
+rec="$(q "SELECT pgcolumnar.recluster('n', 'c');")"
+echo "  (recluster processed $rec groups)"
+check "parity after recluster" "$(fp_n)" "$(fp_h)"
+
+# ---- physical reclaim: steady state across repeated compaction -------------
+# Rounds of {delete a rotating 1/8 slice, compact_rewrite} with NO inserts, so
+# the only writes are compaction's. After the first round establishes a
+# generation, the file must PLATEAU: each round reuses the prior round's freed
+# space instead of extending. A growing file here means reuse regressed.
+sizes=()
+for r in 1 2 3 4; do
+	psql_run "DELETE FROM h WHERE id % 8 = $r;"
+	psql_run "DELETE FROM n WHERE id % 8 = $r;"
+	q "SELECT pgcolumnar.compact_rewrite('n', 0.02);" >/dev/null
+	check "parity after reclaim round $r" "$(fp_n)" "$(fp_h)"
+	sizes+=("$(fsize)")
+	echo "  (round $r file size: ${sizes[-1]})"
+done
+# Rounds 2..4 reuse prior frees; the file must not grow past round 2's size.
+check "reclaim reached steady state (round 4 <= round 2)" \
+	"$([ "${sizes[3]}" -le "${sizes[1]}" ] && echo yes || echo no)" "yes"
+
+pgc_summary


### PR DESCRIPTION
## The bug
`ColumnarAllocateFreeSpace` (physical page reclaim) picks a best-fit `free_space` row and `CatalogTupleDelete`s it, but never runs `CommandCounterIncrement`. When a single compaction command allocates more than one block (many groups × many chunks), the second allocation's `GetLatestSnapshot` scan still sees the just-consumed row as free within the same command id, re-selects it, and deletes it again:

```
ERROR:  tuple already updated by self
```

It only fires **once reusable free space exists** — i.e. the second and later compaction of a table. A fresh load extends the file and never touches `free_space`, which is exactly why the single-cycle `native_reclaim` suite passed. On any real table that has already been compacted once, `compact_rewrite` and `recluster` would error out.

## The fix
`CommandCounterIncrement()` after the delete, so the consumption is visible to the next allocation's scan in the same command. The call site (write-state flush) is not inside an open catalog scan, so the CCI is safe there.

## How it was found + guarded
New **opt-in** `test/native_scale.sh` (not in the default matrix — the recluster at scale is slow) validates online compaction/rewrite/recluster/reclaim at 500K+ rows against a heap mirror. Its **repeated-cycle reclaim phase** surfaced the bug. Post-fix behavior is now the regression guard: after the first compaction generation, repeated delete+compact rounds reach an exact steady-state file size (measured: rounds 1-4 identical), and all parity checks pass at 500K and 2M.

## Validation
Full PostgreSQL 15-19 matrix green. `native_scale.sh` passes at `SCALE_N=500000` and `SCALE_N=2000000`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)