### PR TITLE
Phase G scan core: shared Parquet open/parse + type inference + parquet_schema()

### DIFF
--- a/pgcolumnar--1.0.sql
+++ b/pgcolumnar--1.0.sql
@@ -522,6 +522,14 @@ CREATE FUNCTION pgcolumnar.import_parquet(rel regclass, path text)
 COMMENT ON FUNCTION pgcolumnar.import_parquet(regclass, text)
 	IS 'insert rows from a Parquet file into a table; returns rows inserted (gap 27)';
 
+CREATE FUNCTION pgcolumnar.parquet_schema(path text)
+	RETURNS TABLE(column_name text, data_type text, nullable boolean)
+	LANGUAGE C STRICT
+	AS 'MODULE_PATHNAME', 'columnar_parquet_schema';
+
+COMMENT ON FUNCTION pgcolumnar.parquet_schema(text)
+	IS 'report the leaf columns of a Parquet file and the PostgreSQL type each maps to (Phase G scan core)';
+
 CREATE FUNCTION pgcolumnar.vm_selftest(rel regclass, blk int)
 	RETURNS boolean
 	LANGUAGE C

--- a/src/columnar_parquet_reader.c
+++ b/src/columnar_parquet_reader.c
@@ -39,9 +39,11 @@
 #include "utils/rel.h"
 #include "utils/snapmgr.h"
 #include "utils/timestamp.h"
+#include "utils/tuplestore.h"
 #include "utils/typcache.h"
 
 PG_FUNCTION_INFO_V1(columnar_import_parquet);
+PG_FUNCTION_INFO_V1(columnar_parquet_schema);
 
 #define PG_TO_UNIX_DAYS		((int64) (POSTGRES_EPOCH_JDATE - UNIX_EPOCH_JDATE))
 #define PG_TO_UNIX_USECS	(PG_TO_UNIX_DAYS * USECS_PER_DAY)
@@ -54,6 +56,21 @@ PG_FUNCTION_INFO_V1(columnar_import_parquet);
 #define PQ_DOUBLE		5
 #define PQ_BYTE_ARRAY	6
 #define PQ_FIXED_LEN_BYTE_ARRAY 7
+
+/* ConvertedType (parquet.thrift ConvertedType); -1 means none */
+#define PQ_CT_UTF8				0
+#define PQ_CT_ENUM				4
+#define PQ_CT_DECIMAL			5
+#define PQ_CT_DATE				6
+#define PQ_CT_TIME_MILLIS		7
+#define PQ_CT_TIME_MICROS		8
+#define PQ_CT_TIMESTAMP_MILLIS	9
+#define PQ_CT_TIMESTAMP_MICROS	10
+#define PQ_CT_INT_8				15
+#define PQ_CT_INT_16			16
+#define PQ_CT_INT_32			17
+#define PQ_CT_INT_64			18
+#define PQ_CT_JSON				19
 
 /* Encodings (parquet.thrift Encoding) */
 #define PQE_PLAIN		0
@@ -368,6 +385,8 @@ typedef struct PqSchemaCol
 	int			repetition;		/* 0 required, 1 optional, 2 repeated */
 	int			converted_type;	/* -1 if none */
 	int			type_length;	/* FIXED_LEN_BYTE_ARRAY length */
+	int			scale;			/* DECIMAL scale (0 if none) */
+	int			precision;		/* DECIMAL precision (0 if none) */
 	int			num_children;	/* >0 for a group */
 	char	   *name;
 } PqSchemaCol;
@@ -482,6 +501,8 @@ parse_schema_element(TCReader *r, PqSchemaCol *sc)
 	sc->repetition = 0;
 	sc->converted_type = -1;
 	sc->type_length = 0;
+	sc->scale = 0;
+	sc->precision = 0;
 	sc->num_children = 0;
 	sc->name = NULL;
 
@@ -519,6 +540,12 @@ parse_schema_element(TCReader *r, PqSchemaCol *sc)
 				break;
 			case 6:				/* converted_type */
 				sc->converted_type = (int) tcr_zigzag(r);
+				break;
+			case 7:				/* scale (DECIMAL) */
+				sc->scale = (int) tcr_zigzag(r);
+				break;
+			case 8:				/* precision (DECIMAL) */
+				sc->precision = (int) tcr_zigzag(r);
 				break;
 			default:
 				tcr_skip(r, ft);
