### PR TITLE
Phase F: reconcile free_space against live groups (close truncate's abort seam, keep MVCC)

### DIFF
--- a/design/PHASE_F_END_TRUNCATION_PLAN.md
+++ b/design/PHASE_F_END_TRUNCATION_PLAN.md
@@ -161,10 +161,21 @@ commit) is closed on the next truncation by #3, but a crash there followed by an
 insert and a compaction, before any next truncation, could still reuse a buried
 stale range. It is extremely narrow (a crash inside the sub-millisecond gap
 between the metapage FPI and commit, on an opt-in operation), and the feature ships
-`enable_end_truncation` OFF by default. The clean long-term fix is architectural:
-move the free list into the metapage / dedicated non-transactional pages so the
-highwater and the free list share one persistence class and update atomically. See
-the review thread on PR #92.
+`enable_end_truncation` OFF by default.
+
+UPDATE (2026-07-23): this residual is now closed by reconciliation, on the MVCC
+`free_space` catalog, rather than by moving the free list off the catalog.
+`ColumnarReconcileFreeList(rel)` runs at the start of every reuse op
+(`compact_rewrite`, `recluster`) and deletes any `free_space` row overlapping a
+live row-group footprint, so a range left stale by a crash in the window above is
+dropped before it can be reused. An earlier attempt (PR #94) moved the free list
+into a non-transactional metapage page to make truncate's effects one persistence
+class; it was closed because it made truncate atomic at the cost of the common
+retirement path (which MVCC makes atomic for free), needing the same
+reconciliation anyway, plus a fixed page capacity and a format change.
+Reconciliation is the universal fix and keeps the MVCC catalog's retirement
+atomicity, concurrency, and unbounded free list. Pinned by
+`native_reclaim_reconcile.sh`.
 
 Replication: the `xl_smgr_truncate` record replays on standbys through the
 standard `smgr_redo`, truncating the same fork to the same block. The metapage FPI
@@ -228,9 +239,8 @@ read before implementation.
   any user can invoke them (truncate takes an AccessExclusiveLock, the strongest).
   Add an `object_ownercheck`/`pg_class_ownercheck` gate to all of them in one
   follow-up PR, with the PG15-vs-16 name compat in `columnar_compat.h`.
-- **Architectural abort atomicity.** Move the `free_space` free list into the
-  metapage or dedicated non-transactional pages so the highwater and the free list
-  share one persistence class and update atomically. This closes the residual
-  crash window documented in "WAL, crash, and abort" (highwater lowered by FPI,
-  free_space deletes rolled back) completely, rather than narrowing it. It also
-  simplifies the reasoning to a single class of durability.
+- **Abort atomicity: DONE via reconciliation** (not by moving the free list off
+  the catalog). `ColumnarReconcileFreeList` drops free_space rows overlapping live
+  groups at the start of every reuse, closing the residual window while keeping the
+  MVCC catalog. See the UPDATE note in "WAL, crash, and abort" and PR #94's closure
+  for why the metapage-page approach was rejected.

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -348,6 +348,7 @@ extern bool ColumnarAllocateFreeSpace(uint64 storageId, uint64 dataLength,
 extern bool ColumnarTrailingFreeSpaceSafe(uint64 storageId, uint64 liveEnd,
 										  TransactionId oldestXmin);
 extern void ColumnarDeleteFreeSpaceAtOrAbove(uint64 storageId, uint64 liveEnd);
+extern void ColumnarReconcileFreeList(Relation dataRel);
 extern List *ColumnarComputeAllVisibleGroups(uint64 storageId,
 											 TransactionId oldestXmin);
 

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -887,6 +887,19 @@ typedef struct FootRange
 	uint64		end;
 } FootRange;
 
+static int
+footrange_cmp(const void *a, const void *b)
+{
+	uint64		oa = ((const FootRange *) a)->off;
+	uint64		ob = ((const FootRange *) b)->off;
+
+	if (oa < ob)
+		return -1;
+	if (oa > ob)
+		return 1;
+	return 0;
+}
+
 /* append live row-group footprints for one storage to foots[] */
 static void
 collect_footprints(uint64 storageId, Snapshot snap, FootRange **foots,
@@ -907,6 +920,31 @@ collect_footprints(uint64 storageId, Snapshot snap, FootRange **foots,
 		(*foots)[*nf].end = rg->fileOffset + COLUMNAR_PAGE_ROUND_UP(rg->byteLength);
 		(*nf)++;
 	}
+}
+
+/*
+ * Does [start, end) overlap any footprint? foots is sorted ascending by offset
+ * and the footprints are non-overlapping (they tile live groups), so ends are
+ * also ascending; the footprint with the largest offset below `end` has the
+ * largest end among candidates, so one binary search plus one check settles it.
+ */
+static bool
+range_overlaps_footprint(uint64 start, uint64 end, FootRange *foots, int nf)
+{
+	int			lo = 0;
+	int			hi = nf;			/* find last index with off < end */
+
+	while (lo < hi)
+	{
+		int			mid = (lo + hi) / 2;
+
+		if (foots[mid].off < end)
+			lo = mid + 1;
+		else
+			hi = mid;
+	}
+	/* lo is the count of footprints with off < end; check the last one's end */
+	return lo > 0 && foots[lo - 1].end > start;
 }
 
 /*
@@ -947,25 +985,40 @@ ColumnarReconcileFreeList(Relation dataRel)
 	foots = palloc(sizeof(FootRange) * capf);
 	snap = RegisterSnapshot(GetLatestSnapshot());
 
-	/* live footprints and the storage id set (base + distinct projections) */
+	/* live footprints and the storage id set (base + distinct projections). Store
+	 * storage ids as heap uint64s, not stuffed into pointers, so an id > 2^32 is
+	 * safe on 32-bit builds (matches columnar_end_truncation_storages). */
 	collect_footprints(base, snap, &foots, &nf, &capf);
-	storages = lappend(storages, (void *) (uintptr_t) base);
+	{
+		uint64	   *s = palloc(sizeof(uint64));
+
+		*s = base;
+		storages = lappend(storages, s);
+	}
 	foreach(lc, projs)
 	{
 		ColumnarProjection *p = (ColumnarProjection *) lfirst(lc);
 
 		if (p->projStorageId != base)
 		{
+			uint64	   *s = palloc(sizeof(uint64));
+
 			collect_footprints(p->projStorageId, snap, &foots, &nf, &capf);
-			storages = lappend(storages, (void *) (uintptr_t) p->projStorageId);
+			*s = p->projStorageId;
+			storages = lappend(storages, s);
 		}
 	}
+
+	/* sort once so each free row is checked with a binary search, not a linear
+	 * scan of every footprint (this runs on every reuse op, usually purging
+	 * nothing) */
+	qsort(foots, nf, sizeof(FootRange), footrange_cmp);
 
 	fsrel = open_columnar_table("free_space", RowExclusiveLock);
 	td = RelationGetDescr(fsrel);
 	foreach(lc, storages)
 	{
-		uint64		sid = (uint64) (uintptr_t) lfirst(lc);
+		uint64		sid = *(uint64 *) lfirst(lc);
 		ScanKeyData key[1];
 		SysScanDesc scan;
 		HeapTuple	tuple;
@@ -980,17 +1033,14 @@ ColumnarReconcileFreeList(Relation dataRel)
 				heap_getattr(tuple, Anum_free_space_file_offset, td, &isnull));
 			uint64		len = (uint64) DatumGetInt64(
 				heap_getattr(tuple, Anum_free_space_byte_length, td, &isnull));
-			int			j;
 
-			for (j = 0; j < nf; j++)
-				if (off < foots[j].end && foots[j].off < off + len)
-				{
-					ItemPointer tid = palloc(sizeof(ItemPointerData));
+			if (range_overlaps_footprint(off, off + len, foots, nf))
+			{
+				ItemPointer tid = palloc(sizeof(ItemPointerData));
 
-					*tid = tuple->t_self;
-					tids = lappend(tids, tid);
-					break;
-				}
+				*tid = tuple->t_self;
+				tids = lappend(tids, tid);
+			}
 		}
 		systable_endscan(scan);
 	}
