### PR TITLE
Phase F: move the reclaim free list into block 1 (for review)

### DIFF
--- a/design/PHASE_F_FREE_LIST_METAPAGE_PLAN.md
+++ b/design/PHASE_F_FREE_LIST_METAPAGE_PLAN.md
@@ -1,11 +1,26 @@
 # Phase F reclaim: move the free list into the metapage (design, for review)
 
-Status: proposed, not implemented. This replaces the `pgcolumnar.free_space`
-catalog table with a non-transactional free list stored in the relation's own
-pages, so the free list and the metapage highwater share one persistence class.
-It is corruption-critical (it changes the on-disk format and the crash/abort
-behavior of reclaim), so it is written up in full before any code lands, as
-end-truncation was.
+Status: IMPLEMENTED (2026-07-23), PG17-gated, submitted as a PR for review. This
+replaces the `pgcolumnar.free_space` catalog table with a non-transactional free
+list stored in the relation's own pages, so the free list and the metapage
+highwater share one persistence class. It is corruption-critical (it changes the
+on-disk format and the crash/abort behavior of reclaim).
+
+Implementation notes (small deviations from the design below):
+- The entry count is the block-1 page's `pd_lower`, not a `freeCount` field in the
+  metapage, so block 1 is fully self-describing and each update is a single
+  atomic full-page-image write (`ColumnarFreeListRead` / `ColumnarFreeListWrite`
+  in `columnar_storage.c`). No metapage struct change.
+- The former queryable `free_space` catalog is replaced by an introspection
+  function `pgcolumnar.free_list(regclass)` returning the block-1 entries.
+- `TRUNCATE TABLE` clears block 1 (it is kept by the truncate-to-two-blocks).
+- Truncate's abort window is now closed inherently (all three effects are
+  non-transactional page/file ops in one class); its transaction-block prohibition
+  and ordering are retained as harmless belt-and-suspenders, relaxable in a
+  follow-up.
+- The overflow-leak fallback is exercised by the opt-in `native_free_overflow.sh`:
+  260 non-adjacent retirements fill the page to exactly its 255-entry capacity,
+  data stays correct, and the no-overlap validator stays green.
 
 ## Motivation
 

--- a/design/PHASE_F_FREE_LIST_METAPAGE_PLAN.md
+++ b/design/PHASE_F_FREE_LIST_METAPAGE_PLAN.md
@@ -6,6 +6,21 @@ list stored in the relation's own pages, so the free list and the metapage
 highwater share one persistence class. It is corruption-critical (it changes the
 on-disk format and the crash/abort behavior of reclaim).
 
+Critical correctness addition (from review): the block-1 list is non-transactional,
+but a compaction's `row_group` deletes are transactional, so an aborted or crashed
+retirement leaves the group live again while its free entry persists -- the entry
+then overlaps live data, and a later reuse would write over a live group. The free
+list is therefore reconciled against the `row_group` catalog:
+`ColumnarReconcileFreeList(rel)` runs at the start of every reuse operation
+(`compact_rewrite`, `recluster`), under that operation's ShareUpdateExclusiveLock,
+and drops any free entry overlapping a live row-group footprint (of the base or any
+projection storage) as-of the latest committed state. Between an abort and the next
+reuse only plain inserts run, and inserts never reuse, so no stale entry is ever
+consumed. This is what keeps the two persistence classes (non-transactional free
+list, transactional catalog) consistent, and it is pinned by
+`native_reclaim_abort.sh` (with the reconcile removed, the no-overlap validator
+fires on the double-allocation).
+
 Implementation notes (small deviations from the design below):
 - The entry count is the block-1 page's `pd_lower`, not a `freeCount` field in the
   metapage, so block 1 is fully self-describing and each update is a single
@@ -63,7 +78,7 @@ without SUEL held.)
 
 Block 1 of the main fork (`COLUMNAR_EMPTY_BLOCKNO`) is already reserved and unused;
 data starts at block 2 (`COLUMNAR_FIRST_LOGICAL_OFFSET`). Use block 1 as the
