### PR TITLE
Phase G: range-check narrowing decodes, validate row-group chunk lists

### DIFF
--- a/design/PHASE_G_DECODE_HARDENING_PLAN.md
+++ b/design/PHASE_G_DECODE_HARDENING_PLAN.md
@@ -1,0 +1,140 @@
+# Phase G: Parquet decode hardening
+
+Two correctness defects on `main`, both recorded as follow-ups when #101 merged.
+Neither is caused by pushdown; #101's inversion guard only stopped the skip path
+from trusting the first one's output.
+
+## Defect 1: unchecked narrowing in `plain_value_to_datum()`
+
+`pq_want_phys()` binds several PostgreSQL types to a wider Parquet physical type,
+and the decoder converts with an unchecked cast. A value outside the target
+type's range silently becomes a different value rather than raising an error.
+
+Confirmed: an `int2` column over a Parquet INT32 column holding 30000 and 40000
+reads back as `[-25536, 30000]`. PostgreSQL itself rejects `40000::int2` with
+"smallint out of range", so the read path is inconsistent with the type it claims
+to produce.
+
+Four conversions in the same function share the defect:
+
+| Target | Physical | Conversion | Failure |
+|---|---|---|---|
+| `int2` | INT32 | `(int16) v` | wraps, e.g. 40000 -> -25536 |
+| `date` | INT32 | `(DateADT) (v - PG_TO_UNIX_DAYS)` | int32 subtraction overflows; result may be outside PostgreSQL's date range |
+| `timestamp`, `timestamptz` | INT64 | `(Timestamp) (v - PG_TO_UNIX_USECS)` | int64 subtraction overflows; result may be outside PostgreSQL's timestamp range |
+| `time` | INT64 | `(TimeADT) v` | `TimeADT` must be within `[0, USECS_PER_DAY]`; any other value is an invalid time |
+
+### Approach
+
+Range-check and raise, rather than refusing the bind in `build_imp_targets()`.
+Binding `int2` to INT32 is legitimate and necessary, since Parquet has no 16-bit
+physical type and represents `int2` as INT32 with an `INT(16, true)` logical
+annotation. Refusing the bind would break every file whose values do fit. Erroring
+on the offending value matches what PostgreSQL does for the same conversion.
+
+The function has two classes of caller with different needs:
+
+- **Data path** (dictionary decode, plain decode): must raise a specific error.
+  Today an out-of-range value would have to be reported through the existing
+  `*ok = false` path, whose message is "could not decode Parquet column N in row
+  group M". That is misleading: the file is well-formed, the value simply does not
+  fit the declared column type.
+- **Statistics path** (`pqfdw_clause_excludes_group`): must **not** raise. A group
+  whose statistics fall outside the bound type may still be legitimately skipped,
+  or may never be read at all. Erroring at `BeginForeignScan` would fail queries
+  that would otherwise succeed.
+
+So `plain_value_to_datum()` gains a `bool strict` parameter:
+- `strict = true` -> `ereport(ERROR, ...)` naming the value and target type.
+- `strict = false` -> `*ok = false`, caller declines to skip.
+
+Error codes: `ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE` for `int2`,
+`ERRCODE_DATETIME_FIELD_OVERFLOW` for the date/time/timestamp cases.
+
+Overflow-safe subtraction uses `pg_sub_s32_overflow` / `pg_sub_s64_overflow` from
+`common/int.h` (present in PG13 through 19). Range validity uses `IS_VALID_DATE`
+and `IS_VALID_TIMESTAMP` from `datatype/timestamp.h` (present on all majors).
+
+## Defect 2: row-group chunk list is trusted
+
+`pq_slurp_and_parse()` allocates `rg->chunks` from the row group's **own** column
+count, and leaves it `NULL` when the `columns` field is absent:
+
+```c
+rg->chunks = NULL;
+...
+rg->chunks = palloc0(sizeof(PqChunk) * Max(cn, 1));
+```
+
+Every consumer indexes it by the **schema's** leaf count instead:
+
+- `pq_read_rows()` iterates `i < pf->ncols` and takes `&g->chunks[i]`.
+- `pqfdw_compute_skip()` takes `&pf->rgs[rg].chunks[top->firstLeaf]`.
+
+A file whose row group carries fewer column chunks than the schema has leaves is
+an out-of-bounds read; one carrying none is a NULL dereference. Both are reachable
+from a crafted or truncated file.
+
+### Approach
+
+Record the parsed count per row group, then validate once the schema-derived
+`pf->ncols` is known. `ncols` is computed after the row-group loop, so the check
+belongs after that derivation, not inline. A mismatch fails the parse, which the
+caller already turns into a clean error.
+
+This is a validation, not a repair: a row group that disagrees with the schema is
+malformed and there is no safe interpretation to fall back on.
+
+## Tests
+
+New suite `test/native_parquet_hardening.sh`, registered in
+`run_all_versions.sh`. `corruption.sh` covers the native catalog and `hardening.sh`
+mutates native on-disk bytes; neither covers Parquet input, so this is a new
+surface rather than an extension of either.
+
+Narrowing, built with pyarrow:
+- `int2` over INT32 values beyond `int16` -> error, not a wrapped value.
+- `int2` over INT32 values within range -> still works, proving the check did not
+  disable the legitimate bind.
+- `time` over INT64 micros beyond a day -> error.
+- `date` and `timestamp` at extreme values -> error rather than a garbage date.
+- The same files through `read_parquet()` and `import_parquet()`, since all three
+  surfaces share the decoder.
+
+Malformed chunk list, by byte-editing a valid file's Thrift footer:
+- a row group with a short `columns` list -> clean error, backend survives.
+- a row group with no `columns` field -> clean error, backend survives.
+
+Run on an assert-enabled build so an out-of-bounds access trips an assertion
+rather than passing silently.
+
+## Knock-on: the pushdown suite's inversion test
+
+`native_parquet_pushdown.sh` reached the `min > max` guard added in #101 by
+binding `int2` over out-of-range INT32 values. Fixing defect 1 makes that raise,
+so the scenario can no longer produce readable inverted statistics and the test
+had to change.
+
+Replaced with Parquet's `UINT_32` logical type, which is the other inversion the
+guard covers and stays readable: stored as physical INT32 but with statistics
+ordered unsigned, a group spanning the sign boundary reports `min=1,
+max=-1294967296` while the values themselves decode as ordinary `int4`. Verified
+to still fail with the guard removed, so it remains a real regression test.
+
+## Confirmed pre-existing defect, not fixed here
+
+`pq_leaf_to_pgtype()` maps both `TIMESTAMP_MILLIS` and `TIMESTAMP_MICROS` to
+`timestamp`, but `converted_type` never reaches `PqColPlan` and the decoder treats
+the raw int64 as microseconds. A millisecond column therefore reads 1000x small.
+Confirmed: a file holding 2026-07-24 00:00:00 as `timestamp('ms')`, with
+`parquet_schema()` advising `timestamp`, reads back as `1970-01-21 15:47:31.2`.
+
+`TIME_MILLIS` has the same gap. This is the same class as defect 1, a read path
+inconsistent with the type it claims to produce, but it is pre-existing and needs
+`converted_type` plumbed into the column plan plus a scaling step, so it gets its
+own change rather than widening this one.
+
+## Gate
+
+Full 15 through 19 matrix, in the `pgcolumnar-dev` container, via
+`test/run_all_versions.sh` (which builds each major in its own tree).

