### PR TITLE
bench: full run at f7adbdb, a mutation section, and what the numbers now say

### DIFF
--- a/bench/run_bench.sh
+++ b/bench/run_bench.sh
@@ -452,6 +452,68 @@ SELECT
 SQL
 "
 
+# ---- mutation: UPDATE and DELETE reached by index --------------------------
+# The read benchmarks above leave the tables untouched, so this runs last and on
+# its own copies: an UPDATE would otherwise change what every earlier number was
+# measured against.
+#
+# This is the path issue #143 is about. A fetch by row number decodes the row
+# group the row lives in, so the cost of touching N rows in one group used to be
+# N times the group; a statement-scoped cache of the decoded group (#148) removes
+# the repeat. Two shapes are timed because they differ: ids in row order, which
+# is what a range UPDATE gives, and scattered ids, where consecutive fetches land
+# in different groups and a small cache helps less.
+DSCALE=$(( SCALE / 6 ))
+echo "-- mutation ($DSCALE rows)"
+run_pg "$PSQL <<SQL
+\\set QUIET on
+\\pset pager off
+SET max_parallel_workers_per_gather = 0;
+
+CREATE TABLE dh (LIKE h);
+INSERT INTO dh SELECT * FROM h WHERE id <= $DSCALE;
+CREATE INDEX dh_id ON dh (id);
+ANALYZE dh;
+
+CREATE TABLE dc (LIKE h) USING pgcolumnar;
+INSERT INTO dc SELECT * FROM h WHERE id <= $DSCALE;
+CREATE INDEX dc_id ON dc (id);
+
+\\echo
+\\echo === MUTATION: rows reached by index ($DSCALE rows) ===
+\\echo (median of $REPS for UPDATE; DELETE is a single run, since a repeat
+\\echo  would find nothing left to delete)
+SELECT format('%-34s', op) AS operation,
+       heap_ms, columnar_ms,
+       round(columnar_ms / nullif(heap_ms, 0), 2) AS columnar_over_heap
+FROM (
+	SELECT 'single row by id' AS op,
+	       bench_time('UPDATE dh SET val = val + 1 WHERE id = 1', $REPS) AS heap_ms,
+	       bench_time('UPDATE dc SET val = val + 1 WHERE id = 1', $REPS) AS columnar_ms
+	UNION ALL
+	SELECT '1000 rows, ids in row order',
+	       bench_time('UPDATE dh SET val = val + 1 WHERE id BETWEEN 2000 AND 2999', $REPS),
+	       bench_time('UPDATE dc SET val = val + 1 WHERE id BETWEEN 2000 AND 2999', $REPS)
+	UNION ALL
+	SELECT '1000 rows, ids scattered',
+	       bench_time('UPDATE dh SET val = val + 1 WHERE id % ($DSCALE / 1000) = 7', $REPS),
+	       bench_time('UPDATE dc SET val = val + 1 WHERE id % ($DSCALE / 1000) = 7', $REPS)
+) m;
+
+\\echo
+SELECT format('%-34s', op) AS operation, heap_ms, columnar_ms,
+       round(columnar_ms / nullif(heap_ms, 0), 2) AS columnar_over_heap
+FROM (
+	SELECT 'DELETE 1000 rows by id range' AS op,
+	       bench_rt('DELETE FROM dh WHERE id BETWEEN $(( DSCALE / 2 )) AND $(( DSCALE / 2 + 999 ))') AS heap_ms,
+	       bench_rt('DELETE FROM dc WHERE id BETWEEN $(( DSCALE / 2 )) AND $(( DSCALE / 2 + 999 ))') AS columnar_ms
+) d;
+
+\\echo (row counts must agree after the mutations)
+SELECT (SELECT count(*) FROM dh) AS heap_rows, (SELECT count(*) FROM dc) AS columnar_rows;
+SQL
+"
+
 # ---- optional DuckDB comparison --------------------------------------------
 if [ "${BENCH_DUCKDB:-0}" = "1" ] && command -v duckdb >/dev/null 2>&1; then
 	echo

--- a/bench/sample_output_fsst_pg17.txt
+++ b/bench/sample_output_fsst_pg17.txt
@@ -1,0 +1,12 @@
+===================== FSST INGESTION GATE ======================
+  rows                         3000000
+  heap INSERT                  1918.2 ms
+  columnar INSERT              12370.5 ms
+  round-trip                   MATCH
+  heap size                    439279616 bytes
+  columnar size                105807872 bytes
+  url chunks using FSST        20 / 20 (first-vector = FSST)
+================================================================
+Run once as shipped and once with encode_fsst stubbed to return false;
+the columnar-INSERT delta is FSST's ingestion cost, the size delta its ratio.
+FSST_EXIT=0

--- a/bench/sample_output_pg17_6m.txt
+++ b/bench/sample_output_pg17_6m.txt
@@ -1,7 +1,7 @@
-started 2026-07-26T13:27:48+00:00
+started 2026-07-26T16:43:22+00:00
 == pgColumnar benchmark ==
 PG_CONFIG=/usr/local/pg17_nc/bin/pg_config  (PostgreSQL 17.10)
-scale=6000000 rows  reps=5  workdir=/tmp/pgcolumnar-bench.42LCXN
+scale=6000000 rows  reps=5  workdir=/tmp/pgcolumnar-bench.Vql4Q9
 -- building (non-assert expected)
 -- initdb and start
 -- loading 6000000 rows (staging, heap, columnar zstd, columnar none)
@@ -28,19 +28,19 @@ scale=6000000 rows  reps=5  workdir=/tmp/pgcolumnar-bench.42LCXN
 === QUERY LATENCY: heap vs columnar zstd (median ms of 5) ===
  id |                 query                  | heap_ms | columnar_ms | heap_over_col 
 ----+----------------------------------------+---------+-------------+---------------
-  1 | count(*) full table                    |  251.95 |        0.02 |      12597.50
-  2 | sum/avg over one int column            |  346.99 |        0.53 |        654.70
-  3 | filtered agg, min/max-skippable range  |  270.17 |       90.96 |          2.97
-  4 | point lookup by indexed id             |    0.01 |       26.75 |          0.00
-  5 | projection: 3 of 8 cols, 1% filter     |  260.56 |       80.18 |          3.25
+  1 | count(*) full table                    |  251.34 |        0.02 |      12567.00
+  2 | sum/avg over one int column            |  354.96 |        0.53 |        669.74
+  3 | filtered agg, min/max-skippable range  |  263.62 |       92.35 |          2.85
+  4 | point lookup by indexed id             |    0.01 |       23.75 |          0.00
+  5 | projection: 3 of 8 cols, 1% filter     |  264.94 |       81.58 |          3.25
 (5 rows)
 
 
 === VECTORIZATION on vs off (columnar zstd, median ms) ===
-        query         | on_ms | off_ms | speedup_vec 
-----------------------+-------+--------+-------------
- sum/avg over int     |  0.51 | 795.94 |     1560.67
- filtered agg (range) | 73.19 |  71.86 |        0.98
+        query         | on_ms | off_ms  | speedup_vec 
+----------------------+-------+---------+-------------
+ sum/avg over int     |  0.51 | 1352.10 |     2651.18
+ filtered agg (range) | 87.51 |   86.53 |        0.99
 (2 rows)
 
 
@@ -52,7 +52,7 @@ scale=6000000 rows  reps=5  workdir=/tmp/pgcolumnar-bench.42LCXN
 
      metric      | none | zstd | none_over_zstd 
 -----------------+------+------+----------------
- sum/avg scan ms | 0.50 | 0.50 | 
+ sum/avg scan ms | 0.50 | 0.49 | 
  count(*) ms     | 0.02 | 0.02 | 
 (2 rows)
 
@@ -66,7 +66,7 @@ ANALYZE
 === SORTED PROJECTION: narrow range scan on a scattered key (median ms) ===
         state         |   ms   
 ----------------------+--------
- before vacuum_sorted | 355.04
+ before vacuum_sorted | 348.79
 (1 row)
 
  vacuum_sorted 
