### PR TITLE
Phase G: read FIXED_LEN_BYTE_ARRAY columns (uuid, decimal, fixed bytea)

### DIFF
--- a/src/columnar_parquet_reader.c
+++ b/src/columnar_parquet_reader.c
@@ -62,6 +62,7 @@
 #include "utils/timestamp.h"
 #include "utils/tuplestore.h"
 #include "utils/typcache.h"
+#include "utils/uuid.h"
 
 PG_FUNCTION_INFO_V1(columnar_import_parquet);
 PG_FUNCTION_INFO_V1(columnar_parquet_schema);
@@ -1087,6 +1088,9 @@ typedef struct PqColPlan
 	bool		typbyval;
 	int			expect_phys;	/* required Parquet physical type */
 	int			time_unit;		/* PQ_TU_* when the source column is TIME/TIMESTAMP */
+	int			type_length;	/* FIXED_LEN_BYTE_ARRAY width, for uuid/decimal */
+	int			dec_scale;		/* DECIMAL scale, when the target is numeric */
+	bool		is_decimal;		/* the bytes are a DECIMAL unscaled integer */
 } PqColPlan;
 
 /*
@@ -1119,6 +1123,93 @@ pq_scale_to_usecs(int unit, int64 v, int64 *out)
 			*out = v;
 			return true;
 	}
+}
+
+/*
+ * Build a numeric Datum from a DECIMAL stored as `len` big-endian two's-complement
+ * bytes at the given scale -- the inverse of the exporter's numeric_to_int128 plus
+ * its byte-swap, and the layout pyarrow writes for decimal128. Values up to 16
+ * bytes (128 bits) are supported, which covers DECIMAL(38); a wider decimal256
+ * returns false. The unscaled integer is turned into its canonical text form and
+ * parsed by numeric_in, mirroring how the exporter went numeric -> text.
+ */
+static bool
+pq_decimal_to_numeric(const uint8 *be, int len, int scale, Datum *out)
+{
+	unsigned __int128 mag = 0;
+	__int128	val;
+	bool		neg;
+	char		digits[40];
+	int			nd = 0;
+	char		buf[64];
+	int			bi = 0;
+	int			i;
+
+	if (len < 1 || len > 16)
+		return false;
+
+	for (i = 0; i < len; i++)
+		mag = (mag << 8) | be[i];
+
+	/* interpret as two's complement of `len` bytes */
+	neg = (be[0] & 0x80) != 0;
+	if (len == 16)
+		val = (__int128) mag;	/* full width: the bit pattern is the value */
+	else if (neg)
+		val = (__int128) mag - (((__int128) 1) << (8 * len));
+	else
+		val = (__int128) mag;
+
+	{
+		unsigned __int128 a = (val < 0) ? -(unsigned __int128) val
+			: (unsigned __int128) val;
+
+		if (a == 0)
+			digits[nd++] = '0';
+		while (a > 0)
+		{
+			digits[nd++] = (char) ('0' + (int) (a % 10));
+			a /= 10;
+		}
+	}
+	/* digits[] now holds the magnitude least-significant first */
+
+	if (val < 0)
+		buf[bi++] = '-';
+
+	if (scale <= 0)
+	{
+		for (i = nd - 1; i >= 0; i--)
+			buf[bi++] = digits[i];
+	}
+	else
+	{
+		int			intlen = nd - scale;	/* digits left of the point */
+		int			k;
+
+		if (intlen <= 0)
+		{
+			buf[bi++] = '0';
+			buf[bi++] = '.';
+			for (k = 0; k < -intlen; k++)
+				buf[bi++] = '0';			/* leading fractional zeros */
+			for (i = nd - 1; i >= 0; i--)
+				buf[bi++] = digits[i];
+		}
+		else
+		{
+			for (i = nd - 1; i >= scale; i--)
+				buf[bi++] = digits[i];
+			buf[bi++] = '.';
+			for (; i >= 0; i--)
+				buf[bi++] = digits[i];
+		}
+	}
+	buf[bi] = '\0';
+
+	*out = DirectFunctionCall3(numeric_in, CStringGetDatum(buf),
+							   ObjectIdGetDatum(InvalidOid), Int32GetDatum(-1));
+	return true;
 }
 
 /*
@@ -1292,6 +1383,19 @@ plain_value_to_datum(const PqColPlan *plan, const uint8 **p, const uint8 *end,
 					*ok = false;
 					return (Datum) 0;
 				}
+				if (plan->is_decimal)
+				{
+					Datum	   num;
+
+					if (!pq_decimal_to_numeric(cur, (int) blen,
+						   plan->dec_scale, &num))
+					{
+						*ok = false;
+						return (Datum) 0;
+					}
+					*p = cur + blen;
+					return num;
+				}
 				if (plan->typid == BYTEAOID)
 				{
 					bytea	   *b = (bytea *) palloc(blen + VARHDRSZ);
@@ -1304,6 +1408,51 @@ plain_value_to_datum(const PqColPlan *plan, const uint8 **p, const uint8 *end,
 				t = cstring_to_text_with_len((const char *) cur, blen);
 				*p = cur + blen;
 				return PointerGetDatum(t);
+			}
+			case PQ_FIXED_LEN_BYTE_ARRAY:
+			{
+				int	   flen = plan->type_length;
+
+				if (flen <= 0 || cur + flen > end)
+				{
+					*ok = false;
+					return (Datum) 0;
+				}
+				if (plan->is_decimal)
+				{
+					Datum	   num;
+
+					if (!pq_decimal_to_numeric(cur, flen, plan->dec_scale, &num))
+					{
+						*ok = false;
+						return (Datum) 0;
+					}
+					*p = cur + flen;
+					return num;
+				}
+				if (plan->typid == UUIDOID)
+				{
+					pg_uuid_t  *u;
+
+					if (flen != UUID_LEN)
+					{
+						*ok = false;
+						return (Datum) 0;
+					}
+					u = (pg_uuid_t *) palloc(sizeof(pg_uuid_t));
+					memcpy(u->data, cur, UUID_LEN);
+					*p = cur + flen;
+					return UUIDPGetDatum(u);
+				}
+				/* plain fixed-width bytes -> bytea */
+				{
+					bytea	   *b = (bytea *) palloc(flen + VARHDRSZ);
+
+					SET_VARSIZE(b, flen + VARHDRSZ);
+					memcpy(VARDATA(b), cur, flen);
+					*p = cur + flen;
+					return PointerGetDatum(b);
+				}
 			}
 		default:
 			*ok = false;
