### PR TITLE
Remember the last row group and chunk in the delete buffer

### DIFF
--- a/src/columnar_delete_vector.c
+++ b/src/columnar_delete_vector.c
@@ -46,6 +46,15 @@ typedef struct DeleteVectorBuffer
 	SubTransactionId subid;
 	List	   *chunks;			/* list of DeleteVectorChunkBuffer* */
 	List	   *rowGroupCache;	/* cached NativeRowGroupMetadata* for resolution */
+
+	/*
+	 * Last lookup results. A delete arrives in row-number order, so the previous
+	 * answer is almost always the right one; without these, each row rescans both
+	 * lists from the head, and the entry it wants is the one most recently
+	 * appended to the tail.
+	 */
+	NativeRowGroupMetadata *lastGroup;
+	DeleteVectorChunkBuffer *lastChunk;
 } DeleteVectorBuffer;
 
 static MemoryContext ColumnarDeleteVectorContext = NULL;
@@ -115,6 +124,8 @@ delete_vector_get_buffer(Relation rel, uint64 storageId)
 	buf->subid = subid;
 	buf->chunks = NIL;
 	buf->rowGroupCache = NIL;
+	buf->lastChunk = NULL;
+	buf->lastGroup = NULL;
 	ColumnarDeleteVectorBuffers = lappend(ColumnarDeleteVectorBuffers, buf);
 	MemoryContextSwitchTo(oldContext);
 
@@ -133,6 +144,11 @@ delete_vector_find_row_group(DeleteVectorBuffer *buf, uint64 rowNumber)
 	ListCell   *lc;
 	int			attempt;
 
+	if (buf->lastGroup != NULL &&
+		rowNumber >= buf->lastGroup->firstRowNumber &&
+		rowNumber < buf->lastGroup->firstRowNumber + buf->lastGroup->rowCount)
+		return buf->lastGroup;
+
 	for (attempt = 0; attempt < 2; attempt++)
 	{
 		foreach(lc, buf->rowGroupCache)
@@ -141,7 +157,10 @@ delete_vector_find_row_group(DeleteVectorBuffer *buf, uint64 rowNumber)
 
 			if (rowNumber >= g->firstRowNumber &&
 				rowNumber < g->firstRowNumber + g->rowCount)
+			{
+				buf->lastGroup = g;
 				return g;
+			}
 		}
 
 		if (attempt == 0)
@@ -151,6 +170,7 @@ delete_vector_find_row_group(DeleteVectorBuffer *buf, uint64 rowNumber)
 			Snapshot	snap = ColumnarCatalogSnapshot(GetActiveSnapshot());
 
 			buf->rowGroupCache = ColumnarReadRowGroupList(buf->storageId, snap);
+			buf->lastGroup = NULL;	/* points into the list just replaced */
 			MemoryContextSwitchTo(oldContext);
 		}
 	}
