### PR TITLE
Flush the write buffer when ALTER TABLE changes the column count

### DIFF
--- a/src/columnar_write_state.c
+++ b/src/columnar_write_state.c
@@ -128,6 +128,7 @@ static MemoryContext ColumnarWriteContext = NULL;
 static List *ColumnarWriteStates = NIL;
 
 static void columnar_flush_row_group(ColumnarWriteState *writeState);
+static void flush_ws_projections(ColumnarWriteState *writeState);
 static ChunkGroupBuffer *columnar_start_chunk_group(ColumnarWriteState *writeState);
 static void columnar_init_col_defs(ColumnarWriteState *writeState);
 
@@ -207,8 +208,32 @@ ColumnarGetWriteState(Relation rel)
 	foreach(lc, ColumnarWriteStates)
 	{
 		writeState = (ColumnarWriteState *) lfirst(lc);
-		if (writeState->relid == relid && writeState->subid == subid)
+		if (writeState->relid != relid || writeState->subid != subid)
+			continue;
+
+		/*
+		 * The descriptor is snapshotted when the buffer is opened, so a buffer
+		 * that predates an ALTER TABLE ... ADD COLUMN in this same transaction
+		 * still has the old column count and silently drops every value written
+		 * into the new column: the flushed chunks carry the old shape, and the
+		 * reader then serves the column's missing value for those rows. Nothing
+		 * else invalidates the buffer, since the write state registers no
+		 * relcache callback.
+		 *
+		 * The buffered rows are correct under the descriptor they were written
+		 * with, so flush them under it and open a new buffer for the new shape.
+		 */
+		if (writeState->natts == RelationGetDescr(rel)->natts)
 			return writeState;
+
+		if (writeState->stripeRowCount > 0)
+			columnar_flush_row_group(writeState);
+		flush_ws_projections(writeState);
+
+		oldContext = MemoryContextSwitchTo(ColumnarWriteContext);
+		ColumnarWriteStates = list_delete_ptr(ColumnarWriteStates, writeState);
+		MemoryContextSwitchTo(oldContext);
+		break;
 	}
 
 	if (ColumnarWriteContext == NULL)

--- a/test/audit.sh
+++ b/test/audit.sh
@@ -18,6 +18,11 @@
 #      out-of-range chunk_group_row_limit / stripe_row_limit / compression_level
 #      rather than store it: a zero chunk_group_row_limit records a stripe with
 #      chunk_row_count = 0 and makes delete/update/fetch divide by zero.
+#   5. ALTER TABLE ADD COLUMN while a write buffer is already open in the same
+#      transaction. The buffer snapshots the tuple descriptor when it opens and
+#      nothing invalidates it, so every value written into the new column after
+#      the ALTER was silently dropped and the column read back as its missing
+#      value. Covers INSERT and UPDATE, with and without a default.
 #   4. CREATE INDEX must not leak a relation reference. A parallel index build
 #      opens a TableScanDesc per participant through columnar_scan_begin (which
 #      takes a relation reference); the index_build_range_scan callback owns that
@@ -211,6 +216,46 @@ check "create index no relation leak" "$LEAKS" "0"
 check "create index rows indexed once" \
 	"$(q "SET enable_seqscan=off; SELECT count(*) FROM idxleak WHERE a>0;")" "50000"
 q "DROP TABLE idxleak;" >/dev/null
+
+# ---------------------------------------------------------------------------
+# 5. ALTER TABLE ADD COLUMN with a write buffer already open in the same
+#    transaction. Writes to the new column must survive.
+# ---------------------------------------------------------------------------
+# The buffer is keyed by (relation, subtransaction) and snapshots the descriptor
+# when it opens; nothing invalidates it on DDL. A write before the ALTER opens
+# it with the old column count, so without the fix every value written into the
+# added column afterwards is dropped on the floor and the column reads back as
+# its missing value, with no error.
+
+q "CREATE TABLE wsalter (id int, v text) USING pgcolumnar;" >/dev/null
+q "BEGIN;
+   INSERT INTO wsalter VALUES (0,'x');
+   ALTER TABLE wsalter ADD COLUMN w int DEFAULT 7;
+   INSERT INTO wsalter VALUES (1,'a',99);
+   COMMIT;" >/dev/null
+check "add-column mid-transaction keeps the inserted value" \
+	"$(q "SELECT string_agg(DISTINCT coalesce(w::text,'NULL'), ',' ORDER BY coalesce(w::text,'NULL')) FROM wsalter;")" \
+	"7,99"
+
+q "CREATE TABLE wsalter2 (id int, v text) USING pgcolumnar;" >/dev/null
+q "BEGIN;
+   INSERT INTO wsalter2 VALUES (0,'x');
+   ALTER TABLE wsalter2 ADD COLUMN w int;
+   INSERT INTO wsalter2 VALUES (1,'a',99);
+   COMMIT;" >/dev/null
+check "add-column without a default keeps the inserted value" \
+	"$(q "SELECT count(*) FROM wsalter2 WHERE w = 99;")" "1"
+
+q "CREATE TABLE wsalter3 (id int, v text) USING pgcolumnar;" >/dev/null
+q "BEGIN;
+   INSERT INTO wsalter3 VALUES (0,'x');
+   ALTER TABLE wsalter3 ADD COLUMN w int DEFAULT 7;
+   UPDATE wsalter3 SET w = 55;
+   COMMIT;" >/dev/null
+check "add-column mid-transaction keeps a later UPDATE" \
+	"$(q "SELECT string_agg(DISTINCT w::text, ',') FROM wsalter3;")" "55"
+
+q "DROP TABLE wsalter; DROP TABLE wsalter2; DROP TABLE wsalter3;" >/dev/null
 
 echo
 if [ "$fail" = "0" ]; then


