### PR TITLE
Phase F reclaim: free-space splitting and coalescing

### DIFF
--- a/design/PHASE_F_RECLAIM_SPLIT_COALESCE_PLAN.md
+++ b/design/PHASE_F_RECLAIM_SPLIT_COALESCE_PLAN.md
@@ -1,9 +1,27 @@
 # Phase F reclaim: free-space splitting and coalescing (design, for review)
 
-Status: proposed. Not implemented. This is an allocator change to on-disk offset
-management and is corruption-critical, so it is written up for review before any
-code lands, in the same way end-truncation was deferred in
-[PHASE_F_RECLAIM_PLAN.md](PHASE_F_RECLAIM_PLAN.md).
+Status: IMPLEMENTED (2026-07-23), behind the `pgcolumnar.reclaim_coalesce` GUC
+(default on; off reverts to whole-range reuse). Two refinements were made during
+implementation and are worth recording:
+
+- **Store the page-rounded footprint, not the exact byte length.** `record_free_space`
+  now rounds a freed range up to a whole page (`COLUMNAR_PAGE_ROUND_UP`), so free
+  ranges tile the file page-aligned in both offset and length. This is what makes
+  a split remnant and a coalesced union stay page-aligned, and it also reclaims a
+  group's trailing padding.
+- **Coalesce only ranges freed by the SAME transaction.** Merging a fresh free
+  with an older, already-reusable neighbor forces the union to the newer freed_xid
+  (required for safety), which delays reuse of space that was reusable a moment
+  ago -- a measured regression (the file grew every cycle in native_reclaim_cycles
+  until this was restricted). Same-transaction coalescing still merges the many
+  groups one maintenance operation retires together, which is the fragmentation
+  case that matters, without poisoning older reusable ranges.
+
+Result on the fragmentation test (native_reclaim_frag): retiring 18 adjacent
+groups yields 1 coalesced free range with the GUC on vs 18 fragmented rows off,
+and a large reclustering then reuses in place (smaller final file) instead of
+extending. The assert-only no-overlap validator runs at the end of every online
+maintenance op. The rest of this document is the original design.
 
 ## Current behavior
 

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -82,6 +82,17 @@
 #define COLUMNAR_FIRST_LOGICAL_OFFSET (2 * COLUMNAR_BYTES_PER_PAGE)
 
 /*
+ * Round a logical byte length up to a whole number of pages. Every reservation
+ * (ColumnarReserveOffset) starts on a page boundary and the next one starts on
+ * the next page boundary, so a group's on-disk footprint is its data length
+ * rounded up to a page. Physical reclaim keeps free ranges page-aligned in both
+ * offset and length by working in these footprints.
+ */
+#define COLUMNAR_PAGE_ROUND_UP(n) \
+	(((((uint64) (n)) + COLUMNAR_BYTES_PER_PAGE - 1) / COLUMNAR_BYTES_PER_PAGE) \
+	 * COLUMNAR_BYTES_PER_PAGE)
+
+/*
  * Row-number <-> item-pointer mapping (spec 6).
  *
  * VALID_ITEMPOINTER_OFFSETS is the count of item-pointer offsets we use per
@@ -333,6 +344,21 @@ extern bool ColumnarAllocateFreeSpace(uint64 storageId, uint64 dataLength,
 									  TransactionId oldestXmin, uint64 *fileOffset);
 extern List *ColumnarComputeAllVisibleGroups(uint64 storageId,
 											 TransactionId oldestXmin);
+
+/* physical reclaim: split freed ranges on allocate and coalesce on free (GUC) */
+extern bool columnar_reclaim_coalesce;
+
+/*
+ * Assert-only invariant: a storage's live row-group footprints and its
+ * free_space ranges tile the file page-aligned with no overlap. Compiled and
+ * called only in assert builds (the version matrix builds with asserts).
+ */
+#ifdef USE_ASSERT_CHECKING
+extern void ColumnarCheckFreeSpaceNoOverlap(uint64 storageId);
+#define COLUMNAR_ASSERT_NO_OVERLAP(sid) ColumnarCheckFreeSpaceNoOverlap(sid)
+#else
+#define COLUMNAR_ASSERT_NO_OVERLAP(sid) ((void) 0)
+#endif
 
 /* -------------------------------------------------------------------------
  * metadata layer (columnar_metadata.c)

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -435,12 +435,14 @@ read_row_group_range(uint64 storageId, uint64 groupNumber,
 	return found;
 }
 
-/* record a freed data range for later reuse (Phase F physical reclaim) */
+/* physical reclaim: split freed ranges on allocate and coalesce on free */
+bool		columnar_reclaim_coalesce = true;
+
+/* insert one free_space row (offset, length page-aligned, freed at freedXid) */
 static void
