### PR TITLE
Phase F1: rename row_mask catalog to delete_vector (rename only)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ OBJS = \
 	src/columnar_encoding.o \
 	src/columnar_bloom.o \
 	src/columnar_reader.o \
-	src/columnar_row_mask.o \
+	src/columnar_delete_vector.o \
 	src/columnar_customscan.o \
 	src/columnar_cache.o \
 	src/columnar_vector.o \

--- a/design/PHASE_F_PLAN.md
+++ b/design/PHASE_F_PLAN.md
@@ -44,7 +44,19 @@ that already works, so it is valuable but lower priority and is scheduled after
 the new features (or whenever a clean-catalog break is convenient); F3 wants the
 `delete_vector` naming, so F1 lands before or with F3.
 
-### F1. Native delete vector (catalog alignment) [deferred: cleanup, low priority]
+### F1. Native delete vector (catalog alignment) [rename DONE; column cleanup deferred]
+
+Status (2026-07-23): the rename half landed. `pgcolumnar.row_mask` is now
+`pgcolumnar.delete_vector` (table, sequence, indexes), the C module
+`columnar_row_mask.c` is `columnar_delete_vector.c`, and every `row_mask` /
+`RowMask` / `rowmask` identifier is renamed to the delete_vector form. This was
+kept deliberately small and behavior-preserving: the vestigial columns
+(`id`, `stripe_id`, `chunk_id`, `start_row_number`, `end_row_number`) and the
+row-number-range keying are UNCHANGED, and the spec column names (`group_number`,
+`bitmap`, `deleted_count`) are not yet applied. The structural half below
+(re-key by `group_number`, drop the vestigial columns, rename the data columns)
+is the deferred follow-up; it is behavioral, not a rename, so it is its own PR.
+
 
 Replace the interim `row_mask` with the spec's `pgcolumnar.delete_vector` (spec
 section 11: `storage_id, group_number, bitmap, deleted_count`). Key it by

--- a/pgcolumnar--1.0.sql
+++ b/pgcolumnar--1.0.sql
@@ -6,8 +6,8 @@
  * definitions are part of the on-disk format.
  *
  * The catalog holds the native storage, row_group, column_chunk, zone_map,
- * and bloom tables, the shared row_mask and options tables, the storageid_seq
- * and row_mask_seq sequences, the columnar_handler function, and the columnar
+ * and bloom tables, the shared delete_vector and options tables, the storageid_seq
+ * and delete_vector_seq sequences, the columnar_handler function, and the columnar
  * access method.
  */
 
@@ -22,17 +22,17 @@ CREATE SEQUENCE pgcolumnar.storageid_seq
 	MINVALUE 10000000000
 	NO CYCLE;
 
-CREATE SEQUENCE pgcolumnar.row_mask_seq;
+CREATE SEQUENCE pgcolumnar.delete_vector_seq;
 
 /* ---------------------------------------------------------------------------
- * pgcolumnar.row_mask (spec 7.5)
+ * pgcolumnar.delete_vector (spec 7.5)
  *
  * Tracks deleted rows for updates and deletes without rewriting stripes. One
  * row per chunk group covers the row-number range [start_row_number,
  * end_row_number]; a set bit in "mask" marks a deleted row.
  * ------------------------------------------------------------------------- */
 