-free-list page: a page header plus a packed array of 32-byte entries, about 253
+free-list page: a page header plus a packed array of 32-byte entries, about 255
 entries in the 8 KB page. The metapage (block 0) gains a `freeCount` field (number
 of live entries in block 1). Both blocks are written under an exclusive buffer
 lock with `log_newpage_buffer` (the exact pattern `ColumnarReserveOffset` and
@@ -71,7 +86,7 @@ lock with `log_newpage_buffer` (the exact pattern `ColumnarReserveOffset` and
 identically.
 
 Capacity and overflow. Same-transaction coalescing (already implemented) keeps the
-list compact by merging adjacent frees, so a healthy table stays far below 253
+list compact by merging adjacent frees, so a healthy table stays far below 255
 entries. If the list is full when recording a new range, the range is simply not
 recorded: the space stays reclaimable-in-principle but is not tracked until a full
 rewrite (`compact_rewrite` / `recluster`) rebuilds the groups. This is graceful

--- a/design/PHASE_F_FREE_LIST_METAPAGE_PLAN.md
+++ b/design/PHASE_F_FREE_LIST_METAPAGE_PLAN.md
@@ -1,0 +1,148 @@
+# Phase F reclaim: move the free list into the metapage (design, for review)
+
+Status: proposed, not implemented. This replaces the `pgcolumnar.free_space`
+catalog table with a non-transactional free list stored in the relation's own
+pages, so the free list and the metapage highwater share one persistence class.
+It is corruption-critical (it changes the on-disk format and the crash/abort
+behavior of reclaim), so it is written up in full before any code lands, as
+end-truncation was.
+
+## Motivation
+
+Physical end-truncation (PR #92) has a documented residual abort/crash window: it
+lowers the metapage highwater (a full-page-image write that is NOT rolled back on
+abort) while deleting `free_space` rows (transactional heap deletes that ARE
+rolled back). The two effects are different persistence classes, so a crash
+between lowering the highwater and commit can leave a lowered highwater with the
+trailing free ranges restored (the "inverted" state), which a later insert plus
+compaction could double-allocate. Truncate currently narrows this window
+(transaction-block prohibition, reorder, start-of-run purge) but does not close
+it.
+
+Moving the free list into the metapage's non-transactional pages makes the free
+list and the highwater the same persistence class, so truncate's two effects
+persist or roll back together. That eliminates the window rather than narrowing
+it. Secondary wins: it removes a catalog table and the per-allocation
+`systable_beginscan` over it, and it simplifies the reclaim reasoning to a single
+durability class.
+
+## What the free list needs
+
+An entry is `(storage_id, file_offset, byte_length, freed_xid)` = 32 bytes. It is:
+- Recorded on group retirement (`record_free_space`), with same-transaction
+  coalescing.
+- Consumed on compaction reuse (`ColumnarAllocateFreeSpace`), best-fit, split on
+  oversize, gated on `freed_xid < oldestXmin`.
+- Scanned by the trailing-free horizon guard and the assert-only no-overlap
+  validator, and purged at/above an offset by truncate.
+
+Crucially, EVERY mutation happens under ShareUpdateExclusiveLock: retirement runs
+inside compact / compact_rewrite / recluster (all SUEL), and reuse is gated on the
+writer holding SUEL (`columnar_write_state.c`). SUEL self-conflicts, so free-list
+mutations are globally serialized per relation. That is what lets a page-resident
+list use plain buffer locks instead of MVCC. (Implementation must assert this
+invariant: `record_free_space` / `ColumnarAllocateFreeSpace` are never reached
+without SUEL held.)
+
+## Storage layout
+
+Block 1 of the main fork (`COLUMNAR_EMPTY_BLOCKNO`) is already reserved and unused;
+data starts at block 2 (`COLUMNAR_FIRST_LOGICAL_OFFSET`). Use block 1 as the
+free-list page: a page header plus a packed array of 32-byte entries, about 253
+entries in the 8 KB page. The metapage (block 0) gains a `freeCount` field (number
+of live entries in block 1). Both blocks are written under an exclusive buffer
+lock with `log_newpage_buffer` (the exact pattern `ColumnarReserveOffset` and
+`ColumnarSetReservedOffset` already use), so they are crash-safe and replicate
+identically.
+
+Capacity and overflow. Same-transaction coalescing (already implemented) keeps the
+list compact by merging adjacent frees, so a healthy table stays far below 253
+entries. If the list is full when recording a new range, the range is simply not
+recorded: the space stays reclaimable-in-principle but is not tracked until a full
+rewrite (`compact_rewrite` / `recluster`) rebuilds the groups. This is graceful
+degradation (unreclaimed space, never corruption), and it is logged so it is
+visible. This is the one real trade-off against today's unbounded catalog list;
+see Alternatives.
+
+Per relation, not per storage. Projections share the file and the metapage, so the
+single block-1 list holds entries for the base and all projection storage ids,
+keyed by the `storage_id` field, exactly as the catalog did.
+
+## Truncate becomes fully non-transactional
+
+With the free list in block 1, truncate's effects are: purge block-1 entries at or
+above `liveEnd`, lower the metapage highwater, and `smgrtruncate`. All three are
+non-transactional page/file operations. A crash or abort therefore leaves the same
+consistent state as a commit (highwater lowered, trailing entries gone, file
+short) rather than the inverted state. The residual window is closed. The
+transaction-block prohibition can then be relaxed (truncate no longer has any
+transactional effect to roll back inconsistently), though keeping it for
+least-surprise is a reasonable call to make at implementation time.
+
+## Concurrency and crash safety
+
+- All mutations under SUEL (asserted), so the block-1 buffer lock plus the
+  metapage buffer lock are sufficient; no MVCC, no advisory locks for the list
+  itself. The existing per-chunk-group advisory lock for delete-vector upserts is
+  unaffected (that guards delete vectors, not the free list).
+- Reads (horizon guard, validator) take a share buffer lock on block 1.
+- Every mutation is a full-page-image WAL record, so recovery and standbys are
+  consistent, matching the current metapage writes.
+- `freed_xid < oldestXmin` gating is unchanged; the xid is stored per entry.
+
+## Touchpoints
+
+Almost all of the change is in `columnar_metadata.c`, plus small edits elsewhere:
+- Rewrite `insert_free_space_row`, `record_free_space` (with coalescing),
+  `ColumnarAllocateFreeSpace` (best-fit + split), `ColumnarTrailingFreeSpaceSafe`,
+  `ColumnarDeleteFreeSpaceAtOrAbove`, and `ColumnarCheckFreeSpaceNoOverlap` to
+  operate on the block-1 array under buffer locks instead of the catalog.
+- `columnar.h`: add `freeCount` to `ColumnarMetapage`; a block-1 entry struct and
+  accessors; bump `COLUMNAR_NATIVE_VERSION_*` (on-disk format change).
+- `columnar_storage.c`: initialize block 1 as an empty free-list page in
+  `ColumnarWriteNewMetapage`; helpers to read/modify the block-1 list.
+- `pgcolumnar--1.0.sql`: drop the `free_space` table, its indexes. `ColumnarDeleteMetadata`
+  no longer deletes `free_space` rows (block 1 goes with the relation file).
+- `columnar_metadata.c` Anum/Natts for `free_space`: removed.
+
+No data migration path: this is a dev-version on-disk format change, so existing
+columnar tables must be recreated (note the format-version bump in the commit).
+
+## Test plan
+
+- All existing reclaim suites must stay green unchanged: `native_reclaim`,
+  `native_reclaim_cycles`, `native_reclaim_frag`, `native_gap`, `native_truncate`,
+  and the `truncate_vs_*` isolation specs (the observable behavior is identical).
+- New `native_free_overflow.sh`: drive the free list past its capacity with highly
+  fragmented, non-coalescible retirements and assert graceful degradation (parity
+  vs heap holds, the no-overlap validator stays green, the file is not corrupted;
+  some space is left unreclaimed until a full rewrite, then reclaimed).
+- Abort test: with the transaction-block prohibition relaxed (if we relax it),
+  `BEGIN; truncate; ROLLBACK` followed by insert + compaction must keep the
+  validator green and parity intact, proving the window is closed. If we keep the
+  prohibition, assert it as today.
+- Gate on PG17 during iteration, full 15-19 matrix before merge.
+
+## Alternatives considered
+
+- Overflow to a chain of reserved blocks. Reserve several pages (blocks 1..N)
+  before data, or chain overflow pages, for a larger or unbounded list. Removes
+  the cap but adds page-chain management and wastes pages on unfragmented tables.
+  Deferred; the bounded single page plus coalescing is expected to suffice, and
+  the overflow-leak fallback is safe. Revisit if the overflow test shows the cap
+  bites real workloads.
+- A custom relation fork. PostgreSQL's fork numbers are a fixed enum
+  (MAIN/FSM/VM/INIT); an extension cannot cleanly add one, and FSM tracks
+  block-granular free space, not byte-range extents with an xid. Not viable.
+- Leave the catalog, fix truncate differently. No transactional mechanism can make
+  a metapage FPI and a heap delete atomic across a crash; that is the whole reason
+  for this change.
+
+## Risk and why it is review-gated
+
+It changes the on-disk format and the crash/abort semantics of the reclaim path,
+which is corruption-critical. The design is believed correct (single persistence
+class, all mutations under SUEL, FPI-logged, horizon gating unchanged), but the
+SUEL-serialization invariant and the overflow-leak fallback should be read before
+implementation. The change lands as a single PR (this plan plus the code) for
+review, not auto-merged.

--- a/pgcolumnar--1.0.sql
+++ b/pgcolumnar--1.0.sql
@@ -157,25 +157,12 @@ CREATE UNIQUE INDEX bloom_pkey
 	ON pgcolumnar.bloom USING btree (storage_id, group_number, column_index);
 
 /* ---------------------------------------------------------------------------
- * pgcolumnar.free_space (Phase F physical reclaim)
- *
- * Freed logical byte ranges from retired row groups, available for reuse by a
- * later stripe reservation once no snapshot can still read them. file_offset is
- * page-aligned; freed_xid is the retiring transaction's id, and the range is
- * reusable only once the oldest-xmin horizon has passed it. Reuse makes online
- * compaction space-neutral instead of forever advancing the file highwater.
+ * Physical-reclaim free list (Phase F): NOT a catalog table. Freed page-aligned
+ * byte ranges live in block 1 of each columnar relation's main fork (previously
+ * reserved and empty), so the free list and the metapage highwater share one
+ * non-transactional persistence class and update atomically. See columnar.h
+ * (ColumnarFreeEntry) and design/PHASE_F_FREE_LIST_METAPAGE_PLAN.md.
  * ------------------------------------------------------------------------- */
-
-CREATE TABLE pgcolumnar.free_space (
-	storage_id bigint NOT NULL,
-	file_offset bigint NOT NULL,
-	byte_length bigint NOT NULL,
-	freed_xid bigint NOT NULL
-);
-CREATE UNIQUE INDEX free_space_pkey
-	ON pgcolumnar.free_space USING btree (storage_id, file_offset);
-CREATE INDEX free_space_fit
-	ON pgcolumnar.free_space USING btree (storage_id, byte_length);
 
 /* ---------------------------------------------------------------------------
  * Access method (spec 8.1)
@@ -468,6 +455,16 @@ CREATE FUNCTION pgcolumnar.truncate(tablename regclass)
 
 COMMENT ON FUNCTION pgcolumnar.truncate(regclass)
 	IS 'physical end-truncation: return trailing reclaimed blocks to the OS. Best-effort -- takes AccessExclusiveLock conditionally for the brief physical step and returns 0 without waiting if the table is busy. Only removes space freed before the oldest-xmin horizon. Gated by pgcolumnar.enable_end_truncation. Returns the number of blocks truncated (Phase F)';
+
+CREATE FUNCTION pgcolumnar.free_list(rel regclass,
+	OUT storage_id bigint, OUT file_offset bigint,
+	OUT byte_length bigint, OUT freed_xid bigint)
+	RETURNS SETOF record
+	LANGUAGE C
+	AS 'MODULE_PATHNAME', 'columnar_free_list';
+
+COMMENT ON FUNCTION pgcolumnar.free_list(regclass)
+	IS 'the reclaim free list (block 1 of the relation file): freed page-aligned byte ranges available for reuse, one row per range (Phase F)';
 
 CREATE FUNCTION pgcolumnar.compact_rewrite(
 	tablename regclass,

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -31,7 +31,7 @@
  * shared logical-storage version, independent of the data format; the data
  * format is the native format identified below and in pgcolumnar.storage. */
 #define COLUMNAR_VERSION_MAJOR 2
-#define COLUMNAR_VERSION_MINOR 2
+#define COLUMNAR_VERSION_MINOR 3	/* 2.3: reclaim free list in block 1 */
 
 /*
  * Native format (PGCN v1). The on-disk data format, designed from public
@@ -91,6 +91,28 @@
 #define COLUMNAR_PAGE_ROUND_UP(n) \
 	(((((uint64) (n)) + COLUMNAR_BYTES_PER_PAGE - 1) / COLUMNAR_BYTES_PER_PAGE) \
 	 * COLUMNAR_BYTES_PER_PAGE)
+
+/*
+ * Physical-reclaim free list (Phase F). One entry per freed, page-aligned byte
+ * range, keyed by storage id so the base relation and its projections share the
+ * one list. The list lives in block 1 of the main fork (previously reserved and
+ * empty); the number of live entries is the page's pd_lower, so the page is
+ * self-describing and updated atomically as a single full-page-image write. All
+ * mutations happen under ShareUpdateExclusiveLock (retirement and compaction
+ * reuse), so the block-1 buffer lock is sufficient; there is no MVCC. When the
+ * page is full a new range is simply not recorded (reclaimed later by a full
+ * rewrite), which is graceful degradation, never corruption.
+ */
+#define COLUMNAR_FREELIST_BLOCKNO 1
+typedef struct ColumnarFreeEntry
+{
+	uint64		storageId;
+	uint64		fileOffset;
+	uint64		byteLength;		/* page-aligned footprint */
+	uint64		freedXid;		/* TransactionId; reusable once < oldestXmin */
+} ColumnarFreeEntry;
+#define COLUMNAR_FREELIST_MAX \
+	((int) ((BLCKSZ - SizeOfPageHeaderData) / sizeof(ColumnarFreeEntry)))
 
 /*
  * Row-number <-> item-pointer mapping (spec 6).
@@ -310,6 +332,16 @@ extern void ColumnarReserveOffset(Relation rel, uint64 dataLength,
 extern void ColumnarAdvanceReservedOffset(Relation rel, uint64 addBytes);
 extern void ColumnarSetReservedOffset(Relation rel, uint64 newOffset);
 extern void ColumnarTruncateMainFork(Relation rel, BlockNumber newnblocks);
+
+/*
+ * Block-1 free-list access. Read copies the live entries into the caller's array
+ * (sized COLUMNAR_FREELIST_MAX) and returns the count. Write replaces the whole
+ * list with entries[0..count) (count <= COLUMNAR_FREELIST_MAX) as one WAL-logged
+ * page write. The caller holds ShareUpdateExclusiveLock (or AccessExclusiveLock).
+ */
+extern int	ColumnarFreeListRead(Relation rel, ColumnarFreeEntry *out);
+extern void ColumnarFreeListWrite(Relation rel, ColumnarFreeEntry *entries,
+								  int count);
 extern void ColumnarWriteLogicalData(Relation rel, uint64 logicalOffset,
 									 char *data, uint64 length);
 extern void ColumnarReadLogicalData(Relation rel, uint64 logicalOffset,
@@ -340,14 +372,16 @@ typedef struct ColumnarRowRange
  * deletes (committed or in-progress). Returns a List of ColumnarRowRange *. */
 extern List *ColumnarComputeFullyDeletedGroups(uint64 storageId,
 											   TransactionId oldestXmin);
-extern void ColumnarRetireGroup(uint64 storageId, uint64 groupNumber);
+extern void ColumnarRetireGroup(Relation rel, uint64 groupNumber);
 extern int64 ColumnarRetireFullyDeletedGroups(Relation rel);
 extern void ColumnarLockChunkGroup(uint64 storageId, uint64 groupNumber);
-extern bool ColumnarAllocateFreeSpace(uint64 storageId, uint64 dataLength,
-									  TransactionId oldestXmin, uint64 *fileOffset);
-extern bool ColumnarTrailingFreeSpaceSafe(uint64 storageId, uint64 liveEnd,
-										  TransactionId oldestXmin);
-extern void ColumnarDeleteFreeSpaceAtOrAbove(uint64 storageId, uint64 liveEnd);
+extern bool ColumnarAllocateFreeSpace(Relation rel, uint64 storageId,
+									  uint64 dataLength, TransactionId oldestXmin,
+									  uint64 *fileOffset);
+extern bool ColumnarTrailingFreeSpaceSafe(Relation rel, uint64 storageId,
+										  uint64 liveEnd, TransactionId oldestXmin);
+extern void ColumnarDeleteFreeSpaceAtOrAbove(Relation rel, uint64 storageId,
+											 uint64 liveEnd);
 extern List *ColumnarComputeAllVisibleGroups(uint64 storageId,
 											 TransactionId oldestXmin);
 
@@ -366,10 +400,10 @@ extern void ColumnarRequireTableOwner(Relation rel);
  * called only in assert builds (the version matrix builds with asserts).
  */
 #ifdef USE_ASSERT_CHECKING
-extern void ColumnarCheckFreeSpaceNoOverlap(uint64 storageId);
-#define COLUMNAR_ASSERT_NO_OVERLAP(sid) ColumnarCheckFreeSpaceNoOverlap(sid)
+extern void ColumnarCheckFreeSpaceNoOverlap(Relation rel);
+#define COLUMNAR_ASSERT_NO_OVERLAP(rel) ColumnarCheckFreeSpaceNoOverlap(rel)
 #else
-#define COLUMNAR_ASSERT_NO_OVERLAP(sid) ((void) 0)
+#define COLUMNAR_ASSERT_NO_OVERLAP(rel) ((void) 0)
 #endif
 
 /* -------------------------------------------------------------------------

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -382,6 +382,7 @@ extern bool ColumnarTrailingFreeSpaceSafe(Relation rel, uint64 storageId,
 										  uint64 liveEnd, TransactionId oldestXmin);
 extern void ColumnarDeleteFreeSpaceAtOrAbove(Relation rel, uint64 storageId,
 											 uint64 liveEnd);
+extern void ColumnarReconcileFreeList(Relation rel);
 extern List *ColumnarComputeAllVisibleGroups(uint64 storageId,
 											 TransactionId oldestXmin);
 

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -765,6 +765,105 @@ ColumnarDeleteFreeSpaceAtOrAbove(Relation rel, uint64 storageId, uint64 liveEnd)
 		ColumnarFreeListWrite(rel, list, w);
 }
 
+typedef struct FootRange
+{
+	uint64		off;
+	uint64		end;
+} FootRange;
+
+/* append live row-group footprints for one storage to foots[] */
+static void
+collect_footprints(uint64 storageId, Snapshot snap, FootRange **foots,
+				   int *nf, int *capf)
+{
+	List	   *rgs = ColumnarReadRowGroupList(storageId, snap);
+	ListCell   *lc;
+
+	foreach(lc, rgs)
+	{
+		NativeRowGroupMetadata *rg = (NativeRowGroupMetadata *) lfirst(lc);
+
+		if (rg->byteLength == 0)
+			continue;
+		if (*nf == *capf)
+			*foots = repalloc(*foots, sizeof(FootRange) * (*capf *= 2));
+		(*foots)[*nf].off = rg->fileOffset;
+		(*foots)[*nf].end = rg->fileOffset + COLUMNAR_PAGE_ROUND_UP(rg->byteLength);
+		(*nf)++;
+	}
+}
+
+/*
+ * ColumnarReconcileFreeList
+ *		Drop any block-1 free entry that overlaps a LIVE row-group footprint (of
+ *		the base or any projection storage) as-of the latest committed state.
+ *
+ *		This is what keeps the non-transactional free list consistent with the
+ *		transactional row_group catalog. record_free_space is a non-transactional
+ *		block-1 write, but it is called during compaction whose row_group deletes
+ *		ARE transactional; if that compaction aborts (explicit ROLLBACK,
+ *		mid-statement error, or crash) the group becomes live again while its
+ *		free entry persists, so the entry now overlaps live data. Running this at
+ *		the start of every reuse (before any ColumnarAllocateFreeSpace), under the
+ *		operation's ShareUpdateExclusiveLock, purges such stale entries before they
+ *		can be handed out on top of a live group. Between an abort and the next
+ *		reuse only plain inserts run, and inserts never reuse, so no stale entry is
+ *		ever consumed.
+ */
+void
+ColumnarReconcileFreeList(Relation rel)
+{
+	uint64		base = ColumnarStorageId(rel);
+	List	   *projs = ColumnarListProjections(base);
+	ListCell   *lc;
+	Snapshot	snap;
+	FootRange  *foots;
+	int			nf = 0;
+	int			capf = 64;
+	ColumnarFreeEntry list[COLUMNAR_FREELIST_MAX];
+	int			n;
+	int			i;
+	int			w = 0;
+	bool		changed = false;
+
+	foots = palloc(sizeof(FootRange) * capf);
+	snap = RegisterSnapshot(GetLatestSnapshot());
+	collect_footprints(base, snap, &foots, &nf, &capf);
+	foreach(lc, projs)
+	{
+		ColumnarProjection *p = (ColumnarProjection *) lfirst(lc);
+
+		if (p->projStorageId != base)
+			collect_footprints(p->projStorageId, snap, &foots, &nf, &capf);
+	}
+	UnregisterSnapshot(snap);
+
+	n = ColumnarFreeListRead(rel, list);
+	for (i = 0; i < n; i++)
+	{
+		uint64		estart = list[i].fileOffset;
+		uint64		eend = list[i].fileOffset + list[i].byteLength;
+		bool		overlaps = false;
+		int			j;
+
+		for (j = 0; j < nf; j++)
+			if (estart < foots[j].end && foots[j].off < eend)
+			{
+				overlaps = true;
+				break;
+			}
+		if (overlaps)
+		{
+			changed = true;		/* stale: an aborted/crashed retirement */
+			continue;
+		}
+		list[w++] = list[i];
+	}
+	if (changed)
+		ColumnarFreeListWrite(rel, list, w);
+	pfree(foots);
+}
+
 /*
  * ColumnarRetireFullyDeletedGroups
  *		Online compaction (Phase F3a, lazy path): retire every row group that is

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -93,13 +93,6 @@
 #define Anum_bloom_filter 4
 #define Natts_bloom 4
 
-/* attribute numbers for columnar.free_space (Phase F physical reclaim) */
-#define Anum_free_space_storage_id 1
-#define Anum_free_space_file_offset 2
-#define Anum_free_space_byte_length 3
-#define Anum_free_space_freed_xid 4
-#define Natts_free_space 4
-
 /* attribute numbers for columnar.delete_vector (spec 7.5) */
 #define Anum_delete_vector_storage_id 1
 #define Anum_delete_vector_group_number 2
@@ -438,116 +431,80 @@ read_row_group_range(uint64 storageId, uint64 groupNumber,
 /* physical reclaim: split freed ranges on allocate and coalesce on free */
 bool		columnar_reclaim_coalesce = true;
 
-/* insert one free_space row (offset, length page-aligned, freed at freedXid) */
-static void
-insert_free_space_row(Relation rel, TupleDesc td, uint64 storageId,
-					  uint64 fileOffset, uint64 byteLength, TransactionId freedXid)
-{
-	Datum		values[Natts_free_space];
-	bool		nulls[Natts_free_space];
-	HeapTuple	tuple;
-
-	memset(nulls, false, sizeof(nulls));
-	values[Anum_free_space_storage_id - 1] = Int64GetDatum((int64) storageId);
-	values[Anum_free_space_file_offset - 1] = Int64GetDatum((int64) fileOffset);
-	values[Anum_free_space_byte_length - 1] = Int64GetDatum((int64) byteLength);
-	values[Anum_free_space_freed_xid - 1] = Int64GetDatum((int64) freedXid);
-
-	tuple = heap_form_tuple(td, values, nulls);
-	CatalogTupleInsert(rel, tuple);
-	heap_freetuple(tuple);
-}
-
 /*
  * record_free_space
- *		Record a freed data range for later reuse (Phase F physical reclaim). The
- *		range is stored as its page-aligned footprint (the group's data rounded up
- *		to a whole page), so free ranges tile the file page-aligned and a split
- *		remnant or a coalesced union stays page-aligned.
+ *		Record a freed data range for later reuse (Phase F physical reclaim), in
+ *		the block-1 free list. The range is stored as its page-aligned footprint
+ *		so free ranges tile the file page-aligned and a split remnant or a
+ *		coalesced union stays page-aligned.
  *
  *		When columnar.reclaim_coalesce is on, the new range is merged with any
- *		immediately adjacent existing free range (left neighbor ending at this
- *		offset, or right neighbor starting at this range's end) before insertion,
- *		so a later request larger than either neighbor can still be satisfied from
- *		contiguous free space. The merged freeing xid is the newest of the merged
- *		ranges, so reuse stays gated until every component is behind the horizon.
+ *		immediately adjacent existing range freed by THIS transaction (same
+ *		freed_xid) before insertion, so a later request larger than either neighbor
+ *		can still be satisfied from contiguous free space. Only same-transaction
+ *		ranges are merged: forcing the union to a newer xid would delay reuse of
+ *		space that was reusable a moment ago.
+ *
+ *		If the block-1 list is full and the range does not merge, it is not
+ *		recorded (reclaimed later by a full rewrite). This is graceful degradation,
+ *		logged, never corruption.
  */
 static void
-record_free_space(uint64 storageId, uint64 fileOffset, uint64 byteLength)
+record_free_space(Relation rel, uint64 storageId, uint64 fileOffset,
+				  uint64 byteLength)
 {
-	Relation	rel = open_columnar_table("free_space", RowExclusiveLock);
-	TupleDesc	td = RelationGetDescr(rel);
+	ColumnarFreeEntry list[COLUMNAR_FREELIST_MAX];
+	int			n = ColumnarFreeListRead(rel, list);
 	uint64		off = fileOffset;
 	uint64		len = COLUMNAR_PAGE_ROUND_UP(byteLength);
 	uint64		origOff = off;
 	uint64		origEnd = off + len;
 	TransactionId freedXid = GetCurrentTransactionId();
+	int			i;
 
 	if (columnar_reclaim_coalesce)
 	{
-		Snapshot	snap = RegisterSnapshot(GetLatestSnapshot());
-		ScanKeyData key[1];
-		SysScanDesc scan;
-		HeapTuple	tuple;
-		ItemPointerData mergeTids[2];
-		int			nMerge = 0;
+		int			w = 0;
 
-		ScanKeyInit(&key[0], Anum_free_space_storage_id, BTEqualStrategyNumber,
-					F_INT8EQ, Int64GetDatum((int64) storageId));
-		scan = systable_beginscan(rel, InvalidOid, false, snap, 1, key);
-		while (HeapTupleIsValid(tuple = systable_getnext(scan)))
+		/*
+		 * Drop up to two same-transaction adjacent neighbors (one ending at
+		 * origOff, one starting at origEnd), absorbing them into off/len. The list
+		 * is already maximally coalesced, so adjacency is tested against the
+		 * original bounds.
+		 */
+		for (i = 0; i < n; i++)
 		{
-			bool		isnull;
-			uint64		noff = (uint64) DatumGetInt64(
-				heap_getattr(tuple, Anum_free_space_file_offset, td, &isnull));
-			uint64		nlen = (uint64) DatumGetInt64(
-				heap_getattr(tuple, Anum_free_space_byte_length, td, &isnull));
-			TransactionId nxid = (TransactionId) DatumGetInt64(
-				heap_getattr(tuple, Anum_free_space_freed_xid, td, &isnull));
+			ColumnarFreeEntry *e = &list[i];
 
-			/*
-			 * Only coalesce ranges freed by THIS transaction (same freed_xid).
-			 * Merging a fresh free with an older, already-reusable neighbor would
-			 * force the union to the newer xid (required for safety: reuse must
-			 * wait until every merged component is behind the horizon), which would
-			 * delay reuse of space that was reusable a moment ago -- a net loss.
-			 * Same-xid coalescing still merges the many groups one maintenance
-			 * operation retires together, which is the fragmentation case that
-			 * matters, without poisoning older reusable ranges.
-			 *
-			 * Adjacency is tested against the ORIGINAL range bounds. The file is
-			 * already maximally coalesced before this insert, so there is at most
-			 * one left neighbor (ends at origOff) and one right neighbor (starts
-			 * at origEnd); testing against the accumulating bounds would be wrong.
-			 */
-			if (nxid == freedXid && (noff + nlen == origOff || noff == origEnd))
+			if (e->storageId == storageId &&
+				(TransactionId) e->freedXid == freedXid &&
+				(e->fileOffset + e->byteLength == origOff ||
+				 e->fileOffset == origEnd))
 			{
-				off = Min(off, noff);
-				len += nlen;
-				if (nMerge < 2)
-					mergeTids[nMerge++] = tuple->t_self;
+				off = Min(off, e->fileOffset);
+				len += e->byteLength;
+				continue;		/* remove this neighbor */
 			}
+			list[w++] = *e;
 		}
-		systable_endscan(scan);
-
-		if (nMerge > 0)
-		{
-			int			i;
-
-			for (i = 0; i < nMerge; i++)
-				CatalogTupleDelete(rel, &mergeTids[i]);
-			/* make the deletes visible before inserting the merged row so the
-			 * unique (storage_id, file_offset) key cannot collide with a just-
-			 * deleted neighbor, and so a later record in this command sees it */
-			CommandCounterIncrement();
-		}
-		UnregisterSnapshot(snap);
+		n = w;
 	}
 
-	insert_free_space_row(rel, td, storageId, off, len, freedXid);
-	if (columnar_reclaim_coalesce)
-		CommandCounterIncrement();
-	table_close(rel, RowExclusiveLock);
+	if (n >= COLUMNAR_FREELIST_MAX)
+	{
+		ereport(LOG,
+				(errmsg("pgcolumnar: reclaim free list full for storage "
+						UINT64_FORMAT "; %lu bytes at offset %lu left unreclaimed "
+						"until the next full rewrite",
+						storageId, (unsigned long) len, (unsigned long) off)));
+		return;
+	}
+
+	list[n].storageId = storageId;
+	list[n].fileOffset = off;
+	list[n].byteLength = len;
+	list[n].freedXid = (uint64) freedXid;
+	ColumnarFreeListWrite(rel, list, n + 1);
 }
 
 /*
@@ -561,8 +518,9 @@ record_free_space(uint64 storageId, uint64 fileOffset, uint64 byteLength)
  *		The caller must have verified the group is fully deleted as-of oldestXmin.
  */
 void
-ColumnarRetireGroup(uint64 storageId, uint64 groupNumber)
+ColumnarRetireGroup(Relation rel, uint64 groupNumber)
 {
+	uint64		storageId = ColumnarStorageId(rel);
 	uint64		fileOffset = 0;
 	uint64		byteLength = 0;
 	bool		haveRange = read_row_group_range(storageId, groupNumber,
@@ -580,99 +538,70 @@ ColumnarRetireGroup(uint64 storageId, uint64 groupNumber)
 					  Anum_row_group_group_number, storageId, groupNumber);
 
 	if (haveRange && byteLength > 0)
-		record_free_space(storageId, fileOffset, byteLength);
+		record_free_space(rel, storageId, fileOffset, byteLength);
 }
 
 /*
  * ColumnarAllocateFreeSpace
  *		Try to satisfy a data reservation of dataLength bytes from a previously
  *		freed range (Phase F physical reclaim). Returns true and sets *fileOffset
- *		to a page-aligned freed range that is large enough AND whose freeing
- *		transaction precedes oldestXmin (so no snapshot can still read its old
- *		contents), consuming that free_space row. Best-fit (smallest fitting range)
- *		to limit waste. Reservations are serialized by the relation extension lock,
- *		so no two callers race for the same row.
+ *		to a page-aligned freed range for this storage that is large enough AND
+ *		whose freeing transaction precedes oldestXmin (so no snapshot can still
+ *		read its old contents), consuming that block-1 free-list entry. Best-fit
+ *		(smallest fitting range) to limit waste. Reservations happen only under
+ *		ShareUpdateExclusiveLock (compaction), so no two callers race for the list.
  */
 bool
-ColumnarAllocateFreeSpace(uint64 storageId, uint64 dataLength,
+ColumnarAllocateFreeSpace(Relation rel, uint64 storageId, uint64 dataLength,
 						  TransactionId oldestXmin, uint64 *fileOffset)
 {
-	Relation	rel = open_columnar_table("free_space", RowExclusiveLock);
-	TupleDesc	td = RelationGetDescr(rel);
-	ScanKeyData key[1];
-	SysScanDesc scan;
-	HeapTuple	tuple;
-	Snapshot	snap;
-	bool		found = false;
-	uint64		bestOff = 0;
-	uint64		bestLen = 0;
-	TransactionId bestXid = InvalidTransactionId;
-	ItemPointerData bestTid;
+	ColumnarFreeEntry list[COLUMNAR_FREELIST_MAX];
+	int			n = ColumnarFreeListRead(rel, list);
+	int			best = -1;
+	int			i;
 
-	ItemPointerSetInvalid(&bestTid);
-	snap = RegisterSnapshot(GetLatestSnapshot());
-	ScanKeyInit(&key[0], Anum_free_space_storage_id, BTEqualStrategyNumber,
-				F_INT8EQ, Int64GetDatum((int64) storageId));
-	scan = systable_beginscan(rel, InvalidOid, false, snap, 1, key);
-	while (HeapTupleIsValid(tuple = systable_getnext(scan)))
+	for (i = 0; i < n; i++)
 	{
-		bool		isnull;
-		uint64		len = (uint64) DatumGetInt64(
-			heap_getattr(tuple, Anum_free_space_byte_length, td, &isnull));
-		TransactionId fxid = (TransactionId) DatumGetInt64(
-			heap_getattr(tuple, Anum_free_space_freed_xid, td, &isnull));
+		ColumnarFreeEntry *e = &list[i];
 
-		if (len < dataLength)
+		if (e->storageId != storageId)
+			continue;
+		if (e->byteLength < dataLength)
 			continue;
 		/* not reusable until every live snapshot has passed the freeing xid */
-		if (TransactionIdIsNormal(fxid) &&
-			!TransactionIdPrecedes(fxid, oldestXmin))
+		if (TransactionIdIsNormal((TransactionId) e->freedXid) &&
+			!TransactionIdPrecedes((TransactionId) e->freedXid, oldestXmin))
 			continue;
-		if (!found || len < bestLen)
-		{
-			found = true;
-			bestLen = len;
-			bestXid = fxid;
-			bestOff = (uint64) DatumGetInt64(
-				heap_getattr(tuple, Anum_free_space_file_offset, td, &isnull));
-			bestTid = tuple->t_self;
-		}
+		if (best < 0 || e->byteLength < list[best].byteLength)
+			best = i;
 	}
-	systable_endscan(scan);
+	if (best < 0)
+		return false;
 
-	if (found)
+	*fileOffset = list[best].fileOffset;
+
+	/*
+	 * Split: the reservation consumes a whole number of pages (allocLen), so the
+	 * remnant beyond it stays page-aligned and reusable. Shrink the entry in place
+	 * to the remnant (its freed xid is unchanged, so the same oldest-xmin gate
+	 * still applies). Otherwise consume the whole entry (swap-remove).
+	 */
+	if (columnar_reclaim_coalesce)
 	{
-		CatalogTupleDelete(rel, &bestTid);
-		*fileOffset = bestOff;
+		uint64		allocLen = COLUMNAR_PAGE_ROUND_UP(dataLength);
 
-		/*
-		 * Split: the reservation consumes a whole number of pages (allocLen), so
-		 * the remnant beyond it stays page-aligned and reusable. Record it back
-		 * with the same freeing xid as the consumed range (already frozen, so the
-		 * same oldest-xmin gate still applies). Without this the tail of an
-		 * oversized freed range would leak until its group is re-freed.
-		 */
-		if (columnar_reclaim_coalesce)
+		if (list[best].byteLength > allocLen)
 		{
-			uint64		allocLen = COLUMNAR_PAGE_ROUND_UP(dataLength);
-
-			if (bestLen > allocLen)
-				insert_free_space_row(rel, td, storageId, bestOff + allocLen,
-									  bestLen - allocLen, bestXid);
+			list[best].fileOffset += allocLen;
+			list[best].byteLength -= allocLen;
+			ColumnarFreeListWrite(rel, list, n);
+			return true;
 		}
-
-		/*
-		 * A single compaction command can allocate many blocks in a row. Make
-		 * this consumption (and any remnant) visible to the next allocation's scan
-		 * within the same command; otherwise it would still see this row as free,
-		 * re-select it, and fail with "tuple already updated by self" on the
-		 * second delete.
-		 */
-		CommandCounterIncrement();
 	}
-	UnregisterSnapshot(snap);
-	table_close(rel, RowExclusiveLock);
-	return found;
+
+	list[best] = list[n - 1];
+	ColumnarFreeListWrite(rel, list, n - 1);
+	return true;
 }
 
 #ifdef USE_ASSERT_CHECKING
@@ -698,18 +627,18 @@ reclaim_range_cmp(const void *a, const void *b)
 /*
  * ColumnarCheckFreeSpaceNoOverlap
  *		Assert-only invariant check for physical reclaim: a storage's live
- *		row-group footprints (data rounded up to whole pages) and its free_space
+ *		row-group footprints (data rounded up to whole pages) and its block-1 free
  *		ranges must not overlap. An overlap would mean a reused block was handed
  *		out on top of live data or another free range, i.e. corruption. Called at
  *		the end of the online maintenance operations in assert builds.
  */
 void
-ColumnarCheckFreeSpaceNoOverlap(uint64 storageId)
+ColumnarCheckFreeSpaceNoOverlap(Relation rel)
 {
+	uint64		storageId = ColumnarStorageId(rel);
+	ColumnarFreeEntry list[COLUMNAR_FREELIST_MAX];
 	Relation	rg;
-	Relation	fs;
 	TupleDesc	rgd;
-	TupleDesc	fsd;
 	Snapshot	snap;
 	ScanKeyData key[1];
 	SysScanDesc scan;
@@ -718,14 +647,13 @@ ColumnarCheckFreeSpaceNoOverlap(uint64 storageId)
 	int			n = 0;
 	int			cap = 64;
 	int			i;
+	int			fn;
 
-	/* see this transaction's own writes made so far in the command */
+	/* see this transaction's own catalog writes made so far in the command */
 	CommandCounterIncrement();
 	snap = RegisterSnapshot(GetLatestSnapshot());
 	rg = open_columnar_table("row_group", AccessShareLock);
-	fs = open_columnar_table("free_space", AccessShareLock);
 	rgd = RelationGetDescr(rg);
-	fsd = RelationGetDescr(fs);
 	ranges = palloc(sizeof(ReclaimRange) * cap);
 
 	ScanKeyInit(&key[0], Anum_row_group_storage_id, BTEqualStrategyNumber,
@@ -748,27 +676,21 @@ ColumnarCheckFreeSpaceNoOverlap(uint64 storageId)
 		n++;
 	}
 	systable_endscan(scan);
+	table_close(rg, AccessShareLock);
+	UnregisterSnapshot(snap);
 
-	ScanKeyInit(&key[0], Anum_free_space_storage_id, BTEqualStrategyNumber,
-				F_INT8EQ, Int64GetDatum((int64) storageId));
-	scan = systable_beginscan(fs, InvalidOid, false, snap, 1, key);
-	while (HeapTupleIsValid(t = systable_getnext(scan)))
+	/* free ranges for this storage from the block-1 list */
+	fn = ColumnarFreeListRead(rel, list);
+	for (i = 0; i < fn; i++)
 	{
-		bool		isnull;
-		uint64		off = (uint64) DatumGetInt64(
-			heap_getattr(t, Anum_free_space_file_offset, fsd, &isnull));
-		uint64		len = (uint64) DatumGetInt64(
-			heap_getattr(t, Anum_free_space_byte_length, fsd, &isnull));
-
-		if (len == 0)
+		if (list[i].storageId != storageId || list[i].byteLength == 0)
 			continue;
 		if (n == cap)
 			ranges = repalloc(ranges, sizeof(ReclaimRange) * (cap *= 2));
-		ranges[n].off = off;
-		ranges[n].len = len;
+		ranges[n].off = list[i].fileOffset;
+		ranges[n].len = list[i].byteLength;
 		n++;
 	}
-	systable_endscan(scan);
 
 	qsort(ranges, n, sizeof(ReclaimRange), reclaim_range_cmp);
 	for (i = 1; i < n; i++)
@@ -782,9 +704,6 @@ ColumnarCheckFreeSpaceNoOverlap(uint64 storageId)
 	}
 
 	pfree(ranges);
-	table_close(fs, AccessShareLock);
-	table_close(rg, AccessShareLock);
-	UnregisterSnapshot(snap);
 }
 #endif							/* USE_ASSERT_CHECKING */
 
@@ -799,86 +718,51 @@ ColumnarCheckFreeSpaceNoOverlap(uint64 storageId)
  *		the tail safe to drop.
  */
 bool
-ColumnarTrailingFreeSpaceSafe(uint64 storageId, uint64 liveEnd,
+ColumnarTrailingFreeSpaceSafe(Relation rel, uint64 storageId, uint64 liveEnd,
 							  TransactionId oldestXmin)
 {
-	Relation	rel = open_columnar_table("free_space", AccessShareLock);
-	TupleDesc	td = RelationGetDescr(rel);
-	Snapshot	snap = RegisterSnapshot(GetLatestSnapshot());
-	ScanKeyData key[1];
-	SysScanDesc scan;
-	HeapTuple	tuple;
-	bool		safe = true;
+	ColumnarFreeEntry list[COLUMNAR_FREELIST_MAX];
+	int			n = ColumnarFreeListRead(rel, list);
+	int			i;
 
-	ScanKeyInit(&key[0], Anum_free_space_storage_id, BTEqualStrategyNumber,
-				F_INT8EQ, Int64GetDatum((int64) storageId));
-	scan = systable_beginscan(rel, InvalidOid, false, snap, 1, key);
-	while (HeapTupleIsValid(tuple = systable_getnext(scan)))
+	for (i = 0; i < n; i++)
 	{
-		bool		isnull;
-		uint64		off = (uint64) DatumGetInt64(
-			heap_getattr(tuple, Anum_free_space_file_offset, td, &isnull));
-		TransactionId fxid = (TransactionId) DatumGetInt64(
-			heap_getattr(tuple, Anum_free_space_freed_xid, td, &isnull));
-
-		if (off < liveEnd)
+		if (list[i].storageId != storageId || list[i].fileOffset < liveEnd)
 			continue;
-		if (TransactionIdIsNormal(fxid) &&
-			!TransactionIdPrecedes(fxid, oldestXmin))
-		{
-			safe = false;
-			break;
-		}
+		if (TransactionIdIsNormal((TransactionId) list[i].freedXid) &&
+			!TransactionIdPrecedes((TransactionId) list[i].freedXid, oldestXmin))
+			return false;
 	}
-	systable_endscan(scan);
-	UnregisterSnapshot(snap);
-	table_close(rel, AccessShareLock);
-	return safe;
+	return true;
 }
 
 /*
  * ColumnarDeleteFreeSpaceAtOrAbove
- *		Physical end-truncation: drop every free_space row for this storage whose
- *		offset is at or above liveEnd. Those ranges are being physically removed
- *		from the file, so they must no longer appear as reusable space. The caller
- *		holds AccessExclusiveLock and has verified the tail is safe.
+ *		Physical end-truncation: drop every block-1 free entry for this storage
+ *		whose offset is at or above liveEnd. Those ranges are being physically
+ *		removed from the file, so they must no longer appear as reusable space. The
+ *		caller holds AccessExclusiveLock and has verified the tail is safe.
  */
 void
-ColumnarDeleteFreeSpaceAtOrAbove(uint64 storageId, uint64 liveEnd)
+ColumnarDeleteFreeSpaceAtOrAbove(Relation rel, uint64 storageId, uint64 liveEnd)
 {
-	Relation	rel = open_columnar_table("free_space", RowExclusiveLock);
-	TupleDesc	td = RelationGetDescr(rel);
-	Snapshot	snap = RegisterSnapshot(GetLatestSnapshot());
-	ScanKeyData key[1];
-	SysScanDesc scan;
-	HeapTuple	tuple;
-	List	   *tids = NIL;
-	ListCell   *lc;
+	ColumnarFreeEntry list[COLUMNAR_FREELIST_MAX];
+	int			n = ColumnarFreeListRead(rel, list);
+	int			i;
+	int			w = 0;
+	bool		changed = false;
 
-	ScanKeyInit(&key[0], Anum_free_space_storage_id, BTEqualStrategyNumber,
-				F_INT8EQ, Int64GetDatum((int64) storageId));
-	scan = systable_beginscan(rel, InvalidOid, false, snap, 1, key);
-	while (HeapTupleIsValid(tuple = systable_getnext(scan)))
+	for (i = 0; i < n; i++)
 	{
-		bool		isnull;
-		uint64		off = (uint64) DatumGetInt64(
-			heap_getattr(tuple, Anum_free_space_file_offset, td, &isnull));
-
-		if (off >= liveEnd)
+		if (list[i].storageId == storageId && list[i].fileOffset >= liveEnd)
 		{
-			ItemPointer tid = palloc(sizeof(ItemPointerData));
-
-			*tid = tuple->t_self;
-			tids = lappend(tids, tid);
+			changed = true;
+			continue;
 		}
+		list[w++] = list[i];
 	}
-	systable_endscan(scan);
-
-	foreach(lc, tids)
-		CatalogTupleDelete(rel, (ItemPointer) lfirst(lc));
-
-	UnregisterSnapshot(snap);
-	table_close(rel, RowExclusiveLock);
+	if (changed)
+		ColumnarFreeListWrite(rel, list, w);
 }
 
 /*
@@ -898,7 +782,7 @@ ColumnarRetireFullyDeletedGroups(Relation rel)
 
 	foreach(lc, groups)
 	{
-		ColumnarRetireGroup(storageId, *(uint64 *) lfirst(lc));
+		ColumnarRetireGroup(rel, *(uint64 *) lfirst(lc));
 		retired++;
 	}
 	return retired;
@@ -1246,7 +1130,8 @@ ColumnarDeleteMetadata(uint64 storageId)
 	delete_rows_by_storage_id("column_chunk", Anum_column_chunk_storage_id, storageId);
 	delete_rows_by_storage_id("zone_map", Anum_zone_map_storage_id, storageId);
 	delete_rows_by_storage_id("bloom", Anum_bloom_storage_id, storageId);
-	delete_rows_by_storage_id("free_space", Anum_free_space_storage_id, storageId);
+	/* the reclaim free list lives in block 1 of the relation file, so it is
+	 * dropped with the file; nothing to delete from the catalog here */
 	delete_rows_by_storage_id("row_group", Anum_row_group_storage_id, storageId);
 	delete_rows_by_storage_id("storage", Anum_native_storage_storage_id, storageId);
 }

--- a/src/columnar_projection.c
+++ b/src/columnar_projection.c
@@ -267,6 +267,7 @@ columnar_drop_projection(PG_FUNCTION_ARGS)
 	List	   *existing;
 	ListCell   *lc;
 	int			targetId = -1;
+	uint64		targetStorageId = 0;
 
 	if (PG_ARGISNULL(0) || PG_ARGISNULL(1))
 		ereport(ERROR,
@@ -294,6 +295,7 @@ columnar_drop_projection(PG_FUNCTION_ARGS)
 		if (strcmp(p->name, projname) == 0)
 		{
 			targetId = p->projectionId;
+			targetStorageId = p->projStorageId;
 			break;
 		}
 	}
@@ -309,8 +311,10 @@ columnar_drop_projection(PG_FUNCTION_ARGS)
 				 errmsg("the base projection cannot be dropped")));
 
 	/* phase 1 writes no data to a projection's storage, so there is nothing to
-	 * free yet; later phases free the projection's stripes here. */
+	 * free yet; later phases free the projection's stripes here. Purge any block-1
+	 * free entries for the dropped storage so they cannot orphan (offset 0 = all). */
 	ColumnarDeleteProjectionRow(storageId, targetId);
+	ColumnarDeleteFreeSpaceAtOrAbove(rel, targetStorageId, 0);
 
 	table_close(rel, ShareUpdateExclusiveLock);
 	PG_RETURN_VOID();

--- a/src/columnar_storage.c
+++ b/src/columnar_storage.c
@@ -313,6 +313,74 @@ ColumnarSetReservedOffset(Relation rel, uint64 newOffset)
 }
 
 /*
+ * ColumnarFreeListRead
+ *		Copy the block-1 free-list entries into out[] (caller-sized to
+ *		COLUMNAR_FREELIST_MAX) and return the count. The count is derived from the
+ *		page's pd_lower, so block 1 is self-describing.
+ */
+int
+ColumnarFreeListRead(Relation rel, ColumnarFreeEntry *out)
+{
+	Buffer		buffer;
+	Page		page;
+	int			count;
+
+	buffer = ReadBuffer(rel, COLUMNAR_FREELIST_BLOCKNO);
+	LockBuffer(buffer, BUFFER_LOCK_SHARE);
+	page = BufferGetPage(buffer);
+	count = (int) ((((PageHeader) page)->pd_lower - SizeOfPageHeaderData) /
+				   sizeof(ColumnarFreeEntry));
+	if (count < 0)
+		count = 0;
+	if (count > COLUMNAR_FREELIST_MAX)
+		count = COLUMNAR_FREELIST_MAX;
+	if (count > 0)
+		memcpy(out, (char *) page + SizeOfPageHeaderData,
+			   (Size) count * sizeof(ColumnarFreeEntry));
+	UnlockReleaseBuffer(buffer);
+	return count;
+}
+
+/*
+ * ColumnarFreeListWrite
+ *		Replace the whole block-1 free list with entries[0..count). One exclusive
+ *		buffer lock, one full-page-image WAL record: the list update is atomic and
+ *		crash/replication safe, in the same non-transactional persistence class as
+ *		the metapage highwater.
+ */
+void
+ColumnarFreeListWrite(Relation rel, ColumnarFreeEntry *entries, int count)
+{
+	Buffer		buffer;
+	Page		page;
+
+	Assert(count >= 0 && count <= COLUMNAR_FREELIST_MAX);
+
+	buffer = ReadBuffer(rel, COLUMNAR_FREELIST_BLOCKNO);
+	LockBuffer(buffer, BUFFER_LOCK_EXCLUSIVE);
+	page = BufferGetPage(buffer);
+
+	PageInit(page, BLCKSZ, 0);
+	if (count > 0)
+		memcpy((char *) page + SizeOfPageHeaderData, entries,
+			   (Size) count * sizeof(ColumnarFreeEntry));
+	((PageHeader) page)->pd_lower =
+		SizeOfPageHeaderData + (uint16) (count * sizeof(ColumnarFreeEntry));
+
+	START_CRIT_SECTION();
+	MarkBufferDirty(buffer);
+	if (RelationNeedsWAL(rel))
+	{
+		XLogRecPtr	recptr = log_newpage_buffer(buffer, true);
+
+		PageSetLSN(page, recptr);
+	}
+	END_CRIT_SECTION();
+
+	UnlockReleaseBuffer(buffer);
+}
+
+/*
  * ColumnarTruncateMainFork
  *		Physically truncate the relation's MAIN fork to newnblocks, returning the
  *		trailing blocks to the OS (physical end-truncation). Scoped to the main

--- a/src/columnar_storage.c
+++ b/src/columnar_storage.c
@@ -131,11 +131,14 @@ ColumnarReadMetapage(Relation rel, ColumnarMetapage *meta)
 	memcpy(meta, ColumnarMetapagePointer(page), sizeof(ColumnarMetapage));
 	UnlockReleaseBuffer(buffer);
 
-	if (meta->versionMajor != COLUMNAR_VERSION_MAJOR)
+	if (meta->versionMajor != COLUMNAR_VERSION_MAJOR ||
+		meta->versionMinor < COLUMNAR_VERSION_MINOR)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("unsupported columnar format version %u.%u",
-						meta->versionMajor, meta->versionMinor)));
+						meta->versionMajor, meta->versionMinor),
+				 errdetail("This pgcolumnar build requires format %u.%u; recreate the table.",
+						   COLUMNAR_VERSION_MAJOR, COLUMNAR_VERSION_MINOR)));
 }
 
 uint64
@@ -323,15 +326,17 @@ ColumnarFreeListRead(Relation rel, ColumnarFreeEntry *out)
 {
 	Buffer		buffer;
 	Page		page;
+	int			lower;
 	int			count;
 
 	buffer = ReadBuffer(rel, COLUMNAR_FREELIST_BLOCKNO);
 	LockBuffer(buffer, BUFFER_LOCK_SHARE);
 	page = BufferGetPage(buffer);
-	count = (int) ((((PageHeader) page)->pd_lower - SizeOfPageHeaderData) /
-				   sizeof(ColumnarFreeEntry));
-	if (count < 0)
+	lower = (int) ((PageHeader) page)->pd_lower;
+	if (lower < (int) SizeOfPageHeaderData)
 		count = 0;
+	else
+		count = (lower - (int) SizeOfPageHeaderData) / (int) sizeof(ColumnarFreeEntry);
 	if (count > COLUMNAR_FREELIST_MAX)
 		count = COLUMNAR_FREELIST_MAX;
 	if (count > 0)
@@ -355,6 +360,12 @@ ColumnarFreeListWrite(Relation rel, ColumnarFreeEntry *entries, int count)
 	Page		page;
 
 	Assert(count >= 0 && count <= COLUMNAR_FREELIST_MAX);
+	/* the read-modify-write is atomic only because all free-list mutators hold
+	 * ShareUpdateExclusiveLock (or AccessExclusiveLock), which self-conflict, so
+	 * they are globally serialized. This is the invariant the no-MVCC design rests
+	 * on; enforce it. */
+	Assert(CheckRelationLockedByMe(rel, ShareUpdateExclusiveLock, false) ||
+		   CheckRelationLockedByMe(rel, AccessExclusiveLock, false));
 
 	buffer = ReadBuffer(rel, COLUMNAR_FREELIST_BLOCKNO);
 	LockBuffer(buffer, BUFFER_LOCK_EXCLUSIVE);

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -322,6 +322,9 @@ columnar_relation_nontransactional_truncate(Relation rel)
 	ColumnarDeleteMetadata(storageId);
 	RelationTruncate(rel, 2);
 	ColumnarResetMetapage(rel);
+	/* block 1 (the reclaim free list) is kept by the truncate-to-2-blocks but its
+	 * entries now point into removed data; clear it */
+	ColumnarFreeListWrite(rel, NULL, 0);
 }
 
 /* -------------------------------------------------------------------------

--- a/src/columnar_vacuum.c
+++ b/src/columnar_vacuum.c
@@ -24,6 +24,7 @@
 #include "columnar_compat.h"
 
 #include "fmgr.h"
+#include "funcapi.h"
 #include "access/genam.h"
 #include "access/xact.h"
 #include "access/relation.h"
@@ -58,6 +59,7 @@ PG_FUNCTION_INFO_V1(columnar_compact);
 PG_FUNCTION_INFO_V1(columnar_compact_rewrite);
 PG_FUNCTION_INFO_V1(columnar_recluster);
 PG_FUNCTION_INFO_V1(columnar_truncate);
+PG_FUNCTION_INFO_V1(columnar_free_list);
 PG_FUNCTION_INFO_V1(columnar_debug_advance_reserved_offset);
 
 /* physical end-truncation opt-in (GUC), registered in _PG_init. Default off
@@ -248,7 +250,7 @@ rewrite_one_group(Relation rel, RewriteIndexState *ris, uint64 storageId,
 
 	/* atomically (same transaction) the new group is now in the catalog; drop the
 	 * old one. Heap MVCC keeps the old group readable to older snapshots. */
-	ColumnarRetireGroup(storageId, groupNumber);
+	ColumnarRetireGroup(rel, groupNumber);
 
 	PopActiveSnapshot();
 	UnregisterSnapshot(snap);
@@ -334,7 +336,7 @@ columnar_rewrite_partial_groups(Relation rel, double minDeletedFraction,
 	}
 	rewrite_index_close(&ris);
 
-	COLUMNAR_ASSERT_NO_OVERLAP(storageId);
+	COLUMNAR_ASSERT_NO_OVERLAP(rel);
 	return rewritten;
 }
 
