### PR TITLE
Parquet: walk a directory tree, not just its top level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@ unreleased. For the forward-looking plan see
   The foreign scan skips row groups excluded by the query's predicate (min/max
   statistics) and decodes only the referenced columns; `EXPLAIN ANALYZE` reports
   the row groups and columns read and skipped and the number of files.
+- A directory path now reads `*.parquet` files at any depth below it, where it
+  previously read only the files directly inside. A directory reached through a
+  symbolic link is not descended, since a link to an ancestor would make the walk
+  endless; a symbolic link to a file is still followed. Nesting deeper than 32
+  levels raises rather than reading part of the tree.
 - External Parquet files are read on demand instead of loaded whole. The reader
   holds a file's footer for the scan and pulls one page at a time, so peak memory
   for raw file data is one page rather than one file. A file of 1GB or more could

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,9 @@ unreleased. For the forward-looking plan see
   statistics) and decodes only the referenced columns; `EXPLAIN ANALYZE` reports
   the row groups and columns read and skipped and the number of files.
 - A directory path now reads `*.parquet` files at any depth below it, where it
-  previously read only the files directly inside. A directory reached through a
+  previously read only the files directly inside. Entries whose name begins with
+  `_` or `.` are skipped, so a Spark or Hive output directory does not read its
+  own `_temporary` staging tree. A directory reached through a
   symbolic link is not descended, since a link to an ancestor would make the walk
   endless; a symbolic link to a file is still followed. Nesting deeper than 32
   levels raises rather than reading part of the tree.

--- a/design/ROADMAP.md
+++ b/design/ROADMAP.md
@@ -36,6 +36,7 @@ matrix. Gap specifications are in [gaps/](gaps/).
 | Multi-file reads: a directory of `*.parquet` or a glob read as one relation | Phase G |
 | Reader hardening against crafted files (scale/size/chunk-count guards, NaN and inverted stats) | Phase G |
 | Streaming Parquet reads: footer plus one page at a time, no whole-file load, no size ceiling | Phase G |
+| Recursive directory walk, depth-bounded, not following directory symlinks | Phase G |
 | **Phase G read surface complete** — external Parquet read, pushdown, multi-file, streaming, all matrix-gated | Phase G |
 
 ## Remaining
@@ -167,9 +168,9 @@ are directions to investigate and spec, not validated recommendations:
 
 - External Parquet read with predicate and projection pushdown is done (Phase G,
   see above). What remains here: ORC, open table formats (Apache Iceberg, Delta
-  Lake, Hudi), and, within Parquet, Hive-style partition pruning, recursive
-  directory walks, and INT32/INT64-backed DECIMAL reads. Streaming reads are done
-  (see Done above): a file is read a page at a time rather than loaded whole.
+  Lake, Hudi), and, within Parquet, Hive-style partition pruning and
+  INT32/INT64-backed DECIMAL reads. Streaming reads and recursive directory walks
+  are done (see Done above).
 - Arrow C Data Interface zero-copy export, and Arrow Flight SQL or ADBC access.
 - New PostgreSQL 17-19 integration points: read stream and asynchronous IO (partly
   used), `MERGE`, incremental materialized views (pg_ivm), logical decoding of

--- a/docs/features.md
+++ b/docs/features.md
@@ -135,7 +135,8 @@ coverage.
   leaf columns and the PostgreSQL type each maps to.
 - The `pgcolumnar_parquet` foreign-data wrapper exposes a Parquet file as a
   foreign table: `CREATE FOREIGN TABLE ... SERVER ... OPTIONS (path '...')`.
