### PR TITLE
Phase G: Parquet FDW predicate pushdown (row-group skipping)

### DIFF
--- a/design/PHASE_G_PUSHDOWN_HANDOFF.md
+++ b/design/PHASE_G_PUSHDOWN_HANDOFF.md
@@ -1,0 +1,172 @@
+# Phase G pushdown -- status
+
+## Current state
+
+PR3 is open as #101. The crash is fixed, and so is a float pushdown soundness
+defect found in review. The full 15 through 19 matrix is green: 58 suites on
+each of PG15/16/17/18 and all suites on PG19, zero failures, zero compiler
+warnings on every major.
+
+## What was done and merged to main
+
+`main` tip is the merge of #100 (`748dcd0`). Phase G's first three surfaces:
+
+- **#96** parallel test harness (+ legacy-suite `PGC_SKIP_BUILD` install-race fix).
+- **#97** Phase G external-Parquet design.
+- **#98** scan core: `pq_slurp_and_parse`, `pq_leaf_to_pgtype`, `parquet_schema(path)`.
+- **#99** `read_parquet(path)` + the shared row engine `pq_read_rows`.
+- **#100** Parquet FDW (`pgcolumnar_parquet`).
+
+## PR3 (predicate / row-group skipping)
+
+### Implemented
+- `parse_statistics()` reads the Parquet `Statistics` field (min_value/max_value,
+  with deprecated min/max fallback) into new `PqChunk` fields.
+- `pq_read_rows()` gained a `const bool *skipGroup` param; skipped groups decode
+  and emit nothing. import/read_parquet pass NULL.
+- FDW `pqfdw_compute_skip()` turns pushable `col op const` clauses into a
+  per-row-group skip mask using stats min/max. Restricted to fixed-width ordered
+  physical types (INT32/INT64/FLOAT/DOUBLE), and for float/double to the
+  NaN-safe directions only. Statistics are refused when the interval is inverted.
+  Conservative: only skips when provably empty; the executor still rechecks, so a
+  missed skip only costs work. That is not a safety net for an *unsound* skip,
+  since a skipped group emits nothing to recheck.
+- `pqfdwExplainForeignScan()` prints "Row Groups" / "Row Groups Skipped".
+- Test `test/native_parquet_pushdown.sh` uses pyarrow to write a stats-bearing
+  200k-row / 4-row-group file (our exporter does not write stats), asserts
+  correctness against a heap oracle, and asserts the skip counter.
+
+### The bug, and why the earlier diagnosis was wrong
+
+The previous session recorded the trigger as "more than one row group decoded
+AND a recheck qual present". That was a red herring. On resume, a control matrix
+over four files (1 vs 4 row groups, statistics vs none) showed **every** FDW
+scan corrupting memory, including a plain `SELECT count(*)` with no qual at all.
+Statistics, group count, and quals were all irrelevant. `main` over the same
+files was clean, so the defect was introduced by PR3.
+
+`MemoryContextCheck` checkpoints through `pqfdwBeginForeignScan` all passed,
+proving `ExecutorState` was still intact when that function returned. A gdb
+backtrace on the `pfree` then named the real site:
+
+```
+tts_heap_clear -> tts_heap_store_tuple -> ExecStoreHeapTuple
+  -> ExecCopySlot -> pqfdwIterateForeignScan (columnar_parquet_reader.c:2584)
+```
+
+Root cause: `ForeignNext()` calls `IterateForeignScan` in
+`ecxt_per_tuple_memory`, and `ExecScan` resets that context before every fetch,
+including the no-qual fast path. Whenever `tuplestore_gettupleslot()` hands the
+slot a palloc'd tuple it also transfers ownership (`TTS_FLAG_SHOULDFREE`), and
+the slot frees it on its next store. Allocated in the per-tuple context, that
+pointer is already reclaimed by then, so the next store frees wiped memory (the
+`0x7f7f7f7f...` headers) and corrupts `ExecutorState`.
+
+The checkpoint commit's `copy=true` made this fire on every row. `copy=false`
+was not a fix either: once the tuplestore spills, `readtup()` palloc's in the
+same per-tuple context and sets `should_free`, which was the original spill
+crash. Both symptoms are the same defect.
+
+### The fix
+Pin the context rather than the copy flag: run the tuplestore fetch in
+`es_query_cxt`, where the slot's ownership stays valid until it stores the next
+row. Also:
+- `EndForeignScan` drops the readslot before ending the tuplestore, since a
+  non-copied fetch leaves the slot pointing into tuplestore memory.
+- The scan slot is `TTSOpsHeapTuple`, not virtual. `table_slot_callbacks()`
+  gives foreign tables a heap slot deliberately. The old comment said virtual.
+- PG18 build fix for `pqfdw_compute_skip()`: PG18 generalized index-AM
+  strategies, so `get_op_btree_interpretation()` became
+  `get_op_index_interpretation()` and `OpBtreeInterpretation.strategy` became
+  `OpIndexInterpretation.cmptype`. Shim added to `columnar_compat.h`.
+
+### Verification
+- Full 15 through 19 matrix green: 58 suites on each of PG15/16/17/18 and all
+  suites on PG19, zero failures, zero compiler warnings on any major. The matrix
+  runs in the `pgcolumnar-dev` container (a clone of `plexcellent`), building from
+  a copy of the read-only repo mount; logs land in `/root/matrix*.log` there, not
+  in `plexcellent`. Re-run in full after each source change, including the NaN and
+  inversion guards.
+- A dedicated stress over `work_mem` 64kB/1MB/64MB (forcing tuplestore spill)
+  plus a nested-loop rescan: 14 checks, zero memory diagnostics in the server log.
+- The assert-enabled build is what surfaces this. `AllocSetCheck` reports the
+  corrupted context by name, which is the fastest first signal; note it detects
+  corruption at teardown, not where it was caused.
+
+### Float pushdown was unsound for NaN (found in review of #101)
+
+Parquet writers exclude NaN when computing min/max, so a group holding a NaN
+advertises ordinary finite bounds. PostgreSQL orders NaN above every value and
+treats `NaN = NaN` as true, so `col > c`, `col >= c` and `col = 'NaN'` can all
+match a row the statistics do not describe. Confirmed empirically: a 4-group file
+with one NaN returned 0 rows for `val > 1e300` instead of 1, with all four groups
+skipped. The executor's recheck cannot recover this, because a skipped group
+emits nothing to recheck.
+
+`>` and `>=` are therefore never pushed down for float/double, `=` is refused
+when the constant is NaN, and NaN-valued statistics are ignored outright.
+`<` and `<=` stay sound, since a NaN row cannot satisfy those either. The +/-0
+rules in the same spec block need no handling, because PostgreSQL compares -0 and
++0 as equal.
+
+### Inverted statistics were trusted (found in review of #101)
+
+Same shape as the NaN defect: statistics that do not mean what the comparison
+assumes. Every skip test assumes `min <= max`, and the decoded interval may be
+inverted without any corruption. `pq_want_phys()` maps `INT2OID` to `PQ_INT32`
+and `plain_value_to_datum()` narrows with an unchecked cast, so an `int2` foreign
+column over a Parquet INT32 column holding 30000 and 40000 decodes to
+`min=30000, max=-25536`. `WHERE c = 30000::int2` then takes the `const > max`
+branch and skips a group that genuinely contains the row, because the data path
+applies the identical narrowing. Confirmed empirically: the unfiltered scan
+returned `[-25536, 30000]` while the equality predicate returned 0 rows with
+`Row Groups Skipped: 1`.
+
+Parquet's `UINT_32`/`UINT_64` logical types invert the same way, since they sort
+unsigned while we decode signed, as can a genuinely corrupt file. The guard
+refuses to skip whenever `min > max`.
+
+### Test-harness hardening
+`pgc_set_hash()` returned an empty string when a query errored, so two failing
+queries compared equal and the check passed vacuously. Four checks "passed" this
+way while a server was down. It now returns a per-call unique `QUERY_ERROR.*`
+marker. A genuinely empty result set still hashes to `EMPTY`, so real empty-vs-
+empty comparisons are unaffected.
+
+## Debugging notes worth keeping
+
+- valgrind memcheck does not catch this class of bug: PostgreSQL sub-allocates
+  palloc chunks inside large malloc'd blocks, so intra-block overwrites are
+  invisible unless built with `-DUSE_VALGRIND`.
+- `MemoryContextCheck(CurrentMemoryContext)` checkpoints bisect a corrupting
+  step in one build, without gdb. It only checks the one context.
+- gdb single-user with `break errfinish` gives the faulting backtrace directly:
+  `runuser -u postgres -- gdb -batch -x cmds postgres`, with
+  `run --single -D $PGDATA db < in.sql`. The data directory must stay 0700.
+
+## Follow-ups deliberately not in PR3
+
+- **Malformed-file hardening (pre-existing).** `rg->chunks` is allocated from the
+  row group's own column count and left NULL when the `columns` field is absent,
+  but is indexed by `pf->ncols` in `pq_read_rows()` and by `top->firstLeaf` in the
+  skip path. A short or missing chunk list is an out-of-bounds read or NULL
+  dereference. A `cn == pf->ncols` validation at parse time belongs with the
+  `corruption` suite.
+- **Float `>=` / `>` pushdown.** Disabled for NaN safety. Recovering it needs a
+  per-group NaN indicator; Parquet has no widely written one, so this stays off.
+- **All-NULL group skipping.** `null_count` is no longer parsed. Using it needs
+  the operator's strictness checked, so it goes with the change that wants it.
+- **Unchecked narrowing in `plain_value_to_datum()`.** Silently wrapping a
+  Parquet INT32 40000 into an int16 -25536 is wrong on the read path regardless
+  of pushdown. Either range-check and error, or refuse the bind in
+  `build_imp_targets()`. The inversion guard only stops the skip path from
+  trusting the result; it does not make the value correct.
+- **Costing.** `pqfdwGetForeignPaths` still costs the full relation, so a highly
+  selective scan is costed as if nothing were skipped.
+- **Plain EXPLAIN** reports no row-group counts, since `fdw_state` is NULL under
+  `EXEC_FLAG_EXPLAIN_ONLY`.
+
+Phase G follow-ons (projection/column-chunk pushdown, streaming FDW, multi-file,
+ORC/Iceberg, uuid and numeric decoder gap) are in
+`design/PHASE_G_SCAN_SURFACES_PLAN.md` and
+`design/PHASE_G_EXTERNAL_PARQUET_PLAN.md`.

