### PR TITLE
Check for interrupts in the RLE, dictionary, and ALP decode loops

### DIFF
--- a/src/columnar_encoding.c
+++ b/src/columnar_encoding.c
@@ -258,15 +258,24 @@ decode_rle(const char *enc, uint32 encLen, int w, uint32 n, uint32 rawLen,
 	{
 		uint32		run;
 
-		COLUMNAR_DECODE_INTERRUPT(produced);
 		if (p + sizeof(uint32) > end)
 			DECODE_CORRUPT("RLE run header past encoded length");
 		memcpy(&run, p, sizeof(uint32));
 		p += sizeof(uint32);
 		if (p + w > end)
 			DECODE_CORRUPT("RLE run value past encoded length");
+
+		/*
+		 * The check belongs in the inner loop, not the outer one. A single run
+		 * can cover the whole vector, which is the case RLE is chosen for, and
+		 * the outer loop would then run once. Testing `produced` out here is also
+		 * unsound on its own: it advances by run length rather than by one, so it
+		 * can step over every multiple of the stride and never fire again after
+		 * the first run.
+		 */
 		while (run-- > 0 && produced < n)
 		{
+			COLUMNAR_DECODE_INTERRUPT(produced);
 			memcpy(raw + (uint64) produced * w, p, w);	/* produced < n; n*w == rawLen */
 			produced++;
 		}
@@ -1062,6 +1071,8 @@ decode_alp(const char *enc, uint32 encLen, int w, uint32 n, uint32 rawLen,
 		int64		v = forBase + (int64) offs[i];
 		double		rec = (double) v * alp_F10[f] * alp_IF10[e];
 
+		COLUMNAR_DECODE_INTERRUPT(i);
+
 		if (w == 8)
 			memcpy(raw + (uint64) i * 8, &rec, 8);
 		else
@@ -1244,6 +1255,7 @@ decode_dict(const char *enc, uint32 encLen, Form_pg_attribute att, uint32 n,
 	{
 		uint32		code = (uint32) codes[i];
 
+		COLUMNAR_DECODE_INTERRUPT(i);
 		if (code >= nd)
 			DECODE_CORRUPT("DICT code out of range");
 		if (dlen[code] > rawLen - pos)	/* pos <= rawLen invariant */


### PR DESCRIPTION
Found reviewing everything that landed since the audit began, as a whole rather than PR by PR. #128 covered five of the seven decoders.

## The gap

`decode_dict` and `decode_alp` have no interrupt check. `decode_rle` has one that its own loop structure defeats: the check sits in the outer run loop while the copying happens in the inner one, and a single run can cover the whole vector, which is the case run-length exists for. The outer loop then runs once and every value is copied with no check.

Testing `produced` in the outer loop is also unsound on its own. It advances by run length, not by one, so it can step over every multiple of the 65536 stride and never fire again after the first run. Moving the check into the inner loop fixes both.

## What I could not prove, stated plainly

No test accompanies this, and the reason is worth recording.

I wrote three fixtures (single-column tables, 8,000,000 values, one row group, encoding pinned through `encoding_descriptor`) and ran them against builds with each check individually removed. They passed either way:

| shape | full load | cancel fires | with the check removed |
| --- | --- | --- | --- |
| dictionary text | 193 ms | 63 ms | 186 ms / 63 ms, still passes |
| ALP float | 242 ms | 65 ms | 247 ms / 65 ms, still passes |
| run-length | 95 ms | 91 ms | fails both ways, window too short |

`decode_dict` and `decode_alp` both call `bitunpack` over the same value count before their own loop, and `bitunpack` already checks, so a 50 ms timeout always fires there first. Run-length decodes 8,000,000 values in 95 ms, too short to separate from the timeout itself.

The first version of those fixtures was worse: it had an `id bigint` column alongside the column under test, so the load decoded the id first and the id's own check fired the cancel. That version passed against a build with the check deliberately removed, which is the failure mode this project keeps finding.

So the fixtures are not in this PR. A check that passes with the change removed proves nothing and costs matrix time; `native_cancel`'s existing bigint-ramp case already covers the load path as a whole. Isolating these three would need a vector large enough to dwarf both `bitunpack` and the timeout, which is not a size the matrix should carry.

The RLE change closes a real structural gap. The dictionary and ALP changes are hardening against a loop bounded only by a user-settable setting, and the commit message says exactly that rather than claiming more.

Gate: PG18 + PG19 running.