### PR TITLE
Gate maintenance and projection-DDL functions on table ownership

### DIFF
--- a/src/columnar.h
+++ b/src/columnar.h
@@ -357,6 +357,9 @@ extern bool columnar_reclaim_coalesce;
 /* physical end-truncation opt-in (GUC) */
 extern bool columnar_enable_end_truncation;
 
+/* error unless the current user owns the relation (maintenance/DDL gate) */
+extern void ColumnarRequireTableOwner(Relation rel);
+
 /*
  * Assert-only invariant: a storage's live row-group footprints and its
  * free_space ranges tile the file page-aligned with no overlap. Compiled and

--- a/src/columnar_compat.h
+++ b/src/columnar_compat.h
@@ -60,6 +60,19 @@
 #endif
 
 /* -------------------------------------------------------------------------
+ * pg_class_ownercheck (a relation-specific helper) was generalized to
+ * object_ownercheck(classid, objectid, roleid) in PG16. Both return true for a
+ * superuser, so an owner-or-superuser gate needs no separate superuser bypass.
+ * ------------------------------------------------------------------------- */
+#if PG_VERSION_NUM >= 160000
+#define COLUMNAR_TABLE_OWNERCHECK(relid) \
+	object_ownercheck(RelationRelationId, (relid), GetUserId())
+#else
+#define COLUMNAR_TABLE_OWNERCHECK(relid) \
+	pg_class_ownercheck((relid), GetUserId())
+#endif
+
+/* -------------------------------------------------------------------------
  * RelationCreateStorage() gained a third argument (register_delete, whether to
  * schedule the physical file for unlink on abort) in PG15. Before PG15 it took
  * only (locator, persistence). Heap passes true, and so do we.

--- a/src/columnar_projection.c
+++ b/src/columnar_projection.c
@@ -190,6 +190,7 @@ columnar_add_projection(PG_FUNCTION_ARGS)
 	 * unaffected. (A CONCURRENTLY variant is future work.)
 	 */
 	rel = table_open(relid, ShareLock);
+	ColumnarRequireTableOwner(rel);
 	storageId = ColumnarStorageId(rel);
 
 	existing = ColumnarListProjections(storageId);
@@ -282,6 +283,7 @@ columnar_drop_projection(PG_FUNCTION_ARGS)
 						get_rel_name(relid))));
 
 	rel = table_open(relid, ShareUpdateExclusiveLock);
+	ColumnarRequireTableOwner(rel);
 	storageId = ColumnarStorageId(rel);
 	existing = ColumnarListProjections(storageId);
 

--- a/src/columnar_vacuum.c
+++ b/src/columnar_vacuum.c
@@ -29,6 +29,7 @@
 #include "access/relation.h"
 #include "access/table.h"
 #include "catalog/index.h"
+#include "catalog/pg_class.h"
 #include "catalog/pg_type.h"
 #include "executor/executor.h"
 #include "executor/tuptable.h"
@@ -37,6 +38,7 @@
 #include "storage/lockdefs.h"
 #include "storage/procarray.h"
 #include "storage/smgr.h"
+#include "utils/acl.h"
 #include "utils/array.h"
 #include "utils/inval.h"
 #include "utils/builtins.h"
@@ -61,6 +63,21 @@ PG_FUNCTION_INFO_V1(columnar_debug_advance_reserved_offset);
 /* physical end-truncation opt-in (GUC), registered in _PG_init. Default off
  * until the abort/crash path is fully hardened and matrix-validated. */
 bool		columnar_enable_end_truncation = false;
+
+/*
+ * ColumnarRequireTableOwner
+ *		Error unless the current user owns the relation (superusers pass). Every
+ *		maintenance and projection-DDL function gates on this: they rewrite data,
+ *		reclaim space, or take strong locks (truncate takes AccessExclusiveLock),
+ *		so they must be owner-only, like VACUUM and CLUSTER.
+ */
+void
+ColumnarRequireTableOwner(Relation rel)
+{
+	if (!COLUMNAR_TABLE_OWNERCHECK(RelationGetRelid(rel)))
+		aclcheck_error(ACLCHECK_NOT_OWNER, OBJECT_TABLE,
+					   RelationGetRelationName(rel));
+}
 
 /* Z-order helpers (defined later, used by the online recluster below) */
 static bool cluster_type_supported(Oid typid);
@@ -535,6 +552,8 @@ columnar_recluster(PG_FUNCTION_ARGS)
 						RelationGetRelationName(rel))));
 	}
 
+	ColumnarRequireTableOwner(rel);
+
 	tupdesc = RelationGetDescr(rel);
 	atts = palloc(ncols * sizeof(AttrNumber));
 	for (i = 0; i < ncols; i++)
@@ -608,6 +627,8 @@ columnar_compact_rewrite(PG_FUNCTION_ARGS)
 				 errmsg("relation \"%s\" is not a columnar table",
 						RelationGetRelationName(rel))));
 	}
+
+	ColumnarRequireTableOwner(rel);
 
 	rewritten = columnar_rewrite_partial_groups(rel, minFrac, maxGroups);
 
@@ -1138,6 +1159,8 @@ columnar_vacuum(PG_FUNCTION_ARGS)
 						RelationGetRelationName(rel))));
 	}
 
+	ColumnarRequireTableOwner(rel);
+
 	columnar_compact_relation(rel, 0, NULL);
 
 	/* keep the lock until end of transaction */
@@ -1196,6 +1219,8 @@ columnar_vacuum_sorted(PG_FUNCTION_ARGS)
 				 errmsg("relation \"%s\" is not a columnar table",
 						RelationGetRelationName(rel))));
 	}
