### PR TITLE
count(*) no longer reads zone maps it has no use for

### DIFF
--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -1042,6 +1042,25 @@ columnar_fill_native_metadata_agg(ColumnarAggScanState *state)
 	uint64		storageId;
 	List	   *groups;
 	ListCell   *lc;
+	bool		needZones = false;
+	int			na;
+
+	/*
+	 * count(*) comes from the row group's own stored row count. Every other
+	 * aggregate here reads a zone map, and reading them means one catalog lookup
+	 * per row group returning an entry for every column, whether the query names
+	 * that column or not. For a count(*) on its own that is all waste, and it is
+	 * the whole cost of the query: at 6,000,000 rows and the default limits it
+	 * measured 5.2 ms over 40 row groups, and 1.4 ms over 10 (issue #133).
+	 */
+	for (na = 0; na < state->naggs; na++)
+	{
+		if (state->specs[na].kind != COLUMNAR_AGG_COUNT_STAR)
+		{
+			needZones = true;
+			break;
+		}
+	}
 
 	ColumnarFlushWriteStateForRelation(state->relid);
 	rel = table_open(state->relid, AccessShareLock);
@@ -1053,26 +1072,31 @@ columnar_fill_native_metadata_agg(ColumnarAggScanState *state)
 	foreach(lc, groups)
 	{
 		NativeRowGroupMetadata *rg = (NativeRowGroupMetadata *) lfirst(lc);
-		List	   *zones = ColumnarReadZoneMapList(storageId, rg->groupNumber,
-												   snap);
-		NativeZoneMapMetadata **byCol =
-			palloc0(sizeof(NativeZoneMapMetadata *) * tupdesc->natts);
-		ListCell   *zc;
+		NativeZoneMapMetadata **byCol = NULL;
 		int			a;
 
-		foreach(zc, zones)
+		if (needZones)
 		{
-			NativeZoneMapMetadata *z = (NativeZoneMapMetadata *) lfirst(zc);
+			List	   *zones = ColumnarReadZoneMapList(storageId,
+														rg->groupNumber, snap);
+			ListCell   *zc;
 
-			if (z->columnIndex >= 0 && z->columnIndex < tupdesc->natts)
-				byCol[z->columnIndex] = z;
+			byCol = palloc0(sizeof(NativeZoneMapMetadata *) * tupdesc->natts);
+			foreach(zc, zones)
+			{
+				NativeZoneMapMetadata *z = (NativeZoneMapMetadata *) lfirst(zc);
+
+				if (z->columnIndex >= 0 && z->columnIndex < tupdesc->natts)
+					byCol[z->columnIndex] = z;
+			}
 		}
 
 		for (a = 0; a < state->naggs; a++)
 		{
 			ColumnarAggSpec *spec = &state->specs[a];
 			NativeZoneMapMetadata *z =
-				(spec->attidx >= 0 && spec->attidx < tupdesc->natts)
+				(byCol != NULL && spec->attidx >= 0 &&
+				 spec->attidx < tupdesc->natts)
 				? byCol[spec->attidx] : NULL;
 
 			switch (spec->kind)

--- a/test/native_agg.sh
+++ b/test/native_agg.sh
@@ -90,6 +90,26 @@ par_multi="$(plan_par 'SELECT count(*), sum(id), min(id), max(id) FROM n')"
 check "multi-agg beats a parallel plan" "$(has_aggnode "$par_multi")" "yes"
 check "multi-agg plan has no Gather"    "$(has_gather "$par_multi")"  "no"
 
+# count(*) is answered from each row group's stored row count, so it has no
+# reason to read zone maps at all. Reading them costs one catalog lookup per row
+# group returning an entry for every column, and on a 6,000,000-row table that
+# was the entire cost of the query (issue #133). Count the scans of
+# pgcolumnar.zone_map across the statement: each q is its own backend, and a
+# backend flushes its statistics when it exits, so the counter is settled by the
+# time the next one reads it.
+zm_scans() {
+	q "SELECT coalesce(idx_scan, 0) + coalesce(seq_scan, 0)
+	     FROM pg_stat_all_tables WHERE relid = 'pgcolumnar.zone_map'::regclass;"
+}
+zm_before="$(zm_scans)"; q 'SELECT count(*) FROM n;' >/dev/null; zm_after="$(zm_scans)"
+check "count(*) reads no zone maps" "$((zm_after - zm_before))" "0"
+
+# The same measurement the other way round, so the check above cannot pass just
+# because the counter never moves.
+zm_before="$(zm_scans)"; q 'SELECT count(*), sum(id) FROM n;' >/dev/null; zm_after="$(zm_scans)"
+check "an aggregate that needs zone maps reads them" \
+	"$([ "$((zm_after - zm_before))" -gt 0 ] && echo yes || echo no)" "yes"
+
 # A filtered aggregate falls back (no zone-map answer) but is still correct.
 check "filtered aggregate parity" \
 	"$(q 'SELECT count(*), sum(id) FROM n WHERE id > 5000;')" \


### PR DESCRIPTION
Part 3 of #133, and the part that actually fixes the reported latency.

## What #139 and #140 did not fix

#140 made the planner pick the vectorized aggregate path again instead of a
parallel scan. I then measured the result at benchmark scale rather than assuming
it, and the plan was right while the number was not: `count(*)` on 6,000,000 rows
still took about 6 ms at default settings, against the 0.02 ms this used to be.

So I measured where it went. Execution time tracked the row-group count, not the
row count:

| chunk_group_row_limit | row groups | execution time |
| --- | --- | --- |
| 10000 (default) | 40 | 5.2 ms |
| 100000 | 10 | 1.4 ms |

That is the shape of per-row-group work, not of a constant-time answer.

## The cause

`columnar_fill_native_metadata_agg` called `ColumnarReadZoneMapList` for every row
group, one catalog lookup per group returning an entry for every column in the
table, and then used none of it when the only aggregate was `count(*)`, which
comes from the row group's own stored `rowCount`.

Deciding once, before the loop, whether any aggregate needs a zone map, and
skipping the lookup when none does. `count(col)`, `sum`, `avg`, `min`, and `max`
each read one, so only a pure `count(*)` takes the shorter path.

## Result

Same table, same machine, PG17 non-assert, 6,000,000 rows, `EXPLAIN ANALYZE`
execution time, five runs:

| row groups | before | after |
| --- | --- | --- |
| 40 | 5.2 ms | 0.033 ms |
| 10 | 1.4 ms | 0.029 ms |

Constant with respect to row groups now, which is the point of answering from
metadata, and back to the 0.02 ms class the issue was measured against.

## Proof

`native_agg` counts scans of `pgcolumnar.zone_map` across the statement, from
`pg_stat_all_tables`. Each `q` is its own backend and a backend flushes its
statistics on exit, so the counter is settled by the time the next one reads it.
Two checks, in both directions:

- `count(*)` must add no scans
- `count(*), sum(id)` must add some, so the first check cannot pass merely
  because the counter never moves

On PG18, one variable at a time:

| variant | reads no zone maps | needs and reads them | rest of suite |
| --- | --- | --- | --- |
| as committed, run 1 | PASS | PASS | PASS |
| as committed, run 2 | PASS | PASS | PASS |
| as committed, run 3 | PASS | PASS | PASS |
| `needZones` initialised to `true` (the old behaviour) | **FAIL**, got 5 scans against 0 | PASS | PASS |

Three consecutive clean runs because a statistics-counter assertion is worth
checking for flakiness before it goes into the matrix. The mutation fails exactly
one check and nothing else.

Gate: PG18 + PG19, full suite.
