### PR TITLE
Fix unique-key serialization when backends disagree on the bucket count

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,7 +62,7 @@ pgColumnar has two kinds of settings:
 | Setting | Type | Default | Description |
 | --- | --- | --- | --- |
 | `pgcolumnar.enable_unique_insert_lock` | boolean | `on` | Serialize concurrent inserts of the same unique-index key with a transaction-scoped advisory lock, so overlapping same-key inserts conflict correctly. |
-| `pgcolumnar.unique_lock_buckets` | integer | `128` | Advisory-lock buckets per unique index. Bounds how many advisory locks a transaction holds per unique index. Equal keys always share a bucket; unrelated keys may share one, which only over-serializes. Range 1 to 1048576. |
+| `pgcolumnar.unique_lock_buckets` | integer | `128` | Advisory-lock buckets per unique index. Bounds how many advisory locks a transaction holds per unique index. Equal keys always share a bucket; unrelated keys may share one, which only over-serializes. Range 1 to 1048576. Settable only at server start: the bucket is part of the lock tag, so backends that disagree on this value would not serialize against each other. |
 
 ## Per-table storage options
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,9 +2,11 @@
 
 pgColumnar has two kinds of settings:
 
-- Server settings under the `pgcolumnar.` prefix, listed below. Each can be set in
-  `postgresql.conf`, per session with `SET`, per role, or per database. All of
-  them are `USERSET`, so a session may change them without special privileges.
+- Server settings under the `pgcolumnar.` prefix, listed below. Most can be set in
+  `postgresql.conf`, per session with `SET`, per role, or per database, without
+  special privileges. Two are not: `pgcolumnar.enable_end_truncation` requires
+  superuser, and `pgcolumnar.unique_lock_buckets` can only be set at server start.
+  Each exception is noted in its own row below.
 - Per-table storage options, set with `pgcolumnar.alter_columnar_table_set`. These
   apply to one table and are used when that table writes new data.
 

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -1297,11 +1297,15 @@ _PG_init(void)
 							"Bounds the transaction's held advisory locks to at "
 							"most this many per unique index. Equal keys always "
 							"share a bucket; unrelated keys may share one, which "
-							"only over-serializes.",
+							"only over-serializes. Fixed at server start because "
+							"the bucket is part of the advisory lock tag: two "
+							"backends inserting the same key must compute the "
+							"same bucket, which they only do when they agree on "
+							"this value.",
 							&columnar_unique_lock_buckets,
 							128,
 							1, 1048576,
-							PGC_USERSET,
+							PGC_POSTMASTER,
 							0,
 							NULL, NULL, NULL);
 

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -129,6 +129,10 @@ pgc_setup() {
 		echo "bytea_output='hex'"
 		# Keep planner honest but let small tables use the custom scan.
 		echo "max_parallel_workers_per_gather=0"
+		# The unique-insert lock bucket count is fixed at server start (it is part
+		# of the advisory lock tag, so backends must agree on it). A large prime
+		# keeps unrelated keys out of the same bucket in unique_conc.
+		echo "pgcolumnar.unique_lock_buckets=100003"
 	} | pgc_pg "cat >> '$PGC_PGDATA/postgresql.conf'"
 
 	# Start, retrying a few times: under rapid cluster churn (the version matrix

--- a/test/unique_conc.sh
+++ b/test/unique_conc.sh
@@ -240,8 +240,17 @@ start_session s2
 start_session sh   # holder of the mid-statement pause lock
 send s1 "SET application_name='cc_s1';"
 send s2 "SET application_name='cc_s2';"
-send s1 "SET pgcolumnar.unique_lock_buckets=100003;"   # avoid false bucket sharing
-send s2 "SET pgcolumnar.unique_lock_buckets=100003;"
+# The bucket count is part of the advisory lock tag, so it is fixed at server
+# start rather than set per session: two backends that disagreed would hash the
+# same key to different buckets and not serialize at all. pgc_setup puts the
+# large prime that avoids false bucket sharing into postgresql.conf, and the
+# check below pins that a session cannot change it out from under the guarantee.
+check "the bucket count cannot be changed per session" \
+	"$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -At -c 'SET pgcolumnar.unique_lock_buckets = 1;' 2>&1 |
+		grep -qE 'ERROR:.*cannot be changed' && echo OK || echo "NO ERROR")" "OK"
+check "the cluster runs the bucket count the suite needs" \
+	"$(q 'SHOW pgcolumnar.unique_lock_buckets;')" "100003"
 
 HKEY=1000   # holder advisory-lock key, unique per pause
 


