### PR TITLE
test: parallelize the suite runner (build/install once, ~3-4x faster)

### DIFF
--- a/test/audit.sh
+++ b/test/audit.sh
@@ -51,10 +51,15 @@ echo "== pgColumnar audit test =="
 echo "PG_CONFIG=$PG_CONFIG"
 echo "workdir=$WORKDIR"
 
-echo "-- building"
-make -C "$SRCDIR" PG_CONFIG="$PG_CONFIG" >/dev/null
-echo "-- installing"
-make -C "$SRCDIR" install PG_CONFIG="$PG_CONFIG" >/dev/null
+# The matrix runner installs the extension once per version and sets
+# PGC_SKIP_BUILD; skip the redundant per-suite build+install then, which also
+# avoids racing a concurrent suite's install into the same lib dir.
+if [ -z "${PGC_SKIP_BUILD:-}" ]; then
+	echo "-- building"
+	make -C "$SRCDIR" PG_CONFIG="$PG_CONFIG" >/dev/null
+	echo "-- installing"
+	make -C "$SRCDIR" install PG_CONFIG="$PG_CONFIG" >/dev/null
+fi
 
 if [ "$(id -u)" = "0" ]; then
 	RUNPG=(runuser -u postgres --)

--- a/test/concurrency.sh
+++ b/test/concurrency.sh
@@ -86,10 +86,15 @@ echo "PG_CONFIG=$PG_CONFIG"
 echo "workdir=$WORKDIR"
 echo "port=$PORT (private unix socket in workdir; TCP disabled)"
 
