### PR TITLE
Cost the vectorized aggregate path for what it reads

### DIFF
--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -36,6 +36,8 @@
  */
 #include "columnar.h"
 
+#include <math.h>
+
 #include "access/relation.h"
 #include "access/table.h"
 #include "catalog/pg_aggregate.h"
@@ -57,8 +59,10 @@
 #include "optimizer/optimizer.h"
 #include "optimizer/pathnode.h"
 #include "optimizer/planner.h"
+#include "optimizer/cost.h"
 #include "optimizer/restrictinfo.h"
 #include "utils/builtins.h"
+#include "utils/snapmgr.h"
 #include "utils/datum.h"
 #include "utils/fmgrprotos.h"
 #include "utils/lsyscache.h"
@@ -696,11 +700,83 @@ ColumnarCreateUpperPaths(PlannerInfo *root, UpperRelationKind stage,
 	cpath->path.rows = 1;
 
 	/*
-	 * The bare scan cost, with no per-tuple aggregate overhead: strictly cheaper
-	 * than any Agg-over-scan path, so the planner prefers this one.
+	 * Cost what this path actually reads.
+	 *
+	 * Pricing it at the cheapest scan's cost, as this did, is not merely
+	 * pessimistic: it loses. A parallel Agg divides that same scan cost across
+	 * workers and comes out cheaper, so the planner reads the whole table to
+	 * compute what this path takes from row-group metadata (issue #133).
+	 *
+	 * With no delete vector the executor answers every aggregate from that
+	 * metadata and reads no data pages, so the work is one metadata entry per row
+	 * group. With deletes it falls back to a real scan that applies the delete
+	 * mask, and the scan cost is the right price. The probe below asks the same
+	 * question execution asks; if the answer changes between planning and
+	 * execution the plan is mispriced, never wrong.
 	 */
-	cpath->path.startup_cost = cheapest->total_cost;
-	cpath->path.total_cost = cheapest->total_cost;
+	{
+		bool		hasDeletes = true;
+		Snapshot	snap = GetActiveSnapshot();
+
+		if (snap != NULL)
+		{
+			Relation	frel = table_open(relid, AccessShareLock);
+
+			hasDeletes =
+				ColumnarStorageHasDeleteVector(ColumnarStorageId(frel),
+											   ColumnarCatalogSnapshot(snap));
+			table_close(frel, AccessShareLock);
+		}
+
+		if (hasDeletes)
+		{
+			cpath->path.startup_cost = cheapest->total_cost;
+			cpath->path.total_cost = cheapest->total_cost;
+		}
+		else
+		{
+			ColumnarOptions opts;
+			int			limit = columnar_chunk_group_row_limit;
+			double		rows = input_rel->tuples;
+			double		ngroups;
+			Cost		cost;
+
+			/* the table's own limit when it sets one, else the GUC default */
+			if (ColumnarReadOptions(relid, &opts) &&
+				opts.chunkGroupRowLimitSet && opts.chunkGroupRowLimit > 0)
+				limit = opts.chunkGroupRowLimit;
+			if (limit <= 0)
+				limit = 1;
+
+			/*
+			 * A never-analyzed relation has no row estimate. Deriving one from
+			 * the page count keeps the cost tied to something real, so a missing
+			 * estimate cannot make this path look free.
+			 */
+			if (rows < 0)
+				rows = (input_rel->pages > 0)
+					? (double) input_rel->pages * 100.0
+					: 1000.0;
+			ngroups = ceil(rows / (double) limit);
+			if (ngroups < 1)
+				ngroups = 1;
+
+			cost = cpu_tuple_cost * 10;		/* getting to the catalog */
+			cost += ngroups * (cpu_tuple_cost +
+							   cpu_operator_cost * (double) naggs);
+
+			/* reading metadata is never dearer than reading the table */
+			if (cost > cheapest->total_cost)
+				cost = cheapest->total_cost;
+
+			/*
+			 * One row comes out, and only after every row group is folded in, so
+			 * there is no partial result to start up cheaply with.
+			 */
+			cpath->path.startup_cost = cost;
+			cpath->path.total_cost = cost;
+		}
+	}
 	cpath->path.pathkeys = NIL;
 	cpath->flags = 0;
 	cpath->custom_paths = NIL;

--- a/test/native_agg.sh
+++ b/test/native_agg.sh
@@ -39,6 +39,25 @@ plan() {
 # no separate Aggregate node above a scan; a fallback plan has an Aggregate node
 # and no such line.
 has_aggnode() { echo "$1" | grep -q 'Columnar Vectorized Aggregates' && echo yes || echo no; }
+has_gather() { echo "$1" | grep -q 'Gather' && echo yes || echo no; }
+
+# Same, with a parallel plan available: workers allowed, no setup charge, and no
+# minimum table size, since the suite runs with max_parallel_workers_per_gather=0
+# and a fixture of a few pages, so without this a plan-choice check would never
+# see the alternative it is about.
+#
+# parallel_tuple_cost keeps its default on purpose. Zeroing it makes a Gather of
+# raw rows look free, which makes that Gather the cheapest scan path, and the
+# cost this check exists to catch was inherited from the cheapest scan path. With
+# the charge zeroed the wrong costing still picks the right plan and the check
+# passes for a reason that has nothing to do with the fix.
+plan_par() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -At -c "SET max_parallel_workers_per_gather = 4;
+		SET parallel_setup_cost = 0;
+		SET min_parallel_table_scan_size = 0;
+		EXPLAIN (COSTS OFF) $1" 2>/dev/null
+}
 
 # Supported aggregates answered from zone maps must equal the heap oracle.
 check "count(*)"          "$(q 'SELECT count(*) FROM n;')"        "$(q 'SELECT count(*) FROM h;')"
@@ -58,6 +77,18 @@ check "multi-agg"         "$(q 'SELECT count(*), sum(id), min(id), max(id) FROM 
 check "count(*) uses metadata agg node" "$(has_aggnode "$(plan 'SELECT count(*) FROM n')")" "yes"
 check "sum/min/max uses metadata agg node" \
 	"$(has_aggnode "$(plan 'SELECT sum(id), min(id), max(id) FROM n')")" "yes"
+
+# The path has to win on cost, not only exist. It reads one metadata entry per
+# row group; Gather over Partial Aggregate reads the whole table. Costing this
+# path at the scan's cost let the parallel plan take work the catalog already
+# has (issue #133), so pin the plan the planner picks once a parallel one is on
+# the table.
+par_count="$(plan_par 'SELECT count(*) FROM n')"
+check "count(*) beats a parallel plan"  "$(has_aggnode "$par_count")" "yes"
+check "count(*) plan has no Gather"     "$(has_gather "$par_count")"  "no"
+par_multi="$(plan_par 'SELECT count(*), sum(id), min(id), max(id) FROM n')"
+check "multi-agg beats a parallel plan" "$(has_aggnode "$par_multi")" "yes"
+check "multi-agg plan has no Gather"    "$(has_gather "$par_multi")"  "no"
 
 # A filtered aggregate falls back (no zone-map answer) but is still correct.
 check "filtered aggregate parity" \


### PR DESCRIPTION
Part 2 of #133, on top of #139.

## The defect

`ColumnarAddVecAggPaths` priced the vectorized aggregate path at the cheapest
scan path's total cost, with the comment arguing it is "strictly cheaper than any
Agg-over-scan path, so the planner prefers this one". That holds for serial plans
and fails for parallel ones: `Gather` over `Partial Aggregate` divides the same
scan cost across workers and comes out cheaper. The planner then reads six
million rows to compute what the path takes from row-group metadata.

From the benchmark run, `count(*)` on 6M rows: 6.52 ms at default settings,
about 1.75 ms with `max_parallel_workers_per_gather = 0`, against 0.03 ms
recorded before.

## The fix

Cost the path for what it reads.

With no delete vector the executor answers every aggregate from metadata and
reads no data pages, so the work is one metadata entry per row group, using the
table's own `chunk_group_row_limit` when it sets one. With deletes it falls back
to a real scan that applies the delete mask, and the scan cost stays the right
price. The plan-time probe is the same predicate execution uses
(`ColumnarStorageHasDeleteVector`), so if the answer changes between planning and
execution the plan is mispriced, never wrong.

Two guards: the estimate is clamped at the scan cost, so this can never claim to
be dearer than reading the table; and a never-analyzed relation derives its row
count from the page count, so a missing estimate cannot make the path look free.

Measured on a 500,000-row table, PG18, `EXPLAIN` with costs:

| plan | cost |
| --- | --- |
| vectorized aggregate, this change | 6.21 |
| Gather over Partial Aggregate | 1624.28 |
| serial Agg over Custom Scan | 6497.01 |

## Proving the test

`native_agg` now pins the plan the planner picks, not only that the path exists.
Getting this to fail for the right reason took two attempts, and the first one is
worth recording.

My first version made parallelism maximally attractive, including
`parallel_tuple_cost = 0`. Both checks passed with the fix and passed just as
happily with the fix mutated out. Zeroing the tuple charge makes a `Gather` of
raw rows look free, so that `Gather` becomes the cheapest scan path, and the old
code inherited its cost from the cheapest scan path: 53.50 instead of the serial
107.00, which still beat the parallel aggregate's 66.03. The check was passing
for a reason unrelated to the defect. Leaving `parallel_tuple_cost` at its
default restores the term that made the old costing lose, and it is now commented
in the file so nobody zeroes it back.

With that corrected, on PG18, one variable changed at a time:

| variant | the four new plan checks | rest of native_agg |
| --- | --- | --- |
| as committed | PASS | PASS |
| `if (hasDeletes)` forced true, i.e. the old scan-cost pricing | **all four FAIL**, plan comes back as `Gather` over `Partial Aggregate` | PASS |

Four failures and no others, so the checks catch this costing and nothing else.

Gate: PG18 + PG19, full suite.