@@ -170,12 +190,20 @@ delete_vector_get_chunk(DeleteVectorBuffer *buf, uint64 stripeId, int chunkId,
 	MemoryContext oldContext;
 	DeleteVectorChunkBuffer *chunk;
 
+	chunk = buf->lastChunk;
+	if (chunk != NULL && chunk->stripeId == stripeId &&
+		chunk->chunkId == chunkId && chunk->startRowNumber == startRowNumber)
+		return chunk;
+
 	foreach(lc, buf->chunks)
 	{
 		chunk = (DeleteVectorChunkBuffer *) lfirst(lc);
 		if (chunk->stripeId == stripeId && chunk->chunkId == chunkId &&
 			chunk->startRowNumber == startRowNumber)
+		{
+			buf->lastChunk = chunk;
 			return chunk;
+		}
 	}
 
 	oldContext = MemoryContextSwitchTo(ColumnarDeleteVectorContext);
@@ -188,6 +216,7 @@ delete_vector_get_chunk(DeleteVectorBuffer *buf, uint64 stripeId, int chunkId,
 	chunk->maskLen = (uint32) ((rowCount + 7) / 8);
 	chunk->mask = palloc0(chunk->maskLen);
 	buf->chunks = lappend(buf->chunks, chunk);
+	buf->lastChunk = chunk;
 	MemoryContextSwitchTo(oldContext);
 
 	return chunk;
@@ -330,6 +359,8 @@ delete_vector_flush_buffer(DeleteVectorBuffer *buf)
 
 	buf->chunks = NIL;
 	buf->rowGroupCache = NIL;
+	buf->lastChunk = NULL;
+	buf->lastGroup = NULL;
 }
 
 /*


### PR DESCRIPTION
Audit finding: bulk `DELETE` does work proportional to rows times row groups, in two places that are one line each to fix.

## The two searches

`ColumnarMarkRowDeleted()` runs per deleted row and does two linear scans:

```c
NativeRowGroupMetadata *rg = delete_vector_find_row_group(buf, rowNumber);   /* walks rowGroupCache */
...
chunk = delete_vector_get_chunk(buf, rg->groupNumber, 0, ...);               /* walks buf->chunks */
```

Both lists are built with `lappend` and both are scanned from the head with `foreach`. A `DELETE` driven by a scan arrives in row-number order, so the entry it wants is the one most recently appended — the far end of the list — on essentially every row.

For N rows spread over G row groups, the wanted entry sits at position g in both lists while deleting group g, so the two searches together cost about **N * G** comparisons. At the default 150,000-row stripe limit:

| rows deleted | row groups | comparisons (before) | after |
| --- | --- | --- | --- |
| 1M | 7 | ~7e6 | ~2e6 |
| 10M | 67 | ~6.7e8 | ~2e7 |
| 100M | 667 | ~6.7e10 | ~2e8 |

It is invisible on a small table and grows with the table, which is the shape that makes it easy to miss: the suites exercise correctness on tables where G is single digits.

I am quoting comparison counts rather than a speedup because I cannot measure end-to-end here, and the delete also does catalog work, VM clearing and executor overhead. How much of a real `DELETE` this dominates is worth measuring before deciding how interesting it is — my guess is it starts to matter somewhere in the tens of millions of rows, and dominates well before 100M.

## The change

Remember the last answer from each search and check it first. Sequential deletes then hit on the first comparison for a whole row group's worth of rows, and again for its chunk buffer. A miss falls through to the existing scan, so correctness never depends on the cache being right — only speed does.

Both fields are cleared where they could go stale:

- `lastGroup` when `rowGroupCache` is replaced, since it points into the list being dropped.
- both in `delete_vector_flush_buffer()`, which empties the lists and also `list_sort`s `chunks` on the way out.

`delete_vector_get_buffer()` already uses `palloc0`, so a fresh buffer starts with both NULL; I set them explicitly next to the existing `NIL` initialisers anyway, to keep the reset points together.

## Note on the same pattern elsewhere

`ColumnarDeleteVectorBufferedDeleted()` has the same nested-scan shape (every buffer, every chunk) and is called from the unique-check path on insert. I left it alone: its cost is bounded by inserts rather than by table size, and the right fix there is probably to key chunks by `(stripeId, chunkId)` in a hash rather than to add a third cache. Worth a look if a same-key `UPDATE`-heavy workload ever shows up in a profile.

## Verification

Read-only: the two call sites, the append-then-scan-from-head pattern, every place both lists are reset or reordered, and that `chunk` is assigned before use on all paths through `delete_vector_get_chunk()`.

**Not built, not gated** — no PostgreSQL server headers in my environment. The change is pure lookup memoisation with a fallback, so the risk is low, but it has not been compiled.

Existing coverage should already exercise it: `differential`, `concurrent_diff` and `recovery` all delete and compare against a heap oracle, and a cache that returned the wrong row group would corrupt delete marks loudly rather than subtly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