### PR DESCRIPTION
Silent data loss. Values written into a column added by `ALTER TABLE ... ADD COLUMN` are dropped when a write to the same table already happened earlier in the transaction. No error, no warning; the column reads back as its missing value.

Found by differential-testing transaction and DDL sequences against a heap mirror.

## Reproduction

```sql
CREATE TABLE t (id int, v text) USING pgcolumnar;
BEGIN;
INSERT INTO t VALUES (0,'x');
ALTER TABLE t ADD COLUMN w int DEFAULT 7;
INSERT INTO t VALUES (1,'a',99);   -- 99 is lost
UPDATE t SET w = 55;               -- 55 is lost
COMMIT;
SELECT DISTINCT w FROM t;          -- 7. Only ever 7.
```

The same script on a heap table gives what you would expect. Measured variants on PostgreSQL 18.4, `main`:

| sequence | before | after | correct |
| --- | --- | --- | --- |
| ALTER then INSERT, no earlier write | `99` | `99` | `99` |
| INSERT, ALTER, INSERT | **`7`** | `7,99` | `7,99` |
| INSERT, ALTER, SELECT, INSERT | **`7`** | `7,99` | `7,99` |
| INSERT, ALTER (no default), INSERT | **`NULL`** | `99,NULL` | `99,NULL` |
| INSERT, ALTER, UPDATE | **`7`** | `55` | `55` |

Three things worth pulling out of that table:

- **It is not about the default.** With no default the writes are lost just the same and the column reads back NULL, which is even easier to mistake for correct.
- **It is not only INSERT.** An UPDATE into the new column is lost identically.
- **An intervening `SELECT` does not save you**, even though scans flush the write state for read-your-writes. The flush empties the buffer but leaves it in the list, still holding the old descriptor.

Only a transaction whose *first* write to the table comes after the ALTER escapes, because no buffer exists yet to be stale.

## Cause

`ColumnarGetWriteState()` finds a buffer by `(relation, subtransaction)` and returns it without checking that the relation still has the shape it had when the buffer opened:

```c
	foreach(lc, ColumnarWriteStates)
	{
		writeState = (ColumnarWriteState *) lfirst(lc);
		if (writeState->relid == relid && writeState->subid == subid)
			return writeState;      /* whatever natts it was opened with */
	}
```

The descriptor is snapshotted once at creation (`CreateTupleDescCopyConstr`, and `natts` with it). And unlike `columnar_cache.c` and `columnar_unique.c`, the write state registers **no** relcache callback, so no DDL invalidates it. The flushed chunks then carry the old column count, and the reader treats the added column as absent from those groups and serves its missing value — the same path that legitimately handles rows written before the column existed.

## The fix

When the column count no longer matches, flush what is buffered and open a new buffer. The buffered rows are correct under the descriptor they were written with, so flushing under it is the right thing rather than a compromise: those rows genuinely predate the column, and the reader's missing-value path is exactly right for them.

Comparing `natts` costs nothing on the insert path and covers ADD COLUMN, which is the reachable case. A type change goes through a table rewrite and a new relfilenode instead, so it cannot leave a stale buffer behind.

## Tests

Three checks added to `test/audit.sh`, whose stated convention is that every check fails against the pre-fix code:

```
main    : FAIL  add-column mid-transaction keeps the inserted value: got [7] want [7,99]
          FAIL  add-column without a default keeps the inserted value: got [0] want [1]
          FAIL  add-column mid-transaction keeps a later UPDATE: got [7] want [55]
          AUDIT TEST FAILED

branch  : AUDIT TEST PASSED
```

## Gate

Built clean on PostgreSQL 18.4 (Ubuntu 26.04 container). Green: `audit differential fuzz smoke native_dml concurrent_diff recovery generated_columns projections`.

Not run: the other majors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
