### PR TITLE
Phase G: read_parquet(path) function + shared row engine

### DIFF
--- a/design/PHASE_G_SCAN_SURFACES_PLAN.md
+++ b/design/PHASE_G_SCAN_SURFACES_PLAN.md
@@ -1,0 +1,56 @@
+# Phase G scan surfaces: read_parquet(), FDW, predicate pushdown
+
+Follows the scan core (open/parse, type inference, `parquet_schema`) landed on main.
+Three sequential PRs, each independently reviewable and PG17-gated during development;
+the full 15-19 matrix runs once after all three are submitted.
+
+## Shared row engine (PR1 refactor)
+
+The import path already decodes a Parquet file into rows and assembles nested shapes
+(scalar, 1-D array from LIST, composite from group) via Dremel level walking. That
+row-producing loop is the scan core; it was coupled to a target `Relation` only for
+inserts. PR1 factors it into a Relation-free engine both surfaces call:
+
+- `build_imp_targets(TupleDesc, PqFile*, ...)` loses its `Relation` parameter; on a
+  binding error it just `ereport`s (transaction abort releases any caller lock), so a
+  caller with no relation (the function, the FDW) can bind a tuple descriptor against a
+  file the same way import binds a table's descriptor.
+- `pq_read_rows(pf, filebuf, filelen, tops, ntops, leaves, slot, sink, sinkarg)` runs
+  the per-row-group decode plus per-row assembly, fills `slot`, and calls `sink` per
+  row. Import's sink is `table_tuple_insert`; the function's sink is
+  `tuplestore_puttupleslot`. The sink copies each tuple, so the per-row context reset is
+  safe for both.
+
+## PR1: read_parquet(path text) returns setof record
+
+A set-returning function that streams a file's rows in place. The caller supplies a
+column definition list (`SELECT * FROM pgcolumnar.read_parquet('f.parquet') AS
+t(id int, name text)`); the declared descriptor is bound against the file leaves by
+position, exactly as import binds a target table (same type-compatibility rules, same
+"file column count must match" contract). Materialize-mode SRF, superuser only (reads a
+server-side file).
+
+- Contract: position-based binding, so columns are declared in file order with
+  compatible types. Name-based binding is a possible later enhancement.
+- Differential oracle: `read_parquet(f) AS t(...)` equals `import_parquet` into a table
+  of the same shape, then a native scan.
+
+## PR2: FDW surface
+
+A foreign-data wrapper so a file is a table: `CREATE FOREIGN TABLE ... SERVER ...
+OPTIONS (path '...')`. It plans and executes over the same engine, so results match the
+function; only planning and pushdown differ. Projection pushdown comes from the scan's
+`attrs_used` (read only the referenced column chunks). No predicate pushdown yet.
+
+## PR3: predicate / row-group skipping
+
+The metadata parser currently skips the Parquet `Statistics` field, so there is nothing
+to skip on. PR3 first extends the column-chunk parser to read per-group min/max and
+null-count, then teaches the FDW to turn pushable `col op const` clauses (ordered types)
+into per-row-group skip decisions, with the executor rechecking every returned row so a
+partial or absent pushdown is always correct.
+
+## Not in scope here
+
+Multi-file/directory datasets, Zstd/gzip page codecs, and ORC/Iceberg/Delta remain
+follow-ons per PHASE_G_EXTERNAL_PARQUET_PLAN.md.

--- a/pgcolumnar--1.0.sql
+++ b/pgcolumnar--1.0.sql
@@ -530,6 +530,14 @@ CREATE FUNCTION pgcolumnar.parquet_schema(path text)
 COMMENT ON FUNCTION pgcolumnar.parquet_schema(text)
 	IS 'report the leaf columns of a Parquet file and the PostgreSQL type each maps to (Phase G scan core)';
 
+CREATE FUNCTION pgcolumnar.read_parquet(path text)
+	RETURNS SETOF record
+	LANGUAGE C STRICT
+	AS 'MODULE_PATHNAME', 'columnar_read_parquet';
+
+COMMENT ON FUNCTION pgcolumnar.read_parquet(text)
+	IS 'read a Parquet file in place as a set of rows; requires a column definition list, e.g. SELECT * FROM pgcolumnar.read_parquet(path) AS t(id int, name text) (Phase G)';
+
 CREATE FUNCTION pgcolumnar.vm_selftest(rel regclass, blk int)
 	RETURNS boolean
 	LANGUAGE C

