### PR TITLE
Phase G: Parquet foreign-data wrapper (pgcolumnar_parquet)

### DIFF
--- a/design/PHASE_G_SCAN_SURFACES_PLAN.md
+++ b/design/PHASE_G_SCAN_SURFACES_PLAN.md
@@ -39,16 +39,25 @@ server-side file).
 
 A foreign-data wrapper so a file is a table: `CREATE FOREIGN TABLE ... SERVER ...
 OPTIONS (path '...')`. It plans and executes over the same engine, so results match the
-function; only planning and pushdown differ. Projection pushdown comes from the scan's
-`attrs_used` (read only the referenced column chunks). No predicate pushdown yet.
+function. The scan materializes the file into a tuplestore in BeginForeignScan and
+drains it in IterateForeignScan (streaming and column-chunk projection are follow-ons,
+folded into PR3's pushdown work). The single required table option is `path`; an option
+validator rejects anything else and BeginForeignScan errors clearly on a missing path,
+non-Parquet file, or incompatible declared type. Superuser only.
 
-## PR3: predicate / row-group skipping
+## PR3: pushdown (projection + predicate / row-group skipping)
 
-The metadata parser currently skips the Parquet `Statistics` field, so there is nothing
-to skip on. PR3 first extends the column-chunk parser to read per-group min/max and
-null-count, then teaches the FDW to turn pushable `col op const` clauses (ordered types)
-into per-row-group skip decisions, with the executor rechecking every returned row so a
-partial or absent pushdown is always correct.
+Two pushdowns land together, since both need the scan core to decode a subset of the
+file:
+
+- **Projection** — read only the referenced column chunks, from the scan's `attrs_used`.
+  The row engine gains a per-top "needed" mask; unreferenced tops skip decode and stay
+  NULL.
+- **Predicate / row-group skipping** — the metadata parser currently skips the Parquet
+  `Statistics` field, so PR3 first extends the column-chunk parser to read per-group
+  min/max and null-count, then turns pushable `col op const` clauses (ordered types)
+  into per-row-group skip decisions, with the executor rechecking every returned row so
+  a partial or absent pushdown is always correct.
 
 ## Not in scope here
 

--- a/pgcolumnar--1.0.sql
+++ b/pgcolumnar--1.0.sql
@@ -538,6 +538,33 @@ CREATE FUNCTION pgcolumnar.read_parquet(path text)
 COMMENT ON FUNCTION pgcolumnar.read_parquet(text)
 	IS 'read a Parquet file in place as a set of rows; requires a column definition list, e.g. SELECT * FROM pgcolumnar.read_parquet(path) AS t(id int, name text) (Phase G)';
 
+/* ---------------------------------------------------------------------------
+ * Parquet foreign-data wrapper (Phase G)
+ *
+ * A foreign table over a single Parquet file; its column definitions are bound
+ * against the file by position, like read_parquet's column list. Usage:
+ *   CREATE SERVER pq FOREIGN DATA WRAPPER pgcolumnar_parquet;
+ *   CREATE FOREIGN TABLE ft (id int, name text) SERVER pq
+ *       OPTIONS (path '/data/f.parquet');
+ * ------------------------------------------------------------------------- */
+
+CREATE FUNCTION pgcolumnar.parquet_fdw_handler()
+	RETURNS fdw_handler
+	LANGUAGE C
+	AS 'MODULE_PATHNAME', 'pgcolumnar_parquet_fdw_handler';
+
+CREATE FUNCTION pgcolumnar.parquet_fdw_validator(text[], oid)
+	RETURNS void
+	LANGUAGE C
+	AS 'MODULE_PATHNAME', 'pgcolumnar_parquet_fdw_validator';
+
+CREATE FOREIGN DATA WRAPPER pgcolumnar_parquet
+	HANDLER pgcolumnar.parquet_fdw_handler
+	VALIDATOR pgcolumnar.parquet_fdw_validator;
+
+COMMENT ON FOREIGN DATA WRAPPER pgcolumnar_parquet
+	IS 'read a single Parquet file as a foreign table; table option: path (Phase G)';
+
 CREATE FUNCTION pgcolumnar.vm_selftest(rel regclass, blk int)
 	RETURNS boolean
 	LANGUAGE C

--- a/src/columnar_compat.h
+++ b/src/columnar_compat.h
@@ -372,4 +372,24 @@ ColumnarReindexRelation(Oid relid, int flags)
 #define COLUMNAR_TUPLESORT_NONACCESS false
 #endif
 
+/* -------------------------------------------------------------------------
+ * create_foreignscan_path() gained parameters over time: PG17 inserted a
+ * fdw_restrictinfo list before fdw_private, and PG19 inserted an int
+ * disabled_nodes after rows. We push no restrictinfo and no disabled nodes, so
+ * this wrapper takes the historical ten arguments and fills the extras.
+ * ------------------------------------------------------------------------- */
+#if PG_VERSION_NUM >= 190000
+#define COLUMNAR_CREATE_FOREIGNSCAN_PATH(root, rel, target, rows, startup, total, pathkeys, req_outer, fdw_outer, fdw_priv) \
+	create_foreignscan_path((root), (rel), (target), (rows), 0, (startup), (total), \
+							(pathkeys), (req_outer), (fdw_outer), NIL, (fdw_priv))
+#elif PG_VERSION_NUM >= 170000
+#define COLUMNAR_CREATE_FOREIGNSCAN_PATH(root, rel, target, rows, startup, total, pathkeys, req_outer, fdw_outer, fdw_priv) \
+	create_foreignscan_path((root), (rel), (target), (rows), (startup), (total), \
+							(pathkeys), (req_outer), (fdw_outer), NIL, (fdw_priv))
+#else
+#define COLUMNAR_CREATE_FOREIGNSCAN_PATH(root, rel, target, rows, startup, total, pathkeys, req_outer, fdw_outer, fdw_priv) \
+	create_foreignscan_path((root), (rel), (target), (rows), (startup), (total), \
+							(pathkeys), (req_outer), (fdw_outer), (fdw_priv))
+#endif
+
 #endif							/* COLUMNAR_COMPAT_H */

--- a/src/columnar_compat.h
+++ b/src/columnar_compat.h
@@ -374,11 +374,12 @@ ColumnarReindexRelation(Oid relid, int flags)
 
 /* -------------------------------------------------------------------------
  * create_foreignscan_path() gained parameters over time: PG17 inserted a
- * fdw_restrictinfo list before fdw_private, and PG19 inserted an int
- * disabled_nodes after rows. We push no restrictinfo and no disabled nodes, so
- * this wrapper takes the historical ten arguments and fills the extras.
+ * fdw_restrictinfo list before fdw_private, and PG18 inserted an int
+ * disabled_nodes after rows (kept in PG19). We push no restrictinfo and no
+ * disabled nodes, so this wrapper takes the historical ten arguments and fills
+ * the extras: >=18 -> 12 args, ==17 -> 11 args, <=16 -> 10 args.
  * ------------------------------------------------------------------------- */
-#if PG_VERSION_NUM >= 190000
+#if PG_VERSION_NUM >= 180000
 #define COLUMNAR_CREATE_FOREIGNSCAN_PATH(root, rel, target, rows, startup, total, pathkeys, req_outer, fdw_outer, fdw_priv) \
 	create_foreignscan_path((root), (rel), (target), (rows), 0, (startup), (total), \
 							(pathkeys), (req_outer), (fdw_outer), NIL, (fdw_priv))

--- a/src/columnar_parquet_reader.c
+++ b/src/columnar_parquet_reader.c
@@ -2168,9 +2168,11 @@ pqfdwGetForeignRelSize(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntablei
 	/*
 	 * Estimate row count from the file size without reading it: a generic
 	 * bytes-per-row divisor. Only a planning ballpark; the executor reads the
-	 * real rows.
+	 * real rows. The stat() is gated on superuser -- the same bar the scan
+	 * enforces -- so a non-privileged planner cannot use the EXPLAIN estimate to
+	 * probe whether a server-side path exists or how big it is.
 	 */
-	if (path != NULL && stat(path, &st) == 0 && st.st_size > 0)
+	if (superuser() && path != NULL && stat(path, &st) == 0 && st.st_size > 0)
 		rows = Max(1.0, (double) st.st_size / 64.0);
 	baserel->rows = rows;
 }

--- a/src/columnar_parquet_reader.c
+++ b/src/columnar_parquet_reader.c
@@ -19,17 +19,29 @@
  */
 #include "columnar.h"
 
+#include <sys/stat.h>
+
 #include "fmgr.h"
 #include "funcapi.h"
 #include "access/htup_details.h"
 #include "access/relation.h"
+#include "access/reloptions.h"
 #include "access/table.h"
 #include "access/tableam.h"
 #include "access/xact.h"
+#include "catalog/pg_foreign_table.h"
 #include "catalog/pg_type.h"
+#include "commands/defrem.h"
 #include "executor/tuptable.h"
+#include "foreign/fdwapi.h"
+#include "foreign/foreign.h"
 #include "lib/stringinfo.h"
 #include "miscadmin.h"
+#include "nodes/makefuncs.h"
+#include "optimizer/optimizer.h"
+#include "optimizer/pathnode.h"
+#include "optimizer/planmain.h"
+#include "optimizer/restrictinfo.h"
 #include "storage/fd.h"
 #include "utils/array.h"
 #include "utils/builtins.h"
@@ -45,6 +57,8 @@
 PG_FUNCTION_INFO_V1(columnar_import_parquet);
 PG_FUNCTION_INFO_V1(columnar_parquet_schema);
 PG_FUNCTION_INFO_V1(columnar_read_parquet);
+PG_FUNCTION_INFO_V1(pgcolumnar_parquet_fdw_handler);
+PG_FUNCTION_INFO_V1(pgcolumnar_parquet_fdw_validator);
 
 #define PG_TO_UNIX_DAYS		((int64) (POSTGRES_EPOCH_JDATE - UNIX_EPOCH_JDATE))
 #define PG_TO_UNIX_USECS	(PG_TO_UNIX_DAYS * USECS_PER_DAY)
@@ -2102,4 +2116,226 @@ columnar_parquet_schema(PG_FUNCTION_ARGS)
 	}
 
 	PG_RETURN_NULL();