-record_free_space(uint64 storageId, uint64 fileOffset, uint64 byteLength)
+insert_free_space_row(Relation rel, TupleDesc td, uint64 storageId,
+					  uint64 fileOffset, uint64 byteLength, TransactionId freedXid)
 {
-	Relation	rel = open_columnar_table("free_space", RowExclusiveLock);
-	TupleDesc	td = RelationGetDescr(rel);
 	Datum		values[Natts_free_space];
 	bool		nulls[Natts_free_space];
 	HeapTuple	tuple;
@@ -449,12 +451,102 @@ record_free_space(uint64 storageId, uint64 fileOffset, uint64 byteLength)
 	values[Anum_free_space_storage_id - 1] = Int64GetDatum((int64) storageId);
 	values[Anum_free_space_file_offset - 1] = Int64GetDatum((int64) fileOffset);
 	values[Anum_free_space_byte_length - 1] = Int64GetDatum((int64) byteLength);
-	values[Anum_free_space_freed_xid - 1] =
-		Int64GetDatum((int64) GetCurrentTransactionId());
+	values[Anum_free_space_freed_xid - 1] = Int64GetDatum((int64) freedXid);
 
 	tuple = heap_form_tuple(td, values, nulls);
 	CatalogTupleInsert(rel, tuple);
 	heap_freetuple(tuple);
+}
+
+/*
+ * record_free_space
+ *		Record a freed data range for later reuse (Phase F physical reclaim). The
+ *		range is stored as its page-aligned footprint (the group's data rounded up
+ *		to a whole page), so free ranges tile the file page-aligned and a split
+ *		remnant or a coalesced union stays page-aligned.
+ *
+ *		When columnar.reclaim_coalesce is on, the new range is merged with any
+ *		immediately adjacent existing free range (left neighbor ending at this
+ *		offset, or right neighbor starting at this range's end) before insertion,
+ *		so a later request larger than either neighbor can still be satisfied from
+ *		contiguous free space. The merged freeing xid is the newest of the merged
+ *		ranges, so reuse stays gated until every component is behind the horizon.
+ */
+static void
+record_free_space(uint64 storageId, uint64 fileOffset, uint64 byteLength)
+{
+	Relation	rel = open_columnar_table("free_space", RowExclusiveLock);
+	TupleDesc	td = RelationGetDescr(rel);
+	uint64		off = fileOffset;
+	uint64		len = COLUMNAR_PAGE_ROUND_UP(byteLength);
+	uint64		origOff = off;
+	uint64		origEnd = off + len;
+	TransactionId freedXid = GetCurrentTransactionId();
+
+	if (columnar_reclaim_coalesce)
+	{
+		Snapshot	snap = RegisterSnapshot(GetLatestSnapshot());
+		ScanKeyData key[1];
+		SysScanDesc scan;
+		HeapTuple	tuple;
+		ItemPointerData mergeTids[2];
+		int			nMerge = 0;
+
+		ScanKeyInit(&key[0], Anum_free_space_storage_id, BTEqualStrategyNumber,
+					F_INT8EQ, Int64GetDatum((int64) storageId));
+		scan = systable_beginscan(rel, InvalidOid, false, snap, 1, key);
+		while (HeapTupleIsValid(tuple = systable_getnext(scan)))
+		{
+			bool		isnull;
+			uint64		noff = (uint64) DatumGetInt64(
+				heap_getattr(tuple, Anum_free_space_file_offset, td, &isnull));
+			uint64		nlen = (uint64) DatumGetInt64(
+				heap_getattr(tuple, Anum_free_space_byte_length, td, &isnull));
+			TransactionId nxid = (TransactionId) DatumGetInt64(
+				heap_getattr(tuple, Anum_free_space_freed_xid, td, &isnull));
+
+			/*
+			 * Only coalesce ranges freed by THIS transaction (same freed_xid).
+			 * Merging a fresh free with an older, already-reusable neighbor would
+			 * force the union to the newer xid (required for safety: reuse must
+			 * wait until every merged component is behind the horizon), which would
+			 * delay reuse of space that was reusable a moment ago -- a net loss.
+			 * Same-xid coalescing still merges the many groups one maintenance
+			 * operation retires together, which is the fragmentation case that
+			 * matters, without poisoning older reusable ranges.
+			 *
+			 * Adjacency is tested against the ORIGINAL range bounds. The file is
+			 * already maximally coalesced before this insert, so there is at most
+			 * one left neighbor (ends at origOff) and one right neighbor (starts
+			 * at origEnd); testing against the accumulating bounds would be wrong.
+			 */
+			if (nxid == freedXid && (noff + nlen == origOff || noff == origEnd))
+			{
+				off = Min(off, noff);
+				len += nlen;
+				if (nMerge < 2)
+					mergeTids[nMerge++] = tuple->t_self;
+			}
+		}
+		systable_endscan(scan);
+
+		if (nMerge > 0)
+		{
+			int			i;
+
+			for (i = 0; i < nMerge; i++)
+				CatalogTupleDelete(rel, &mergeTids[i]);
+			/* make the deletes visible before inserting the merged row so the
+			 * unique (storage_id, file_offset) key cannot collide with a just-
+			 * deleted neighbor, and so a later record in this command sees it */
+			CommandCounterIncrement();
+		}
+		UnregisterSnapshot(snap);
+	}
+
+	insert_free_space_row(rel, td, storageId, off, len, freedXid);
+	if (columnar_reclaim_coalesce)
+		CommandCounterIncrement();
 	table_close(rel, RowExclusiveLock);
 }
 