--- a/src/columnar_parquet_reader.c
+++ b/src/columnar_parquet_reader.c
@@ -44,6 +44,7 @@
 
 PG_FUNCTION_INFO_V1(columnar_import_parquet);
 PG_FUNCTION_INFO_V1(columnar_parquet_schema);
+PG_FUNCTION_INFO_V1(columnar_read_parquet);
 
 #define PG_TO_UNIX_DAYS		((int64) (POSTGRES_EPOCH_JDATE - UNIX_EPOCH_JDATE))
 #define PG_TO_UNIX_USECS	(PG_TO_UNIX_DAYS * USECS_PER_DAY)
@@ -1464,9 +1465,14 @@ typedef struct ImpTop
  * Build the target tree from the tuple descriptor and bind each leaf to a
  * Parquet leaf column (validating physical type and Dremel level bounds).
  * Returns the tops array; sets the leaves array and top count via out-params.
+ *
+ * Relation-free: on a binding error it just ereports, and any relation the caller
+ * holds is released by transaction abort. This lets a caller with no relation (the
+ * read_parquet function, the FDW) bind a descriptor against a file exactly as
+ * import binds a target table's descriptor.
  */
 static ImpTop *
-build_imp_targets(Relation rel, TupleDesc tupdesc, PqFile *pf,
+build_imp_targets(TupleDesc tupdesc, PqFile *pf,
 				  ImpLeaf **pleaves, int *ntops)
 {
 	int			natts = tupdesc->natts;
@@ -1477,9 +1483,7 @@ build_imp_targets(Relation rel, TupleDesc tupdesc, PqFile *pf,
 	int			i;
 
 #define IMP_FAIL(...) \
-	do { table_close(rel, RowExclusiveLock); \
-		 ereport(ERROR, (errcode(ERRCODE_DATATYPE_MISMATCH), errmsg(__VA_ARGS__))); \
-	} while (0)
+	ereport(ERROR, (errcode(ERRCODE_DATATYPE_MISMATCH), errmsg(__VA_ARGS__)))
 
 	for (i = 0; i < natts; i++)
 	{
@@ -1678,64 +1682,66 @@ pq_slurp_and_parse(const char *path, uint8 **bufOut, long *lenOut, PqFile *pf)
 }
 
 /*
- * columnar.import_parquet(rel regclass, path text) -> bigint
+ * Row sink for the shared reader: called once per assembled row with the row in
+ * slot (already ExecStoreVirtualTuple'd). The sink must copy the row out, because
+ * the caller resets the per-row memory immediately after; both table_tuple_insert
+ * and tuplestore_puttupleslot do.
  */
-Datum
-columnar_import_parquet(PG_FUNCTION_ARGS)
+typedef void (*PqRowSink) (TupleTableSlot *slot, void *arg);
+
+typedef struct PqInsertSinkArg
 {
-	Oid			relid = PG_GETARG_OID(0);
-	char	   *path = text_to_cstring(PG_GETARG_TEXT_PP(1));
 	Relation	rel;
-	TupleDesc	tupdesc;
-	int			natts;
-	long		filelen;
-	uint8	   *filebuf;
-	PqFile		pf;
-	ImpTop	   *tops;
-	ImpLeaf    *leaves;
-	int			ntops;
-	TupleTableSlot *slot;
+	CommandId	cid;
+}			PqInsertSinkArg;
+
+static void
+pq_insert_sink(TupleTableSlot *slot, void *arg)
+{
+	PqInsertSinkArg *a = (PqInsertSinkArg *) arg;
+
+	table_tuple_insert(a->rel, slot, a->cid, 0, NULL);
+}
+
+static void
+pq_tuplestore_sink(TupleTableSlot *slot, void *arg)
+{
+	tuplestore_puttupleslot((Tuplestorestate *) arg, slot);
+}
+
+/*
+ * The shared row-producing core (Phase G scan core). For each row group it decodes
+ * every leaf column into its Dremel entry stream, then assembles each row into slot
+ * per the bound target tree (scalar, 1-D array from a LIST, composite from a group)
+ * and hands it to sink. Returns the number of rows produced.
+ *
+ * groupCtx bounds each group's decoded streams; rowCtx bounds each row's transient
+ * arrays/composites and is reset after the sink copies the row, so a large file
+ * never accumulates O(rows) memory. Both import (insert sink) and read_parquet
+ * (tuplestore sink) run through here, so their row semantics are identical.
+ */
+static int64
+pq_read_rows(PqFile *pf, const uint8 *filebuf, long filelen,
+			 ImpTop *tops, int ntops, ImpLeaf *leaves,
+			 TupleTableSlot *slot, PqRowSink sink, void *sinkarg)
+{
+	int			natts = slot->tts_tupleDescriptor->natts;
 	MemoryContext groupCtx;
 	MemoryContext rowCtx;
-	CommandId	cid = GetCurrentCommandId(true);
 	int64		total = 0;
 	int			i;
 	int			rg;
 
-	if (!superuser())
-		ereport(ERROR,
-				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-				 errmsg("columnar.import_parquet requires superuser (reads a server-side file)")));
-
-	/* read + parse the file before taking the table lock (no lock held on I/O) */
-	pq_slurp_and_parse(path, &filebuf, &filelen, &pf);
-
-	rel = table_open(relid, RowExclusiveLock);
-	tupdesc = RelationGetDescr(rel);
-	natts = tupdesc->natts;
-
-	/* build the target tree and bind each Parquet leaf column to it */
-	tops = build_imp_targets(rel, tupdesc, &pf, &leaves, &ntops);
-
-	slot = table_slot_create(rel, NULL);
-
-	/*
-	 * groupCtx holds each row group's decoded leaf entry streams (reset when the
-	 * next group is decoded); rowCtx holds the per-row reconstructed arrays and
-	 * composites (reset after each insert). Without these, a large file would
-	 * accumulate O(rows) transient memory. table_tuple_insert copies the tuple
-	 * into the write state's own context, so rowCtx is safe to reset per row.
-	 */
 	groupCtx = AllocSetContextCreate(CurrentMemoryContext,
-									 "columnar parquet import group",
+									 "columnar parquet read group",
 									 ALLOCSET_DEFAULT_SIZES);
 	rowCtx = AllocSetContextCreate(CurrentMemoryContext,
-								   "columnar parquet import row",
+								   "columnar parquet read row",
 								   ALLOCSET_DEFAULT_SIZES);
 
-	for (rg = 0; rg < pf.nrowgroups; rg++)
+	for (rg = 0; rg < pf->nrowgroups; rg++)
 	{
-		PqRowGroup *g = &pf.rgs[rg];
+		PqRowGroup *g = &pf->rgs[rg];
 		int64		n = g->num_rows;
 		int64		r;
 		int			t;
@@ -1744,7 +1750,7 @@ columnar_import_parquet(PG_FUNCTION_ARGS)
 		/* decode every leaf column of this row group into its entry stream */
 		MemoryContextReset(groupCtx);
 		oldCtx = MemoryContextSwitchTo(groupCtx);
-		for (i = 0; i < pf.ncols; i++)
+		for (i = 0; i < pf->ncols; i++)
 		{
 			ImpLeaf    *l = &leaves[i];
 			PqChunk    *ch = &g->chunks[i];
@@ -1761,7 +1767,6 @@ columnar_import_parquet(PG_FUNCTION_ARGS)
 									 &l->nEntries, &l->nPresent))
 			{
 				MemoryContextSwitchTo(oldCtx);
-				table_close(rel, RowExclusiveLock);
 				ereport(ERROR, (errcode(ERRCODE_DATA_CORRUPTED),
 								errmsg("could not decode Parquet column %d in row group %d",
 									   i, rg)));
@@ -1897,7 +1902,7 @@ columnar_import_parquet(PG_FUNCTION_ARGS)
 			}
 
 			ExecStoreVirtualTuple(slot);
-			table_tuple_insert(rel, slot, cid, 0, NULL);
+			sink(slot, sinkarg);
 			MemoryContextSwitchTo(rowOld);
 			MemoryContextReset(rowCtx);
 			total++;
@@ -1907,10 +1912,123 @@ columnar_import_parquet(PG_FUNCTION_ARGS)
 
 	MemoryContextDelete(groupCtx);
 	MemoryContextDelete(rowCtx);
+	return total;
+}
+
+/*
+ * columnar.import_parquet(rel regclass, path text) -> bigint
+ */
+Datum
+columnar_import_parquet(PG_FUNCTION_ARGS)
+{
+	Oid			relid = PG_GETARG_OID(0);
+	char	   *path = text_to_cstring(PG_GETARG_TEXT_PP(1));
+	Relation	rel;
+	TupleDesc	tupdesc;
+	long		filelen;
+	uint8	   *filebuf;
+	PqFile		pf;
+	ImpTop	   *tops;
+	ImpLeaf    *leaves;
+	int			ntops;
+	TupleTableSlot *slot;
+	PqInsertSinkArg sinkarg;
+	int64		total;
+
+	if (!superuser())
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 errmsg("columnar.import_parquet requires superuser (reads a server-side file)")));
+
+	/* read + parse the file before taking the table lock (no lock held on I/O) */
+	pq_slurp_and_parse(path, &filebuf, &filelen, &pf);
+
+	rel = table_open(relid, RowExclusiveLock);
+	tupdesc = RelationGetDescr(rel);
+
+	/* build the target tree and bind each Parquet leaf column to it */
+	tops = build_imp_targets(tupdesc, &pf, &leaves, &ntops);
+
+	slot = table_slot_create(rel, NULL);
+
+	sinkarg.rel = rel;
+	sinkarg.cid = GetCurrentCommandId(true);
+	total = pq_read_rows(&pf, filebuf, filelen, tops, ntops, leaves,
+						 slot, pq_insert_sink, &sinkarg);
+
 	ExecDropSingleTupleTableSlot(slot);
 	table_close(rel, RowExclusiveLock);
 
 	PG_RETURN_INT64(total);
+}
+
+/*
+ * columnar.read_parquet(path text) returns setof record
+ *
+ * Stream a server-side Parquet file's rows in place, without importing. The caller
+ * supplies a column definition list:
+ *
+ *   SELECT * FROM pgcolumnar.read_parquet('/data/f.parquet') AS t(id int, name text);
+ *
+ * The declared descriptor is bound against the file's leaf columns by position,
+ * exactly as import binds a target table's descriptor (same type-compatibility
+ * rules, same "declared column count must equal the file's" contract), and rows are
+ * produced through the shared scan core. Superuser only (reads a server-side file);
+ * materialize-mode SRF.
+ */
+Datum
+columnar_read_parquet(PG_FUNCTION_ARGS)
+{
+	char	   *path = text_to_cstring(PG_GETARG_TEXT_PP(0));
+	ReturnSetInfo *rsinfo = (ReturnSetInfo *) fcinfo->resultinfo;
+	TupleDesc	retdesc;
+	long		filelen;
+	uint8	   *filebuf;
+	PqFile		pf;
+	ImpTop	   *tops;
+	ImpLeaf    *leaves;
+	int			ntops;
+	Tuplestorestate *tupstore;
+	TupleTableSlot *slot;
+	MemoryContext oldContext;
+
+	if (!superuser())
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 errmsg("pgcolumnar.read_parquet requires superuser (reads a server-side file)")));
+
+	if (rsinfo == NULL || !IsA(rsinfo, ReturnSetInfo) ||
+		!(rsinfo->allowedModes & SFRM_Materialize))
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("set-valued function called in context that cannot accept a set")));
+
+	/* the caller's column definition list defines the output columns and types */
+	if (get_call_result_type(fcinfo, NULL, &retdesc) != TYPEFUNC_COMPOSITE)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("pgcolumnar.read_parquet requires a column definition list"),
+				 errhint("Call it as SELECT * FROM pgcolumnar.read_parquet(path) AS t(col1 type1, ...).")));
+
+	pq_slurp_and_parse(path, &filebuf, &filelen, &pf);
+
+	/* bind the declared descriptor against the file (validates types + count) */
+	tops = build_imp_targets(retdesc, &pf, &leaves, &ntops);
+
+	oldContext = MemoryContextSwitchTo(rsinfo->econtext->ecxt_per_query_memory);
+	retdesc = CreateTupleDescCopy(retdesc);
+	tupstore = tuplestore_begin_heap(true, false, work_mem);
+	rsinfo->returnMode = SFRM_Materialize;
+	rsinfo->setResult = tupstore;
+	rsinfo->setDesc = retdesc;
+	MemoryContextSwitchTo(oldContext);
+
+	slot = MakeSingleTupleTableSlot(retdesc, &TTSOpsVirtual);
+	(void) pq_read_rows(&pf, filebuf, filelen, tops, ntops, leaves,
+						slot, pq_tuplestore_sink, tupstore);
+	ExecDropSingleTupleTableSlot(slot);
+
+	PG_RETURN_NULL();
 }
 
 /*

--- a/test/native_read_parquet.sh
+++ b/test/native_read_parquet.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# pgColumnar external-Parquet read (Phase G). pgcolumnar.read_parquet(path) streams
+# a server-side Parquet file's rows in place, with a caller-supplied column
+# definition list. This suite is the round-trip differential: it exports a columnar
+# table (scalars, then nested int[]/text[]/composite), reads the file back with
+# read_parquet, and asserts the rows are identical to the source. The exporter and
+# the scan core share the decode, so a faithful reader reproduces the source rows.
+# It also checks the argument-validation errors (no column list, wrong count/type).
+#
+# Usage:  test/native_read_parquet.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+expect_error() {  # expect_error LABEL SQL
+	local label="$1" sql="$2"
+	if psql_run "$sql" >/dev/null 2>&1; then
+		check "$label (expected error)" "succeeded" "error"
+	else
+		check "$label" "error" "error"
+	fi
+}
+
+# ---- scalar round-trip ------------------------------------------------------
+# The shared decoder supports the pq_want_phys type set (int/float/bool/text/bytea/
+# date/time/timestamp). uuid and numeric(DECIMAL) are reported by parquet_schema but
+# not yet decodable by import/read_parquet -- a shared-decoder follow-up.
+SCALAR="$PGC_WORKDIR/scalar.parquet"
+scalar_cols="c_i2 int2, c_i4 int4, c_i8 int8, c_f4 float4, c_f8 float8, c_bool bool,
+             c_text text, c_bytea bytea, c_date date, c_time time, c_ts timestamp"
+
+psql_run "CREATE TABLE s ($scalar_cols) USING pgcolumnar;"
+psql_run "INSERT INTO s
+	SELECT (g%100)::int2, g, g::int8*1000, (g/2.0)::float4, (g/4.0)::float8, (g%2=0),
+	       'row'||g, decode(lpad(to_hex(g),8,'0'),'hex'), date '2020-01-01' + g,
+	       time '00:00:00' + (g||' seconds')::interval,
+	       timestamp '2020-01-01' + (g||' minutes')::interval
+	FROM generate_series(1, 5000) g;"
+# an all-NULL row so nullability round-trips
+psql_run "INSERT INTO s VALUES (NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL);"
+
+check "scalar export rows" "$(q "SELECT pgcolumnar.export_parquet('s', '$SCALAR');")" "5001"
+
+# read the file back and hash-compare (order-independent) against the source table
+rp_scalar() { pgc_set_hash "SELECT * FROM pgcolumnar.read_parquet('$SCALAR')
+	AS t($scalar_cols)"; }
+src_scalar() { pgc_set_hash "SELECT * FROM s"; }
+check "scalar round-trip: read_parquet == source" "$(rp_scalar)" "$(src_scalar)"
+check "scalar read_parquet row count" \
+	"$(q "SELECT count(*) FROM pgcolumnar.read_parquet('$SCALAR') AS t($scalar_cols)")" "5001"
+
+# a projection over the function still returns the projected column faithfully
+check "projected column round-trips" \
+	"$(pgc_set_hash "SELECT c_text FROM pgcolumnar.read_parquet('$SCALAR') AS t($scalar_cols)")" \
+	"$(pgc_set_hash "SELECT c_text FROM s")"
+
+# ---- nested round-trip (int[], text[], composite) ---------------------------
+psql_run "CREATE TYPE rp_npc AS (x int, y text);"
+psql_run "CREATE TABLE np (id int, ia int[], ta text[], c rp_npc) USING pgcolumnar;"
+psql_run "INSERT INTO np
+	SELECT g,
+	       CASE WHEN g%11=0 THEN NULL WHEN g%7=0 THEN '{}'::int[]
+	            ELSE ARRAY[g, g+1, g+2] END,
+	       CASE WHEN g%13=0 THEN NULL ELSE ARRAY['a'||g, 'b'||g] END,
+	       CASE WHEN g%5=0 THEN NULL ELSE ROW(g, 'c'||g)::rp_npc END
+	FROM generate_series(1, 3000) g;"
+NESTED="$PGC_WORKDIR/nested.parquet"
+check "nested export rows" "$(q "SELECT pgcolumnar.export_parquet('np', '$NESTED');")" "3000"
+
+nested_cols="id int, ia int[], ta text[], c rp_npc"
+check "nested round-trip: read_parquet == source" \
+	"$(pgc_set_hash "SELECT * FROM pgcolumnar.read_parquet('$NESTED') AS t($nested_cols)")" \
+	"$(pgc_set_hash "SELECT * FROM np")"
+
+# ---- argument validation ----------------------------------------------------
+# no column definition list -> record-returning function has no shape
+expect_error "reject missing column definition list" \
+	"SELECT * FROM pgcolumnar.read_parquet('$SCALAR')"
+
+# too few columns declared (file has 11 leaves)
+expect_error "reject fewer columns than file" \
+	"SELECT * FROM pgcolumnar.read_parquet('$SCALAR') AS t(c_i2 int2)"
+
+# incompatible declared type (c_i4 is INT32, not text)
+expect_error "reject incompatible declared type" \
+	"SELECT * FROM pgcolumnar.read_parquet('$SCALAR')
+	 AS t(c_i2 int2, c_i4 text, c_i8 int8, c_f4 float4, c_f8 float8, c_bool bool,
+	      c_text text, c_bytea bytea, c_date date, c_time time, c_ts timestamp)"
+
+# not a Parquet file
+printf 'not parquet' > "$PGC_WORKDIR/bad.dat"
+chmod 644 "$PGC_WORKDIR/bad.dat"
+expect_error "reject non-parquet file" \
+	"SELECT * FROM pgcolumnar.read_parquet('$PGC_WORKDIR/bad.dat') AS t(a int)"
+
+# ---- import parity: read_parquet == import_parquet of the same file ---------
+psql_run "CREATE TABLE imp ($scalar_cols) USING pgcolumnar;"
+check "import parity rows" "$(q "SELECT pgcolumnar.import_parquet('imp', '$SCALAR');")" "5001"
+check "read_parquet == import_parquet" \
+	"$(rp_scalar)" "$(pgc_set_hash "SELECT * FROM imp")"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -27,7 +27,7 @@ SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUITES=(smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
 	differential recovery fuzz hardening concurrent_diff parallel sorted_projection \
 	arrow_export parquet_export read_stream corruption \
-	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip native_index native_dml native_ios native_projection native_cluster native_compact native_recluster native_reclaim native_ownership native_reclaim_cycles native_reclaim_frag native_gap native_truncate native_rewrite native_rewrite_conc native_parquet_schema isolation)
+	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip native_index native_dml native_ios native_projection native_cluster native_compact native_recluster native_reclaim native_ownership native_reclaim_cycles native_reclaim_frag native_gap native_truncate native_rewrite native_rewrite_conc native_parquet_schema native_read_parquet isolation)
 
 # Default matrix: one assert-enabled pg_config per major, 15 through 19.
 DEFAULT_CONFIGS=(


### PR DESCRIPTION
Second Phase G sequencing step (after the scan core in #98). Factors the row-producing core out of import and exposes the first user-facing external read. Stacked ahead of the FDW and predicate-pushdown PRs to follow.

## What
- **Shared row engine** — `pq_read_rows()` runs the per-row-group decode + per-row assembly (scalar, 1-D array from LIST, composite from group) and hands each row to a *sink*. Import's sink is `table_tuple_insert`; `read_parquet`'s is `tuplestore_puttupleslot`. So both surfaces produce rows through one code path with identical semantics.
- `build_imp_targets()` **loses its `Relation` parameter** — on a binding error it just `ereport`s (transaction abort releases any caller lock), so a caller with no relation (the function, the coming FDW) binds a descriptor against a file exactly as import binds a table.
- **`pgcolumnar.read_parquet(path text) RETURNS SETOF record`** — stream a file's rows in place. The caller supplies a column definition list:
  ```sql
  SELECT * FROM pgcolumnar.read_parquet('/data/f.parquet') AS t(id int, name text);
  ```
  The declared descriptor is bound against the file's leaf columns **by position**, exactly as import binds a target table (same type-compatibility rules, same "declared count must equal the file's" contract). Superuser only; materialize-mode SRF.

## Scope / known gap
Supports the shared decoder's type set: int2/4/8, float4/8, bool, text/varchar/bytea, date, time, timestamp, and their arrays/composites. **`uuid` and `numeric` (DECIMAL) are reported by `parquet_schema` but not yet decodable** by import or `read_parquet` — a pre-existing decoder gap (import never supported them). Closing it is a shared-decoder follow-up that benefits both paths; called out in the test and commit.

## Test — `native_read_parquet.sh`
Round-trips a scalar table and a nested (`int[]`/`text[]`/composite) table through `export_parquet` → `read_parquet` and asserts **identity with the source**; also checks a projection, the argument-validation errors (missing column list, wrong count, incompatible type, non-parquet file), and **`read_parquet` == `import_parquet` parity**. PG17 green (12 checks); `parquet_import`, `parquet_nested_import`, and `native_parquet_schema` still pass, confirming the import refactor is safe.

Full 15-19 matrix will run once after the FDW and pushdown PRs are also up.

Design: `design/PHASE_G_SCAN_SURFACES_PLAN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)