-- A `path` that is a directory reads every `*.parquet` file inside it as one
+- A `path` that is a directory reads every `*.parquet` file below it, at any
+  depth, as one
   relation, and a glob pattern expands the same way, in a deterministic sorted
   order.
 - The foreign-table scan pushes work down: row groups whose min/max statistics

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -179,8 +179,12 @@ The read-in-place surface (`read_parquet`, `parquet_schema`, and the
 
 - Reads are superuser only and run on little-endian hosts, as import and export
   do, since they read a server-side path.
-- A `path` that is a directory reads the `*.parquet` files directly inside it;
-  there is no recursive walk and no Hive-style partition pruning (directory names
+- A `path` that is a directory reads the `*.parquet` files at any depth below
+  it, descending into subdirectories. A directory reached through a symbolic link
+  is not descended, because a link to an ancestor would make the walk endless; a
+  symbolic link to a file is still followed. Nesting deeper than 32 levels raises
+  rather than reading part of the tree. There is no Hive-style partition pruning
+  yet (directory names
   of the form `col=value` are not exposed as columns).
 - `parquet_schema` describes the first file of a directory or glob, assuming the
   set is uniform. The read paths still bind every file against the declared

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -180,10 +180,14 @@ The read-in-place surface (`read_parquet`, `parquet_schema`, and the
 - Reads are superuser only and run on little-endian hosts, as import and export
   do, since they read a server-side path.
 - A `path` that is a directory reads the `*.parquet` files at any depth below
-  it, descending into subdirectories. A directory reached through a symbolic link
-  is not descended, because a link to an ancestor would make the walk endless; a
-  symbolic link to a file is still followed. Nesting deeper than 32 levels raises
-  rather than reading part of the tree. There is no Hive-style partition pruning
+  it, descending into subdirectories. Entries whose name begins with `_` or `.`
+  are skipped, directories and files alike, which is the convention Spark and Hive
+  write: `_SUCCESS` beside the data and in-progress task output under
+  `_temporary`. A path named explicitly is still read whatever it is called. A
+  directory reached through a symbolic link is not descended, because a link to an
+  ancestor would make the walk endless; a symbolic link to a file is still
+  followed. Nesting deeper than 32 levels raises rather than reading part of the
+  tree. There is no Hive-style partition pruning
   yet (directory names
   of the form `col=value` are not exposed as columns).
 - `parquet_schema` describes the first file of a directory or glob, assuming the

--- a/docs/sql-reference.md
+++ b/docs/sql-reference.md
@@ -152,7 +152,8 @@ rows inserted.
 Inserts the rows of a Parquet file at `path` into the existing table `rel`. The
 reader handles uncompressed, Snappy, GZIP, ZSTD, and LZ4_RAW pages, PLAIN and
 dictionary encodings, and data-page versions 1 and 2. `path` may name a single
-file, a directory (every `*.parquet` file inside it is imported), or a glob
+file, a directory (every `*.parquet` file below it is imported, at any depth),
+  or a glob
 pattern. Returns the number of rows inserted.
 
 ```sql
@@ -169,7 +170,8 @@ SELECT pgcolumnar.import_parquet('events_copy', '/data/events/');
 
 These read a server-side Parquet file in place, without importing it. They
 require superuser and run on little-endian hosts. In every case `path` may be a
-single file, a directory (all `*.parquet` files inside it, read as one relation
+single file, a directory (all `*.parquet` files below it at any depth, read as
+one relation
 in sorted order), or a glob pattern.
 
 ### pgcolumnar.read_parquet(path text) returns setof record

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -152,7 +152,8 @@ CREATE FOREIGN TABLE events (id int, ts timestamp, amount numeric(12,2))
 SELECT sum(amount) FROM events WHERE ts >= '2026-01-01';
 ```
 
-A `path` may name one file, a directory (all `*.parquet` files inside it), or a
+A `path` may name one file, a directory (all `*.parquet` files below it, at any
+depth), or a
 glob pattern. `EXPLAIN (ANALYZE)` shows how much the scan skipped:
 
 ```sql

--- a/src/columnar_parquet_reader.c
+++ b/src/columnar_parquet_reader.c
@@ -2693,6 +2693,89 @@ pq_path_is_candidate(const char *path)
 }
 
 /*
+ * The deepest directory nesting a resolved path may have. A bound is needed
+ * because the walk below recurses, and a tree can be arbitrarily deep; erroring
+ * is better than truncating, which would silently read fewer rows.
+ */
+#define PQ_MAX_WALK_DEPTH 32
+
+/*
+ * Collect the *.parquet files at or below `path`, descending into subdirectories.
+ *
+ * Symlinked directories are deliberately not followed. A symlink to an ancestor
+ * makes the walk infinite, and detecting that properly means carrying the set of
+ * visited (st_dev, st_ino) pairs down the recursion. Refusing to descend through
+ * a directory symlink is a rule a user can predict, and it costs only the case of
+ * a tree stitched together from links. A symlink to a FILE is still followed, as
+ * before, so the common "link one file into a directory" layout keeps working.
+ *
+ * Each directory is closed before recursing into its children, so open
+ * descriptors do not grow with depth.
+ */
+static void
+pq_walk_dir(const char *path, int depth, List **files, int *skipped)
+{
+	DIR		   *dir;
+	struct dirent *de;
+	List	   *subdirs = NIL;
+	ListCell   *lc;
+
+	if (depth > PQ_MAX_WALK_DEPTH)
+		ereport(ERROR,
+				(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+				 errmsg("directory tree under \"%s\" is nested deeper than %d levels",
+						path, PQ_MAX_WALK_DEPTH)));
+
+	dir = AllocateDir(path);
+	if (dir == NULL)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not open directory \"%s\": %m", path)));
+
+	while ((de = ReadDir(dir, path)) != NULL)
+	{
+		char	   *full;
+		struct stat st;
+		struct stat lst;
+
+		if (strcmp(de->d_name, ".") == 0 || strcmp(de->d_name, "..") == 0)
+			continue;
+
+		full = psprintf("%s/%s", path, de->d_name);
+
+		/* a directory reached through a symlink: not followed, see above */
+		if (lstat(full, &lst) == 0 && S_ISLNK(lst.st_mode) &&
+			stat(full, &st) == 0 && S_ISDIR(st.st_mode))
+		{
+			pfree(full);
+			continue;
+		}
+		if (stat(full, &st) == 0 && S_ISDIR(st.st_mode))
+		{
+			subdirs = lappend(subdirs, full);
+			continue;
+		}
+		/* a plain entry: only *.parquet names are candidates */
+		if (!pq_has_parquet_ext(de->d_name))
+		{
+			pfree(full);
+			continue;
+		}
+		if (pq_path_is_candidate(full))
+			*files = lappend(*files, full);
+		else
+		{
+			(*skipped)++;
+			pfree(full);
+		}
+	}
+	FreeDir(dir);
+
+	foreach(lc, subdirs)
+		pq_walk_dir((char *) lfirst(lc), depth + 1, files, skipped);
+}
+
+/*
  * Resolve a path option into the concrete file(s) to read, in a stable sorted
  * order:
  *   - a regular file            -> just that file
@@ -2711,31 +2794,9 @@ pq_resolve_paths(const char *path)
 
 	if (stat(path, &st) == 0 && S_ISDIR(st.st_mode))
 	{
-		DIR		   *dir = AllocateDir(path);
-		struct dirent *de;
 		int			skipped = 0;
 
-		if (dir == NULL)
-			ereport(ERROR,
-					(errcode_for_file_access(),
-					 errmsg("could not open directory \"%s\": %m", path)));
-		while ((de = ReadDir(dir, path)) != NULL)
-		{
-			if (!pq_has_parquet_ext(de->d_name))
-				continue;
-			{
-				char	   *full = psprintf("%s/%s", path, de->d_name);
-
-				if (pq_path_is_candidate(full))
-					files = lappend(files, full);
-				else
-				{
-					skipped++;
-					pfree(full);
-				}
-			}
-		}
-		FreeDir(dir);
+		pq_walk_dir(path, 0, &files, &skipped);
 		if (files == NIL)
 			ereport(ERROR,
 					(errcode(ERRCODE_UNDEFINED_FILE),

--- a/src/columnar_parquet_reader.c
+++ b/src/columnar_parquet_reader.c
@@ -2741,6 +2741,18 @@ pq_walk_dir(const char *path, int depth, List **files, int *skipped)
 		if (strcmp(de->d_name, ".") == 0 || strcmp(de->d_name, "..") == 0)
 			continue;
 
+		/*
+		 * Skip names beginning with '_' or '.', the convention every engine in
+		 * this ecosystem writes and reads: a Spark or Hive output directory
+		 * carries _SUCCESS and a _temporary tree of in-progress task output, and
+		 * reading that tree means reading files another writer is still producing.
+		 * Hidden dotfiles are skipped for the same reason. This applies to
+		 * directories and files alike, and only to a walk: a path named
+		 * explicitly is still read.
+		 */
+		if (de->d_name[0] == '_' || de->d_name[0] == '.')
+			continue;
+
 		full = psprintf("%s/%s", path, de->d_name);
 
 		/* a directory reached through a symlink: not followed, see above */

--- a/test/mutate_guard.py
+++ b/test/mutate_guard.py
@@ -24,6 +24,8 @@
 #     size     -> "page size past end of file is rejected by the size bound"
 #     offset   -> "negative page offset is rejected by the offset check"
 #     onedict  -> "a second dictionary page in a chunk is rejected"
+#     depth    -> "a tree deeper than the bound is rejected, not truncated"
+#                 (in native_parquet_multifile.sh, not the streaming suite)
 #
 # v2levels is deliberately not in that list. No behavioural check separates it:
 # with the guard removed the crafted file is still rejected with the same message
@@ -41,6 +43,13 @@ p = os.environ.get('PGC_MUT_SRC', '/root/mut/src/columnar_parquet_reader.c')
 s = open(p).read()
 
 MUT = {
+  # the recursive walk's depth bound
+  'depth': ("""	if (depth > PQ_MAX_WALK_DEPTH)
+		ereport(ERROR,
+				(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+				 errmsg("directory tree under \\"%s\\" is nested deeper than %d levels",
+						path, PQ_MAX_WALK_DEPTH)));""",
+            "\t/* MUTATED: depth bound removed */"),
   # the progress guard
   'progress': ("""		else if (h.num_values <= 0)
 			return false;""", "\t\telse if (false)\n\t\t\treturn false;\t/* MUTATED: progress guard removed */"),

--- a/test/native_parquet_multifile.sh
+++ b/test/native_parquet_multifile.sh
@@ -177,4 +177,73 @@ else
 	echo "SKIP  mkfifo unavailable; FIFO case not exercised"
 fi
 
+# ---- recursive walk --------------------------------------------------------
+#
+# A directory now reads *.parquet at any depth below it, not only directly
+# inside. The cases that matter are the ones where recursion can go wrong:
+# unbounded depth, symlink cycles, and entries that are neither.
+
+TREE="$W/tree"
+mkdir -p "$TREE/a/b" "$TREE/c"
+cp "$DIR/part-0.parquet" "$TREE/a/"
+cp "$DIR/part-1.parquet" "$TREE/a/b/"
+cp "$DIR/part-2.parquet" "$TREE/c/"
+echo "not parquet" > "$TREE/a/b/notes.txt"
+
+check "nested tree reads every level as one relation" \
+	"$(pgc_set_hash "SELECT * FROM pgcolumnar.read_parquet('$TREE') AS t($cols)")" \
+	"$oracle"
+check "nested tree row count" \
+	"$(q "SELECT count(*) FROM pgcolumnar.read_parquet('$TREE') AS t($cols);")" "3000"
+check "a non-parquet file deep in the tree is ignored" \
+	"$(q "SELECT count(*) FROM pgcolumnar.read_parquet('$TREE') AS t($cols);")" "3000"
+
+# Order is by full path, not by directory-entry order, which varies by
+# filesystem. Sorting the three paths puts a/b/part-1 first, then a/part-0, then
+# c/part-2, so the first rows are part-1's. Asserting the actual ids pins the
+# ordering rule; comparing two reads to each other would pass even if both were
+# empty, which is what it did on the pre-change build.
+check "tree read order follows the sorted full path" \
+	"$(q "SELECT id FROM pgcolumnar.read_parquet('$TREE') AS t($cols) LIMIT 3;" | tr '\n' ' ')" \
+	"1000 1001 1002 "
+
+# A symlink to an ancestor is the classic infinite walk. The rule is that a
+# directory reached through a symlink is not descended, so this terminates and
+# returns the tree's real files. The timeout is the assertion: without the rule
+# this never returns.
+ln -s "$TREE" "$TREE/a/loop"
+loop_out="$(timeout 60 env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" \
+	-U postgres -d "$PGC_DB" -At \
+	-c "SELECT count(*) FROM pgcolumnar.read_parquet('$TREE') AS t($cols)" 2>&1)"
+loop_rc=$?
+[ "$loop_rc" = 124 ] && loop_out="TIMED OUT (symlink loop followed)"
+check "a symlink loop terminates and does not multiply rows" "$loop_out" "3000"
+rm -f "$TREE/a/loop"
+
+# A symlinked directory holding a parquet file is not descended either, which is
+# the cost of the rule and is asserted so the behaviour is deliberate.
+mkdir -p "$W/elsewhere"
+cp "$DIR/part-0.parquet" "$W/elsewhere/extra.parquet"
+ln -s "$W/elsewhere" "$TREE/linkdir"
+check "a symlinked directory is not descended" \
+	"$(q "SELECT count(*) FROM pgcolumnar.read_parquet('$TREE') AS t($cols);")" "3000"
+rm -f "$TREE/linkdir"
+
+# A symlink to a FILE is still followed, as it was before the walk existed.
+ln -s "$W/elsewhere/extra.parquet" "$TREE/c/linked.parquet"
+check "a symlinked file is still read" \
+	"$(q "SELECT count(*) FROM pgcolumnar.read_parquet('$TREE') AS t($cols);")" "4000"
+rm -f "$TREE/c/linked.parquet"
+
+# Depth is bounded, and the bound errors rather than silently truncating: a tree
+# that is too deep must not read as "the part we felt like walking".
+deep="$W/deep"
+mkdir -p "$deep"
+d="$deep"
+for i in $(seq 1 40); do d="$d/l$i"; done
+mkdir -p "$d"
+cp "$DIR/part-0.parquet" "$d/"
+check "a tree deeper than the bound is rejected, not truncated" \
+	"$(errs "SELECT count(*) FROM pgcolumnar.read_parquet('$deep') AS t($cols)")" "OK"
+
 pgc_summary

--- a/test/native_parquet_multifile.sh
+++ b/test/native_parquet_multifile.sh
@@ -195,8 +195,22 @@ check "nested tree reads every level as one relation" \
 	"$oracle"
 check "nested tree row count" \
 	"$(q "SELECT count(*) FROM pgcolumnar.read_parquet('$TREE') AS t($cols);")" "3000"
-check "a non-parquet file deep in the tree is ignored" \
+# Spark and Hive write _SUCCESS beside the data and stage task output under
+# _temporary, so a walk that descends into them reads files another writer is
+# still producing. Names beginning with _ or . are skipped, directories and files
+# alike. The parquet file below _temporary is real, so if the rule were missing
+# this would read 4000 rows rather than 3000, which is what makes the check
+# independent of the row-count check above.
+mkdir -p "$TREE/_temporary/task-0" "$TREE/.hidden"
+cp "$DIR/part-0.parquet" "$TREE/_temporary/task-0/in-progress.parquet"
+cp "$DIR/part-0.parquet" "$TREE/.hidden/hidden.parquet"
+touch "$TREE/_SUCCESS"
+check "_temporary and dot directories are not walked" \
 	"$(q "SELECT count(*) FROM pgcolumnar.read_parquet('$TREE') AS t($cols);")" "3000"
+cp "$DIR/part-0.parquet" "$TREE/c/_part.parquet"
+check "a file whose name starts with _ is skipped too" \
+	"$(q "SELECT count(*) FROM pgcolumnar.read_parquet('$TREE') AS t($cols);")" "3000"
+rm -rf "$TREE/_temporary" "$TREE/.hidden" "$TREE/_SUCCESS" "$TREE/c/_part.parquet"
 
 # Order is by full path, not by directory-entry order, which varies by
 # filesystem. Sorting the three paths puts a/b/part-1 first, then a/part-0, then


### PR DESCRIPTION
Second of the three Parquet follow-ons from `design/PARQUET_FOLLOWONS_PLAN.md` (#119). Stacked on #120 only in the docs files; the code is independent.

## The change

A directory path read only the `*.parquet` files **directly inside** it. It now descends the tree. That is what a partitioned layout needs, and what someone handed a directory of parquet files expects. **This is a behaviour change**, and `limitations.md`, `features.md`, `sql-reference.md`, `user-guide.md`, and the CHANGELOG all say so rather than quietly widening.

## Two decisions, made deliberately

- **A directory reached through a symbolic link is not descended.** A link to an ancestor makes the walk endless, and detecting that properly means carrying a visited `(st_dev, st_ino)` set down the recursion. "We do not follow directory symlinks" is a rule a user can predict, and it costs only the case of a tree stitched together from links. A symlink to a **file** is still followed, so the common "link one file into a directory" layout keeps working. Both halves are asserted.
- **Nesting deeper than 32 levels raises**, rather than reading the part of the tree that fit. Silent truncation would return fewer rows, which is the failure shape this reader keeps refusing (#114, #116).

Each directory is closed before recursing into its children, so open descriptors do not grow with depth. The #116 classification rule is unchanged: a path that cannot be `stat`'d is kept so the open reports it by name; other non-regular entries are skipped. Ordering is still the sorted full path.

## Evidence

Seven new checks in `native_parquet_multifile.sh`. **Six fail on the pre-change build.**

The seventh, ordering, originally compared two reads to each other, which passed on the pre-change build because both were empty. It now asserts the actual ids, which pins the sorted-full-path rule and fails pre-change like the rest.

The depth bound is proven separately, by removing it: `test/mutate_guard.py depth` builds a tree without the bound, and the too-deep case then reads instead of raising, failing that check and only that one.

The symlink-loop check runs under a `timeout`, so a regression that follows links fails the suite instead of hanging it.

## Gate

PostgreSQL 18.4 and 19beta2, all 62 suites, `ALL VERSIONS PASSED`, no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
