### PR TITLE
Remove the orphaned pgcolumnar.enable_metadata_count GUC

### DIFF
--- a/design/ISSUE_133_PLAN.md
+++ b/design/ISSUE_133_PLAN.md
@@ -1,0 +1,87 @@
+# Issue #133: the orphaned count GUC and the losing aggregate plan
+
+Two separate defects found by the 6M-row benchmark run. They land as two PRs so
+each is gated on its own.
+
+## Part 1: remove `pgcolumnar.enable_metadata_count`
+
+State today: declared in `src/columnar.h:159`, defined in
+`src/columnar_vector.c:74`, registered in `src/columnar_tableam.c:1193`, read by
+nothing. Its consumer left with the 2.2 format in `881fa51`.
+
+Decision: remove it rather than wire it back.
+
+The behaviour the name promises is real but is not a separable code path. An
+ungrouped aggregate over a native table is answered from row-group metadata by
+the vectorized aggregate path in `columnar_vector.c`, and `count(*)` is one case
+of that (`COLUMNAR_AGG_COUNT_STAR` sums `rg->rowCount` at
+`src/columnar_vector.c:1008`). Gating only the pure-`count(*)` subset would
+invent a boundary that exists nowhere in the code, purely to give the name
+something to do, and would leave two knobs whose scopes overlap without matching.
+
+The escape hatch a user would actually want, forcing a real count when the
+metadata is under suspicion, already exists under a correctly scoped name:
+`pgcolumnar.enable_vectorization = off` falls back to an ordinary `Agg` over the
+custom scan.
+
+Changes:
+
+- delete the declaration, definition, and `DefineCustomBoolVariable` call
+- `docs/configuration.md:38`: drop the row
+- `docs/features.md:48`: the line "`count(*)` with no filter is answered from
+  catalog metadata without scanning" states a behaviour that the bullet above it
+  already covers more accurately. Fold it into that bullet and name
+  `pgcolumnar.enable_vectorization` as the control.
+
+## Part 2: cost the vectorized aggregate path for what it reads
+
+`ColumnarAddVecAggPaths` sets both costs to the cheapest scan path's total cost
+(`src/columnar_vector.c:705`). The comment argues this is strictly cheaper than
+any `Agg` over a scan, which holds for serial plans and fails for parallel ones:
+`Gather` over `Partial Aggregate` divides the same scan cost across workers and
+wins. That is the benchmark regression, `count(*)` at 6M rows going from about
+0.03 ms on the columnar path to 6.52 ms through a parallel scan, and back to
+about 1.75 ms with `max_parallel_workers_per_gather = 0`.
+
+The path does not read the table. It reads one metadata entry per row group, so
+its cost should be a function of the row-group count, not of table size in pages.
+
+Model to implement:
+
+    ngroups   = ceil(rel->tuples / columnar_chunk_group_row_limit), floor 1
+    startup   = cpu_tuple_cost * 10          /* catalog access to get started */
+    total     = startup + ngroups * cpu_tuple_cost * (1 + naggs * 0.5)
+
+At 6M rows and the 10000 default that is about 600 groups, so a total near 6
+against thousands for either scan plan. The path stays serial and
+`parallel_safe = false`; it does not need workers to win once it is costed
+honestly.
+
+Open question to settle while implementing: `rel->tuples` is the planner's
+estimate and can be 0 on a never-analyzed relation. Use
+`Max(rel->tuples, rel->pages * 100)` or fall back to a fixed small group count so
+a stale estimate cannot make the path look free on a table that has none of the
+metadata it needs.
+
+## Verification
+
+Part 1 is a removal, so the proof is that the tree builds with no reference left
+(`grep -rn columnar_enable_metadata_count src/ docs/` empty) and the suites pass.
+
+Part 2 needs a plan-shape check, because a result-only check passes either way.
+Add to `test/native_agg.sh`, with parallelism left at its default:
+
+    EXPLAIN (COSTS OFF) SELECT count(*) FROM <native table>;
+
+must contain `Custom Scan (ColumnarScan)` and must not contain `Gather`. Prove it
+by mutation: restore `total_cost = cheapest->total_cost` and confirm the new
+check fails while the rest of the suite still passes. The table must be large
+enough that a parallel plan is otherwise attractive, so the fixture needs enough
+rows and pages for the planner to consider `Gather` at all. Confirm on the real
+benchmark table too: `count(*)` at 6M rows back to sub-millisecond with default
+settings.
+
+## Gate
+
+PG18 and PG19 per PR, per the standing rule. Part 2 touches planning for every
+native aggregate, so the whole suite matters, not just `native_agg`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,7 +35,6 @@ pgColumnar has two kinds of settings:
 | `pgcolumnar.enable_qual_pushdown` | boolean | `on` | Push scan qualifiers down so per-chunk min and max values can skip chunk groups. |
 | `pgcolumnar.enable_vectorization` | boolean | `on` | Use the vectorized aggregate path for supported ungrouped aggregates. |
 | `pgcolumnar.enable_bloom_filter` | boolean | `on` | Skip chunk groups on equality filters using per-chunk bloom filters. |
