### PR TITLE
design: correct the fetch plan's ordering

### DIFF
--- a/design/FETCH_BY_ROW_PLAN.md
+++ b/design/FETCH_BY_ROW_PLAN.md
@@ -76,12 +76,23 @@ directly from the row offset. Variable-width columns need an offset array, which
 the decoder can produce as it walks, at the cost of one array per decoded chunk.
 Worth doing after B, since B changes how often step 4 runs.
 
-## Also worth doing: fetch only the columns the caller needs
+## Fetch only the columns the caller needs: smaller than it looks
 
-The uniqueness check needs the key columns; the fetch decodes all of them. A
-needed-columns bitmap through `ColumnarReadRowByNumber` would cut the constant
-factor for the check without touching the caching question. Smallest of the three
-changes and fully independent.
+The first version of this plan put a needed-columns bitmap first, on the argument
+that the uniqueness check only needs the key columns. Checking the call path
+before writing it says otherwise.
+
+The check reaches the same callback every other fetch does. Core's
+`table_index_fetch_tuple_check` creates a slot, calls `table_index_fetch_tuple`,
+and throws the slot away; the access method cannot tell that call apart from a
+real fetch, and `columnar_index_fetch_tuple` fills every column of the slot
+either way. So a bitmap does not help the caller that would benefit most, because
+that caller has no way to declare what it needs.
+
+It still helps callers that do know, and it is still independent of the caching
+question, but it is no longer the piece to start with. Making the check itself
+cheap would need a visibility-only path, which is a change to what the callback
+does rather than to what it decodes, and is out of scope here.
 
 ## Proving it
 
@@ -102,11 +113,18 @@ sizes, where the wrong implementation cannot produce both.
 
 ## Order
 
-1. Needed-columns bitmap (independent, small, no caching questions).
-2. Statement-scoped decoded-group cache (option B), with the memory cap measured.
-3. Positional indexing to remove the walk (option C).
+1. Statement-scoped decoded-group cache (option B), with the memory cap measured.
+   It is the only piece that helps every caller, including the uniqueness check.
+2. Positional indexing to remove the walk (option C).
+3. Needed-columns bitmap, for the callers that can declare their needs.
 
 Each is its own PR with its own gate.
+
+On scoping the cache to a statement in practice: `GetCurrentCommandId(false)`
+recorded alongside the entry is enough, since any command boundary changes it, so
+a `pgcolumnar.vacuum` in the same transaction invalidates the entry without a
+dedicated hook. Key on the storage id as well, so a rewrite that allocates new
+storage cannot be served the old decode.
 
 ## Not this
 


### PR DESCRIPTION
Follow-up to #144, design document only.

I checked the call path before writing the piece the plan listed first, and it does not do what the plan assumed. The uniqueness check reaches `columnar_index_fetch_tuple` through core's `table_index_fetch_tuple_check`, which builds a slot, calls the ordinary fetch callback, and throws the slot away. The access method cannot distinguish that from a real fetch, so a needed-columns bitmap cannot help the caller it was aimed at.

Reordered: the statement-scoped decoded-group cache goes first, since it helps every caller including the check. Also recorded that `GetCurrentCommandId(false)` is enough to scope the cache to a statement, so a `pgcolumnar.vacuum` in the same transaction invalidates it without a dedicated hook.