### PR TITLE
Parquet: read a DECIMAL held in an INT32 or INT64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,9 @@ unreleased. For the forward-looking plan see
   `MaxAllocSize`; that ceiling is gone. A row group excluded by predicate
   pushdown is now never read from disk, and `pgcolumnar.parquet_schema` reads
   only the footer.
+- A Parquet DECIMAL is also read when it is stored as an INT32 or INT64 holding
+  the unscaled integer, which is how writers store small precisions;
+  `pgcolumnar.parquet_schema` advises `numeric(p,s)` for those columns.
 - Parquet read type coverage extended to uuid and numeric (from fixed and
   variable DECIMAL, precision up to 38), fixed-length binary, and millisecond,
   microsecond, and nanosecond time units.

--- a/design/ROADMAP.md
+++ b/design/ROADMAP.md
@@ -36,6 +36,7 @@ matrix. Gap specifications are in [gaps/](gaps/).
 | Multi-file reads: a directory of `*.parquet` or a glob read as one relation | Phase G |
 | Reader hardening against crafted files (scale/size/chunk-count guards, NaN and inverted stats) | Phase G |
 | Streaming Parquet reads: footer plus one page at a time, no whole-file load, no size ceiling | Phase G |
+| DECIMAL read from INT32/INT64 as well as fixed and variable byte arrays | Phase G |
 | **Phase G read surface complete** — external Parquet read, pushdown, multi-file, streaming, all matrix-gated | Phase G |
 
 ## Remaining
@@ -168,8 +169,8 @@ are directions to investigate and spec, not validated recommendations:
 - External Parquet read with predicate and projection pushdown is done (Phase G,
   see above). What remains here: ORC, open table formats (Apache Iceberg, Delta
   Lake, Hudi), and, within Parquet, Hive-style partition pruning, recursive
-  directory walks, and INT32/INT64-backed DECIMAL reads. Streaming reads are done
-  (see Done above): a file is read a page at a time rather than loaded whole.
+  directory walks. Streaming reads and INT32/INT64-backed DECIMAL reads are done
+  (see Done above).
 - Arrow C Data Interface zero-copy export, and Arrow Flight SQL or ADBC access.
 - New PostgreSQL 17-19 integration points: read stream and asynchronous IO (partly
   used), `MERGE`, incremental materialized views (pg_ivm), logical decoding of

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -147,7 +147,8 @@ listed are rejected.
 
 `uuid` is imported from a 16-byte fixed-length binary column, and `numeric` from
 a DECIMAL column stored as fixed or variable big-endian bytes with precision up
-to 38. A DECIMAL backed by an INT32 or INT64 physical column is not yet read.
+to 38, or from an INT32 or INT64 holding the unscaled integer, which is how
+writers store small precisions.
 
 `numeric` needs a declared precision for a Parquet round trip. The exporter
 writes DECIMAL only for a column declared `numeric(p,s)` with `p` up to 38; a

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -208,8 +208,9 @@ correct rows; these are the conditions under which it can skip at all:
   from `PREPARE`, does not drive skipping. This is deliberate: the skip set is
   computed once when the scan starts and reused across rescans.
 - The column must be stored as a Parquet INT32, INT64, FLOAT, or DOUBLE. Text,
-  bytea, uuid, numeric, and boolean columns are filtered but never skipped,
-  whatever their statistics.
+  bytea, uuid, and boolean columns are filtered but never skipped, whatever their
+  statistics. A `numeric` column follows its storage: one written as an INT32 or
+  INT64 DECIMAL does skip, one written as a byte-array DECIMAL does not.
 - The constant's type must match the column's type exactly. A cross-type
   comparison such as `ts >= DATE '2026-01-01'` against a `timestamp` column, or
   `bigint_col > 5::int`, does not skip.