@@ -77,7 +77,7 @@ ANALYZE
 ANALYZE
         state        |  ms   
 ---------------------+-------
- after vacuum_sorted | 45.81
+ after vacuum_sorted | 45.47
 (1 row)
 
 -- index-only scan
@@ -92,9 +92,9 @@ VACUUM
 ANALYZE
 
 === INDEX-ONLY SCAN on vs off (covering range count, median ms) ===
-             query              | on_ms |  off_ms  | speedup_ios 
---------------------------------+-------+----------+-------------
- covering count, id range (~2%) |  7.31 | 31845.77 |     4356.47
+             query              | on_ms | off_ms | speedup_ios 
+--------------------------------+-------+--------+-------------
+ covering count, id range (~2%) |  7.24 | 689.21 |       95.19
 (1 row)
 
 SET
@@ -113,7 +113,7 @@ ANALYZE
 === PROJECTION SCAN on vs off (covering row scan on a scattered sort key, median ms) ===
                 query                 | on_ms  | off_ms | speedup_proj 
 --------------------------------------+--------+--------+--------------
- sortk,val where sortk in ~0.1% range | 184.20 | 619.66 |         3.36
+ sortk,val where sortk in ~0.1% range | 201.16 | 646.43 |         3.21
 (1 row)
 
 SET
@@ -125,8 +125,8 @@ CREATE FUNCTION
 === EXPORT: Arrow IPC and Parquet (6000000 rows, 5 columns) ===
   format  |   ms   | file_size | m_rows_per_s 
 ----------+--------+-----------+--------------
- arrow    |  923.0 | 186 MB    |          6.5
- parquet  | 1009.8 | 186 MB    |          5.9
+ arrow    | 1029.3 | 186 MB    |          5.8
+ parquet  | 1113.7 | 186 MB    |          5.4
 (2 rows)
 
 -- import
@@ -138,8 +138,8 @@ CREATE FUNCTION
 === IMPORT: Arrow IPC and Parquet (6000000 rows, 5 columns) ===
   format  |   ms    | m_rows_per_s 
 ----------+---------+--------------
- arrow    | 16783.5 |          0.4
- parquet  | 17171.9 |          0.3
+ arrow    | 18533.2 |          0.3
+ parquet  | 18746.0 |          0.3
 (2 rows)
 
 (row-count check: expect 6000000 for both)
@@ -162,8 +162,8 @@ CREATE FUNCTION
 === NESTED export + import (1000000 rows: int[3] array + composite) ===
   format  | export_ms | import_ms | file_size 
 ----------+-----------+-----------+-----------
- arrow    |     528.5 |    4589.8 | 38 MB
- parquet  |     502.8 |    4709.5 | 35 MB
+ arrow    |     580.0 |    4914.0 | 38 MB
+ parquet  |     533.4 |    4923.5 | 35 MB
 (2 rows)
 
 (round-trip check: rows in source but not reconstructed; expect 0/0)
@@ -179,15 +179,15 @@ CREATE FUNCTION
 would find nothing left to delete)
              operation              | heap_ms | columnar_ms | columnar_over_heap 
 ------------------------------------+---------+-------------+--------------------
- single row by id                   |    0.02 |        0.20 |              10.00
- 1000 rows, ids in row order        |    3.68 |       22.34 |               6.07
- 1000 rows, ids scattered           |   42.38 |      161.08 |               3.80
+ single row by id                   |    0.02 |        0.22 |              11.00
+ 1000 rows, ids in row order        |    3.76 |       20.78 |               5.53
+ 1000 rows, ids scattered           |   44.07 |      146.07 |               3.31
 (3 rows)
 
 
              operation              | heap_ms | columnar_ms | columnar_over_heap 
 ------------------------------------+---------+-------------+--------------------
- DELETE 1000 rows by id range       |     0.5 |      1509.5 |            3019.00
+ DELETE 1000 rows by id range       |     0.5 |        22.8 |              45.60
 (1 row)
 
 (row counts must agree after the mutations)
@@ -198,28 +198,28 @@ would find nothing left to delete)
 
 
 === DuckDB comparison (same data, in-process columnar engine) ===
-Run Time (s): real 0.274 user 0.954821 sys 0.177469
+Run Time (s): real 0.291 user 1.031020 sys 0.175280
 ┌──────────────┐
 │ count_star() │
 │    int64     │
 ├──────────────┤
 │      6000000 │
 └──────────────┘
-Run Time (s): real 0.001 user 0.000417 sys 0.003882
+Run Time (s): real 0.001 user 0.003005 sys 0.000003
 ┌─────────────┬──────────┐
 │  sum(val)   │ avg(val) │
 │   int128    │  double  │
 ├─────────────┼──────────┤
 │ 29997000000 │   4999.5 │
 └─────────────┴──────────┘
-Run Time (s): real 0.004 user 0.010155 sys 0.001412
+Run Time (s): real 0.005 user 0.011782 sys 0.002136
 ┌───────────┐
 │ sum(val)  │
 │  int128   │
 ├───────────┤
 │ 599940000 │
 └───────────┘
-Run Time (s): real 0.000 user 0.001621 sys 0.000122
+Run Time (s): real 0.001 user 0.001992 sys 0.000000
 
 === Cross-engine read of pgColumnar's Parquet output (same file) ===
 ┌─────────┬─────────────┐
@@ -228,9 +228,9 @@ Run Time (s): real 0.000 user 0.001621 sys 0.000122
 ├─────────┼─────────────┤
 │ 6000000 │ 29997000000 │
 └─────────┴─────────────┘
-Run Time (s): real 0.008 user 0.030169 sys 0.003603
-pyarrow read_table: rows=6000000  sum_val=29997000000  128.3 ms
+Run Time (s): real 0.009 user 0.033436 sys 0.001970
+pyarrow read_table: rows=6000000  sum_val=29997000000  142.3 ms
 
 == benchmark complete ==
 BENCH_EXIT=0
-finished 2026-07-26T13:34:34+00:00
+finished 2026-07-26T16:47:12+00:00

--- a/bench/sample_output_pg17_6m.txt
+++ b/bench/sample_output_pg17_6m.txt
@@ -1,9 +1,7 @@
-===== commit under test =====
-2f1320f test: pin the WAL discipline this extension has to keep
-===== 1/3 main benchmark, 6M rows, PG17 non-assert, with DuckDB =====
+started 2026-07-26T13:27:48+00:00
 == pgColumnar benchmark ==
 PG_CONFIG=/usr/local/pg17_nc/bin/pg_config  (PostgreSQL 17.10)
-scale=6000000 rows  reps=5  workdir=/tmp/pgcolumnar-bench.wCjGZp
+scale=6000000 rows  reps=5  workdir=/tmp/pgcolumnar-bench.42LCXN
 -- building (non-assert expected)
 -- initdb and start
 -- loading 6000000 rows (staging, heap, columnar zstd, columnar none)
@@ -30,19 +28,19 @@ scale=6000000 rows  reps=5  workdir=/tmp/pgcolumnar-bench.wCjGZp
 === QUERY LATENCY: heap vs columnar zstd (median ms of 5) ===
  id |                 query                  | heap_ms | columnar_ms | heap_over_col 
 ----+----------------------------------------+---------+-------------+---------------
-  1 | count(*) full table                    |  210.07 |        6.52 |         32.22
-  2 | sum/avg over one int column            |  281.55 |        6.50 |         43.32
-  3 | filtered agg, min/max-skippable range  |  217.54 |       81.74 |          2.66
-  4 | point lookup by indexed id             |    0.01 |       26.77 |          0.00
-  5 | projection: 3 of 8 cols, 1% filter     |  214.04 |       74.78 |          2.86
+  1 | count(*) full table                    |  251.95 |        0.02 |      12597.50
+  2 | sum/avg over one int column            |  346.99 |        0.53 |        654.70
+  3 | filtered agg, min/max-skippable range  |  270.17 |       90.96 |          2.97
+  4 | point lookup by indexed id             |    0.01 |       26.75 |          0.00
+  5 | projection: 3 of 8 cols, 1% filter     |  260.56 |       80.18 |          3.25
 (5 rows)
 
 
 === VECTORIZATION on vs off (columnar zstd, median ms) ===