--- a/src/columnar_parquet_reader.c
+++ b/src/columnar_parquet_reader.c
@@ -25,6 +25,7 @@
 #include "fmgr.h"
 #include "funcapi.h"
 #include "access/htup_details.h"
+#include "common/int.h"
 #include "access/relation.h"
 #include "access/reloptions.h"
 #include "access/stratnum.h"
@@ -442,7 +443,8 @@ typedef struct PqChunk
 typedef struct PqRowGroup
 {
 	int64		num_rows;
-	PqChunk    *chunks;			/* [ncols] */
+	PqChunk    *chunks;			/* [nchunks]; consumers require nchunks == ncols */
+	int			nchunks;		/* column chunks this row group actually carries */
 } PqRowGroup;
 
 typedef struct PqFile
@@ -767,6 +769,7 @@ parse_file_metadata(const uint8 *buf, size_t len, PqFile *pf)
 				int			rgLast = 0;
 
 				rg->chunks = NULL;
+				rg->nchunks = 0;
 				for (;;)
 				{
 					int			rft,
@@ -782,6 +785,7 @@ parse_file_metadata(const uint8 *buf, size_t len, PqFile *pf)
 						uint32		ci;
 
 						rg->chunks = palloc0(sizeof(PqChunk) * Max(cn, 1));
+						rg->nchunks = (int) cn;
 						for (ci = 0; ci < cn && !r.error; ci++)
 							parse_column_chunk(&r, &rg->chunks[ci]);
 					}
@@ -813,7 +817,38 @@ parse_file_metadata(const uint8 *buf, size_t len, PqFile *pf)
 		pf->ncols = nleaf;
 		pf->leaves = leaves;
 	}
-	return pf->ncols > 0;
+	if (pf->ncols <= 0)
+		return false;
+
+	return true;
+}
+
+/*
+ * Reject a file whose row groups do not carry one column chunk per schema leaf.
+ *
+ * Every value consumer indexes rgs[].chunks[] by the schema's leaf count, not by
+ * whatever the row group happened to carry: pq_read_rows() walks i < ncols and
+ * pqfdw_compute_skip() takes chunks[top->firstLeaf]. A row group with a short
+ * column list is therefore an out-of-bounds read, and one with no `columns` field
+ * at all leaves chunks NULL. A row group that disagrees with the schema is
+ * malformed and there is no safe reading of it.
+ *
+ * This is deliberately separate from parsing, and from the schema itself, so that
+ * parquet_schema() still describes such a file. Reporting the schema is exactly
+ * what one wants when diagnosing a suspect file, and it touches no chunk.
+ */
+static void
+pq_check_row_groups(const PqFile *pf, const char *path)
+{
+	int			rg;
+
+	for (rg = 0; rg < pf->nrowgroups; rg++)
+		if (pf->rgs[rg].chunks == NULL || pf->rgs[rg].nchunks != pf->ncols)
+			ereport(ERROR,
+					(errcode(ERRCODE_DATA_CORRUPTED),
+					 errmsg("Parquet file \"%s\" has a malformed row group", path),
+					 errdetail("Row group %d carries %d column chunks, but the schema has %d leaf columns.",
+							   rg, pf->rgs[rg].nchunks, pf->ncols)));
 }
 
 /* -------------------------------------------------------------------------
@@ -918,10 +953,40 @@ typedef struct PqColPlan
 	int			expect_phys;	/* required Parquet physical type */
 } PqColPlan;
 