-CREATE TABLE pgcolumnar.row_mask (
+CREATE TABLE pgcolumnar.delete_vector (
 	id bigint NOT NULL,
 	storage_id bigint NOT NULL,
 	stripe_id bigint NOT NULL,
@@ -43,14 +43,14 @@ CREATE TABLE pgcolumnar.row_mask (
 	mask bytea
 );
 
-CREATE UNIQUE INDEX row_mask_pkey
-	ON pgcolumnar.row_mask USING btree (id, storage_id, start_row_number, end_row_number);
+CREATE UNIQUE INDEX delete_vector_pkey
+	ON pgcolumnar.delete_vector USING btree (id, storage_id, start_row_number, end_row_number);
 
-CREATE UNIQUE INDEX row_mask_chunk_unique
-	ON pgcolumnar.row_mask USING btree (storage_id, stripe_id, chunk_id, start_row_number);
+CREATE UNIQUE INDEX delete_vector_chunk_unique
+	ON pgcolumnar.delete_vector USING btree (storage_id, stripe_id, chunk_id, start_row_number);
 
-CREATE UNIQUE INDEX row_mask_stripe_unique
-	ON pgcolumnar.row_mask USING btree (storage_id, stripe_id, start_row_number);
+CREATE UNIQUE INDEX delete_vector_stripe_unique
+	ON pgcolumnar.delete_vector USING btree (storage_id, stripe_id, start_row_number);
 
 /* ---------------------------------------------------------------------------
  * pgcolumnar.options (spec 7.4)
@@ -420,7 +420,7 @@ CREATE FUNCTION pgcolumnar.stats(
 		   rg.file_offset,
 		   rg.row_count,
 		   COALESCE((SELECT sum(rm.deleted_rows)::bigint
-					 FROM pgcolumnar.row_mask rm
+					 FROM pgcolumnar.delete_vector rm
 					 WHERE rm.storage_id = rg.storage_id
 					   AND rm.stripe_id = rg.group_number), 0::bigint),
 		   (SELECT count(DISTINCT zm.vector_index)::int

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -248,12 +248,12 @@ typedef struct NativeBloomMetadata
 } NativeBloomMetadata;
 
 /*
- * One columnar.row_mask row (spec 7.5). Covers the row-number range
+ * One columnar.delete_vector row (spec 7.5). Covers the row-number range
  * [startRowNumber, endRowNumber] of a single chunk group; a set bit in mask
  * marks a deleted row. Bit i (0-based) corresponds to row number
  * startRowNumber + i and is stored LSB-first in byte i/8.
  */
-typedef struct RowMaskMetadata
+typedef struct DeleteVectorMetadata
 {
 	uint64		id;
 	uint64		stripeId;
@@ -263,7 +263,7 @@ typedef struct RowMaskMetadata
 	int			deletedRows;
 	char	   *mask;			/* maskLen bytes, in the caller's context */
 	uint32		maskLen;
-} RowMaskMetadata;
+} DeleteVectorMetadata;
 
 /*
  * One columnar.projection row (gap 26, format 2.2). A projection is a named,
@@ -382,12 +382,12 @@ extern bool ColumnarIsColumnarRelation(Oid relid);
  */
 extern Snapshot ColumnarCatalogSnapshot(Snapshot base);
 
-/* row_mask catalog access (spec 7.5) */
-extern List *ColumnarReadRowMaskList(uint64 storageId, uint64 stripeId,
+/* delete_vector catalog access (spec 7.5) */
+extern List *ColumnarReadDeleteVectorList(uint64 storageId, uint64 stripeId,
 									 Snapshot snapshot);
-extern bool ColumnarStorageHasRowMask(uint64 storageId, Snapshot snapshot);
-extern void ColumnarUpsertRowMask(uint64 storageId, RowMaskMetadata *rm);
-extern uint64 ColumnarNextRowMaskId(void);
+extern bool ColumnarStorageHasDeleteVector(uint64 storageId, Snapshot snapshot);
+extern void ColumnarUpsertDeleteVector(uint64 storageId, DeleteVectorMetadata *rm);
+extern uint64 ColumnarNextDeleteVectorId(void);
 
 /* -------------------------------------------------------------------------
  * writer (columnar_write_state.c)
@@ -413,15 +413,15 @@ extern void ColumnarWriteStatePromoteSubXact(SubTransactionId subid,
 											 SubTransactionId parent);
 
 /* -------------------------------------------------------------------------
- * row mask / delete tracking (columnar_row_mask.c, spec 7.5, 9)
+ * delete vector / delete tracking (columnar_delete_vector.c, spec 7.5, 9)
  * ------------------------------------------------------------------------- */
 extern void ColumnarMarkRowDeleted(Relation rel, uint64 rowNumber);
-extern bool ColumnarRowMaskBufferedDeleted(Relation rel, uint64 rowNumber);
-extern void ColumnarFlushRowMaskForRelation(Relation rel);
-extern void ColumnarFlushAllRowMasks(void);
-extern void ColumnarDiscardAllRowMasks(void);
-extern void ColumnarRowMaskDiscardSubXact(SubTransactionId subid);
-extern void ColumnarRowMaskPromoteSubXact(SubTransactionId subid,
+extern bool ColumnarDeleteVectorBufferedDeleted(Relation rel, uint64 rowNumber);
+extern void ColumnarFlushDeleteVectorForRelation(Relation rel);
+extern void ColumnarFlushAllDeleteVectors(void);
+extern void ColumnarDiscardAllDeleteVectors(void);
+extern void ColumnarDeleteVectorDiscardSubXact(SubTransactionId subid);
+extern void ColumnarDeleteVectorPromoteSubXact(SubTransactionId subid,
 										  SubTransactionId parent);
 
 /* -------------------------------------------------------------------------
@@ -470,7 +470,7 @@ extern uint64 ColumnarVectorsSkipped(ColumnarReadState *readState);
  * Fetch a single row by its 1-based row number (spec 6), for the table AM's
  * fetch-by-tid callback used by UPDATE. Fills values/nulls (by-reference values
  * are allocated in the current memory context) and returns true when the row
- * exists and is not marked deleted in the row mask.
+ * exists and is not marked deleted in the delete vector.
  */
 /* cached base-liveness for a projection scan (gap 26): build once per scan,
  * probe per row with a binary search instead of a per-row catalog scan */
@@ -488,7 +488,7 @@ extern bool ColumnarReadRowByNumber(Relation rel, Snapshot snapshot,
  *
  * A ColumnarVector is one decoded chunk group: for each projected column, the
  * whole group's values and null flags as flat arrays, plus the per-row deleted
- * flag resolved from the row mask. The vectorized aggregate builds a selection
+ * flag resolved from the delete vector. The vectorized aggregate builds a selection
  * vector over it (ColumnarVecSelect); the scan itself is the scalar per-row
  * reader (ColumnarReadNextRow).
  * ------------------------------------------------------------------------- */

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -812,7 +812,7 @@ ColumnarBeginCustomScan(CustomScanState *node, EState *estate, int eflags)
 	 * the table AM's own scan_begin.
 	 */
 	ColumnarFlushWriteStateForRelation(RelationGetRelid(rel));
-	ColumnarFlushRowMaskForRelation(rel);
+	ColumnarFlushDeleteVectorForRelation(rel);
 
 	if (cstate->projName != NULL)
 	{
@@ -856,7 +856,7 @@ columnar_projection_scan_next(ScanState *ss)
 			return NULL;
 
 		/* deletes/visibility come from the base (gap 26): the projection stores
-		 * no row mask, so filter by the stored base row number via the cache */
+		 * no delete vector, so filter by the stored base row number via the cache */
 		baseRow = (uint64) DatumGetInt64(cstate->projValues[0]);
 		if (!ColumnarLivenessCacheIsLive(cstate->livenessCache, baseRow))
 			continue;

--- a/src/columnar_delete_vector.c
+++ b/src/columnar_delete_vector.c
@@ -1,8 +1,8 @@
 /*-------------------------------------------------------------------------
  *
- * columnar_row_mask.c
+ * columnar_delete_vector.c
  *		Delete and update marking for pgColumnar (spec 7.5, 9). Deletes do not
- *		rewrite stripes; instead a bit is set in the columnar.row_mask entry for
+ *		rewrite stripes; instead a bit is set in the columnar.delete_vector entry for
  *		the affected chunk group. Update is delete-plus-insert, so it also uses
  *		this path for the old row.
  *
@@ -27,7 +27,7 @@
 #include "utils/snapmgr.h"
 
 /* one chunk group's accumulated delete bits */
-typedef struct RowMaskChunkBuffer
+typedef struct DeleteVectorChunkBuffer
 {
 	uint64		stripeId;
 	int			chunkId;
@@ -36,43 +36,43 @@ typedef struct RowMaskChunkBuffer
 	uint64		rowCount;
 	char	   *mask;			/* maskLen bytes */
 	uint32		maskLen;
-} RowMaskChunkBuffer;
+} DeleteVectorChunkBuffer;
 
 /* pending delete marks for one storage id under one subtransaction */
-typedef struct RowMaskBuffer
+typedef struct DeleteVectorBuffer
 {
 	Oid			relid;
 	uint64		storageId;
 	SubTransactionId subid;
-	List	   *chunks;			/* list of RowMaskChunkBuffer* */
+	List	   *chunks;			/* list of DeleteVectorChunkBuffer* */
 	List	   *rowGroupCache;	/* cached NativeRowGroupMetadata* for resolution */
-} RowMaskBuffer;
+} DeleteVectorBuffer;
 
-static MemoryContext ColumnarRowMaskContext = NULL;
-static List *ColumnarRowMaskBuffers = NIL;
+static MemoryContext ColumnarDeleteVectorContext = NULL;
+static List *ColumnarDeleteVectorBuffers = NIL;
 
-static RowMaskBuffer *rowmask_get_buffer(Relation rel, uint64 storageId);
-static NativeRowGroupMetadata *rowmask_find_row_group(RowMaskBuffer *buf,
+static DeleteVectorBuffer *delete_vector_get_buffer(Relation rel, uint64 storageId);
+static NativeRowGroupMetadata *delete_vector_find_row_group(DeleteVectorBuffer *buf,
 													  uint64 rowNumber);
-static RowMaskChunkBuffer *rowmask_get_chunk(RowMaskBuffer *buf,
+static DeleteVectorChunkBuffer *delete_vector_get_chunk(DeleteVectorBuffer *buf,
 											 uint64 stripeId, int chunkId,
 											 uint64 startRowNumber,
 											 uint64 endRowNumber,
 											 uint64 rowCount);
-static void rowmask_flush_buffer(RowMaskBuffer *buf);
+static void delete_vector_flush_buffer(DeleteVectorBuffer *buf);
 
 /*
- * rowmask_chunk_cmp
+ * delete_vector_chunk_cmp
  *		Total order over chunk-group buffers by (stripeId, chunkId,
  *		startRowNumber). Flushing in this order makes every transaction acquire
  *		the per-chunk-group locks (columnar_metadata.c) in the same global
  *		order, so two concurrent deleters cannot form an AB-BA deadlock cycle.
  */
 static int
-rowmask_chunk_cmp(const ListCell *a, const ListCell *b)
+delete_vector_chunk_cmp(const ListCell *a, const ListCell *b)
 {
-	const RowMaskChunkBuffer *ca = (const RowMaskChunkBuffer *) lfirst(a);
-	const RowMaskChunkBuffer *cb = (const RowMaskChunkBuffer *) lfirst(b);
+	const DeleteVectorChunkBuffer *ca = (const DeleteVectorChunkBuffer *) lfirst(a);
+	const DeleteVectorChunkBuffer *cb = (const DeleteVectorChunkBuffer *) lfirst(b);
 
 	if (ca->stripeId != cb->stripeId)
 		return ca->stripeId < cb->stripeId ? -1 : 1;
@@ -84,38 +84,38 @@ rowmask_chunk_cmp(const ListCell *a, const ListCell *b)
 }
 
 /*
- * rowmask_get_buffer
+ * delete_vector_get_buffer
  *		Find or create the delete buffer for a storage id under the current
  *		subtransaction.
  */
-static RowMaskBuffer *
-rowmask_get_buffer(Relation rel, uint64 storageId)
+static DeleteVectorBuffer *
+delete_vector_get_buffer(Relation rel, uint64 storageId)
 {
 	SubTransactionId subid = GetCurrentSubTransactionId();
 	ListCell   *lc;
 	MemoryContext oldContext;
-	RowMaskBuffer *buf;
+	DeleteVectorBuffer *buf;
 
-	foreach(lc, ColumnarRowMaskBuffers)
+	foreach(lc, ColumnarDeleteVectorBuffers)
 	{
-		buf = (RowMaskBuffer *) lfirst(lc);
+		buf = (DeleteVectorBuffer *) lfirst(lc);
 		if (buf->storageId == storageId && buf->subid == subid)
 			return buf;
 	}
 
-	if (ColumnarRowMaskContext == NULL)
-		ColumnarRowMaskContext = AllocSetContextCreate(TopTransactionContext,
-													   "columnar row mask",
+	if (ColumnarDeleteVectorContext == NULL)
+		ColumnarDeleteVectorContext = AllocSetContextCreate(TopTransactionContext,
+													   "columnar delete vector",
 													   ALLOCSET_DEFAULT_SIZES);
 
-	oldContext = MemoryContextSwitchTo(ColumnarRowMaskContext);
-	buf = palloc0(sizeof(RowMaskBuffer));
+	oldContext = MemoryContextSwitchTo(ColumnarDeleteVectorContext);
+	buf = palloc0(sizeof(DeleteVectorBuffer));
 	buf->relid = RelationGetRelid(rel);
 	buf->storageId = storageId;
 	buf->subid = subid;
 	buf->chunks = NIL;
 	buf->rowGroupCache = NIL;
-	ColumnarRowMaskBuffers = lappend(ColumnarRowMaskBuffers, buf);
+	ColumnarDeleteVectorBuffers = lappend(ColumnarDeleteVectorBuffers, buf);
 	MemoryContextSwitchTo(oldContext);
 
 	return buf;
@@ -123,12 +123,12 @@ rowmask_get_buffer(Relation rel, uint64 storageId)
 
 
 /*
- * rowmask_find_row_group
- *		Native (PGCN v1) analog of rowmask_find_stripe: return the row group that
+ * delete_vector_find_row_group
+ *		Native (PGCN v1) analog of delete_vector_find_stripe: return the row group that
  *		contains rowNumber, rebuilding the cache from the catalog on a miss.
  */
 static NativeRowGroupMetadata *
-rowmask_find_row_group(RowMaskBuffer *buf, uint64 rowNumber)
+delete_vector_find_row_group(DeleteVectorBuffer *buf, uint64 rowNumber)
 {
 	ListCell   *lc;
 	int			attempt;
@@ -147,7 +147,7 @@ rowmask_find_row_group(RowMaskBuffer *buf, uint64 rowNumber)
 		if (attempt == 0)
 		{
 			MemoryContext oldContext =
-				MemoryContextSwitchTo(ColumnarRowMaskContext);
+				MemoryContextSwitchTo(ColumnarDeleteVectorContext);
 			Snapshot	snap = ColumnarCatalogSnapshot(GetActiveSnapshot());
 
 			buf->rowGroupCache = ColumnarReadRowGroupList(buf->storageId, snap);
@@ -159,27 +159,27 @@ rowmask_find_row_group(RowMaskBuffer *buf, uint64 rowNumber)
 }
 
 /*
- * rowmask_get_chunk
+ * delete_vector_get_chunk
  *		Find or create the chunk-group delete buffer for a chunk group.
  */
-static RowMaskChunkBuffer *
-rowmask_get_chunk(RowMaskBuffer *buf, uint64 stripeId, int chunkId,
+static DeleteVectorChunkBuffer *
+delete_vector_get_chunk(DeleteVectorBuffer *buf, uint64 stripeId, int chunkId,
 				  uint64 startRowNumber, uint64 endRowNumber, uint64 rowCount)
 {
 	ListCell   *lc;
 	MemoryContext oldContext;
-	RowMaskChunkBuffer *chunk;
+	DeleteVectorChunkBuffer *chunk;
 
 	foreach(lc, buf->chunks)
 	{
-		chunk = (RowMaskChunkBuffer *) lfirst(lc);
+		chunk = (DeleteVectorChunkBuffer *) lfirst(lc);
 		if (chunk->stripeId == stripeId && chunk->chunkId == chunkId &&
 			chunk->startRowNumber == startRowNumber)
 			return chunk;
 	}
 
-	oldContext = MemoryContextSwitchTo(ColumnarRowMaskContext);
-	chunk = palloc0(sizeof(RowMaskChunkBuffer));
+	oldContext = MemoryContextSwitchTo(ColumnarDeleteVectorContext);
+	chunk = palloc0(sizeof(DeleteVectorChunkBuffer));
 	chunk->stripeId = stripeId;
 	chunk->chunkId = chunkId;
 	chunk->startRowNumber = startRowNumber;
@@ -206,16 +206,17 @@ void
 ColumnarMarkRowDeleted(Relation rel, uint64 rowNumber)
 {
 	uint64		storageId = ColumnarStorageId(rel);
-	RowMaskBuffer *buf = rowmask_get_buffer(rel, storageId);
+	DeleteVectorBuffer *buf = delete_vector_get_buffer(rel, storageId);
 	uint64		startRowNumber;
 	uint64		endRowNumber;
 	uint64		bitIndex;
-	RowMaskChunkBuffer *chunk;
-	NativeRowGroupMetadata *rg = rowmask_find_row_group(buf, rowNumber);
+	DeleteVectorChunkBuffer *chunk;
+	NativeRowGroupMetadata *rg = delete_vector_find_row_group(buf, rowNumber);
 
 	/*
-	 * The whole row group is one mask (chunk id 0), sized to its row count. Phase
-	 * F replaces this interim row mask with a first-class delete vector.
+	 * The whole row group is one bitmap (chunk id 0), sized to its row count. The
+	 * vestigial stripe_id/chunk_id/start/end columns and group-number re-keying
+	 * are pending cleanup (see design/PHASE_F_PLAN.md, F1).
 	 */
 	if (rg == NULL)
 		elog(ERROR,
@@ -224,7 +225,7 @@ ColumnarMarkRowDeleted(Relation rel, uint64 rowNumber)
 
 	startRowNumber = rg->firstRowNumber;
 	endRowNumber = startRowNumber + rg->rowCount - 1;
-	chunk = rowmask_get_chunk(buf, rg->groupNumber, 0,
+	chunk = delete_vector_get_chunk(buf, rg->groupNumber, 0,
 							  startRowNumber, endRowNumber, rg->rowCount);
 	bitIndex = rowNumber - startRowNumber;
 	chunk->mask[bitIndex >> 3] |= (char) (1 << (bitIndex & 7));
@@ -238,7 +239,7 @@ ColumnarMarkRowDeleted(Relation rel, uint64 rowNumber)
 }
 
 /*
- * ColumnarRowMaskBufferedDeleted
+ * ColumnarDeleteVectorBufferedDeleted
  *		True when the row is marked deleted in an in-memory row-mask buffer that
  *		has not yet been flushed to the catalog. The unique/primary-key check runs
  *		as part of an insert (or the insert half of an update) and fetches a
@@ -248,14 +249,14 @@ ColumnarMarkRowDeleted(Relation rel, uint64 rowNumber)
  *		across subtransactions.
  */
 bool
-ColumnarRowMaskBufferedDeleted(Relation rel, uint64 rowNumber)
+ColumnarDeleteVectorBufferedDeleted(Relation rel, uint64 rowNumber)
 {
 	Oid			relid = RelationGetRelid(rel);
 	ListCell   *lc;
 
-	foreach(lc, ColumnarRowMaskBuffers)
+	foreach(lc, ColumnarDeleteVectorBuffers)
 	{
-		RowMaskBuffer *buf = (RowMaskBuffer *) lfirst(lc);
+		DeleteVectorBuffer *buf = (DeleteVectorBuffer *) lfirst(lc);
 		ListCell   *cc;
 
 		if (buf->relid != relid)
@@ -263,7 +264,7 @@ ColumnarRowMaskBufferedDeleted(Relation rel, uint64 rowNumber)
 
 		foreach(cc, buf->chunks)
 		{
-			RowMaskChunkBuffer *chunk = (RowMaskChunkBuffer *) lfirst(cc);
+			DeleteVectorChunkBuffer *chunk = (DeleteVectorChunkBuffer *) lfirst(cc);
 			uint64		bitIndex;
 
 			if (rowNumber < chunk->startRowNumber ||
@@ -280,13 +281,13 @@ ColumnarRowMaskBufferedDeleted(Relation rel, uint64 rowNumber)
 }
 
 /*
- * rowmask_flush_buffer
+ * delete_vector_flush_buffer
  *		Apply one buffer's accumulated marks to the catalog and empty it. Each
  *		chunk group is upserted exactly once, so no catalog tuple is updated
  *		more than once in this command.
  */
 static void
-rowmask_flush_buffer(RowMaskBuffer *buf)
+delete_vector_flush_buffer(DeleteVectorBuffer *buf)
 {
 	ListCell   *lc;
 	bool		pushedSnapshot = false;
@@ -295,7 +296,7 @@ rowmask_flush_buffer(RowMaskBuffer *buf)
 		return;
 
 	/* deterministic lock-acquisition order across transactions (issue #4) */
-	list_sort(buf->chunks, rowmask_chunk_cmp);
+	list_sort(buf->chunks, delete_vector_chunk_cmp);
 
 	if (!ActiveSnapshotSet())
 	{
@@ -305,8 +306,8 @@ rowmask_flush_buffer(RowMaskBuffer *buf)
 
 	foreach(lc, buf->chunks)
 	{
-		RowMaskChunkBuffer *chunk = (RowMaskChunkBuffer *) lfirst(lc);
-		RowMaskMetadata rm;
+		DeleteVectorChunkBuffer *chunk = (DeleteVectorChunkBuffer *) lfirst(lc);
+		DeleteVectorMetadata rm;
 		uint32		i;
 		int			bit;
 		int			deleted = 0;
@@ -316,7 +317,7 @@ rowmask_flush_buffer(RowMaskBuffer *buf)
 				if (chunk->mask[i] & (1 << bit))
 					deleted++;
 
-		rm.id = ColumnarNextRowMaskId();
+		rm.id = ColumnarNextDeleteVectorId();
 		rm.stripeId = chunk->stripeId;
 		rm.chunkId = chunk->chunkId;
 		rm.startRowNumber = chunk->startRowNumber;
@@ -325,7 +326,7 @@ rowmask_flush_buffer(RowMaskBuffer *buf)
 		rm.mask = chunk->mask;
 		rm.maskLen = chunk->maskLen;
 
-		ColumnarUpsertRowMask(buf->storageId, &rm);
+		ColumnarUpsertDeleteVector(buf->storageId, &rm);
 	}
 
 	if (pushedSnapshot)
@@ -336,91 +337,91 @@ rowmask_flush_buffer(RowMaskBuffer *buf)
 }
 
 /*
- * ColumnarFlushRowMaskForRelation
+ * ColumnarFlushDeleteVectorForRelation
  *		Flush pending delete marks for one relation. Called at scan start so a
  *		delete made earlier in this transaction is visible to a later scan.
  */
 void
-ColumnarFlushRowMaskForRelation(Relation rel)
+ColumnarFlushDeleteVectorForRelation(Relation rel)
 {
 	Oid			relid = RelationGetRelid(rel);
 	ListCell   *lc;
 
-	foreach(lc, ColumnarRowMaskBuffers)
+	foreach(lc, ColumnarDeleteVectorBuffers)
 	{
-		RowMaskBuffer *buf = (RowMaskBuffer *) lfirst(lc);
+		DeleteVectorBuffer *buf = (DeleteVectorBuffer *) lfirst(lc);
 
 		if (buf->relid == relid)
-			rowmask_flush_buffer(buf);
+			delete_vector_flush_buffer(buf);
 	}
 }
 
 /*
- * ColumnarFlushAllRowMasks
+ * ColumnarFlushAllDeleteVectors
  *		Flush every pending delete buffer. Called at transaction pre-commit.
  */
 void
-ColumnarFlushAllRowMasks(void)
+ColumnarFlushAllDeleteVectors(void)
 {
 	ListCell   *lc;
 
-	foreach(lc, ColumnarRowMaskBuffers)
-		rowmask_flush_buffer((RowMaskBuffer *) lfirst(lc));
+	foreach(lc, ColumnarDeleteVectorBuffers)
+		delete_vector_flush_buffer((DeleteVectorBuffer *) lfirst(lc));
 }
 
 /*
- * ColumnarDiscardAllRowMasks
+ * ColumnarDiscardAllDeleteVectors
  *		Forget all pending delete buffers (transaction end).
  */
 void
-ColumnarDiscardAllRowMasks(void)
+ColumnarDiscardAllDeleteVectors(void)
 {
-	ColumnarRowMaskBuffers = NIL;
-	ColumnarRowMaskContext = NULL;
+	ColumnarDeleteVectorBuffers = NIL;
+	ColumnarDeleteVectorContext = NULL;
 }
 
 /*
- * ColumnarRowMaskDiscardSubXact
+ * ColumnarDeleteVectorDiscardSubXact
  *		Drop delete buffers made in an aborting subtransaction. The catalog
  *		rows they would have produced were never written (or, if a scan flushed
  *		them, are made invisible by the subtransaction abort itself).
  */
 void
-ColumnarRowMaskDiscardSubXact(SubTransactionId subid)
+ColumnarDeleteVectorDiscardSubXact(SubTransactionId subid)
 {
 	List	   *kept = NIL;
 	ListCell   *lc;
 	MemoryContext oldContext;
 
-	if (ColumnarRowMaskBuffers == NIL)
+	if (ColumnarDeleteVectorBuffers == NIL)
 		return;
 
-	oldContext = MemoryContextSwitchTo(ColumnarRowMaskContext);
-	foreach(lc, ColumnarRowMaskBuffers)
+	oldContext = MemoryContextSwitchTo(ColumnarDeleteVectorContext);
+	foreach(lc, ColumnarDeleteVectorBuffers)
 	{
-		RowMaskBuffer *buf = (RowMaskBuffer *) lfirst(lc);
+		DeleteVectorBuffer *buf = (DeleteVectorBuffer *) lfirst(lc);
 
 		if (buf->subid != subid)
 			kept = lappend(kept, buf);
 	}
 	MemoryContextSwitchTo(oldContext);
 
-	ColumnarRowMaskBuffers = kept;
+	ColumnarDeleteVectorBuffers = kept;
 }
 
 /*
- * ColumnarRowMaskPromoteSubXact
+ * ColumnarDeleteVectorPromoteSubXact
  *		On subtransaction commit, reassign its delete buffers to the parent so
  *		they survive until the parent resolves.
  */
 void
-ColumnarRowMaskPromoteSubXact(SubTransactionId subid, SubTransactionId parent)
+ColumnarDeleteVectorPromoteSubXact(SubTransactionId subid, SubTransactionId parent)
 {
 	ListCell   *lc;
 
-	foreach(lc, ColumnarRowMaskBuffers)
+	foreach(lc, ColumnarDeleteVectorBuffers)
 	{
-		RowMaskBuffer *buf = (RowMaskBuffer *) lfirst(lc);
+		DeleteVectorBuffer *buf = (DeleteVectorBuffer *) lfirst(lc);
 
 		if (buf->subid == subid)
 			buf->subid = parent;

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -100,16 +100,16 @@
 #define Anum_free_space_freed_xid 4
 #define Natts_free_space 4
 
-/* attribute numbers for columnar.row_mask (spec 7.5) */
-#define Anum_row_mask_id 1
-#define Anum_row_mask_storage_id 2
-#define Anum_row_mask_stripe_id 3
-#define Anum_row_mask_chunk_id 4
-#define Anum_row_mask_start_row_number 5
-#define Anum_row_mask_end_row_number 6
-#define Anum_row_mask_deleted_rows 7
-#define Anum_row_mask_mask 8
-#define Natts_row_mask 8
+/* attribute numbers for columnar.delete_vector (spec 7.5) */
+#define Anum_delete_vector_id 1
+#define Anum_delete_vector_storage_id 2
+#define Anum_delete_vector_stripe_id 3
+#define Anum_delete_vector_chunk_id 4
+#define Anum_delete_vector_start_row_number 5
+#define Anum_delete_vector_end_row_number 6
+#define Anum_delete_vector_deleted_rows 7
+#define Anum_delete_vector_mask 8
+#define Natts_delete_vector 8
 
 static Oid	columnar_schema_oid(void);
 static Relation open_columnar_table(const char *name, LOCKMODE lockmode);
@@ -161,19 +161,19 @@ ColumnarNextStorageId(void)
 }
 
 /*
- * ColumnarNextRowMaskId
- *		Draw the next value from columnar.row_mask_seq (spec 7.5, 7.6).
+ * ColumnarNextDeleteVectorId
+ *		Draw the next value from columnar.delete_vector_seq (spec 7.5, 7.6).
  */
 uint64
-ColumnarNextRowMaskId(void)
+ColumnarNextDeleteVectorId(void)
 {
 	Oid			nspOid = columnar_schema_oid();
-	Oid			seqOid = get_relname_relid("row_mask_seq", nspOid);
+	Oid			seqOid = get_relname_relid("delete_vector_seq", nspOid);
 
 	if (!OidIsValid(seqOid))
 		ereport(ERROR,
 				(errcode(ERRCODE_UNDEFINED_OBJECT),
-				 errmsg("columnar.row_mask_seq does not exist")));
+				 errmsg("columnar.delete_vector_seq does not exist")));
 
 	return (uint64) nextval_internal(seqOid, false);
 }
@@ -284,10 +284,10 @@ ColumnarComputeAllVisibleGroups(uint64 storageId, TransactionId oldestXmin)
 		if (rowCount == 0)
 			continue;
 
-		rmList = ColumnarReadRowMaskList(storageId, groupNumber, &dirty);
+		rmList = ColumnarReadDeleteVectorList(storageId, groupNumber, &dirty);
 		foreach(lc, rmList)
 		{
-			if (((RowMaskMetadata *) lfirst(lc))->deletedRows > 0)
+			if (((DeleteVectorMetadata *) lfirst(lc))->deletedRows > 0)
 			{
 				hasDelete = true;
 				break;
@@ -324,7 +324,7 @@ ColumnarComputeFullyDeletedGroups(uint64 storageId, TransactionId oldestXmin)
 {
 	Relation	grel = open_columnar_table("row_group", AccessShareLock);
 	TupleDesc	gtd = RelationGetDescr(grel);
-	Relation	mrel = open_columnar_table("row_mask", AccessShareLock);
+	Relation	mrel = open_columnar_table("delete_vector", AccessShareLock);
 	TupleDesc	mtd = RelationGetDescr(mrel);
 	ScanKeyData gkey[1];
 	SysScanDesc gscan;
@@ -361,14 +361,14 @@ ColumnarComputeFullyDeletedGroups(uint64 storageId, TransactionId oldestXmin)
 			continue;
 
 		/*
-		 * Sum the deleted-row counts of this group's row_mask rows, counting only
+		 * Sum the deleted-row counts of this group's delete_vector rows, counting only
 		 * masks whose own xmin precedes oldestXmin -- those are visible to every
 		 * live snapshot. A more recent delete (xmin >= oldestXmin) is not yet
 		 * visible to all, so the group is not retired this pass.
 		 */
-		ScanKeyInit(&mkey[0], Anum_row_mask_storage_id, BTEqualStrategyNumber,
+		ScanKeyInit(&mkey[0], Anum_delete_vector_storage_id, BTEqualStrategyNumber,
 					F_INT8EQ, Int64GetDatum((int64) storageId));
-		ScanKeyInit(&mkey[1], Anum_row_mask_stripe_id, BTEqualStrategyNumber,
+		ScanKeyInit(&mkey[1], Anum_delete_vector_stripe_id, BTEqualStrategyNumber,
 					F_INT8EQ, Int64GetDatum((int64) groupNumber));
 		mscan = systable_beginscan(mrel, InvalidOid, false, snap, 2, mkey);
 		while (HeapTupleIsValid(mtuple = systable_getnext(mscan)))
@@ -379,7 +379,7 @@ ColumnarComputeFullyDeletedGroups(uint64 storageId, TransactionId oldestXmin)
 				!TransactionIdPrecedes(mxmin, oldestXmin))
 				continue;
 			deletedSeen += DatumGetInt32(
-				heap_getattr(mtuple, Anum_row_mask_deleted_rows, mtd, &isnull));
+				heap_getattr(mtuple, Anum_delete_vector_deleted_rows, mtd, &isnull));
 		}
 		systable_endscan(mscan);
 
@@ -483,7 +483,7 @@ record_free_space(uint64 storageId, uint64 fileOffset, uint64 byteLength)
 /*
  * ColumnarRetireGroup
  *		Drop all catalog rows for one row group (row_group, column_chunk,
- *		zone_map, bloom, row_mask) in the current transaction (Phase F3a). The
+ *		zone_map, bloom, delete_vector) in the current transaction (Phase F3a). The
  *		storage row is left intact. Heap MVCC on these deletes keeps the group
  *		readable to older snapshots. The group's data byte range is recorded in
  *		free_space so a later reservation can reuse it once the oldest-xmin horizon
@@ -498,8 +498,8 @@ ColumnarRetireGroup(uint64 storageId, uint64 groupNumber)
 	bool		haveRange = read_row_group_range(storageId, groupNumber,
 												 &fileOffset, &byteLength);
 
-	delete_group_rows("row_mask", Anum_row_mask_storage_id,
-					  Anum_row_mask_stripe_id, storageId, groupNumber);
+	delete_group_rows("delete_vector", Anum_delete_vector_storage_id,
+					  Anum_delete_vector_stripe_id, storageId, groupNumber);
 	delete_group_rows("column_chunk", Anum_column_chunk_storage_id,
 					  Anum_column_chunk_group_number, storageId, groupNumber);
 	delete_group_rows("zone_map", Anum_zone_map_storage_id,
@@ -611,45 +611,45 @@ ColumnarRetireFullyDeletedGroups(Relation rel)
 
 
 /*
- * ColumnarReadRowMaskList
- *		Read all row_mask rows for a stripe (spec 7.5). Returns a list of
- *		RowMaskMetadata* allocated in the current memory context.
+ * ColumnarReadDeleteVectorList
+ *		Read all delete_vector rows for a stripe (spec 7.5). Returns a list of
+ *		DeleteVectorMetadata* allocated in the current memory context.
  */
 List *
-ColumnarReadRowMaskList(uint64 storageId, uint64 stripeId, Snapshot snapshot)
+ColumnarReadDeleteVectorList(uint64 storageId, uint64 stripeId, Snapshot snapshot)
 {
-	Relation	rel = open_columnar_table("row_mask", AccessShareLock);
+	Relation	rel = open_columnar_table("delete_vector", AccessShareLock);
 	TupleDesc	tupdesc = RelationGetDescr(rel);
 	ScanKeyData key[2];
 	SysScanDesc scan;
 	HeapTuple	tuple;
 	List	   *result = NIL;
 
-	ScanKeyInit(&key[0], Anum_row_mask_storage_id, BTEqualStrategyNumber,
+	ScanKeyInit(&key[0], Anum_delete_vector_storage_id, BTEqualStrategyNumber,
 				F_INT8EQ, Int64GetDatum((int64) storageId));
-	ScanKeyInit(&key[1], Anum_row_mask_stripe_id, BTEqualStrategyNumber,
+	ScanKeyInit(&key[1], Anum_delete_vector_stripe_id, BTEqualStrategyNumber,
 				F_INT8EQ, Int64GetDatum((int64) stripeId));
 
 	scan = systable_beginscan(rel, InvalidOid, false, snapshot, 2, key);
 	while (HeapTupleIsValid(tuple = systable_getnext(scan)))
 	{
-		RowMaskMetadata *rm = palloc0(sizeof(RowMaskMetadata));
+		DeleteVectorMetadata *rm = palloc0(sizeof(DeleteVectorMetadata));
 		bool		isnull;
 		Datum		maskDatum;
 
 		rm->id = (uint64) DatumGetInt64(
-			heap_getattr(tuple, Anum_row_mask_id, tupdesc, &isnull));
+			heap_getattr(tuple, Anum_delete_vector_id, tupdesc, &isnull));
 		rm->stripeId = stripeId;
 		rm->chunkId = DatumGetInt32(
-			heap_getattr(tuple, Anum_row_mask_chunk_id, tupdesc, &isnull));
+			heap_getattr(tuple, Anum_delete_vector_chunk_id, tupdesc, &isnull));
 		rm->startRowNumber = (uint64) DatumGetInt64(
-			heap_getattr(tuple, Anum_row_mask_start_row_number, tupdesc, &isnull));
+			heap_getattr(tuple, Anum_delete_vector_start_row_number, tupdesc, &isnull));
 		rm->endRowNumber = (uint64) DatumGetInt64(
-			heap_getattr(tuple, Anum_row_mask_end_row_number, tupdesc, &isnull));
+			heap_getattr(tuple, Anum_delete_vector_end_row_number, tupdesc, &isnull));
 		rm->deletedRows = DatumGetInt32(
-			heap_getattr(tuple, Anum_row_mask_deleted_rows, tupdesc, &isnull));
+			heap_getattr(tuple, Anum_delete_vector_deleted_rows, tupdesc, &isnull));
 
-		maskDatum = heap_getattr(tuple, Anum_row_mask_mask, tupdesc, &isnull);
+		maskDatum = heap_getattr(tuple, Anum_delete_vector_mask, tupdesc, &isnull);
 		if (!isnull)
 		{
 			bytea	   *maskb = DatumGetByteaP(maskDatum);
@@ -674,21 +674,21 @@ ColumnarReadRowMaskList(uint64 storageId, uint64 stripeId, Snapshot snapshot)
 }
 
 /*
- * ColumnarStorageHasRowMask
- *		True when the storage has any row_mask row, i.e. at least one delete has
+ * ColumnarStorageHasDeleteVector
+ *		True when the storage has any delete_vector row, i.e. at least one delete has
  *		been recorded. Used to decide whether the native zone-map-only aggregate
  *		is valid (it is only correct when no rows are deleted) or must fall back to
  *		a delete-applying scan (D6b).
  */
 bool
-ColumnarStorageHasRowMask(uint64 storageId, Snapshot snapshot)
+ColumnarStorageHasDeleteVector(uint64 storageId, Snapshot snapshot)
 {
-	Relation	rel = open_columnar_table("row_mask", AccessShareLock);
+	Relation	rel = open_columnar_table("delete_vector", AccessShareLock);
 	ScanKeyData key[1];
 	SysScanDesc scan;
 	bool		found;
 
-	ScanKeyInit(&key[0], Anum_row_mask_storage_id, BTEqualStrategyNumber,
+	ScanKeyInit(&key[0], Anum_delete_vector_storage_id, BTEqualStrategyNumber,
 				F_INT8EQ, Int64GetDatum((int64) storageId));
 	scan = systable_beginscan(rel, InvalidOid, false, snapshot, 1, key);
 	found = HeapTupleIsValid(systable_getnext(scan));
@@ -699,7 +699,7 @@ ColumnarStorageHasRowMask(uint64 storageId, Snapshot snapshot)
 }
 
 /*
- * rowmask_chunk_lock_key
+ * delete_vector_chunk_lock_key
  *		Mix the identity of a chunk group into a 64-bit advisory-lock key. The
  *		triple (storage_id, stripe_id, chunk_id) uniquely names a chunk group
  *		(start_row_number is a function of the stripe and chunk), so it is the
@@ -708,7 +708,7 @@ ColumnarStorageHasRowMask(uint64 storageId, Snapshot snapshot)
  *		chunk groups serialize needlessly, it never affects correctness.
  */
 static uint64
-rowmask_chunk_lock_key(uint64 storageId, uint64 stripeId, int chunkId)
+delete_vector_chunk_lock_key(uint64 storageId, uint64 stripeId, int chunkId)
 {
 	uint64		h = 1469598103934665603UL;	/* FNV-1a 64-bit offset basis */
 
@@ -727,9 +727,9 @@ rowmask_chunk_lock_key(uint64 storageId, uint64 stripeId, int chunkId)
 }
 
 /*
- * rowmask_lock_chunk_group
+ * delete_vector_lock_chunk_group
  *		Take a transaction-scoped exclusive lock covering one chunk group's
- *		row_mask tuple, so that the read-modify-write in ColumnarUpsertRowMask
+ *		delete_vector tuple, so that the read-modify-write in ColumnarUpsertDeleteVector
  *		serializes against any concurrent deleter or updater touching the SAME
  *		chunk group, while deletes to different chunk groups still proceed
  *		concurrently. The lock is held until this transaction ends (commit or
@@ -737,18 +737,18 @@ rowmask_chunk_lock_key(uint64 storageId, uint64 stripeId, int chunkId)
  *		after us must not run its SnapshotSelf read until our merged tuple is
  *		committed and therefore visible to it.
  *
- *		An advisory lock tag is used because the row_mask heap tuple to protect
+ *		An advisory lock tag is used because the delete_vector heap tuple to protect
  *		may not exist yet on the first delete of a chunk group; the key names
  *		the chunk group itself, so the first-insert race is serialized too. The
  *		lock is taken with a plain wait (deadlock-detector armed); callers must
  *		acquire chunk-group locks in a consistent global order (see
- *		rowmask_flush_buffer) so two transactions cannot form an AB-BA cycle.
+ *		delete_vector_flush_buffer) so two transactions cannot form an AB-BA cycle.
  */
 static void
-rowmask_lock_chunk_group(uint64 storageId, uint64 stripeId, int chunkId)
+delete_vector_lock_chunk_group(uint64 storageId, uint64 stripeId, int chunkId)
 {
 	LOCKTAG		tag;
-	uint64		key = rowmask_chunk_lock_key(storageId, stripeId, chunkId);
+	uint64		key = delete_vector_chunk_lock_key(storageId, stripeId, chunkId);
 
 	SET_LOCKTAG_ADVISORY(tag, MyDatabaseId,
 						 (uint32) (key >> 32), (uint32) (key & 0xFFFFFFFF), 1);
@@ -758,17 +758,17 @@ rowmask_lock_chunk_group(uint64 storageId, uint64 stripeId, int chunkId)
 }
 
 /*
- * ColumnarUpsertRowMask
- *		Insert or replace the row_mask row for one chunk group, identified by
+ * ColumnarUpsertDeleteVector
+ *		Insert or replace the delete_vector row for one chunk group, identified by
  *		(storage_id, stripe_id, chunk_id, start_row_number). If a row already
  *		exists it is replaced with the merged mask carried in rm; otherwise a
- *		fresh row is inserted with a new id from row_mask_seq. Used at flush of
- *		the in-memory delete buffer (columnar_row_mask.c), at most once per
+ *		fresh row is inserted with a new id from delete_vector_seq. Used at flush of
+ *		the in-memory delete buffer (columnar_delete_vector.c), at most once per
  *		chunk group per flush, so a single heap tuple is never updated twice in
  *		the same command.
  *
  *		Concurrency (issue #4): the whole read-modify-write is guarded by a
- *		transaction-scoped chunk-group lock (rowmask_lock_chunk_group), so two
+ *		transaction-scoped chunk-group lock (delete_vector_lock_chunk_group), so two
  *		transactions deleting different rows in the same chunk group serialize
  *		instead of overwriting each other's delete bits. Once the lock is held,
  *		any earlier writer to this chunk group has committed, so the existing
@@ -801,18 +801,18 @@ row_group_exists(uint64 storageId, uint64 groupNumber, Snapshot snapshot)
 /*
  * ColumnarLockChunkGroup
  *		Take the transaction-scoped advisory lock for one chunk group (the whole
- *		row group, chunk id 0), the same lock ColumnarUpsertRowMask takes. Used by
+ *		row group, chunk id 0), the same lock ColumnarUpsertDeleteVector takes. Used by
  *		online compaction (Phase F3b) so a rewrite of a group serializes with
  *		concurrent deletes to that group.
  */
 void
 ColumnarLockChunkGroup(uint64 storageId, uint64 groupNumber)
 {
-	rowmask_lock_chunk_group(storageId, groupNumber, 0);
+	delete_vector_lock_chunk_group(storageId, groupNumber, 0);
 }
 
 void
-ColumnarUpsertRowMask(uint64 storageId, RowMaskMetadata *rm)
+ColumnarUpsertDeleteVector(uint64 storageId, DeleteVectorMetadata *rm)
 {
 	Relation	rel;
 	TupleDesc	tupdesc;
@@ -820,15 +820,15 @@ ColumnarUpsertRowMask(uint64 storageId, RowMaskMetadata *rm)
 	SysScanDesc scan;
 	HeapTuple	existing;
 	HeapTuple	tuple;
-	Datum		values[Natts_row_mask];
-	bool		nulls[Natts_row_mask];
+	Datum		values[Natts_delete_vector];
+	bool		nulls[Natts_delete_vector];
 	bytea	   *maskb;
 	uint64		id = rm->id;
 	int			deletedRows = rm->deletedRows;
 	ItemPointerData replaceTid;
 	bool		haveReplace = false;
 
-	rowmask_lock_chunk_group(storageId, rm->stripeId, rm->chunkId);
+	delete_vector_lock_chunk_group(storageId, rm->stripeId, rm->chunkId);
 
 	/*
 	 * Phase F3b conflict detection. Having taken the chunk-group advisory lock,
@@ -847,7 +847,7 @@ ColumnarUpsertRowMask(uint64 storageId, RowMaskMetadata *rm)
 		/*
 		 * Latest committed state, with curcid advanced (ColumnarCatalogSnapshot)
 		 * so a group this same transaction just flushed (pending writes flush
-		 * before row masks at pre-commit) is visible and does not look retired.
+		 * before delete vectors at pre-commit) is visible and does not look retired.
 		 * A group retired by a concurrent COMMITTED rewrite is gone here.
 		 */
 		PushActiveSnapshot(GetLatestSnapshot());
@@ -861,16 +861,16 @@ ColumnarUpsertRowMask(uint64 storageId, RowMaskMetadata *rm)
 					 errhint("Retry the transaction.")));
 	}
 
-	rel = open_columnar_table("row_mask", RowExclusiveLock);
+	rel = open_columnar_table("delete_vector", RowExclusiveLock);
 	tupdesc = RelationGetDescr(rel);
 
-	ScanKeyInit(&key[0], Anum_row_mask_storage_id, BTEqualStrategyNumber,
+	ScanKeyInit(&key[0], Anum_delete_vector_storage_id, BTEqualStrategyNumber,
 				F_INT8EQ, Int64GetDatum((int64) storageId));
-	ScanKeyInit(&key[1], Anum_row_mask_stripe_id, BTEqualStrategyNumber,
+	ScanKeyInit(&key[1], Anum_delete_vector_stripe_id, BTEqualStrategyNumber,
 				F_INT8EQ, Int64GetDatum((int64) rm->stripeId));
-	ScanKeyInit(&key[2], Anum_row_mask_chunk_id, BTEqualStrategyNumber,
+	ScanKeyInit(&key[2], Anum_delete_vector_chunk_id, BTEqualStrategyNumber,
 				F_INT4EQ, Int32GetDatum(rm->chunkId));
-	ScanKeyInit(&key[3], Anum_row_mask_start_row_number, BTEqualStrategyNumber,
+	ScanKeyInit(&key[3], Anum_delete_vector_start_row_number, BTEqualStrategyNumber,
 				F_INT8EQ, Int64GetDatum((int64) rm->startRowNumber));
 
 	scan = systable_beginscan(rel, InvalidOid, false, SnapshotSelf, 4, key);
@@ -881,9 +881,9 @@ ColumnarUpsertRowMask(uint64 storageId, RowMaskMetadata *rm)
 
 		/* keep the existing id; merge the existing mask bits into rm->mask */
 		id = (uint64) DatumGetInt64(
-			heap_getattr(existing, Anum_row_mask_id, tupdesc, &isnull));
+			heap_getattr(existing, Anum_delete_vector_id, tupdesc, &isnull));
 
-		existingMask = heap_getattr(existing, Anum_row_mask_mask, tupdesc, &isnull);
+		existingMask = heap_getattr(existing, Anum_delete_vector_mask, tupdesc, &isnull);
 		if (!isnull)
 		{
 			bytea	   *eb = DatumGetByteaP(existingMask);
@@ -911,18 +911,18 @@ ColumnarUpsertRowMask(uint64 storageId, RowMaskMetadata *rm)
 	systable_endscan(scan);
 
 	memset(nulls, false, sizeof(nulls));
-	values[Anum_row_mask_id - 1] = Int64GetDatum((int64) id);
-	values[Anum_row_mask_storage_id - 1] = Int64GetDatum((int64) storageId);
-	values[Anum_row_mask_stripe_id - 1] = Int64GetDatum((int64) rm->stripeId);
-	values[Anum_row_mask_chunk_id - 1] = Int32GetDatum(rm->chunkId);
-	values[Anum_row_mask_start_row_number - 1] = Int64GetDatum((int64) rm->startRowNumber);
-	values[Anum_row_mask_end_row_number - 1] = Int64GetDatum((int64) rm->endRowNumber);
-	values[Anum_row_mask_deleted_rows - 1] = Int32GetDatum(deletedRows);
+	values[Anum_delete_vector_id - 1] = Int64GetDatum((int64) id);
+	values[Anum_delete_vector_storage_id - 1] = Int64GetDatum((int64) storageId);
+	values[Anum_delete_vector_stripe_id - 1] = Int64GetDatum((int64) rm->stripeId);
+	values[Anum_delete_vector_chunk_id - 1] = Int32GetDatum(rm->chunkId);
+	values[Anum_delete_vector_start_row_number - 1] = Int64GetDatum((int64) rm->startRowNumber);
+	values[Anum_delete_vector_end_row_number - 1] = Int64GetDatum((int64) rm->endRowNumber);
+	values[Anum_delete_vector_deleted_rows - 1] = Int32GetDatum(deletedRows);
 
 	maskb = (bytea *) palloc(VARHDRSZ + rm->maskLen);
 	SET_VARSIZE(maskb, VARHDRSZ + rm->maskLen);
 	memcpy(VARDATA(maskb), rm->mask, rm->maskLen);
-	values[Anum_row_mask_mask - 1] = PointerGetDatum(maskb);
+	values[Anum_delete_vector_mask - 1] = PointerGetDatum(maskb);
 
 	tuple = heap_form_tuple(tupdesc, values, nulls);
 
@@ -966,7 +966,7 @@ delete_rows_by_storage_id(const char *tableName, AttrNumber storageAttno,
 void
 ColumnarDeleteMetadata(uint64 storageId)
 {
-	delete_rows_by_storage_id("row_mask", Anum_row_mask_storage_id, storageId);
+	delete_rows_by_storage_id("delete_vector", Anum_delete_vector_storage_id, storageId);
 	/* native format catalog (PGCN v1); no-op rows for 2.2-line tables */
 	delete_rows_by_storage_id("column_chunk", Anum_column_chunk_storage_id, storageId);
 	delete_rows_by_storage_id("zone_map", Anum_zone_map_storage_id, storageId);
@@ -1004,7 +1004,7 @@ ColumnarInsertNativeStorageRow(const NativeStorageMetadata *s)
 	 * both insert and the second would fail on storage_pkey (issue seen by the
 	 * concurrent differential suite in native mode). Serialize creators with a
 	 * transaction-scoped advisory lock keyed by the storage id (discriminator 2,
-	 * distinct from the row_mask lock's 1), then re-check against the latest
+	 * distinct from the delete_vector lock's 1), then re-check against the latest
 	 * committed state: the loser of the race sees the winner's committed row and
 	 * skips the insert. The lock is held to transaction end so the winner's row
 	 * is committed and visible before the loser proceeds.

--- a/src/columnar_projection.c
+++ b/src/columnar_projection.c
@@ -318,7 +318,7 @@ columnar_drop_projection(PG_FUNCTION_ARGS)
  * columnar.read_projection(rel, name) -> setof text
  *		Debug/verification reader for a projection's storage (gap 26, phase 2).
  *		Scans the projection's stripes (in stored sort order), skips rows whose
- *		base row number is deleted or invisible per the base row_mask/visibility,
+ *		base row number is deleted or invisible per the base delete_vector/visibility,
  *		and returns each live row's projection columns rendered by their output
  *		functions and joined by '|' (a NULL column renders as \N). The base is
  *		flushed first so rows written earlier in this transaction are visible.

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -120,8 +120,8 @@ struct ColumnarReadState
 	/*
 	 * Native delete visibility (Phase D6b): the current row group's combined
 	 * delete mask (one bit per row-in-group, set = deleted), from
-	 * pgcolumnar.row_mask keyed by group number. NULL when the group has no
-	 * deletes. The interim row mask; Phase F replaces it with a delete vector.
+	 * pgcolumnar.delete_vector keyed by group number. NULL when the group has no
+	 * deletes.
 	 */
 	char	   *nativeDeleteMask;
 	uint32		nativeDeleteMaskLen;
@@ -918,7 +918,7 @@ columnar_native_load_group(ColumnarReadState *rs)
 	rs->nativeDeleteMask = NULL;
 	rs->nativeDeleteMaskLen = 0;
 	{
-		List	   *maskList = ColumnarReadRowMaskList(rs->storageId,
+		List	   *maskList = ColumnarReadDeleteVectorList(rs->storageId,
 													   rg->groupNumber,
 													   rs->metaSnapshot);
 		ListCell   *mlc;
@@ -926,7 +926,7 @@ columnar_native_load_group(ColumnarReadState *rs)
 
 		foreach(mlc, maskList)
 		{
-			RowMaskMetadata *rm = (RowMaskMetadata *) lfirst(mlc);
+			DeleteVectorMetadata *rm = (DeleteVectorMetadata *) lfirst(mlc);
 			uint32		i;
 
 			if (rm->mask == NULL || rm->maskLen == 0)
@@ -1105,7 +1105,7 @@ ColumnarReadSetParallelCounter(ColumnarReadState *readState,
 /* -------------------------------------------------------------------------
  * Liveness cache (gap 26, phase 4): a projection scan must test each row's base
  * row number for deletion/visibility. The cache reads the base row-group list
- * and row masks once (at the scan's snapshot) into memory, then answers each
+ * and delete vectors once (at the scan's snapshot) into memory, then answers each
  * test with a binary search over row groups plus a bitmap probe. Consistent
  * with the scan's fixed snapshot, the same way ColumnarBeginRead reads those
  * lists once at begin.
@@ -1156,7 +1156,7 @@ ColumnarBuildLivenessCache(Relation rel, Snapshot snapshot)
 
 	/*
 	 * Each native row group is one liveness entry with a single whole-group
-	 * delete mask (the row mask is keyed by group number, chunk id 0). Modeling
+	 * delete mask (the delete vector is keyed by group number, chunk id 0). Modeling
 	 * it as chunkGroupCount 1 with chunkRowCount == rowCount makes the shared
 	 * ColumnarLivenessCacheIsLive map every row to chunk 0.
 	 */
@@ -1179,10 +1179,10 @@ ColumnarBuildLivenessCache(Relation rel, Snapshot snapshot)
 		e->masks = palloc0(sizeof(char *) * 1);
 		e->maskLens = palloc0(sizeof(uint32) * 1);
 
-		rml = ColumnarReadRowMaskList(storageId, rg->groupNumber, metaSnapshot);
+		rml = ColumnarReadDeleteVectorList(storageId, rg->groupNumber, metaSnapshot);
 		foreach(mc, rml)
 		{
-			RowMaskMetadata *rm = (RowMaskMetadata *) lfirst(mc);
+			DeleteVectorMetadata *rm = (DeleteVectorMetadata *) lfirst(mc);
 			uint32		b;
 
 			if (rm->mask == NULL || rm->maskLen == 0)
@@ -1251,7 +1251,7 @@ ColumnarFreeLivenessCache(ColumnarLivenessCache *cache)
  *		table AM's fetch-by-tid callback (UPDATE re-fetches the old row). Reads
  *		only the one chunk group that holds the row and decodes each column up
  *		to the row's position. Returns false when no stripe covers the row or
- *		the row is marked deleted in the row mask (spec 7.5).
+ *		the row is marked deleted in the delete vector (spec 7.5).
  */
 bool
 ColumnarReadRowByNumber(Relation rel, Snapshot snapshot, uint64 rowNumber,
@@ -1283,7 +1283,7 @@ ColumnarReadRowByNumber(Relation rel, Snapshot snapshot, uint64 rowNumber,
 	/*
 	 * Native (PGCN v1) fetch-by-row-number: find the row group covering the row
 	 * and reconstruct each column's value at its position. Index and bitmap scans
-	 * and unique enforcement call this. A deleted row (in the group's row mask or
+	 * and unique enforcement call this. A deleted row (in the group's delete vector or
 	 * a not-yet-flushed buffered delete) is not visible.
 	 */
 	rgList = ColumnarReadRowGroupList(storageId, metaSnapshot);
@@ -1307,15 +1307,15 @@ ColumnarReadRowByNumber(Relation rel, Snapshot snapshot, uint64 rowNumber,
 	rowInGrp = rowNumber - rg->firstRowNumber;
 
 	{
-		List	   *maskList = ColumnarReadRowMaskList(storageId,
+		List	   *maskList = ColumnarReadDeleteVectorList(storageId,
 													   rg->groupNumber,
 													   metaSnapshot);
 		ListCell   *mlc;
-		bool		deleted = ColumnarRowMaskBufferedDeleted(rel, rowNumber);
+		bool		deleted = ColumnarDeleteVectorBufferedDeleted(rel, rowNumber);
 
 		foreach(mlc, maskList)
 		{
-			RowMaskMetadata *rm = (RowMaskMetadata *) lfirst(mlc);
+			DeleteVectorMetadata *rm = (DeleteVectorMetadata *) lfirst(mlc);
 
 			if (rm->mask != NULL && (rowInGrp >> 3) < rm->maskLen &&
 				(rm->mask[rowInGrp >> 3] & (1 << (rowInGrp & 7))) != 0)

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -5,7 +5,7 @@
  *		GUCs, the pre-commit flush hook, and drop-time metadata cleanup.
  *
  * Implements the subset of TableAmRoutine built through phase 3: create, bulk
- * insert, sequential scan, delete and update via the row mask, fetch by tid,
+ * insert, sequential scan, delete and update via the delete vector, fetch by tid,
  * size estimation, and non-transactional truncate. Index, vacuum, and sample
  * callbacks are stubbed for later phases.
  *
@@ -110,7 +110,7 @@ columnar_scan_begin(Relation rel, Snapshot snapshot, int nkeys,
 	 * (spec 9).
 	 */
 	ColumnarFlushWriteStateForRelation(RelationGetRelid(rel));
-	ColumnarFlushRowMaskForRelation(rel);
+	ColumnarFlushDeleteVectorForRelation(rel);
 
 	scan = (ColumnarScanDesc) palloc0(sizeof(ColumnarScanDescData));
 	scan->rs_base.rs_rd = rel;
@@ -284,7 +284,7 @@ columnar_finish_bulk_insert(Relation rel, COLUMNAR_TABLE_OPTIONS options)
 	 * spans a later statement or savepoint boundary (spec 9).
 	 */
 	ColumnarFlushWriteStateForRelation(RelationGetRelid(rel));
-	ColumnarFlushRowMaskForRelation(rel);
+	ColumnarFlushDeleteVectorForRelation(rel);
 }
 
 /* -------------------------------------------------------------------------
@@ -393,7 +393,7 @@ columnar_scan_analyze_next_tuple(COLUMNAR_ANALYZE_NEXT_TUPLE_ARGS)
 	return false;
 }
 
-/* VACUUM: nothing to do in phase 1 (row mask / compaction arrive later) */
+/* VACUUM: nothing to do in phase 1 (delete vector / compaction arrive later) */
 static void
 columnar_relation_vacuum(Relation rel, COLUMNAR_VACUUM_PARAMS params,
 						 BufferAccessStrategy bstrategy)
@@ -458,7 +458,7 @@ columnar_index_fetch_end(struct IndexFetchTableData *scan)
 /*
  * columnar_index_fetch_tuple
  *		Fetch the columnar row addressed by an index item pointer (spec 6) into
- *		the slot. Returns false when the row is marked deleted in the row mask
+ *		the slot. Returns false when the row is marked deleted in the delete vector
  *		or does not exist, so an index scan never returns a deleted row and a
  *		unique check does not treat a deleted row as a live duplicate (spec 9).
  *
@@ -547,14 +547,14 @@ columnar_tuple_satisfies_snapshot(Relation rel, TupleTableSlot *slot,
  * columnar_index_delete_tuples
  *		Opportunistic index tuple deletion. An index entry is deletable exactly
  *		when its row is no longer visible, i.e. ColumnarReadRowByNumber cannot
- *		return it (deleted via the row mask). Reporting deletability by actual
+ *		return it (deleted via the delete vector). Reporting deletability by actual
  *		liveness is required for correctness: nbtree's deletion pass (including
  *		bottom-up deletion of duplicate keys, which a same-key UPDATE produces)
  *		marks candidate items and calls this callback as the authority; leaving a
  *		genuinely dead item marked non-deletable would make nbtree assert
  *		(ndeletable > 0 || nupdatable > 0). Entries left in place are still
  *		filtered on fetch, so either way is correct. The snapshot conflict horizon
- *		is reported as invalid (no conflict), matching the row mask's own MVCC on
+ *		is reported as invalid (no conflict), matching the delete vector's own MVCC on
  *		the catalog.
  */
 #if PG_VERSION_NUM < 140000
@@ -616,7 +616,7 @@ columnar_tuple_complete_speculative(Relation rel, TupleTableSlot *slot,
 
 /*
  * columnar_tuple_delete
- *		Mark the row addressed by tid as deleted in the row mask (spec 9). The
+ *		Mark the row addressed by tid as deleted in the delete vector (spec 9). The
  *		stripe is not rewritten. The tid is the synthetic item pointer the scan
  *		produced, which maps back to the row number.
  */
@@ -632,7 +632,7 @@ columnar_tuple_delete(COLUMNAR_TUPLE_DELETE_ARGS)
 /*
  * columnar_tuple_update
  *		Update is delete-plus-insert (spec 9): mark the old row deleted in the
- *		row mask and append the new tuple as a fresh row with a new row number.
+ *		delete vector and append the new tuple as a fresh row with a new row number.
  *		The new row's item pointer is published on the slot and index
  *		maintenance is requested, so the new row gets fresh index entries. The
  *		old row's index entries remain but are filtered on fetch because the old
@@ -690,7 +690,7 @@ columnar_relation_copy_for_cluster(COLUMNAR_COPY_FOR_CLUSTER_ARGS)
  * columnar_index_build_range_scan
  *		Scan every live row of the columnar table and hand it to the index
  *		build callback, so CREATE INDEX (btree or hash) works over a columnar
- *		table (spec 9). Deleted rows (row mask) are skipped by the reader, so
+ *		table (spec 9). Deleted rows (delete vector) are skipped by the reader, so
  *		they are not indexed. Each row's synthetic item pointer (spec 6) is the
  *		TID recorded in the index.
  *
@@ -725,7 +725,7 @@ columnar_index_build_range_scan(Relation table_rel, Relation index_rel,
 
 	/* persist buffered rows and delete marks so the build sees them (spec 9) */
 	ColumnarFlushWriteStateForRelation(RelationGetRelid(table_rel));
-	ColumnarFlushRowMaskForRelation(table_rel);
+	ColumnarFlushDeleteVectorForRelation(table_rel);
 
 	estate = CreateExecutorState();
 	econtext = GetPerTupleExprContext(estate);
@@ -917,14 +917,14 @@ columnar_xact_callback(XactEvent event, void *arg)
 		case XACT_EVENT_PARALLEL_PRE_COMMIT:
 		case XACT_EVENT_PREPARE:
 			ColumnarFlushAllPendingWrites();
-			ColumnarFlushAllRowMasks();
+			ColumnarFlushAllDeleteVectors();
 			break;
 		case XACT_EVENT_COMMIT:
 		case XACT_EVENT_ABORT:
 		case XACT_EVENT_PARALLEL_COMMIT:
 		case XACT_EVENT_PARALLEL_ABORT:
 			ColumnarDiscardAllPendingWrites();
-			ColumnarDiscardAllRowMasks();
+			ColumnarDiscardAllDeleteVectors();
 			break;
 		default:
 			break;
@@ -943,11 +943,11 @@ columnar_subxact_callback(SubXactEvent event, SubTransactionId mySubid,
 	{
 		case SUBXACT_EVENT_ABORT_SUB:
 			ColumnarWriteStateDiscardSubXact(mySubid);
-			ColumnarRowMaskDiscardSubXact(mySubid);
+			ColumnarDeleteVectorDiscardSubXact(mySubid);
 			break;
 		case SUBXACT_EVENT_COMMIT_SUB:
 			ColumnarWriteStatePromoteSubXact(mySubid, parentSubid);
-			ColumnarRowMaskPromoteSubXact(mySubid, parentSubid);
+			ColumnarDeleteVectorPromoteSubXact(mySubid, parentSubid);
 			break;
 		default:
 			break;
@@ -975,7 +975,7 @@ columnar_executor_end(QueryDesc *queryDesc)
 		standard_ExecutorEnd(queryDesc);
 
 	ColumnarFlushAllPendingWrites();
-	ColumnarFlushAllRowMasks();
+	ColumnarFlushAllDeleteVectors();
 }
 
 /* -------------------------------------------------------------------------
@@ -1017,7 +1017,7 @@ columnar_object_access(ObjectAccessType access, Oid classId, Oid objectId,
  * A columnar table has no visibility map, so an index-only scan cannot decide
  * visibility from the map and is not supported (spec 9). An ordinary index scan
  * is fine because it fetches each row through index_fetch_tuple, which applies
- * the row mask. We forbid index-only scans by clearing each candidate index's
+ * the delete vector. We forbid index-only scans by clearing each candidate index's
  * per-column "can return" flags for a columnar table, before the planner builds
  * any path; the planner then builds a plain index scan instead of an index-only
  * scan for the same index.

--- a/src/columnar_unique.c
+++ b/src/columnar_unique.c
@@ -15,7 +15,7 @@
  * The fix here serializes inserters of the SAME unique key. Before a row is
  * handed back to the executor's index maintenance, the table AM insert paths
  * call ColumnarLockUniqueKeys, which takes a transaction-scoped advisory lock
- * (the same SET_LOCKTAG_ADVISORY primitive used by the issue #4 row_mask lock)
+ * (the same SET_LOCKTAG_ADVISORY primitive used by the issue #4 delete_vector lock)
  * keyed by the row's unique key value(s). Because the lock is held to commit,
  * when a second inserter finally acquires it the first inserter has either
  * committed (its statement-end flush ran, so its row is now visible and the
@@ -58,12 +58,12 @@ bool		columnar_enable_unique_lock = true;
 int			columnar_unique_lock_buckets = 128;
 
 /*
- * Advisory-lock discriminator in locktag_field4. The issue #4 row_mask lock
+ * Advisory-lock discriminator in locktag_field4. The issue #4 delete_vector lock
  * uses 1; the unique-key lock uses 2 so the two lock spaces never false-share.
  */
 #define COLUMNAR_UNIQUE_LOCK_CLASS 2
 
-/* 64-bit FNV-1a basis/prime, matching rowmask_chunk_lock_key's mixer */
+/* 64-bit FNV-1a basis/prime, matching delete_vector_chunk_lock_key's mixer */
 #define COLUMNAR_FNV_OFFSET UINT64CONST(1469598103934665603)
 #define COLUMNAR_FNV_PRIME  UINT64CONST(1099511628211)
 
@@ -307,7 +307,7 @@ columnar_unique_lookup(Relation rel)
  * lock-key computation and acquisition
  * ------------------------------------------------------------------------- */
 
-/* splitmix64/murmur3 finalizer, matching rowmask_chunk_lock_key */
+/* splitmix64/murmur3 finalizer, matching delete_vector_chunk_lock_key */
 static inline uint64
 columnar_hash_finalize(uint64 h)
 {

--- a/src/columnar_vacuum.c
+++ b/src/columnar_vacuum.c
@@ -4,7 +4,7 @@
  *		Compaction, statistics, and storage-id lookup functions for pgColumnar
  *		(spec 8.2, 9). columnar.vacuum rewrites a columnar table's live rows
  *		into fresh, full stripes: this combines many small stripes into few and
- *		physically reclaims the space of rows marked deleted in the row mask,
+ *		physically reclaims the space of rows marked deleted in the delete vector,
  *		since deleted rows are simply not read back. columnar.stats reports the
  *		per-stripe layout (implemented in SQL over the catalog, using the
  *		get_storage_id function here to resolve a relation to its storage id).
@@ -77,7 +77,7 @@ uint64_cmp(const void *a, const void *b)
  * rests on the protocol in design/PHASE_F3B_PLAN.md: the rewrite serializes with
  * deleters on the per-chunk-group advisory lock, and a delete that races a
  * rewrite of its group is aborted with a serialization failure by the
- * conflict check in ColumnarUpsertRowMask.
+ * conflict check in ColumnarUpsertDeleteVector.
  * ------------------------------------------------------------------------- */
 
 /* the relation's ready+valid indexes, opened once for a rewrite pass */
@@ -190,7 +190,7 @@ rewrite_one_group(Relation rel, RewriteIndexState *ris, uint64 storageId,
 	uint64		r;
 	int64		moved = 0;
 
-	/* serialize with concurrent deleters to this group (see ColumnarUpsertRowMask) */
+	/* serialize with concurrent deleters to this group (see ColumnarUpsertDeleteVector) */
 	ColumnarLockChunkGroup(storageId, groupNumber);
 
 	/* Read the group's live set under a snapshot taken after the lock, so every
@@ -257,7 +257,7 @@ columnar_rewrite_partial_groups(Relation rel, double minDeletedFraction,
 
 	/* persist own pending work so the group list and deletes are current */
 	ColumnarFlushWriteStateForRelation(relid);
-	ColumnarFlushRowMaskForRelation(rel);
+	ColumnarFlushDeleteVectorForRelation(rel);
 
 	/* collect candidate groups first (do not mutate the catalog mid-scan) */
 	snap = RegisterSnapshot(GetLatestSnapshot());
@@ -271,9 +271,9 @@ columnar_rewrite_partial_groups(Relation rel, double minDeletedFraction,
 
 		if (rg->rowCount == 0)
 			continue;
-		rmList = ColumnarReadRowMaskList(storageId, rg->groupNumber, snap);
+		rmList = ColumnarReadDeleteVectorList(storageId, rg->groupNumber, snap);
 		foreach(lc2, rmList)
-			deleted += ((RowMaskMetadata *) lfirst(lc2))->deletedRows;
+			deleted += ((DeleteVectorMetadata *) lfirst(lc2))->deletedRows;
 
 		/* partially deleted and past the threshold; fully-dead is F3a's job */
 		if (deleted > 0 && deleted < (int64) rg->rowCount &&
@@ -357,7 +357,7 @@ columnar_recluster_online(Relation rel, int ncols, AttrNumber *atts)
 
 	/* persist own pending work so the group list and deletes are current */
 	ColumnarFlushWriteStateForRelation(relid);
-	ColumnarFlushRowMaskForRelation(rel);
+	ColumnarFlushDeleteVectorForRelation(rel);
 
 	/* capture the current groups (retired at the end, after the new ones exist) */
 	listSnap = RegisterSnapshot(GetLatestSnapshot());
@@ -793,7 +793,7 @@ columnar_compact_relation(Relation rel, int nsortkeys, AttrNumber *sortAtts)
 
 	/* persist any pending work so the read below sees it (spec 9) */
 	ColumnarFlushWriteStateForRelation(relid);
-	ColumnarFlushRowMaskForRelation(rel);
+	ColumnarFlushDeleteVectorForRelation(rel);
 
 	oldStorageId = ColumnarStorageId(rel);
 
@@ -995,7 +995,7 @@ columnar_compact_relation_zorder(Relation rel, int ncols, AttrNumber *atts)
 
 	/* persist pending work so the read below sees it (spec 9) */
 	ColumnarFlushWriteStateForRelation(relid);
-	ColumnarFlushRowMaskForRelation(rel);
+	ColumnarFlushDeleteVectorForRelation(rel);
 
 	oldStorageId = ColumnarStorageId(rel);
 	oldProjs = ColumnarListProjections(oldStorageId);

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -887,7 +887,7 @@ columnar_apply_one(ColumnarAggScanState *state, ColumnarAggSpec *spec,
  * columnar_run_agg
  *		Scan the base relation once and fold every chunk group into the aggregate
  *		accumulators. The reader (ColumnarBeginRead) applies min/max chunk-group
- *		skipping and the row mask. With no pushed-down predicates and fixed-width
+ *		skipping and the delete vector. With no pushed-down predicates and fixed-width
  *		aggregate columns, groups are folded run-at-a-time over the value stream
  *		(I3 compressed execution); otherwise, and for groups with deletes, the
  *		per-row vectorized path is used. Returns the read state so the caller can
@@ -1094,7 +1094,7 @@ columnar_native_scan_agg(ColumnarAggScanState *state)
 		projected = bms_make_singleton(0);	/* count(*) only: one column */
 
 	ColumnarFlushWriteStateForRelation(state->relid);
-	ColumnarFlushRowMaskForRelation(rel);
+	ColumnarFlushDeleteVectorForRelation(rel);
 
 	rs = ColumnarBeginRead(rel, estate->es_snapshot, NULL, projected, 0, NULL);
 	while (ColumnarReadNextRow(rs, values, nulls, &rowNumber))
@@ -1139,8 +1139,8 @@ ColumnarExecAggScan(CustomScanState *node)
 	 */
 	frel = table_open(state->relid, AccessShareLock);
 	ColumnarFlushWriteStateForRelation(state->relid);
-	ColumnarFlushRowMaskForRelation(frel);
-	hasDeletes = ColumnarStorageHasRowMask(ColumnarStorageId(frel),
+	ColumnarFlushDeleteVectorForRelation(frel);
+	hasDeletes = ColumnarStorageHasDeleteVector(ColumnarStorageId(frel),
 										   ColumnarCatalogSnapshot(estate->es_snapshot));
 	table_close(frel, AccessShareLock);
 

--- a/src/columnar_write_state.c
+++ b/src/columnar_write_state.c
@@ -981,7 +981,7 @@ columnar_flush_row_group(ColumnarWriteState *writeState)
  * projection's sort key and written as a stripe to the projection's storage,
  * reusing the base stripe encoder (ColumnarWriteRow + columnar_flush_row_group).
  * The base row number is stored as a leading int8 column so the projection can
- * be joined back to the base; deletes/visibility come from the base row_mask, so
+ * be joined back to the base; deletes/visibility come from the base delete_vector, so
  * only INSERT fans out (see design/gaps/26-IMPL-projections-phase2-plan.md).
  * ------------------------------------------------------------------------- */
 
@@ -1339,7 +1339,7 @@ ColumnarBackfillProjection(Relation rel, const ColumnarProjection *proj)
 
 	/* flush any pending base writes so the scan sees this transaction's rows */
 	ColumnarFlushWriteStateForRelation(relid);
-	ColumnarFlushRowMaskForRelation(rel);
+	ColumnarFlushDeleteVectorForRelation(rel);
 
 	w = build_proj_writer(rel, proj, stripeRowLimit, chunkGroupRowLimit,
 						  compType, compLevel);

--- a/test/concurrency.sh
+++ b/test/concurrency.sh
@@ -2,7 +2,7 @@
 #
 # pgColumnar concurrency regression test (tracking issue #4).
 #
-# Deletes are recorded by merging bits into a single shared pgcolumnar.row_mask
+# Deletes are recorded by merging bits into a single shared pgcolumnar.delete_vector
 # heap tuple per (storage id, stripe, chunk group). Before the fix, the delete
 # path did an unguarded read-modify-write of that tuple: two transactions
 # deleting different rows in the SAME chunk group could both read the old mask
@@ -29,8 +29,8 @@
 # wait, not a fixed sleep, so the interleaving is forced, not raced.
 #
 # Two chunk-group states are exercised:
-#   A. a row_mask tuple already exists for the chunk group (update path)
-#   B. no row_mask tuple exists yet     (first-delete insert race)
+#   A. a delete_vector tuple already exists for the chunk group (update path)
+#   B. no delete_vector tuple exists yet     (first-delete insert race)
 #
 # It also checks the intended concurrency is preserved: two deletes to
 # DIFFERENT chunk groups do not block each other.
@@ -255,14 +255,14 @@ wait_idle_intx() {  # application_name
 ctl_q "CREATE EXTENSION pgcolumnar;" >/dev/null
 
 # ---------------------------------------------------------------------------
-# Scenario A: row_mask tuple already exists for the chunk group.
+# Scenario A: delete_vector tuple already exists for the chunk group.
 # All rows land in one stripe / one chunk group (default 10000 rows/group).
-# An initial committed delete creates the row_mask tuple; then two concurrent
+# An initial committed delete creates the delete_vector tuple; then two concurrent
 # deletes of different rows in that same group must both survive.
 # ---------------------------------------------------------------------------
 ctl_q "CREATE TABLE t (id int) USING pgcolumnar;" >/dev/null
 ctl_q "INSERT INTO t SELECT g FROM generate_series(1,6) g;" >/dev/null
-ctl_q "DELETE FROM t WHERE id = 6;" >/dev/null   # creates the row_mask tuple
+ctl_q "DELETE FROM t WHERE id = 6;" >/dev/null   # creates the delete_vector tuple
 
 start_session s1
 start_session s2
@@ -294,9 +294,9 @@ check "A row count after concurrent deletes" \
 	"$(ctl_q "SELECT count(*) FROM t;")" "3"
 
 # ---------------------------------------------------------------------------
-# Scenario B: no row_mask tuple exists yet (first-delete insert race).
+# Scenario B: no delete_vector tuple exists yet (first-delete insert race).
 # Two concurrent first deletes of different rows in one chunk group race to
-# create the initial row_mask row; both bits must survive.
+# create the initial delete_vector row; both bits must survive.
 # ---------------------------------------------------------------------------
 ctl_q "CREATE TABLE t2 (id int) USING pgcolumnar;" >/dev/null
 ctl_q "INSERT INTO t2 SELECT g FROM generate_series(1,6) g;" >/dev/null

--- a/test/concurrent_diff.sh
+++ b/test/concurrent_diff.sh
@@ -7,7 +7,7 @@
 # table. Because the ranges are disjoint the final logical state is deterministic
 # regardless of interleaving, so the columnar table must end byte-for-byte equal
 # to the heap oracle. This exercises concurrent writers to one columnar relation
-# (stripe/row-number reservation, the row mask, and index maintenance) with the
+# (stripe/row-number reservation, the delete vector, and index maintenance) with the
 # format 2.1 encoding and bloom-filter write paths active.
 #
 # Usage:  test/concurrent_diff.sh [PG_CONFIG]

--- a/test/native_dml.sh
+++ b/test/native_dml.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 #
 # pgColumnar native delete and update (Phase D6b): DELETE, UPDATE and MERGE on a
-# native-format (PGCN v1) table, via the interim row mask keyed by row group. Every
+# native-format (PGCN v1) table, via the interim delete vector keyed by row group. Every
 # result is compared to a heap mirror: the surviving rows, counts, aggregates after
 # deletes (which fall back from the zone-map path to a delete-applying scan), and
-# index lookups of deleted vs live rows. The interim row mask; Phase F replaces it
+# index lookups of deleted vs live rows. The interim delete vector; Phase F replaces it
 # with a first-class delete vector.
 #
 # Usage:  test/native_dml.sh [PG_CONFIG]

--- a/test/native_projection.sh
+++ b/test/native_projection.sh
@@ -6,7 +6,7 @@
 # 2.2 while the reader took the base table's format, so a native base's projection
 # scan returned nothing. This suite checks the write fan-out reproduces the base's
 # live rows, the projection storage is native, deletes are reflected via the base
-# row mask, and fan-out spans multiple projection row groups.
+# delete vector, and fan-out spans multiple projection row groups.
 #
 # Usage:  test/native_projection.sh [PG_CONFIG]
 # Written fresh for pgColumnar.
@@ -39,7 +39,7 @@ check "fp storage is native" \
 check "fp has zone maps (native skip metadata)" \
 	"$([ "$(q "SELECT count(*) FROM pgcolumnar.zone_map WHERE storage_id = (SELECT proj_storage_id FROM pgcolumnar.projection WHERE storage_id = pgcolumnar.get_storage_id('fo') AND name='fp');")" -ge 1 ] && echo yes || echo no)" "yes"
 
-# Deletes on the base are reflected in the projection (via the base row mask).
+# Deletes on the base are reflected in the projection (via the base delete vector).
 psql_run "DELETE FROM fo WHERE a BETWEEN 1000 AND 2000;"
 check "fp reflects deletes (a,c)" \
 	"$(pgc_set_hash "SELECT pgcolumnar.read_projection('fo','fp')")" \

--- a/test/phase3.sh
+++ b/test/phase3.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# pgColumnar phase 3 test: update and delete via the row mask, snapshot
+# pgColumnar phase 3 test: update and delete via the delete vector, snapshot
 # visibility and same-transaction read-your-writes, transaction and savepoint
 # rollback, and temporary columnar tables. Also re-runs the phase 1 and phase 2
 # regression checks.
@@ -107,7 +107,7 @@ check "ryw persisted" "$(q 'SELECT count(*) FROM ryw;')" "1001"
 q "DROP TABLE ryw;" >/dev/null
 
 # ---------------------------------------------------------------------------
-# DELETE marks rows in the row mask; scans return exactly the survivors.
+# DELETE marks rows in the delete vector; scans return exactly the survivors.
 # 25000 rows span three chunk groups (10000/10000/5000), so the deleted range
 # below straddles a chunk-group boundary.
 # ---------------------------------------------------------------------------
@@ -123,9 +123,9 @@ check "delete boundaries"  "$(q 'SELECT min(id)||chr(47)||max(id) FROM d;')"    
 q "DELETE FROM d WHERE id > 20000;" >/dev/null
 check "delete tail count"  "$(q 'SELECT count(*) FROM d;')"                       "19989"
 check "delete tail max"    "$(q 'SELECT max(id) FROM d;')"                        "20000"
-# row_mask catalog reflects the deletions
-check "row_mask rows>0"    "$(q 'SELECT (count(*) > 0)::int FROM pgcolumnar.row_mask;')" "1"
-check "row_mask deleted"   "$(q 'SELECT sum(deleted_rows) FROM pgcolumnar.row_mask;')"   "5011"
+# delete_vector catalog reflects the deletions
+check "delete_vector rows>0"    "$(q 'SELECT (count(*) > 0)::int FROM pgcolumnar.delete_vector;')" "1"
+check "delete_vector deleted"   "$(q 'SELECT sum(deleted_rows) FROM pgcolumnar.delete_vector;')"   "5011"
 q "DROP TABLE d;" >/dev/null
 
 # ---------------------------------------------------------------------------
@@ -196,7 +196,7 @@ check "temp survivors" "$TEMPRES" "1600"
 check "temp deleted"   "$(q 'CREATE TEMP TABLE t_tmp2 (a int) USING pgcolumnar; INSERT INTO t_tmp2 SELECT g FROM generate_series(1,2000) g; DELETE FROM t_tmp2 WHERE a % 5 = 0; SELECT count(*) FROM t_tmp2 WHERE a % 5 = 0;')" "0"
 
 # ---------------------------------------------------------------------------
-# Deletes survive across transactions, and drop cleans up row_mask rows.
+# Deletes survive across transactions, and drop cleans up delete_vector rows.
 # ---------------------------------------------------------------------------
 echo "-- durability and cleanup"
 q "CREATE TABLE dur (a int) USING pgcolumnar;" >/dev/null
@@ -205,7 +205,7 @@ q "DELETE FROM dur WHERE a % 2 = 0;" >/dev/null
 check "durable survivors" "$(q 'SELECT count(*) FROM dur;')"                 "500"
 check "durable odd only"  "$(q 'SELECT count(*) FROM dur WHERE a % 2 = 0;')" "0"
 q "DROP TABLE dur;" >/dev/null
-check "row_mask cleaned"  "$(q 'SELECT count(*) FROM pgcolumnar.row_mask;')" "0"
+check "delete_vector cleaned"  "$(q 'SELECT count(*) FROM pgcolumnar.delete_vector;')" "0"
 check "row group cleaned" "$(q 'SELECT count(*) FROM pgcolumnar.row_group;')" "0"
 
 echo

--- a/test/phase4.sh
+++ b/test/phase4.sh
@@ -2,7 +2,7 @@
 #
 # pgColumnar phase 4 test: indexes and constraints. Covers btree and hash index
 # build and scan over a columnar table, index fetch by item pointer respecting
-# the row mask, unique/primary-key constraint enforcement (across statements and
+# the delete vector, unique/primary-key constraint enforcement (across statements and
 # within a single statement), NOT NULL and CHECK constraints, heap<->columnar
 # conversion round-trips, and confirmation that ordinary index scans work (with
 # the index-only-scan fallback verified when the feature is turned off; the
@@ -168,7 +168,7 @@ expect_fail "check reject"     "INSERT INTO ck VALUES (3, -1);"
 check "ck unchanged"        "$(q 'SELECT count(*) FROM ck;')" "2"
 
 # ---------------------------------------------------------------------------
-# Index scan does not return rows marked deleted in the row mask.
+# Index scan does not return rows marked deleted in the delete vector.
 # ---------------------------------------------------------------------------
 echo "-- index scan skips row-mask-deleted rows"
 q "CREATE TABLE di (a int, b text) USING pgcolumnar;" >/dev/null

--- a/test/phase6.sh
+++ b/test/phase6.sh
@@ -230,9 +230,9 @@ eq_on_off "group by (fallback)"   "SELECT s, count(*) FROM t WHERE s < 3 GROUP B
 eq_on_off "count distinct"        "SELECT count(DISTINCT s) FROM t;" "1000"
 
 # ---------------------------------------------------------------------------
-# Interaction with deletes: the aggregate and scan must honor the row mask.
+# Interaction with deletes: the aggregate and scan must honor the delete vector.
 # ---------------------------------------------------------------------------
-echo "-- aggregate and scan honor the row mask (deletes)"
+echo "-- aggregate and scan honor the delete vector (deletes)"
 q "DELETE FROM t WHERE id % 2 = 0;" >/dev/null
 eq_on_off "count after delete"  "SELECT count(*) FROM t;"  "25000"
 eq_on_off "sum after delete"    "SELECT sum(id) FROM t;"

--- a/test/projections.sh
+++ b/test/projections.sh
@@ -89,7 +89,7 @@ check "back-fill: p2 matches base (b column)" \
 # ---------------------------------------------------------------------------
 # Phase 2: write fan-out. Projections declared before load are populated by
 # INSERT; read_projection reproduces the base's live rows for the projection's
-# columns (deletes come from the base row_mask). Values are rendered by their
+# columns (deletes come from the base delete_vector). Values are rendered by their
 # output functions and joined by '|' on both sides for an exact multiset match.
 # ---------------------------------------------------------------------------
 echo "-- phase 2: write fan-out populates projections"
@@ -116,7 +116,7 @@ fp_minmax="$(q "SELECT count(*) FROM pgcolumnar.zone_map WHERE storage_id = $fp_
 check "fp chunks carry min/max skip metadata" \
 	"$([ "$fp_minmax" -ge 1 ] && echo yes || echo no)" "yes"
 
-echo "-- phase 2: deletes reflected via the base row_mask"
+echo "-- phase 2: deletes reflected via the base delete_vector"
 psql_run "DELETE FROM fo WHERE a BETWEEN 1000 AND 2000;"
 check "fp reflects deletes (a,c)" \
 	"$(pgc_set_hash "SELECT pgcolumnar.read_projection('fo','fp')")" \
@@ -171,7 +171,7 @@ check "reconstruct row count matches base" \
 # ---------------------------------------------------------------------------
 # Phase 4b: the planner scans a covering projection when its sort key is
 # restricted, and the executor returns correct rows from the projection storage
-# (deletes filtered by the base row_mask). pgcolumnar.enable_projection_scan gates
+# (deletes filtered by the base delete_vector). pgcolumnar.enable_projection_scan gates
 # it; a query referencing a non-covered column falls back to the base.
 # ---------------------------------------------------------------------------
 echo "-- phase 4b: planner selects a covering projection for a sort-key predicate"
@@ -195,7 +195,7 @@ check "GUC off: no projection scan" \
 check "non-covering query (references b) uses the base" \
 	"$(q "EXPLAIN (COSTS OFF) SELECT a, b, c FROM ps WHERE c BETWEEN 100 AND 200;" | grep -c 'Columnar Projection')" "0"
 
-echo "-- phase 4b: projection scan reflects deletes (base row_mask)"
+echo "-- phase 4b: projection scan reflects deletes (base delete_vector)"
 psql_run "DELETE FROM ps   WHERE a BETWEEN 5000 AND 6000;"
 psql_run "DELETE FROM ps_h WHERE a BETWEEN 5000 AND 6000;"
 check "projection scan matches oracle after delete" \


### PR DESCRIPTION
Aligns the interim delete-tracking catalog with the format spec's name. `pgcolumnar.row_mask` becomes `pgcolumnar.delete_vector` (table, sequence, indexes), `columnar_row_mask.c` becomes `columnar_delete_vector.c`, and every `row_mask` / `RowMask` / `rowmask` identifier is renamed (249 one-to-one swaps, no line-count change).

**Rename only, behavior-preserving.** The delete mechanism (mark, buffer, merge-on-read, subxact discard/promote, deadlock-safe lock ordering, read-your-writes) is untouched. The vestigial columns (`id`, `stripe_id`, `chunk_id`, `start_row_number`, `end_row_number`) and row-number-range keying are unchanged.

**Deferred (own PR):** the structural half of F1 — re-key by `group_number`, drop the vestigial columns, rename data columns to the spec's `bitmap` / `deleted_count`. That is behavioral, not a rename. Documented in `design/PHASE_F_PLAN.md`.

Full PostgreSQL 15-19 matrix green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)