### PR TITLE
Phase G: honour Parquet TIME/TIMESTAMP units (fixes #103)

### DIFF
--- a/src/columnar_parquet_reader.c
+++ b/src/columnar_parquet_reader.c
@@ -96,6 +96,34 @@ PG_FUNCTION_INFO_V1(pgcolumnar_parquet_fdw_validator);
 #define PQ_CT_INT_64			18
 #define PQ_CT_JSON				19
 
+/*
+ * Resolved time unit for a TIME/TIMESTAMP column. Parquet carries this two ways:
+ * the deprecated ConvertedType (TIME_MILLIS ... TIMESTAMP_MICROS) and the current
+ * LogicalType union, whose TimeType/TimestampType hold a TimeUnit union. Only the
+ * latter can express NANOS. Writers commonly emit both, but neither alone is
+ * guaranteed, so both are read and PQ_TU_NONE means the column is not temporal.
+ */
+/*
+ * NONE is 0 deliberately: PqColPlan is palloc0'd, so a plan whose time_unit is
+ * never assigned defaults to "no unit / passthrough" rather than to a scaling
+ * factor. A future code path that binds a temporal plan and forgets to set the
+ * unit then decodes the raw value, not a value silently multiplied by 1000 --
+ * which is exactly this bug's failure mode. pq_scale_to_usecs treats NONE as
+ * passthrough.
+ */
+#define PQ_TU_NONE		0
+#define PQ_TU_MILLIS	1
+#define PQ_TU_MICROS	2
+#define PQ_TU_NANOS		3
+
+/* LogicalType union field ids (parquet.thrift LogicalType) */
+#define PQ_LT_TIME		7
+#define PQ_LT_TIMESTAMP	8
+/* TimeUnit union field ids */
+#define PQ_TUNIT_MILLIS	1
+#define PQ_TUNIT_MICROS	2
+#define PQ_TUNIT_NANOS	3
+
 /* Encodings (parquet.thrift Encoding) */
 #define PQE_PLAIN		0
 #define PQE_PLAIN_DICTIONARY 2
@@ -408,6 +436,8 @@ typedef struct PqSchemaCol
 	int			phys_type;		/* PQ_* physical type (-1 for a group) */
 	int			repetition;		/* 0 required, 1 optional, 2 repeated */
 	int			converted_type;	/* -1 if none */
+	int			time_unit;		/* PQ_TU_* for a TIME/TIMESTAMP column */
+	bool		is_timestamp;	/* the unit belongs to TIMESTAMP, not TIME */
 	int			type_length;	/* FIXED_LEN_BYTE_ARRAY length */
 	int			scale;			/* DECIMAL scale (0 if none) */
 	int			precision;		/* DECIMAL precision (0 if none) */
@@ -443,7 +473,8 @@ typedef struct PqChunk
 typedef struct PqRowGroup
 {
 	int64		num_rows;
-	PqChunk    *chunks;			/* [nchunks]; consumers require nchunks == ncols */
+	PqChunk    *chunks;			/* [nchunks]; consumers index by ncols, so a value
+								 * read path must call pq_check_row_groups() first */
 	int			nchunks;		/* column chunks this row group actually carries */
 } PqRowGroup;
 
@@ -616,7 +647,80 @@ parse_column_chunk(TCReader *r, PqChunk *ch)
 	}
 }
 