-/* convert one PLAIN physical value at *p (advancing *p) to a target Datum */
+/*
+ * A physical value that does not fit the bound PostgreSQL type. On the data path
+ * (strict) this is an error: the file is well-formed, the value simply cannot be
+ * represented as the column's declared type, and silently substituting a wrapped
+ * one would be a wrong answer. On the statistics path (not strict) it only means
+ * the bounds cannot be trusted, so the caller declines to skip and reads the group.
+ */
+static Datum
+pq_value_out_of_range(bool strict, bool *ok, int sqlerrcode, const char *typname,
+					  int64 value)
+{
+	if (strict)
+		ereport(ERROR,
+				(errcode(sqlerrcode),
+				 errmsg("value out of range for type %s", typname),
+				 errdetail("The Parquet file stores " INT64_FORMAT
+						   ", which cannot be represented as %s.",
+						   value, typname)));
+	*ok = false;
+	return (Datum) 0;
+}
+
+/*
+ * Convert one PLAIN physical value at *p (advancing *p) to a target Datum.
+ *
+ * Several PostgreSQL types bind to a wider Parquet physical type, because Parquet
+ * has no narrower one: int2 and date ride on INT32, time and the timestamps on
+ * INT64. Those conversions are range-checked rather than cast, so an out-of-range
+ * value raises instead of wrapping. See pq_value_out_of_range for what strict
+ * selects.
+ */
 static Datum
 plain_value_to_datum(const PqColPlan *plan, const uint8 **p, const uint8 *end,
-					 bool *ok)
+					 bool strict, bool *ok)
 {
 	const uint8 *cur = *p;
 
@@ -940,9 +1005,24 @@ plain_value_to_datum(const PqColPlan *plan, const uint8 **p, const uint8 *end,
 				memcpy(&v, cur, 4);
 				*p = cur + 4;
 				if (plan->typid == INT2OID)
+				{
+					if (v < PG_INT16_MIN || v > PG_INT16_MAX)
+						return pq_value_out_of_range(strict, ok,
+													 ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE,
+													 "smallint", (int64) v);
 					return Int16GetDatum((int16) v);
+				}
 				if (plan->typid == DATEOID)
-					return DateADTGetDatum((DateADT) (v - PG_TO_UNIX_DAYS));
+				{
+					int32		d;
+
+					if (pg_sub_s32_overflow(v, PG_TO_UNIX_DAYS, &d) ||
+						!IS_VALID_DATE((DateADT) d))
+						return pq_value_out_of_range(strict, ok,
+													 ERRCODE_DATETIME_FIELD_OVERFLOW,
+													 "date", (int64) v);
+					return DateADTGetDatum((DateADT) d);
+				}
 				return Int32GetDatum(v);
 			}
 		case PQ_INT64:
@@ -957,9 +1037,27 @@ plain_value_to_datum(const PqColPlan *plan, const uint8 **p, const uint8 *end,
 				memcpy(&v, cur, 8);
 				*p = cur + 8;
 				if (plan->typid == TIMESTAMPOID || plan->typid == TIMESTAMPTZOID)
-					return TimestampGetDatum((Timestamp) (v - PG_TO_UNIX_USECS));
+				{
+					int64		t;
+
+					if (pg_sub_s64_overflow(v, PG_TO_UNIX_USECS, &t) ||
+						!IS_VALID_TIMESTAMP((Timestamp) t))
+						return pq_value_out_of_range(strict, ok,
+													 ERRCODE_DATETIME_FIELD_OVERFLOW,
+													 plan->typid == TIMESTAMPOID
+													 ? "timestamp" : "timestamp with time zone",
+													 v);
+					return TimestampGetDatum((Timestamp) t);
+				}
 				if (plan->typid == TIMEOID)
+				{
+					/* TimeADT is microseconds since midnight; nothing else is a time */
+					if (v < INT64CONST(0) || v > USECS_PER_DAY)
+						return pq_value_out_of_range(strict, ok,
+													 ERRCODE_DATETIME_FIELD_OVERFLOW,
+													 "time", v);
 					return TimeADTGetDatum((TimeADT) v);
+				}
 				return Int64GetDatum(v);
 			}
 		case PQ_FLOAT:
@@ -1238,7 +1336,7 @@ decode_leaf_entries(const uint8 *filebuf, size_t filelen, PqChunk *ch,
 				{
 					bool		ok;
 
-					dict[i] = plain_value_to_datum(plan, &p, end, &ok);
+					dict[i] = plain_value_to_datum(plan, &p, end, true, &ok);
 					if (!ok)
 						return false;
 				}
@@ -1390,7 +1488,7 @@ decode_leaf_entries(const uint8 *filebuf, size_t filelen, PqChunk *ch,
 					{
 						bool		ok;
 
-						pv[i] = plain_value_to_datum(plan, &p, end, &ok);
+						pv[i] = plain_value_to_datum(plan, &p, end, true, &ok);
 						if (!ok)
 							return false;
 					}
@@ -2072,6 +2170,7 @@ columnar_import_parquet(PG_FUNCTION_ARGS)
 
 	/* read + parse the file before taking the table lock (no lock held on I/O) */
 	pq_slurp_and_parse(path, &filebuf, &filelen, &pf);
+	pq_check_row_groups(&pf, path);
 
 	rel = table_open(relid, RowExclusiveLock);
 	tupdesc = RelationGetDescr(rel);
@@ -2141,6 +2240,7 @@ columnar_read_parquet(PG_FUNCTION_ARGS)
 				 errhint("Call it as SELECT * FROM pgcolumnar.read_parquet(path) AS t(col1 type1, ...).")));
 
 	pq_slurp_and_parse(path, &filebuf, &filelen, &pf);
+	pq_check_row_groups(&pf, path);
 
 	/* bind the declared descriptor against the file (validates types + count) */
 	tops = build_imp_targets(retdesc, &pf, &leaves, &ntops);
@@ -2372,11 +2472,11 @@ pqfdw_clause_excludes_group(ImpLeaf *leaf, PqChunk *ch, int strategy,
 		return false;
 
 	p = ch->stat_min;
-	minD = plain_value_to_datum(&leaf->plan, &p, p + ch->stat_min_len, &ok);
+	minD = plain_value_to_datum(&leaf->plan, &p, p + ch->stat_min_len, false, &ok);
 	if (!ok)
 		return false;
 	p = ch->stat_max;
-	maxD = plain_value_to_datum(&leaf->plan, &p, p + ch->stat_max_len, &ok);
+	maxD = plain_value_to_datum(&leaf->plan, &p, p + ch->stat_max_len, false, &ok);
 	if (!ok)
 		return false;
 
@@ -2603,6 +2703,7 @@ pqfdwBeginForeignScan(ForeignScanState *node, int eflags)
 						RelationGetRelationName(rel))));
 
 	pq_slurp_and_parse(path, &filebuf, &filelen, &pf);