-| `pgcolumnar.enable_metadata_count` | boolean | `on` | Answer `count(*)` from catalog metadata without scanning the table. |
 | `pgcolumnar.enable_read_stream` | boolean | `on` | Prefetch block reads with the read stream API. Effective on PostgreSQL 17 and later. |
 
 ### Index-only scan and projections

--- a/docs/features.md
+++ b/docs/features.md
@@ -44,8 +44,10 @@ settings see the [configuration reference](configuration.md); for constraints se
 - Vectorized aggregate: an ungrouped `count`, `sum`, `avg`, `min`, or `max` over
   a supported column type is answered from the zone-map metadata, or by a
   column-at-a-time fold over the decoded values when the group has deletes,
-  without the per-tuple executor path.
-- `count(*)` with no filter is answered from catalog metadata without scanning.
+  without the per-tuple executor path. `count(*)` with no filter is one case of
+  this: it is answered from each row group's stored row count and reads no column
+  data. Set `pgcolumnar.enable_vectorization` to `off` to force an ordinary
+  aggregate over the scan instead.
 - Parallel scan across a table's row groups.
 - Read stream prefetch of block reads on PostgreSQL 17 and later
   (`pgcolumnar.enable_read_stream`).

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -156,7 +156,6 @@ extern bool columnar_enable_bloom_filter;	/* bloom equality skipping (I7) */
 
 /* Phase 6 GUCs (spec 8.3) */
 extern bool columnar_enable_vectorization;	/* vectorized aggregate path */
-extern bool columnar_enable_metadata_count;	/* count(*) from catalog metadata (gap 28) */
 extern bool columnar_enable_column_cache;	/* decompressed-chunk cache */
 extern bool columnar_enable_read_stream;	/* stream/prefetch block reads (PG17+) */
 extern bool columnar_enable_index_only_scan;	/* allow index-only scans (gap 28) */

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -1190,15 +1190,6 @@ _PG_init(void)
 							 0,
 							 NULL, NULL, NULL);
 