@@ -1314,6 +1341,79 @@ pq_want_phys(Oid typid)
 	}
 }
 
+/*
+ * Infer the PostgreSQL column type a Parquet leaf should map to. This is the
+ * inverse of the exporter's parquet_kind_for_type (columnar_parquet.c): it reads
+ * the physical type plus the ConvertedType annotation, so a round-tripped file
+ * reports the source column types. It is tolerant of files other writers produce
+ * (both the millis and micros time/timestamp variants, INT_8/INT_32 widths) so
+ * the schema view is useful for foreign Parquet too. Returns true and sets
+ * the out-params typid and typmod on success; returns false for a leaf whose
+ * type cannot be mapped to a supported scalar (the caller reports it unknown).
+ */
+static bool
+pq_leaf_to_pgtype(const PqSchemaCol *sc, Oid *typid, int32 *typmod)
+{
+	int			ct = sc->converted_type;
+
+	*typmod = -1;
+
+	switch (sc->phys_type)
+	{
+		case PQ_BOOLEAN:
+			*typid = BOOLOID;
+			return true;
+		case PQ_INT32:
+			if (ct == PQ_CT_DATE)
+				*typid = DATEOID;
+			else if (ct == PQ_CT_INT_8 || ct == PQ_CT_INT_16)
+				*typid = INT2OID;
+			else
+				*typid = INT4OID;	/* INT_32 or unannotated */
+			return true;
+		case PQ_INT64:
+			if (ct == PQ_CT_TIMESTAMP_MICROS || ct == PQ_CT_TIMESTAMP_MILLIS)
+				*typid = TIMESTAMPOID;
+			else if (ct == PQ_CT_TIME_MICROS || ct == PQ_CT_TIME_MILLIS)
+				*typid = TIMEOID;
+			else
+				*typid = INT8OID;	/* INT_64 or unannotated */
+			return true;
+		case PQ_FLOAT:
+			*typid = FLOAT4OID;
+			return true;
+		case PQ_DOUBLE:
+			*typid = FLOAT8OID;
+			return true;
+		case PQ_BYTE_ARRAY:
+			/* UTF8/ENUM/JSON annotate string data; anything else is raw bytes */
+			if (ct == PQ_CT_UTF8 || ct == PQ_CT_ENUM || ct == PQ_CT_JSON)
+				*typid = TEXTOID;
+			else
+				*typid = BYTEAOID;
+			return true;
+		case PQ_FIXED_LEN_BYTE_ARRAY:
+			if (ct == PQ_CT_DECIMAL && sc->precision >= 1 && sc->precision <= 38 &&
+				sc->scale >= 0 && sc->scale <= sc->precision)
+			{
+				*typid = NUMERICOID;
+				*typmod = (int32) (((sc->precision << 16) | (sc->scale & 0xffff)) +
+								   VARHDRSZ);
+				return true;
+			}
+			if (ct < 0 && sc->type_length == 16)
+			{
+				/* the exporter writes uuid as an unannotated 16-byte FLBA */
+				*typid = UUIDOID;
+				return true;
+			}
+			*typid = BYTEAOID;
+			return true;
+		default:
+			return false;
+	}
+}
+
 /* -------------------------------------------------------------------------
  * Nested import assembly. A target column is one of three shapes, mirroring the
  * nested Parquet exporter: a scalar leaf, a 1-D array (LIST of one element leaf),
@@ -1521,6 +1621,63 @@ build_imp_targets(Relation rel, TupleDesc tupdesc, PqFile *pf,
 }
 
 /*
+ * Read an entire server-side Parquet file into a palloc'd buffer and parse its
+ * footer metadata into *pf. On success the file bytes are returned in *bufOut
+ * (length *lenOut), allocated in the caller's memory context. This never returns
+ * on failure: any open/size/read/format/metadata error is reported with ereport,
+ * so the caller does not need to check a return value or clean the buffer up.
+ * The caller is responsible for any privilege check before calling.
+ */
+static void
+pq_slurp_and_parse(const char *path, uint8 **bufOut, long *lenOut, PqFile *pf)
+{
+	FILE	   *f;
+	long		filelen;
+	uint8	   *filebuf;
+	uint32		metalen;
+
+	f = AllocateFile(path, PG_BINARY_R);
+	if (f == NULL)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not open file \"%s\" for reading: %m", path)));
+	if (fseek(f, 0, SEEK_END) != 0 || (filelen = ftell(f)) < 0)
+	{
+		FreeFile(f);
+		ereport(ERROR, (errcode_for_file_access(), errmsg("could not size \"%s\": %m", path)));
+	}
+	if (filelen < 12)
+	{
+		FreeFile(f);
+		ereport(ERROR, (errcode(ERRCODE_DATA_CORRUPTED), errmsg("\"%s\" is not a Parquet file", path)));
+	}
+	filebuf = (uint8 *) palloc(filelen);
+	if (fseek(f, 0, SEEK_SET) != 0 ||
+		fread(filebuf, 1, filelen, f) != (size_t) filelen)
+	{
+		FreeFile(f);
+		ereport(ERROR, (errcode_for_file_access(), errmsg("could not read \"%s\": %m", path)));
+	}
+	FreeFile(f);
+
+	if (memcmp(filebuf, "PAR1", 4) != 0 ||
+		memcmp(filebuf + filelen - 4, "PAR1", 4) != 0)
+		ereport(ERROR, (errcode(ERRCODE_DATA_CORRUPTED),
+						errmsg("\"%s\" is not a Parquet file (bad magic)", path)));
+	memcpy(&metalen, filebuf + filelen - 8, 4);
+	if ((long) metalen + 8 > filelen)
+		ereport(ERROR, (errcode(ERRCODE_DATA_CORRUPTED),
+						errmsg("\"%s\" has a corrupt Parquet footer", path)));
+
+	if (!parse_file_metadata(filebuf + filelen - 8 - metalen, metalen, pf))
+		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						errmsg("could not parse \"%s\" (unsupported or corrupt Parquet metadata)", path)));
+
+	*bufOut = filebuf;
+	*lenOut = filelen;
+}
+
+/*
  * columnar.import_parquet(rel regclass, path text) -> bigint
  */
 Datum