@@ -1770,9 +1919,22 @@ pq_leaf_sc(const PqFile *pf, int lf)
 static int
 pq_want_phys_for(Oid typid, const PqSchemaCol *sc)
 {
-	if (typid == TIMEOID && sc != NULL &&
-		sc->time_unit == PQ_TU_MILLIS && !sc->is_timestamp)
-		return PQ_INT32;
+	if (sc != NULL)
+	{
+		if (typid == TIMEOID &&
+			sc->time_unit == PQ_TU_MILLIS && !sc->is_timestamp)
+			return PQ_INT32;
+		/* uuid is a 16-byte fixed-length binary */
+		if (typid == UUIDOID)
+			return PQ_FIXED_LEN_BYTE_ARRAY;
+		/* DECIMAL stored as fixed or variable big-endian two's-complement bytes;
+		 * INT32/INT64-backed decimals are a follow-on (they also need a schema
+		 * mapping, which pq_leaf_to_pgtype does not yet advertise). */
+		if (typid == NUMERICOID && sc->converted_type == PQ_CT_DECIMAL &&
+			(sc->phys_type == PQ_FIXED_LEN_BYTE_ARRAY ||
+			 sc->phys_type == PQ_BYTE_ARRAY))
+			return sc->phys_type;
+	}
 	return pq_want_phys(typid);
 }
 