--- a/src/columnar_parquet_reader.c
+++ b/src/columnar_parquet_reader.c
@@ -1258,6 +1258,50 @@ pq_scale_to_usecs(int unit, int64 v, int64 *out)
 }
 
 /*
+ * The DECIMAL precision and scale a file declares, and the PostgreSQL typmod they
+ * map to. One implementation, used by both the schema-advice path and the bind
+ * path, so a file can never be described one way and bound another. The bound
+ * matters beyond tidiness: pq_decimal_to_numeric zero-fills about `scale` bytes
+ * into a fixed buffer, so an unvalidated scale is a stack overflow.
+ */
+static inline bool
+pq_decimal_bounds_ok(const PqSchemaCol *sc)
+{
+	return sc->precision >= 1 && sc->precision <= 38 &&
+		sc->scale >= 0 && sc->scale <= sc->precision;
+}
+
+static inline int32
+pq_decimal_typmod(const PqSchemaCol *sc)
+{
+	return (int32) (((sc->precision << 16) | (sc->scale & 0xffff)) + VARHDRSZ);
+}
+
+/*
+ * Build a numeric Datum from a DECIMAL held in an INT32 or INT64. Parquet stores
+ * that form as the plain little-endian integer, not as the big-endian bytes the
+ * byte-array forms use, so it is widened into a big-endian buffer and handed to
+ * the one conversion that knows about scale. Sign-extending into the buffer keeps
+ * negatives correct: pq_decimal_to_numeric reads the top bit of the first byte.
+ */
+static bool pq_decimal_to_numeric(const uint8 *be, int len, int scale, Datum *out);
+
+static bool
+pq_int_decimal_to_numeric(int64 v, int width, int scale, Datum *out)
+{
+	uint8		be[8];
+	int			i;
+
+	Assert(width == 4 || width == 8);
+	for (i = width - 1; i >= 0; i--)
+	{
+		be[i] = (uint8) (v & 0xff);
+		v >>= 8;
+	}
+	return pq_decimal_to_numeric(be, width, scale, out);
+}
+
+/*
  * Build a numeric Datum from a DECIMAL stored as `len` big-endian two's-complement
  * bytes at the given scale -- the inverse of the exporter's numeric_to_int128 plus
  * its byte-swap, and the layout pyarrow writes for decimal128. Values up to 16
@@ -1404,6 +1448,18 @@ plain_value_to_datum(const PqColPlan *plan, const uint8 **p, const uint8 *end,
 				}
 				memcpy(&v, cur, 4);
 				*p = cur + 4;
+				if (plan->is_decimal)
+				{
+					Datum		num;
+
+					if (!pq_int_decimal_to_numeric((int64) v, 4,
+												   plan->dec_scale, &num))
+					{
+						*ok = false;
+						return (Datum) 0;
+					}
+					return num;
+				}
 				if (plan->typid == INT2OID)
 				{
 					if (v < PG_INT16_MIN || v > PG_INT16_MAX)
@@ -1448,6 +1504,17 @@ plain_value_to_datum(const PqColPlan *plan, const uint8 **p, const uint8 *end,
 				}
 				memcpy(&v, cur, 8);
 				*p = cur + 8;
+				if (plan->is_decimal)
+				{
+					Datum		num;
+
+					if (!pq_int_decimal_to_numeric(v, 8, plan->dec_scale, &num))
+					{
+						*ok = false;
+						return (Datum) 0;
+					}
+					return num;
+				}
 				if (plan->typid == TIMESTAMPOID || plan->typid == TIMESTAMPTZOID)
 				{
 					int64		us;
@@ -2320,17 +2387,17 @@ pq_want_phys_for(Oid typid, const PqSchemaCol *sc)
 		/* uuid is a 16-byte fixed-length binary */
 		if (typid == UUIDOID)
 			return PQ_FIXED_LEN_BYTE_ARRAY;