--- a/src/columnar_compat.h
+++ b/src/columnar_compat.h
@@ -60,6 +60,50 @@
 #endif
 
 /* -------------------------------------------------------------------------
+ * PG18 generalized index-AM strategies. get_op_btree_interpretation() became
+ * get_op_index_interpretation(), and its result element lost the btree-specific
+ * OpBtreeInterpretation.strategy (a BT*StrategyNumber) in favour of
+ * OpIndexInterpretation.cmptype (a CompareType). Predicate pushdown reasons in
+ * btree strategy numbers, so map the generic comparison type back to one; a
+ * comparison with no btree equivalent yields 0, which callers treat as "not
+ * pushable".
+ * ------------------------------------------------------------------------- */
+#include "access/stratnum.h"
+#include "utils/lsyscache.h"
+
+#if PG_VERSION_NUM >= 180000
+#define ColumnarOpInterpretation OpIndexInterpretation
+#define ColumnarGetOpInterpretation(opno) get_op_index_interpretation(opno)
+static inline int
+ColumnarOpInterpStrategy(const OpIndexInterpretation *o)
+{
+	switch (o->cmptype)
+	{
+		case COMPARE_LT:
+			return BTLessStrategyNumber;
+		case COMPARE_LE:
+			return BTLessEqualStrategyNumber;
+		case COMPARE_EQ:
+			return BTEqualStrategyNumber;
+		case COMPARE_GE:
+			return BTGreaterEqualStrategyNumber;
+		case COMPARE_GT:
+			return BTGreaterStrategyNumber;
+		default:
+			return 0;
+	}
+}
+#else
+#define ColumnarOpInterpretation OpBtreeInterpretation
+#define ColumnarGetOpInterpretation(opno) get_op_btree_interpretation(opno)
+static inline int
+ColumnarOpInterpStrategy(const OpBtreeInterpretation *o)
+{
+	return o->strategy;
+}
+#endif
+
+/* -------------------------------------------------------------------------
  * pg_class_ownercheck (a relation-specific helper) was generalized to
  * object_ownercheck(classid, objectid, roleid) in PG16. Both return true for a
  * superuser, so an owner-or-superuser gate needs no separate superuser bypass.

--- a/src/columnar_parquet_reader.c
+++ b/src/columnar_parquet_reader.c
@@ -19,6 +19,7 @@
  */
 #include "columnar.h"
 
+#include <math.h>
 #include <sys/stat.h>
 
 #include "fmgr.h"
@@ -26,12 +27,19 @@
 #include "access/htup_details.h"
 #include "access/relation.h"
 #include "access/reloptions.h"
+#include "access/stratnum.h"
 #include "access/table.h"
 #include "access/tableam.h"
 #include "access/xact.h"
 #include "catalog/pg_foreign_table.h"
 #include "catalog/pg_type.h"
 #include "commands/defrem.h"
+#if PG_VERSION_NUM >= 180000
+#include "commands/explain_format.h"
+#include "commands/explain_state.h"
+#else
+#include "commands/explain.h"
+#endif
 #include "executor/tuptable.h"
 #include "foreign/fdwapi.h"
 #include "foreign/foreign.h"
