### PR TITLE
Parquet path resolution: drop only what we know is not a file

### DIFF
--- a/src/columnar_parquet_reader.c
+++ b/src/columnar_parquet_reader.c
@@ -2415,13 +2415,32 @@ pq_has_parquet_ext(const char *name)
 	return n >= 8 && pg_strcasecmp(name + n - 8, ".parquet") == 0;
 }
 
-/* true if path is a regular file (not a directory, symlink to a dir, etc.) */
+/*
+ * Whether a path produced by a directory listing or a glob expansion should be
+ * handed to the reader.
+ *
+ * The test is not "is this a regular file" but "do we know what it is". A path we
+ * cannot stat is kept, so the reader's open reports it by name with errno
+ * (a dangling symlink, a parent that denies search, a symlink loop); dropping it
+ * here would turn those into a query that succeeds with fewer rows, which is the
+ * one failure a read surface must not produce.
+ *
+ * A directory is skipped: a foo.parquet directory is a normal thing to find in a
+ * Hive-style tree, and before this it reached the parser as "not a Parquet file".
+ * Any other non-regular entry is skipped too, and that exclusion is not
+ * cosmetic: AllocateFile() on a FIFO blocks in open(2) until a writer appears,
+ * and because the signal handlers are installed with SA_RESTART the open resumes
+ * rather than failing with EINTR, so a query cancel does not reliably get the
+ * backend back.
+ */
 static bool
-pq_is_regular_file(const char *path)
+pq_path_is_candidate(const char *path)
 {
 	struct stat st;
 
-	return stat(path, &st) == 0 && S_ISREG(st.st_mode);
+	if (stat(path, &st) != 0)
+		return true;			/* unknown: let the caller's open report it */
+	return S_ISREG(st.st_mode);
 }
 
 /*
@@ -2445,6 +2464,7 @@ pq_resolve_paths(const char *path)
 	{
 		DIR		   *dir = AllocateDir(path);
 		struct dirent *de;
+		int			skipped = 0;
 
 		if (dir == NULL)
 			ereport(ERROR,
@@ -2457,19 +2477,25 @@ pq_resolve_paths(const char *path)
 			{
 				char	   *full = psprintf("%s/%s", path, de->d_name);
 
-				/* an entry named *.parquet that is a subdirectory, not a file,
-				 * is skipped rather than read and failed on */
-				if (pq_is_regular_file(full))
+				if (pq_path_is_candidate(full))
 					files = lappend(files, full);
 				else
+				{
+					skipped++;
 					pfree(full);
+				}
 			}
 		}
 		FreeDir(dir);
 		if (files == NIL)
 			ereport(ERROR,
 					(errcode(ERRCODE_UNDEFINED_FILE),
-					 errmsg("directory \"%s\" contains no .parquet files", path)));
+					 errmsg("directory \"%s\" contains no .parquet files", path),
+			/* say why a name the user can see in the listing did not count */
+					 skipped > 0 ?
+					 errdetail_plural("%d matching name is not a regular file.",
+									  "%d matching names are not regular files.",
+									  skipped, skipped) : 0));
 		list_sort(files, pq_list_str_cmp);
 		return files;
 	}
@@ -2497,7 +2523,7 @@ pq_resolve_paths(const char *path)
 					 errmsg("could not expand pattern \"%s\"", path)));
 		}
 		for (i = 0; i < g.gl_pathc; i++)
-			if (pq_is_regular_file(g.gl_pathv[i]))
+			if (pq_path_is_candidate(g.gl_pathv[i]))
 				files = lappend(files, pstrdup(g.gl_pathv[i]));
 		globfree(&g);
 		if (files == NIL)

--- a/test/native_parquet_multifile.sh
+++ b/test/native_parquet_multifile.sh
@@ -141,4 +141,40 @@ check "glob skips a directory match, reads the files" \
 	"$oracle"
 rmdir "$DIR/part-9.parquet"
 