-		/* DECIMAL stored as fixed or variable big-endian two's-complement bytes;
-		 * INT32/INT64-backed decimals are a follow-on (they also need a schema
-		 * mapping, which pq_leaf_to_pgtype does not yet advertise). precision and
-		 * scale come straight from the footer, so bound them the same way the
-		 * schema-advice path (pq_leaf_to_pgtype) does before the decoder trusts
-		 * scale: an unvalidated scale drives pq_decimal_to_numeric's zero-fill. */
+		/* DECIMAL as fixed or variable big-endian two's-complement bytes, or as
+		 * an INT32/INT64 holding the unscaled integer (what writers use for small
+		 * precisions). precision and scale come straight from the footer, so they
+		 * are bounded before the decoder trusts scale: an unvalidated scale drives
+		 * pq_decimal_to_numeric's zero-fill. */
 		if (typid == NUMERICOID && sc->converted_type == PQ_CT_DECIMAL &&
-			sc->precision >= 1 && sc->precision <= 38 &&
-			sc->scale >= 0 && sc->scale <= sc->precision &&
+			pq_decimal_bounds_ok(sc) &&
 			(sc->phys_type == PQ_FIXED_LEN_BYTE_ARRAY ||
-			 sc->phys_type == PQ_BYTE_ARRAY))
+			 sc->phys_type == PQ_BYTE_ARRAY ||
+			 sc->phys_type == PQ_INT32 ||
+			 sc->phys_type == PQ_INT64))
 			return sc->phys_type;
 	}
 	return pq_want_phys(typid);
@@ -2359,6 +2426,12 @@ pq_leaf_to_pgtype(const PqSchemaCol *sc, Oid *typid, int32 *typmod)
 			*typid = BOOLOID;
 			return true;
 		case PQ_INT32:
+			if (ct == PQ_CT_DECIMAL && pq_decimal_bounds_ok(sc))
+			{
+				*typid = NUMERICOID;
+				*typmod = pq_decimal_typmod(sc);
+				return true;
+			}
 			if (ct == PQ_CT_DATE)
 				*typid = DATEOID;
 			else if (sc->time_unit != PQ_TU_NONE && !sc->is_timestamp)
@@ -2381,6 +2454,12 @@ pq_leaf_to_pgtype(const PqSchemaCol *sc, Oid *typid, int32 *typmod)
 			 * than either: a nanosecond timestamp of this era needs about 61 bits
 			 * and a double carries 53, so it cannot even represent the value.
 			 */
+			if (ct == PQ_CT_DECIMAL && pq_decimal_bounds_ok(sc))
+			{
+				*typid = NUMERICOID;
+				*typmod = pq_decimal_typmod(sc);
+				return true;
+			}
 			if (sc->time_unit == PQ_TU_MILLIS || sc->time_unit == PQ_TU_MICROS)
 				*typid = sc->is_timestamp ? TIMESTAMPOID : TIMEOID;
 			else
@@ -2400,12 +2479,10 @@ pq_leaf_to_pgtype(const PqSchemaCol *sc, Oid *typid, int32 *typmod)
 				*typid = BYTEAOID;
 			return true;
 		case PQ_FIXED_LEN_BYTE_ARRAY:
-			if (ct == PQ_CT_DECIMAL && sc->precision >= 1 && sc->precision <= 38 &&
-				sc->scale >= 0 && sc->scale <= sc->precision)
+			if (ct == PQ_CT_DECIMAL && pq_decimal_bounds_ok(sc))
 			{
 				*typid = NUMERICOID;
-				*typmod = (int32) (((sc->precision << 16) | (sc->scale & 0xffff)) +
-								   VARHDRSZ);
+				*typmod = pq_decimal_typmod(sc);
 				return true;
 			}
 			if (ct < 0 && sc->type_length == 16)

--- a/test/native_parquet_flba.sh
+++ b/test/native_parquet_flba.sh
@@ -180,6 +180,56 @@ PY
 		"$(q "SELECT pgc_try_flba(\$q\$SELECT * FROM pgcolumnar.read_parquet('$W/dec_badscale.parquet') AS t(d numeric)\$q\$);")" \
 		"REJECTED"
 	check "backend survived the crafted scale" "$(q 'SELECT 1;')" "1"
