### PR TITLE
Do not build a bloom filter the size cap cannot size properly

### DIFF
--- a/src/columnar_bloom.c
+++ b/src/columnar_bloom.c
@@ -95,6 +95,23 @@ ColumnarBloomBuild(const uint32 *hashes, uint32 n, char **out, uint32 *outLen)
 	if (n < 64)
 		return false;			/* min/max and per-group scan suffice */
 
+	/*
+	 * Refuse to build a filter the cap cannot size properly. A filter is stored
+	 * per stripe, so n grows with pgcolumnar.stripe_row_limit (a USERSET GUC and
+	 * a reloption); once n * BLOOM_BITS_PER_VALUE exceeds BLOOM_MAX_BITS,
+	 * next_pow2 clamps and the bits-per-value falls below the ~10 this k was
+	 * chosen for. The filter then saturates: at four times the default stripe
+	 * limit almost every bit is set, so the probe answers "may be present" for
+	 * everything while still costing 256 KB per column per stripe to store and
+	 * read. No filter is better than one that never skips, and the reader
+	 * already treats an absent filter as "may match".
+	 *
+	 * This also keeps the multiply below in range: past this point it would
+	 * overflow uint32 for a large enough n.
+	 */
+	if ((uint64) n * BLOOM_BITS_PER_VALUE > BLOOM_MAX_BITS)
+		return false;
+
 	nbits = next_pow2(n * BLOOM_BITS_PER_VALUE);
 	nbytes = nbits / 8;
 	total = sizeof(uint32) + sizeof(uint8) + nbytes;


### PR DESCRIPTION
Second audit finding. Not a correctness bug: a bloom filter that saturates only ever answers "may be present", which is the safe direction. It is a silent loss of the feature plus a standing storage and read cost.

## What happens

`ColumnarBloomBuild` sizes at `next_pow2(n * BLOOM_BITS_PER_VALUE)` and clamps to `BLOOM_MAX_BITS` (2^21 bits, 256 KB). The filter is stored per **stripe** — `groupNumber = writeState->stripeId`, and the hash buffer is accumulated across every chunk group in the stripe — so `n` is the stripe's non-null value count for that column, not the chunk group's.

`pgcolumnar.stripe_row_limit` is `PGC_USERSET` with range `1000..INT_MAX`, and it is settable per table through the reloption. Raising it is ordinary tuning: bigger stripes compress better and produce fewer catalog rows. But once `n` passes roughly 210,000 the clamp binds and bits-per-value drops below the ~10 that `BLOOM_K = 6` was chosen for:

| n (values in the stripe) | bits/value | false-positive rate |
| --- | --- | --- |
| 150,000 (default limit) | 13.98 | **0.18%** |
| 300,000 | 6.99 | 3.66% |
| 500,000 | 4.19 | 19.39% |
| 1,000,000 | 2.10 | 70.22% |
| 2,000,000 | 1.05 | 98.05% |
| 5,000,000 | 0.42 | 100.00% |

(standard `(1 - e^{-kn/m})^k`, with `m` clamped at 2^21 and `k` = 6.)

So a table tuned to million-row stripes has filters that skip essentially nothing, while still paying 256 KB per column per stripe on disk and a read plus six probes on every scan that has an equality predicate. The header's "target ~1% false positives" quietly stops being true, and nothing surfaces that — the filter is not wrong, just useless, so no test notices.

## The change

Refuse to build when the cap cannot deliver the design ratio:

```c
if ((uint64) n * BLOOM_BITS_PER_VALUE > BLOOM_MAX_BITS)
    return false;
```

The cutoff is exactly where the design target stops being met: at `n = 209,715` the filter is at 10 bits/value and 0.84% false positives, and past there it degrades. `ColumnarBloomProbe` and the reader already treat an absent filter as "may match", and the writer only records a bloom row when the build returns true, so this trades a filter that cannot skip for not paying for one. Nothing at or below the cap changes, which includes every table on the default limit.

It also keeps `n * BLOOM_BITS_PER_VALUE` inside `uint32`. That multiply can overflow in principle; today it is unreachable because the hash buffer is a `StringInfo` and would hit `MaxAllocSize` at about 268M values first, so I am not claiming it as a live bug — just noting the guard closes it.

## Alternative worth considering instead

Raising `BLOOM_MAX_BITS` proportionally would keep the filter working at large stripes, but a correctly sized filter for a 5M-row stripe is ~6 MB per column, which is a different tradeoff than the 256 KB cap was chosen for. Dropping the filter leaves the choice with the user: lower `stripe_row_limit` if bloom skipping matters more than stripe size. If you would rather keep some filtering, a middle option is to allow down to ~4 bits/value (about 19% false positives, still skipping four times out of five) and refuse below that — a one-constant change to the same guard.

## What I verified, and what I did not

Verified by reading: the per-stripe granularity (`groupNumber = writeState->stripeId`), that the hash buffer spans all chunk groups in the stripe, the GUC bounds and the reloption path, and that both the probe and the reader treat a missing filter conservatively. The table above is arithmetic, not measurement.

**Not verified: I could not build or run anything** — no PostgreSQL server headers in my environment. Unbuilt, ungated.

A test would want to assert the absence rather than the ratio: set `stripe_row_limit` above the cutoff, load a stripe, and check that no `pgcolumnar.bloom_filter` row exists for that column and stripe, with the mirror case below the cutoff asserting one does. That is deterministic and needs no timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
