### PR TITLE
Phase F1 (structural): re-key delete_vector to the spec's four columns

### DIFF
--- a/design/PHASE_F_PLAN.md
+++ b/design/PHASE_F_PLAN.md
@@ -53,9 +53,16 @@ Status (2026-07-23): the rename half landed. `pgcolumnar.row_mask` is now
 kept deliberately small and behavior-preserving: the vestigial columns
 (`id`, `stripe_id`, `chunk_id`, `start_row_number`, `end_row_number`) and the
 row-number-range keying are UNCHANGED, and the spec column names (`group_number`,
-`bitmap`, `deleted_count`) are not yet applied. The structural half below
-(re-key by `group_number`, drop the vestigial columns, rename the data columns)
-is the deferred follow-up; it is behavioral, not a rename, so it is its own PR.
+`bitmap`, `deleted_count`) are not yet applied. Structural half (2026-07-23, done in this PR): the catalog is now the spec's
+four columns `(storage_id, group_number, bitmap, deleted_count)` keyed uniquely by
+`(storage_id, group_number)`. Dropped the surrogate `id` (and its
+`delete_vector_seq` sequence), `chunk_id`, `start_row_number`, and
+`end_row_number`, plus the two extra unique indexes. This is safe because no
+consumer used those columns: the bitmap is interpreted group-relative from the
+row_group's `first_row_number` (e.g. `rowInGrp = rowNumber - rg->firstRowNumber`
+in the reader), never from a stored `start_row_number`, and there is exactly one
+delete_vector row per group (chunk id always 0). The in-memory delete buffer is
+unchanged; only the catalog DTO and I/O changed.
 
 
 Replace the interim `row_mask` with the spec's `pgcolumnar.delete_vector` (spec

--- a/pgcolumnar--1.0.sql
+++ b/pgcolumnar--1.0.sql
@@ -7,8 +7,7 @@
  *
  * The catalog holds the native storage, row_group, column_chunk, zone_map,
  * and bloom tables, the shared delete_vector and options tables, the storageid_seq
- * and delete_vector_seq sequences, the columnar_handler function, and the columnar
- * access method.
+ * sequence, the columnar_handler function, and the columnar access method.
  */
 
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
@@ -22,35 +21,24 @@ CREATE SEQUENCE pgcolumnar.storageid_seq
 	MINVALUE 10000000000
 	NO CYCLE;
 
-CREATE SEQUENCE pgcolumnar.delete_vector_seq;
-
 /* ---------------------------------------------------------------------------
  * pgcolumnar.delete_vector (spec 7.5)
  *
  * Tracks deleted rows for updates and deletes without rewriting stripes. One
- * row per chunk group covers the row-number range [start_row_number,
- * end_row_number]; a set bit in "mask" marks a deleted row.
+ * row per chunk group, keyed by group_number; a set bit in "bitmap" marks a
+ * deleted row (bit i is the group's i-th row, row_group.first_row_number + i,
+ * LSB-first in byte i/8). deleted_count is the number of set bits.
  * ------------------------------------------------------------------------- */
 
 CREATE TABLE pgcolumnar.delete_vector (
-	id bigint NOT NULL,
 	storage_id bigint NOT NULL,
-	stripe_id bigint NOT NULL,
-	chunk_id integer NOT NULL,
-	start_row_number bigint NOT NULL,
-	end_row_number bigint NOT NULL,
-	deleted_rows integer NOT NULL,
-	mask bytea
+	group_number bigint NOT NULL,
+	bitmap bytea,
+	deleted_count integer NOT NULL
 );
 
 CREATE UNIQUE INDEX delete_vector_pkey