@@ -1002,6 +1052,8 @@ ColumnarReconcileFreeList(Relation dataRel)
 
 	table_close(fsrel, RowExclusiveLock);
 	UnregisterSnapshot(snap);
+	list_free_deep(storages);
+	list_free_deep(tids);
 	pfree(foots);
 }
 

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -881,6 +881,130 @@ ColumnarDeleteFreeSpaceAtOrAbove(uint64 storageId, uint64 liveEnd)
 	table_close(rel, RowExclusiveLock);
 }
 
+typedef struct FootRange
+{
+	uint64		off;
+	uint64		end;
+} FootRange;
+
+/* append live row-group footprints for one storage to foots[] */
+static void
+collect_footprints(uint64 storageId, Snapshot snap, FootRange **foots,
+				   int *nf, int *capf)
+{
+	List	   *rgs = ColumnarReadRowGroupList(storageId, snap);
+	ListCell   *lc;
+
+	foreach(lc, rgs)
+	{
+		NativeRowGroupMetadata *rg = (NativeRowGroupMetadata *) lfirst(lc);
+
+		if (rg->byteLength == 0)
+			continue;
+		if (*nf == *capf)
+			*foots = repalloc(*foots, sizeof(FootRange) * (*capf *= 2));
+		(*foots)[*nf].off = rg->fileOffset;
+		(*foots)[*nf].end = rg->fileOffset + COLUMNAR_PAGE_ROUND_UP(rg->byteLength);
+		(*nf)++;
+	}
+}
+
+/*
+ * ColumnarReconcileFreeList
+ *		Delete any free_space row (for the base or any projection storage of this
+ *		relation) that overlaps a LIVE row-group footprint as-of the latest
+ *		committed state.
+ *
+ *		Retirement is atomic on this catalog design (the row_group delete and the
+ *		free_space insert are both transactional), so a normal aborted compaction
+ *		leaves no stale entries. The one seam that remains is physical
+ *		end-truncation: it lowers the metapage highwater (a non-transactional
+ *		full-page-image write that persists on abort) while deleting free_space
+ *		rows (transactional, which roll back). A crash in the narrow window between
+ *		the highwater lowering and commit can therefore leave a lowered highwater
+ *		with the trailing free rows restored; a later insert then places a live
+ *		group over one of those ranges. Running this at the start of every reuse
+ *		(compact_rewrite, recluster), under ShareUpdateExclusiveLock and before any
+ *		ColumnarAllocateFreeSpace, drops such an entry before it can be handed out
+ *		on top of a live group. Inserts never reuse, so no stale entry is consumed
+ *		between the crash and the next reuse.
+ */
+void
+ColumnarReconcileFreeList(Relation dataRel)
+{
+	uint64		base = ColumnarStorageId(dataRel);
+	List	   *projs = ColumnarListProjections(base);
+	ListCell   *lc;
+	Snapshot	snap;
+	FootRange  *foots;
+	int			nf = 0;
+	int			capf = 64;
+	Relation	fsrel;
+	TupleDesc	td;
+	List	   *storages = NIL;
+	List	   *tids = NIL;
+
+	foots = palloc(sizeof(FootRange) * capf);
+	snap = RegisterSnapshot(GetLatestSnapshot());
+
+	/* live footprints and the storage id set (base + distinct projections) */
+	collect_footprints(base, snap, &foots, &nf, &capf);
+	storages = lappend(storages, (void *) (uintptr_t) base);
+	foreach(lc, projs)
+	{
+		ColumnarProjection *p = (ColumnarProjection *) lfirst(lc);
+
+		if (p->projStorageId != base)
+		{
+			collect_footprints(p->projStorageId, snap, &foots, &nf, &capf);
+			storages = lappend(storages, (void *) (uintptr_t) p->projStorageId);
+		}
+	}
+
+	fsrel = open_columnar_table("free_space", RowExclusiveLock);
+	td = RelationGetDescr(fsrel);
+	foreach(lc, storages)
+	{
+		uint64		sid = (uint64) (uintptr_t) lfirst(lc);
+		ScanKeyData key[1];
+		SysScanDesc scan;
+		HeapTuple	tuple;
+
+		ScanKeyInit(&key[0], Anum_free_space_storage_id, BTEqualStrategyNumber,
+					F_INT8EQ, Int64GetDatum((int64) sid));
+		scan = systable_beginscan(fsrel, InvalidOid, false, snap, 1, key);
+		while (HeapTupleIsValid(tuple = systable_getnext(scan)))
+		{
+			bool		isnull;
+			uint64		off = (uint64) DatumGetInt64(
+				heap_getattr(tuple, Anum_free_space_file_offset, td, &isnull));
+			uint64		len = (uint64) DatumGetInt64(
+				heap_getattr(tuple, Anum_free_space_byte_length, td, &isnull));
+			int			j;
+
+			for (j = 0; j < nf; j++)
+				if (off < foots[j].end && foots[j].off < off + len)
+				{
+					ItemPointer tid = palloc(sizeof(ItemPointerData));
+
+					*tid = tuple->t_self;
+					tids = lappend(tids, tid);
+					break;
+				}
+		}
+		systable_endscan(scan);
+	}
+
+	foreach(lc, tids)
+		CatalogTupleDelete(fsrel, (ItemPointer) lfirst(lc));
+	if (tids != NIL)
+		CommandCounterIncrement();
+
+	table_close(fsrel, RowExclusiveLock);
+	UnregisterSnapshot(snap);
+	pfree(foots);
+}
+
 /*
  * ColumnarRetireFullyDeletedGroups
  *		Online compaction (Phase F3a, lazy path): retire every row group that is

--- a/src/columnar_vacuum.c
+++ b/src/columnar_vacuum.c
@@ -1421,6 +1421,10 @@ columnar_compact(PG_FUNCTION_ARGS)
 
 	ColumnarRequireTableOwner(rel);
 
+	/* self-heal a truncate crash-residual so the no-overlap assert holds eagerly,
+	 * even though compact does not reuse (see ColumnarReconcileFreeList) */
+	ColumnarReconcileFreeList(rel);
+
 	retired = ColumnarRetireFullyDeletedGroups(rel);
 
 	COLUMNAR_ASSERT_NO_OVERLAP(ColumnarStorageId(rel));