+# a glob whose every match is a directory has nothing to read and must say so
+mkdir -p "$W/onlydirs/a.parquet" "$W/onlydirs/b.parquet"
+check "glob matching only directories errors" \
+	"$(errs "SELECT * FROM pgcolumnar.read_parquet('$W/onlydirs/*.parquet') AS t($cols)")" "OK"
+check "directory of only *.parquet subdirs errors" \
+	"$(errs "SELECT * FROM pgcolumnar.read_parquet('$W/onlydirs') AS t($cols)")" "OK"
+rmdir "$W/onlydirs/a.parquet" "$W/onlydirs/b.parquet"
+
+# A path we cannot stat must NOT be dropped: a dangling symlink named *.parquet
+# has to surface as an error naming the file, not as a query that quietly returns
+# the other files' rows. Silent row loss is the failure this reader must not have.
+ln -s "$DIR/does-not-exist.parquet" "$DIR/broken.parquet"
+check "dangling symlink in directory errors, not skipped" \
+	"$(errs "SELECT count(*) FROM pgcolumnar.read_parquet('$DIR') AS t($cols)")" "OK"
+check "dangling symlink in a glob errors, not skipped" \
+	"$(errs "SELECT count(*) FROM pgcolumnar.read_parquet('$DIR/*.parquet') AS t($cols)")" "OK"
+rm -f "$DIR/broken.parquet"
+
+# A FIFO must be skipped rather than opened: AllocateFile() on a FIFO blocks in
+# open(2) until a writer appears, and with SA_RESTART handlers a query cancel
+# does not reliably return the backend. The timeout is the real assertion here;
+# without it a regression hangs the suite instead of failing it.
+if mkfifo "$DIR/pipe.parquet" 2>/dev/null; then
+	fifo_out="$(timeout 30 env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 \
+		-p "$PGC_PORT" -U postgres -d "$PGC_DB" -At \
+		-c "SELECT count(*) FROM pgcolumnar.read_parquet('$DIR') AS t($cols)" 2>&1)"
+	fifo_rc=$?
+	if [ "$fifo_rc" = 124 ]; then
+		fifo_out="TIMED OUT (blocked opening the FIFO)"
+	fi
+	check "FIFO named *.parquet is skipped, does not block" "$fifo_out" "3000"
+	rm -f "$DIR/pipe.parquet"
+else
+	echo "SKIP  mkfifo unavailable; FIFO case not exercised"
+fi
+
 pgc_summary


### PR DESCRIPTION
Fixes #114, taking the refinement from the issue thread rather than the fix the issue originally proposed.

## The bug

#113 filtered directory and glob matches with `S_ISREG`, which also swallowed every `stat` failure. A dangling symlink named `part-3.parquet`, a parent that denies search, or a symlink loop was skipped silently, so the query succeeded and returned the other files' rows. A read surface returning fewer rows with no error is the one failure mode it must not have.

## Why not "skip S_ISDIR only"

That was the issue's proposal, and it would regress a case #113 fixed: `AllocateFile()` on a FIFO blocks in `open(2)` until a writer appears, and because the signal handlers carry `SA_RESTART` the open resumes rather than failing with `EINTR`, so a query cancel does not reliably get the backend back. A `mkfifo part-3.parquet` in a read directory would hang the session. That catch is ChronicallyJD's, from the review thread on #114.

## What it does

The test is now "do we know what it is", not "is it a regular file":

- `stat` fails: keep the path, and let the reader's open report it by name with errno, which is what happened before #113.
- `S_ISDIR`: skip. A `foo.parquet` directory is normal in a Hive-style tree.
- Any other non-regular entry: skip, for the FIFO reason above.

The directory `contains no .parquet files` error gains a detail line counting the matching names that were not regular files, so a user who can see `foo.parquet` in the listing is told why it did not count. The glob's `matched no regular files` stays accurate: under the new rule the only filtered entries are ones `stat` proved are not files.

## Tests

Four new checks in `test/native_parquet_multifile.sh`, 23 total:

- A dangling symlink raises through the directory path and through the glob path. **Both verified to FAIL on the pre-fix code** with `got [NO ERROR] want [OK]`, which is exactly the silent row loss this fixes.
- A glob whose every match is a directory, and a directory holding only `*.parquet` subdirectories, both error. This covers the branch #113 added without coverage.
- A FIFO named `*.parquet` is skipped rather than opened, asserted under a 30 second `timeout` so a regression fails the suite instead of hanging it. This one passes on both sides by design: it pins the behaviour #113 introduced and this change deliberately keeps.

## Gate

PostgreSQL 18.4 and 19beta2, all 61 suites, `ALL VERSIONS PASSED`, no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