-        query         | on_ms | off_ms  | speedup_vec 
-----------------------+-------+---------+-------------
- sum/avg over int     |  6.35 | 1117.15 |      175.93
- filtered agg (range) | 76.99 |   77.89 |        1.01
+        query         | on_ms | off_ms | speedup_vec 
+----------------------+-------+--------+-------------
+ sum/avg over int     |  0.51 | 795.94 |     1560.67
+ filtered agg (range) | 73.19 |  71.86 |        0.98
 (2 rows)
 
 
@@ -54,8 +52,8 @@ scale=6000000 rows  reps=5  workdir=/tmp/pgcolumnar-bench.wCjGZp
 
      metric      | none | zstd | none_over_zstd 
 -----------------+------+------+----------------
- sum/avg scan ms | 6.29 | 6.23 | 
- count(*) ms     | 6.27 | 6.25 | 
+ sum/avg scan ms | 0.50 | 0.50 | 
+ count(*) ms     | 0.02 | 0.02 | 
 (2 rows)
 
 -- sorted projection
@@ -68,7 +66,7 @@ ANALYZE
 === SORTED PROJECTION: narrow range scan on a scattered key (median ms) ===
         state         |   ms   
 ----------------------+--------
- before vacuum_sorted | 311.09
+ before vacuum_sorted | 355.04
 (1 row)
 
  vacuum_sorted 
@@ -79,7 +77,7 @@ ANALYZE
 ANALYZE
         state        |  ms   
 ---------------------+-------
- after vacuum_sorted | 44.77
+ after vacuum_sorted | 45.81
 (1 row)
 
 -- index-only scan
@@ -94,9 +92,9 @@ VACUUM
 ANALYZE
 
 === INDEX-ONLY SCAN on vs off (covering range count, median ms) ===
-             query              | on_ms |  off_ms   | speedup_ios 
---------------------------------+-------+-----------+-------------
- covering count, id range (~2%) |  6.11 | 154877.94 |    25348.27
+             query              | on_ms |  off_ms  | speedup_ios 
+--------------------------------+-------+----------+-------------
+ covering count, id range (~2%) |  7.31 | 31845.77 |     4356.47
 (1 row)
 
 SET
@@ -115,7 +113,7 @@ ANALYZE
 === PROJECTION SCAN on vs off (covering row scan on a scattered sort key, median ms) ===
                 query                 | on_ms  | off_ms | speedup_proj 
 --------------------------------------+--------+--------+--------------
- sortk,val where sortk in ~0.1% range | 169.43 | 531.94 |         3.14
+ sortk,val where sortk in ~0.1% range | 184.20 | 619.66 |         3.36
 (1 row)
 
 SET
@@ -125,10 +123,10 @@ INSERT 0 6000000
 CREATE FUNCTION
 
 === EXPORT: Arrow IPC and Parquet (6000000 rows, 5 columns) ===
-  format  |  ms   | file_size | m_rows_per_s 
-----------+-------+-----------+--------------
- arrow    | 763.2 | 186 MB    |          7.9
- parquet  | 824.7 | 186 MB    |          7.3
+  format  |   ms   | file_size | m_rows_per_s 
+----------+--------+-----------+--------------
+ arrow    |  923.0 | 186 MB    |          6.5
+ parquet  | 1009.8 | 186 MB    |          5.9
 (2 rows)
 
 -- import
@@ -140,8 +138,8 @@ CREATE FUNCTION
 === IMPORT: Arrow IPC and Parquet (6000000 rows, 5 columns) ===
   format  |   ms    | m_rows_per_s 
 ----------+---------+--------------
- arrow    | 13638.3 |          0.4
- parquet  | 13569.0 |          0.4
+ arrow    | 16783.5 |          0.4
+ parquet  | 17171.9 |          0.3
 (2 rows)
 
 (row-count check: expect 6000000 for both)
@@ -164,8 +162,8 @@ CREATE FUNCTION
 === NESTED export + import (1000000 rows: int[3] array + composite) ===
   format  | export_ms | import_ms | file_size 
 ----------+-----------+-----------+-----------
- arrow    |     422.6 |    3727.1 | 38 MB
- parquet  |     407.8 |    3770.2 | 35 MB
+ arrow    |     528.5 |    4589.8 | 38 MB
+ parquet  |     502.8 |    4709.5 | 35 MB
 (2 rows)
 
 (round-trip check: rows in source but not reconstructed; expect 0/0)
@@ -174,30 +172,54 @@ CREATE FUNCTION
           0 |            0
 (1 row)
 
+-- mutation (1000000 rows)
+
+=== MUTATION: rows reached by index (1000000 rows) ===
+(median of 5 for UPDATE; DELETE is a single run, since a repeat
+would find nothing left to delete)
+             operation              | heap_ms | columnar_ms | columnar_over_heap 
+------------------------------------+---------+-------------+--------------------
+ single row by id                   |    0.02 |        0.20 |              10.00
+ 1000 rows, ids in row order        |    3.68 |       22.34 |               6.07
+ 1000 rows, ids scattered           |   42.38 |      161.08 |               3.80
+(3 rows)
+
+
+             operation              | heap_ms | columnar_ms | columnar_over_heap 
+------------------------------------+---------+-------------+--------------------
+ DELETE 1000 rows by id range       |     0.5 |      1509.5 |            3019.00
+(1 row)
+
+(row counts must agree after the mutations)
+ heap_rows | columnar_rows 
+-----------+---------------
+    999000 |        999000
+(1 row)
+
 
 === DuckDB comparison (same data, in-process columnar engine) ===
-Run Time (s): real 0.201 user 0.738602 sys 0.163594
+Run Time (s): real 0.274 user 0.954821 sys 0.177469
 ┌──────────────┐
 │ count_star() │
 │    int64     │
 ├──────────────┤
 │      6000000 │
 └──────────────┘
-Run Time (s): real 0.001 user 0.001594 sys 0.003643
+Run Time (s): real 0.001 user 0.000417 sys 0.003882
 ┌─────────────┬──────────┐
 │  sum(val)   │ avg(val) │
 │   int128    │  double  │
 ├─────────────┼──────────┤
 │ 29997000000 │   4999.5 │
 └─────────────┴──────────┘
-Run Time (s): real 0.003 user 0.010682 sys 0.000497
+Run Time (s): real 0.004 user 0.010155 sys 0.001412
 ┌───────────┐
 │ sum(val)  │
 │  int128   │
 ├───────────┤
 │ 599940000 │
 └───────────┘
-Run Time (s): real 0.000 user 0.001548 sys 0.000128
+Run Time (s): real 0.000 user 0.001621 sys 0.000122
 
 === Cross-engine read of pgColumnar's Parquet output (same file) ===
 ┌─────────┬─────────────┐
@@ -206,58 +228,9 @@ Run Time (s): real 0.000 user 0.001548 sys 0.000128
 ├─────────┼─────────────┤
 │ 6000000 │ 29997000000 │
 └─────────┴─────────────┘
-Run Time (s): real 0.006 user 0.025412 sys 0.003242
-pyarrow read_table: rows=6000000  sum_val=29997000000  104.5 ms
+Run Time (s): real 0.008 user 0.030169 sys 0.003603
+pyarrow read_table: rows=6000000  sum_val=29997000000  128.3 ms
 
 == benchmark complete ==