@@ -514,6 +606,7 @@ ColumnarAllocateFreeSpace(uint64 storageId, uint64 dataLength,
 	bool		found = false;
 	uint64		bestOff = 0;
 	uint64		bestLen = 0;
+	TransactionId bestXid = InvalidTransactionId;
 	ItemPointerData bestTid;
 
 	ItemPointerSetInvalid(&bestTid);
@@ -539,6 +632,7 @@ ColumnarAllocateFreeSpace(uint64 storageId, uint64 dataLength,
 		{
 			found = true;
 			bestLen = len;
+			bestXid = fxid;
 			bestOff = (uint64) DatumGetInt64(
 				heap_getattr(tuple, Anum_free_space_file_offset, td, &isnull));
 			bestTid = tuple->t_self;
@@ -550,11 +644,29 @@ ColumnarAllocateFreeSpace(uint64 storageId, uint64 dataLength,
 	{
 		CatalogTupleDelete(rel, &bestTid);
 		*fileOffset = bestOff;
+
+		/*
+		 * Split: the reservation consumes a whole number of pages (allocLen), so
+		 * the remnant beyond it stays page-aligned and reusable. Record it back
+		 * with the same freeing xid as the consumed range (already frozen, so the
+		 * same oldest-xmin gate still applies). Without this the tail of an
+		 * oversized freed range would leak until its group is re-freed.
+		 */
+		if (columnar_reclaim_coalesce)
+		{
+			uint64		allocLen = COLUMNAR_PAGE_ROUND_UP(dataLength);
+
+			if (bestLen > allocLen)
+				insert_free_space_row(rel, td, storageId, bestOff + allocLen,
+									  bestLen - allocLen, bestXid);
+		}
+
 		/*
 		 * A single compaction command can allocate many blocks in a row. Make
-		 * this consumption visible to the next allocation's scan within the same
-		 * command; otherwise it would still see this row as free, re-select it,
-		 * and fail with "tuple already updated by self" on the second delete.
+		 * this consumption (and any remnant) visible to the next allocation's scan
+		 * within the same command; otherwise it would still see this row as free,
+		 * re-select it, and fail with "tuple already updated by self" on the
+		 * second delete.
 		 */
 		CommandCounterIncrement();
 	}
@@ -562,6 +674,119 @@ ColumnarAllocateFreeSpace(uint64 storageId, uint64 dataLength,
 	table_close(rel, RowExclusiveLock);
 	return found;
 }
+
+#ifdef USE_ASSERT_CHECKING
+typedef struct ReclaimRange
+{
+	uint64		off;
+	uint64		len;
+} ReclaimRange;
+
+static int
+reclaim_range_cmp(const void *a, const void *b)
+{
+	uint64		oa = ((const ReclaimRange *) a)->off;
+	uint64		ob = ((const ReclaimRange *) b)->off;
+
+	if (oa < ob)
+		return -1;
+	if (oa > ob)
+		return 1;
+	return 0;
+}
+
+/*
+ * ColumnarCheckFreeSpaceNoOverlap
+ *		Assert-only invariant check for physical reclaim: a storage's live
+ *		row-group footprints (data rounded up to whole pages) and its free_space
+ *		ranges must not overlap. An overlap would mean a reused block was handed
+ *		out on top of live data or another free range, i.e. corruption. Called at
+ *		the end of the online maintenance operations in assert builds.
+ */
+void
+ColumnarCheckFreeSpaceNoOverlap(uint64 storageId)
+{
+	Relation	rg;
+	Relation	fs;
+	TupleDesc	rgd;
+	TupleDesc	fsd;
+	Snapshot	snap;
+	ScanKeyData key[1];
+	SysScanDesc scan;
+	HeapTuple	t;
+	ReclaimRange *ranges;
+	int			n = 0;
+	int			cap = 64;
+	int			i;
+
+	/* see this transaction's own writes made so far in the command */
+	CommandCounterIncrement();
+	snap = RegisterSnapshot(GetLatestSnapshot());
+	rg = open_columnar_table("row_group", AccessShareLock);
+	fs = open_columnar_table("free_space", AccessShareLock);
+	rgd = RelationGetDescr(rg);
+	fsd = RelationGetDescr(fs);
+	ranges = palloc(sizeof(ReclaimRange) * cap);
+
+	ScanKeyInit(&key[0], Anum_row_group_storage_id, BTEqualStrategyNumber,
+				F_INT8EQ, Int64GetDatum((int64) storageId));
+	scan = systable_beginscan(rg, InvalidOid, false, snap, 1, key);
+	while (HeapTupleIsValid(t = systable_getnext(scan)))
+	{
+		bool		isnull;
+		uint64		off = (uint64) DatumGetInt64(
+			heap_getattr(t, Anum_row_group_file_offset, rgd, &isnull));
+		uint64		blen = (uint64) DatumGetInt64(
+			heap_getattr(t, Anum_row_group_byte_length, rgd, &isnull));
+
+		if (blen == 0)
+			continue;
+		if (n == cap)
+			ranges = repalloc(ranges, sizeof(ReclaimRange) * (cap *= 2));
+		ranges[n].off = off;
+		ranges[n].len = COLUMNAR_PAGE_ROUND_UP(blen);
+		n++;
+	}
+	systable_endscan(scan);
+
+	ScanKeyInit(&key[0], Anum_free_space_storage_id, BTEqualStrategyNumber,
+				F_INT8EQ, Int64GetDatum((int64) storageId));
+	scan = systable_beginscan(fs, InvalidOid, false, snap, 1, key);
+	while (HeapTupleIsValid(t = systable_getnext(scan)))
+	{
+		bool		isnull;
+		uint64		off = (uint64) DatumGetInt64(
+			heap_getattr(t, Anum_free_space_file_offset, fsd, &isnull));
+		uint64		len = (uint64) DatumGetInt64(
+			heap_getattr(t, Anum_free_space_byte_length, fsd, &isnull));
+
+		if (len == 0)
+			continue;
+		if (n == cap)
+			ranges = repalloc(ranges, sizeof(ReclaimRange) * (cap *= 2));
+		ranges[n].off = off;
+		ranges[n].len = len;
+		n++;
+	}
+	systable_endscan(scan);
+
+	qsort(ranges, n, sizeof(ReclaimRange), reclaim_range_cmp);
+	for (i = 1; i < n; i++)
+	{
+		if (ranges[i].off < ranges[i - 1].off + ranges[i - 1].len)
+			elog(ERROR,
+				 "columnar reclaim: overlapping ranges [" UINT64_FORMAT ",+"
+				 UINT64_FORMAT ") and [" UINT64_FORMAT ",+" UINT64_FORMAT ")",
+				 ranges[i - 1].off, ranges[i - 1].len,
+				 ranges[i].off, ranges[i].len);
+	}
+
+	pfree(ranges);
+	table_close(fs, AccessShareLock);
+	table_close(rg, AccessShareLock);
+	UnregisterSnapshot(snap);
+}
+#endif							/* USE_ASSERT_CHECKING */
 
 /*
  * ColumnarRetireFullyDeletedGroups

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -1200,6 +1200,17 @@ _PG_init(void)
 							 0,
 							 NULL, NULL, NULL);
 
+	DefineCustomBoolVariable("pgcolumnar.reclaim_coalesce",
+							 "Split oversized freed ranges on reuse and coalesce "
+							 "adjacent freed ranges, so compaction reclaims space "
+							 "under fragmentation. Off reverts to whole-range reuse.",
+							 NULL,
+							 &columnar_reclaim_coalesce,
+							 true,
+							 PGC_USERSET,
+							 0,
+							 NULL, NULL, NULL);
+
 	DefineCustomBoolVariable("pgcolumnar.enable_read_stream",
 							 "Prefetch block reads with the read stream API (PostgreSQL 17+).",
 							 NULL,

--- a/src/columnar_vacuum.c
+++ b/src/columnar_vacuum.c
@@ -305,6 +305,7 @@ columnar_rewrite_partial_groups(Relation rel, double minDeletedFraction,
 	}
 	rewrite_index_close(&ris);
 
+	COLUMNAR_ASSERT_NO_OVERLAP(storageId);
 	return rewritten;
 }
 
@@ -462,6 +463,8 @@ columnar_recluster_online(Relation rel, int ncols, AttrNumber *atts)
 	PopActiveSnapshot();
 	UnregisterSnapshot(snap);
 	pfree(oldGroups);
+
+	COLUMNAR_ASSERT_NO_OVERLAP(storageId);
 	return nGroups;
 }
 
@@ -1370,6 +1373,8 @@ columnar_compact(PG_FUNCTION_ARGS)
 	}
 
 	retired = ColumnarRetireFullyDeletedGroups(rel);
+
+	COLUMNAR_ASSERT_NO_OVERLAP(ColumnarStorageId(rel));
 
 	/* keep the lock until end of transaction */
 	table_close(rel, NoLock);

--- a/test/native_reclaim_frag.sh
+++ b/test/native_reclaim_frag.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# pgColumnar physical reclaim under fragmentation (Phase F split/coalesce).
+#
+# Runs an identical retire+recluster workload twice -- once with
+# pgcolumnar.reclaim_coalesce on (split oversized freed ranges on reuse, coalesce
+# adjacent same-transaction frees) and once off (whole-range reuse) -- and
+# asserts:
+#   * the live set matches a heap mirror in BOTH modes (correctness);
+#   * coalescing actually merges: fully deleting a large CONTIGUOUS block of
+#     groups and compacting frees many small adjacent byte ranges, and with the
+#     GUC on they collapse to FEWER free_space rows than with it off (direct,
+#     deterministic evidence the coalesce path runs); and
+#   * coalesce is never worse than whole-range reuse for the final file size.
+# The assert-build no-overlap validator (ColumnarCheckFreeSpaceNoOverlap) runs at
+# the end of every compaction here, so this also exercises the tiling invariant
+# on variable-size ranges.
+#
+# Usage:  test/native_reclaim_frag.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+# group k (= id/1000) gets width 10..250 bytes, so byte sizes vary widely.
+GEN="SELECT g AS id, repeat('ab', 5 + ((g / 1000) % 16) * 8) AS payload
+  FROM generate_series(1, 30000) g"
+
+freerows() { q "SELECT count(*) FROM pgcolumnar.free_space WHERE storage_id = pgcolumnar.get_storage_id('n');"; }
+
+run() {			# $1 = on|off ; echoes "<free_rows_after_compact>|<final_size>|<ok|MISMATCH>"
+	{
+		psql_run "DROP TABLE IF EXISTS n;"
+		psql_run "DROP TABLE IF EXISTS h;"
+		psql_run "CREATE TABLE h (id int, payload text);"
+		psql_run "CREATE TABLE n (id int, payload text) USING pgcolumnar;"
+		# 30 groups of 1000 rows so a deleted block frees many adjacent ranges.
+		psql_run "SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 1000, chunk_group_row_limit => 1000);"
+		psql_run "SET pgcolumnar.reclaim_coalesce = $1; INSERT INTO h $GEN;"
+		psql_run "SET pgcolumnar.reclaim_coalesce = $1; INSERT INTO n $GEN;"
+		# fully delete a large CONTIGUOUS block of groups, then compact: many small
+		# adjacent byte ranges are freed in one transaction.
+		psql_run "SET pgcolumnar.reclaim_coalesce = $1; DELETE FROM h WHERE id BETWEEN 6001 AND 24000;"
+		psql_run "SET pgcolumnar.reclaim_coalesce = $1; DELETE FROM n WHERE id BETWEEN 6001 AND 24000;"
+		psql_run "SET pgcolumnar.reclaim_coalesce = $1; SELECT pgcolumnar.compact('n');"
+	} >/dev/null 2>&1
+
+	# free_space rows right after the compaction, before anything consumes them.
+	local fr size ph hh
+	fr="$(freerows)"
+
+	{
+		# force large output groups and recluster: reuses the freed space.
+		psql_run "SET pgcolumnar.reclaim_coalesce = $1; SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 20000, chunk_group_row_limit => 20000);"
+		psql_run "SET pgcolumnar.reclaim_coalesce = $1; SELECT pgcolumnar.recluster('n', 'id');"
+	} >/dev/null 2>&1
+
+	size="$(q 'SELECT pg_relation_size('"'"'n'"'"');')"
+	ph="$(pgc_set_hash 'SELECT id, payload FROM n')"
+	hh="$(pgc_set_hash 'SELECT id, payload FROM h')"
+	echo "${fr}|${size}|$([ "$ph" = "$hh" ] && echo ok || echo MISMATCH)"
+}
+
+on="$(run on)";  off="$(run off)"
+on_fr="${on%%|*}";   on_rest="${on#*|}";   on_size="${on_rest%%|*}";   on_par="${on##*|}"
+off_fr="${off%%|*}"; off_rest="${off#*|}"; off_size="${off_rest%%|*}"; off_par="${off##*|}"
+
+check "coalesce on: parity with heap"  "$on_par"  "ok"
+check "coalesce off: parity with heap" "$off_par" "ok"
+echo "  (free_space rows after compact: coalesce-on=$on_fr coalesce-off=$off_fr)"
+echo "  (final file size: coalesce-on=$on_size coalesce-off=$off_size)"
+check "coalesce merges adjacent frees (fewer free_space rows)" \
+	"$([ "$on_fr" -lt "$off_fr" ] && echo yes || echo no)" "yes"
+check "coalesce never larger than whole-range reuse" \
+	"$([ "$on_size" -le "$off_size" ] && echo yes || echo no)" "yes"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -27,7 +27,7 @@ SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUITES=(smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
 	differential recovery fuzz hardening concurrent_diff parallel sorted_projection \
 	arrow_export parquet_export read_stream corruption \
-	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip native_index native_dml native_ios native_projection native_cluster native_compact native_recluster native_reclaim native_reclaim_cycles native_rewrite native_rewrite_conc isolation)
+	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip native_index native_dml native_ios native_projection native_cluster native_compact native_recluster native_reclaim native_reclaim_cycles native_reclaim_frag native_rewrite native_rewrite_conc isolation)
 
 # Default matrix: one assert-enabled pg_config per major, 15 through 19.
 DEFAULT_CONFIGS=(


### PR DESCRIPTION
Adds partial-block reuse (split-on-allocate) and adjacency coalescing (coalesce-on-free) to the physical-reclaim free list, behind `pgcolumnar.reclaim_coalesce` (default on; off reverts to whole-range reuse).

- `record_free_space` stores the page-aligned footprint, so free ranges tile the file page-aligned.
- `ColumnarAllocateFreeSpace` splits an oversized chosen range and records the page-aligned remnant.
- `record_free_space` merges an immediately adjacent range before insertion — **restricted to ranges freed by the same transaction**, so it never forces an older already-reusable neighbor to a newer `freed_xid` (which delays reuse; `native_reclaim_cycles` caught that regression). Same-transaction coalescing still merges the many groups one maintenance op retires together — the fragmentation case that matters.

**Guards:** an assert-only invariant (`ColumnarCheckFreeSpaceNoOverlap`) runs at the end of each online maintenance op — live footprints and free ranges must tile with no overlap. New `native_reclaim_frag.sh`: retiring 18 adjacent groups → **1** coalesced free range (GUC on) vs **18** fragmented rows (off), and a large recluster then reuses in place (smaller final file) instead of extending; parity holds in both modes.

Full PostgreSQL 15-19 matrix green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)