@@ -1971,6 +2133,10 @@ build_imp_targets(TupleDesc tupdesc, PqFile *pf,
 			get_typlenbyval(elemtype, &l->plan.typlen, &l->plan.typbyval);
 			l->plan.expect_phys = want;
 			l->plan.time_unit = pf->leaves[lf].sc->time_unit;
+			l->plan.type_length = pf->leaves[lf].sc->type_length;
+			l->plan.dec_scale = pf->leaves[lf].sc->scale;
+			l->plan.is_decimal = (l->plan.typid == NUMERICOID &&
+				pf->leaves[lf].sc->converted_type == PQ_CT_DECIMAL);
 			l->max_def = pf->leaves[lf].max_def;
 			l->max_rep = pf->leaves[lf].max_rep;
 			lf++;
@@ -2025,6 +2191,10 @@ build_imp_targets(TupleDesc tupdesc, PqFile *pf,
 				get_typlenbyval(fa->atttypid, &l->plan.typlen, &l->plan.typbyval);
 				l->plan.expect_phys = want;
 				l->plan.time_unit = pf->leaves[lf].sc->time_unit;
+				l->plan.type_length = pf->leaves[lf].sc->type_length;
+				l->plan.dec_scale = pf->leaves[lf].sc->scale;
+				l->plan.is_decimal = (l->plan.typid == NUMERICOID &&
+					pf->leaves[lf].sc->converted_type == PQ_CT_DECIMAL);
 				l->max_def = pf->leaves[lf].max_def;
 				l->max_rep = pf->leaves[lf].max_rep;
 				t->fieldLeaf[a] = lf;
@@ -2056,6 +2226,10 @@ build_imp_targets(TupleDesc tupdesc, PqFile *pf,
 			get_typlenbyval(typid, &l->plan.typlen, &l->plan.typbyval);
 			l->plan.expect_phys = want;
 			l->plan.time_unit = pf->leaves[lf].sc->time_unit;
+			l->plan.type_length = pf->leaves[lf].sc->type_length;
+			l->plan.dec_scale = pf->leaves[lf].sc->scale;
+			l->plan.is_decimal = (l->plan.typid == NUMERICOID &&
+				pf->leaves[lf].sc->converted_type == PQ_CT_DECIMAL);
 			l->max_def = pf->leaves[lf].max_def;
 			l->max_rep = pf->leaves[lf].max_rep;
 			lf++;

--- a/src/columnar_parquet_reader.c
+++ b/src/columnar_parquet_reader.c
@@ -1147,6 +1147,15 @@ pq_decimal_to_numeric(const uint8 *be, int len, int scale, Datum *out)
 
 	if (len < 1 || len > 16)
 		return false;
+	/*
+	 * Defence in depth against a crafted scale: the bind-time guard in
+	 * pq_want_phys_for already rejects scale outside [0, precision<=38], but this
+	 * function's zero-fill writes about scale bytes into a fixed buffer, so refuse
+	 * anything it could not hold even if reached another way. A negative scale
+	 * would also decode as an unscaled integer, a wrong value; reject it too.
+	 */
+	if (scale < 0 || scale > 38)
+		return false;
 
 	for (i = 0; i < len; i++)
 		mag = (mag << 8) | be[i];
@@ -1910,6 +1919,22 @@ pq_leaf_sc(const PqFile *pf, int lf)
 }
 
 /*
+ * Copy the schema-derived decode parameters for one leaf onto its plan. Called at
+ * each bind site once plan->typid and expect_phys are set. is_decimal keys off the
+ * already-set typid, so the decoder only treats bytes as a DECIMAL when the target
+ * really is numeric.
+ */
+static void
+pq_plan_bind_schema(PqColPlan *plan, const PqSchemaCol *sc)
+{
+	plan->time_unit = sc->time_unit;
+	plan->type_length = sc->type_length;
+	plan->dec_scale = sc->scale;
+	plan->is_decimal = (plan->typid == NUMERICOID &&
+						sc->converted_type == PQ_CT_DECIMAL);
+}
+
+/*
  * The Parquet physical type a target PostgreSQL type must be stored as, for one
  * specific source column. Only `time` is column-dependent: Parquet spells
  * TIME_MILLIS as INT32 and TIME_MICROS/TIME_NANOS as INT64, so the same
@@ -1929,8 +1954,13 @@ pq_want_phys_for(Oid typid, const PqSchemaCol *sc)
 			return PQ_FIXED_LEN_BYTE_ARRAY;
 		/* DECIMAL stored as fixed or variable big-endian two's-complement bytes;
 		 * INT32/INT64-backed decimals are a follow-on (they also need a schema
-		 * mapping, which pq_leaf_to_pgtype does not yet advertise). */
+		 * mapping, which pq_leaf_to_pgtype does not yet advertise). precision and
+		 * scale come straight from the footer, so bound them the same way the
+		 * schema-advice path (pq_leaf_to_pgtype) does before the decoder trusts
+		 * scale: an unvalidated scale drives pq_decimal_to_numeric's zero-fill. */
 		if (typid == NUMERICOID && sc->converted_type == PQ_CT_DECIMAL &&
+			sc->precision >= 1 && sc->precision <= 38 &&
+			sc->scale >= 0 && sc->scale <= sc->precision &&
 			(sc->phys_type == PQ_FIXED_LEN_BYTE_ARRAY ||
 			 sc->phys_type == PQ_BYTE_ARRAY))
 			return sc->phys_type;
@@ -2132,11 +2162,7 @@ build_imp_targets(TupleDesc tupdesc, PqFile *pf,
 			l->plan.typid = elemtype;
 			get_typlenbyval(elemtype, &l->plan.typlen, &l->plan.typbyval);
 			l->plan.expect_phys = want;
-			l->plan.time_unit = pf->leaves[lf].sc->time_unit;
-			l->plan.type_length = pf->leaves[lf].sc->type_length;
-			l->plan.dec_scale = pf->leaves[lf].sc->scale;
-			l->plan.is_decimal = (l->plan.typid == NUMERICOID &&
-				pf->leaves[lf].sc->converted_type == PQ_CT_DECIMAL);
+			pq_plan_bind_schema(&l->plan, pf->leaves[lf].sc);
 			l->max_def = pf->leaves[lf].max_def;
 			l->max_rep = pf->leaves[lf].max_rep;
 			lf++;
@@ -2190,11 +2216,7 @@ build_imp_targets(TupleDesc tupdesc, PqFile *pf,
 				l->plan.typid = fa->atttypid;
 				get_typlenbyval(fa->atttypid, &l->plan.typlen, &l->plan.typbyval);
 				l->plan.expect_phys = want;
-				l->plan.time_unit = pf->leaves[lf].sc->time_unit;
-				l->plan.type_length = pf->leaves[lf].sc->type_length;
-				l->plan.dec_scale = pf->leaves[lf].sc->scale;
-				l->plan.is_decimal = (l->plan.typid == NUMERICOID &&
-					pf->leaves[lf].sc->converted_type == PQ_CT_DECIMAL);
+				pq_plan_bind_schema(&l->plan, pf->leaves[lf].sc);
 				l->max_def = pf->leaves[lf].max_def;
 				l->max_rep = pf->leaves[lf].max_rep;
 				t->fieldLeaf[a] = lf;
@@ -2225,11 +2247,7 @@ build_imp_targets(TupleDesc tupdesc, PqFile *pf,
 			l->plan.typid = typid;
 			get_typlenbyval(typid, &l->plan.typlen, &l->plan.typbyval);
 			l->plan.expect_phys = want;
-			l->plan.time_unit = pf->leaves[lf].sc->time_unit;
-			l->plan.type_length = pf->leaves[lf].sc->type_length;
-			l->plan.dec_scale = pf->leaves[lf].sc->scale;
-			l->plan.is_decimal = (l->plan.typid == NUMERICOID &&
-				pf->leaves[lf].sc->converted_type == PQ_CT_DECIMAL);
+			pq_plan_bind_schema(&l->plan, pf->leaves[lf].sc);
 			l->max_def = pf->leaves[lf].max_def;
 			l->max_rep = pf->leaves[lf].max_rep;
 			lf++;

--- a/test/native_parquet_flba.sh
+++ b/test/native_parquet_flba.sh
@@ -83,6 +83,103 @@ PY
 	check "pyarrow decimal128 values are exact" \
 		"$(pgc_set_hash "SELECT d FROM pgcolumnar.read_parquet('$W/pa_dec.parquet') AS t(d numeric(10,2))")" \
 		"$(pgc_set_hash "SELECT * FROM (VALUES (123.45::numeric(10,2)),(-9999.99),(0.01),(0.00)) v(d)")"
+
+	# ---- crafted out-of-range scale must be rejected, not decoded -----------
+	# The DECIMAL scale comes straight from the footer, and left unvalidated it
+	# drives pq_decimal_to_numeric's zero-fill (~scale bytes) into a fixed stack
+	# buffer: a large scale is a stack smash on a crafted file. Rewrite the schema
+	# element's scale field (SchemaElement field 7) in a decimal128(10,2) file from
+	# 2 to 50 -- out of range (> precision, > 38) but small enough that the
+	# unguarded decoder does NOT crash: it decodes a (wrong) value with no error.
+	# The guard must instead reject the bind. zigzag(2)=0x04 and zigzag(50)=0x64 are
+	# both one byte, so the edit is in place and the footer stays well-formed.
+	python3 - "$W" <<'PY'
+import sys, decimal, pyarrow as pa, pyarrow.parquet as pq
+W = sys.argv[1]
+pq.write_table(pa.table({"d": pa.array([decimal.Decimal("1.23")], pa.decimal128(10, 2))}),
+               f"{W}/dec_badscale.parquet")
+raw = bytearray(open(f"{W}/dec_badscale.parquet", "rb").read())
+flen = int.from_bytes(raw[-8:-4], "little")
+pos = len(raw) - 8 - flen
+
+def varint():
+    global pos
+    sh = 0; out = 0
+    while True:
+        b = raw[pos]; pos += 1
+        out |= (b & 0x7F) << sh
+        if not b & 0x80: return out
+        sh += 7
+def zigzag():
+    u = varint(); return (u >> 1) ^ -(u & 1)
+def field(last):
+    global pos
+    b = raw[pos]; pos += 1
+    if b == 0: return 0, 0, last
+    t = b & 0x0F; d = b >> 4
+    fid = last + d if d else zigzag()
+    return t, fid, fid
+def skip(t):
+    global pos
+    if t in (1, 2): return
+    if t == 3: pos += 1
+    elif t in (4, 5, 6): zigzag()
+    elif t == 7: pos += 8
+    elif t == 8:
+        blen = varint()      # advance past the length bytes, then the content;
+        pos += blen          # `pos += varint()` would drop the length advance
+    elif t in (9, 10):
+        b = raw[pos]; pos += 1
+        n = (b >> 4) & 0x0F; et = b & 0x0F
+        if n == 0x0F: n = varint()
+        for _ in range(n): skip(et)
+    elif t == 12:
+        last = 0
+        while True:
+            ft, _f, last = field(last)
+            if ft == 0: break
+            skip(ft)
+
+# FileMetaData field 2 is the schema list<SchemaElement>; the scale (field 7) sits
+# on the leaf element. Walk to it and patch the one byte in place.
+patched = False
+last = 0
+while not patched:
+    ft, fid, last = field(last)
+    if ft == 0: break
+    if fid == 2 and ft in (9, 10):
+        b = raw[pos]; pos += 1
+        n = (b >> 4) & 0x0F; et = b & 0x0F
+        if n == 0x0F: n = varint()
+        for _ in range(n):
+            elast = 0
+            while True:
+                eft, efid, elast = field(elast)
+                if eft == 0: break
+                if efid == 7 and eft in (5, 6, 4):
+                    assert raw[pos] == 0x04, hex(raw[pos])   # zigzag(2)
+                    raw[pos] = 0x64                           # zigzag(50)
+                    patched = True
+                    break
+                skip(eft)
+            if patched: break
+        break
+    skip(ft)
+assert patched, "did not find a scale field to patch"
+open(f"{W}/dec_badscale.parquet", "wb").write(bytes(raw))
+print("  patched scale 2 -> 50", file=sys.stderr)
+PY
+
+	psql_run "CREATE FUNCTION pgc_try_flba(q text) RETURNS text LANGUAGE plpgsql AS \$\$
+	          BEGIN EXECUTE q; RETURN 'NO ERROR';
+	          EXCEPTION WHEN OTHERS THEN RETURN 'REJECTED'; END \$\$;"
+	# Fixed: the bind guard rejects scale > precision/38 -> REJECTED. Unguarded: the
+	# decoder accepts it and returns a wrong-but-valid numeric -> NO ERROR. So this
+	# check distinguishes fixed from unfixed without depending on a crash.
+	check "crafted out-of-range scale is rejected, not decoded" \
+		"$(q "SELECT pgc_try_flba(\$q\$SELECT * FROM pgcolumnar.read_parquet('$W/dec_badscale.parquet') AS t(d numeric)\$q\$);")" \
+		"REJECTED"
+	check "backend survived the crafted scale" "$(q 'SELECT 1;')" "1"
 else
 	echo "SKIP  pyarrow not available; foreign-producer FLBA cases skipped"
 fi

--- a/test/native_parquet_flba.sh
+++ b/test/native_parquet_flba.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# pgColumnar Parquet FIXED_LEN_BYTE_ARRAY read coverage (Phase G).
+#
+# The reader advertises uuid and numeric(p,s) for FLBA columns via
+# parquet_schema(), and the exporter writes both. This suite covers the read side
+# that made those advertisements truthful: uuid as a 16-byte FLBA, and DECIMAL as
+# a big-endian two's-complement integer at the column's scale, in either a fixed
+# (FLBA) or variable (BYTE_ARRAY) width. It rounds our own export back through the
+# reader and also reads pyarrow-written files, and checks correctness against a
+# heap oracle.
+#
+# Usage:  test/native_parquet_flba.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+have_pyarrow=0
+python3 -c 'import pyarrow.parquet' 2>/dev/null && have_pyarrow=1
+
+W="$PGC_WORKDIR"
+psql_run "CREATE SERVER pq FOREIGN DATA WRAPPER pgcolumnar_parquet;"
+
+# ---- round-trip our own exporter (uuid + numeric via FLBA) -----------------
+psql_run "CREATE TABLE src (
+            id int,
+            u  uuid,
+            d  numeric(12,4),
+            dn numeric(12,4),
+            fb bytea)
+          USING pgcolumnar;"
+psql_run "INSERT INTO src VALUES
+            (1, '11111111-2222-3333-4444-555555555555', 123.4500, -0.0001, '\\xdeadbeef'),
+            (2, 'ffffffff-ffff-ffff-ffff-ffffffffffff', -9999.9999, 0, '\\x00'),
+            (3, '00000000-0000-0000-0000-000000000000', 0.0000, 42.0, NULL);"
+
+EXP="$W/roundtrip.parquet"
+psql_run "SELECT pgcolumnar.export_parquet('src'::regclass, '$EXP');"
+
+# read_parquet must return exactly what the heap holds
+check "uuid round-trips through export/read" \
+	"$(pgc_set_hash "SELECT id, u FROM pgcolumnar.read_parquet('$EXP') AS t(id int, u uuid, d numeric(12,4), dn numeric(12,4), fb bytea)")" \
+	"$(pgc_set_hash "SELECT id, u FROM src")"
+check "numeric round-trips through export/read" \
+	"$(pgc_set_hash "SELECT id, d, dn FROM pgcolumnar.read_parquet('$EXP') AS t(id int, u uuid, d numeric(12,4), dn numeric(12,4), fb bytea)")" \
+	"$(pgc_set_hash "SELECT id, d, dn FROM src")"
+check "whole-row round-trip == source" \
+	"$(pgc_set_hash "SELECT * FROM pgcolumnar.read_parquet('$EXP') AS t(id int, u uuid, d numeric(12,4), dn numeric(12,4), fb bytea)")" \
+	"$(pgc_set_hash "SELECT * FROM src")"
+
+# import_parquet shares the decoder
+psql_run "CREATE TABLE imp (id int, u uuid, d numeric(12,4), dn numeric(12,4), fb bytea);"
+psql_run "SELECT pgcolumnar.import_parquet('imp'::regclass, '$EXP');"
+check "import_parquet == source" \
+	"$(pgc_set_hash "SELECT * FROM imp")" "$(pgc_set_hash "SELECT * FROM src")"
+
+# FDW surface
+psql_run "CREATE FOREIGN TABLE ft (id int, u uuid, d numeric(12,4), dn numeric(12,4), fb bytea)
+          SERVER pq OPTIONS (path '$EXP');"
+check "FDW scan == source" \
+	"$(pgc_set_hash "SELECT * FROM ft")" "$(pgc_set_hash "SELECT * FROM src")"
+
+# ---- pyarrow-written files (foreign producer) ------------------------------
+if [ "$have_pyarrow" = 1 ]; then
+	python3 - "$W" <<'PY'
+import sys, uuid, decimal, pyarrow as pa, pyarrow.parquet as pq
+W = sys.argv[1]
+us = [uuid.UUID('11111111-2222-3333-4444-555555555555').bytes,
+      uuid.UUID('00000000-0000-0000-0000-000000000000').bytes]
+pq.write_table(pa.table({"u": pa.array(us, pa.binary(16))}), f"{W}/pa_uuid.parquet")
+# decimal128 -> FLBA; a range that stresses sign and scale
+ds = [decimal.Decimal("123.45"), decimal.Decimal("-9999.99"),
+      decimal.Decimal("0.01"), decimal.Decimal("0.00")]
+pq.write_table(pa.table({"d": pa.array(ds, pa.decimal128(10, 2))}), f"{W}/pa_dec.parquet")
+PY
+	# uuid stored as raw bytes; declare bytea to compare, since pyarrow gives no
+	# uuid logical type, then also read as uuid (our exporter's convention).
+	check "pyarrow uuid reads as uuid" \
+		"$(q "SELECT u::text FROM pgcolumnar.read_parquet('$W/pa_uuid.parquet') AS t(u uuid) ORDER BY u LIMIT 1;")" \
+		"00000000-0000-0000-0000-000000000000"
+	check "pyarrow decimal128 values are exact" \
+		"$(pgc_set_hash "SELECT d FROM pgcolumnar.read_parquet('$W/pa_dec.parquet') AS t(d numeric(10,2))")" \
+		"$(pgc_set_hash "SELECT * FROM (VALUES (123.45::numeric(10,2)),(-9999.99),(0.01),(0.00)) v(d)")"
+else
+	echo "SKIP  pyarrow not available; foreign-producer FLBA cases skipped"
+fi
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -27,7 +27,7 @@ SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUITES=(harness_selftest smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
 	differential recovery fuzz hardening concurrent_diff parallel sorted_projection \
 	arrow_export parquet_export read_stream corruption \
-	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip native_index native_dml native_ios native_projection native_cluster native_compact native_recluster native_reclaim native_ownership native_reclaim_cycles native_reclaim_frag native_gap native_truncate native_rewrite native_rewrite_conc native_parquet_schema native_read_parquet native_parquet_fdw native_parquet_pushdown native_parquet_hardening native_parquet_units isolation)
+	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap native_skip native_agg native_bloom native_vecskip native_index native_dml native_ios native_projection native_cluster native_compact native_recluster native_reclaim native_ownership native_reclaim_cycles native_reclaim_frag native_gap native_truncate native_rewrite native_rewrite_conc native_parquet_schema native_read_parquet native_parquet_fdw native_parquet_pushdown native_parquet_hardening native_parquet_units native_parquet_flba isolation)
 
 # Default matrix: one assert-enabled pg_config per major, 15 through 19.
 DEFAULT_CONFIGS=(


### PR DESCRIPTION
First of the Phase G read-coverage follow-ons.

## The gap

`parquet_schema()` advertised `uuid` and `numeric(p,s)` for FIXED_LEN_BYTE_ARRAY
columns, and the exporter writes both — but the reader had no
`PQ_FIXED_LEN_BYTE_ARRAY` decode case (it fell through to `default: *ok = false`)
and `pq_want_phys` rejected the bind outright. So reading any FLBA column errored,
**including our own exported uuid files**:

```
schema(uuid file):  uuid
read uuid file:     ERROR: column "u" has type uuid, which ... does not support
schema(decimal):    numeric(10,2)
read decimal file:  ERROR: ... does not support
```

Advertise-a-type-you-cannot-read — the same class as the narrowing, NaN, and
time-unit fixes earlier in Phase G.

## The fix

The decoder now handles FLBA, and DECIMAL over either FLBA or BYTE_ARRAY:

- **uuid** — a 16-byte FLBA copied straight into a `pg_uuid_t`.
- **numeric** — DECIMAL as a big-endian two's-complement integer at the column's
  scale, fixed-width (FLBA) or variable (BYTE_ARRAY). `pq_decimal_to_numeric`
  inverts the exporter's `numeric_to_int128` plus its byte-swap and matches
  pyarrow's `decimal128` layout: up to 16 bytes (DECIMAL(38)), rendered to
  canonical text and parsed by `numeric_in`. A wider `decimal256` returns a clean
  decode error rather than a wrong value.
- **any other FLBA** — raw bytes as `bytea`.

`pq_want_phys_for()` accepts uuid (always FLBA) and numeric (the file's physical
type when DECIMAL-annotated over FLBA/BYTE_ARRAY), and the three plan-build sites
carry `type_length` and `scale` onto `PqColPlan`, the same way `time_unit` is
plumbed.

**Deliberately deferred:** INT32/INT64-backed decimals. They also need a schema
mapping that `pq_leaf_to_pgtype` does not yet advertise, so declaring `numeric`
over one still errors cleanly at bind rather than decoding wrongly. Kept out to
keep schema advice and decode consistent within this PR; noted as a follow-on.

## Tests

`test/native_parquet_flba.sh` rounds uuid and numeric — negatives, zeros,
sub-unit values, NULL — through our own `export_parquet` and back via
`read_parquet`, `import_parquet`, and the FDW, each against a heap oracle. It also
reads pyarrow-written `binary(16)` and `decimal128` files, so a foreign producer
is covered, not just our own round-trip. Fails against `main` with seven failures.

## Verification

PG18 + PG19 dev gate green (the per-PR cadence); the full 15-19 matrix runs at the
completion of the read-coverage feature set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