+
+	ColumnarRequireTableOwner(rel);
 
 	tupdesc = RelationGetDescr(rel);
 	sortAtts = palloc(ncols * sizeof(AttrNumber));
@@ -1298,6 +1323,8 @@ columnar_cluster(PG_FUNCTION_ARGS)
 						RelationGetRelationName(rel))));
 	}
 
+	ColumnarRequireTableOwner(rel);
+
 	tupdesc = RelationGetDescr(rel);
 	atts = palloc(ncols * sizeof(AttrNumber));
 
@@ -1383,6 +1410,8 @@ columnar_compact(PG_FUNCTION_ARGS)
 				 errmsg("relation \"%s\" is not a columnar table",
 						RelationGetRelationName(rel))));
 	}
+
+	ColumnarRequireTableOwner(rel);
 
 	retired = ColumnarRetireFullyDeletedGroups(rel);
 
@@ -1582,6 +1611,8 @@ columnar_truncate(PG_FUNCTION_ARGS)
 				 errmsg("relation \"%s\" is not a columnar table",
 						RelationGetRelationName(rel))));
 	}
+
+	ColumnarRequireTableOwner(rel);
 
 	if (columnar_enable_end_truncation &&
 		ConditionalLockRelation(rel, AccessExclusiveLock))

--- a/test/native_ownership.sh
+++ b/test/native_ownership.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# pgColumnar maintenance/DDL ownership gate. The maintenance functions rewrite
+# data, reclaim space, or take strong locks (truncate takes AccessExclusiveLock),
+# so they must be owner-only, like VACUUM and CLUSTER. This suite proves a
+# non-owner role is refused by every one of them with "must be owner", and that
+# the owner is allowed. The ownership check sits right after the relation is
+# opened and confirmed columnar, before any work, so a non-owner hits it rather
+# than a later catalog-permission error.
+#
+# Usage:  test/native_ownership.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+# run a single statement AS alice (a non-owner). A direct connection keeps it a
+# single-statement autocommit query, so truncate's transaction-block guard is not
+# tripped first -- we reach the ownership check.
+as_alice() { env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U alice -d "$PGC_DB" -Atq -c "$1" 2>&1; }
+
+psql_run "CREATE ROLE alice NOSUPERUSER LOGIN;"
+psql_run "GRANT USAGE ON SCHEMA pgcolumnar TO alice;"
+psql_run "CREATE TABLE n (id int, v int) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 1000, chunk_group_row_limit => 1000);"
+psql_run "INSERT INTO n SELECT g, g FROM generate_series(1, 3000) g;"
+
+# every maintenance/DDL function must refuse a non-owner with "must be owner".
+refused() {
+	local out
+	out="$(as_alice "SELECT pgcolumnar.$1;")"
+	check "non-owner refused: ${1%%(*}" \
+		"$(printf '%s' "$out" | grep -qi 'must be owner' && echo yes || echo "no")" "yes"
+}
+
+refused "compact('n')"
+refused "compact_rewrite('n', 0.0)"
+refused "recluster('n', 'id')"
+refused "vacuum('n')"
+refused "vacuum_sorted('n', 'id')"
+refused "cluster('n', 'id')"
+refused "truncate('n')"
+refused "add_projection('n', 'p', ARRAY['id','v'])"
+refused "drop_projection('n', 'p')"
+
+# the owner (here the superuser that created the table) is allowed through.
+check "owner compact allowed" \
+	"$(q "SELECT (pgcolumnar.compact('n') >= 0)::text;")" "true"
+check "owner recluster allowed" \
+	"$(q "SELECT (pgcolumnar.recluster('n', 'id') >= 0)::text;")" "true"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -27,7 +27,7 @@ SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUITES=(smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
 	differential recovery fuzz hardening concurrent_diff parallel sorted_projection \
 	arrow_export parquet_export read_stream corruption \
-	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip native_index native_dml native_ios native_projection native_cluster native_compact native_recluster native_reclaim native_reclaim_cycles native_reclaim_frag native_gap native_truncate native_rewrite native_rewrite_conc isolation)
+	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip native_index native_dml native_ios native_projection native_cluster native_compact native_recluster native_reclaim native_ownership native_reclaim_cycles native_reclaim_frag native_gap native_truncate native_rewrite native_rewrite_conc isolation)
 
 # Default matrix: one assert-enabled pg_config per major, 15 through 19.
 DEFAULT_CONFIGS=(


### PR DESCRIPTION
Follow-up to the end-truncation review. `compact`, `compact_rewrite`, `recluster`, `vacuum`, `vacuum_sorted`, `cluster`, `truncate`, `add_projection`, and `drop_projection` had no privilege check — any user could invoke them, and `truncate` takes an AccessExclusiveLock. They rewrite data, reclaim space, or take strong locks, so they are now owner-only, like VACUUM and CLUSTER.

Adds `ColumnarRequireTableOwner(rel)` (standard `must be owner of table ...`, superusers pass), placed right after the relation is opened and confirmed columnar, before any work, so a non-owner hits it rather than a later catalog-permission error. New `COLUMNAR_TABLE_OWNERCHECK` compat covers `pg_class_ownercheck` (PG15) vs `object_ownercheck` (PG16+). Read-only introspection (`get_storage_id`, `read_projection`, `reconstruct_via_projection`) and the test-only debug hook are not gated.

`native_ownership.sh`: a NOSUPERUSER role is refused by all nine functions with "must be owner"; the owner is allowed. PG17 full-suite gate green; PG15 build-clean (the `pg_class_ownercheck` branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)