### PR TITLE
test: make unique_conc's bucket-count checks actually run

### DIFF
--- a/test/unique_conc.sh
+++ b/test/unique_conc.sh
@@ -128,6 +128,12 @@ run_pg "echo \"listen_addresses=''\" >> '$PGDATA/postgresql.conf'"
 run_pg "echo \"unix_socket_directories='$WORKDIR'\" >> '$PGDATA/postgresql.conf'"
 # Cap any real hang so a bug cannot masquerade as a pass by blocking forever.
 run_pg "echo \"lock_timeout=60000\" >> '$PGDATA/postgresql.conf'"
+# The bucket count is part of the advisory lock tag, so it is fixed at server
+# start rather than set per session: two backends that disagreed would hash the
+# same key to different buckets and not serialize at all. A large prime keeps
+# unrelated keys out of the same bucket, so a serialization this suite observes
+# is the real guarantee and not two keys colliding into one lock.
+run_pg "echo \"pgcolumnar.unique_lock_buckets=100003\" >> '$PGDATA/postgresql.conf'"
 echo "-- start"
 run_pg "pg_ctl -D '$PGDATA' -l '$LOGFILE' start -w" >/dev/null
 run_pg "createdb -h '$WORKDIR' -p $PORT uconc"
@@ -135,6 +141,9 @@ run_pg "createdb -h '$WORKDIR' -p $PORT uconc"
 PSQL="psql -h '$WORKDIR' -p $PORT -d uconc -qAtX -v ON_ERROR_STOP=1"
 SPSQL="psql -h '$WORKDIR' -p $PORT -d uconc -qAtX"
 ctl_q() { run_pg "$PSQL -c \"$1\""; }
+# Same, but keeps going on error and captures the message, for checks whose
+# subject is the error itself.
+ctl_qe() { run_pg "$SPSQL -c \"$1\" 2>&1"; }
 
 fail=0
 check() {  # name got want
@@ -240,17 +249,19 @@ start_session s2
 start_session sh   # holder of the mid-statement pause lock
 send s1 "SET application_name='cc_s1';"
 send s2 "SET application_name='cc_s2';"
-# The bucket count is part of the advisory lock tag, so it is fixed at server
-# start rather than set per session: two backends that disagreed would hash the
-# same key to different buckets and not serialize at all. pgc_setup puts the
-# large prime that avoids false bucket sharing into postgresql.conf, and the
-# check below pins that a session cannot change it out from under the guarantee.
+# This suite's cluster is started with the large prime above. Pin both halves of
+# what that buys: a session cannot change the count out from under the advisory
+# lock tag, and the cluster really is running the count the suite needs.
+# The output is captured before it is matched: piping ctl_qe straight into
+# grep -q makes grep exit on the first match, the psql upstream take SIGPIPE,
+# and the pipeline report failure under `set -o pipefail` even though the
+# message was there, which turns this into a check that can never pass.
+bucket_set_err="$(ctl_qe 'SET pgcolumnar.unique_lock_buckets = 1;')"
 check "the bucket count cannot be changed per session" \
-	"$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
-		-d "$PGC_DB" -At -c 'SET pgcolumnar.unique_lock_buckets = 1;' 2>&1 |
+	"$(echo "$bucket_set_err" |
 		grep -qE 'ERROR:.*cannot be changed' && echo OK || echo "NO ERROR")" "OK"
 check "the cluster runs the bucket count the suite needs" \
-	"$(q 'SHOW pgcolumnar.unique_lock_buckets;')" "100003"
+	"$(ctl_q 'SHOW pgcolumnar.unique_lock_buckets;')" "100003"
 
 HKEY=1000   # holder advisory-lock key, unique per pause
 


### PR DESCRIPTION
`unique_conc` is red on `main`, and has been since 09ba7a7. This fixes it.

## What broke

09ba7a7 replaced two per-session `SET pgcolumnar.unique_lock_buckets=100003`
statements with two checks, because #131 made the GUC `PGC_POSTMASTER` and a
session can no longer set it. The replacement was written against `test/lib.sh`
conventions and put into a suite that does not use `pgc_setup`:

- it called `psql -h 127.0.0.1 -p "$PGC_PORT"`, but `unique_conc.sh` starts its
  own cluster with `listen_addresses=''` and a private unix socket, so there is
  nothing listening on TCP to connect to;
- it used `$PGC_BINDIR`, `$PGC_PORT`, `$PGC_DB` and the `q` helper, none of which
  exist in this script;
- and nothing ever wrote `pgcolumnar.unique_lock_buckets=100003` into this
  suite's `postgresql.conf`, so the cluster ran the 128 default.

Both checks failed on every branch, unconditionally. It showed up as
`unique_conc=FAIL` on unrelated PRs (#137 among them), which is how I found it.

## The fix

Give this suite's own cluster the large prime the comment describes, and run both
checks through the suite's own `ctl_q` / `SPSQL` helpers over its unix socket.

One subtlety is worth the comment it now carries in the file. This form cannot
pass no matter how right the connection is:

```sh
"$(ctl_qe 'SET ...;' | grep -qE 'ERROR:.*cannot be changed' && echo OK || echo "NO ERROR")"
```

`grep -q` exits at the first match, the `psql` upstream takes SIGPIPE, and under
the script's `set -o pipefail` the pipeline reports failure even though the
message matched. I hit exactly this while fixing the connection, and it reported
`NO ERROR` while a debug print of the same command showed the error text. The
output is now captured first and matched afterward.

## Proof

Each check fails for its own reason and for nothing else, PG18, one variable at a
time:

| variant | cannot-be-changed check | bucket-count check | suite |
| --- | --- | --- | --- |
| as committed | PASS | PASS `100003` | PASSED |
| `postgresql.conf` line deleted | PASS | **FAIL** got `128` | FAILED |
| extension built with the GUC as `PGC_USERSET` | **FAIL** got `NO ERROR` | PASS | FAILED |

So the first check is what holds the `PGC_POSTMASTER` context, the second is what
holds the cluster's bucket count, and neither passes by accident.

Test-only change. Gate: PG18 + PG19 full suite.