@@ -487,13 +489,13 @@ columnar_recluster_online(Relation rel, int ncols, AttrNumber *atts)
 
 	/* retire the old groups; heap MVCC keeps them readable to older snapshots */
 	for (i = 0; i < nGroups; i++)
-		ColumnarRetireGroup(storageId, oldGroups[i]);
+		ColumnarRetireGroup(rel, oldGroups[i]);
 
 	PopActiveSnapshot();
 	UnregisterSnapshot(snap);
 	pfree(oldGroups);
 
-	COLUMNAR_ASSERT_NO_OVERLAP(storageId);
+	COLUMNAR_ASSERT_NO_OVERLAP(rel);
 	return nGroups;
 }
 
@@ -1415,7 +1417,7 @@ columnar_compact(PG_FUNCTION_ARGS)
 
 	retired = ColumnarRetireFullyDeletedGroups(rel);
 
-	COLUMNAR_ASSERT_NO_OVERLAP(ColumnarStorageId(rel));
+	COLUMNAR_ASSERT_NO_OVERLAP(rel);
 
 	/* keep the lock until end of transaction */
 	table_close(rel, NoLock);
@@ -1473,24 +1475,20 @@ columnar_end_truncation_storages(uint64 base)
  *
  *		Safe point = the end of the highest-offset LIVE row group across every
  *		storage id in the file (footprints are page-aligned). The trailing region