@@ -1531,10 +1688,8 @@ columnar_import_parquet(PG_FUNCTION_ARGS)
 	Relation	rel;
 	TupleDesc	tupdesc;
 	int			natts;
-	FILE	   *f;
 	long		filelen;
 	uint8	   *filebuf;
-	uint32		metalen;
 	PqFile		pf;
 	ImpTop	   *tops;
 	ImpLeaf    *leaves;
@@ -1552,62 +1707,12 @@ columnar_import_parquet(PG_FUNCTION_ARGS)
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 				 errmsg("columnar.import_parquet requires superuser (reads a server-side file)")));
 
+	/* read + parse the file before taking the table lock (no lock held on I/O) */
+	pq_slurp_and_parse(path, &filebuf, &filelen, &pf);
+
 	rel = table_open(relid, RowExclusiveLock);
 	tupdesc = RelationGetDescr(rel);
 	natts = tupdesc->natts;
-
-	/* read the whole file into memory */
-	f = AllocateFile(path, PG_BINARY_R);
-	if (f == NULL)
-	{
-		table_close(rel, RowExclusiveLock);
-		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not open file \"%s\" for reading: %m", path)));
-	}
-	if (fseek(f, 0, SEEK_END) != 0 || (filelen = ftell(f)) < 0)
-	{
-		FreeFile(f);
-		table_close(rel, RowExclusiveLock);
-		ereport(ERROR, (errcode_for_file_access(), errmsg("could not size \"%s\": %m", path)));
-	}
-	if (filelen < 12)
-	{
-		FreeFile(f);
-		table_close(rel, RowExclusiveLock);
-		ereport(ERROR, (errcode(ERRCODE_DATA_CORRUPTED), errmsg("\"%s\" is not a Parquet file", path)));
-	}
-	filebuf = (uint8 *) palloc(filelen);
-	if (fseek(f, 0, SEEK_SET) != 0 ||
-		fread(filebuf, 1, filelen, f) != (size_t) filelen)
-	{
-		FreeFile(f);
-		table_close(rel, RowExclusiveLock);
-		ereport(ERROR, (errcode_for_file_access(), errmsg("could not read \"%s\": %m", path)));
-	}
-	FreeFile(f);
-
-	if (memcmp(filebuf, "PAR1", 4) != 0 ||
-		memcmp(filebuf + filelen - 4, "PAR1", 4) != 0)
-	{
-		table_close(rel, RowExclusiveLock);
-		ereport(ERROR, (errcode(ERRCODE_DATA_CORRUPTED),
-						errmsg("\"%s\" is not a Parquet file (bad magic)", path)));
-	}
-	memcpy(&metalen, filebuf + filelen - 8, 4);
-	if ((long) metalen + 8 > filelen)
-	{
-		table_close(rel, RowExclusiveLock);
-		ereport(ERROR, (errcode(ERRCODE_DATA_CORRUPTED),
-						errmsg("\"%s\" has a corrupt Parquet footer", path)));
-	}
-
-	if (!parse_file_metadata(filebuf + filelen - 8 - metalen, metalen, &pf))
-	{
-		table_close(rel, RowExclusiveLock);
-		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("could not parse \"%s\" (unsupported or corrupt Parquet metadata)", path)));
-	}
 
 	/* build the target tree and bind each Parquet leaf column to it */
 	tops = build_imp_targets(rel, tupdesc, &pf, &leaves, &ntops);