-===== 2/3 FSST string benchmark =====
-== pgColumnar FSST ingestion micro-benchmark ==
-PG_CONFIG=/usr/local/pg17_nc/bin/pg_config  (PostgreSQL 17.10)
-scale=3000000 rows  workdir=/tmp/pgcolumnar-fsstbench.AWhi7H
--- building (non-assert expected)
--- initdb and start
--- staging 3000000 rows of shared-substring text
--- timing heap ingestion (baseline)
--- timing columnar (compression=none) ingestion
- alter_columnar_table_set 
---------------------------
- 
-(1 row)
-
--- verify round-trip (heap vs columnar fingerprint)
--- sizes and FSST usage
-
-===================== FSST INGESTION GATE ======================
-  rows                         3000000
-  heap INSERT                  1538.4 ms
-  columnar INSERT              9936.6 ms
-  round-trip                   MATCH
-  heap size                    439279616 bytes
-  columnar size                105807872 bytes
-  url chunks using FSST        20 / 20 (first-vector = FSST)
-================================================================
-Run once as shipped and once with encode_fsst stubbed to return false;
-the columnar-INSERT delta is FSST's ingestion cost, the size delta its ratio.
-===== 3/3 read stream / AIO benchmark, PG18 io_uring build =====
-== pgColumnar read-stream / AIO benchmark ==
-PG_CONFIG=/usr/local/pg18_uring/bin/pg_config  (PostgreSQL 18.4)
-rows=60000000  workdir=/tmp/pgcolumnar-rsbench.b0mNLq
--- build + install
--- initdb
--- load 60000000 rows x 8 random bigint columns (columnar, compression=none)
-   table size: 3675 MB   file: base/16384/16514   shared_buffers: 128MB
-
-=== COLD-SCAN LATENCY: io_method x read_stream (median of 3, ms) ===
-io_method  | rs_on_ms     | rs_off_ms    | rs_speedup
------------+--------------+--------------+-----------
-sync       | 30886.249    | 30944.736    | 1.00x
-worker     | 29697.394    | 30511.991    | 1.03x
-io_uring   | 29201.295    | 30180.758    | 1.03x
-
-=== io_method speedup vs sync (read_stream on) ===
-sync        30886.249 ms  (1.00x vs sync)
-worker      29697.394 ms  (1.04x vs sync)
-io_uring    29201.295 ms  (1.06x vs sync)
-
-== benchmark complete ==
-(benchmarks done)
+BENCH_EXIT=0
+finished 2026-07-26T13:34:34+00:00

--- a/bench/sample_readstream_pg18_uring.txt
+++ b/bench/sample_readstream_pg18_uring.txt
@@ -1,44 +1,14 @@
-== pgColumnar read-stream / AIO benchmark ==
-PG_CONFIG=/usr/local/pg18_uring/bin/pg_config  (PostgreSQL 18.4, --with-liburing, non-assert)
-rows=30000000 x 8 random bigint columns, compression=none
-table size: 2038 MB    shared_buffers: 128MB    effective_io_concurrency: 32
-cold reads forced by cluster restart + posix_fadvise(DONTNEED) on the relation files
-query: SELECT sum(c0)+...+sum(c7) FROM t   (scans all 8 column streams cold)
-
 === COLD-SCAN LATENCY: io_method x read_stream (median of 3, ms) ===
 io_method  | rs_on_ms     | rs_off_ms    | rs_speedup
 -----------+--------------+--------------+-----------
-sync       | 16171.784    | 16242.102    | 1.00x
-worker     | 15880.983    | 16241.464    | 1.02x
-io_uring   | 15901.153    | 16217.671    | 1.02x
+sync       | 38115.636    | 38052.314    | 1.00x
+worker     | 37490.493    | 38240.673    | 1.02x
+io_uring   | 38030.433    | 38913.360    | 1.02x
 
 === io_method speedup vs sync (read_stream on) ===
-sync        16171.784 ms  (1.00x vs sync)
-worker      15880.983 ms  (1.02x vs sync)
-io_uring    15901.153 ms  (1.02x vs sync)
+sync        38115.636 ms  (1.00x vs sync)
+worker      37490.493 ms  (1.02x vs sync)
+io_uring    38030.433 ms  (1.00x vs sync)
 
-Interpretation
---------------
-On this hardware (local NVMe) and workload, the read stream + AIO give about 2%
-(io_uring and worker are within noise of each other; read_stream on vs off is
-1.00-1.02x). Two reasons:
-
-1. A columnar scan is decode-CPU-bound here, not I/O-bound. Reading 2 GB cold
-   takes ~16 s wall clock = ~15 M values/s over 240 M decoded values (~65 ns per
-   value), so the CPU decode dominates and there is little I/O wait for AIO to
-   overlap.
-2. Sequential reads already benefit from Linux kernel read-ahead, so explicit
-   prefetch/AIO adds little on top for a sequential scan on local storage.
-
-Where read stream + AIO (especially io_uring) is expected to help more, and why
-the integration is still worth having:
-- High-latency storage (network/cloud block devices, EBS-class) where per-block
-  I/O latency is large and OS read-ahead is less effective.
-- Higher I/O concurrency and random-access patterns (index-driven fetches,
-  future bitmap paths) where AIO can keep many requests in flight.
-- Staying current with the PostgreSQL 18 I/O model; the path is gated and falls
-  back to synchronous reads on PostgreSQL 13-16.
-
-Correctness (byte-identical output with read_stream on vs off, PG13-19) is
-covered by test/read_stream.sh and the full matrix; this benchmark measures only
-latency.
+== benchmark complete ==
+RS_EXIT=0

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -18,7 +18,7 @@ Environment variables: `BENCH_SCALE` (rows, default 6000000), `BENCH_REPS`
 (set to 1 to add a DuckDB comparison when `duckdb` is on `PATH`).
 
 The numbers below are one full run of all three harnesses, measured 2026-07-26 at