-	DefineCustomBoolVariable("pgcolumnar.enable_metadata_count",
-							 "Answer count(*) from catalog metadata without scanning.",
-							 NULL,
-							 &columnar_enable_metadata_count,
-							 true,
-							 PGC_USERSET,
-							 0,
-							 NULL, NULL, NULL);
-
 	DefineCustomBoolVariable("pgcolumnar.enable_bloom_filter",
 							 "Skip chunk groups on equality using per-chunk bloom filters.",
 							 NULL,

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -70,9 +70,6 @@
 /* GUC: use the vectorized aggregate path (spec 8.3 scan control) */
 bool		columnar_enable_vectorization = true;
 
-/* GUC: answer count(*) from catalog metadata without scanning data (gap 28) */
-bool		columnar_enable_metadata_count = true;
-
 /* -------------------------------------------------------------------------
  * shared column-at-a-time filter
  * ------------------------------------------------------------------------- */

--- a/test/differential.sh
+++ b/test/differential.sh
@@ -365,10 +365,11 @@ diff_query "wide most"     "SELECT id, a FROM %T WHERE sel > 100"
 # ---------------------------------------------------------------------------
 # Part 7: covering count(*) from metadata (gap 28)
 #
-# count(*) with no filter is answered from the catalog (visible stripe row
-# counts minus visible row-mask deletes), skipping the data scan. It must equal
-# the heap oracle after inserts, deletes, and updates, whether the metadata path
-# is on or off; and with it on, EXPLAIN ANALYZE shows no chunk groups scanned.
+# count(*) with no filter is answered from each row group's stored row count
+# (minus visible row-mask deletes), skipping the data scan. It must equal the
+# heap oracle after inserts, deletes, and updates, whether that path is taken or
+# not, so the loop below runs it both ways through
+# pgcolumnar.enable_vectorization, which is the switch that selects it.
 # ---------------------------------------------------------------------------
 echo "-- part 7: covering count(*)"
 
@@ -381,10 +382,10 @@ psql_run "UPDATE t_heap SET v = v + 1 WHERE id % 17 = 0;"
 psql_run "UPDATE t_col  SET v = v + 1 WHERE id % 17 = 0;"
 
 for mode in on off; do
-	q "ALTER DATABASE $PGC_DB SET pgcolumnar.enable_metadata_count=$mode;" >/dev/null
+	q "ALTER DATABASE $PGC_DB SET pgcolumnar.enable_vectorization=$mode;" >/dev/null
 	diff_query "count meta=$mode" "SELECT count(*) FROM %T"
 done
-q "ALTER DATABASE $PGC_DB RESET pgcolumnar.enable_metadata_count;" >/dev/null
+q "ALTER DATABASE $PGC_DB RESET pgcolumnar.enable_vectorization;" >/dev/null
 # The metadata count fast path is proven by the native_agg suite; the oracle
 # checks above prove the count is correct with the path on and off.
 


### PR DESCRIPTION
Part 1 of #133. Part 2, the costing defect that lets a parallel scan beat the
vectorized aggregate path, follows in its own PR on top of this one.

## The setting does nothing

`pgcolumnar.enable_metadata_count` is declared in `src/columnar.h`, defined in
`src/columnar_vector.c`, registered in `src/columnar_tableam.c`, and read
nowhere. `git log -S` puts the loss at `881fa51`, which removed the 1.0-dev (2.2)
format along with the code that consulted it. Since then it has been a
user-visible boolean, defaulting to on, whose description and
`docs/configuration.md` row both promise it controls whether `count(*)` is
answered from catalog metadata.

## Why removing beats wiring it back

The behaviour is real, but it is not a separable path. An ungrouped aggregate
over a native table is answered from row-group metadata by the vectorized
aggregate path, and `count(*)` is one case of it, summing each row group's stored
row count. To give this name something to do I would have to gate only that
subset, inventing a boundary that exists nowhere in the code and leaving two
settings whose scopes overlap without matching.

The escape hatch a user would actually want, forcing a real count when the
metadata is in doubt, already exists and is correctly scoped:
`pgcolumnar.enable_vectorization = off` falls back to an ordinary `Agg` over the
custom scan.

## Changes

- drop the declaration, definition, and registration
- `docs/configuration.md`: drop the row
- `docs/features.md`: the separate `count(*)` bullet claimed a mechanism that the
  vectorized-aggregate bullet above it already describes more accurately. Folded
  in, naming the setting that really selects it.
- `test/differential.sh` part 7 kept its meaning. It checks `count(*)` against
  the heap oracle with the metadata path taken and not taken, after inserts,
  deletes, and updates; it now toggles `pgcolumnar.enable_vectorization`, which
  is the switch that really selects the path. Left as-is it would have failed
  outright, since `pgcolumnar` is a reserved GUC prefix and setting a name the
  extension no longer defines is an error.

`grep -rn enable_metadata_count` over the tree comes back with nothing outside
the plan document.

Gate: PG18 + PG19, full suite.