-/* parse a SchemaElement into *sc; returns num_children (0 for a leaf) */
+/*
+ * Parse a LogicalType union into *sc, recording the time unit for TIME and
+ * TIMESTAMP. Every other member is skipped: the ConvertedType path already covers
+ * what the reader uses of them. TimeUnit is itself a union of empty structs, so
+ * the set field id is the whole answer.
+ *
+ * This hand-walks nested Thrift unions and assumes the compact-protocol field
+ * ordering the spec prescribes. A writer that reorders or partially populates the
+ * union could desync the cursor -- but a desync fails the surrounding footer
+ * parse (tcr_field / bounds checks catch it), so the blast radius is "file
+ * rejected", never a wrong value silently returned from a good decode.
+ */
+static void
+parse_logical_type(TCReader *r, PqSchemaCol *sc)
+{
+	int			lastId = 0;
+
+	for (;;)
+	{
+		int			ft,
+					fid;
+
+		tcr_field(r, &ft, &fid, &lastId);
+		if (ft == TC_STOP || r->error)
+			break;
+		if ((fid == PQ_LT_TIME || fid == PQ_LT_TIMESTAMP) && ft == TC_STRUCT)
+		{
+			int			innerLast = 0;
+			bool		isTs = (fid == PQ_LT_TIMESTAMP);
+
+			for (;;)
+			{
+				int			ift,
+							ifid;
+
+				tcr_field(r, &ift, &ifid, &innerLast);
+				if (ift == TC_STOP || r->error)
+					break;
+				if (ifid == 2 && ift == TC_STRUCT)	/* unit: union TimeUnit */
+				{
+					int			uLast = 0;
+					int			uft,
+								ufid;
+
+					tcr_field(r, &uft, &ufid, &uLast);
+					if (uft != TC_STOP && !r->error)
+					{
+						switch (ufid)
+						{
+							case PQ_TUNIT_MILLIS:
+								sc->time_unit = PQ_TU_MILLIS;
+								break;
+							case PQ_TUNIT_MICROS:
+								sc->time_unit = PQ_TU_MICROS;
+								break;
+							case PQ_TUNIT_NANOS:
+								sc->time_unit = PQ_TU_NANOS;
+								break;
+						}
+						sc->is_timestamp = isTs;
+						tcr_skip(r, uft);	/* the unit member is an empty struct */
+						/* consume the union's STOP */
+						tcr_field(r, &uft, &ufid, &uLast);
+					}
+				}
+				else
+					tcr_skip(r, ift);	/* isAdjustedToUTC and anything later */
+			}
+		}
+		else
+			tcr_skip(r, ft);
+	}
+}
+
 static int
 parse_schema_element(TCReader *r, PqSchemaCol *sc)
 {
@@ -626,6 +730,8 @@ parse_schema_element(TCReader *r, PqSchemaCol *sc)
 	sc->phys_type = -1;
 	sc->repetition = 0;
 	sc->converted_type = -1;
+	sc->time_unit = PQ_TU_NONE;
+	sc->is_timestamp = false;
 	sc->type_length = 0;
 	sc->scale = 0;
 	sc->precision = 0;
@@ -673,8 +779,37 @@ parse_schema_element(TCReader *r, PqSchemaCol *sc)
 			case 8:				/* precision (DECIMAL) */
 				sc->precision = (int) tcr_zigzag(r);
 				break;
+			case 10:			/* logicalType */
+				parse_logical_type(r, sc);
+				break;
 			default:
 				tcr_skip(r, ft);
+				break;
+		}
+	}
+
+	/*
+	 * Fall back to the deprecated ConvertedType when no LogicalType was present.
+	 * LogicalType wins when both appear: it is the current spelling, and it is the
+	 * only one that can say NANOS.
+	 */
+	if (sc->time_unit == PQ_TU_NONE)
+	{
+		switch (sc->converted_type)
+		{
+			case PQ_CT_TIMESTAMP_MILLIS:
+				sc->time_unit = PQ_TU_MILLIS;
+				sc->is_timestamp = true;
+				break;
+			case PQ_CT_TIMESTAMP_MICROS:
+				sc->time_unit = PQ_TU_MICROS;
+				sc->is_timestamp = true;
+				break;
+			case PQ_CT_TIME_MILLIS:
+				sc->time_unit = PQ_TU_MILLIS;
+				break;
+			case PQ_CT_TIME_MICROS:
+				sc->time_unit = PQ_TU_MICROS;
 				break;
 		}
 	}
@@ -951,7 +1086,40 @@ typedef struct PqColPlan
 	int16		typlen;
 	bool		typbyval;
 	int			expect_phys;	/* required Parquet physical type */
+	int			time_unit;		/* PQ_TU_* when the source column is TIME/TIMESTAMP */
 } PqColPlan;