-	ON pgcolumnar.delete_vector USING btree (id, storage_id, start_row_number, end_row_number);
-
-CREATE UNIQUE INDEX delete_vector_chunk_unique
-	ON pgcolumnar.delete_vector USING btree (storage_id, stripe_id, chunk_id, start_row_number);
-
-CREATE UNIQUE INDEX delete_vector_stripe_unique
-	ON pgcolumnar.delete_vector USING btree (storage_id, stripe_id, start_row_number);
+	ON pgcolumnar.delete_vector USING btree (storage_id, group_number);
 
 /* ---------------------------------------------------------------------------
  * pgcolumnar.options (spec 7.4)
@@ -419,10 +407,10 @@ CREATE FUNCTION pgcolumnar.stats(
 	SELECT rg.group_number,
 		   rg.file_offset,
 		   rg.row_count,
-		   COALESCE((SELECT sum(rm.deleted_rows)::bigint
+		   COALESCE((SELECT sum(rm.deleted_count)::bigint
 					 FROM pgcolumnar.delete_vector rm
 					 WHERE rm.storage_id = rg.storage_id
-					   AND rm.stripe_id = rg.group_number), 0::bigint),
+					   AND rm.group_number = rg.group_number), 0::bigint),
 		   (SELECT count(DISTINCT zm.vector_index)::int
 			FROM pgcolumnar.zone_map zm
 			WHERE zm.storage_id = rg.storage_id

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -248,21 +248,18 @@ typedef struct NativeBloomMetadata
 } NativeBloomMetadata;
 
 /*
- * One columnar.delete_vector row (spec 7.5). Covers the row-number range
- * [startRowNumber, endRowNumber] of a single chunk group; a set bit in mask
- * marks a deleted row. Bit i (0-based) corresponds to row number
- * startRowNumber + i and is stored LSB-first in byte i/8.
+ * One columnar.delete_vector row (spec 7.5): one row per chunk group, keyed by
+ * (storage_id, group_number). A set bit in the bitmap marks a deleted row; bit i
+ * (0-based) corresponds to the group's i-th row (row number
+ * row_group.first_row_number + i) and is stored LSB-first in byte i/8. The group
+ * origin comes from the row_group, so it is not stored here.
  */
 typedef struct DeleteVectorMetadata
 {
-	uint64		id;
-	uint64		stripeId;
-	int			chunkId;
-	uint64		startRowNumber;
-	uint64		endRowNumber;
-	int			deletedRows;
-	char	   *mask;			/* maskLen bytes, in the caller's context */
-	uint32		maskLen;
+	uint64		groupNumber;
+	int			deletedCount;
+	char	   *bitmap;			/* bitmapLen bytes, in the caller's context */
+	uint32		bitmapLen;
 } DeleteVectorMetadata;
 
 /*
@@ -387,7 +384,6 @@ extern List *ColumnarReadDeleteVectorList(uint64 storageId, uint64 stripeId,
 									 Snapshot snapshot);
 extern bool ColumnarStorageHasDeleteVector(uint64 storageId, Snapshot snapshot);
 extern void ColumnarUpsertDeleteVector(uint64 storageId, DeleteVectorMetadata *rm);
-extern uint64 ColumnarNextDeleteVectorId(void);
 
 /* -------------------------------------------------------------------------
  * writer (columnar_write_state.c)

--- a/src/columnar_delete_vector.c
+++ b/src/columnar_delete_vector.c
@@ -317,14 +317,10 @@ delete_vector_flush_buffer(DeleteVectorBuffer *buf)
 				if (chunk->mask[i] & (1 << bit))
 					deleted++;
 
-		rm.id = ColumnarNextDeleteVectorId();
-		rm.stripeId = chunk->stripeId;
-		rm.chunkId = chunk->chunkId;
-		rm.startRowNumber = chunk->startRowNumber;
-		rm.endRowNumber = chunk->endRowNumber;
-		rm.deletedRows = deleted;
-		rm.mask = chunk->mask;
-		rm.maskLen = chunk->maskLen;
+		rm.groupNumber = chunk->stripeId;
+		rm.deletedCount = deleted;
+		rm.bitmap = chunk->mask;
+		rm.bitmapLen = chunk->maskLen;
 
 		ColumnarUpsertDeleteVector(buf->storageId, &rm);
 	}

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -101,15 +101,11 @@
 #define Natts_free_space 4
 
 /* attribute numbers for columnar.delete_vector (spec 7.5) */