@@ -421,6 +429,14 @@ typedef struct PqChunk
 	int64		data_page_offset;
 	int64		dict_page_offset;	/* 0 if none */
 	int64		total_compressed_size;
+	/* Statistics (optional). min/max point into the metadata buffer, so they are
+	 * valid as long as the file buffer lives (through a scan). */
+	bool		has_min;
+	bool		has_max;
+	const uint8 *stat_min;
+	const uint8 *stat_max;
+	uint32		stat_min_len;
+	uint32		stat_max_len;
 } PqChunk;
 
 typedef struct PqRowGroup
@@ -440,6 +456,87 @@ typedef struct PqFile
 	PqRowGroup *rgs;
 } PqFile;
 
+/*
+ * Parse a Statistics struct into *ch. Prefers the current min_value (field 6) /
+ * max_value (field 5) over the deprecated min (2) / max (1). Values are kept as
+ * raw pointers into the metadata buffer. Other fields, including null_count, are
+ * skipped: nothing reads them yet, and an all-NULL skip would additionally need
+ * the operator's strictness checked.
+ */
+static void
+parse_statistics(TCReader *r, PqChunk *ch)
+{
+	int			lastId = 0;
+
+	for (;;)
+	{
+		int			ft,
+					fid;
+
+		tcr_field(r, &ft, &fid, &lastId);
+		if (ft == TC_STOP || r->error)
+			break;
+		switch (fid)
+		{
+			case 1:				/* max (deprecated): fallback only */
+				{
+					uint32		n;
+					const uint8 *p = tcr_bytes(r, &n);
+
+					if (p && !ch->has_max)
+					{
+						ch->stat_max = p;
+						ch->stat_max_len = n;
+						ch->has_max = true;
+					}
+					break;
+				}
+			case 2:				/* min (deprecated): fallback only */
+				{
+					uint32		n;
+					const uint8 *p = tcr_bytes(r, &n);
+
+					if (p && !ch->has_min)
+					{
+						ch->stat_min = p;
+						ch->stat_min_len = n;
+						ch->has_min = true;
+					}
+					break;
+				}
+			case 5:				/* max_value (preferred) */
+				{
+					uint32		n;
+					const uint8 *p = tcr_bytes(r, &n);
+
+					if (p)
+					{
+						ch->stat_max = p;
+						ch->stat_max_len = n;
+						ch->has_max = true;
+					}
+					break;
+				}
+			case 6:				/* min_value (preferred) */
+				{
+					uint32		n;
+					const uint8 *p = tcr_bytes(r, &n);
+
+					if (p)
+					{
+						ch->stat_min = p;
+						ch->stat_min_len = n;
+						ch->has_min = true;
+					}
+					break;
+				}
+			default:
+				tcr_skip(r, ft);
+				break;
+		}
+	}
+}
+
 /* parse a ColumnMetaData struct into *ch */
 static void
 parse_column_meta(TCReader *r, PqChunk *ch)
@@ -451,6 +548,12 @@ parse_column_meta(TCReader *r, PqChunk *ch)
 	ch->data_page_offset = 0;
 	ch->dict_page_offset = 0;
 	ch->total_compressed_size = 0;
+	ch->has_min = false;
+	ch->has_max = false;
+	ch->stat_min = NULL;
+	ch->stat_max = NULL;
+	ch->stat_min_len = 0;
+	ch->stat_max_len = 0;
 
 	for (;;)
 	{
@@ -476,6 +579,12 @@ parse_column_meta(TCReader *r, PqChunk *ch)
 				break;
 			case 11:			/* dictionary_page_offset */
 				ch->dict_page_offset = tcr_zigzag(r);
+				break;
+			case 12:			/* statistics */
+				if (ft == TC_STRUCT)
+					parse_statistics(r, ch);
+				else
+					tcr_skip(r, ft);
 				break;
 			default:
 				tcr_skip(r, ft);
@@ -1737,7 +1846,8 @@ pq_tuplestore_sink(TupleTableSlot *slot, void *arg)
 static int64
 pq_read_rows(PqFile *pf, const uint8 *filebuf, long filelen,
 			 ImpTop *tops, int ntops, ImpLeaf *leaves,
-			 TupleTableSlot *slot, PqRowSink sink, void *sinkarg)
+			 TupleTableSlot *slot, PqRowSink sink, void *sinkarg,
+			 const bool *skipGroup)
 {
 	int			natts = slot->tts_tupleDescriptor->natts;
 	MemoryContext groupCtx;
@@ -1760,6 +1870,12 @@ pq_read_rows(PqFile *pf, const uint8 *filebuf, long filelen,
 		int64		r;
 		int			t;
 		MemoryContext oldCtx;
+
+		/* row-group skipping (predicate pushdown): the group cannot match, so
+		 * decode nothing and emit nothing. The executor still rechecks quals on
+		 * the rows we do emit, so a missed skip only costs work, never rows. */
+		if (skipGroup != NULL && skipGroup[rg])
+			continue;
 
 		/* decode every leaf column of this row group into its entry stream */
 		MemoryContextReset(groupCtx);
@@ -1968,7 +2084,7 @@ columnar_import_parquet(PG_FUNCTION_ARGS)
 	sinkarg.rel = rel;
 	sinkarg.cid = GetCurrentCommandId(true);
 	total = pq_read_rows(&pf, filebuf, filelen, tops, ntops, leaves,
-						 slot, pq_insert_sink, &sinkarg);
+						 slot, pq_insert_sink, &sinkarg, NULL);
 
 	ExecDropSingleTupleTableSlot(slot);
 	table_close(rel, RowExclusiveLock);
@@ -2039,7 +2155,7 @@ columnar_read_parquet(PG_FUNCTION_ARGS)
 
 	slot = MakeSingleTupleTableSlot(retdesc, &TTSOpsVirtual);
 	(void) pq_read_rows(&pf, filebuf, filelen, tops, ntops, leaves,
-						slot, pq_tuplestore_sink, tupstore);
+						slot, pq_tuplestore_sink, tupstore, NULL);
 	ExecDropSingleTupleTableSlot(slot);
 
 	PG_RETURN_NULL();
@@ -2139,6 +2255,8 @@ typedef struct PqFdwScanState
 {
 	Tuplestorestate *tupstore;
 	TupleTableSlot *readslot;
+	int			groupsTotal;	/* row groups in the file */
+	int			groupsSkipped;	/* skipped by predicate pushdown */
 }			PqFdwScanState;
 
 /* the "path" option of a foreign table, or NULL if unset */