+
+	# ---- DECIMAL held in an INT32 or INT64 ----------------------------------
+	#
+	# The spec allows a DECIMAL to be stored as a plain integer, which is what
+	# writers use for small precisions, and pyarrow does it on request. Verified
+	# in this pyarrow (23.0.1) rather than assumed from the spec's thresholds:
+	# precision up to 9 becomes INT32, up to 18 becomes INT64, beyond that FLBA.
+	# Unlike the byte-array forms the integer is little-endian, so the decode
+	# widens it into a big-endian buffer and reuses the one scale conversion.
+	python3 - "$W" <<'PYINT'
+import decimal, os, sys
+import pyarrow as pa, pyarrow.parquet as pq
+W = sys.argv[1]
+vals = [decimal.Decimal("1.25"), decimal.Decimal("-3.50"),
+        decimal.Decimal("0.00"), None]
+for name, p, s in (("i32", 9, 2), ("i64", 18, 6)):
+    t = pa.table({"d": pa.array([None if v is None else v.scaleb(0) for v in vals],
+                                pa.decimal128(p, s))})
+    pq.write_table(t, os.path.join(W, f"dec_{name}.parquet"),
+                   store_decimal_as_integer=True, compression="none")
+phys = {}
+for name in ("i32", "i64"):
+    f = pq.ParquetFile(os.path.join(W, f"dec_{name}.parquet"))
+    phys[name] = f.metadata.row_group(0).column(0).physical_type
+if phys != {"i32": "INT32", "i64": "INT64"}:
+    sys.exit("unexpected physical types: %s" % phys)
+PYINT
+	if [ $? -ne 0 ]; then
+		echo "SKIP  this pyarrow does not store decimals as integers as expected"
+	else
+		check "INT32-backed DECIMAL reads" \
+			"$(q "SELECT string_agg(d::text, ',' ORDER BY d) FROM pgcolumnar.read_parquet('$W/dec_i32.parquet') AS t(d numeric);")" \
+			"-3.50,0.00,1.25"
+		check "INT64-backed DECIMAL reads" \
+			"$(q "SELECT string_agg(d::text, ',' ORDER BY d) FROM pgcolumnar.read_parquet('$W/dec_i64.parquet') AS t(d numeric);")" \
+			"-3.500000,0.000000,1.250000"
+		check "INT32-backed DECIMAL keeps its null" \
+			"$(q "SELECT count(*) - count(d) FROM pgcolumnar.read_parquet('$W/dec_i32.parquet') AS t(d numeric);")" "1"
+		check "parquet_schema advises numeric for an INT32 DECIMAL" \
+			"$(q "SELECT data_type FROM pgcolumnar.parquet_schema('$W/dec_i32.parquet');")" \
+			"numeric(9,2)"
+		check "parquet_schema advises numeric for an INT64 DECIMAL" \
+			"$(q "SELECT data_type FROM pgcolumnar.parquet_schema('$W/dec_i64.parquet');")" \
+			"numeric(18,6)"
+		# the integer reading is not silently reinterpreted: declaring bigint
+		# against a DECIMAL column must still bind to the raw integer
+		check "an INT64 DECIMAL still binds to bigint as the unscaled integer" \
+			"$(q "SELECT string_agg(d::text, ',' ORDER BY d) FROM pgcolumnar.read_parquet('$W/dec_i64.parquet') AS t(d bigint);")" \
+			"-3500000,0,1250000"
+	fi
 else
 	echo "SKIP  pyarrow not available; foreign-producer FLBA cases skipped"
 fi

--- a/test/native_parquet_pushdown.sh
+++ b/test/native_parquet_pushdown.sh
@@ -182,4 +182,48 @@ check "read_parquet same file == oracle" \
 	"$(pgc_set_hash "SELECT * FROM pgcolumnar.read_parquet('$PARQ') AS t(id int4, val float8)")" \
 	"$(pgc_set_hash "SELECT * FROM h")"
 