+}
+
+/* -------------------------------------------------------------------------
+ * Parquet foreign-data wrapper (Phase G). A foreign table over a single Parquet
+ * file: its column definitions are bound against the file's leaves exactly as
+ * read_parquet's column list is, and rows are produced through the same scan
+ * core. Read-only, superuser (reads a server-side file). The single required
+ * table option is "path". Projection and predicate pushdown are a follow-on; this
+ * surface returns full rows and lets the executor project and filter.
+ *
+ *   CREATE SERVER pq FOREIGN DATA WRAPPER pgcolumnar_parquet;
+ *   CREATE FOREIGN TABLE ft (id int, name text) SERVER pq
+ *       OPTIONS (path '/data/f.parquet');
+ * ------------------------------------------------------------------------- */
+
+/* per-scan state: the whole file materialized into a tuplestore, drained by
+ * IterateForeignScan. Eager (reads the file up front); streaming is a follow-on.
+ * readslot is a minimal-tuple slot the tuplestore drains into; each row is then
+ * copied into the scan slot, whose ops are not guaranteed to be minimal-tuple. */
+typedef struct PqFdwScanState
+{
+	Tuplestorestate *tupstore;
+	TupleTableSlot *readslot;
+}			PqFdwScanState;
+
+/* the "path" option of a foreign table, or NULL if unset */
+static char *
+pqfdw_get_path(Oid foreigntableid)
+{
+	ForeignTable *ft = GetForeignTable(foreigntableid);
+	ListCell   *lc;
+
+	foreach(lc, ft->options)
+	{
+		DefElem    *def = (DefElem *) lfirst(lc);
+
+		if (strcmp(def->defname, "path") == 0)
+			return defGetString(def);
+	}
+	return NULL;
+}
+
+static void
+pqfdwGetForeignRelSize(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid)
+{
+	char	   *path = pqfdw_get_path(foreigntableid);
+	struct stat st;
+	double		rows = 1000.0;
+
+	/*
+	 * Estimate row count from the file size without reading it: a generic
+	 * bytes-per-row divisor. Only a planning ballpark; the executor reads the
+	 * real rows.
+	 */
+	if (path != NULL && stat(path, &st) == 0 && st.st_size > 0)
+		rows = Max(1.0, (double) st.st_size / 64.0);
+	baserel->rows = rows;
+}
+
+static void
+pqfdwGetForeignPaths(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid)
+{
+	Cost		startup_cost = 0;
+	Cost		total_cost = baserel->rows;
+
+	add_path(baserel, (Path *)
+			 COLUMNAR_CREATE_FOREIGNSCAN_PATH(root, baserel,
+											  NULL, /* default pathtarget */
+											  baserel->rows,
+											  startup_cost, total_cost,
+											  NIL,	/* no pathkeys */
+											  NULL, /* no outer rel */
+											  NULL, /* no extra plan */
+											  NIL));
+}
+
+static ForeignScan *
+pqfdwGetForeignPlan(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid,
+					ForeignPath *best_path, List *tlist, List *scan_clauses,
+					Plan *outer_plan)
+{
+	/* all filtering is done by the executor for now (no pushdown) */
+	scan_clauses = extract_actual_clauses(scan_clauses, false);
+	return make_foreignscan(tlist, scan_clauses, baserel->relid,
+							NIL, NIL, NIL, NIL, outer_plan);
+}
+
+static void
+pqfdwBeginForeignScan(ForeignScanState *node, int eflags)
+{
+	Relation	rel = node->ss.ss_currentRelation;
+	TupleDesc	tupdesc = RelationGetDescr(rel);
+	char	   *path;
+	long		filelen;
+	uint8	   *filebuf;
+	PqFile		pf;
+	ImpTop	   *tops;
+	ImpLeaf    *leaves;
+	int			ntops;
+	TupleTableSlot *slot;
+	PqFdwScanState *st;
+
+	/* nothing to do for a plan-only (EXPLAIN without ANALYZE) invocation */
+	if (eflags & EXEC_FLAG_EXPLAIN_ONLY)
+		return;
+
+	if (!superuser())
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 errmsg("pgcolumnar_parquet foreign tables require superuser (read a server-side file)")));
+
+	path = pqfdw_get_path(RelationGetRelid(rel));
+	if (path == NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_FDW_OPTION_NAME_NOT_FOUND),
+				 errmsg("foreign table \"%s\" has no \"path\" option",
+						RelationGetRelationName(rel))));
+
+	pq_slurp_and_parse(path, &filebuf, &filelen, &pf);
+	tops = build_imp_targets(tupdesc, &pf, &leaves, &ntops);
+
+	st = (PqFdwScanState *) palloc0(sizeof(PqFdwScanState));
+	/* randomAccess so ReScan can rewind the materialized rows */
+	st->tupstore = tuplestore_begin_heap(true, false, work_mem);
+	st->readslot = MakeSingleTupleTableSlot(tupdesc, &TTSOpsMinimalTuple);
+
+	slot = MakeSingleTupleTableSlot(tupdesc, &TTSOpsVirtual);
+	(void) pq_read_rows(&pf, filebuf, filelen, tops, ntops, leaves,
+						slot, pq_tuplestore_sink, st->tupstore);
+	ExecDropSingleTupleTableSlot(slot);
+
+	node->fdw_state = st;
+}
+
+static TupleTableSlot *
+pqfdwIterateForeignScan(ForeignScanState *node)
+{
+	PqFdwScanState *st = (PqFdwScanState *) node->fdw_state;
+	TupleTableSlot *slot = node->ss.ss_ScanTupleSlot;
+
+	if (st == NULL)
+		return ExecClearTuple(slot);
+	/* drain into our minimal-tuple slot, then copy into the scan slot */
+	if (!tuplestore_gettupleslot(st->tupstore, true, false, st->readslot))
+		return ExecClearTuple(slot);
+	return ExecCopySlot(slot, st->readslot);
+}
+
+static void
+pqfdwReScanForeignScan(ForeignScanState *node)
+{
+	PqFdwScanState *st = (PqFdwScanState *) node->fdw_state;
+
+	if (st != NULL && st->tupstore != NULL)
+		tuplestore_rescan(st->tupstore);
+}
+
+static void
+pqfdwEndForeignScan(ForeignScanState *node)
+{
+	PqFdwScanState *st = (PqFdwScanState *) node->fdw_state;
+
+	if (st == NULL)
+		return;
+	if (st->tupstore != NULL)
+	{
+		tuplestore_end(st->tupstore);
+		st->tupstore = NULL;
+	}
+	if (st->readslot != NULL)
+	{
+		ExecDropSingleTupleTableSlot(st->readslot);
+		st->readslot = NULL;
+	}
+}
+
+Datum
+pgcolumnar_parquet_fdw_handler(PG_FUNCTION_ARGS)
+{
+	FdwRoutine *r = makeNode(FdwRoutine);
+
+	r->GetForeignRelSize = pqfdwGetForeignRelSize;
+	r->GetForeignPaths = pqfdwGetForeignPaths;
+	r->GetForeignPlan = pqfdwGetForeignPlan;
+	r->BeginForeignScan = pqfdwBeginForeignScan;
+	r->IterateForeignScan = pqfdwIterateForeignScan;
+	r->ReScanForeignScan = pqfdwReScanForeignScan;
+	r->EndForeignScan = pqfdwEndForeignScan;
+
+	PG_RETURN_POINTER(r);
+}
+
+/*
+ * Option validator: the only accepted option is "path" on a foreign table. Server,
+ * wrapper, and user-mapping objects take no options.
+ */
+Datum
+pgcolumnar_parquet_fdw_validator(PG_FUNCTION_ARGS)
+{
+	List	   *options = untransformRelOptions(PG_GETARG_DATUM(0));
+	Oid			catalog = PG_GETARG_OID(1);
+	ListCell   *lc;
+
+	foreach(lc, options)
+	{
+		DefElem    *def = (DefElem *) lfirst(lc);
+
+		if (catalog == ForeignTableRelationId && strcmp(def->defname, "path") == 0)
+		{
+			if (defGetString(def)[0] == '\0')
+				ereport(ERROR,
+						(errcode(ERRCODE_FDW_INVALID_OPTION_NAME),
+						 errmsg("\"path\" option cannot be empty")));
+		}
+		else
+			ereport(ERROR,
+					(errcode(ERRCODE_FDW_INVALID_OPTION_NAME),
+					 errmsg("invalid option \"%s\"", def->defname),
+					 errhint("The pgcolumnar_parquet wrapper accepts only the foreign-table option \"path\".")));
+	}
+
+	PG_RETURN_VOID();
 }