-echo "-- building"
-make -C "$SRCDIR" PG_CONFIG="$PG_CONFIG" >/dev/null
-echo "-- installing"
-make -C "$SRCDIR" install PG_CONFIG="$PG_CONFIG" >/dev/null
+# The matrix runner installs the extension once per version and sets
+# PGC_SKIP_BUILD; skip the redundant per-suite build+install then, which also
+# avoids racing a concurrent suite's install into the same lib dir.
+if [ -z "${PGC_SKIP_BUILD:-}" ]; then
+	echo "-- building"
+	make -C "$SRCDIR" PG_CONFIG="$PG_CONFIG" >/dev/null
+	echo "-- installing"
+	make -C "$SRCDIR" install PG_CONFIG="$PG_CONFIG" >/dev/null
+fi
 
 if [ "$(id -u)" = "0" ]; then
 	RUNPG=(runuser -u postgres --)

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -52,10 +52,16 @@ pgc_setup() {
 	echo "version=$("$PGC_PG_CONFIG" --version)"
 	echo "workdir=$PGC_WORKDIR"
 
-	echo "-- building"
-	make -C "$PGC_SRCDIR" PG_CONFIG="$PGC_PG_CONFIG" >/dev/null
-	echo "-- installing"
-	make -C "$PGC_SRCDIR" install PG_CONFIG="$PGC_PG_CONFIG" >/dev/null
+	# The matrix runner builds and installs once per version and sets
+	# PGC_SKIP_BUILD so parallel suites do not each rebuild (a no-op relink) or
+	# race on writing the shared .so during "make install". A suite run on its own
+	# still builds and installs.
+	if [ -z "${PGC_SKIP_BUILD:-}" ]; then
+		echo "-- building"
+		make -C "$PGC_SRCDIR" PG_CONFIG="$PGC_PG_CONFIG" >/dev/null
+		echo "-- installing"
+		make -C "$PGC_SRCDIR" install PG_CONFIG="$PGC_PG_CONFIG" >/dev/null
+	fi
 
 	# initdb and pg_ctl cannot run as root; use postgres when we are root.
 	if [ "$(id -u)" = "0" ]; then

--- a/test/phase2.sh
+++ b/test/phase2.sh
@@ -28,10 +28,15 @@ echo "== pgColumnar phase 2 test =="
 echo "PG_CONFIG=$PG_CONFIG"
 echo "workdir=$WORKDIR"
 
-echo "-- building"
-make -C "$SRCDIR" PG_CONFIG="$PG_CONFIG" >/dev/null
-echo "-- installing"
-make -C "$SRCDIR" install PG_CONFIG="$PG_CONFIG" >/dev/null
+# The matrix runner installs the extension once per version and sets
+# PGC_SKIP_BUILD; skip the redundant per-suite build+install then, which also
+# avoids racing a concurrent suite's install into the same lib dir.
+if [ -z "${PGC_SKIP_BUILD:-}" ]; then
+	echo "-- building"
+	make -C "$SRCDIR" PG_CONFIG="$PG_CONFIG" >/dev/null
+	echo "-- installing"
+	make -C "$SRCDIR" install PG_CONFIG="$PG_CONFIG" >/dev/null
+fi
 
 if [ "$(id -u)" = "0" ]; then
 	RUNPG=(runuser -u postgres --)

--- a/test/phase3.sh
+++ b/test/phase3.sh
@@ -30,10 +30,15 @@ echo "== pgColumnar phase 3 test =="
 echo "PG_CONFIG=$PG_CONFIG"
 echo "workdir=$WORKDIR"
 
-echo "-- building"
-make -C "$SRCDIR" PG_CONFIG="$PG_CONFIG" >/dev/null
-echo "-- installing"
-make -C "$SRCDIR" install PG_CONFIG="$PG_CONFIG" >/dev/null
+# The matrix runner installs the extension once per version and sets
+# PGC_SKIP_BUILD; skip the redundant per-suite build+install then, which also
+# avoids racing a concurrent suite's install into the same lib dir.
+if [ -z "${PGC_SKIP_BUILD:-}" ]; then
+	echo "-- building"
+	make -C "$SRCDIR" PG_CONFIG="$PG_CONFIG" >/dev/null
+	echo "-- installing"
+	make -C "$SRCDIR" install PG_CONFIG="$PG_CONFIG" >/dev/null
+fi
 
 if [ "$(id -u)" = "0" ]; then
 	RUNPG=(runuser -u postgres --)

--- a/test/phase4.sh
+++ b/test/phase4.sh
@@ -33,10 +33,15 @@ echo "== pgColumnar phase 4 test =="
 echo "PG_CONFIG=$PG_CONFIG"
 echo "workdir=$WORKDIR"
 
-echo "-- building"
-make -C "$SRCDIR" PG_CONFIG="$PG_CONFIG" >/dev/null
-echo "-- installing"
-make -C "$SRCDIR" install PG_CONFIG="$PG_CONFIG" >/dev/null
+# The matrix runner installs the extension once per version and sets
+# PGC_SKIP_BUILD; skip the redundant per-suite build+install then, which also
+# avoids racing a concurrent suite's install into the same lib dir.
+if [ -z "${PGC_SKIP_BUILD:-}" ]; then
+	echo "-- building"
+	make -C "$SRCDIR" PG_CONFIG="$PG_CONFIG" >/dev/null
+	echo "-- installing"
+	make -C "$SRCDIR" install PG_CONFIG="$PG_CONFIG" >/dev/null
+fi
 
 if [ "$(id -u)" = "0" ]; then
 	RUNPG=(runuser -u postgres --)

--- a/test/phase5.sh
+++ b/test/phase5.sh
@@ -36,10 +36,15 @@ echo "== pgColumnar phase 5 test =="
 echo "PG_CONFIG=$PG_CONFIG"
 echo "workdir=$WORKDIR"
 
-echo "-- building"
-make -C "$SRCDIR" PG_CONFIG="$PG_CONFIG" >/dev/null
-echo "-- installing"
-make -C "$SRCDIR" install PG_CONFIG="$PG_CONFIG" >/dev/null
+# The matrix runner installs the extension once per version and sets
+# PGC_SKIP_BUILD; skip the redundant per-suite build+install then, which also
+# avoids racing a concurrent suite's install into the same lib dir.
+if [ -z "${PGC_SKIP_BUILD:-}" ]; then
+	echo "-- building"
+	make -C "$SRCDIR" PG_CONFIG="$PG_CONFIG" >/dev/null
+	echo "-- installing"
+	make -C "$SRCDIR" install PG_CONFIG="$PG_CONFIG" >/dev/null
+fi
 
 if [ "$(id -u)" = "0" ]; then
 	RUNPG=(runuser -u postgres --)

--- a/test/phase6.sh
+++ b/test/phase6.sh
@@ -40,10 +40,15 @@ echo "== pgColumnar phase 6 test =="
 echo "PG_CONFIG=$PG_CONFIG"
 echo "workdir=$WORKDIR"
 
-echo "-- building"
-make -C "$SRCDIR" PG_CONFIG="$PG_CONFIG" >/dev/null
-echo "-- installing"
-make -C "$SRCDIR" install PG_CONFIG="$PG_CONFIG" >/dev/null
+# The matrix runner installs the extension once per version and sets
+# PGC_SKIP_BUILD; skip the redundant per-suite build+install then, which also
+# avoids racing a concurrent suite's install into the same lib dir.
+if [ -z "${PGC_SKIP_BUILD:-}" ]; then
+	echo "-- building"
+	make -C "$SRCDIR" PG_CONFIG="$PG_CONFIG" >/dev/null
+	echo "-- installing"
+	make -C "$SRCDIR" install PG_CONFIG="$PG_CONFIG" >/dev/null
+fi
 
 if [ "$(id -u)" = "0" ]; then
 	RUNPG=(runuser -u postgres --)

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -87,12 +87,37 @@ for pgc in "${CONFIGS[@]}"; do
 		continue
 	fi
 
+	# Install the extension once for this version; the suites then skip their own
+	# build/install (PGC_SKIP_BUILD) and run in parallel, each in its own throwaway
+	# cluster on its own port. This keeps per-suite cluster isolation (crash and
+	# recovery suites need it) while removing the redundant per-suite rebuild and
+	# the serial initdb/start bottleneck. PGC_JOBS controls the degree.
+	if ! make -C "$builddir" install PG_CONFIG="$pgc" >/dev/null 2>>"$builddir/build.err"; then
+		echo "INSTALL FAILED"
+		sed 's/^/    /' "$builddir/build.err"
+		SUMMARY+=("FAIL   PG$major  (install)")
+		overall=1
+		continue
+	fi
+
 	verfail=0
 	results=""
+	maxjobs="${PGC_JOBS:-6}"
 	for s in "${SUITES[@]}"; do
+		# throttle to maxjobs concurrent suites
+		while [ "$(jobs -rp | wc -l)" -ge "$maxjobs" ]; do wait -n; done
 		port=$((BASE_PORT++))
-		if PGC_PORT="$port" bash "$builddir/test/${s}.sh" "$pgc" \
-			>"$builddir/${s}.log" 2>&1; then
+		(
+			PGC_SKIP_BUILD=1 PGC_PORT="$port" \
+				bash "$builddir/test/${s}.sh" "$pgc" >"$builddir/${s}.log" 2>&1
+			echo $? >"$builddir/${s}.rc"
+		) &
+	done
+	wait
+
+	# collect results in suite order for a stable, readable summary
+	for s in "${SUITES[@]}"; do
+		if [ "$(cat "$builddir/${s}.rc" 2>/dev/null)" = 0 ]; then
 			echo "  PASS  $s"
 			results+="$s=PASS "
 		else

--- a/test/smoke.sh
+++ b/test/smoke.sh
@@ -30,10 +30,15 @@ echo "PG_CONFIG=$PG_CONFIG"
 echo "workdir=$WORKDIR"
 
 # ---- build and install -----------------------------------------------------
-echo "-- building"
-make -C "$SRCDIR" PG_CONFIG="$PG_CONFIG" >/dev/null
-echo "-- installing"
-make -C "$SRCDIR" install PG_CONFIG="$PG_CONFIG" >/dev/null
+# The matrix runner installs the extension once per version and sets
+# PGC_SKIP_BUILD; skip the redundant per-suite build+install then, which also
+# avoids racing a concurrent suite's install into the same lib dir.
+if [ -z "${PGC_SKIP_BUILD:-}" ]; then
+	echo "-- building"
+	make -C "$SRCDIR" PG_CONFIG="$PG_CONFIG" >/dev/null
+	echo "-- installing"
+	make -C "$SRCDIR" install PG_CONFIG="$PG_CONFIG" >/dev/null
+fi
 
 # ---- decide how to run cluster commands ------------------------------------
 # pg_regress and initdb cannot run as root; use the postgres user if we are

--- a/test/unique_conc.sh
+++ b/test/unique_conc.sh
@@ -85,10 +85,15 @@ echo "PG_CONFIG=$PG_CONFIG (major $PG_MAJOR)"
 echo "workdir=$WORKDIR"
 echo "port=$PORT (private unix socket in workdir; TCP disabled)"
 
-echo "-- building"
-make -C "$SRCDIR" PG_CONFIG="$PG_CONFIG" >/dev/null
-echo "-- installing"
-make -C "$SRCDIR" install PG_CONFIG="$PG_CONFIG" >/dev/null
+# The matrix runner installs the extension once per version and sets
+# PGC_SKIP_BUILD; skip the redundant per-suite build+install then, which also
+# avoids racing a concurrent suite's install into the same lib dir.
+if [ -z "${PGC_SKIP_BUILD:-}" ]; then
+	echo "-- building"
+	make -C "$SRCDIR" PG_CONFIG="$PG_CONFIG" >/dev/null
+	echo "-- installing"
+	make -C "$SRCDIR" install PG_CONFIG="$PG_CONFIG" >/dev/null
+fi
 
 if [ "$(id -u)" = "0" ]; then
 	RUNPG=(runuser -u postgres --)


### PR DESCRIPTION
The matrix ran every suite serially, and each suite's `pgc_setup` rebuilt + reinstalled the extension before starting its cluster. The rebuild is a no-op relink (already built once per version), the install would race under concurrency, and the serial `initdb`/cluster-start dominated wall time.

## Change
- `run_all_versions.sh` installs the extension **once per version**, then runs suites in a **bounded parallel pool** (`PGC_JOBS`, default 6), each in its own throwaway cluster on its own port, with `PGC_SKIP_BUILD=1` so `pgc_setup` skips the redundant per-suite build/install.
- Results collected in suite order for a stable summary.
- `lib.sh`: `pgc_setup` skips build/install when `PGC_SKIP_BUILD` is set; a suite run **on its own still builds/installs** (unchanged standalone behavior).

## What's preserved
- **Per-suite cluster isolation** — each suite still gets its own fresh `initdb`'d cluster (the `recovery`/`corruption`/crash-abort suites need this). Only *how fast* changes, not *what* is tested.

## Result
PG17 full suite: **ALL VERSIONS PASSED**, **~138s** vs several minutes serial (~3-4×).

🤖 Generated with [Claude Code](https://claude.com/claude-code)