+	pq_check_row_groups(&pf, path);
 	tops = build_imp_targets(tupdesc, &pf, &leaves, &ntops);
 
 	st = (PqFdwScanState *) palloc0(sizeof(PqFdwScanState));

--- a/test/native_parquet_hardening.sh
+++ b/test/native_parquet_hardening.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+#
+# pgColumnar Parquet decode-hardening suite (Phase G).
+#
+# The Parquet reader binds several PostgreSQL types to a wider physical type,
+# because Parquet has no narrower one: int2 and date ride on INT32, time and the
+# timestamps on INT64. A value outside the target type's range must raise, not
+# wrap into a different value. Separately, the row-group column-chunk list is
+# indexed by the schema's leaf count, so a row group that carries a different
+# number of chunks must be rejected at parse time rather than read out of bounds.
+#
+# This complements test/corruption.sh (native catalog fields) and
+# test/hardening.sh (native on-disk bytes); neither covers Parquet input.
+# Run on an assert-enabled build so an out-of-bounds access trips an assertion
+# rather than passing silently.
+#
+# Usage:  test/native_parquet_hardening.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+if ! python3 -c 'import pyarrow.parquet' 2>/dev/null; then
+	echo "SKIP  pyarrow not available; Parquet hardening suite needs it"
+	pgc_summary
+	exit 0
+fi
+
+W="$PGC_WORKDIR"
+psql_run "CREATE SERVER pq FOREIGN DATA WRAPPER pgcolumnar_parquet;"
+
+# errtext QUERY -> the raised error text, or "NO ERROR"
+errtext() {
+	local out
+	out="$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -At -c "$1" 2>&1 | grep -m1 '^ERROR:')"
+	[ -z "$out" ] && out="NO ERROR"
+	echo "$out"
+}
+
+# errs QUERY -> "OK" when the statement raises, "NO ERROR: <rows>" when it does not
+errs() {
+	local out
+	out="$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -At -c "$1" 2>&1)"
+	case "$out" in
+		*ERROR*) echo "OK" ;;
+		*) echo "NO ERROR: $out" ;;
+	esac
+}
+
+# ---- narrowing: out-of-range values must raise, not wrap --------------------
+python3 - "$W" <<'PY'
+import sys, pyarrow as pa, pyarrow.parquet as pq
+W = sys.argv[1]
+# int2 bound over INT32: 40000 does not fit int16 (would wrap to -25536)
+pq.write_table(pa.table({"c": pa.array([30000, 40000], pa.int32())}),
+               f"{W}/i2_bad.parquet")
+# same bind, all values in range: must keep working
+pq.write_table(pa.table({"c": pa.array([-30000, 0, 30000], pa.int32())}),
+               f"{W}/i2_ok.parquet")
+# time bound over INT64 micros: beyond one day is not a time
+pq.write_table(pa.table({"c": pa.array([0, 86400000000 + 1], pa.int64())}),
+               f"{W}/time_bad.parquet")
+pq.write_table(pa.table({"c": pa.array([0, 3600000000], pa.int64())}),
+               f"{W}/time_ok.parquet")
+# date bound over INT32 days since epoch. INT32 max does NOT overflow the epoch
+# offset (2147483647 - 10957 stays in range); it is rejected by IS_VALID_DATE.
+pq.write_table(pa.table({"c": pa.array([0, 2147483647], pa.int32())}),
+               f"{W}/date_bad.parquet")
+# INT32 min is what overflows the subtraction itself, exercising the other branch
+pq.write_table(pa.table({"c": pa.array([0, -2147483648], pa.int32())}),
+               f"{W}/date_ovf.parquet")
+pq.write_table(pa.table({"c": pa.array([0, 19000], pa.int32())}),
+               f"{W}/date_ok.parquet")
+# timestamp bound over INT64 micros: INT64 min overflows the epoch-offset
+# subtraction. INT64 max does NOT -- it still lands inside PostgreSQL's timestamp
+# range (year ~294276), so it is deliberately not the case tested here.
+pq.write_table(pa.table({"c": pa.array([0, -9223372036854775808], pa.int64())}),
+               f"{W}/ts_bad.parquet")
+pq.write_table(pa.table({"c": pa.array([0, 1700000000000000], pa.int64())}),
+               f"{W}/ts_ok.parquet")
+PY
+
+psql_run "CREATE FOREIGN TABLE f_i2_bad   (c int2)      SERVER pq OPTIONS (path '$W/i2_bad.parquet');"
+psql_run "CREATE FOREIGN TABLE f_i2_ok    (c int2)      SERVER pq OPTIONS (path '$W/i2_ok.parquet');"
+psql_run "CREATE FOREIGN TABLE f_time_bad (c time)      SERVER pq OPTIONS (path '$W/time_bad.parquet');"
+psql_run "CREATE FOREIGN TABLE f_time_ok  (c time)      SERVER pq OPTIONS (path '$W/time_ok.parquet');"
+psql_run "CREATE FOREIGN TABLE f_date_bad (c date)      SERVER pq OPTIONS (path '$W/date_bad.parquet');"
+psql_run "CREATE FOREIGN TABLE f_date_ovf (c date)     SERVER pq OPTIONS (path '$W/date_ovf.parquet');"
+psql_run "CREATE FOREIGN TABLE f_date_ok  (c date)      SERVER pq OPTIONS (path '$W/date_ok.parquet');"
+psql_run "CREATE FOREIGN TABLE f_ts_bad   (c timestamp) SERVER pq OPTIONS (path '$W/ts_bad.parquet');"
+psql_run "CREATE FOREIGN TABLE f_ts_ok    (c timestamp) SERVER pq OPTIONS (path '$W/ts_ok.parquet');"
+
+# Pin the SQLSTATE rather than accepting any error, so an unrelated failure
+# cannot pass these: 22003 numeric_value_out_of_range, 22008 datetime_field_overflow.
+psql_run "CREATE FUNCTION pgc_try(q text) RETURNS text LANGUAGE plpgsql AS \$\$
+          BEGIN EXECUTE q; RETURN 'NO ERROR';
+          EXCEPTION WHEN OTHERS THEN RETURN SQLSTATE; END \$\$;"
+sqlstate() { q "SELECT pgc_try(\$q\$$1\$q\$);"; }
+
+check "int2 out of range -> 22003"        "$(sqlstate 'SELECT * FROM f_i2_bad')"   "22003"
+check "time out of day -> 22008"          "$(sqlstate 'SELECT * FROM f_time_bad')" "22008"
+check "date invalid -> 22008"             "$(sqlstate 'SELECT * FROM f_date_bad')" "22008"
+check "date offset overflow -> 22008"     "$(sqlstate 'SELECT * FROM f_date_ovf')" "22008"
+check "timestamp overflow -> 22008"       "$(sqlstate 'SELECT * FROM f_ts_bad')"   "22008"
+
+# the legitimate binds must still work: the check must not disable them
+check "int2 in range still reads"      "$(q "SELECT string_agg(c::text, ' ' ORDER BY c) FROM f_i2_ok;")" "-30000 0 30000"
+check "time in range still reads"      "$(q 'SELECT count(*) FROM f_time_ok;')" "2"
+check "date in range still reads"      "$(q 'SELECT count(*) FROM f_date_ok;')" "2"
+check "timestamp in range still reads" "$(q 'SELECT count(*) FROM f_ts_ok;')"   "2"
+
+# no wrapped value may ever be observable
+check "no wrapped -25536 appears" \
+	"$(q "SELECT count(*) FROM f_i2_ok WHERE c = (-25536)::int2;")" "0"
+
+# ---- the same decoder is shared by read_parquet and import_parquet ----------
+check "read_parquet also raises 22003" \
+	"$(sqlstate "SELECT * FROM pgcolumnar.read_parquet('$W/i2_bad.parquet') AS t(c int2)")" "22003"
+check "read_parquet in range still reads" \
+	"$(q "SELECT count(*) FROM pgcolumnar.read_parquet('$W/i2_ok.parquet') AS t(c int2);")" "3"
+
+psql_run "CREATE TABLE imp_bad (c int2);"
+check "import_parquet also raises 22003" \
+	"$(sqlstate "SELECT pgcolumnar.import_parquet('imp_bad'::regclass, '$W/i2_bad.parquet')")" "22003"
+check "import_parquet left no wrapped rows" "$(q 'SELECT count(*) FROM imp_bad;')" "0"
+
+# ---- malformed row-group chunk list ----------------------------------------
+# Truncate the column-chunk list of a valid two-column file so the row group
+# carries fewer chunks than the schema has leaves. The reader indexes chunks[] by
+# the schema leaf count, so this must be rejected at parse time.
+python3 - "$W" <<'PY'
+import sys, pyarrow as pa, pyarrow.parquet as pq
+W = sys.argv[1]
+pq.write_table(pa.table({"a": pa.array([1, 2, 3], pa.int32()),
+                         "b": pa.array([4, 5, 6], pa.int32())}),
+               f"{W}/two.parquet")
+
+# Walk the Thrift-compact footer to the exact byte holding the row group's
+# `columns` list header, then claim it holds one fewer chunk than it does.
+# Blind byte-searching is not reliable here: the same byte value occurs in the
+# data pages, so the header has to be located structurally.
+raw = bytearray(open(f"{W}/two.parquet", "rb").read())
+flen = int.from_bytes(raw[-8:-4], "little")
+base = len(raw) - 8 - flen          # start of FileMetaData
+pos = base
+
+def varint():
+    global pos
+    shift = 0; out = 0
+    while True:
+        b = raw[pos]; pos += 1
+        out |= (b & 0x7F) << shift
+        if not b & 0x80:
+            return out
+        shift += 7
+
+def zigzag():
+    u = varint()
+    return (u >> 1) ^ -(u & 1)
+
+def list_hdr():
+    global pos
+    b = raw[pos]; pos += 1
+    size = (b >> 4) & 0x0F
+    et = b & 0x0F
+    if size == 0x0F:
+        size = varint()
+    return size, et
+
+def skip(t):
+    global pos
+    if t in (1, 2):          return                 # bool: value is in the header
+    if t == 3:               pos += 1               # byte
+    elif t in (4, 5, 6):     zigzag()               # i16/i32/i64
+    elif t == 7:             pos += 8               # double
+    elif t == 8:             pos += varint()        # binary
+    elif t in (9, 10):
+        n, et = list_hdr()
+        for _ in range(n): skip(et)
+    elif t == 12:
+        last = 0
+        while True:
+            ft, _fid, last = field(last)
+            if ft == 0: break
+            skip(ft)
+
+def field(last):
+    global pos
+    b = raw[pos]; pos += 1
+    if b == 0:
+        return 0, 0, last
+    t = b & 0x0F
+    delta = b >> 4
+    fid = last + delta if delta else zigzag()
+    return t, fid, fid
+
+# FileMetaData -> field 4 (row_groups) -> first RowGroup -> field 1 (columns)
+target = None
+last = 0
+while True:
+    ft, fid, last = field(last)
+    if ft == 0:
+        break
+    if fid == 4 and ft == 9:                 # row_groups: list<RowGroup>
+        nrg, _et = list_hdr()
+        assert nrg >= 1, nrg
+        rlast = 0
+        while True:
+            rft, rfid, rlast = field(rlast)
+            if rft == 0:
+                break
+            if rfid == 1 and rft == 9:       # columns: list<ColumnChunk>
+                target = pos                 # byte holding this list's header
+                n, et = list_hdr()
+                assert n == 2, f"expected 2 column chunks, got {n}"
+                skip(et)                     # past ColumnChunk[0]
+                start2 = pos
+                skip(et)                     # past ColumnChunk[1]
+                end2 = pos
+                break
+            skip(rft)
+        break
+    skip(ft)
+
+assert target is not None, "row group columns list not found"
+# Remove ColumnChunk[1] outright and say so in the header, so the footer stays a
+# well-formed Thrift struct. Decrementing the count alone would desync the parser
+# and fail for an unrelated reason; the only defect must be that the row group
+# carries fewer chunks than the schema has leaves.
+assert (raw[target] >> 4) == 2, hex(raw[target])
+raw[target] = (1 << 4) | (raw[target] & 0x0F)
+removed = end2 - start2
+del raw[start2:end2]
+raw[-8:-4] = (flen - removed).to_bytes(4, "little")
+open(f"{W}/short_chunks.parquet", "wb").write(bytes(raw))
+print(f"  columns list at {target}: 2 chunks -> 1, removed {removed} footer bytes",
+      file=sys.stderr)
+PY
+
+psql_run "CREATE FOREIGN TABLE f_short (a int4, b int4) SERVER pq OPTIONS (path '$W/short_chunks.parquet');"
+# Must be the specific malformed-row-group rejection. Before the guard this read
+# chunks[1] out of bounds and failed incidentally, e.g. "invalid memory alloc
+# request size", an out-of-bounds read that merely tripped an allocator check.
+case "$(errtext 'SELECT * FROM f_short;')" in
+	*"has a malformed row group"*) short_verdict="CLEAN REJECT" ;;
+	*) short_verdict="$(errtext 'SELECT * FROM f_short;')" ;;
+esac
+check "short chunk list rejected with a specific error" "$short_verdict" "CLEAN REJECT"
+check "backend survived short chunk list" "$(q 'SELECT 1;')" "1"
+# The validation gates the read paths, not parsing, so the diagnostic function
+# still works on exactly the file one would be diagnosing.
+check "parquet_schema still describes a bad chunk list" \
+	"$(q "SELECT count(*) FROM pgcolumnar.parquet_schema('$W/short_chunks.parquet');")" "2"
+check "valid two-column file still reads" \
+	"$(q "SELECT count(*) FROM pgcolumnar.read_parquet('$W/two.parquet') AS t(a int4, b int4);")" "3"
+
+pgc_summary