+
+/*
+ * Convert a stored TIME/TIMESTAMP value to the microseconds PostgreSQL stores,
+ * per the column's declared unit. Returns false if the conversion overflows.
+ *
+ * A column with no declared unit is read as microseconds: the target type is
+ * microsecond-based and there is nothing else to go on.
+ *
+ * NANOS is divided rather than refused. PostgreSQL has no nanosecond timestamp,
+ * so sub-microsecond precision cannot survive regardless; truncating yields the
+ * right instant, whereas reading nanoseconds as microseconds is wrong by a factor
+ * of 1000. C division truncates toward zero, so a pre-epoch value rounds toward
+ * the epoch rather than toward negative infinity: a sub-microsecond difference,
+ * and the same narrowing other readers apply.
+ */
+static bool
+pq_scale_to_usecs(int unit, int64 v, int64 *out)
+{
+	switch (unit)
+	{
+		case PQ_TU_MILLIS:
+			return !pg_mul_s64_overflow(v, INT64CONST(1000), out);
+		case PQ_TU_NANOS:
+			*out = v / INT64CONST(1000);
+			return true;
+		case PQ_TU_MICROS:
+		case PQ_TU_NONE:
+		default:
+			*out = v;
+			return true;
+	}
+}
 
 /*
  * A physical value that does not fit the bound PostgreSQL type. On the data path
@@ -1012,6 +1180,18 @@ plain_value_to_datum(const PqColPlan *plan, const uint8 **p, const uint8 *end,
 													 "smallint", (int64) v);
 					return Int16GetDatum((int16) v);
 				}
+				if (plan->typid == TIMEOID)
+				{
+					int64		us;
+
+					/* TIME_MILLIS: milliseconds since midnight, in an INT32 */
+					if (!pq_scale_to_usecs(plan->time_unit, (int64) v, &us) ||
+						us < INT64CONST(0) || us > USECS_PER_DAY)
+						return pq_value_out_of_range(strict, ok,
+													 ERRCODE_DATETIME_FIELD_OVERFLOW,
+													 "time", (int64) v);
+					return TimeADTGetDatum((TimeADT) us);
+				}
 				if (plan->typid == DATEOID)
 				{
 					int32		d;
@@ -1038,25 +1218,30 @@ plain_value_to_datum(const PqColPlan *plan, const uint8 **p, const uint8 *end,
 				*p = cur + 8;
 				if (plan->typid == TIMESTAMPOID || plan->typid == TIMESTAMPTZOID)
 				{
+					int64		us;
 					int64		t;
+					const char *tn = (plan->typid == TIMESTAMPOID)
+						? "timestamp" : "timestamp with time zone";
 
-					if (pg_sub_s64_overflow(v, PG_TO_UNIX_USECS, &t) ||
+					if (!pq_scale_to_usecs(plan->time_unit, v, &us) ||
+						pg_sub_s64_overflow(us, PG_TO_UNIX_USECS, &t) ||
 						!IS_VALID_TIMESTAMP((Timestamp) t))
 						return pq_value_out_of_range(strict, ok,
 													 ERRCODE_DATETIME_FIELD_OVERFLOW,
-													 plan->typid == TIMESTAMPOID
-													 ? "timestamp" : "timestamp with time zone",
-													 v);
+													 tn, v);
 					return TimestampGetDatum((Timestamp) t);
 				}
 				if (plan->typid == TIMEOID)
 				{
+					int64		us;
+
 					/* TimeADT is microseconds since midnight; nothing else is a time */
-					if (v < INT64CONST(0) || v > USECS_PER_DAY)
+					if (!pq_scale_to_usecs(plan->time_unit, v, &us) ||
+						us < INT64CONST(0) || us > USECS_PER_DAY)
 						return pq_value_out_of_range(strict, ok,
 													 ERRCODE_DATETIME_FIELD_OVERFLOW,
 													 "time", v);
-					return TimeADTGetDatum((TimeADT) v);
+					return TimeADTGetDatum((TimeADT) us);
 				}
 				return Int64GetDatum(v);
 			}
@@ -1564,6 +1749,34 @@ pq_want_phys(Oid typid)
 }
 
 /*
+ * The schema column for leaf lf, or NULL when lf is past the file's columns.
+ * The bind sites below compute the wanted physical type before checking that
+ * lf is in range, so this must tolerate an out-of-range index rather than read
+ * past pf->leaves[].
+ */
+static const PqSchemaCol *
+pq_leaf_sc(const PqFile *pf, int lf)
+{
+	return (lf >= 0 && lf < pf->ncols) ? pf->leaves[lf].sc : NULL;
+}
+
+/*
+ * The Parquet physical type a target PostgreSQL type must be stored as, for one
+ * specific source column. Only `time` is column-dependent: Parquet spells
+ * TIME_MILLIS as INT32 and TIME_MICROS/TIME_NANOS as INT64, so the same
+ * PostgreSQL type binds to either width depending on the unit the file declares.
+ * Everything else is a fixed mapping and falls through to pq_want_phys().
+ */
+static int
+pq_want_phys_for(Oid typid, const PqSchemaCol *sc)
+{
+	if (typid == TIMEOID && sc != NULL &&
+		sc->time_unit == PQ_TU_MILLIS && !sc->is_timestamp)
+		return PQ_INT32;
+	return pq_want_phys(typid);
+}
+
+/*
  * Infer the PostgreSQL column type a Parquet leaf should map to. This is the
  * inverse of the exporter's parquet_kind_for_type (columnar_parquet.c): it reads
  * the physical type plus the ConvertedType annotation, so a round-tripped file
@@ -1588,18 +1801,30 @@ pq_leaf_to_pgtype(const PqSchemaCol *sc, Oid *typid, int32 *typmod)
 		case PQ_INT32:
 			if (ct == PQ_CT_DATE)
 				*typid = DATEOID;
+			else if (sc->time_unit != PQ_TU_NONE && !sc->is_timestamp)
+				*typid = TIMEOID;	/* TIME_MILLIS is physically INT32 */
 			else if (ct == PQ_CT_INT_8 || ct == PQ_CT_INT_16)
 				*typid = INT2OID;
 			else
 				*typid = INT4OID;	/* INT_32 or unannotated */
 			return true;
 		case PQ_INT64:
-			if (ct == PQ_CT_TIMESTAMP_MICROS || ct == PQ_CT_TIMESTAMP_MILLIS)
-				*typid = TIMESTAMPOID;
-			else if (ct == PQ_CT_TIME_MICROS || ct == PQ_CT_TIME_MILLIS)
-				*typid = TIMEOID;
+
+			/*
+			 * Advise a temporal type only when the unit converts to PostgreSQL's
+			 * microseconds without loss. Millis and micros do. Nanos do not:
+			 * PostgreSQL has no nanosecond type, so the advice stays bigint, which
+			 * holds the stored value exactly and leaves the choice to the user.
+			 * Declaring timestamp anyway is supported and decodes correctly, with
+			 * the sub-microsecond digits truncated -- but that is a loss worth
+			 * opting into rather than being advised into. float8 would be worse
+			 * than either: a nanosecond timestamp of this era needs about 61 bits
+			 * and a double carries 53, so it cannot even represent the value.
+			 */
+			if (sc->time_unit == PQ_TU_MILLIS || sc->time_unit == PQ_TU_MICROS)
+				*typid = sc->is_timestamp ? TIMESTAMPOID : TIMEOID;
 			else
-				*typid = INT8OID;	/* INT_64 or unannotated */
+				*typid = INT8OID;	/* INT_64, nanos, or unannotated */
 			return true;
 		case PQ_FLOAT:
 			*typid = FLOAT4OID;