-commit `f7adbdb`: PostgreSQL 17.10 non-assert (18.4 with io_uring for the read
+commit `1be027b`: PostgreSQL 17.10 non-assert (18.4 with io_uring for the read
 stream harness), 6,000,000 rows, 8-column table, median of 5, on 8 cores with
 24 GB of memory. Raw output is in
 [../bench/sample_output_pg17_6m.txt](../bench/sample_output_pg17_6m.txt). They
@@ -64,11 +64,11 @@ Heap versus columnar (zstd), median milliseconds:
 
 | query | heap | columnar | heap / columnar |
 | --- | --- | --- | --- |
-| count(*) full table | 251.95 | 0.02 | 12597 |
-| sum/avg over one int column | 346.99 | 0.53 | 655 |
-| filtered agg, min/max-skippable range | 270.17 | 90.96 | 2.97 |
-| projection: 3 of 8 cols, 1% filter | 260.56 | 80.18 | 3.25 |
-| point lookup by indexed id | 0.01 | 26.75 | 0.00 |
+| count(*) full table | 251.34 | 0.02 | 12567 |
+| sum/avg over one int column | 354.96 | 0.53 | 670 |
+| filtered agg, min/max-skippable range | 263.62 | 92.35 | 2.85 |
+| projection: 3 of 8 cols, 1% filter | 264.94 | 81.58 | 3.25 |
+| point lookup by indexed id | 0.01 | 23.75 | 0.00 |
 
 `count(*)` and the ungrouped aggregates are answered from row-group metadata
 without decoding column data, which is why they are microseconds rather than
@@ -87,14 +87,20 @@ deleted the metadata answer would be wrong and the executor falls back to a scan
 
 | state | count(*) | sum/avg | min/max |
 | --- | --- | --- | --- |
-| no deletes | 0.02 ms | 0.29 ms | 0.30 ms |
-| after deleting 1 row of 6,000,000 | 222.28 ms | 233.89 ms | 317.22 ms |
-| after `pgcolumnar.vacuum` | 0.02 ms | 0.30 ms | 0.30 ms |
+| no deletes | 0.02 ms | 0.32 ms | 0.32 ms |
+| after deleting 1 row of 6,000,000 | 0.18 ms | 6.87 ms | 8.44 ms |
+| after `pgcolumnar.vacuum` | 0.02 ms | 0.31 ms | 0.31 ms |
 
-The fallback is table-wide rather than per row group, so one deleted row takes all
-40 groups off the fast path, including the 39 with no deletes
-([issue #149](https://github.com/jdatcmd/pgcolumnar/issues/149)). Vacuuming
-restores it. Plan for this on tables that take deletes or updates.
+The fallback is per row group, so a delete costs only the groups it touches: the
+39 clean groups still fold from their zone maps and only the dirty one is read,
+which is why `sum/avg` costs one group's scan rather than forty. `count(*)` barely
+moves at all, because a group's live count is exactly its row count minus its
+deleted count and needs no data either way.
+
+This used to be storage-wide, and one deleted row put `count(*)` at 222 ms and
+`min/max` at 317 ms instead of the figures above
+([issue #149](https://github.com/jdatcmd/pgcolumnar/issues/149), fixed). Vacuuming
+still helps, since it returns the dirty group to the clean path.
 
 ## Mutation
 
@@ -103,18 +109,20 @@ single run for the delete:
 
 | operation | heap | columnar | columnar / heap |
 | --- | --- | --- | --- |
-| UPDATE single row by id | 0.02 ms | 0.20 ms | 10 |
-| UPDATE 1000 rows, ids in row order | 3.68 ms | 22.34 ms | 6.1 |
-| UPDATE 1000 rows, ids scattered | 42.38 ms | 161.08 ms | 3.8 |
-| DELETE 1000 rows by id range | 0.5 ms | 1509.5 ms | 3019 |
+| UPDATE single row by id | 0.02 ms | 0.22 ms | 11 |
+| UPDATE 1000 rows, ids in row order | 3.76 ms | 20.78 ms | 5.5 |
+| UPDATE 1000 rows, ids scattered | 44.07 ms | 146.07 ms | 3.3 |
+| DELETE 1000 rows by id range | 0.5 ms | 22.8 ms | 46 |
 
 Row-ordered access does better than scattered because consecutive fetches stay
 inside one row group, which the statement-scoped decoded-group cache serves
-without re-decoding. The delete figure is the weakest number in this document.
+without re-decoding.
 
-Touching N rows in one row group is still quadratic in N: a cache hit skips the
-read and the decode but still walks to the row's position, and that walk is linear
-in the offset. See [issue #143](https://github.com/jdatcmd/pgcolumnar/issues/143).
+The delete figure was the weakest number in this document at 1509 ms, when
+reaching a row still meant walking to it through every earlier row in its group.
+Both halves of [issue #143](https://github.com/jdatcmd/pgcolumnar/issues/143) are
+now in: the group is decoded once and cached, and a row's value is reached by rank
+rather than by walking. Deleting 1000 rows costs 22.8 ms rather than 1509.
 
 ## Feature toggles
 
@@ -122,34 +130,36 @@ Vectorization on versus off (columnar zstd, median ms):
 
 | query | on | off | speedup |
 | --- | --- | --- | --- |
-| sum/avg over int | 0.51 | 795.94 | 1561 |
-| filtered agg (range) | 73.19 | 71.86 | 0.98 |
+| sum/avg over int | 0.51 | 1352.10 | 2651 |
+| filtered agg (range) | 87.51 | 86.53 | 0.99 |
 
 Index-only scan on versus off (covering range count, median ms):
 
 | query | on | off | speedup |
 | --- | --- | --- | --- |
-| covering count, id range (~2%) | 7.31 | 31845.77 | 4356 |
+| covering count, id range (~2%) | 7.24 | 689.21 | 95 |
 
 The "off" column is the fetch-by-row path doing nothing else, which makes it the
-clearest single view of what that path costs.
+clearest single view of what that path costs, and the clearest measure of what
+#143 changed: this shape was 200.9 s before the decoded-group cache, 31.8 s after
+it, and 0.69 s once the walk to the row went too.
 
 Projection scan on versus off (covering scan on a scattered sort key, median ms):
 
 | query | on | off | speedup |
 | --- | --- | --- | --- |
-| sortk, val where sortk in ~0.1% range | 184.20 | 619.66 | 3.36 |
+| sortk, val where sortk in ~0.1% range | 201.16 | 646.43 | 3.21 |
 
 Sorted storage (`pgcolumnar.vacuum_sorted`), narrow range scan on a key not
 correlated with insert order, median ms:
 
 | state | ms |
 | --- | --- |
-| before vacuum_sorted | 355.04 |
-| after vacuum_sorted | 45.81 |
+| before vacuum_sorted | 348.79 |
+| after vacuum_sorted | 45.47 |
 
 Compression none versus zstd (columnar table-only): 40 MB versus 5.95 MB, with
-scan latency unchanged (0.50 ms against 0.50 ms), because the encoded stream is
+scan latency unchanged (0.50 ms against 0.49 ms), because the encoded stream is
 already small and the aggregates do not read it.
 
 ## Import and export
@@ -158,15 +168,15 @@ Export, 6,000,000 rows, 5 columns:
 
 | format | ms | file size | M rows/s |
 | --- | --- | --- | --- |
-| arrow | 923.0 | 186 MB | 6.5 |
-| parquet | 1009.8 | 186 MB | 5.9 |
+| arrow | 1029.3 | 186 MB | 5.8 |
+| parquet | 1113.7 | 186 MB | 5.4 |
 
 Import, 6,000,000 rows, 5 columns:
 
 | format | ms | M rows/s |
 | --- | --- | --- |
-| arrow | 16783.5 | 0.4 |
-| parquet | 17171.9 | 0.3 |
+| arrow | 18533.2 | 0.3 |
+| parquet | 18746.0 | 0.3 |
 
 Import is about 18x slower than export and is the clearest optimisation target in
 the interop path: export writes a prepared buffer, while import goes through the
@@ -177,8 +187,8 @@ column:
 
 | format | export ms | import ms | file size |
 | --- | --- | --- | --- |
-| arrow | 528.5 | 4589.8 | 38 MB |
-| parquet | 502.8 | 4709.5 | 35 MB |
+| arrow | 580.0 | 4914.0 | 38 MB |
+| parquet | 533.4 | 4923.5 | 35 MB |
 
 Both reconstructed tables matched the source exactly (zero differing rows).
 
@@ -248,34 +258,43 @@ These confirm the Parquet output is read by other engines without conversion.
 
 The previous version of this document recorded a run at commit `2f1320f` and
 flagged `count(*)` as slower than it should be, tracked as issue #133. That is
-fixed. To measure the difference honestly rather than compare across machines and
-days, the same harness was run on this machine on this day at both commits:
+fixed, and two further changes landed while this run was being written up. To
+measure honestly rather than compare across machines and days, the same harness
+was run on this machine on this day at each commit:
 
-| metric | 2f1320f | f7adbdb | |
-| --- | --- | --- | --- |
-| count(*) | 8.27 ms | 0.02 ms | 413x |
-| sum/avg over int | 8.04 ms | 0.53 ms | 15x |
-| covering count, index-only scan off | 200914.88 ms | 31845.77 ms | 6.3x |
-| sum/avg, vectorization off | 1381.37 ms | 795.94 ms | 1.7x |
-| point lookup by id | 32.96 ms | 26.75 ms | 1.2x |
-| projection: 3 of 8 cols | 91.68 ms | 80.18 ms | 1.14x |
-| filtered agg | 99.62 ms | 90.96 ms | 1.10x |
-| storage, all three tables | identical | identical | no change |
-| arrow export / import | 929.9 / 16950.9 ms | 923.0 / 16783.5 ms | no change |
+| metric | 2f1320f | f7adbdb | 1be027b | |
+| --- | --- | --- | --- | --- |
+| count(*) | 8.27 ms | 0.02 ms | 0.02 ms | 413x |
+| sum/avg over int | 8.04 ms | 0.53 ms | 0.53 ms | 15x |
+| covering count, index-only scan off | 200914.88 ms | 31845.77 ms | 689.21 ms | 291x |
+| DELETE 1000 rows by id range | not measured | 1509.5 ms | 22.8 ms | 66x |
+| count(*) with one row deleted | not measured | 222.28 ms | 0.18 ms | 1235x |
+| point lookup by id | 32.96 ms | 26.75 ms | 23.75 ms | 1.4x |
+| projection: 3 of 8 cols | 91.68 ms | 80.18 ms | 81.58 ms | 1.12x |
+| storage, all three tables | identical | identical | identical | no change |
 
-Two changes account for most of it. Issue #133 fixed the aggregate path: the
-planner had been losing to a parallel scan on cost, and `count(*)` was reading
-every column's zone maps and using none of them. Issue #143 step one added the
-statement-scoped decoded-group cache, which is what the index-only-scan-off row
-measures, since that shape does nothing but fetch rows by number.
+Four changes account for it:
+
+- **#133** fixed the aggregate path. The planner had been losing to a parallel
+  scan on cost, and `count(*)` was reading every column's zone maps and using none
+  of them.
+- **#148** cached the decoded row group for the length of a statement, so
+  fetching many rows from one group decodes it once.
+- **#152** replaced the walk to a row's position with a rank lookup, which is what
+  takes the index-only-scan-off shape from 31.8 s to 0.69 s and the delete from
+  1509 ms to 23 ms. Together with #148 that is issue #143 closed: the path is no
+  longer quadratic in the rows touched per group.
+- **#151** made the delete fallback per row group instead of per storage, so one
+  deleted row no longer costs the whole table its metadata answers.
 
 Nothing measured got slower.
 
 The absolute ingestion and I/O figures in this document are higher than the
-previous run recorded (arrow import 16.8 s against 13.6 s, FSST columnar insert
-12.4 s against 9.9 s, cold scans about 38 s against about 30 s). Re-running
-`2f1320f` today reproduces today's figures, not the recorded ones, so this is the
-machine and not the code. It is the reason for the warning at the top about
+previous run recorded (arrow import 18.5 s against 13.6 s, cold scans about 38 s
+against about 30 s), and they moved again between the two runs on this same day
+(arrow export 923 ms then 1029 ms) without any code touching that path.
+Re-running `2f1320f` today reproduces today's figures rather than the recorded
+ones, so this is the machine. It is the reason for the warning at the top about
 comparing ratios rather than milliseconds.
 
 ## Reading the results

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -178,9 +178,21 @@ Import, 6,000,000 rows, 5 columns:
 | arrow | 18533.2 | 0.3 |
 | parquet | 18746.0 | 0.3 |
 
-Import is about 18x slower than export and is the clearest optimisation target in
-the interop path: export writes a prepared buffer, while import goes through the
-full insert path including encoding selection and index maintenance.
+Import is about 18x slower than export, and the reason is not the import code.
+Measured separately: `import_arrow` costs 12,150 ms against 12,990 ms for an
+`INSERT INTO ... SELECT` of the same rows with no file involved, so there is no
+import-specific overhead. Reading the whole Parquet file through `read_parquet`
+costs 1,415 ms, 11% of the import. The other 89% is the write path, which is also
+4.9x slower than a heap insert of the same rows.
+
+So the target is bulk load in general rather than the interop path: both readers
+decode a column-oriented file into per-row values, and the writer copies them back
+into per-column buffers. Tracked as
+[issue #155](https://github.com/jdatcmd/pgcolumnar/issues/155) with a plan in
+`design/IMPORT_THROUGHPUT_PLAN.md`.
+
+Index maintenance is not in this path at all, which is a correctness bug rather
+than a cost: see [issue #153](https://github.com/jdatcmd/pgcolumnar/issues/153).
 
 Nested round-trip, 1,000,000 rows, one `int[3]` array column and one composite
 column:

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -26,6 +26,11 @@ show the shape of the tradeoff, not a precise score. The dataset is synthetic an
 deliberately mixes column shapes that suit different encodings, so a table of
 purely random values will look worse and a repetitive one better.
 
+One change landed after these were measured and is not reflected in them: #160
+made the zone min/max tracking on the write path 5 to 7% faster, so every
+ingestion figure here (loads, imports, the FSST insert) is a floor rather than
+what the current tree does. Query latency and storage are unaffected.
+
 **Compare ratios across runs, not absolute milliseconds.** Re-measuring the
 previous run's commit on this machine on the same day (see
 [What changed](#what-changed-since-the-previous-run)) reproduced its query

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -17,12 +17,21 @@ Environment variables: `BENCH_SCALE` (rows, default 6000000), `BENCH_REPS`
 (timed repetitions, median reported, default 5), `BENCH_PORT`, and `BENCH_DUCKDB`
 (set to 1 to add a DuckDB comparison when `duckdb` is on `PATH`).
 
-The numbers below are one full run, measured 2026-07-25 at commit `2f1320f`:
-PostgreSQL 17.10 non-assert, 6,000,000 rows, 8-column table, median of 5. Raw
-output is in [../bench/sample_output_pg17_6m.txt](../bench/sample_output_pg17_6m.txt).
-They show the shape of the tradeoff, not a precise score. The dataset is synthetic
-and deliberately mixes column shapes that suit different encodings, so a table of
+The numbers below are one full run of all three harnesses, measured 2026-07-26 at
+commit `f7adbdb`: PostgreSQL 17.10 non-assert (18.4 with io_uring for the read
+stream harness), 6,000,000 rows, 8-column table, median of 5, on 8 cores with
+24 GB of memory. Raw output is in
+[../bench/sample_output_pg17_6m.txt](../bench/sample_output_pg17_6m.txt). They
+show the shape of the tradeoff, not a precise score. The dataset is synthetic and
+deliberately mixes column shapes that suit different encodings, so a table of
 purely random values will look worse and a repetitive one better.
+
+**Compare ratios across runs, not absolute milliseconds.** Re-measuring the
+previous run's commit on this machine on the same day (see
+[What changed](#what-changed-since-the-previous-run)) reproduced its query
+latencies but came out about 20% slower on ingestion and I/O shapes than when
+those numbers were first recorded. Absolute figures move with the machine; the
+same-day comparison is the one to trust.
 
 ## Storage
 
@@ -55,19 +64,57 @@ Heap versus columnar (zstd), median milliseconds:
 
 | query | heap | columnar | heap / columnar |
 | --- | --- | --- | --- |
-| count(*) full table | 210.07 | 6.52 | 32.2 |
-| sum/avg over one int column | 281.55 | 6.50 | 43.3 |
-| filtered agg, min/max-skippable range | 217.54 | 81.74 | 2.7 |
-| projection: 3 of 8 cols, 1% filter | 214.04 | 74.78 | 2.9 |
-| point lookup by indexed id | 0.01 | 26.77 | 0.00 |
+| count(*) full table | 251.95 | 0.02 | 12597 |
+| sum/avg over one int column | 346.99 | 0.53 | 655 |
+| filtered agg, min/max-skippable range | 270.17 | 90.96 | 2.97 |
+| projection: 3 of 8 cols, 1% filter | 260.56 | 80.18 | 3.25 |
+| point lookup by indexed id | 0.01 | 26.75 | 0.00 |
+
+`count(*)` and the ungrouped aggregates are answered from row-group metadata
+without decoding column data, which is why they are microseconds rather than
+milliseconds.
 
 The point lookup is the trade the design makes and does not hide: a single-row
-fetch decodes the vector containing the row. Columnar suits scans and aggregates;
-heap suits point lookups and write-heavy OLTP.
+fetch decodes the row group the row lives in, so one row costs a whole group's
+decode. Columnar suits scans and aggregates; heap suits point lookups and
+write-heavy OLTP.
 
-`count(*)` is answered from row-group metadata rather than by decoding column
-data. It is nonetheless slower here than it should be, and slower than this
-document previously recorded: see [Known issues](#known-issues-in-these-numbers).
+## Aggregates fall back once anything is deleted
+
+The metadata answers above hold only while the storage has no delete vector. A
+zone map covers every row in its group including deleted ones, so once a row is
+deleted the metadata answer would be wrong and the executor falls back to a scan:
+
+| state | count(*) | sum/avg | min/max |
+| --- | --- | --- | --- |
+| no deletes | 0.02 ms | 0.29 ms | 0.30 ms |
+| after deleting 1 row of 6,000,000 | 222.28 ms | 233.89 ms | 317.22 ms |
+| after `pgcolumnar.vacuum` | 0.02 ms | 0.30 ms | 0.30 ms |
+
+The fallback is table-wide rather than per row group, so one deleted row takes all
+40 groups off the fast path, including the 39 with no deletes
+([issue #149](https://github.com/jdatcmd/pgcolumnar/issues/149)). Vacuuming
+restores it. Plan for this on tables that take deletes or updates.
+
+## Mutation
+
+Rows reached by index, on a 1,000,000-row copy, median of 5 for the updates and a
+single run for the delete:
+
+| operation | heap | columnar | columnar / heap |
+| --- | --- | --- | --- |
+| UPDATE single row by id | 0.02 ms | 0.20 ms | 10 |
+| UPDATE 1000 rows, ids in row order | 3.68 ms | 22.34 ms | 6.1 |
+| UPDATE 1000 rows, ids scattered | 42.38 ms | 161.08 ms | 3.8 |
+| DELETE 1000 rows by id range | 0.5 ms | 1509.5 ms | 3019 |
+
+Row-ordered access does better than scattered because consecutive fetches stay
+inside one row group, which the statement-scoped decoded-group cache serves
+without re-decoding. The delete figure is the weakest number in this document.
+
+Touching N rows in one row group is still quadratic in N: a cache hit skips the
+read and the decode but still walks to the row's position, and that walk is linear
+in the offset. See [issue #143](https://github.com/jdatcmd/pgcolumnar/issues/143).
 
 ## Feature toggles
 
@@ -75,39 +122,35 @@ Vectorization on versus off (columnar zstd, median ms):
 
 | query | on | off | speedup |
 | --- | --- | --- | --- |
-| sum/avg over int | 6.35 | 1117.15 | 175.9 |
-| filtered agg (range) | 76.99 | 77.89 | 1.01 |
-
-The filtered aggregate is unmoved because that query is dominated by the filter,
-not by the aggregate.
+| sum/avg over int | 0.51 | 795.94 | 1561 |
+| filtered agg (range) | 73.19 | 71.86 | 0.98 |
 
 Index-only scan on versus off (covering range count, median ms):
 
 | query | on | off | speedup |
 | --- | --- | --- | --- |
-| covering count, id range (~2%) | 6.11 | 154877.94 | very large |
+| covering count, id range (~2%) | 7.31 | 31845.77 | 4356 |
 
-Read that as "the difference between a viable and an unviable plan" rather than a
-25000x speedup of the same work: with the feature off, the alternative is a
-per-row fetch, not a slower index scan.
+The "off" column is the fetch-by-row path doing nothing else, which makes it the
+clearest single view of what that path costs.
 
 Projection scan on versus off (covering scan on a scattered sort key, median ms):
 
 | query | on | off | speedup |
 | --- | --- | --- | --- |
-| sortk, val where sortk in ~0.1% range | 169.43 | 531.94 | 3.1 |
+| sortk, val where sortk in ~0.1% range | 184.20 | 619.66 | 3.36 |
 
 Sorted storage (`pgcolumnar.vacuum_sorted`), narrow range scan on a key not
 correlated with insert order, median ms:
 
 | state | ms |
 | --- | --- |
-| before vacuum_sorted | 311.09 |
-| after vacuum_sorted | 44.77 |
+| before vacuum_sorted | 355.04 |
+| after vacuum_sorted | 45.81 |
 
-Compression none versus zstd (columnar table-only): 40 MB versus 5.95 MB, 6.8x,
-with scan latency essentially unchanged because the encoded stream is already
-small.
+Compression none versus zstd (columnar table-only): 40 MB versus 5.95 MB, with
+scan latency unchanged (0.50 ms against 0.50 ms), because the encoded stream is
+already small and the aggregates do not read it.
 
 ## Import and export
 
@@ -115,19 +158,29 @@ Export, 6,000,000 rows, 5 columns:
 
 | format | ms | file size | M rows/s |
 | --- | --- | --- | --- |
-| arrow | 763.2 | 186 MB | 7.9 |
-| parquet | 824.7 | 186 MB | 7.3 |
+| arrow | 923.0 | 186 MB | 6.5 |
+| parquet | 1009.8 | 186 MB | 5.9 |
 
 Import, 6,000,000 rows, 5 columns:
 
 | format | ms | M rows/s |
 | --- | --- | --- |
-| arrow | 13638.3 | 0.4 |
-| parquet | 13569.0 | 0.4 |
+| arrow | 16783.5 | 0.4 |
+| parquet | 17171.9 | 0.3 |
 
 Import is about 18x slower than export and is the clearest optimisation target in
 the interop path: export writes a prepared buffer, while import goes through the
 full insert path including encoding selection and index maintenance.
+
+Nested round-trip, 1,000,000 rows, one `int[3]` array column and one composite
+column:
+
+| format | export ms | import ms | file size |
+| --- | --- | --- | --- |
+| arrow | 528.5 | 4589.8 | 38 MB |
+| parquet | 502.8 | 4709.5 | 35 MB |
+
+Both reconstructed tables matched the source exactly (zero differing rows).
 
 ## String ingestion (FSST)
 
@@ -135,37 +188,37 @@ full insert path including encoding selection and index maintenance.
 
 | | |
 | --- | --- |
-| heap INSERT | 1.54 s |
-| columnar INSERT | 9.94 s |
+| heap INSERT | 1.92 s |
+| columnar INSERT | 12.37 s |
 | heap size | 419 MB |
 | columnar size | 101 MB |
 | vectors using FSST | 20 of 20 |
 | round trip | exact match |
 
-FSST is chosen for every vector of the URL column and gives 4.1x on size, paid for
-with 6.5x on ingestion time. That ratio is why encoding selection is worth
+FSST is chosen for every vector of the URL column and gives 4.2x on size, paid for
+with 6.4x on ingestion time. That ratio is why encoding selection is worth
 optimising, and why choosing candidates from a sample rather than applying all of
 them (`pgcolumnar.encoding_sample_rows`) measured 1.33x faster loads with
 byte-identical output.
 
 ## Read stream and asynchronous IO
 
-Cold-scan latency on the PostgreSQL 18 io_uring build, median of 3, caches dropped
-between runs:
+Cold-scan latency on the PostgreSQL 18 io_uring build, 60,000,000 rows, median of
+3, caches dropped between runs:
 
 | io_method | read stream on | off | gain |
 | --- | --- | --- | --- |
-| `sync` | 30.89 s | 30.94 s | 1.00x |
-| `worker` | 29.70 s | 30.51 s | 1.03x |
-| `io_uring` | 29.20 s | 30.18 s | 1.03x |
+| `sync` | 38.12 s | 38.05 s | 1.00x |
+| `worker` | 37.49 s | 38.24 s | 1.02x |
+| `io_uring` | 38.03 s | 38.91 s | 1.02x |
 
-Across methods with the read stream on: `worker` 1.04x and `io_uring` 1.06x
-against `sync`.
+Across methods with the read stream on: `worker` 1.02x against `sync`, `io_uring`
+1.00x.
 
-These are small, and the honest reading is that this workload is not I/O-bound in
-the way prefetching helps most: the columnar layout already reads few, large,
-sequential regions. The feature costs nothing and helps slightly. It is not a
-headline.
+These are small, and the honest reading is unchanged from the previous run: this
+workload is not I/O-bound in the way prefetching helps most, because the columnar
+layout already reads few, large, sequential regions. The feature costs nothing and
+helps slightly. It is not a headline.
 
 ## Cross-engine read
 
@@ -174,39 +227,66 @@ magnitude rather than a competitive claim:
 
 | query | DuckDB | pgColumnar |
 | --- | --- | --- |
-| count(*) | 1 ms | 6.52 ms |
-| sum/avg over int | 3 ms | 6.50 ms |
+| count(*) | 1 ms | 0.02 ms |
+| sum/avg over int | 4 ms | 0.53 ms |
 
-Same order of magnitude, DuckDB ahead. It is a purpose-built analytical engine
-with no PostgreSQL executor or MVCC visibility work in the path.
+pgColumnar is now ahead on both, which says less than it appears to: these are the
+two shapes it answers from catalog metadata without touching column data, and
+DuckDB is scanning. On the shapes that actually scan, the filtered aggregate and
+the projection, it remains the other way round.
 
-## Known issues in these numbers
+Reading the Parquet file pgColumnar wrote, 6,000,000 rows, count and sum:
 
-`count(*)` is **slower than this document previously recorded at the same scale**:
-0.03 ms then, 6.52 ms now. Two causes, tracked as issue #133:
+| reader | time |
+| --- | --- |
+| DuckDB `read_parquet` (stats-accelerated) | 8 ms |
+| pyarrow `read_table` (full materialization) | 128 ms |
 
-- `pgcolumnar.enable_metadata_count` is registered as a GUC but never read. The
-  dedicated catalog-level shortcut went with the format 2.2 removal in Phase H2
-  and the knob stayed behind, so the setting documents behaviour it no longer
-  controls.
-- With parallelism at its default the planner prefers a parallel scan over the
-  columnar aggregate path. Setting `max_parallel_workers_per_gather = 0` gives
-  about 1.75 ms instead of 6.52 ms.
+These confirm the Parquet output is read by other engines without conversion.
 
-Results are correct either way; the cost is performance and a misleading setting.
-The projection query is also somewhat slower than previously recorded (74.78 ms
-against 48.00 ms) and may be the same effect.
+## What changed since the previous run
 
-Everything else moved the other way over the same period: table-only size fell
-from 81 MB to 40 MB uncompressed and 48 MB to 5.95 MB with zstd, and the sum/avg
-aggregate fell from 142.34 ms to 6.50 ms.
+The previous version of this document recorded a run at commit `2f1320f` and
+flagged `count(*)` as slower than it should be, tracked as issue #133. That is
+fixed. To measure the difference honestly rather than compare across machines and
+days, the same harness was run on this machine on this day at both commits:
+
+| metric | 2f1320f | f7adbdb | |
+| --- | --- | --- | --- |
+| count(*) | 8.27 ms | 0.02 ms | 413x |
+| sum/avg over int | 8.04 ms | 0.53 ms | 15x |
+| covering count, index-only scan off | 200914.88 ms | 31845.77 ms | 6.3x |
+| sum/avg, vectorization off | 1381.37 ms | 795.94 ms | 1.7x |
+| point lookup by id | 32.96 ms | 26.75 ms | 1.2x |
+| projection: 3 of 8 cols | 91.68 ms | 80.18 ms | 1.14x |
+| filtered agg | 99.62 ms | 90.96 ms | 1.10x |
+| storage, all three tables | identical | identical | no change |
+| arrow export / import | 929.9 / 16950.9 ms | 923.0 / 16783.5 ms | no change |
+
+Two changes account for most of it. Issue #133 fixed the aggregate path: the
+planner had been losing to a parallel scan on cost, and `count(*)` was reading
+every column's zone maps and using none of them. Issue #143 step one added the
+statement-scoped decoded-group cache, which is what the index-only-scan-off row
+measures, since that shape does nothing but fetch rows by number.
+
+Nothing measured got slower.
+
+The absolute ingestion and I/O figures in this document are higher than the
+previous run recorded (arrow import 16.8 s against 13.6 s, FSST columnar insert
+12.4 s against 9.9 s, cold scans about 38 s against about 30 s). Re-running
+`2f1320f` today reproduces today's figures, not the recorded ones, so this is the
+machine and not the code. It is the reason for the warning at the top about
+comparing ratios rather than milliseconds.
 
 ## Reading the results
 
-Columnar wins on analytic shapes: aggregates, filtered aggregates that minimum,
-maximum and bloom skipping can prune, wide-table projections, and index-only
-covering scans. The size reduction comes mostly from the encoding layer before
-zstd. Vectorization adds a large further speedup on aggregates, and storing a
-table sorted on its range key improves skipping. Heap wins on a single-row index
-fetch. Columnar is the wrong choice for write-heavy OLTP and the right choice for
+Columnar wins on analytic shapes: aggregates answered from metadata, filtered
+aggregates that minimum, maximum and bloom skipping can prune, wide-table
+projections, and index-only covering scans. The size reduction comes mostly from
+the encoding layer before zstd. Vectorization adds a large further speedup on
+aggregates, and storing a table sorted on its range key improves skipping.
+
+Heap wins on single-row fetches and on deletes, both by wide margins, and the
+aggregate advantage disappears on a table with deletes until it is vacuumed.
+Columnar is the wrong choice for write-heavy OLTP and the right choice for
 scan-heavy and aggregate-heavy analytics over wide, append-mostly tables.


### PR DESCRIPTION
All three harnesses re-run on one idle machine on one day, at `f7adbdb`, plus a same-day re-run of the previous document's commit so the comparison is worth something.

## New: mutation

Nothing in `bench/` measured `UPDATE` or `DELETE`. That is where this week's work landed and where the remaining weakness is, so the main harness now has a mutation section. It runs last and on its own copies, because an UPDATE would change what every earlier number was measured against.

| operation | heap | columnar | columnar / heap |
| --- | --- | --- | --- |
| UPDATE single row by id | 0.02 ms | 0.20 ms | 10 |
| UPDATE 1000 rows, ids in row order | 3.68 ms | 22.34 ms | 6.1 |
| UPDATE 1000 rows, ids scattered | 42.38 ms | 161.08 ms | 3.8 |
| DELETE 1000 rows by id range | 0.5 ms | 1509.5 ms | 3019 |

Row-ordered beats scattered because consecutive fetches stay inside one row group and the decoded-group cache serves them. The delete number is the weakest figure in the document and is now stated as such.

## Same-day before and after

Comparing against numbers recorded on another day turned out to be worthless, so I re-ran the previous document's commit (`2f1320f`) on this machine today:

| metric | 2f1320f | f7adbdb | |
| --- | --- | --- | --- |
| count(*) | 8.27 ms | 0.02 ms | 413x |
| sum/avg over int | 8.04 ms | 0.53 ms | 15x |
| covering count, index-only scan off | 200914.88 ms | 31845.77 ms | 6.3x |
| point lookup by id | 32.96 ms | 26.75 ms | 1.2x |
| storage, all three tables | identical | identical | no change |
| arrow export / import | 929.9 / 16950.9 ms | 923.0 / 16783.5 ms | no change |

Issue #133 accounts for the aggregates; #143 step one accounts for the index-only-scan-off row, which does nothing but fetch rows by number. Nothing measured got slower, and the `count(*)` entry under Known issues is gone because it is fixed.

## Two findings

**A single deleted row costs the whole table its fast path.** 0.02 ms to 222.28 ms on `count(*)` after deleting one row out of six million, restored by `pgcolumnar.vacuum`. The fallback is correct, since a zone map covers deleted rows too, but it is storage-wide rather than per row group, so 39 groups with no deletes lose the fast path along with the one that has it. Filed as #149; the document records the measurement.

**Absolute figures moved and the code did not.** Ingestion and I/O are about 20% slower than the previous run recorded (arrow import 16.8 s against 13.6 s, FSST insert 12.4 s against 9.9 s, cold scans ~38 s against ~30 s). Re-running `2f1320f` today reproduces today's figures, not the recorded ones, so it is the machine. The document now opens by saying to compare ratios across runs rather than milliseconds, and explains why.

## Verification

Every figure in the document was checked to appear in the committed raw output. Raw output for all three harnesses is committed: `bench/sample_output_pg17_6m.txt`, `bench/sample_output_fsst_pg17.txt`, `bench/sample_readstream_pg18_uring.txt`.

Docs and bench harness only, no extension code, so no matrix gate. The harness change was exercised by the run itself.