--- a/test/native_parquet_pushdown.sh
+++ b/test/native_parquet_pushdown.sh
@@ -136,37 +136,46 @@ do
 done
 
 # ---- inverted statistics must never drive a skip ---------------------------
-# A PG int2 column binds to a Parquet INT32 column, and the decoder narrows with
-# an unchecked cast. A group holding 30000 and 40000 therefore decodes to
-# min=30000, max=-25536: an inverted interval. Every skip test assumes min <= max,
-# so without a guard the equality test skips a group that really does contain the
-# row. The data path applies the same narrowing, so those rows are genuine
-# matches. (Parquet UINT_32/UINT_64 invert the same way, being unsigned-ordered.)
-WIDEP="$PGC_WORKDIR/wide.parquet"
-python3 - "$WIDEP" <<'PY'
+# Parquet's UINT_32 logical type is stored as physical INT32 but its statistics
+# are ordered UNSIGNED, while the reader decodes signed. A group spanning the
+# sign boundary therefore reports min=1, max=-1294967296: an inverted interval.
+# Every skip test assumes min <= max, so without a guard the equality and range
+# tests skip groups that really do contain matching rows. The values themselves
+# read back fine as int4, so this is a well-formed file producing bad bounds.
+#
+# (The same inversion arises from narrowing a wide INT32 into int2, but that now
+# raises rather than wrapping -- see native_parquet_hardening.sh -- so it cannot
+# be used to reach this code path.)
+INVP="$PGC_WORKDIR/inverted.parquet"
+python3 - "$INVP" <<'PY'
 import sys, pyarrow as pa, pyarrow.parquet as pq