### PR DESCRIPTION
Fourth audit finding, and the one I would look at first. A `UNIQUE` index on a columnar table can accept a duplicate when two backends disagree on one `PGC_USERSET` setting.

## The mechanism

The bucket is part of the advisory lock tag:

```c
/* columnar_unique.c, ColumnarLockUniqueKeys() */
numBuckets = (uint32) Max(1, columnar_unique_lock_buckets);   /* read per insert */
...
bucket = (uint32) (combined % (uint64) numBuckets);
...
SET_LOCKTAG_ADVISORY(tag, MyDatabaseId, (uint32) indexOid, bucket,
                     COLUMNAR_UNIQUE_LOCK_CLASS);
```

`numBuckets` comes from the session's current value of `pgcolumnar.unique_lock_buckets`, which is `PGC_USERSET`. So two backends inserting **the same key** under different settings compute different buckets, take different advisory locks, and never block each other.

That is precisely the window this lock exists to close. The btree's own `_bt_check_unique` cannot resolve a conflict against a row that an in-progress transaction has not yet made fetchable through the columnar AM, which is why same-key inserts are serialized here rather than left to the index. Remove the serialization and the duplicate can commit.

Note it is not only "weird" values that collide. 128 versus 64 is enough: `h % 128 = 70` maps to bucket 6 under 64, so roughly half of all keys diverge even between two power-of-two settings that look compatible.

## Three docs state the invariant this breaks

- `docs/limitations.md`: "unrelated keys sharing a bucket are over-serialized, **never under-serialized**"
- `docs/configuration.md`: "**Equal keys always share a bucket**"
- the GUC's own long description, same sentence

Each is true only under the unstated assumption that both backends have the same value.

## Reachability

No malice needed:

- The setting exists to be tuned, and `docs/administration.md` presents it as a knob next to a lock you are told to leave on. A session raising it for a bulk load while other sessions run at the default is the obvious case.
- Even with nobody using `SET`: a `postgresql.conf` change plus `pg_reload_conf()` takes effect per backend at its next `ProcessConfigFile`, so concurrent backends genuinely straddle the change for a window.

## The fix here, and the better one

`PGC_POSTMASTER` makes the value identical in every backend for the postmaster's lifetime, which is what a lock tag needs. **`PGC_SIGHUP` would not be enough** — a reload still leaves backends holding different values for a window, which is the second reachability case above.

The better long-term fix is to record the bucket count per index at creation, so it cannot drift and can still be chosen per index. That is a larger change wanting its own tests; this closes the hole in one line. If you would rather go straight to the per-index version, close this and I will not be offended.

## Verified, and not

Verified by reading: that `numBuckets` is read per insert inside `ColumnarLockUniqueKeys`, that the bucket reaches `SET_LOCKTAG_ADVISORY` as a tag field, that the `coarse` path is unaffected (it pins `bucket = 0`, so those indexes always agree), the GUC's context and range, and the three doc sentences.

**Not verified: I could not build or run anything** — no PostgreSQL server headers here, so this is unbuilt and ungated, and I have not demonstrated a duplicate landing in an index.

A test would be an isolation-style one, in the shape `test/unique_conc.sh` already uses: two sessions, `SET pgcolumnar.unique_lock_buckets` to different values, both insert the same key in overlapping transactions, both commit, then assert the index contains one row. Pre-fix that should produce two; post-fix the second session should block and then fail with `unique_violation` or a deadlock, which the existing suite already accepts as equivalent outcomes.

Worth checking a related question I could not answer without a server: whether the same divergence can happen through `pgcolumnar.enable_unique_insert_lock` itself. One backend with the lock off and another with it on would also fail to serialize, and that setting is `PGC_USERSET` too — but turning it off is documented as opting out of the guarantee, so it may be intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