--- a/test/native_parquet_fdw.sh
+++ b/test/native_parquet_fdw.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# pgColumnar Parquet foreign-data wrapper (Phase G). The pgcolumnar_parquet FDW
+# exposes a single Parquet file as a foreign table, binding its column definitions
+# against the file like read_parquet's column list and producing rows through the
+# same scan core. This suite exports a columnar table, reads it back through a
+# foreign table, and asserts identity with the source across full scan, projection,
+# predicate (executor-applied), self-join (rescan), and a nested-type table. It also
+# checks EXPLAIN shows a Foreign Scan and the option validator/scan errors.
+#
+# Usage:  test/native_parquet_fdw.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+expect_error() {  # expect_error LABEL SQL
+	local label="$1" sql="$2"
+	if psql_run "$sql" >/dev/null 2>&1; then
+		check "$label (expected error)" "succeeded" "error"
+	else
+		check "$label" "error" "error"
+	fi
+}
+
+psql_run "CREATE SERVER pqsrv FOREIGN DATA WRAPPER pgcolumnar_parquet;"
+
+# ---- scalar foreign table ---------------------------------------------------
+SCALAR="$PGC_WORKDIR/scalar.parquet"
+scalar_cols="c_i2 int2, c_i4 int4, c_i8 int8, c_f4 float4, c_f8 float8, c_bool bool,
+             c_text text, c_bytea bytea, c_date date, c_time time, c_ts timestamp"
+
+psql_run "CREATE TABLE s ($scalar_cols) USING pgcolumnar;"
+psql_run "INSERT INTO s
+	SELECT (g%100)::int2, g, g::int8*1000, (g/2.0)::float4, (g/4.0)::float8, (g%2=0),
+	       'row'||g, decode(lpad(to_hex(g),8,'0'),'hex'), date '2020-01-01' + g,
+	       time '00:00:00' + (g||' seconds')::interval,
+	       timestamp '2020-01-01' + (g||' minutes')::interval
+	FROM generate_series(1, 5000) g;"
+psql_run "INSERT INTO s VALUES (NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL);"
+check "scalar export rows" "$(q "SELECT pgcolumnar.export_parquet('s', '$SCALAR');")" "5001"
+
+psql_run "CREATE FOREIGN TABLE fs ($scalar_cols) SERVER pqsrv OPTIONS (path '$SCALAR');"
+
+check "full scan: fdw == source" \
+	"$(pgc_set_hash "SELECT * FROM fs")" "$(pgc_set_hash "SELECT * FROM s")"
+check "fdw row count" "$(q "SELECT count(*) FROM fs")" "5001"
+
+# projection (executor discards other columns)
+check "projection: fdw == source" \
+	"$(pgc_set_hash "SELECT c_text FROM fs")" "$(pgc_set_hash "SELECT c_text FROM s")"
+
+# predicate applied by the executor
+check "predicate: fdw == source" \
+	"$(pgc_set_hash "SELECT c_i4, c_text FROM fs WHERE c_i4 > 2500 AND c_bool")" \
+	"$(pgc_set_hash "SELECT c_i4, c_text FROM s  WHERE c_i4 > 2500 AND c_bool")"
+
+# self-join forces the scan to be re-executed (ReScan); result must match source
+psql_run "SET enable_hashjoin=off; SET enable_mergejoin=off;"
+check "nested-loop self-join (rescan): fdw == source" \
+	"$(q "SELECT count(*) FROM fs a JOIN fs b ON a.c_i4 = b.c_i4 WHERE a.c_i4 < 200")" \
+	"$(q "SELECT count(*) FROM s  a JOIN s  b ON a.c_i4 = b.c_i4 WHERE a.c_i4 < 200")"
+psql_run "RESET enable_hashjoin; RESET enable_mergejoin;"
+
+# the plan is a Foreign Scan
+check "EXPLAIN shows Foreign Scan" \
+	"$(q "EXPLAIN (COSTS OFF) SELECT * FROM fs" | grep -c 'Foreign Scan')" "1"
+
+# ---- nested foreign table (int[], text[], composite) ------------------------
+psql_run "CREATE TYPE fdw_npc AS (x int, y text);"
+psql_run "CREATE TABLE np (id int, ia int[], ta text[], c fdw_npc) USING pgcolumnar;"
+psql_run "INSERT INTO np
+	SELECT g,
+	       CASE WHEN g%11=0 THEN NULL WHEN g%7=0 THEN '{}'::int[] ELSE ARRAY[g,g+1] END,
+	       CASE WHEN g%13=0 THEN NULL ELSE ARRAY['a'||g,'b'||g] END,
+	       CASE WHEN g%5=0 THEN NULL ELSE ROW(g,'c'||g)::fdw_npc END
+	FROM generate_series(1, 3000) g;"
+NESTED="$PGC_WORKDIR/nested.parquet"
+check "nested export rows" "$(q "SELECT pgcolumnar.export_parquet('np', '$NESTED');")" "3000"
+psql_run "CREATE FOREIGN TABLE fnp (id int, ia int[], ta text[], c fdw_npc)
+	SERVER pqsrv OPTIONS (path '$NESTED');"
+check "nested full scan: fdw == source" \
+	"$(pgc_set_hash "SELECT * FROM fnp")" "$(pgc_set_hash "SELECT * FROM np")"
+
+# ---- option validation + scan errors ----------------------------------------
+expect_error "reject invalid table option" \
+	"CREATE FOREIGN TABLE fbad ($scalar_cols) SERVER pqsrv OPTIONS (path '$SCALAR', bogus 'x');"
+expect_error "reject empty path option" \
+	"CREATE FOREIGN TABLE fempty ($scalar_cols) SERVER pqsrv OPTIONS (path '');"
+
+# a foreign table with no path errors at scan time
+psql_run "CREATE FOREIGN TABLE fnopath ($scalar_cols) SERVER pqsrv;"
+expect_error "scan without path option errors" "SELECT * FROM fnopath"
+
+# a path that is not a Parquet file errors at scan time
+printf 'not parquet' > "$PGC_WORKDIR/bad.dat"
+chmod 644 "$PGC_WORKDIR/bad.dat"
+psql_run "CREATE FOREIGN TABLE fbadfile ($scalar_cols) SERVER pqsrv OPTIONS (path '$PGC_WORKDIR/bad.dat');"
+expect_error "scan of non-parquet file errors" "SELECT * FROM fbadfile"
+
+# a declared type incompatible with the file column errors at scan time
+psql_run "CREATE FOREIGN TABLE fwrongtype (c_i2 int2, c_i4 text, c_i8 int8, c_f4 float4,
+	c_f8 float8, c_bool bool, c_text text, c_bytea bytea, c_date date, c_time time,
+	c_ts timestamp) SERVER pqsrv OPTIONS (path '$SCALAR');"
+expect_error "scan with incompatible declared type errors" "SELECT * FROM fwrongtype"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -27,7 +27,7 @@ SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUITES=(smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
 	differential recovery fuzz hardening concurrent_diff parallel sorted_projection \
 	arrow_export parquet_export read_stream corruption \
-	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip native_index native_dml native_ios native_projection native_cluster native_compact native_recluster native_reclaim native_ownership native_reclaim_cycles native_reclaim_frag native_gap native_truncate native_rewrite native_rewrite_conc native_parquet_schema native_read_parquet isolation)
+	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip native_index native_dml native_ios native_projection native_cluster native_compact native_recluster native_reclaim native_ownership native_reclaim_cycles native_reclaim_frag native_gap native_truncate native_rewrite native_rewrite_conc native_parquet_schema native_read_parquet native_parquet_fdw isolation)
 
 # Default matrix: one assert-enabled pg_config per major, 15 through 19.
 DEFAULT_CONFIGS=(


### PR DESCRIPTION
Third Phase G sequencing step. A read-only FDW exposing a single Parquet file as a foreign table, on the same scan core as `read_parquet` (#99). **Stacked on #99** — review/merge that first; this PR's base is `phase-g/read-parquet`.

## What
```sql
CREATE SERVER pq FOREIGN DATA WRAPPER pgcolumnar_parquet;
CREATE FOREIGN TABLE ft (id int, name text) SERVER pq OPTIONS (path '/data/f.parquet');
SELECT * FROM ft;
```
- **`pgcolumnar_parquet` wrapper** (HANDLER + VALIDATOR). One required foreign-table option: `path`. The validator rejects any other option and an empty path; `BeginForeignScan` errors clearly on a missing path, a non-Parquet file, or an incompatible declared type. Superuser only.
- The foreign table's columns are bound against the file's leaves **by position** (same contract as `read_parquet`), and rows are produced through the shared `pq_read_rows`. The scan materializes the file into a tuplestore up front and drains it per row (into a minimal-tuple slot, then `ExecCopySlot` into the scan slot — whose ops aren't guaranteed minimal-tuple). `randomAccess` tuplestore so a nested-loop **ReScan** rewinds correctly.

## Version compat
`create_foreignscan_path` gained parameters over the majors (PG17 `fdw_restrictinfo`, PG19 `disabled_nodes`). `COLUMNAR_CREATE_FOREIGNSCAN_PATH` in `columnar_compat.h` fills the extras so the call is version-clean. `make_foreignscan` is stable across 15-19.

## Scope
Returns full rows; the executor projects and filters. **Streaming and column-chunk projection + predicate/row-group skipping are the next PR** (folded together since both need the engine to decode a column/row-group subset).

## Test — `native_parquet_fdw.sh`
Exports a columnar table, reads it back through a foreign table, and asserts identity with the source across full scan, projection, executor-applied predicate, a **nested-loop self-join (ReScan)**, and a nested-type (`int[]`/`text[]`/composite) table. Checks `EXPLAIN` shows a `Foreign Scan` and the validator/scan errors (invalid option, empty path, missing path, non-parquet file, incompatible type). PG17 green (14 checks).

Full 15-19 matrix runs once after the pushdown PR is up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)