### PR TITLE
Phase F: gap-tolerant writes (end-truncation prerequisite)

### DIFF
--- a/src/columnar.h
+++ b/src/columnar.h
@@ -307,6 +307,7 @@ extern void ColumnarReserveRowNumbers(Relation rel, uint64 rowCount,
 									  uint64 *stripeId, uint64 *firstRowNumber);
 extern void ColumnarReserveOffset(Relation rel, uint64 dataLength,
 								  uint64 *fileOffset);
+extern void ColumnarAdvanceReservedOffset(Relation rel, uint64 addBytes);
 extern void ColumnarWriteLogicalData(Relation rel, uint64 logicalOffset,
 									 char *data, uint64 length);
 extern void ColumnarReadLogicalData(Relation rel, uint64 logicalOffset,

--- a/src/columnar_storage.c
+++ b/src/columnar_storage.c
@@ -238,6 +238,41 @@ ColumnarReserveOffset(Relation rel, uint64 dataLength, uint64 *fileOffset)
 }
 
 /*
+ * ColumnarAdvanceReservedOffset
+ *		Increase the metapage highwater by addBytes without writing any data,
+ *		leaving a gap between the physical EOF and the new highwater. This is a
+ *		test hook for the gap-tolerant write path (it deliberately produces the
+ *		"highwater ahead of EOF" state that an aborted end-truncation leaves).
+ *		Increase-only, so it can never make the highwater overlap live data.
+ */
+void
+ColumnarAdvanceReservedOffset(Relation rel, uint64 addBytes)
+{
+	Buffer		buffer;
+	Page		page;
+	ColumnarMetapage *meta;
+
+	buffer = ReadBuffer(rel, COLUMNAR_METAPAGE_BLOCKNO);
+	LockBuffer(buffer, BUFFER_LOCK_EXCLUSIVE);
+	page = BufferGetPage(buffer);
+	meta = ColumnarMetapagePointer(page);
+
+	meta->reservedOffset += addBytes;
+
+	START_CRIT_SECTION();
+	MarkBufferDirty(buffer);
+	if (RelationNeedsWAL(rel))
+	{
+		XLogRecPtr	recptr = log_newpage_buffer(buffer, true);
+
+		PageSetLSN(page, recptr);
+	}
+	END_CRIT_SECTION();
+
+	UnlockReleaseBuffer(buffer);
+}
+
+/*
  * ColumnarWriteLogicalData
  *		Write a contiguous logical byte range starting at a page-aligned
  *		logical offset, splitting it across the physical pages it maps to
@@ -245,6 +280,14 @@ ColumnarReserveOffset(Relation rel, uint64 dataLength, uint64 *fileOffset)
  *		blocks below it are reused freed ranges (Phase F reclaim) and written in
  *		place. Reuse is only ever handed out for ranges no snapshot can still read
  *		(oldest-xmin gated), so overwriting the old contents is safe.
+ *
+ *		The target block may be strictly BEYOND the current EOF (a gap) when the
+ *		metapage highwater is ahead of the physical file -- this is the state left
+ *		by an aborted or crash-interrupted end-truncation (the file was shortened
+ *		but the highwater was not, or the shortening's catalog changes rolled back).
+ *		Such a gap is filled with empty pages up to the target block, so the state
+ *		self-heals: the next write simply re-extends the fork. The caller holds the
+ *		relation extension lock, so the P_NEW extensions here are serialized.
  */
 void
 ColumnarWriteLogicalData(Relation rel, uint64 logicalOffset,
@@ -275,7 +318,31 @@ ColumnarWriteLogicalData(Relation rel, uint64 logicalOffset,
 		}
 		else
 		{
-			/* append: extend the relation by one block */
+			/*
+			 * Fill any gap between the current EOF and the target block with
+			 * empty, WAL-logged pages so a standby extends identically, then the
+			 * final P_NEW lands exactly on the target block. In the common append
+			 * case (blockno == nblocks) the gap loop does nothing.
+			 */
+			while (nblocks < blockno)
+			{
+				Buffer		gap = ReadBufferExtended(rel, MAIN_FORKNUM, P_NEW,
+													 RBM_NORMAL, NULL);
+				Page		gpage;
+
+				LockBuffer(gap, BUFFER_LOCK_EXCLUSIVE);
+				gpage = BufferGetPage(gap);
+				PageInit(gpage, BLCKSZ, 0);
+				START_CRIT_SECTION();
+				MarkBufferDirty(gap);
+				if (RelationNeedsWAL(rel))
+					PageSetLSN(gpage, log_newpage_buffer(gap, true));
+				END_CRIT_SECTION();
+				UnlockReleaseBuffer(gap);
+				nblocks++;
+			}
+
+			/* append: extend the relation by one block onto the target */
 			buffer = ReadBufferExtended(rel, MAIN_FORKNUM, P_NEW,
 										RBM_NORMAL, NULL);
 			if (BufferGetBlockNumber(buffer) != blockno)

--- a/src/columnar_vacuum.c
+++ b/src/columnar_vacuum.c
@@ -49,6 +49,7 @@ PG_FUNCTION_INFO_V1(columnar_cluster);
 PG_FUNCTION_INFO_V1(columnar_compact);
 PG_FUNCTION_INFO_V1(columnar_compact_rewrite);
 PG_FUNCTION_INFO_V1(columnar_recluster);
+PG_FUNCTION_INFO_V1(columnar_debug_advance_reserved_offset);
 
 /* Z-order helpers (defined later, used by the online recluster below) */
 static bool cluster_type_supported(Oid typid);
@@ -1380,4 +1381,39 @@ columnar_compact(PG_FUNCTION_ARGS)
 	table_close(rel, NoLock);
 
 	PG_RETURN_INT64(retired);
+}
+
+/*
+ * columnar_debug_advance_reserved_offset
+ *		SQL test hook: advance a columnar table's write highwater by N pages
+ *		without writing data, leaving a gap between the physical EOF and the
+ *		highwater so the next write exercises the gap-tolerant path. Not bound in
+ *		the shipped catalog; the gap test creates the SQL binding itself.
+ */
+Datum
+columnar_debug_advance_reserved_offset(PG_FUNCTION_ARGS)
+{
+	Oid			relid = PG_GETARG_OID(0);
+	int32		npages = PG_GETARG_INT32(1);
+	Relation	rel;
+
+	if (npages < 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("npages must be non-negative")));
+
+	rel = table_open(relid, RowExclusiveLock);
+	if (!ColumnarIsColumnarRelation(relid))
+	{
+		table_close(rel, RowExclusiveLock);
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+				 errmsg("relation \"%s\" is not a columnar table",
+						RelationGetRelationName(rel))));
+	}
+
+	ColumnarAdvanceReservedOffset(rel, (uint64) npages * COLUMNAR_BYTES_PER_PAGE);
+
+	table_close(rel, NoLock);
+	PG_RETURN_VOID();
 }