@@ -1806,4 +1911,77 @@ columnar_import_parquet(PG_FUNCTION_ARGS)
 	table_close(rel, RowExclusiveLock);
 
 	PG_RETURN_INT64(total);
+}
+
+/*
+ * columnar.parquet_schema(path text)
+ *     -> table(column_name text, data_type text, nullable bool)
+ *
+ * Read a server-side Parquet file's footer and report its leaf columns with the
+ * PostgreSQL type each maps to (see pq_leaf_to_pgtype). This is the schema half
+ * of the external-Parquet scan core: it shares the file open/parse and type
+ * inference the data path will use, and lets a caller inspect a file (and the
+ * round-trip test confirm exported types) without importing it. A leaf whose
+ * physical type has no supported mapping is reported with data_type NULL. Nested
+ * files are reported as their flattened leaf columns.
+ */
+Datum
+columnar_parquet_schema(PG_FUNCTION_ARGS)
+{
+	char	   *path = text_to_cstring(PG_GETARG_TEXT_PP(0));
+	ReturnSetInfo *rsinfo = (ReturnSetInfo *) fcinfo->resultinfo;
+	long		filelen;
+	uint8	   *filebuf;
+	PqFile		pf;
+	TupleDesc	retdesc;
+	Tuplestorestate *tupstore;
+	MemoryContext oldContext;
+	int			i;
+
+	if (!superuser())
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 errmsg("columnar.parquet_schema requires superuser (reads a server-side file)")));
+
+	if (rsinfo == NULL || !IsA(rsinfo, ReturnSetInfo) ||
+		!(rsinfo->allowedModes & SFRM_Materialize))
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("set-valued function called in context that cannot accept a set")));
+
+	pq_slurp_and_parse(path, &filebuf, &filelen, &pf);
+
+	retdesc = CreateTemplateTupleDesc(3);
+	TupleDescInitEntry(retdesc, 1, "column_name", TEXTOID, -1, 0);
+	TupleDescInitEntry(retdesc, 2, "data_type", TEXTOID, -1, 0);
+	TupleDescInitEntry(retdesc, 3, "nullable", BOOLOID, -1, 0);
+
+	oldContext = MemoryContextSwitchTo(rsinfo->econtext->ecxt_per_query_memory);
+	tupstore = tuplestore_begin_heap(true, false, work_mem);
+	rsinfo->returnMode = SFRM_Materialize;
+	rsinfo->setResult = tupstore;
+	rsinfo->setDesc = retdesc;
+	MemoryContextSwitchTo(oldContext);
+
+	for (i = 0; i < pf.ncols; i++)
+	{
+		PqSchemaCol *sc = pf.leaves[i].sc;
+		Oid			typid;
+		int32		typmod;
+		Datum		values[3];
+		bool		nulls[3] = {false, false, false};
+
+		values[0] = CStringGetTextDatum(sc->name != NULL ? sc->name : "");
+		if (pq_leaf_to_pgtype(sc, &typid, &typmod))
+			values[1] = CStringGetTextDatum(
+				format_type_extended(typid, typmod, FORMAT_TYPE_TYPEMOD_GIVEN));
+		else
+			nulls[1] = true;
+		/* a column is nullable iff it is OPTIONAL somewhere above the leaf */
+		values[2] = BoolGetDatum(pf.leaves[i].max_def > 0);
+
+		tuplestore_putvalues(tupstore, retdesc, values, nulls);
+	}
+
+	PG_RETURN_NULL();
 }