-#define Anum_delete_vector_id 1
-#define Anum_delete_vector_storage_id 2
-#define Anum_delete_vector_stripe_id 3
-#define Anum_delete_vector_chunk_id 4
-#define Anum_delete_vector_start_row_number 5
-#define Anum_delete_vector_end_row_number 6
-#define Anum_delete_vector_deleted_rows 7
-#define Anum_delete_vector_mask 8
-#define Natts_delete_vector 8
+#define Anum_delete_vector_storage_id 1
+#define Anum_delete_vector_group_number 2
+#define Anum_delete_vector_bitmap 3
+#define Anum_delete_vector_deleted_count 4
+#define Natts_delete_vector 4
 
 static Oid	columnar_schema_oid(void);
 static Relation open_columnar_table(const char *name, LOCKMODE lockmode);
@@ -158,24 +154,6 @@ ColumnarNextStorageId(void)
 
 	value = nextval_internal(seqOid, false);
 	return (uint64) value;
-}
-
-/*
- * ColumnarNextDeleteVectorId
- *		Draw the next value from columnar.delete_vector_seq (spec 7.5, 7.6).
- */
-uint64
-ColumnarNextDeleteVectorId(void)
-{
-	Oid			nspOid = columnar_schema_oid();
-	Oid			seqOid = get_relname_relid("delete_vector_seq", nspOid);
-
-	if (!OidIsValid(seqOid))
-		ereport(ERROR,
-				(errcode(ERRCODE_UNDEFINED_OBJECT),
-				 errmsg("columnar.delete_vector_seq does not exist")));
-
-	return (uint64) nextval_internal(seqOid, false);
 }
 
 /*
@@ -287,7 +265,7 @@ ColumnarComputeAllVisibleGroups(uint64 storageId, TransactionId oldestXmin)
 		rmList = ColumnarReadDeleteVectorList(storageId, groupNumber, &dirty);
 		foreach(lc, rmList)
 		{
-			if (((DeleteVectorMetadata *) lfirst(lc))->deletedRows > 0)
+			if (((DeleteVectorMetadata *) lfirst(lc))->deletedCount > 0)
 			{
 				hasDelete = true;
 				break;
@@ -368,7 +346,7 @@ ColumnarComputeFullyDeletedGroups(uint64 storageId, TransactionId oldestXmin)
 		 */
 		ScanKeyInit(&mkey[0], Anum_delete_vector_storage_id, BTEqualStrategyNumber,
 					F_INT8EQ, Int64GetDatum((int64) storageId));
-		ScanKeyInit(&mkey[1], Anum_delete_vector_stripe_id, BTEqualStrategyNumber,
+		ScanKeyInit(&mkey[1], Anum_delete_vector_group_number, BTEqualStrategyNumber,
 					F_INT8EQ, Int64GetDatum((int64) groupNumber));
 		mscan = systable_beginscan(mrel, InvalidOid, false, snap, 2, mkey);
 		while (HeapTupleIsValid(mtuple = systable_getnext(mscan)))
@@ -379,7 +357,7 @@ ColumnarComputeFullyDeletedGroups(uint64 storageId, TransactionId oldestXmin)
 				!TransactionIdPrecedes(mxmin, oldestXmin))
 				continue;
 			deletedSeen += DatumGetInt32(
-				heap_getattr(mtuple, Anum_delete_vector_deleted_rows, mtd, &isnull));
+				heap_getattr(mtuple, Anum_delete_vector_deleted_count, mtd, &isnull));
 		}
 		systable_endscan(mscan);
 