--- a/test/native_gap.sh
+++ b/test/native_gap.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# pgColumnar gap-tolerant write path (Phase F, prerequisite for end-truncation).
+#
+# The metapage highwater (reservedOffset) can legitimately sit AHEAD of the
+# physical EOF: that is the state an aborted or crash-interrupted end-truncation
+# leaves (the file was shortened but the highwater was not). A write whose target
+# block is beyond EOF must fill the gap with empty pages and succeed, so the state
+# self-heals on the next write. This suite forces that state with a test-only hook
+# (columnar_debug_advance_reserved_offset, bound here rather than shipped) and
+# asserts writes across the gap succeed, data stays correct against a heap mirror,
+# the file physically materializes the gap, and the table is fully usable after.
+#
+# Usage:  test/native_gap.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+# bind the internal test hook (deliberately not in the shipped catalog).
+psql_run "CREATE FUNCTION pgcolumnar.debug_advance_reserved_offset(regclass, int)
+  RETURNS void AS 'pgcolumnar', 'columnar_debug_advance_reserved_offset'
+  LANGUAGE C;"
+
+psql_run "CREATE TABLE h (id int, v text);"
+psql_run "CREATE TABLE n (id int, v text) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 1000, chunk_group_row_limit => 1000);"
+
+hash_n() { pgc_set_hash 'SELECT id, v FROM n'; }
+hash_h() { pgc_set_hash 'SELECT id, v FROM h'; }
+
+psql_run "INSERT INTO h SELECT g, md5(g::text) FROM generate_series(1, 3000) g;"
+psql_run "INSERT INTO n SELECT g, md5(g::text) FROM generate_series(1, 3000) g;"
+check "baseline row count" "$(q 'SELECT count(*) FROM n;')" "3000"
+check "baseline parity" "$(hash_n)" "$(hash_h)"
+size1="$(q 'SELECT pg_relation_size('"'"'n'"'"');')"
+
+# push the highwater 50 pages past the physical EOF, creating a gap.
+psql_run "SELECT pgcolumnar.debug_advance_reserved_offset('n', 50);"
+
+# writes now target blocks beyond EOF: they must gap-fill and succeed.
+psql_run "INSERT INTO h SELECT g, md5(g::text) FROM generate_series(3001, 6000) g;"
+psql_run "INSERT INTO n SELECT g, md5(g::text) FROM generate_series(3001, 6000) g;"
+check "row count after gapped insert" "$(q 'SELECT count(*) FROM n;')" "6000"
+check "parity after gapped insert" "$(hash_n)" "$(hash_h)"
+size2="$(q 'SELECT pg_relation_size('"'"'n'"'"');')"
+echo "  (file size: before-gap=$size1 after-gap=$size2)"
+# the 50-page gap plus new data must have physically extended the file well past
+# the pre-gap size (allow slack; assert at least ~40 pages of growth).
+check "gap was physically materialized" \
+	"$([ "$size2" -gt "$((size1 + 40 * 8192))" ] && echo yes || echo no)" "yes"
+
+# the table stays fully usable: more inserts, an index, and an indexed lookup.
+psql_run "INSERT INTO h SELECT g, md5(g::text) FROM generate_series(6001, 7000) g;"
+psql_run "INSERT INTO n SELECT g, md5(g::text) FROM generate_series(6001, 7000) g;"
+check "parity after post-gap insert" "$(hash_n)" "$(hash_h)"
+psql_run "CREATE INDEX n_id ON n (id);"
+check "indexed lookup after gap" \
+	"$(q 'SELECT count(*) FROM n WHERE id BETWEEN 1 AND 7000;')" "7000"
+
+# a delete + reader still resolves correctly across the gapped layout.
+psql_run "DELETE FROM h WHERE id % 7 = 0;"
+psql_run "DELETE FROM n WHERE id % 7 = 0;"
+check "parity after delete on gapped layout" "$(hash_n)" "$(hash_h)"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -27,7 +27,7 @@ SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUITES=(smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
 	differential recovery fuzz hardening concurrent_diff parallel sorted_projection \
 	arrow_export parquet_export read_stream corruption \
-	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip native_index native_dml native_ios native_projection native_cluster native_compact native_recluster native_reclaim native_reclaim_cycles native_reclaim_frag native_rewrite native_rewrite_conc isolation)
+	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip native_index native_dml native_ios native_projection native_cluster native_compact native_recluster native_reclaim native_reclaim_cycles native_reclaim_frag native_gap native_rewrite native_rewrite_conc isolation)
 
 # Default matrix: one assert-enabled pg_config per major, 15 through 19.
 DEFAULT_CONFIGS=(


### PR DESCRIPTION
Makes `ColumnarWriteLogicalData` fill a gap between the physical EOF and a target block beyond it with empty WAL-logged pages, instead of erroring. This is the "metapage highwater ahead of physical EOF" state an aborted or crash-interrupted end-truncation leaves; it now self-heals (the next write re-extends). The common append case is unchanged; P_NEW extensions stay under the caller's extension lock.

Prerequisite for physical end-truncation (`design/PHASE_F_END_TRUNCATION_PLAN.md`): decouples truncation correctness from `smgrtruncate` being non-transactional, so truncate-then-abort or a crash never faults a later write.

Adds a test-only hook `columnar_debug_advance_reserved_offset` (not in the shipped catalog; `native_gap.sh` binds it itself) to force the gap deterministically. `native_gap.sh` proves writes across a 50-page gap succeed, parity vs a heap mirror holds, the gap materializes physically, and the table stays usable (inserts, index scan, delete) after.

PG17 full-suite gate green; full 15-19 matrix runs in the daily gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)