+# ---- an INT32/INT64-backed DECIMAL is skippable ----------------------------
+#
+# A numeric column is only skippable when the file stores it as an INT32 or INT64
+# DECIMAL, because those are the physical types the statistics decode from; a
+# byte-array DECIMAL is filtered but never skipped. That distinction is newly
+# reachable (a numeric target could not bind to an integer leaf before), and a
+# scan that stops skipping still returns correct rows, so without this the
+# regression would be silent.
+
+if python3 -c 'import pyarrow.parquet' 2>/dev/null; then
+	python3 - "$PGC_WORKDIR" <<'PYDEC'
+import decimal, os, sys
+import pyarrow as pa, pyarrow.parquet as pq
+W = sys.argv[1]
+# four row groups with disjoint ranges, so a predicate can exclude three
+vals = [decimal.Decimal(i) / 100 for i in range(0, 40000)]
+t = pa.table({"d": pa.array(vals, pa.decimal128(18, 2))})
+pq.write_table(t, os.path.join(W, "dec_push.parquet"),
+               store_decimal_as_integer=True, compression="none",
+               row_group_size=10000)
+f = pq.ParquetFile(os.path.join(W, "dec_push.parquet"))
+if f.metadata.row_group(0).column(0).physical_type != "INT64":
+    sys.exit("decimal was not stored as INT64")
+if f.metadata.num_row_groups != 4:
+    sys.exit("expected 4 row groups")
+PYDEC
+	if [ $? -ne 0 ]; then
+		echo "SKIP  could not build the integer-DECIMAL pushdown file"
+	else
+		psql_run "CREATE FOREIGN TABLE ftdec (d numeric) SERVER pq
+		          OPTIONS (path '$PGC_WORKDIR/dec_push.parquet');"
+		# values 0.00 .. 399.99 across four groups of 100.00 each: a range inside
+		# the second group must exclude the other three
+		check "INT64-backed DECIMAL: predicate skips 3 of 4 groups" \
+			"$(skipped_for_t ftdec "d BETWEEN 120.00 AND 130.00")" "3"
+		check "INT64-backed DECIMAL: skipping did not drop rows" \
+			"$(q 'SELECT count(*) FROM ftdec WHERE d BETWEEN 120.00 AND 130.00;')" "1001"
+		check "INT64-backed DECIMAL: unfiltered scan skips nothing" \
+			"$(skipped_for_t ftdec 'd >= 0')" "0"
+	fi
+else
+	echo "SKIP  pyarrow not available; integer-DECIMAL pushdown case skipped"
+fi
+
 pgc_summary


### PR DESCRIPTION
First of the three Parquet follow-ons planned in `design/PARQUET_FOLLOWONS_PLAN.md` (#119), smallest first. One item, one PR.

## What was missing

A `numeric` target bound only to a DECIMAL stored as fixed or variable big-endian bytes. The spec also allows the unscaled integer in an **INT32 or INT64**, which is what writers use for small precisions. Those columns could not be read at all, and `parquet_schema` described them as `integer` or `bigint`.

Rather than taking the spec's thresholds on faith, I checked what this pyarrow (23.0.1) actually emits with `store_decimal_as_integer`: precision up to 9 is INT32, up to 18 is INT64, wider stays `FIXED_LEN_BYTE_ARRAY`. The tests are built on that observed behaviour and assert it, so a pyarrow that changes its mind makes the suite skip loudly rather than silently testing nothing.

## The change

- `pq_leaf_to_pgtype` advises `numeric(p,s)` for an INT32/INT64 DECIMAL; `pq_want_phys_for` accepts those physical types.
- Both now share **one** bounds check (`pq_decimal_bounds_ok`) and one typmod builder, including the byte-array path that previously open-coded them. A file cannot be described one way and bound another.
- That bound is load-bearing, not tidiness: `pq_decimal_to_numeric` zero-fills about `scale` bytes into a fixed buffer, so an unvalidated scale is a stack overflow. The crafted-scale test already in this suite is why that is known.
- The integer forms are **little-endian**, unlike the byte-array forms, so the decode sign-extends into a big-endian buffer and reuses the single scale conversion instead of adding a second implementation of scale handling.

## Tests

Six new checks in `native_parquet_flba.sh`: values and nulls for both widths, schema advice for both, and one that declaring `bigint` against such a column still yields the raw unscaled integer, so the new path cannot silently reinterpret a column someone reads deliberately.

**Five were verified to FAIL on the pre-change build** (reads returning nothing, `parquet_schema` advising `integer`/`bigint`). The sixth passes on both sides by design: it pins behaviour this change must not alter, which is a different job from proving the change.

## Gate

PostgreSQL 18.4 and 19beta2, all 62 suites, `ALL VERSIONS PASSED`, no failures. Full 15 through 19 matrix once at the end of the three follow-ons, per the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
