### PR TITLE
Parquet: decode Hive partition values, and honour the null marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ unreleased. For the forward-looking plan see
   candidate to every vector. Measured on a 6,000,000-row load: 20.9 s to 15.7 s,
   with byte-identical output. `pgcolumnar.encoding_sample_rows` controls the
   sample size and `0` restores the previous exhaustive selection.
+- Partition values are percent-decoded, so a directory named `region=a%3Db` reads
+  as `a=b`, and `__HIVE_DEFAULT_PARTITION__` reads as NULL rather than as that
+  literal string, matching what Hive and Spark write.
 - Hive-style partitioning on the `pgcolumnar_parquet` foreign-data wrapper. A
   foreign table declaring `partition_columns` reads `col=value` directory names
   as column values, and a predicate on a partition column drops whole files

--- a/design/ROADMAP.md
+++ b/design/ROADMAP.md
@@ -170,8 +170,8 @@ are directions to investigate and spec, not validated recommendations:
 
 - External Parquet read with predicate and projection pushdown is done (Phase G,
   see above). What remains here: ORC, open table formats (Apache Iceberg, Delta
-  Lake, Hudi). Within Parquet the remaining items are percent-decoding of
-  partition values and partition inference; streaming reads, INT32/INT64-backed
+  Lake, Hudi). Within Parquet the remaining item is partition inference; streaming
+  reads, INT32/INT64-backed
   DECIMAL reads, recursive directory walks, and Hive-style partition pruning are
   done (see Done above).
 - Arrow C Data Interface zero-copy export, and Arrow Flight SQL or ADBC access.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -192,11 +192,10 @@ The read-in-place surface (`read_parquet`, `parquet_schema`, and the
 - Hive-style partitioning is available on the foreign-data wrapper only, through
   the `partition_columns` table option. The columns are declared, not inferred
   from the tree, and `read_parquet` has no equivalent. A value is taken from the
-  directory name literally: percent-encoded characters, which Hive writes for
-  values containing a slash or an equals sign, are not decoded, and
-  `__HIVE_DEFAULT_PARTITION__`, the marker Hive and Spark write for a null
-  partition value, is not recognized (it reaches the column's input function and
-  fails there for any type that cannot parse it). A file that does not carry a
+  directory name after percent-decoding, so a value written as `a%3Db` reads as
+  `a=b`, and `__HIVE_DEFAULT_PARTITION__`, the marker Hive and Spark write for a
+  null partition value, reads as NULL rather than as that string. A file that does
+  not carry a
   directory component for every declared column raises rather than producing rows
   with nulls in the partition columns.
 - Only the directory components between the declared path and the file are read

--- a/src/columnar_parquet_reader.c
+++ b/src/columnar_parquet_reader.c
@@ -19,7 +19,6 @@
  */
 #include "columnar.h"
 
-#include <ctype.h>
 #include <math.h>
 #include <sys/stat.h>
 #include <dirent.h>
@@ -48,6 +47,7 @@
 #include "foreign/fdwapi.h"
 #include "foreign/foreign.h"
 #include "lib/stringinfo.h"
+#include "mb/pg_wchar.h"
 #include "miscadmin.h"
 #include "nodes/makefuncs.h"
 #include "optimizer/optimizer.h"
@@ -3603,7 +3603,7 @@ pqfdw_partition_mask(Oid foreigntableid, TupleDesc tupdesc, int *ncols)
 #define PQ_HIVE_NULL_PARTITION "__HIVE_DEFAULT_PARTITION__"
 
 /*
- * Percent-decode a partition value in place.
+ * Percent-decode a partition value.
  *
  * A path component cannot contain a slash, and an equals sign in a value would be
  * ambiguous against the key separator, so writers percent-encode those and any
@@ -3614,10 +3614,47 @@ pqfdw_partition_mask(Oid foreigntableid, TupleDesc tupdesc, int *ncols)
  * Only a well-formed %XX with two hex digits is decoded. A stray percent is left
  * alone rather than treated as an error, because a value that legitimately
  * contains one and was written by something that does not encode is more likely
- * than a corrupt path, and the type's input function still gets the final say.
+ * than a corrupt path.
+ *
+ * Two things the decoding itself must refuse, because percent-encoding can carry
+ * any byte and the value ends up in a PostgreSQL text datum:
+ *
+ * - An embedded NUL. Everything downstream is a C string, so %00 would truncate
+ *   the value silently; for a typed column the short text usually fails to parse,
+ *   but for text or varchar it lands as a quietly different value. The explicit
+ *   check below is for the diagnosis, not the detection: pg_verifymbstr also
+ *   rejects an embedded NUL, verified by removing this check and watching the
+ *   same file fail with "invalid byte sequence for encoding UTF8: 0x00". This
+ *   message names the file and says what is wrong with it, so it is kept, but no
+ *   test can isolate it from the encoding check and none claims to.
+ * - A byte sequence invalid in the server encoding. textin does not validate
+ *   encoding, so %FF in a UTF-8 database would admit invalid text that then flows
+ *   into result sets, comparisons and indexes. PostgreSQL validates
+ *   externally-sourced text at the boundary for this reason, which is what COPY
+ *   does with pg_verifymbstr, and this is the same boundary.
+ *
+ * The hex tests are ASCII-only rather than the ctype macros, whose behaviour is
+ * locale-dependent in principle.
  */
+static inline bool
+pq_is_hex(char c)
+{
+	return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') ||
+		(c >= 'A' && c <= 'F');
+}
+
+static inline int
+pq_hex_val(char c)
+{
+	if (c >= '0' && c <= '9')
+		return c - '0';
+	if (c >= 'a' && c <= 'f')
+		return c - 'a' + 10;
+	return c - 'A' + 10;
+}
+
 static char *
-pq_percent_decode(const char *src)
+pq_percent_decode(const char *src, const char *file)
 {
 	char	   *out = palloc(strlen(src) + 1);
 	const char *in = src;
@@ -3625,21 +3662,25 @@ pq_percent_decode(const char *src)
 
 	while (*in != '\0')
 	{
-		if (in[0] == '%' && isxdigit((unsigned char) in[1]) &&
-			isxdigit((unsigned char) in[2]))
+		if (in[0] == '%' && pq_is_hex(in[1]) && pq_is_hex(in[2]))
 		{
-			int			hi = isdigit((unsigned char) in[1])
-				? in[1] - '0' : (tolower((unsigned char) in[1]) - 'a' + 10);
-			int			lo = isdigit((unsigned char) in[2])
-				? in[2] - '0' : (tolower((unsigned char) in[2]) - 'a' + 10);
+			int			b = (pq_hex_val(in[1]) << 4) | pq_hex_val(in[2]);
 
-			*o++ = (char) ((hi << 4) | lo);
+			if (b == 0)
+				ereport(ERROR,
+						(errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
+						 errmsg("partition value in \"%s\" contains an encoded null byte",
+								file)));
+			*o++ = (char) b;
 			in += 3;
 		}
 		else
 			*o++ = *in++;
 	}
 	*o = '\0';
+
+	/* the same check COPY makes on text arriving from outside the server */
+	pg_verifymbstr(out, o - out, false);
 	return out;
 }
 
@@ -3711,7 +3752,7 @@ pqfdw_partition_values(const char *root, const char *file, TupleDesc tupdesc,
 			if (strcmp(NameStr(att->attname), key) != 0)
 				continue;
 			{
-				char	   *text = pq_percent_decode(eq + 1);
+				char	   *text = pq_percent_decode(eq + 1, file);
 
 				/*
 				 * The null marker is checked after decoding, so a value that

--- a/src/columnar_parquet_reader.c
+++ b/src/columnar_parquet_reader.c
@@ -19,6 +19,7 @@
  */
 #include "columnar.h"
 
+#include <ctype.h>
 #include <math.h>
 #include <sys/stat.h>
 #include <dirent.h>
@@ -2990,7 +2991,8 @@ pq_read_rows(PqFile *pf, PqSource *src,
 			 ImpTop *tops, int ntops, ImpLeaf *leaves,
 			 TupleTableSlot *slot, PqRowSink sink, void *sinkarg,
 			 const bool *skipGroup, const bool *needTop,
-			 const Datum *constVals, const bool *constHas)
+			 const Datum *constVals, const bool *constHas,
+			 const bool *constNull)
 {
 	int			natts = slot->tts_tupleDescriptor->natts;
 	MemoryContext groupCtx;
@@ -3091,8 +3093,10 @@ pq_read_rows(PqFile *pf, PqSource *src,
 				{
 					if (constHas[i])
 					{
-						slot->tts_values[i] = constVals[i];
-						slot->tts_isnull[i] = false;
+						bool		null = constNull != NULL && constNull[i];
+
+						slot->tts_values[i] = null ? (Datum) 0 : constVals[i];
+						slot->tts_isnull[i] = null;
 					}
 				}
 			}
@@ -3257,7 +3261,7 @@ pq_read_file_into(const char *path, TupleDesc tupdesc, TupleTableSlot *slot,
 	pq_check_row_groups(&pf, path);
 	tops = build_imp_targets(tupdesc, &pf, &leaves, &ntops, NULL);
 	n = pq_read_rows(&pf, &src, tops, ntops, leaves,
-					 slot, sink, sinkarg, NULL, NULL, NULL, NULL);
+					 slot, sink, sinkarg, NULL, NULL, NULL, NULL, NULL);
 	pq_source_close(&src);
 	return n;
 }
@@ -3592,6 +3596,54 @@ pqfdw_partition_mask(Oid foreigntableid, TupleDesc tupdesc, int *ncols)
 }
 
 /*
+ * The marker Hive and Spark write for a null partition value. A directory named
+ * dt=__HIVE_DEFAULT_PARTITION__ means the column is null for those rows, not that
+ * it holds that string, and every reader in this ecosystem treats it that way.
+ */
+#define PQ_HIVE_NULL_PARTITION "__HIVE_DEFAULT_PARTITION__"
+
+/*
+ * Percent-decode a partition value in place.
+ *
+ * A path component cannot contain a slash, and an equals sign in a value would be
+ * ambiguous against the key separator, so writers percent-encode those and any
+ * character they consider unsafe. Decoding is therefore part of reading the value,
+ * not a nicety: a value written as a%3Db is the string "a=b", and reading it
+ * literally gives a different value with no error.
+ *
+ * Only a well-formed %XX with two hex digits is decoded. A stray percent is left
+ * alone rather than treated as an error, because a value that legitimately
+ * contains one and was written by something that does not encode is more likely
+ * than a corrupt path, and the type's input function still gets the final say.
+ */
+static char *
+pq_percent_decode(const char *src)
+{
+	char	   *out = palloc(strlen(src) + 1);
+	const char *in = src;
+	char	   *o = out;
+
+	while (*in != '\0')
+	{
+		if (in[0] == '%' && isxdigit((unsigned char) in[1]) &&
+			isxdigit((unsigned char) in[2]))
+		{
+			int			hi = isdigit((unsigned char) in[1])
+				? in[1] - '0' : (tolower((unsigned char) in[1]) - 'a' + 10);
+			int			lo = isdigit((unsigned char) in[2])
+				? in[2] - '0' : (tolower((unsigned char) in[2]) - 'a' + 10);
+
+			*o++ = (char) ((hi << 4) | lo);
+			in += 3;
+		}
+		else
+			*o++ = *in++;
+	}
+	*o = '\0';
+	return out;
+}
+
+/*
  * Read one file's partition values out of its path.
  *
  * Every declared partition column must appear as a `name=value` directory
@@ -3607,7 +3659,8 @@ pqfdw_partition_mask(Oid foreigntableid, TupleDesc tupdesc, int *ncols)
  */
 static void
 pqfdw_partition_values(const char *root, const char *file, TupleDesc tupdesc,
-					   const bool *partMask, Datum *vals, bool *have)
+					   const bool *partMask, Datum *vals, bool *have,
+					   bool *isnull)
 {
 	size_t		rootlen = strlen(root);
 	const char *rel = file;
@@ -3634,7 +3687,10 @@ pqfdw_partition_values(const char *root, const char *file, TupleDesc tupdesc,
 		*work = '\0';			/* the file sits directly in the root */
 
 	for (i = 0; i < tupdesc->natts; i++)
+	{
 		have[i] = false;
+		isnull[i] = false;
+	}
 
 	for (comp = strtok_r(work, "/", &save); comp != NULL;
 		 comp = strtok_r(NULL, "/", &save))
@@ -3655,12 +3711,28 @@ pqfdw_partition_values(const char *root, const char *file, TupleDesc tupdesc,
 			if (strcmp(NameStr(att->attname), key) != 0)
 				continue;
 			{
-				Oid			infunc;
-				Oid			ioparam;
+				char	   *text = pq_percent_decode(eq + 1);
 
-				getTypeInputInfo(att->atttypid, &infunc, &ioparam);
-				vals[i] = OidInputFunctionCall(infunc, eq + 1, ioparam,
-											   att->atttypmod);
+				/*
+				 * The null marker is checked after decoding, so a value that
+				 * spells it out through escapes is treated the same way a writer
+				 * that emitted it plainly would be.
+				 */
+				if (strcmp(text, PQ_HIVE_NULL_PARTITION) == 0)
+				{
+					vals[i] = (Datum) 0;
+					isnull[i] = true;
+				}
+				else
+				{
+					Oid			infunc;
+					Oid			ioparam;
+
+					getTypeInputInfo(att->atttypid, &infunc, &ioparam);
+					vals[i] = OidInputFunctionCall(infunc, text, ioparam,
+												   att->atttypmod);
+					isnull[i] = false;
+				}
 				have[i] = true;
 			}
 			break;
@@ -3754,7 +3826,7 @@ pqfdw_partition_quals(ForeignScanState *node, TupleDesc tupdesc,
 static bool
 pqfdw_partition_excludes_file(ForeignScanState *node, TupleTableSlot *slot,
 							  List *partQuals, TupleDesc tupdesc,
-							  Datum *vals, bool *have)
+							  Datum *vals, bool *have, const bool *isnull)
 {
 	ExprContext *econtext = node->ss.ps.ps_ExprContext;
 	ListCell   *lc;
@@ -3766,8 +3838,8 @@ pqfdw_partition_excludes_file(ForeignScanState *node, TupleTableSlot *slot,
 	ExecClearTuple(slot);
 	for (i = 0; i < tupdesc->natts; i++)
 	{
-		slot->tts_values[i] = have[i] ? vals[i] : (Datum) 0;
-		slot->tts_isnull[i] = !have[i];
+		slot->tts_values[i] = (have[i] && !isnull[i]) ? vals[i] : (Datum) 0;
+		slot->tts_isnull[i] = !have[i] || isnull[i];
 	}
 	ExecStoreVirtualTuple(slot);
 
@@ -4138,6 +4210,7 @@ pqfdwBeginForeignScan(ForeignScanState *node, int eflags)
 	int			nPart;
 	Datum	   *partVals = NULL;
 	bool	   *partHas = NULL;
+	bool	   *partNull = NULL;
 	List	   *partQuals = NIL;
 	TupleTableSlot *partSlot = NULL;
 
@@ -4202,10 +4275,11 @@ pqfdwBeginForeignScan(ForeignScanState *node, int eflags)
 		{
 			partVals = (Datum *) palloc0(sizeof(Datum) * Max(tupdesc->natts, 1));
 			partHas = (bool *) palloc0(sizeof(bool) * Max(tupdesc->natts, 1));
+			partNull = (bool *) palloc0(sizeof(bool) * Max(tupdesc->natts, 1));
 			pqfdw_partition_values(path, (char *) lfirst(lc), tupdesc, partMask,
-								   partVals, partHas);
+								   partVals, partHas, partNull);
 			if (pqfdw_partition_excludes_file(node, partSlot, partQuals, tupdesc,
-											  partVals, partHas))
+											  partVals, partHas, partNull))
 			{
 				st->filesPruned++;
 				MemoryContextSwitchTo(old);
@@ -4231,7 +4305,7 @@ pqfdwBeginForeignScan(ForeignScanState *node, int eflags)
 
 		(void) pq_read_rows(&pf, &src, tops, ntops, leaves,
 							slot, pq_tuplestore_sink, st->tupstore, skipGroup,
-							needTop, partVals, partHas);
+							needTop, partVals, partHas, partNull);
 		pq_source_close(&src);
 
 		MemoryContextSwitchTo(old);

--- a/test/native_parquet_partition.sh
+++ b/test/native_parquet_partition.sh
@@ -179,4 +179,47 @@ check "declaring a file column as a partition column errors" \
 	"$(errs 'SELECT count(*) FROM ev_dup;')" "OK"
 check "backend survived the bad declarations" "$(q 'SELECT 1;')" "1"
 
+# ---- Hive value encoding ---------------------------------------------------
+#
+# A path component cannot hold a slash, and an equals sign would be ambiguous
+# against the key separator, so writers percent-encode them. Reading the value
+# literally gives a different value with no error, which is why this is part of
+# reading a partition rather than a nicety. __HIVE_DEFAULT_PARTITION__ is the
+# marker Hive and Spark write when the partition value is null.
+ENC="$W/enc"
+python3 - "$ENC" <<'PYENC'
+import os, sys
+import pyarrow as pa, pyarrow.parquet as pq
+ENC = sys.argv[1]
+# region=a=b percent-encoded, and a null partition marker
+plan = [("a%3Db", 0), ("__HIVE_DEFAULT_PARTITION__", 1000), ("plain", 2000)]
+for region, base in plan:
+    d = os.path.join(ENC, "region=" + region)
+    os.makedirs(d, exist_ok=True)
+    pq.write_table(pa.table({"id": pa.array(range(base, base + 100), pa.int32())}),
+                   os.path.join(d, "part.parquet"), compression="none")
+PYENC
+
+psql_run "CREATE FOREIGN TABLE ev_enc (id int, region text)
+          SERVER pq OPTIONS (path '$ENC', partition_columns 'region');"
+
+check "a percent-encoded partition value decodes" \
+	"$(q "SELECT DISTINCT region FROM ev_enc WHERE id < 100;")" "a=b"
+check "the encoded value is queryable as itself" \
+	"$(q "SELECT count(*) FROM ev_enc WHERE region = 'a=b';")" "100"
+check "__HIVE_DEFAULT_PARTITION__ reads as null" \
+	"$(q "SELECT count(*) FROM ev_enc WHERE region IS NULL;")" "100"
+check "a null partition value is not the literal marker" \
+	"$(q "SELECT count(*) FROM ev_enc WHERE region = '__HIVE_DEFAULT_PARTITION__';")" "0"
+check "an unencoded value is unaffected" \
+	"$(q "SELECT count(*) FROM ev_enc WHERE region = 'plain';")" "100"
+check "all three partitions still read" "$(q 'SELECT count(*) FROM ev_enc;')" "300"
+
+# A null partition value prunes like any other: IS NOT NULL excludes exactly the
+# file whose directory carries the marker.
+check "a null partition value prunes" \
+	"$(q "EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+	      SELECT count(*) FROM ev_enc WHERE region IS NOT NULL" \
+		| grep 'Files Pruned' | grep -oE '[0-9]+' | head -1)" "1"
+
 pgc_summary

--- a/test/native_parquet_partition.sh
+++ b/test/native_parquet_partition.sh
@@ -222,4 +222,24 @@ check "a null partition value prunes" \
 	      SELECT count(*) FROM ev_enc WHERE region IS NOT NULL" \
 		| grep 'Files Pruned' | grep -oE '[0-9]+' | head -1)" "1"
 
+# Percent-encoding can carry any byte, and the value becomes a PostgreSQL text
+# datum, so two byte sequences have to be refused rather than passed through.
+# A NUL would truncate the value silently (everything downstream is a C string),
+# and a byte invalid in the server encoding would admit invalid text, which
+# textin does not check. Both are what a path written by another tool can contain.
+mkdir -p "$ENC/region=a%00b" "$ENC/region=a%FFb"
+cp "$ENC/region=plain/part.parquet" "$ENC/region=a%00b/part.parquet"
+cp "$ENC/region=plain/part.parquet" "$ENC/region=a%FFb/part.parquet"
+# The NUL case is caught by the encoding validation as well as by the explicit
+# check, so this asserts the pair rather than either one; removing the explicit
+# check leaves it passing, which was verified rather than assumed.
+check "an encoded null byte in a partition value is rejected" \
+	"$(errs 'SELECT count(*) FROM ev_enc;')" "OK"
+rm -rf "$ENC/region=a%00b"
+check "a byte invalid in the server encoding is rejected" \
+	"$(errs 'SELECT count(*) FROM ev_enc;')" "OK"
+rm -rf "$ENC/region=a%FFb"
+check "the tree reads again once both are gone" "$(q 'SELECT count(*) FROM ev_enc;')" "300"
+check "backend survived the malformed partition values" "$(q 'SELECT 1;')" "1"
+
 pgc_summary


### PR DESCRIPTION
Two limitations the partition work in #122 documented rather than solved. Both come from the same writers, and both are cheap now that the plumbing exists.

## Percent-decoding is part of reading the value

A path component cannot hold a slash, and an equals sign would be ambiguous against the key separator, so writers percent-encode them. Reading `region=a%3Db` literally yields the string `a%3Db` rather than `a=b`: **a wrong value, with no error**. That is why this is not a nicety.

Only a well-formed `%XX` is decoded, and a stray percent is left alone rather than treated as an error, because a value that legitimately contains one and was written by something that does not encode is likelier than a corrupt path, and the column's input function still has the last word.

## `__HIVE_DEFAULT_PARTITION__` means NULL

That is the marker Hive and Spark write when a partition value is null, and every reader in this ecosystem treats it that way. It previously reached the column's input function and failed there for any type that could not parse it. It now reads as NULL, and is matched **after** decoding, so a writer that escapes it is treated the same as one that does not.

Threading that through meant the per-file constant columns carry a null flag as well as a value, so a NULL partition value is a real NULL in the row rather than a zero Datum. Null partition values prune like any other value: `region IS NOT NULL` prunes exactly the file whose directory carries the marker.

## Evidence

Seven new checks. **Five fail on the pre-change build**, including the two that matter most: the encoded value read back as `a%3Db`, and the null marker read as the literal string. The other two (an unencoded value is unaffected, all three partitions still read) pass both sides by design, since they pin behaviour this must not change.

## Gate

PostgreSQL 18.4 and 19beta2, all 63 suites, ALL VERSIONS PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)