@@ -2199,10 +2317,257 @@ pqfdwGetForeignPlan(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid,
 					ForeignPath *best_path, List *tlist, List *scan_clauses,
 					Plan *outer_plan)
 {
-	/* all filtering is done by the executor for now (no pushdown) */
+	/*
+	 * Clause evaluation stays with the executor; pushdown here is row-group
+	 * skipping only (see pqfdw_compute_skip), so every clause is still recheckable
+	 * and must remain in the plan's qual.
+	 */
 	scan_clauses = extract_actual_clauses(scan_clauses, false);
 	return make_foreignscan(tlist, scan_clauses, baserel->relid,
 							NIL, NIL, NIL, NIL, outer_plan);
+}
+
+/* the top (target column) bound to attribute attno0, or NULL */
+static ImpTop *
+pqfdw_top_for_attno(ImpTop *tops, int ntops, int attno0)
+{
+	int			t;
+
+	for (t = 0; t < ntops; t++)
+		if (tops[t].attno == attno0)
+			return &tops[t];
+	return NULL;
+}
+
+/*
+ * Decide whether a single row group can be skipped for the qual `col op const`
+ * (with the Var on varLeft). Conservative: returns true only when the group's
+ * min/max prove no row can match. Anything uncertain -- missing stats, an
+ * unsupported physical type, a mismatched constant type, a non-btree operator --
+ * returns false (do not skip). Restricted to fixed-width ordered physical types,
+ * whose statistics decode unambiguously.
+ */
+static bool
+pqfdw_clause_excludes_group(ImpLeaf *leaf, PqChunk *ch, int strategy,
+							bool varLeft, Const *con)
+{
+	TypeCacheEntry *tce;
+	const uint8 *p;
+	bool		ok;
+	Datum		minD;
+	Datum		maxD;
+	int			phys = leaf->plan.expect_phys;
+
+	if (!ch->has_min || !ch->has_max)
+		return false;
+	/* only fixed-width ordered stats decode without ambiguity */
+	if (phys != PQ_INT32 && phys != PQ_INT64 &&
+		phys != PQ_FLOAT && phys != PQ_DOUBLE)
+		return false;
+	if (con->consttype != leaf->plan.typid || con->constisnull)
+		return false;
+
+	tce = lookup_type_cache(leaf->plan.typid, TYPECACHE_CMP_PROC_FINFO);
+	if (!OidIsValid(tce->cmp_proc_finfo.fn_oid))
+		return false;
+
+	p = ch->stat_min;
+	minD = plain_value_to_datum(&leaf->plan, &p, p + ch->stat_min_len, &ok);
+	if (!ok)
+		return false;
+	p = ch->stat_max;
+	maxD = plain_value_to_datum(&leaf->plan, &p, p + ch->stat_max_len, &ok);
+	if (!ok)
+		return false;
+
+#define PQ_CMP(a, b) \
+	DatumGetInt32(FunctionCall2Coll(&tce->cmp_proc_finfo, InvalidOid, (a), (b)))
+
+	/*
+	 * Every test below assumes min <= max, and the decoded statistics may not
+	 * satisfy that. plain_value_to_datum() narrows a Parquet INT32 to int16 when
+	 * the column is bound to a PG int2, so a group holding 30000 and 40000
+	 * decodes to min=30000, max=-25536. Parquet's UINT_32/UINT_64 logical types
+	 * sort unsigned while we decode signed, so any group straddling the sign
+	 * boundary inverts the same way, as can a corrupt file. Refuse to skip on an
+	 * interval we cannot trust: the data path applies the identical narrowing, so
+	 * those rows are real matches and dropping them would be an unsound skip that
+	 * the executor's recheck can never recover.
+	 */
+	if (PQ_CMP(minD, maxD) > 0)
+		return false;
+
+	/* normalize `const op var` to `var op' const` by flipping the strategy */
+	if (!varLeft)
+	{
+		switch (strategy)
+		{
+			case BTLessStrategyNumber:
+				strategy = BTGreaterStrategyNumber;
+				break;
+			case BTLessEqualStrategyNumber:
+				strategy = BTGreaterEqualStrategyNumber;
+				break;
+			case BTGreaterStrategyNumber:
+				strategy = BTLessStrategyNumber;
+				break;
+			case BTGreaterEqualStrategyNumber:
+				strategy = BTLessEqualStrategyNumber;
+				break;
+				/* BTEqual is symmetric */
+		}
+	}
+
+	/*
+	 * Float and double statistics do not describe NaN. parquet.thrift's
+	 * TypeDefinedOrder compatibility rules exclude NaN from min/max, and require
+	 * that a NaN-valued min or max be ignored outright. PostgreSQL instead orders
+	 * NaN above every other value and treats NaN = NaN as true, so a group that
+	 * holds a NaN advertises finite bounds while its NaN row still satisfies
+	 * col > c, col >= c and col = 'NaN'. Skipping on those would drop rows that
+	 * never reach the executor's recheck, so refuse them. col < c and col <= c
+	 * stay sound, because a NaN row cannot satisfy those either.
+	 *
+	 * The +/-0 clauses in the same spec block need no handling: PostgreSQL
+	 * compares -0 and +0 as equal, which is exactly what those rules require.
+	 */
+	if (phys == PQ_FLOAT || phys == PQ_DOUBLE)
+	{
+		float8		lo = (phys == PQ_FLOAT)
+			? (float8) DatumGetFloat4(minD) : DatumGetFloat8(minD);
+		float8		hi = (phys == PQ_FLOAT)
+			? (float8) DatumGetFloat4(maxD) : DatumGetFloat8(maxD);
+		float8		c = (phys == PQ_FLOAT)
+			? (float8) DatumGetFloat4(con->constvalue)
+			: DatumGetFloat8(con->constvalue);
+
+		if (isnan(lo) || isnan(hi))
+			return false;
+		if (strategy == BTGreaterStrategyNumber ||
+			strategy == BTGreaterEqualStrategyNumber)
+			return false;
+		if (strategy == BTEqualStrategyNumber && isnan(c))
+			return false;
+	}
+
+	switch (strategy)
+	{
+		case BTLessStrategyNumber:	/* col < const: skip if min >= const */
+			return PQ_CMP(minD, con->constvalue) >= 0;
+		case BTLessEqualStrategyNumber: /* col <= const: skip if min > const */
+			return PQ_CMP(minD, con->constvalue) > 0;
+		case BTEqualStrategyNumber: /* col = const: skip if const outside [min,max] */
+			return PQ_CMP(con->constvalue, minD) < 0 ||
+				PQ_CMP(con->constvalue, maxD) > 0;
+		case BTGreaterEqualStrategyNumber:	/* col >= const: skip if max < const */
+			return PQ_CMP(maxD, con->constvalue) < 0;
+		case BTGreaterStrategyNumber:	/* col > const: skip if max <= const */
+			return PQ_CMP(maxD, con->constvalue) <= 0;
+		default:
+			return false;
+	}
+#undef PQ_CMP
+}
+
+/*
+ * Compute the per-row-group skip mask from the scan's restriction clauses and the
+ * file's statistics. skipGroup[rg] becomes true when some pushable `col op const`
+ * clause proves the group empty. Returns the number of groups marked skippable.
+ *
+ * Only Const operands are pushable, so the mask cannot change between rescans;
+ * that is what lets BeginForeignScan compute it once and ReScanForeignScan merely
+ * rewind. Adding Param support would invalidate that and require recomputing the
+ * mask (and re-reading the file) on each rescan.
+ *
+ * leaves[] and rgs[rg].chunks[] are both indexed by top->firstLeaf. That is valid
+ * because build_imp_targets() binds leaves strictly positionally against
+ * pf->leaves[] and errors unless it consumes exactly pf->ncols of them, which is
+ * the same identity pq_read_rows() already relies on.
+ */
+static int
+pqfdw_compute_skip(ForeignScanState *node, PqFile *pf,
+				   ImpTop *tops, int ntops, ImpLeaf *leaves, bool *skipGroup)
+{
+	ForeignScan *fs = (ForeignScan *) node->ss.ps.plan;
+	List	   *quals = fs->scan.plan.qual;
+	int			skipped = 0;
+	int			rg;
+
+	for (rg = 0; rg < pf->nrowgroups; rg++)
+	{
+		ListCell   *lc;
+
+		skipGroup[rg] = false;
+		foreach(lc, quals)
+		{
+			OpExpr	   *op = (OpExpr *) lfirst(lc);
+			Node	   *larg;
+			Node	   *rarg;
+			Var		   *var;
+			Const	   *con;
+			bool		varLeft;
+			ImpTop	   *top;
+			List	   *interp;
+			ListCell   *ic;
+			int			strategy = 0;
+
+			if (!IsA(op, OpExpr) || list_length(op->args) != 2)
+				continue;
+			larg = (Node *) linitial(op->args);
+			rarg = (Node *) lsecond(op->args);
+			if (IsA(larg, Var) && IsA(rarg, Const))
+			{
+				var = (Var *) larg;
+				con = (Const *) rarg;
+				varLeft = true;
+			}
+			else if (IsA(larg, Const) && IsA(rarg, Var))
+			{
+				var = (Var *) rarg;
+				con = (Const *) larg;
+				varLeft = false;
+			}
+			else
+				continue;
+			if (var->varattno < 1)
+				continue;
+
+			top = pqfdw_top_for_attno(tops, ntops, var->varattno - 1);
+			if (top == NULL || top->kind != IMP_SCALAR)
+				continue;
+
+			/*
+			 * First btree comparison interpretation gives the strategy. Any
+			 * btree family will do: a given operator means the same comparison
+			 * in every family that lists it.
+			 */
+			interp = ColumnarGetOpInterpretation(op->opno);
+			foreach(ic, interp)
+			{
+				ColumnarOpInterpretation *o = (ColumnarOpInterpretation *) lfirst(ic);
+				int			s = ColumnarOpInterpStrategy(o);
+
+				if (s >= BTLessStrategyNumber && s <= BTGreaterStrategyNumber)
+				{
+					strategy = s;
+					break;
+				}
+			}
+			if (strategy == 0)
+				continue;
+
+			if (pqfdw_clause_excludes_group(&leaves[top->firstLeaf],
+											&pf->rgs[rg].chunks[top->firstLeaf],
+											strategy, varLeft, con))
+			{
+				skipGroup[rg] = true;
+				break;
+			}
+		}
+		if (skipGroup[rg])
+			skipped++;
+	}
+	return skipped;
 }
 
 static void