@@ -1518,13 +1522,17 @@ columnar_do_end_truncation(Relation rel)
 	highwater = meta.reservedOffset;
 
 	/*
-	 * Self-heal a prior crash: a free_space row at or above the highwater cannot
-	 * exist in a consistent state (freed ranges are always below the highwater),
-	 * so any such row is the residual of a crash between lowering the highwater
-	 * and commit. Drop it before it can be reused.
+	 * Self-heal a prior crash. Two residual shapes are possible and both are
+	 * cleaned before we proceed: a free_space row at or above the highwater (freed
+	 * ranges are always below it, so any such row is the artifact of a crash
+	 * between lowering the highwater and commit), and a row below the highwater
+	 * that overlaps a live group (a range this truncation would have removed, left
+	 * by such a crash and then covered by a later insert). The latter also keeps
+	 * the end-of-run no-overlap assert valid.
 	 */
 	foreach(lc, storages)
 		ColumnarDeleteFreeSpaceAtOrAbove(*(uint64 *) lfirst(lc), highwater);
+	ColumnarReconcileFreeList(rel);
 
 	/* highest live-data end across all storages, in the latest committed state */
 	snap = RegisterSnapshot(GetLatestSnapshot());

--- a/src/columnar_vacuum.c
+++ b/src/columnar_vacuum.c
@@ -288,6 +288,10 @@ columnar_rewrite_partial_groups(Relation rel, double minDeletedFraction,
 	ColumnarFlushWriteStateForRelation(relid);
 	ColumnarFlushDeleteVectorForRelation(rel);
 
+	/* drop any free_space row overlapping a live group (the residual of a crash
+	 * in end-truncation's narrow window) before reusing anything */
+	ColumnarReconcileFreeList(rel);
+
 	/* collect candidate groups first (do not mutate the catalog mid-scan) */
 	snap = RegisterSnapshot(GetLatestSnapshot());
 	rgList = ColumnarReadRowGroupList(storageId, snap);
@@ -388,6 +392,10 @@ columnar_recluster_online(Relation rel, int ncols, AttrNumber *atts)
 	/* persist own pending work so the group list and deletes are current */
 	ColumnarFlushWriteStateForRelation(relid);
 	ColumnarFlushDeleteVectorForRelation(rel);
+
+	/* drop any free_space row overlapping a live group (the residual of a crash
+	 * in end-truncation's narrow window) before reusing anything */
+	ColumnarReconcileFreeList(rel);
 
 	/* capture the current groups (retired at the end, after the new ones exist) */
 	listSnap = RegisterSnapshot(GetLatestSnapshot());

--- a/test/native_reclaim_reconcile.sh
+++ b/test/native_reclaim_reconcile.sh
@@ -24,6 +24,10 @@ pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
 hash_n() { pgc_set_hash 'SELECT id, v FROM n'; }
 hash_h() { pgc_set_hash 'SELECT id, v FROM h'; }
 
+# enable end-truncation for the whole db (a single-statement truncate below must
+# not be wrapped in a transaction block, which truncate refuses).
+psql_run "ALTER DATABASE $PGC_DB SET pgcolumnar.enable_end_truncation = on;"
+
 psql_run "CREATE TABLE h (id int, v text);"
 psql_run "CREATE TABLE n (id int, v text) USING pgcolumnar;"
 psql_run "SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 1000, chunk_group_row_limit => 1000);"
@@ -40,18 +44,40 @@ off="$(q "SELECT fileoffset FROM pgcolumnar.stats('n') ORDER BY fileoffset LIMIT
 len="$(q "SELECT datalength FROM pgcolumnar.stats('n') ORDER BY fileoffset LIMIT 1;")"
 
 # synthesize the post-crash inverted state: a reusable (ancient freed_xid) free
-# range sitting on top of a live group.
-psql_run "INSERT INTO pgcolumnar.free_space VALUES ($sid, $off, $len, 1);"
-check "stale overlapping free row injected" \
-	"$(q "SELECT count(*) FROM pgcolumnar.free_space WHERE storage_id=$sid AND file_offset=$off AND freed_xid=1;")" "1"
+# range sitting on top of a live group. len is the raw datalength, not the
+# page-rounded footprint real free_space rows store; it still overlaps the group,
+# which is all the reconcile keys on.
+inject() {  # inject a stale free row over the first live group; echoes nothing
+	local o l
+	o="$(q "SELECT fileoffset FROM pgcolumnar.stats('n') ORDER BY fileoffset LIMIT 1;")"
+	l="$(q "SELECT datalength FROM pgcolumnar.stats('n') ORDER BY fileoffset LIMIT 1;")"
+	psql_run "INSERT INTO pgcolumnar.free_space VALUES ($sid, $o, $l, 1);"
+}
+stalerows() { q "SELECT count(*) FROM pgcolumnar.free_space WHERE freed_xid=1;"; }
+
+inject
+check "stale overlapping free row injected" "$(stalerows)" "1"
 
 # compact_rewrite reconciles first, so it neither reuses the stale row nor trips
 # the no-overlap validator; data stays correct.
 psql_run "SELECT pgcolumnar.compact_rewrite('n', 0.1);"
-check "reconcile purged the stale overlapping row" \
-	"$(q "SELECT count(*) FROM pgcolumnar.free_space WHERE freed_xid=1;")" "0"
+check "compact_rewrite reconciled the stale row" "$(stalerows)" "0"
 check "data intact after reconcile + rewrite" "$(hash_n)" "$(hash_h)"
 check "row count intact" "$(q 'SELECT count(*) FROM n;')" "$(q 'SELECT count(*) FROM h;')"
+
+# a PLAIN compact must also self-heal it: it asserts the no-overlap invariant but
+# does not reuse, so it must reconcile too (fails without that call).
+inject
+psql_run "SELECT pgcolumnar.compact('n');"
+check "plain compact reconciled the stale row" "$(stalerows)" "0"
+check "data intact after compact reconcile" "$(hash_n)" "$(hash_h)"
+
+# a truncate must likewise self-heal it (its start purge only removes rows at or
+# above the highwater; the stale row sits below it, over a live group).
+inject
+psql_run "SELECT pgcolumnar.truncate('n');"
+check "truncate reconciled the stale row" "$(stalerows)" "0"
+check "data intact after truncate reconcile" "$(hash_n)" "$(hash_h)"
 
 # reuse keeps working correctly afterward.
 for r in 1 2; do

--- a/test/native_reclaim_reconcile.sh
+++ b/test/native_reclaim_reconcile.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# pgColumnar reclaim reconciliation (Phase F). The free_space catalog is
+# transactional, so normal retirement is atomic. The one seam is physical
+# end-truncation: a crash in its narrow window can leave a free_space row that
+# overlaps a live group (the highwater was lowered but the row's delete rolled
+# back, and a later insert placed a live group there). ColumnarReconcileFreeList
+# runs at the start of every reuse op (compact_rewrite, recluster) and drops any
+# free_space row overlapping a live row-group footprint, so it cannot be handed
+# out on top of a live group.
+#
+# This suite synthesizes that post-crash state directly: it INSERTs a stale
+# free_space row over a live group's byte range, then runs compact_rewrite and
+# asserts the reconcile purged it and data is intact. (Without the reconcile the
+# assert-build no-overlap validator fires on the overlapping row.)
+#
+# Usage:  test/native_reclaim_reconcile.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+hash_n() { pgc_set_hash 'SELECT id, v FROM n'; }
+hash_h() { pgc_set_hash 'SELECT id, v FROM h'; }
+
+psql_run "CREATE TABLE h (id int, v text);"
+psql_run "CREATE TABLE n (id int, v text) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.alter_columnar_table_set('n', stripe_row_limit => 1000, chunk_group_row_limit => 1000);"
+psql_run "INSERT INTO h SELECT g, md5(g::text) FROM generate_series(1, 8000) g;"
+psql_run "INSERT INTO n SELECT g, md5(g::text) FROM generate_series(1, 8000) g;"
+# partial deletes so every group is a compact_rewrite candidate
+psql_run "DELETE FROM h WHERE id % 3 = 0;"
+psql_run "DELETE FROM n WHERE id % 3 = 0;"
+check "parity before" "$(hash_n)" "$(hash_h)"
+
+# a live group's byte range, and the storage id
+sid="$(q "SELECT pgcolumnar.get_storage_id('n');")"
+off="$(q "SELECT fileoffset FROM pgcolumnar.stats('n') ORDER BY fileoffset LIMIT 1;")"
+len="$(q "SELECT datalength FROM pgcolumnar.stats('n') ORDER BY fileoffset LIMIT 1;")"
+
+# synthesize the post-crash inverted state: a reusable (ancient freed_xid) free
+# range sitting on top of a live group.
+psql_run "INSERT INTO pgcolumnar.free_space VALUES ($sid, $off, $len, 1);"
+check "stale overlapping free row injected" \
+	"$(q "SELECT count(*) FROM pgcolumnar.free_space WHERE storage_id=$sid AND file_offset=$off AND freed_xid=1;")" "1"
+
+# compact_rewrite reconciles first, so it neither reuses the stale row nor trips
+# the no-overlap validator; data stays correct.
+psql_run "SELECT pgcolumnar.compact_rewrite('n', 0.1);"
+check "reconcile purged the stale overlapping row" \
+	"$(q "SELECT count(*) FROM pgcolumnar.free_space WHERE freed_xid=1;")" "0"
+check "data intact after reconcile + rewrite" "$(hash_n)" "$(hash_h)"
+check "row count intact" "$(q 'SELECT count(*) FROM n;')" "$(q 'SELECT count(*) FROM h;')"
+
+# reuse keeps working correctly afterward.
+for r in 1 2; do
+	psql_run "DELETE FROM h WHERE id % 5 = $r;"
+	psql_run "DELETE FROM n WHERE id % 5 = $r;"
+	psql_run "SELECT pgcolumnar.compact_rewrite('n', 0.0);"
+	check "parity after reuse cycle $r" "$(hash_n)" "$(hash_h)"
+done
+
+pgc_summary


### PR DESCRIPTION
Closes end-truncation's residual abort/crash window **on the MVCC `free_space` catalog** — the alternative to moving the free list off the catalog (now-closed PR #94).

## Why (and why not #94)
end-truncation lowers the metapage highwater (a non-transactional FPI that persists on abort) while deleting `free_space` rows (transactional, roll back). A crash in the narrow window between the highwater lowering and commit can leave a lowered highwater with the trailing free rows restored; a later insert then places a live group over one of those ranges, which a compaction could reuse on top of live data.

PR #94 moved the free list into a non-transactional metapage page to make truncate's effects one persistence class. It was **closed** because it made *truncate* atomic at the cost of the *common retirement path* (which MVCC makes atomic for free) — it needed the same reconciliation anyway, plus a fixed 255-entry page cap and an on-disk format change. Reconciliation is the universal fix and keeps MVCC's retirement atomicity, concurrency, and unbounded free list.

## How
`ColumnarReconcileFreeList(rel)` runs at the start of every reuse op (`compact_rewrite`, `recluster`), under SUEL and before any `ColumnarAllocateFreeSpace`, and deletes any `free_space` row (base or projection storage) overlapping a live row-group footprint as-of the latest committed state. Inserts never reuse, so no stale range is consumed between the crash and the next reuse. Normal retirement stays atomic, so this is purely a defense for the truncate seam.

**No** format change, page cap, or SUEL-serialization dependency — it's a small, additive change on top of the merged reclaim.

## Test
`native_reclaim_reconcile.sh` injects a stale `free_space` row over a live group's byte range (the synthesized post-crash state), runs `compact_rewrite`, and asserts the reconcile purged it and data is intact. **Verified load-bearing**: with the reconcile removed, the assert-build no-overlap validator fires (`overlapping ranges [16336,+16336) and [16336,+196032)`).

PG17 full-suite gate green. Full 15-19 matrix before merge on your go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)