- *		[liveEnd, EOF) is truncated only when every free_space range there was
- *		freed before the oldest-xmin horizon: a more recent retirement could still
- *		be read by a snapshot older than it, and that read would fault past the
+ *		[liveEnd, EOF) is truncated only when every free range there was freed
+ *		before the oldest-xmin horizon: a more recent retirement could still be
+ *		read by a snapshot older than it, and that read would fault past the
  *		shrunken EOF.
  *
- *		Ordering for crash safety: the physical smgrtruncate is done BEFORE the
- *		metapage highwater is lowered. The highwater lowering is a full-page-image
- *		WAL that persists even on abort, whereas the free_space deletes are
- *		transactional; performing the shrink first means a crash in the large
- *		window (after the truncate, before the highwater is lowered) leaves
- *		"highwater still high + free_space restored + file short", which the
- *		gap-tolerant write path self-heals. The function also runs outside a
- *		transaction block (see columnar_truncate), so a user ROLLBACK cannot land
- *		in the residual window between lowering the highwater and commit; and it
- *		first purges any free_space row at or above the current highwater, which
- *		under the exclusive lock is stale by definition and would otherwise be the
- *		artifact of a prior crash in that residual window. Readers only ever touch
- *		live groups, none of which are in the truncated region.
+ *		Crash safety is now inherent: the free list lives in block 1, so purging
+ *		the trailing free entries, lowering the metapage highwater, and the
+ *		smgrtruncate are all non-transactional page/file operations in the same
+ *		persistence class. A crash or abort leaves the same consistent state as a
+ *		commit, so the abort window the earlier catalog-based design had is gone.
+ *		The steps below (shrink before lowering the highwater, purge stale entries
+ *		first, the transaction-block prohibition in columnar_truncate) are retained
+ *		as harmless belt-and-suspenders; relaxing them is a follow-up. Readers only
+ *		ever touch live groups, none of which are in the truncated region.
  */
 static int64
 columnar_do_end_truncation(Relation rel)