@@ -2219,6 +2584,7 @@ pqfdwBeginForeignScan(ForeignScanState *node, int eflags)
 	int			ntops;
 	TupleTableSlot *slot;
 	PqFdwScanState *st;
+	bool	   *skipGroup;
 
 	/* nothing to do for a plan-only (EXPLAIN without ANALYZE) invocation */
 	if (eflags & EXEC_FLAG_EXPLAIN_ONLY)
@@ -2243,10 +2609,15 @@ pqfdwBeginForeignScan(ForeignScanState *node, int eflags)
 	/* randomAccess so ReScan can rewind the materialized rows */
 	st->tupstore = tuplestore_begin_heap(true, false, work_mem);
 	st->readslot = MakeSingleTupleTableSlot(tupdesc, &TTSOpsMinimalTuple);
+	st->groupsTotal = pf.nrowgroups;
+
+	/* predicate pushdown: mark row groups the quals prove empty */
+	skipGroup = (bool *) palloc0(sizeof(bool) * Max(pf.nrowgroups, 1));
+	st->groupsSkipped = pqfdw_compute_skip(node, &pf, tops, ntops, leaves, skipGroup);
 
 	slot = MakeSingleTupleTableSlot(tupdesc, &TTSOpsVirtual);
 	(void) pq_read_rows(&pf, filebuf, filelen, tops, ntops, leaves,
-						slot, pq_tuplestore_sink, st->tupstore);
+						slot, pq_tuplestore_sink, st->tupstore, skipGroup);
 	ExecDropSingleTupleTableSlot(slot);
 
 	node->fdw_state = st;
@@ -2257,11 +2628,32 @@ pqfdwIterateForeignScan(ForeignScanState *node)
 {
 	PqFdwScanState *st = (PqFdwScanState *) node->fdw_state;
 	TupleTableSlot *slot = node->ss.ss_ScanTupleSlot;
+	MemoryContext oldcxt;
+	bool		got;
 
 	if (st == NULL)
 		return ExecClearTuple(slot);
-	/* drain into our minimal-tuple slot, then copy into the scan slot */
-	if (!tuplestore_gettupleslot(st->tupstore, true, false, st->readslot))
+
+	/*
+	 * Drain one row into our minimal-tuple readslot, then copy it into the scan
+	 * slot (a heap-tuple slot: table_slot_callbacks() hands foreign tables
+	 * TTSOpsHeapTuple, which cannot receive a minimal tuple directly).
+	 *
+	 * The fetch must run in a context that outlives the row. ForeignNext() calls
+	 * us in ecxt_per_tuple_memory, and ExecScan resets that before every fetch --
+	 * including the no-qual fast path. Whenever tuplestore_gettupleslot hands the
+	 * slot a palloc'd tuple it also hands over ownership (TTS_FLAG_SHOULDFREE),
+	 * and the slot frees it on its next store. Allocated in the per-tuple context
+	 * that pointer is already reclaimed by then, so the next store frees wiped
+	 * memory and corrupts the allocator. That happens for a spilled tuplestore
+	 * even with copy=false (readtup palloc's and sets should_free), so pin the
+	 * context rather than the copy flag.
+	 */
+	oldcxt = MemoryContextSwitchTo(node->ss.ps.state->es_query_cxt);
+	got = tuplestore_gettupleslot(st->tupstore, true, false, st->readslot);
+	MemoryContextSwitchTo(oldcxt);
+
+	if (!got)
 		return ExecClearTuple(slot);
 	return ExecCopySlot(slot, st->readslot);
 }