--- a/test/native_parquet_schema.sh
+++ b/test/native_parquet_schema.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# pgColumnar external-Parquet scan core (Phase G). pgcolumnar.parquet_schema(path)
+# reads a server-side Parquet file's footer and reports its leaf columns with the
+# PostgreSQL type each maps to. This suite is the round-trip differential: it
+# exports a columnar table covering every type the Parquet exporter emits, then
+# asserts parquet_schema reports the source column types back. The exporter and
+# the scan core share the type mapping, so a faithful mapping is a byte-for-byte
+# inverse.
+#
+# A pyarrow-guarded tail writes a file with a REQUIRED (non-null) column to
+# confirm the nullable flag reports both ways (the exporter only ever writes
+# OPTIONAL columns).
+#
+# Usage:  test/native_parquet_schema.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+PARQUET="$PGC_WORKDIR/schema.parquet"
+
+psql_run "CREATE TABLE n (
+	c_i2  int2,
+	c_i4  int4,
+	c_i8  int8,
+	c_f4  float4,
+	c_f8  float8,
+	c_bool bool,
+	c_text text,
+	c_bytea bytea,
+	c_date date,
+	c_time time,
+	c_ts  timestamp,
+	c_uuid uuid,
+	c_num numeric(10,2)
+) USING pgcolumnar;"
+
+# one populated row plus an all-NULL row (columns are exported OPTIONAL either way)
+psql_run "INSERT INTO n VALUES
+	(2::int2, 3, 4::int8, 1.5::float4, 2.5::float8, true, 'hi',
+	 '\\xdeadbeef'::bytea, '2020-01-01'::date, '12:34:56'::time,
+	 '2020-01-01 12:34:56'::timestamp,
+	 '11111111-1111-1111-1111-111111111111'::uuid, 123.45::numeric(10,2)),
+	(NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);"
+
+rows="$(q "SELECT pgcolumnar.export_parquet('n', '$PARQUET');")"
+check "export_parquet rows written" "$rows" "2"
+
+# leaf-column count matches the table
+check "parquet_schema column count" \
+	"$(q "SELECT count(*) FROM pgcolumnar.parquet_schema('$PARQUET');")" "13"
+
+# name-keyed so the assertion does not depend on result ordering. Each entry is
+# "column_name|expected_data_type" (all exporter columns are nullable=t).
+assert_col() {  # assert_col NAME EXPECTED_TYPE
+	local name="$1" want="$2" got
+	got="$(q "SELECT data_type FROM pgcolumnar.parquet_schema('$PARQUET') WHERE column_name = '$name';")"
+	check "type of $name" "$got" "$want"
+	got="$(q "SELECT nullable FROM pgcolumnar.parquet_schema('$PARQUET') WHERE column_name = '$name';")"
+	check "nullable of $name" "$got" "t"
+}
+
+assert_col c_i2   "smallint"
+assert_col c_i4   "integer"
+assert_col c_i8   "bigint"
+assert_col c_f4   "real"
+assert_col c_f8   "double precision"
+assert_col c_bool "boolean"
+assert_col c_text "text"
+assert_col c_bytea "bytea"
+assert_col c_date "date"
+assert_col c_time "time without time zone"
+assert_col c_ts   "timestamp without time zone"
+assert_col c_uuid "uuid"
+assert_col c_num  "numeric(10,2)"
+
+# unsupported / corrupt inputs are rejected, not silently empty
+notpq="$PGC_WORKDIR/not.parquet"
+psql_run "SELECT 1;" >/dev/null   # noop to keep ordering readable
+printf 'this is not a parquet file at all' > "$notpq"
+chmod 644 "$notpq"
+err="$(q "SELECT count(*) FROM pgcolumnar.parquet_schema('$notpq');" 2>&1)"
+check "bad magic rejected (empty At output)" "$err" ""
+
+# ---- nullable=false path (needs a REQUIRED column; only pyarrow writes one) ---
+if python3 -c 'import pyarrow.parquet' 2>/dev/null; then
+	REQ="$PGC_WORKDIR/required.parquet"
+	python3 - "$REQ" <<'PY'
+import sys, pyarrow as pa, pyarrow.parquet as pq
+schema = pa.schema([
+    pa.field("req_i", pa.int32(), nullable=False),
+    pa.field("opt_s", pa.string(), nullable=True),
+])
+tbl = pa.table({"req_i": pa.array([1, 2, 3], pa.int32()),
+                "opt_s": pa.array(["a", None, "c"], pa.string())}, schema=schema)
+pq.write_table(tbl, sys.argv[1])
+PY
+	check "REQUIRED column reports nullable=f" \
+		"$(q "SELECT nullable FROM pgcolumnar.parquet_schema('$REQ') WHERE column_name='req_i';")" "f"
+	check "OPTIONAL column reports nullable=t" \
+		"$(q "SELECT nullable FROM pgcolumnar.parquet_schema('$REQ') WHERE column_name='opt_s';")" "t"
+	check "REQUIRED int32 maps to integer" \
+		"$(q "SELECT data_type FROM pgcolumnar.parquet_schema('$REQ') WHERE column_name='req_i';")" "integer"
+else
+	echo "SKIP  pyarrow not available; REQUIRED-column nullable check skipped"
+fi
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -27,7 +27,7 @@ SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUITES=(smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
 	differential recovery fuzz hardening concurrent_diff parallel sorted_projection \
 	arrow_export parquet_export read_stream corruption \
-	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip native_index native_dml native_ios native_projection native_cluster native_compact native_recluster native_reclaim native_ownership native_reclaim_cycles native_reclaim_frag native_gap native_truncate native_rewrite native_rewrite_conc isolation)
+	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip native_index native_dml native_ios native_projection native_cluster native_compact native_recluster native_reclaim native_ownership native_reclaim_cycles native_reclaim_frag native_gap native_truncate native_rewrite native_rewrite_conc native_parquet_schema isolation)
 
 # Default matrix: one assert-enabled pg_config per major, 15 through 19.
 DEFAULT_CONFIGS=(


### PR DESCRIPTION
First Phase G (external Parquet) sequencing step. Each step is its own PR for review; this one builds the shared scan core and exposes its schema half.

## What
- **`pq_slurp_and_parse()`** — the file slurp + magic/footer-locate + metadata parse, factored out of `columnar_import_parquet` (was inlined). Import now reads and parses the file *before* taking the table lock (no lock held during I/O; drops the `table_close`-before-`ereport` cleanup).
- **`pq_leaf_to_pgtype()`** — infer the PostgreSQL type a Parquet leaf maps to; the inverse of the exporter's `parquet_kind_for_type`. Tolerant of foreign writers (millis and micros time/timestamp, INT_8/16/32 widths). Parses the SchemaElement `scale`/`precision` fields so DECIMAL maps back to `numeric(p,s)`.
- **`pgcolumnar.parquet_schema(path) -> table(column_name text, data_type text, nullable boolean)`** — report a file's leaf columns and mapped types. Superuser only (reads a server-side file); materialize-mode SRF.

## Why this shape
The FDW and `read_parquet()` surfaces to come (per the [design](design/PHASE_G_EXTERNAL_PARQUET_PLAN.md)) both need the same file-open, footer-parse, and type mapping. Landing it once, with an independently testable schema function, keeps each later surface a thin binding over a verified core.

## Test
`native_parquet_schema.sh` exports a columnar table covering every type the Parquet exporter emits, then asserts `parquet_schema` reports the source column types back. Because the exporter and this core share the mapping, that is a byte-for-byte round-trip inverse. A pyarrow-guarded tail writes a REQUIRED (non-null) column to confirm the `nullable` flag reports both ways (the exporter only ever writes OPTIONAL). Registered in the matrix runner.

## Gate
PG17 green: `native_parquet_schema` (32 checks), `parquet_export` (14), `parquet_import` (11, confirms the import refactor is safe). Full 15-19 matrix at the end-of-day gate per the standing PG17-first workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)