@@ -1516,7 +1514,7 @@ columnar_do_end_truncation(Relation rel)
 	 * and commit. Drop it before it can be reused.
 	 */
 	foreach(lc, storages)
-		ColumnarDeleteFreeSpaceAtOrAbove(*(uint64 *) lfirst(lc), highwater);
+		ColumnarDeleteFreeSpaceAtOrAbove(rel, *(uint64 *) lfirst(lc), highwater);
 
 	/* highest live-data end across all storages, in the latest committed state */
 	snap = RegisterSnapshot(GetLatestSnapshot());
@@ -1546,20 +1544,20 @@ columnar_do_end_truncation(Relation rel)
 
 	/* the trailing region must be entirely behind the oldest-xmin horizon */
 	foreach(lc, storages)
-		if (!ColumnarTrailingFreeSpaceSafe(*(uint64 *) lfirst(lc), liveEnd,
+		if (!ColumnarTrailingFreeSpaceSafe(rel, *(uint64 *) lfirst(lc), liveEnd,
 										   oldestXmin))
 			return 0;			/* a recent retirement is in the tail; retry later */
 
 	/* drop the trailing free ranges, shrink the file, THEN lower the highwater */
 	foreach(lc, storages)
-		ColumnarDeleteFreeSpaceAtOrAbove(*(uint64 *) lfirst(lc), liveEnd);
+		ColumnarDeleteFreeSpaceAtOrAbove(rel, *(uint64 *) lfirst(lc), liveEnd);
 	CommandCounterIncrement();
 	ColumnarTruncateMainFork(rel, truncBlock);
 	ColumnarSetReservedOffset(rel, liveEnd);
 
 	/* stale offset-keyed cache entries for this relation must go */
 	CacheInvalidateRelcacheByRelid(RelationGetRelid(rel));
-	COLUMNAR_ASSERT_NO_OVERLAP(base);
+	COLUMNAR_ASSERT_NO_OVERLAP(rel);
 
 	return (int64) (oldnblocks - truncBlock);
 }
@@ -1621,6 +1619,76 @@ columnar_truncate(PG_FUNCTION_ARGS)
 	/* keep the locks until end of transaction */
 	table_close(rel, NoLock);
 	PG_RETURN_INT64(result);
+}
+
+/*
+ * columnar_free_list
+ *		SQL: pgcolumnar.free_list(regclass) -> setof (storage_id, file_offset,
+ *		byte_length, freed_xid). Introspection over the block-1 reclaim free list
+ *		(the replacement for the old pgcolumnar.free_space table): the freed,
+ *		page-aligned byte ranges currently tracked for reuse.
+ */
+Datum
+columnar_free_list(PG_FUNCTION_ARGS)
+{
+	Oid			relid;
+	ReturnSetInfo *rsinfo = (ReturnSetInfo *) fcinfo->resultinfo;
+	Relation	rel;
+	Tuplestorestate *tupstore;
+	TupleDesc	tupdesc;
+	MemoryContext oldcontext;
+	ColumnarFreeEntry list[COLUMNAR_FREELIST_MAX];
+	int			n;
+	int			i;
+
+	if (PG_ARGISNULL(0))
+		ereport(ERROR,
+				(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+				 errmsg("table name cannot be null")));
+	relid = PG_GETARG_OID(0);
+
+	if (rsinfo == NULL || !IsA(rsinfo, ReturnSetInfo) ||
+		!(rsinfo->allowedModes & SFRM_Materialize))
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("set-valued function called in context that cannot accept a set")));
+	if (get_call_result_type(fcinfo, NULL, &tupdesc) != TYPEFUNC_COMPOSITE)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("return type must be a row type")));
+
+	rel = table_open(relid, AccessShareLock);
+	if (!ColumnarIsColumnarRelation(relid))
+	{
+		table_close(rel, AccessShareLock);
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+				 errmsg("relation \"%s\" is not a columnar table",
+						RelationGetRelationName(rel))));
+	}
+
+	oldcontext = MemoryContextSwitchTo(rsinfo->econtext->ecxt_per_query_memory);
+	tupstore = tuplestore_begin_heap(true, false, work_mem);
+	rsinfo->returnMode = SFRM_Materialize;
+	rsinfo->setResult = tupstore;
+	rsinfo->setDesc = tupdesc;
+	MemoryContextSwitchTo(oldcontext);
+
+	n = ColumnarFreeListRead(rel, list);
+	for (i = 0; i < n; i++)
+	{
+		Datum		values[4];
+		bool		nulls[4] = {false, false, false, false};
+
+		values[0] = Int64GetDatum((int64) list[i].storageId);
+		values[1] = Int64GetDatum((int64) list[i].fileOffset);
+		values[2] = Int64GetDatum((int64) list[i].byteLength);
+		values[3] = Int64GetDatum((int64) list[i].freedXid);
+		tuplestore_putvalues(tupstore, tupdesc, values, nulls);
+	}
+
+	table_close(rel, AccessShareLock);
+	return (Datum) 0;
 }
 
 /*

--- a/src/columnar_vacuum.c
+++ b/src/columnar_vacuum.c
@@ -290,6 +290,10 @@ columnar_rewrite_partial_groups(Relation rel, double minDeletedFraction,
 	ColumnarFlushWriteStateForRelation(relid);
 	ColumnarFlushDeleteVectorForRelation(rel);
 
+	/* purge any free entry left overlapping a live group by a prior aborted or
+	 * crashed retirement, before we reuse anything (see ColumnarReconcileFreeList) */
+	ColumnarReconcileFreeList(rel);
+
 	/* collect candidate groups first (do not mutate the catalog mid-scan) */
 	snap = RegisterSnapshot(GetLatestSnapshot());
 	rgList = ColumnarReadRowGroupList(storageId, snap);