@@ -2282,16 +2674,31 @@ pqfdwEndForeignScan(ForeignScanState *node)
 
 	if (st == NULL)
 		return;
-	if (st->tupstore != NULL)
-	{
-		tuplestore_end(st->tupstore);
-		st->tupstore = NULL;
-	}
+
+	/* drop the slot first: a non-copied fetch leaves it pointing into the
+	 * tuplestore's own memory, which tuplestore_end() releases */
 	if (st->readslot != NULL)
 	{
 		ExecDropSingleTupleTableSlot(st->readslot);
 		st->readslot = NULL;
 	}
+	if (st->tupstore != NULL)
+	{
+		tuplestore_end(st->tupstore);
+		st->tupstore = NULL;
+	}
+}
+
+static void
+pqfdwExplainForeignScan(ForeignScanState *node, ExplainState *es)
+{
+	PqFdwScanState *st = (PqFdwScanState *) node->fdw_state;
+
+	/* only populated once the scan has begun (EXPLAIN ANALYZE) */
+	if (st == NULL)
+		return;
+	ExplainPropertyInteger("Row Groups", NULL, st->groupsTotal, es);
+	ExplainPropertyInteger("Row Groups Skipped", NULL, st->groupsSkipped, es);
 }
 
 Datum
@@ -2305,6 +2712,7 @@ pgcolumnar_parquet_fdw_handler(PG_FUNCTION_ARGS)
 	r->BeginForeignScan = pqfdwBeginForeignScan;
 	r->IterateForeignScan = pqfdwIterateForeignScan;
 	r->ReScanForeignScan = pqfdwReScanForeignScan;