@@ -499,7 +477,7 @@ ColumnarRetireGroup(uint64 storageId, uint64 groupNumber)
 												 &fileOffset, &byteLength);
 
 	delete_group_rows("delete_vector", Anum_delete_vector_storage_id,
-					  Anum_delete_vector_stripe_id, storageId, groupNumber);
+					  Anum_delete_vector_group_number, storageId, groupNumber);
 	delete_group_rows("column_chunk", Anum_column_chunk_storage_id,
 					  Anum_column_chunk_group_number, storageId, groupNumber);
 	delete_group_rows("zone_map", Anum_zone_map_storage_id,
@@ -627,7 +605,7 @@ ColumnarReadDeleteVectorList(uint64 storageId, uint64 stripeId, Snapshot snapsho
 
 	ScanKeyInit(&key[0], Anum_delete_vector_storage_id, BTEqualStrategyNumber,
 				F_INT8EQ, Int64GetDatum((int64) storageId));
-	ScanKeyInit(&key[1], Anum_delete_vector_stripe_id, BTEqualStrategyNumber,
+	ScanKeyInit(&key[1], Anum_delete_vector_group_number, BTEqualStrategyNumber,
 				F_INT8EQ, Int64GetDatum((int64) stripeId));
 
 	scan = systable_beginscan(rel, InvalidOid, false, snapshot, 2, key);
@@ -635,34 +613,26 @@ ColumnarReadDeleteVectorList(uint64 storageId, uint64 stripeId, Snapshot snapsho
 	{
 		DeleteVectorMetadata *rm = palloc0(sizeof(DeleteVectorMetadata));
 		bool		isnull;
-		Datum		maskDatum;
+		Datum		bitmapDatum;
 
-		rm->id = (uint64) DatumGetInt64(
-			heap_getattr(tuple, Anum_delete_vector_id, tupdesc, &isnull));
-		rm->stripeId = stripeId;
-		rm->chunkId = DatumGetInt32(
-			heap_getattr(tuple, Anum_delete_vector_chunk_id, tupdesc, &isnull));
-		rm->startRowNumber = (uint64) DatumGetInt64(
-			heap_getattr(tuple, Anum_delete_vector_start_row_number, tupdesc, &isnull));
-		rm->endRowNumber = (uint64) DatumGetInt64(
-			heap_getattr(tuple, Anum_delete_vector_end_row_number, tupdesc, &isnull));
-		rm->deletedRows = DatumGetInt32(
-			heap_getattr(tuple, Anum_delete_vector_deleted_rows, tupdesc, &isnull));
+		rm->groupNumber = stripeId;
+		rm->deletedCount = DatumGetInt32(
+			heap_getattr(tuple, Anum_delete_vector_deleted_count, tupdesc, &isnull));
 
-		maskDatum = heap_getattr(tuple, Anum_delete_vector_mask, tupdesc, &isnull);
+		bitmapDatum = heap_getattr(tuple, Anum_delete_vector_bitmap, tupdesc, &isnull);
 		if (!isnull)
 		{
-			bytea	   *maskb = DatumGetByteaP(maskDatum);
+			bytea	   *bitmapb = DatumGetByteaP(bitmapDatum);
 
-			rm->maskLen = VARSIZE(maskb) >= VARHDRSZ ?
-				(uint32) (VARSIZE(maskb) - VARHDRSZ) : 0;
-			rm->mask = palloc(rm->maskLen + 1);
-			memcpy(rm->mask, VARDATA(maskb), rm->maskLen);
+			rm->bitmapLen = VARSIZE(bitmapb) >= VARHDRSZ ?
+				(uint32) (VARSIZE(bitmapb) - VARHDRSZ) : 0;
+			rm->bitmap = palloc(rm->bitmapLen + 1);
+			memcpy(rm->bitmap, VARDATA(bitmapb), rm->bitmapLen);
 		}
 		else
 		{
-			rm->mask = NULL;
-			rm->maskLen = 0;
+			rm->bitmap = NULL;
+			rm->bitmapLen = 0;
 		}
 
 		result = lappend(result, rm);
@@ -760,12 +730,11 @@ delete_vector_lock_chunk_group(uint64 storageId, uint64 stripeId, int chunkId)
 /*
  * ColumnarUpsertDeleteVector
  *		Insert or replace the delete_vector row for one chunk group, identified by
- *		(storage_id, stripe_id, chunk_id, start_row_number). If a row already
- *		exists it is replaced with the merged mask carried in rm; otherwise a
- *		fresh row is inserted with a new id from delete_vector_seq. Used at flush of
- *		the in-memory delete buffer (columnar_delete_vector.c), at most once per
- *		chunk group per flush, so a single heap tuple is never updated twice in
- *		the same command.
+ *		(storage_id, group_number). If a row already exists it is replaced with the
+ *		merged bitmap carried in rm; otherwise a fresh row is inserted. Used at
+ *		flush of the in-memory delete buffer (columnar_delete_vector.c), at most
+ *		once per chunk group per flush, so a single heap tuple is never updated
+ *		twice in the same command.
  *
  *		Concurrency (issue #4): the whole read-modify-write is guarded by a
  *		transaction-scoped chunk-group lock (delete_vector_lock_chunk_group), so two
@@ -773,7 +742,7 @@ delete_vector_lock_chunk_group(uint64 storageId, uint64 stripeId, int chunkId)
  *		instead of overwriting each other's delete bits. Once the lock is held,
  *		any earlier writer to this chunk group has committed, so the existing
  *		row is located with SnapshotSelf (which also sees this transaction's own
- *		prior modifications) and its bits are merged (bitwise OR) into rm->mask.
+ *		prior modifications) and its bits are merged (bitwise OR) into rm->bitmap.
  *		Because no concurrent writer can touch the tuple while we hold the lock,
  *		the CatalogTupleUpdate cannot lose an update and the CatalogTupleInsert
  *		on the first-delete path cannot hit a duplicate-key race.
@@ -816,19 +785,18 @@ ColumnarUpsertDeleteVector(uint64 storageId, DeleteVectorMetadata *rm)
 {
 	Relation	rel;
 	TupleDesc	tupdesc;
-	ScanKeyData key[4];
+	ScanKeyData key[2];
 	SysScanDesc scan;
 	HeapTuple	existing;
 	HeapTuple	tuple;
 	Datum		values[Natts_delete_vector];
 	bool		nulls[Natts_delete_vector];
-	bytea	   *maskb;
-	uint64		id = rm->id;
-	int			deletedRows = rm->deletedRows;
+	bytea	   *bitmapb;
+	int			deletedCount = rm->deletedCount;
 	ItemPointerData replaceTid;
 	bool		haveReplace = false;
 
-	delete_vector_lock_chunk_group(storageId, rm->stripeId, rm->chunkId);
+	delete_vector_lock_chunk_group(storageId, rm->groupNumber, 0);
 
 	/*
 	 * Phase F3b conflict detection. Having taken the chunk-group advisory lock,
@@ -852,7 +820,7 @@ ColumnarUpsertDeleteVector(uint64 storageId, DeleteVectorMetadata *rm)
 		 */
 		PushActiveSnapshot(GetLatestSnapshot());
 		latest = ColumnarCatalogSnapshot(GetActiveSnapshot());
-		exists = row_group_exists(storageId, rm->stripeId, latest);
+		exists = row_group_exists(storageId, rm->groupNumber, latest);
 		PopActiveSnapshot();
 		if (!exists)
 			ereport(ERROR,
@@ -866,43 +834,36 @@ ColumnarUpsertDeleteVector(uint64 storageId, DeleteVectorMetadata *rm)
 
 	ScanKeyInit(&key[0], Anum_delete_vector_storage_id, BTEqualStrategyNumber,
 				F_INT8EQ, Int64GetDatum((int64) storageId));
-	ScanKeyInit(&key[1], Anum_delete_vector_stripe_id, BTEqualStrategyNumber,
-				F_INT8EQ, Int64GetDatum((int64) rm->stripeId));
-	ScanKeyInit(&key[2], Anum_delete_vector_chunk_id, BTEqualStrategyNumber,
-				F_INT4EQ, Int32GetDatum(rm->chunkId));
-	ScanKeyInit(&key[3], Anum_delete_vector_start_row_number, BTEqualStrategyNumber,
-				F_INT8EQ, Int64GetDatum((int64) rm->startRowNumber));
+	ScanKeyInit(&key[1], Anum_delete_vector_group_number, BTEqualStrategyNumber,
+				F_INT8EQ, Int64GetDatum((int64) rm->groupNumber));
 
-	scan = systable_beginscan(rel, InvalidOid, false, SnapshotSelf, 4, key);
+	scan = systable_beginscan(rel, InvalidOid, false, SnapshotSelf, 2, key);
 	if (HeapTupleIsValid(existing = systable_getnext(scan)))
 	{
 		bool		isnull;
-		Datum		existingMask;
+		Datum		existingBitmap;
 
-		/* keep the existing id; merge the existing mask bits into rm->mask */
-		id = (uint64) DatumGetInt64(
-			heap_getattr(existing, Anum_delete_vector_id, tupdesc, &isnull));
-
-		existingMask = heap_getattr(existing, Anum_delete_vector_mask, tupdesc, &isnull);
+		/* merge the existing bitmap bits into rm->bitmap and recount */
+		existingBitmap = heap_getattr(existing, Anum_delete_vector_bitmap, tupdesc, &isnull);
 		if (!isnull)
 		{
-			bytea	   *eb = DatumGetByteaP(existingMask);
+			bytea	   *eb = DatumGetByteaP(existingBitmap);
 			uint32		elen = VARSIZE(eb) >= VARHDRSZ ?
 				(uint32) (VARSIZE(eb) - VARHDRSZ) : 0;
 			char	   *ebytes = VARDATA(eb);
 			uint32		i;
 			int			bit;
 
-			deletedRows = 0;
-			for (i = 0; i < rm->maskLen; i++)
+			deletedCount = 0;
+			for (i = 0; i < rm->bitmapLen; i++)
 			{
 				if (i < elen)
-					rm->mask[i] |= ebytes[i];
+					rm->bitmap[i] |= ebytes[i];
 			}
-			for (i = 0; i < rm->maskLen; i++)
+			for (i = 0; i < rm->bitmapLen; i++)
 				for (bit = 0; bit < 8; bit++)
-					if (rm->mask[i] & (1 << bit))
-						deletedRows++;
+					if (rm->bitmap[i] & (1 << bit))
+						deletedCount++;
 		}
 
 		replaceTid = existing->t_self;
@@ -911,18 +872,14 @@ ColumnarUpsertDeleteVector(uint64 storageId, DeleteVectorMetadata *rm)
 	systable_endscan(scan);
 
 	memset(nulls, false, sizeof(nulls));
-	values[Anum_delete_vector_id - 1] = Int64GetDatum((int64) id);
 	values[Anum_delete_vector_storage_id - 1] = Int64GetDatum((int64) storageId);
-	values[Anum_delete_vector_stripe_id - 1] = Int64GetDatum((int64) rm->stripeId);
-	values[Anum_delete_vector_chunk_id - 1] = Int32GetDatum(rm->chunkId);
-	values[Anum_delete_vector_start_row_number - 1] = Int64GetDatum((int64) rm->startRowNumber);
-	values[Anum_delete_vector_end_row_number - 1] = Int64GetDatum((int64) rm->endRowNumber);
-	values[Anum_delete_vector_deleted_rows - 1] = Int32GetDatum(deletedRows);
+	values[Anum_delete_vector_group_number - 1] = Int64GetDatum((int64) rm->groupNumber);
+	values[Anum_delete_vector_deleted_count - 1] = Int32GetDatum(deletedCount);
 
-	maskb = (bytea *) palloc(VARHDRSZ + rm->maskLen);
-	SET_VARSIZE(maskb, VARHDRSZ + rm->maskLen);
-	memcpy(VARDATA(maskb), rm->mask, rm->maskLen);
-	values[Anum_delete_vector_mask - 1] = PointerGetDatum(maskb);
+	bitmapb = (bytea *) palloc(VARHDRSZ + rm->bitmapLen);
+	SET_VARSIZE(bitmapb, VARHDRSZ + rm->bitmapLen);
+	memcpy(VARDATA(bitmapb), rm->bitmap, rm->bitmapLen);
+	values[Anum_delete_vector_bitmap - 1] = PointerGetDatum(bitmapb);
 
 	tuple = heap_form_tuple(tupdesc, values, nulls);
 

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -929,15 +929,15 @@ columnar_native_load_group(ColumnarReadState *rs)
 			DeleteVectorMetadata *rm = (DeleteVectorMetadata *) lfirst(mlc);
 			uint32		i;
 
-			if (rm->mask == NULL || rm->maskLen == 0)
+			if (rm->bitmap == NULL || rm->bitmapLen == 0)
 				continue;
 			if (rs->nativeDeleteMask == NULL)
 			{
 				rs->nativeDeleteMask = palloc0(want > 0 ? want : 1);
 				rs->nativeDeleteMaskLen = want;
 			}
-			for (i = 0; i < rm->maskLen && i < want; i++)
-				rs->nativeDeleteMask[i] |= rm->mask[i];
+			for (i = 0; i < rm->bitmapLen && i < want; i++)
+				rs->nativeDeleteMask[i] |= rm->bitmap[i];
 		}
 	}
 
@@ -1185,15 +1185,15 @@ ColumnarBuildLivenessCache(Relation rel, Snapshot snapshot)
 			DeleteVectorMetadata *rm = (DeleteVectorMetadata *) lfirst(mc);
 			uint32		b;
 
-			if (rm->mask == NULL || rm->maskLen == 0)
+			if (rm->bitmap == NULL || rm->bitmapLen == 0)
 				continue;
 			if (e->masks[0] == NULL)
 			{
 				e->masks[0] = palloc0(want > 0 ? want : 1);
 				e->maskLens[0] = want;
 			}
-			for (b = 0; b < rm->maskLen && b < want; b++)
-				e->masks[0][b] |= rm->mask[b];
+			for (b = 0; b < rm->bitmapLen && b < want; b++)
+				e->masks[0][b] |= rm->bitmap[b];
 		}
 	}
 
@@ -1317,8 +1317,8 @@ ColumnarReadRowByNumber(Relation rel, Snapshot snapshot, uint64 rowNumber,
 		{
 			DeleteVectorMetadata *rm = (DeleteVectorMetadata *) lfirst(mlc);
 
-			if (rm->mask != NULL && (rowInGrp >> 3) < rm->maskLen &&
-				(rm->mask[rowInGrp >> 3] & (1 << (rowInGrp & 7))) != 0)
+			if (rm->bitmap != NULL && (rowInGrp >> 3) < rm->bitmapLen &&
+				(rm->bitmap[rowInGrp >> 3] & (1 << (rowInGrp & 7))) != 0)
 				deleted = true;
 		}
 		if (deleted)

--- a/src/columnar_vacuum.c
+++ b/src/columnar_vacuum.c
@@ -273,7 +273,7 @@ columnar_rewrite_partial_groups(Relation rel, double minDeletedFraction,
 			continue;
 		rmList = ColumnarReadDeleteVectorList(storageId, rg->groupNumber, snap);
 		foreach(lc2, rmList)
-			deleted += ((DeleteVectorMetadata *) lfirst(lc2))->deletedRows;
+			deleted += ((DeleteVectorMetadata *) lfirst(lc2))->deletedCount;
 
 		/* partially deleted and past the threshold; fully-dead is F3a's job */
 		if (deleted > 0 && deleted < (int64) rg->rowCount &&

--- a/test/phase3.sh
+++ b/test/phase3.sh
@@ -125,7 +125,7 @@ check "delete tail count"  "$(q 'SELECT count(*) FROM d;')"                     
 check "delete tail max"    "$(q 'SELECT max(id) FROM d;')"                        "20000"
 # delete_vector catalog reflects the deletions
 check "delete_vector rows>0"    "$(q 'SELECT (count(*) > 0)::int FROM pgcolumnar.delete_vector;')" "1"
-check "delete_vector deleted"   "$(q 'SELECT sum(deleted_rows) FROM pgcolumnar.delete_vector;')"   "5011"
+check "delete_vector deleted"   "$(q 'SELECT sum(deleted_count) FROM pgcolumnar.delete_vector;')"   "5011"
 q "DROP TABLE d;" >/dev/null
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Completes F1. The `delete_vector` catalog is now the spec's `(storage_id, group_number, bitmap, deleted_count)` keyed uniquely by `(storage_id, group_number)`. Dropped the surrogate `id` column and its `delete_vector_seq` sequence, `chunk_id`, `start_row_number`, `end_row_number`, and the two extra unique indexes; renamed the data columns to `bitmap` / `deleted_count`.

**Safe because no consumer used the dropped columns.** Every reader interprets the bitmap group-relative from the row_group's `first_row_number` (`rowInGrp = rowNumber - rg->firstRowNumber`), never from a stored `start_row_number`, and there is exactly one `delete_vector` row per group (chunk id always 0), so `(storage_id, group_number)` is the natural key. The in-memory delete buffer is unchanged; only the catalog DTO and its I/O changed. The chunk-group advisory lock and the F3b concurrent-rewrite conflict detection are preserved.

Net −56 lines. Full PostgreSQL 15-19 matrix green; the delete-mechanism suites (DML, differential oracle, concurrency, unique-conflict, rewrite, reclaim-cycles, isolation) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)