### PR TITLE
test: fail the clean-rebuild on compiler warnings

### DIFF
--- a/test/rebuild.sh
+++ b/test/rebuild.sh
@@ -86,6 +86,15 @@ if ! make PG_CONFIG="$PG_CONFIG" -j"$(nproc)" > "$buildlog" 2>&1; then
 fi
 warns="$(grep -cE 'warning:' "$buildlog")"
 echo "-- build: OK ($warns warnings)"
+# The version matrix (run_all_versions.sh) treats any compiler warning as a
+# failure, so the dev inner loop must too -- otherwise a warning slips through
+# here and only surfaces at the gate. Set PGC_ALLOW_WARNINGS=1 to override for a
+# deliberate warning-tolerant build.
+if [ "$warns" -gt 0 ] && [ -z "${PGC_ALLOW_WARNINGS:-}" ]; then
+	echo "rebuild: $warns compiler warning(s) -- the matrix gate rejects these" >&2
+	grep -E 'warning:' "$buildlog" | head -20 >&2
+	exit 1
+fi
 
 if ! make PG_CONFIG="$PG_CONFIG" install >/dev/null 2>&1; then
 	echo "rebuild: INSTALL FAILED" >&2


### PR DESCRIPTION
rebuild.sh counted warnings but did not fail on them, while run_all_versions.sh treats any compiler warning as a failure. A warning could pass the dev inner loop and only surface at the gate (this is how a `-Wdeclaration-after-statement` warning reached a full matrix run). rebuild.sh — and thus devloop.sh, which treats a rebuild failure as fatal — now exits non-zero on any warning, matching the gate. `PGC_ALLOW_WARNINGS=1` overrides for a deliberate warning-tolerant build.

Test-tooling only; no extension code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)