+	r->ExplainForeignScan = pqfdwExplainForeignScan;
 	r->EndForeignScan = pqfdwEndForeignScan;
 
 	PG_RETURN_POINTER(r);

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -190,14 +190,26 @@ check() {
 # in the wrapper (dollar-quoting + chr(10)) so the inner query may contain its
 # own quotes freely.
 pgc_set_hash() {
-	local query="$1" out
+	local query="$1" out res
 	out="$PGC_SQLDIR/h.$$.$RANDOM.sql"
 	cat > "$out" <<SQL
 SELECT coalesce(md5(string_agg(t, chr(10) ORDER BY t)), \$e\$EMPTY\$e\$)
 FROM (SELECT _row::text AS t FROM ( $query ) _row) _s;
 SQL
-	psql_file "$out"
+	res="$(psql_file "$out")"
 	rm -f "$out"
+	# A blank result means the query errored or the server is gone; a genuinely
+	# empty result set hashes to EMPTY. Return a value unique to this call, so
+	# two failing queries can never compare equal and pass the check vacuously.
+	# The counter lives in a file because each call runs in its own subshell, and
+	# $$/$RANDOM are not reliably distinct between siblings on every bash.
+	if [ -z "$res" ]; then
+		local seq
+		seq=$(( $(cat "$PGC_WORKDIR/.query_error_seq" 2>/dev/null || echo 0) + 1 ))
+		echo "$seq" > "$PGC_WORKDIR/.query_error_seq"
+		res="QUERY_ERROR.$seq"
+	fi
+	printf '%s\n' "$res"
 }
 
 # diff_query LABEL "QUERY with %T placeholder for the table name"

--- a/test/native_parquet_pushdown.sh
+++ b/test/native_parquet_pushdown.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+#
+# pgColumnar Parquet FDW predicate / row-group skipping (Phase G). The FDW reads
+# each row group's min/max statistics and skips groups that a pushable col-op-const
+# clause proves empty; the executor still rechecks every returned row, so a skip can
+# only save work, never drop rows. This suite needs a statistics-bearing file, which
+# our exporter does not write, so it uses pyarrow to produce a multi-row-group file
+# with per-group stats. It asserts correctness against a heap oracle (skipping never
+# changes results) AND that groups are actually skipped (via EXPLAIN ANALYZE's
+# "Row Groups Skipped" counter).
+#
+# Usage:  test/native_parquet_pushdown.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+if ! python3 -c 'import pyarrow.parquet' 2>/dev/null; then
+	echo "SKIP  pyarrow not available; predicate-pushdown suite needs it to write stats"
+	pgc_summary
+	exit 0
+fi
+
+PARQ="$PGC_WORKDIR/stats.parquet"
+# 200000 rows sorted by id, 4 row groups of 50000 -> disjoint id ranges
+# [0,50000) [50000,100000) [100000,150000) [150000,200000), each with min/max stats.
+python3 - "$PARQ" <<'PY'
+import sys, pyarrow as pa, pyarrow.parquet as pq
+n = 200000
+ids = pa.array(range(n), pa.int32())
+vals = pa.array([i * 1.5 for i in range(n)], pa.float64())
+tbl = pa.table({"id": ids, "val": vals})
+pq.write_table(tbl, sys.argv[1], row_group_size=50000)
+t = pq.ParquetFile(sys.argv[1])
+assert t.num_row_groups == 4, t.num_row_groups
+PY
+
+# heap oracle with identical data
+psql_run "CREATE TABLE h (id int, val float8);"
+psql_run "INSERT INTO h SELECT g, g*1.5 FROM generate_series(0,199999) g;"
+
+psql_run "CREATE SERVER pq FOREIGN DATA WRAPPER pgcolumnar_parquet;"
+psql_run "CREATE FOREIGN TABLE ft (id int4, val float8) SERVER pq OPTIONS (path '$PARQ');"
+
+# ---- correctness: skipping never changes results (vs heap oracle) -----------
+check "full scan == oracle" \
+	"$(pgc_set_hash "SELECT * FROM ft")" "$(pgc_set_hash "SELECT * FROM h")"
+for pred in \
+	"id = 60000" \
+	"id BETWEEN 60000 AND 70000" \
+	"id < 100" \
+	"id >= 199900" \
+	"id > 60000 AND id < 60010" \
+	"id <= 5 OR id >= 199995" \
+	"val > 90000 AND val < 90030"
+do
+	check "predicate [$pred] == oracle" \
+		"$(pgc_set_hash "SELECT * FROM ft WHERE $pred")" \
+		"$(pgc_set_hash "SELECT * FROM h  WHERE $pred")"
+done
+
+# ---- skipping actually happens (EXPLAIN ANALYZE counter) --------------------
+skipped_for() {  # skipped_for WHERE
+	q "EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+	   SELECT count(*) FROM ft WHERE $1" \
+		| grep 'Row Groups Skipped' | grep -oE '[0-9]+' | head -1
+}
+skipped_for_t() {  # skipped_for_t TABLE WHERE
+	q "EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+	   SELECT count(*) FROM $1 WHERE $2" \
+		| grep 'Row Groups Skipped' | grep -oE '[0-9]+' | head -1
+}
+groups_for() {  # groups_for WHERE  -> total groups reported
+	q "EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+	   SELECT count(*) FROM ft WHERE $1" \
+		| grep 'Row Groups:' | grep -oE '[0-9]+' | head -1
+}
+
+check "reports 4 row groups" "$(groups_for 'id >= 0')" "4"
+# a value in group 1 ([50000,100000)) -> other 3 groups skip
+check "range in one group skips 3" "$(skipped_for 'id BETWEEN 60000 AND 70000')" "3"
+# equality in group 0 -> 3 skipped
+check "point in group 0 skips 3" "$(skipped_for 'id = 123')" "3"
+# open range hitting only the last group -> 3 skipped
+check "id >= 199900 skips 3" "$(skipped_for 'id >= 199900')" "3"
+# open range hitting only the first group -> 3 skipped
+check "id < 100 skips 3" "$(skipped_for 'id < 100')" "3"
+# A float predicate confined to group 1 (val = id*1.5; [90000,90030] -> id in
+# [60000,60020]). Only 2 groups skip, not 3: float >= and > are never pushed down,
+# because Parquet excludes NaN from min/max while PostgreSQL sorts NaN above every
+# value, so a NaN row can satisfy them while the stats look empty. The <= side
+# still skips the two groups above the range.
+check "float predicate skips 2 (>= not pushed, NaN-unsafe)" \
+	"$(skipped_for 'val >= 90000 AND val <= 90030')" "2"
+check "float < still skips" "$(skipped_for 'val < 1.0')" "3"
+# a predicate spanning all groups -> 0 skipped
+check "spanning predicate skips 0" "$(skipped_for 'id >= 0 AND id < 200000')" "0"
+# no predicate -> 0 skipped
+check "no predicate skips 0" "$(skipped_for 'true')" "0"
+
+# ---- NaN soundness: skipping must never drop a NaN row ---------------------
+# Parquet writers exclude NaN when computing min/max, so a group holding a NaN
+# advertises ordinary finite bounds. PostgreSQL orders NaN above every value and
+# treats NaN = NaN as true, so col > c, col >= c and col = 'NaN' can all match a
+# row the statistics do not describe. Skipping on those would drop it silently,
+# and the executor's recheck cannot recover a group that emitted nothing.
+NANP="$PGC_WORKDIR/nan.parquet"
+python3 - "$NANP" <<'PY'
+import sys, pyarrow as pa, pyarrow.parquet as pq
+vals = [float(i) for i in range(4000)]
+vals[500] = float('nan')          # one NaN, in row group 0
+tbl = pa.table({"id": pa.array(range(4000), pa.int32()),
+                "val": pa.array(vals, pa.float64())})
+pq.write_table(tbl, sys.argv[1], row_group_size=1000)
+assert pq.ParquetFile(sys.argv[1]).num_row_groups == 4
+PY
+
+psql_run "CREATE FOREIGN TABLE ftn (id int4, val float8) SERVER pq OPTIONS (path '$NANP');"
+psql_run "CREATE TABLE hn (id int, val float8);"
+psql_run "INSERT INTO hn SELECT g, CASE WHEN g = 500 THEN 'NaN'::float8 ELSE g END
+          FROM generate_series(0,3999) g;"
+
+for pred in \
+	"val > 1e300" \
+	"val >= 1e300" \
+	"val = 'NaN'::float8" \
+	"val > 3998" \
+	"val < 10" \
+	"val <= 10" \
+	"val = 1234"
+do
+	check "NaN-safe [$pred] == oracle" \
+		"$(pgc_set_hash "SELECT * FROM ftn WHERE $pred")" \
+		"$(pgc_set_hash "SELECT * FROM hn  WHERE $pred")"
+done
+
+# ---- inverted statistics must never drive a skip ---------------------------
+# A PG int2 column binds to a Parquet INT32 column, and the decoder narrows with
+# an unchecked cast. A group holding 30000 and 40000 therefore decodes to
+# min=30000, max=-25536: an inverted interval. Every skip test assumes min <= max,
+# so without a guard the equality test skips a group that really does contain the
+# row. The data path applies the same narrowing, so those rows are genuine
+# matches. (Parquet UINT_32/UINT_64 invert the same way, being unsigned-ordered.)
+WIDEP="$PGC_WORKDIR/wide.parquet"
+python3 - "$WIDEP" <<'PY'
+import sys, pyarrow as pa, pyarrow.parquet as pq
+pq.write_table(pa.table({"c": pa.array([30000, 40000], pa.int32())}),
+               sys.argv[1], row_group_size=2)
+PY
+
+psql_run "CREATE FOREIGN TABLE ftw (c int2) SERVER pq OPTIONS (path '$WIDEP');"
+# oracle: exactly what the narrowing read path yields for those two INT32 values
+psql_run "CREATE TABLE hw (c int2);"
+psql_run "INSERT INTO hw VALUES (30000::int2), ((-25536)::int2);"
+
+for pred in \
+	"c = 30000::int2" \
+	"c = (-25536)::int2" \
+	"c >= 30000::int2" \
+	"c <= (-25536)::int2" \
+	"c < 0::int2" \
+	"c > 0::int2"
+do
+	check "inverted-stats [$pred] == oracle" \
+		"$(pgc_set_hash "SELECT * FROM ftw WHERE $pred")" \
+		"$(pgc_set_hash "SELECT * FROM hw  WHERE $pred")"
+done
+check "inverted stats skip nothing" "$(skipped_for_t ftw 'c = 30000::int2')" "0"
+
+# ---- read_parquet over the same file ignores stats (reads all) but matches --
+check "read_parquet same file == oracle" \
+	"$(pgc_set_hash "SELECT * FROM pgcolumnar.read_parquet('$PARQ') AS t(id int4, val float8)")" \
+	"$(pgc_set_hash "SELECT * FROM h")"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -27,7 +27,7 @@ SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUITES=(smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
 	differential recovery fuzz hardening concurrent_diff parallel sorted_projection \
 	arrow_export parquet_export read_stream corruption \
-	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip native_index native_dml native_ios native_projection native_cluster native_compact native_recluster native_reclaim native_ownership native_reclaim_cycles native_reclaim_frag native_gap native_truncate native_rewrite native_rewrite_conc native_parquet_schema native_read_parquet native_parquet_fdw isolation)
+	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip native_index native_dml native_ios native_projection native_cluster native_compact native_recluster native_reclaim native_ownership native_reclaim_cycles native_reclaim_frag native_gap native_truncate native_rewrite native_rewrite_conc native_parquet_schema native_read_parquet native_parquet_fdw native_parquet_pushdown isolation)
 
 # Default matrix: one assert-enabled pg_config per major, 15 through 19.
 DEFAULT_CONFIGS=(


### PR DESCRIPTION
Phase G PR3: Parquet FDW predicate pushdown (row-group skipping).

## What this adds

The FDW reads each row group's min/max statistics and skips groups that a
pushable `col op const` clause proves empty.

- `parse_statistics()` reads the Parquet `Statistics` field (min_value/max_value,
  with the deprecated min/max as fallback) into new `PqChunk` fields. Values are
  kept as pointers into the metadata buffer, which lives for the scan.
- `pq_read_rows()` gained a `const bool *skipGroup` parameter. Skipped groups
  decode and emit nothing. `import_parquet` and `read_parquet` pass NULL, so the
  shared row engine behaves identically for them.
- `pqfdw_compute_skip()` turns pushable clauses into a per-row-group skip mask.
  Restricted to fixed-width ordered physical types (INT32/INT64/FLOAT/DOUBLE),
  and for float/double to the NaN-safe comparison directions described below. A
  group is skipped only when proven empty, and the executor still rechecks every
  row returned.
- `pqfdwExplainForeignScan()` reports "Row Groups" and "Row Groups Skipped" under
  EXPLAIN ANALYZE, which makes skipping observable and testable.

"The executor rechecks" only covers a *missed* skip. It is not a safety net for
an *unsound* skip, because a skipped group emits nothing to recheck. That
distinction is what the NaN handling exists to respect.

## Float and double statistics do not describe NaN

`parquet.thrift`'s `TypeDefinedOrder` compatibility rules exclude NaN from
min/max, and require a NaN-valued min or max to be ignored outright. PostgreSQL
instead orders NaN above every other value and treats `NaN = NaN` as true. So a
group holding a NaN advertises ordinary finite bounds while its NaN row still
satisfies `col > c`, `col >= c` and `col = 'NaN'`.

Confirmed on a 4-group file with one NaN, where group 0 reported
`min=-0.0 max=999.0`:

```
SELECT count(*) FROM ft WHERE val > 1e300;
  -> 0 rows, want 1        EXPLAIN: Row Groups: 4, Row Groups Skipped: 4
```

A silent wrong answer. So for float and double: NaN-valued statistics are
ignored, `>` and `>=` are never pushed down, and `=` is refused when the constant
is NaN. `<` and `<=` remain sound, because a NaN row cannot satisfy those either.
The +/-0 clauses in the same spec block need no handling, since PostgreSQL
compares -0 and +0 as equal.

## Inverted statistics are refused

Every skip test assumes `min <= max`, and the decoded interval can be inverted
without any corruption. `pq_want_phys()` maps `INT2OID` to `PQ_INT32` and
`plain_value_to_datum()` narrows with an unchecked cast, so an `int2` foreign
column over a Parquet INT32 column holding 30000 and 40000 decodes to
`min=30000, max=-25536`:

```
SELECT * FROM ft                        -> [-25536, 30000]   (both rows present)
SELECT count(*) FROM ft WHERE c = 30000::int2
  -> 0 rows, want 1        EXPLAIN: Row Groups: 1, Row Groups Skipped: 1
```

The `const > max` branch skipped a group that genuinely contains the row, since
the data path narrows identically. Parquet's `UINT_32`/`UINT_64` logical types
invert the same way, sorting unsigned while we decode signed, as can a corrupt
file. The guard refuses to skip whenever `min > max`.

Note the underlying narrowing is a separate defect, recorded as a follow-up: this
guard stops the skip path from trusting a wrapped value, it does not make the
value correct.

## Correctness fix in the FDW scan

Landing this surfaced a memory-corruption bug in the FDW drain path.

`ForeignNext()` calls `IterateForeignScan` in `ecxt_per_tuple_memory`, and
`ExecScan` resets that context before every fetch, including the no-qual fast
path. Whenever `tuplestore_gettupleslot()` hands the slot a palloc'd tuple it
also transfers ownership (`TTS_FLAG_SHOULDFREE`), and the slot frees it on its
next store. Allocated in the per-tuple context, that pointer has already been
reclaimed by then, so the next store freed wiped memory and corrupted
`ExecutorState`.

`copy=true` made this fire on every row; `copy=false` was not a fix either,
because once the tuplestore spills, `readtup()` palloc's in the same per-tuple
context and sets `should_free`. Both are the same defect, so the fix pins the
context rather than the copy flag: the fetch runs in `es_query_cxt`, where the
slot's ownership stays valid until it stores the next row.

Two related corrections:

- `EndForeignScan` now drops the readslot before ending the tuplestore, since a
  non-copied fetch leaves the slot pointing into tuplestore memory.
- The scan slot is `TTSOpsHeapTuple`, not virtual. `table_slot_callbacks()`
  gives foreign tables a heap slot deliberately. A comment said otherwise.

## PG18 build fix

PG18 generalized index-AM strategies: `get_op_btree_interpretation()` became
`get_op_index_interpretation()`, and `OpBtreeInterpretation.strategy` (a btree
strategy number) became `OpIndexInterpretation.cmptype` (a `CompareType`). A shim
in `columnar_compat.h` maps the comparison type back to a btree strategy number;
a comparison with no btree equivalent yields 0, which callers treat as not
pushable.

## Test harness

`test/native_parquet_pushdown.sh` uses pyarrow to write a stats-bearing
200k-row / 4-row-group file, because our exporter does not write statistics. It
asserts correctness against a heap oracle across many predicates and asserts the
skip counter via EXPLAIN ANALYZE. It also covers NaN soundness with a second file
holding a NaN in one group, and covers inverted statistics with an `int2` column
bound over out-of-range INT32 values. Both compare against a heap oracle. The
suite goes from 17 to 32 checks. Registered in `run_all_versions.sh`.

`pgc_set_hash()` returned an empty string when a query errored, so two failing
queries compared equal and their check passed vacuously. It now returns a
per-call unique marker taken from a counter file, rather than `$RANDOM`, so it
does not depend on subshell reseeding behaviour. A genuinely empty result set
still hashes to `EMPTY`, so real empty-vs-empty comparisons are unaffected.

## Verification

- Full 15 through 19 matrix, all suites, re-run after each source change
  (most recently the inversion guard). Runs in the `pgcolumnar-dev` container.
- Zero compiler warnings on every major.
- A dedicated stress over `work_mem` 64kB/1MB/64MB, which forces the tuplestore
  to spill, plus a nested-loop rescan: zero memory diagnostics in the server log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