@@ -390,6 +394,10 @@ columnar_recluster_online(Relation rel, int ncols, AttrNumber *atts)
 	/* persist own pending work so the group list and deletes are current */
 	ColumnarFlushWriteStateForRelation(relid);
 	ColumnarFlushDeleteVectorForRelation(rel);
+
+	/* purge any free entry left overlapping a live group by a prior aborted or
+	 * crashed retirement, before we reuse anything (see ColumnarReconcileFreeList) */
+	ColumnarReconcileFreeList(rel);
 
 	/* capture the current groups (retired at the end, after the new ones exist) */
 	listSnap = RegisterSnapshot(GetLatestSnapshot());

--- a/src/columnar_write_state.c
+++ b/src/columnar_write_state.c
@@ -901,7 +901,7 @@ columnar_flush_row_group(ColumnarWriteState *writeState)
 	reusedOffset = false;
 	if (dataLength > 0 &&
 		CheckRelationLockedByMe(rel, ShareUpdateExclusiveLock, false))
-		reusedOffset = ColumnarAllocateFreeSpace(ColumnarStorageId(rel), dataLength,
+		reusedOffset = ColumnarAllocateFreeSpace(rel, ColumnarStorageId(rel), dataLength,
 												 ColumnarOldestXmin(rel), &fileOffset);
 
 	LockRelationForExtension(rel, ExclusiveLock);

--- a/test/native_free_overflow.sh
+++ b/test/native_free_overflow.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# pgColumnar reclaim free-list overflow (Phase F, block-1 free list). The free
+# list lives in one page (block 1), so it holds a bounded number of entries
+# (COLUMNAR_FREELIST_MAX, about 255). When it is full, a further freed range is
+# simply not recorded (reclaimed later by a full rewrite): graceful degradation,
+# never corruption. This OPT-IN suite (not in the default matrix -- it needs many
+# groups) drives the list past capacity with many NON-adjacent, non-coalescible
+# retirements and asserts: data stays correct against a heap mirror, the free-list
+# entry count is capped (never exceeds the page), and the assert-build no-overlap
+# validator (run inside compact) stays green -- i.e. no double-allocation.
+#
+# Usage:  test/native_free_overflow.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+# 520 groups of 1000 rows. Deleting every OTHER whole group leaves 260 retired,
+# non-adjacent ranges (live groups sit between them, so they cannot coalesce),
+# which is past the ~255-entry page capacity.
+N=520000
+psql_run "CREATE TABLE h (id int, v text);"
+psql_run "CREATE TABLE n (id int, v text) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 1000, chunk_group_row_limit => 1000);"
+psql_run "INSERT INTO h SELECT g, md5(g::text) FROM generate_series(1, $N) g;"
+psql_run "INSERT INTO n SELECT g, md5(g::text) FROM generate_series(1, $N) g;"
+
+hash_n() { pgc_set_hash 'SELECT id, v FROM n'; }
+hash_h() { pgc_set_hash 'SELECT id, v FROM h'; }
+freecount() { q "SELECT count(*) FROM pgcolumnar.free_list('n');"; }
+maxentries() { q "SELECT (current_setting('block_size')::int - 24) / 32;"; }
+
+check "load parity" "$(hash_n)" "$(hash_h)"
+
+# fully delete every other group (ids in even-numbered 1000-blocks), then compact.
+psql_run "DELETE FROM h WHERE (id - 1) / 1000 % 2 = 0;"
+psql_run "DELETE FROM n WHERE (id - 1) / 1000 % 2 = 0;"
+psql_run "SELECT pgcolumnar.compact('n');"
+
+fc="$(freecount)"
+cap="$(maxentries)"
+echo "  (free-list entries=$fc  page capacity=$cap)"
+check "data correct after overflowing compaction" "$(hash_n)" "$(hash_h)"
+check "free-list entry count never exceeds the page" \
+	"$([ "$fc" -le "$cap" ] && echo yes || echo no)" "yes"
+check "free list actually filled (overflow exercised)" \
+	"$([ "$fc" -ge "$((cap - 5))" ] && echo yes || echo no)" "yes"
+
+# still fully usable: a full recluster rebuilds every group (rebuilding the free
+# list from scratch), the no-overlap validator runs inside it, and data holds.
+psql_run "SELECT pgcolumnar.recluster('n', 'id');"
+check "data correct after recluster over overflowed list" "$(hash_n)" "$(hash_h)"
+check "row count intact" "$(q 'SELECT count(*) FROM n;')" "$(q 'SELECT count(*) FROM h;')"
+
+pgc_summary

--- a/test/native_reclaim.sh
+++ b/test/native_reclaim.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 #
 # pgColumnar physical page reclaim (Phase F free-list). Retiring a row group
-# records its data byte range in pgcolumnar.free_space; an online compaction
+# records its data byte range in the block-1 free list; an online compaction
 # (which holds ShareUpdateExclusiveLock and is self-serialized) then reserves from
 # a freed range instead of advancing the file highwater, once the oldest-xmin
 # horizon has passed the freeing transaction. So repeated online compaction reuses
 # space and the relation file plateaus instead of growing every cycle. Plain
 # inserts always append (they never race a reuse). This suite proves that repeated
-# recluster keeps the file bounded (reuse), that free_space is populated and
+# recluster keeps the file bounded (reuse), that the free list is populated and
 # consumed, and that the reused blocks hold correct data (parity with a heap
 # mirror).
 #
@@ -27,14 +27,14 @@ psql_run "INSERT INTO h $GEN;"
 psql_run "INSERT INTO n $GEN;"
 
 fsize() { q "SELECT pg_relation_size('n');"; }
-freerows() { q "SELECT count(*) FROM pgcolumnar.free_space WHERE storage_id = pgcolumnar.get_storage_id('n');"; }
+freerows() { q "SELECT count(*) FROM pgcolumnar.free_list('n') WHERE storage_id = pgcolumnar.get_storage_id('n');"; }
 
 size1="$(fsize)"
 check "initial data present" "$(q 'SELECT count(*) FROM n;')" "6000"
 check "no free space yet" "$(freerows)" "0"
 
 # First online recluster: retires the original groups (freed) and writes new ones.
-# With no reusable space yet it appends, so the file grows and free_space fills.
+# With no reusable space yet it appends, so the file grows and the free list fills.
 psql_run "SELECT pgcolumnar.recluster('n', 'id');"
 size2="$(fsize)"
 check "free space recorded after first recluster" \
@@ -49,7 +49,7 @@ for i in 1 2 3 4; do
 	psql_run "SELECT pgcolumnar.recluster('n', 'id');"
 done
 size3="$(fsize)"
-echo "  (file size: initial=$size1 after-1-recluster=$size2 after-5-reclusters=$size3; free_space rows=$(freerows))"
+echo "  (file size: initial=$size1 after-1-recluster=$size2 after-5-reclusters=$size3; free-list entries=$(freerows))"
 
 check "repeated recluster reuses space (file plateaus)" \
 	"$([ "$size3" -le "$((size2 + size1))" ] && echo yes || echo no)" "yes"

--- a/test/native_reclaim_abort.sh
+++ b/test/native_reclaim_abort.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# pgColumnar reclaim: aborted compaction must not corrupt (Phase F, block-1 free
+# list). The free list is non-transactional (block 1), but a compaction's
+# row_group deletes are transactional. If a compaction aborts, the groups come
+# back live while the recorded free entries persist, so those entries now overlap
+# live data. ColumnarReconcileFreeList purges such stale entries at the start of
+# every reuse, before ColumnarAllocateFreeSpace can hand one out on top of a live
+# group. This suite aborts a compaction mid-flight (BEGIN; compact_rewrite;
+# ROLLBACK), confirms the stale entries persist, then runs a real compaction and
+# asserts data is intact against a heap mirror (the assert-build no-overlap
+# validator also runs inside the compaction, so any double-allocation would fire).
+#
+# Usage:  test/native_reclaim_abort.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+raw() { env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" -Atq -c "$1" 2>&1; }
+hash_n() { pgc_set_hash 'SELECT id, v FROM n'; }
+hash_h() { pgc_set_hash 'SELECT id, v FROM h'; }
+freecount() { q "SELECT count(*) FROM pgcolumnar.free_list('n');"; }
+
+psql_run "CREATE TABLE h (id int, v text);"
+psql_run "CREATE TABLE n (id int, v text) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 1000, chunk_group_row_limit => 1000);"
+psql_run "INSERT INTO h SELECT g, md5(g::text) FROM generate_series(1, 8000) g;"
+psql_run "INSERT INTO n SELECT g, md5(g::text) FROM generate_series(1, 8000) g;"
+# partially delete each group so every group is a rewrite candidate
+psql_run "DELETE FROM h WHERE id % 3 = 0;"
+psql_run "DELETE FROM n WHERE id % 3 = 0;"
+check "parity before" "$(hash_n)" "$(hash_h)"
+
+# abort a compaction mid-flight: the row_group deletes roll back, but the block-1
+# free entries recorded during it persist (non-transactional).
+raw "BEGIN; SELECT pgcolumnar.compact_rewrite('n', 0.1); ROLLBACK;" >/dev/null
+check "parity after aborted compaction (rollback restored the groups)" \
+	"$(hash_n)" "$(hash_h)"
+stale="$(freecount)"
+echo "  (stale free entries left by the aborted compaction: $stale)"
+check "aborted compaction did leave stale free entries" \
+	"$([ "$stale" -gt 0 ] && echo yes || echo no)" "yes"
+
+# a real compaction reconciles (purges the stale, overlapping entries) before
+# reusing, so it cannot double-allocate over a live group.
+psql_run "SELECT pgcolumnar.compact_rewrite('n', 0.0);"
+check "data intact after recompaction (no double-allocation)" \
+	"$(hash_n)" "$(hash_h)"
+check "row count intact" "$(q 'SELECT count(*) FROM n;')" "$(q 'SELECT count(*) FROM h;')"
+
+# reuse keeps working across further delete+compact cycles, still correct.
+for r in 1 2 3; do
+	psql_run "DELETE FROM h WHERE id % 5 = $r;"
+	psql_run "DELETE FROM n WHERE id % 5 = $r;"
+	psql_run "SELECT pgcolumnar.compact_rewrite('n', 0.0);"
+	check "parity after reuse cycle $r" "$(hash_n)" "$(hash_h)"
+done
+
+pgc_summary

--- a/test/native_reclaim_frag.sh
+++ b/test/native_reclaim_frag.sh
@@ -9,7 +9,7 @@
 #   * the live set matches a heap mirror in BOTH modes (correctness);
 #   * coalescing actually merges: fully deleting a large CONTIGUOUS block of
 #     groups and compacting frees many small adjacent byte ranges, and with the
-#     GUC on they collapse to FEWER free_space rows than with it off (direct,
+#     GUC on they collapse to FEWER free-list entries than with it off (direct,
 #     deterministic evidence the coalesce path runs); and
 #   * coalesce is never worse than whole-range reuse for the final file size.
 # The assert-build no-overlap validator (ColumnarCheckFreeSpaceNoOverlap) runs at
@@ -27,7 +27,7 @@ pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
 GEN="SELECT g AS id, repeat('ab', 5 + ((g / 1000) % 16) * 8) AS payload
   FROM generate_series(1, 30000) g"
 
-freerows() { q "SELECT count(*) FROM pgcolumnar.free_space WHERE storage_id = pgcolumnar.get_storage_id('n');"; }
+freerows() { q "SELECT count(*) FROM pgcolumnar.free_list('n') WHERE storage_id = pgcolumnar.get_storage_id('n');"; }
 
 run() {			# $1 = on|off ; echoes "<free_rows_after_compact>|<final_size>|<ok|MISMATCH>"
 	{
@@ -46,7 +46,7 @@ run() {			# $1 = on|off ; echoes "<free_rows_after_compact>|<final_size>|<ok|MIS
 		psql_run "SET pgcolumnar.reclaim_coalesce = $1; SELECT pgcolumnar.compact('n');"
 	} >/dev/null 2>&1
 
-	# free_space rows right after the compaction, before anything consumes them.
+	# free-list entries right after the compaction, before anything consumes them.
 	local fr size ph hh
 	fr="$(freerows)"
 
@@ -68,9 +68,9 @@ off_fr="${off%%|*}"; off_rest="${off#*|}"; off_size="${off_rest%%|*}"; off_par="
 
 check "coalesce on: parity with heap"  "$on_par"  "ok"
 check "coalesce off: parity with heap" "$off_par" "ok"
-echo "  (free_space rows after compact: coalesce-on=$on_fr coalesce-off=$off_fr)"
+echo "  (free-list entries after compact: coalesce-on=$on_fr coalesce-off=$off_fr)"
 echo "  (final file size: coalesce-on=$on_size coalesce-off=$off_size)"
-check "coalesce merges adjacent frees (fewer free_space rows)" \
+check "coalesce merges adjacent frees (fewer free-list entries)" \
 	"$([ "$on_fr" -lt "$off_fr" ] && echo yes || echo no)" "yes"
 check "coalesce never larger than whole-range reuse" \
 	"$([ "$on_size" -le "$off_size" ] && echo yes || echo no)" "yes"

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -27,7 +27,7 @@ SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUITES=(smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
 	differential recovery fuzz hardening concurrent_diff parallel sorted_projection \
 	arrow_export parquet_export read_stream corruption \
-	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip native_index native_dml native_ios native_projection native_cluster native_compact native_recluster native_reclaim native_ownership native_reclaim_cycles native_reclaim_frag native_gap native_truncate native_rewrite native_rewrite_conc isolation)
+	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip native_index native_dml native_ios native_projection native_cluster native_compact native_recluster native_reclaim native_ownership native_reclaim_abort native_reclaim_cycles native_reclaim_frag native_gap native_truncate native_rewrite native_rewrite_conc isolation)
 
 # Default matrix: one assert-enabled pg_config per major, 15 through 19.
 DEFAULT_CONFIGS=(


### PR DESCRIPTION
Replaces the `pgcolumnar.free_space` catalog table with a non-transactional free list stored in **block 1** of each columnar relation's main fork (previously reserved and empty; data starts at block 2). The free list and the metapage highwater now share **one persistence class**.

> Corruption-critical (on-disk format + reclaim crash/abort behavior). **Requesting review**, not auto-merging. Design: `design/PHASE_F_FREE_LIST_METAPAGE_PLAN.md`.

## Why
End-truncation (PR #92) had a documented residual abort/crash window because the highwater lowering (a non-transactional FPI) and the `free_space` deletes (transactional) were different persistence classes. Moving the free list to block 1 makes them one class, so purging trailing entries + lowering the highwater + `smgrtruncate` are all non-transactional page/file ops — a crash or abort leaves the same consistent state as a commit. The window is **eliminated**, not narrowed. Secondary wins: removes a catalog table and the per-allocation `systable` scan; reduces reclaim to a single durability class.

## How
- Block 1 is self-describing: a packed `ColumnarFreeEntry` array (`storage_id, file_offset, byte_length, freed_xid`), count = `pd_lower`, each update one FPI write (`ColumnarFreeListRead`/`Write`). No metapage struct change; format minor bumped 2.2 → 2.3.
- `record_free_space` / `ColumnarAllocateFreeSpace` / `ColumnarTrailingFreeSpaceSafe` / `ColumnarDeleteFreeSpaceAtOrAbove` / the assert no-overlap validator all operate on the block-1 array (Relation threaded through). All mutations are under SUEL, so a buffer lock replaces MVCC; coalescing / split / horizon gating unchanged.
- **Capacity** is one page (~255 entries). Coalescing keeps it compact; on overflow a range is simply not recorded (reclaimed by the next full rewrite) — graceful degradation, logged, never corruption.
- `pgcolumnar.free_list(regclass)` replaces the queryable table. `TRUNCATE TABLE` clears block 1. Truncate's txn-block guard/ordering retained as belt-and-suspenders (the window they guarded is now closed); relaxing them is a noted follow-up.

## Review focus
- The SUEL-serialization invariant (buffer lock instead of MVCC) — is every `record_free_space`/`ColumnarAllocateFreeSpace` path really under SUEL?
- The overflow-leak fallback and its cap.
- Block-1 lifecycle: init (already `PageInit`'d), `TRUNCATE TABLE` reset, crash/replication via FPI.

## Tests
All reclaim/behavior suites pass unchanged (`native_reclaim*`, `native_gap`, `native_truncate`, `isolation`, `differential`, …); `native_reclaim`/`frag` now introspect via `free_list()`. New opt-in `native_free_overflow.sh` fills the page to exactly its 255-entry capacity and asserts graceful degradation with the no-overlap validator green. **PG17 full-suite gate green**; full 15-19 matrix runs in the daily gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)