### PR TITLE
docs: five majors, not seven

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -3,7 +3,8 @@
 ## PostgreSQL versions
 
 pgColumnar builds from one source tree on PostgreSQL 15, 16, 17, 18, and
-19. Every test suite runs on all seven majors.
+19. Every test suite runs on all five majors. PostgreSQL 13 and 14 still build
+but are out of the tested matrix.
 
 Two behaviors depend on the major:
 


### PR DESCRIPTION
Trivial audit finding, batched with nothing else because it is one word.

`docs/limitations.md` lists PostgreSQL 15, 16, 17, 18 and 19, then says every test suite runs on "all seven majors". Seven was correct when the supported range was 13 through 19; the count was not updated when 13 and 14 left the matrix in #112. `README.md`, `docs/index.md` and `test/run_all_versions.sh` all agree on 15 through 19.

I also added the sentence `installation.md` already carries about 13 and 14 still building but being out of the tested matrix, because the section goes on to document their `ALTER TABLE ... SET ACCESS METHOD` fallback two lines later, which reads oddly against an opening that implies they are unsupported.

Docs only, and verified only by reading. No build here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)