@@ -1724,7 +1949,7 @@ build_imp_targets(TupleDesc tupdesc, PqFile *pf,
 		if (OidIsValid(elemtype))
 		{
 			/* 1-D array -> LIST(element) */
-			int			want = pq_want_phys(elemtype);
+			int			want = pq_want_phys_for(elemtype, pq_leaf_sc(pf, lf));
 			ImpLeaf    *l = &leaves[lf];
 
 			if (want < 0)
@@ -1745,6 +1970,7 @@ build_imp_targets(TupleDesc tupdesc, PqFile *pf,
 			l->plan.typid = elemtype;
 			get_typlenbyval(elemtype, &l->plan.typlen, &l->plan.typbyval);
 			l->plan.expect_phys = want;
+			l->plan.time_unit = pf->leaves[lf].sc->time_unit;
 			l->max_def = pf->leaves[lf].max_def;
 			l->max_rep = pf->leaves[lf].max_rep;
 			lf++;
@@ -1769,7 +1995,7 @@ build_imp_targets(TupleDesc tupdesc, PqFile *pf,
 					t->fieldLeaf[a] = -1;
 					continue;
 				}
-				want = pq_want_phys(fa->atttypid);
+				want = pq_want_phys_for(fa->atttypid, pq_leaf_sc(pf, lf));
 				if (want < 0)
 				{
 					ReleaseTupleDesc(td);
@@ -1798,6 +2024,7 @@ build_imp_targets(TupleDesc tupdesc, PqFile *pf,
 				l->plan.typid = fa->atttypid;
 				get_typlenbyval(fa->atttypid, &l->plan.typlen, &l->plan.typbyval);
 				l->plan.expect_phys = want;
+				l->plan.time_unit = pf->leaves[lf].sc->time_unit;
 				l->max_def = pf->leaves[lf].max_def;
 				l->max_rep = pf->leaves[lf].max_rep;
 				t->fieldLeaf[a] = lf;
@@ -1809,7 +2036,7 @@ build_imp_targets(TupleDesc tupdesc, PqFile *pf,
 		else
 		{
 			/* plain scalar */
-			int			want = pq_want_phys(typid);
+			int			want = pq_want_phys_for(typid, pq_leaf_sc(pf, lf));
 			ImpLeaf    *l = &leaves[lf];
 
 			if (want < 0)
@@ -1828,6 +2055,7 @@ build_imp_targets(TupleDesc tupdesc, PqFile *pf,
 			l->plan.typid = typid;
 			get_typlenbyval(typid, &l->plan.typlen, &l->plan.typbyval);
 			l->plan.expect_phys = want;
+			l->plan.time_unit = pf->leaves[lf].sc->time_unit;
 			l->max_def = pf->leaves[lf].max_def;
 			l->max_rep = pf->leaves[lf].max_rep;
 			lf++;

--- a/test/native_parquet_units.sh
+++ b/test/native_parquet_units.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+#
+# pgColumnar Parquet TIME/TIMESTAMP unit handling (Phase G).
+#
+# Parquet stores a time unit alongside TIME and TIMESTAMP columns, two ways: the
+# deprecated ConvertedType (TIME_MILLIS ... TIMESTAMP_MICROS) and the current
+# LogicalType union, whose TimeUnit can also say NANOS. PostgreSQL stores
+# microseconds, so a reader that ignores the unit silently returns values off by
+# a factor of 1000 -- in range, so nothing errors and nothing looks wrong.
+#
+# pyarrow writes ConvertedType for millis and micros but only LogicalType for
+# nanos, so this suite exercises both metadata paths.
+#
+# Usage:  test/native_parquet_units.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+if ! python3 -c 'import pyarrow.parquet' 2>/dev/null; then
+	echo "SKIP  pyarrow not available; Parquet unit suite needs it"
+	pgc_summary
+	exit 0
+fi
+
+W="$PGC_WORKDIR"
+psql_run "CREATE SERVER pq FOREIGN DATA WRAPPER pgcolumnar_parquet;"
+
+# 2026-07-24 00:00:00 UTC, written in each unit. The same instant every time, so
+# any unit mishandling shows up as a different timestamp rather than an error.
+python3 - "$W" <<'PY'
+import sys, pyarrow as pa, pyarrow.parquet as pq
+W = sys.argv[1]
+secs = 1784851200
+for unit, mult, ver in [("ms", 10**3, "1.0"), ("us", 10**6, "1.0"), ("ns", 10**9, "2.6")]:
+    pq.write_table(pa.table({"t": pa.array([secs * mult], pa.int64()).cast(pa.timestamp(unit))}),
+                   f"{W}/ts_{unit}.parquet", version=ver)
+# time-of-day: 01:02:03.000004 in micros (TIME_MICROS, physically INT64)
+pq.write_table(pa.table({"t": pa.array([3723000004], pa.int64()).cast(pa.time64('us'))}),
+               f"{W}/time_us.parquet")
+# the same time to millisecond resolution (TIME_MILLIS, physically INT32)
+pq.write_table(pa.table({"t": pa.array([3723000], pa.int32()).cast(pa.time32('ms'))}),
+               f"{W}/time_ms.parquet")
+# A genuine TIMESTAMP_MILLIS column whose conversion to microseconds overflows
+# int64. An unannotated int64 would not do: with no unit there is no scaling, so
+# nothing would overflow and the test would pass for the wrong reason.
+pq.write_table(pa.table({"t": pa.array([9223372036854776], pa.int64()).cast(pa.timestamp('ms'))}),
+               f"{W}/ms_overflow.parquet")
+
+# Nanos truncation. pq_scale_to_usecs divides by 1000 with C semantics (toward
+# zero), which the code comment reasons about but the round-number cases above do
+# not exercise: they are exact multiples of 1000 and non-negative. Write a value
+# with sub-microsecond digits, and a pre-epoch (negative) one, as nanos; write the
+# toward-zero-truncated microseconds directly as the reference. Reading the two as
+# timestamp must agree, which pins the rounding direction.
+def trunc_us(ns):                       # toward zero, unlike Python's floor //
+    return -(-ns // 1000) if ns < 0 else ns // 1000
+for tag, ns in [("frac", 1784851200_123_456_789), ("neg", -1784851200_123_456_789)]:
+    pq.write_table(pa.table({"t": pa.array([ns], pa.int64()).cast(pa.timestamp('ns'))}),
+                   f"{W}/tsns_{tag}.parquet", version="2.6")
+    pq.write_table(pa.table({"t": pa.array([trunc_us(ns)], pa.int64()).cast(pa.timestamp('us'))}),
+                   f"{W}/tsus_{tag}.parquet", version="1.0")
+
+# Row-group skipping over a unit-scaled column: two groups of millis timestamps
+# with disjoint ranges. The FDW decodes each group's min/max through the same
+# scaling as its values, so a predicate must skip the group it cannot match. If
+# the stats were read unscaled while the constant is a real timestamp, the compare
+# would be nonsense and the skip wrong.
+HOUR = 3600000
+g0base = 1704067200000                    # 2024-01-01 00:00:00 UTC, in millis
+g1base = 1751328000000                    # 2025-07-01 00:00:00 UTC, in millis
+g0 = [g0base + i * HOUR for i in range(1000)]   # Jan-Feb 2024, hourly
+g1 = [g1base + i * HOUR for i in range(1000)]   # Jul-Aug 2025, hourly
+pq.write_table(pa.table({"t": pa.array(g0 + g1, pa.int64()).cast(pa.timestamp('ms'))}),
+               f"{W}/ms_groups.parquet", row_group_size=1000)
+assert pq.ParquetFile(f"{W}/ms_groups.parquet").num_row_groups == 2
+PY
+
+for u in ms us ns; do
+	psql_run "CREATE FOREIGN TABLE fts_$u (t timestamp) SERVER pq OPTIONS (path '$W/ts_$u.parquet');"
+done
+psql_run "CREATE FOREIGN TABLE ftime (t time) SERVER pq OPTIONS (path '$W/time_us.parquet');"
+psql_run "CREATE FOREIGN TABLE ftime_ms (t time) SERVER pq OPTIONS (path '$W/time_ms.parquet');"
+
+# ---- the same instant, whatever the unit -----------------------------------
+# Before the unit was honoured, millis read 1000x small (1970-01-21 15:47:31.2)
+# and nanos declared as timestamp read 1000x large, both silently.
+for u in ms us ns; do
+	check "ts_$u decodes to the right instant" \
+		"$(q "SELECT t::text FROM fts_$u;")" "2026-07-24 00:00:00"
+done
+
+check "time micros decodes to the right time" \
+	"$(q 'SELECT t::text FROM ftime;')" "01:02:03.000004"
+
+# TIME_MILLIS is physically INT32, not INT64. Before the unit was resolved from
+# the schema, that branch could never fire for a spec-conforming file: the column
+# fell through to int4, so parquet_schema advised a number for a time column and
+# declaring `time` was rejected as an incompatible physical type.
+check "time millis decodes to the right time" \
+	"$(q 'SELECT t::text FROM ftime_ms;')" "01:02:03"
+check "parquet_schema advises time for TIME_MILLIS" \
+	"$(q "SELECT data_type FROM pgcolumnar.parquet_schema('$W/time_ms.parquet');")" \
+	"time without time zone"
+
+# ---- schema advice ---------------------------------------------------------
+# millis and micros convert to timestamp without loss, so parquet_schema advises
+# it. Nanos cannot: PostgreSQL has no nanosecond timestamp, so the advice stays
+# bigint, which is exact. Declaring timestamp anyway is allowed and truncates.
+check "parquet_schema advises timestamp for millis" \
+	"$(q "SELECT data_type FROM pgcolumnar.parquet_schema('$W/ts_ms.parquet');")" \
+	"timestamp without time zone"
+check "parquet_schema advises timestamp for micros" \
+	"$(q "SELECT data_type FROM pgcolumnar.parquet_schema('$W/ts_us.parquet');")" \
+	"timestamp without time zone"
+# bigint, not timestamp: nanos cannot reach microseconds without loss, and not
+# float8 either, which has 53 mantissa bits for a value needing about 61.
+check "parquet_schema advises bigint for nanos (lossless)" \
+	"$(q "SELECT data_type FROM pgcolumnar.parquet_schema('$W/ts_ns.parquet');")" \
+	"bigint"
+check "nanos read as bigint is exact" \
+	"$(q "SELECT t::text FROM pgcolumnar.read_parquet('$W/ts_ns.parquet') AS t(t int8);")" \
+	"1784851200000000000"
+
+# ---- overflow --------------------------------------------------------------
+# INT64 max milliseconds cannot be expressed in microseconds; it must raise
+# rather than wrap. 22008 is datetime_field_overflow.
+psql_run "CREATE FUNCTION pgc_try(q text) RETURNS text LANGUAGE plpgsql AS \$\$
+          BEGIN EXECUTE q; RETURN 'NO ERROR';
+          EXCEPTION WHEN OTHERS THEN RETURN SQLSTATE; END \$\$;"
+sqlstate() { q "SELECT pgc_try(\$q\$$1\$q\$);"; }
+
+check "millis-to-micros overflow raises 22008" \
+	"$(sqlstate "SELECT * FROM pgcolumnar.read_parquet('$W/ms_overflow.parquet') AS t(t timestamp)")" \
+	"22008"
+
+# ---- all three surfaces share the decoder ----------------------------------
+check "read_parquet honours the unit" \
+	"$(q "SELECT t::text FROM pgcolumnar.read_parquet('$W/ts_ms.parquet') AS t(t timestamp);")" \
+	"2026-07-24 00:00:00"
+
+psql_run "CREATE TABLE imp_ms (t timestamp);"
+psql_run "SELECT pgcolumnar.import_parquet('imp_ms'::regclass, '$W/ts_ms.parquet');"
+check "import_parquet honours the unit" \
+	"$(q 'SELECT t::text FROM imp_ms;')" "2026-07-24 00:00:00"
+
+# ---- oracle: every unit agrees with every other -----------------------------
+check "millis == micros" \
+	"$(pgc_set_hash 'SELECT t FROM fts_ms')" "$(pgc_set_hash 'SELECT t FROM fts_us')"
+check "nanos == micros" \
+	"$(pgc_set_hash 'SELECT t FROM fts_ns')" "$(pgc_set_hash 'SELECT t FROM fts_us')"
+
+# ---- nanos truncation direction (toward zero) ------------------------------
+# The nanos value carries sub-microsecond digits the micros reference cannot, so
+# equality holds only if the reader truncates toward zero exactly as the reference
+# was computed. The negative case is the one that distinguishes toward-zero from
+# floor.
+for tag in frac neg; do
+	check "nanos sub-us truncates toward zero [$tag]" \
+		"$(q "SELECT t::text FROM pgcolumnar.read_parquet('$W/tsns_$tag.parquet') AS t(t timestamp);")" \
+		"$(q "SELECT t::text FROM pgcolumnar.read_parquet('$W/tsus_$tag.parquet') AS t(t timestamp);")"
+done
+
+# ---- pushdown over a unit-scaled column ------------------------------------
+# The predicate falls entirely in the second group's range, so the first group's
+# stats (Jan-Mar 2024) prove it empty and it must be skipped -- but only if those
+# stats are scaled from millis the same way the values are.
+psql_run "CREATE FOREIGN TABLE fmsg (t timestamp) SERVER pq OPTIONS (path '$W/ms_groups.parquet');"
+skipped_ms() {
+	q "EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+	   SELECT count(*) FROM fmsg WHERE $1" \
+		| grep 'Row Groups Skipped' | grep -oE '[0-9]+' | head -1
+}
+# 2025-06-01 is inside group 1 only.
+check "millis-scaled stats skip the non-matching group" \
+	"$(skipped_ms "t >= timestamp '2025-06-01'")" "1"
+# correctness: the skip must not drop a matching row (oracle = a heap mirror)
+psql_run "CREATE TABLE hmsg (t timestamp);"
+psql_run "INSERT INTO hmsg SELECT t FROM pgcolumnar.read_parquet('$W/ms_groups.parquet') AS t(t timestamp);"
+check "millis pushdown result == oracle" \
+	"$(pgc_set_hash "SELECT t FROM fmsg WHERE t >= timestamp '2025-06-01'")" \
+	"$(pgc_set_hash "SELECT t FROM hmsg WHERE t >= timestamp '2025-06-01'")"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -27,7 +27,7 @@ SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUITES=(harness_selftest smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
 	differential recovery fuzz hardening concurrent_diff parallel sorted_projection \
 	arrow_export parquet_export read_stream corruption \
-	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip native_index native_dml native_ios native_projection native_cluster native_compact native_recluster native_reclaim native_ownership native_reclaim_cycles native_reclaim_frag native_gap native_truncate native_rewrite native_rewrite_conc native_parquet_schema native_read_parquet native_parquet_fdw native_parquet_pushdown native_parquet_hardening isolation)
+	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip native_index native_dml native_ios native_projection native_cluster native_compact native_recluster native_reclaim native_ownership native_reclaim_cycles native_reclaim_frag native_gap native_truncate native_rewrite native_rewrite_conc native_parquet_schema native_read_parquet native_parquet_fdw native_parquet_pushdown native_parquet_hardening native_parquet_units isolation)
 
 # Default matrix: one assert-enabled pg_config per major, 15 through 19.
 DEFAULT_CONFIGS=(


### PR DESCRIPTION
Closes #103.

## The bug

`parquet_schema()` reported `timestamp` for a `TIMESTAMP_MILLIS` column, but the
decoder treated the stored int64 as **microseconds**. Nothing scaled
milliseconds anywhere in the reader, so the value read 1000x too small --
silently, and in range, so nothing errored:

```
file:   2026-07-24 00:00:00, written as timestamp('ms')
reads:  1970-01-21 15:47:31.2
```

## Wider than the reported case

The reader only ever read the deprecated `ConvertedType` and skipped
`LogicalType` (field 10) entirely. That matters because pyarrow, and other modern
writers, emit **only** `LogicalType` for nanoseconds, and often for millis too.
So the defect had two more faces than #103's millis example:

- A `NANOS` column bound to `timestamp` read 1000x too *large*. The suite catches
  it reading back as year **58529**.
- Any millis file written with only `LogicalType` and no `ConvertedType` was
  wrong in the same way as the reported case, so a `converted_type`-only fix
  would not have closed it.

This is why the change is larger than the issue's Option 1 sketch: both metadata
paths have to be parsed.

## The fix

`parse_logical_type()` reads the `TimeType`/`TimestampType` unit from the
`LogicalType` union. The deprecated `ConvertedType` fills in only when no
`LogicalType` is present -- the current spelling wins, and is the only one that
can say nanos. The resolved unit rides on `PqColPlan`, and `pq_scale_to_usecs()`
converts on decode: millis multiply (overflow-checked), micros pass through,
nanos divide, with the existing range check applied after scaling.

Type mapping follows the same resolved unit:

- millis, micros -> `timestamp` / `time`, which convert without loss.
- nanos -> `bigint`, which is **exact**. PostgreSQL has no nanosecond type.
  `float8` would be worse than either: a nanosecond timestamp of this era needs
  about 61 bits and a double carries 53, so it cannot represent the value at all.
  Declaring `timestamp` over a nanos column is still supported and truncates --
  a loss the user opts into rather than one the tool advises them into.

## Secondary defect from #103, also fixed

`TIME_MILLIS` is physically INT32, not INT64, so its branch could never fire for
a spec-conforming file: the column fell through to `int4`, `parquet_schema`
advised a number for a time column, and declaring `time` was rejected as an
incompatible physical type. `pq_want_phys_for()` now binds `time` to INT32 when
the file says `TIME_MILLIS` and INT64 otherwise, and the INT32 decode path scales
it.

That accessor reads the schema column for a leaf, which surfaced an out-of-bounds
risk: the bind sites compute the wanted physical type *before* the `lf < ncols`
check, so reading `pf->leaves[lf].sc` directly would read past the array on a
table declaring more columns than the file has. `pq_leaf_sc()` bounds-checks the
index and returns NULL past the end -- the same defect class as the chunk-list
fix in #102, caught by reading the surrounding code rather than the diff.

## Tests

`test/native_parquet_units.sh` writes the same instant in each unit and asserts
they all decode identically, that `parquet_schema` advises the lossless type,
that a millis-to-micros overflow raises `22008`, and that all three read surfaces
(`read_parquet`, `import_parquet`, the FDW) honour the unit. pyarrow emits
`ConvertedType` for millis/micros but only `LogicalType` for nanos, so both
metadata paths are exercised.

Verified to fail against `main` with twelve failures, including the `ts_ns`
year-58529 case, the `TIME_MILLIS`-advised-as-integer case, the both-groups
wrongly-skipped case, and the negative-nanos underflow.

## Review notes already applied

ChronicallyJD reviewed the branch before this PR opened; the notes are folded in:

- **`PQ_TU_NONE` is now 0.** `PqColPlan` is `palloc0`'d, so with millis at 0 an
  unset unit would default to a silent x1000 -- this bug's own failure mode. With
  NONE at 0 a missed assignment is a passthrough no-op instead. It converts the
  invariant from "true if you trace the typid assignment" to "true by
  construction."
- **Nanos truncation is now exercised.** The toward-zero division had only
  round-number, non-negative inputs; added a sub-microsecond value and a
  pre-epoch negative one, referenced against directly-written truncated micros.
  The negative case is the one that distinguishes toward-zero from floor -- and
  on `main` it errors outright (a negative nanos-as-micros underflows the
  timestamp range), so the fix rescues it rather than merely correcting it.
- **A skip test now runs with a unit in play.** A two-row-group millis file with a
  range predicate: the group the predicate cannot match must be skipped, which
  requires the stats to be scaled the same way the values are. On `main` this
  skips *both* groups -- unscaled millis stats read ~1000x small, so the constant
  looks larger than everything -- a silent wrong-answer skip of exactly the kind
  the inverted-stats work in #101/#102 guarded against.
- The `parse_logical_type` union walk is documented as failing closed (a Thrift
  desync fails the footer parse, never returns a wrong value), and a
  discoverability comment on `PqRowGroup.chunks` points chunk consumers at
  `pq_check_row_groups()`.

## Verification

Full 15 through 19 matrix, all suites, on an idle container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