-pq.write_table(pa.table({"c": pa.array([30000, 40000], pa.int32())}),
+pq.write_table(pa.table({"c": pa.array([1, 3000000000], pa.uint32())}),
                sys.argv[1], row_group_size=2)
+st = pq.ParquetFile(sys.argv[1]).metadata.row_group(0).column(0).statistics
+assert st.min == 1 and st.max == 3000000000, (st.min, st.max)
 PY
 
-psql_run "CREATE FOREIGN TABLE ftw (c int2) SERVER pq OPTIONS (path '$WIDEP');"
-# oracle: exactly what the narrowing read path yields for those two INT32 values
-psql_run "CREATE TABLE hw (c int2);"
-psql_run "INSERT INTO hw VALUES (30000::int2), ((-25536)::int2);"
+psql_run "CREATE FOREIGN TABLE fti (c int4) SERVER pq OPTIONS (path '$INVP');"
+# oracle: the signed reading of those two stored values, which is what the data
+# path yields; 3000000000 unsigned is -1294967296 as int4
+psql_run "CREATE TABLE hi (c int4);"
+psql_run "INSERT INTO hi VALUES (1), (-1294967296);"
 
+check "inverted stats: unfiltered == oracle" \
+	"$(pgc_set_hash "SELECT * FROM fti")" "$(pgc_set_hash "SELECT * FROM hi")"
 for pred in \
-	"c = 30000::int2" \
-	"c = (-25536)::int2" \
-	"c >= 30000::int2" \
-	"c <= (-25536)::int2" \
-	"c < 0::int2" \
-	"c > 0::int2"
+	"c = 1" \
+	"c = -1294967296" \
+	"c >= 1" \
+	"c <= -1294967296" \
+	"c < 0" \
+	"c > 0"
 do
 	check "inverted-stats [$pred] == oracle" \
-		"$(pgc_set_hash "SELECT * FROM ftw WHERE $pred")" \
-		"$(pgc_set_hash "SELECT * FROM hw  WHERE $pred")"
+		"$(pgc_set_hash "SELECT * FROM fti WHERE $pred")" \
+		"$(pgc_set_hash "SELECT * FROM hi  WHERE $pred")"
 done
-check "inverted stats skip nothing" "$(skipped_for_t ftw 'c = 30000::int2')" "0"
+check "inverted stats skip nothing" "$(skipped_for_t fti 'c = 1')" "0"
 
 # ---- read_parquet over the same file ignores stats (reads all) but matches --
 check "read_parquet same file == oracle" \

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -27,7 +27,7 @@ SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUITES=(harness_selftest smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
 	differential recovery fuzz hardening concurrent_diff parallel sorted_projection \
 	arrow_export parquet_export read_stream corruption \
-	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip native_index native_dml native_ios native_projection native_cluster native_compact native_recluster native_reclaim native_ownership native_reclaim_cycles native_reclaim_frag native_gap native_truncate native_rewrite native_rewrite_conc native_parquet_schema native_read_parquet native_parquet_fdw native_parquet_pushdown isolation)
+	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip native_index native_dml native_ios native_projection native_cluster native_compact native_recluster native_reclaim native_ownership native_reclaim_cycles native_reclaim_frag native_gap native_truncate native_rewrite native_rewrite_conc native_parquet_schema native_read_parquet native_parquet_fdw native_parquet_pushdown native_parquet_hardening isolation)
 
 # Default matrix: one assert-enabled pg_config per major, 15 through 19.
 DEFAULT_CONFIGS=(


### PR DESCRIPTION
Fixes the two correctness defects recorded as follow-ups when #101 merged.
Neither comes from pushdown; #101's inversion guard only stopped the skip path
from trusting the first one's output.

## Unchecked narrowing in `plain_value_to_datum()`

Several PostgreSQL types bind to a wider Parquet physical type, because Parquet
has no narrower one. The decoder converted with a plain cast, so a value outside
the target range silently became a different value:

```
int2 column over Parquet INT32 holding [30000, 40000]
  -> reads back as [-25536, 30000]
```

PostgreSQL itself rejects `40000::int2` with "smallint out of range", so the read
path was inconsistent with the type it claimed to produce. Four conversions
shared the defect:

| Target | Physical | Old conversion | Failure |
|---|---|---|---|
| `int2` | INT32 | `(int16) v` | wraps |
| `date` | INT32 | `(DateADT) (v - PG_TO_UNIX_DAYS)` | int32 subtraction overflows; result may be outside PostgreSQL's date range |
| `timestamp`, `timestamptz` | INT64 | `(Timestamp) (v - PG_TO_UNIX_USECS)` | int64 subtraction overflows |
| `time` | INT64 | `(TimeADT) v` | anything outside `[0, USECS_PER_DAY]` is not a time |

**Range-checked rather than refusing the bind.** Binding `int2` to INT32 is
legitimate and necessary, since Parquet represents `int2` as INT32 with an
`INT(16, true)` annotation; refusing the bind would break every file whose values
do fit. Erroring on the offending value is what PostgreSQL does for the same
conversion.

The function gained a `strict` flag because its two caller classes need opposite
behaviour:

- **Data path** must raise a specific error. The existing `*ok = false` path
  reports "could not decode Parquet column N in row group M", which is misleading
  here: the file is well-formed, the value simply does not fit the declared type.
- **Statistics path** (`pqfdw_clause_excludes_group`) must **not** raise. A group
  whose bounds fall outside the bound type may still be legitimately skipped, or
  never read at all. Erroring at `BeginForeignScan` would fail queries that
  otherwise succeed.

Overflow uses `pg_sub_s32_overflow` / `pg_sub_s64_overflow`; range validity uses
`IS_VALID_DATE` / `IS_VALID_TIMESTAMP`.

Worth noting `INT64_MAX` micros is **not** an out-of-range timestamp: minus the
epoch offset it still lands inside PostgreSQL's range (year ~294276). `INT64_MIN`
is what overflows, and that is what the test uses.

## Row-group chunk lists were trusted

`pq_slurp_and_parse()` sized `rg->chunks` from the row group's **own** column
count and left it `NULL` when the `columns` field was absent, while every
consumer indexes it by the **schema's** leaf count: `pq_read_rows()` walks
`i < ncols`, `pqfdw_compute_skip()` takes `chunks[top->firstLeaf]`. A short list
is an out-of-bounds read, a missing one a NULL dereference, both reachable from a
crafted or truncated file.

On a footer with one ColumnChunk removed, `main` produces:

```
ERROR:  invalid memory alloc request size 18302063728033398268
```

which is the out-of-bounds read yielding a garbage length and merely happening to
trip the allocator's sanity check. The parsed count is now recorded per row group
and validated against the schema-derived `ncols` once known, rejecting the file
instead of reading past the array.

## Knock-on: the pushdown suite's inversion test

`native_parquet_pushdown.sh` reached #101's `min <= max` guard by binding `int2`
over out-of-range INT32 values — which now raises, so that scenario can no longer
produce readable inverted statistics.

Replaced with Parquet's `UINT_32` logical type, the other inversion that guard
covers and one that stays readable: physical INT32 with statistics ordered
unsigned, so a group spanning the sign boundary reports `min=1,
max=-1294967296` while the values decode as ordinary `int4`. Confirmed to still
fail with the guard removed, so it remains a real regression test.

## Tests

New suite `test/native_parquet_hardening.sh`, registered in
`run_all_versions.sh`. `corruption.sh` covers the native catalog and
`hardening.sh` mutates native on-disk bytes; neither covers Parquet input.

It asserts the out-of-range binds raise, that the in-range binds still work (so
the check did not simply disable a legitimate bind), that `read_parquet` and
`import_parquet` behave identically since all three surfaces share the decoder,
and that a short chunk list is rejected **at parse time** specifically, rather
than failing incidentally later.

The malformed file is produced by walking the Thrift-compact footer structurally
to the row group's `columns` list, removing a `ColumnChunk` outright, and fixing
both the list header and the footer length. Decrementing the count alone would
desync the parser and fail for an unrelated reason; this way the only defect is
the count mismatch. Blind byte-searching is not viable either, since the same
byte values occur in the data pages.

The whole suite fails against `main`.

## `test/rebuild.sh`

Two stale-artifact failures cost real time while working on this, and neither
announced itself:

1. `make clean` without `PG_CONFIG` uses whatever `pg_config` is on PATH, so
   nothing is cleaned and the previous major's objects are relinked into this
   major's `.so`. It installs fine and fails at load with an undefined symbol.
2. Installing from one build tree while running a suite from another leaves the
   suite measuring the wrong `.so` entirely.

`make` alone does not save you: after a PG18 build the objects are newer than the
sources, so a subsequent `make PG_CONFIG=<pg17>` does nothing at all and silently
keeps the PG18 `.so`.

The script cleans with the correct `PG_CONFIG`, asserts the tree holds no
`.o`/`.so`/`.bc`, removes the installed artifacts so a failed install cannot
leave the old one loadable, rebuilds, installs, and verifies every undefined
symbol resolves against the target `postgres`, that binary's shared libraries,
and the `.so`'s own. On a deliberately staled build it reports exactly the two
symbols that broke the PG18 build earlier:

```
rebuild: UNRESOLVED SYMBOLS against PostgreSQL 18.4:
get_op_btree_interpretation
smgrtruncate2
```

## Verification

- Full 15 through 19 matrix, all suites, in the `pgcolumnar-dev` container.
- Zero compiler warnings on every major.
- New hardening suite and the amended pushdown suite both verified to fail
  against the code they guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
