### PR TITLE
design: plans for column statistics (#154) and bulk-load throughput (#155)

### DIFF
--- a/design/ANALYZE_STATISTICS_PLAN.md
+++ b/design/ANALYZE_STATISTICS_PLAN.md
@@ -35,25 +35,43 @@ and zone maps skip physically whatever the planner believed.
 
 ## The trap to design around first
 
-The `scan_analyze_next_block` / `scan_analyze_next_tuple` contract is
-block-oriented and assumes heap addressing. The obvious columnar mapping is to
-treat the block number as a row group ordinal and return rows from within that
-group. That is cluster sampling, not simple random sampling, and for this engine
-it is wrong in a specific and dangerous direction.
+**Corrected after implementation (#159). The prediction below was half wrong, and
+the half that was wrong is the interesting half.**
 
-A table sorted or Z-ordered on a key holds a narrow slice of that key's range in
-each row group. Sampling whole groups therefore underestimates `n_distinct` and
-skews the most-common-value list toward whatever happened to be in the groups
-chosen. **The better the clustering, the worse the estimate**, which means a naive
-implementation produces confidently wrong statistics on exactly the tables the
-engine works hardest to optimise. Confidently wrong is worse than absent, because
-the planner trusts what it is given.
+The `scan_analyze_next_block` contract is block-oriented and assumes heap
+addressing. The obvious columnar mapping is to treat the block number as a row
+group ordinal and return rows from within that group. That is cluster sampling,
+not simple random sampling.
 
-The fix is to spread the sample across many groups rather than take all of it
-from few. That is affordable now in a way it was not a week ago: #152 replaced the
-walk to a row's position with a rank lookup, so reaching row *r* of a group no
-longer costs O(r), and a scattered sample within a group is no more expensive than
-a contiguous one.
+What this plan predicted: on a table sorted or Z-ordered on a key, each row group
+holds a narrow slice, so whole-group sampling would underestimate `n_distinct`
+and skew the most-common-value list, worst on exactly the tables the engine works
+hardest to produce.
+
+**That does not happen, and it was checked rather than argued about.** #159
+implemented the whole-group variant to find out. Offering every row of a group
+for each of the many blocks that group spans hands core far more rows than it
+asked for, so its reservoir ends up sampling most of the table and the
+distribution statistics come out fine: `n_distinct` 1000 against a true 1001 on
+the clustered fixture.
+
+What breaks instead is the row count, because those rows are counted against the
+fraction of blocks core visited:
+
+| mapping | reltuples for a 1,000,000-row table |
+| --- | --- |
+| whole row group per block | 20,500,000 |
+| one row slice per block | 986,666 |
+
+A factor of twenty, which is worse for the planner than any distribution skew
+would have been. So the mapping still matters and the slice approach is still
+right; the reason is the row count, not the distribution, and a test written to
+watch `n_distinct` on a clustered table would pass against the wrong
+implementation. #159's suite watches `reltuples` and says so.
+
+The general lesson is the one worth keeping: a predicted failure mode is a
+hypothesis, and writing the test for the predicted symptom rather than the
+measured one produces a check that passes against the bug.
 
 ## Approach
 
@@ -69,10 +87,22 @@ uses. `ColumnarReadRowByNumber` already produces `values`/`nulls` for a row
 number, so this is `heap_form_tuple` over that, with a synthetic item pointer from
 the row number as the index path already does.
 
-**Correlation.** Once rows carry their row numbers, core's own correlation
-computation works, because row number order is physical order. This falls out of
-the design rather than needing special handling, and it is the statistic worth the
-most here.
+**Correlation.** Worth the most here, and it does **not** fall out of the design,
+which is what an earlier revision of this plan claimed.
+
+`acquire_sample_rows` sorts the sample by item pointer, and the sample arrives
+through `ExecCopySlotHeapTuple`. A virtual slot's copy is `heap_form_tuple` over
+the slot's values, which sets `t_self` invalid and never reads `tts_tid`, so
+setting the slot's item pointer is not enough: every sampled tuple carries an
+invalid pointer. On a non-assert build the sort then permutes them arbitrarily
+and correlation comes out as noise; on an assert build the backend aborts on
+`ItemPointerIsValid`.
+
+The access method has to supply its own `copy_heap_tuple` that carries `tts_tid`
+into `t_self`, which is what #159 does. Correlation then reads 1.0 on an ascending
+column, matching a heap mirror. Recorded because the claim cost a revision to
+discover, and because the same one-line cause produced both the missing statistic
+and a crash.
 
 **Relation-level stats.** `vac_update_relstats` should record the live row count
 and the block count so `pg_class` stops reporting 0 rows, which is separately

--- a/design/ANALYZE_STATISTICS_PLAN.md
+++ b/design/ANALYZE_STATISTICS_PLAN.md
@@ -1,0 +1,113 @@
+# Plan: collect column statistics for ANALYZE
+
+`ANALYZE` on a columnar table reports success and collects nothing.
+`columnar_scan_analyze_next_block` and `columnar_scan_analyze_next_tuple` both
+return false (`src/columnar_tableam.c:386`), so `pg_statistic` stays empty and
+every predicate is estimated with planner defaults. Documented in #130, not fixed.
+
+## What is and is not missing
+
+Worth stating precisely, because the gap is narrower than "the planner is blind".
+
+`columnar_relation_estimate_size` is implemented and returns an accurate live row
+count derived from the row group metadata rather than from the metapage
+reservation high-water mark. So the planner already has the right `rel->tuples`
+and `rel->pages` at planning time, even though `pg_class.reltuples` stays 0.
+
+What is missing is everything about distribution: null fraction, `n_distinct`,
+most common values, histograms, and correlation. The consequences, in the order
+they hurt:
+
+- **Joins.** A columnar fact table joined to dimension tables is the workload this
+  engine exists for, and it is the case where a selectivity guess compounds into a
+  wrong join order rather than a slightly slow scan. `WHERE status = 'x'` is
+  estimated at 0.5% and `WHERE ts > $1` at a third, regardless of the data.
+- **Grouping.** No `n_distinct` means hash aggregate memory is guessed, so the
+  planner does not predict the spills it causes.
+- **Correlation.** This one is specific to this engine and nothing else will
+  supply it. `pgcolumnar.vacuum_sorted` and Z-order clustering exist to create
+  physical locality, and the planner currently has no way to know they were used
+  or how much skipping to expect.
+
+Single-table analytic queries mostly survive without any of this, because the
+custom scan is chosen structurally, ungrouped aggregates go to the metadata path,
+and zone maps skip physically whatever the planner believed.
+
+## The trap to design around first
+
+The `scan_analyze_next_block` / `scan_analyze_next_tuple` contract is
+block-oriented and assumes heap addressing. The obvious columnar mapping is to
+treat the block number as a row group ordinal and return rows from within that
+group. That is cluster sampling, not simple random sampling, and for this engine
+it is wrong in a specific and dangerous direction.
+
+A table sorted or Z-ordered on a key holds a narrow slice of that key's range in
+each row group. Sampling whole groups therefore underestimates `n_distinct` and
+skews the most-common-value list toward whatever happened to be in the groups
+chosen. **The better the clustering, the worse the estimate**, which means a naive
+implementation produces confidently wrong statistics on exactly the tables the
+engine works hardest to optimise. Confidently wrong is worse than absent, because
+the planner trusts what it is given.
+
+The fix is to spread the sample across many groups rather than take all of it
+from few. That is affordable now in a way it was not a week ago: #152 replaced the
+walk to a row's position with a rank lookup, so reaching row *r* of a group no
+longer costs O(r), and a scattered sample within a group is no more expensive than
+a contiguous one.
+
+## Approach
+
+**Sampling unit.** Report a block count equal to the row group count, and let core
+choose which groups to visit through its existing two-stage sampling. Within a
+chosen group, take a bounded random sample of live row numbers rather than the
+first N, and reject rows the delete vector marks. The decoded-group cache from
+#148 means the group is decoded once for the whole sample.
+
+**Rows returned.** `scan_analyze_next_tuple` hands core a `HeapTuple`, so the
+sampled row has to be materialised through the same reconstruction the fetch path
+uses. `ColumnarReadRowByNumber` already produces `values`/`nulls` for a row
+number, so this is `heap_form_tuple` over that, with a synthetic item pointer from
+the row number as the index path already does.
+
+**Correlation.** Once rows carry their row numbers, core's own correlation
+computation works, because row number order is physical order. This falls out of
+the design rather than needing special handling, and it is the statistic worth the
+most here.
+
+**Relation-level stats.** `vac_update_relstats` should record the live row count
+and the block count so `pg_class` stops reporting 0 rows, which is separately
+confusing when reading `\d+` output even though the planner does not rely on it.
+
+## What this does not attempt
+
+Extended statistics, per-row-group statistics as a planner input, and pushing zone
+maps into selectivity estimation. All three are interesting and none is needed to
+close #130. Zone maps in particular would be a larger and more speculative piece:
+they describe physical layout, and the planner's model wants distribution.
+
+## Testing
+
+Correctness of a statistics implementation is awkward to assert because the
+numbers are estimates. Three checks that do discriminate:
+
+1. **Against heap on identical data.** Load the same rows into a heap table and a
+   columnar table, `ANALYZE` both, and compare `pg_stats`: `null_frac`,
+   `n_distinct` and `most_common_vals` should agree within a stated tolerance.
+   This is the differential-oracle pattern the rest of the suite uses, and it is
+   what catches a sampling bias rather than a coding error.
+2. **The clustering trap specifically.** Build a table sorted on a key so each row
+   group holds a narrow slice, `ANALYZE`, and check `n_distinct` is within
+   tolerance of the true value. A cluster-sampling implementation fails this and
+   passes check 1, which is the whole reason to write it separately.
+3. **Plan shape.** A join between a large columnar table and a small one should
+   pick the same plan shape as the equivalent heap join. Assert on the plan, not
+   the timing.
+
+Every one of these must be shown to fail against the current `return false`
+implementation, which for checks 1 and 3 it will trivially, and for check 2 only
+once a sampler exists to get it wrong.
+
+## Effort
+
+3 to 5 dev-months for two people, with the sampling design and the clustering
+question being most of the risk. The API surface itself is small.

--- a/design/IMPORT_THROUGHPUT_PLAN.md
+++ b/design/IMPORT_THROUGHPUT_PLAN.md
@@ -61,26 +61,54 @@ suggests.
 
 ## Order
 
-1. **A batching entry point.** Give the write path a way to accept many rows at
-   once, as `table_multi_insert` does for COPY, and have both importers use it.
-   This is worth doing first even without the column-wise work: it amortises the
-   per-call overhead and it is what the column-wise path needs underneath.
-2. **Column-wise transfer for the simple cases.** Fixed-width, no nulls, type
-   matches exactly. Measure before extending: if this does not move the number,
-   the model above is wrong and the rest should not be built on it.
-3. **Nullable and varying-length columns**, if step 2 pays.
-4. **Encoding selection reuse across chunks of the same column.** The selector
-   re-decides per vector; a column whose first several chunks all chose the same
-   encoding is unlikely to want a different one, and the sample cost could be
-   skipped after a run of agreement. This is the smallest of the four and should
-   be measured on its own, since it is easy to convince oneself it helps.
+**Corrected after measurement (#160). Step 1 as written would have delivered
+close to nothing, and that was worth finding before someone spent a month on
+it.**
+
+This plan reasoned that the waste is the per-row round trip, so a batching entry
+point should come first and would "amortise the per-call overhead" even on its
+own. If per-call overhead were the cost, a one-column load would show it as
+clearly as a five-column one, since it is the same rows and the same number of
+`table_tuple_insert` calls. Measured, 3,000,000 rows:
+
+| shape | heap | columnar | |
+| --- | --- | --- | --- |
+| 1 int column | 1272.4 ms | **908.1 ms** | **0.71x, faster than heap** |
+| 5 int columns | 1364.1 ms | 3697.0 ms | 2.7x |
+| 1 text column | 1284.3 ms | 4680.1 ms | 3.6x |
+| 5 mixed, one text | 1494.7 ms | 8604.8 ms | 5.8x |
+
+At one integer column the columnar write path beats heap. There is no per-call
+overhead to amortise. The cost is per value and roughly additive per column,
+about 900 ms per numeric column and about 4,600 ms for a text column, so the 4.9x
+this plan opens with is really "five columns, one of them text".
+
+Two further results from the same measurement: compression is not a factor
+(`none` is 2% faster than `zstd 3`, `lz4` indistinguishable), and ablation puts
+zone min/max tracking at 15 to 17% of the remaining per-value cost with no other
+single dominant term. #160 took that piece: comparing integer-family values
+directly instead of through fmgr, and testing the maximum first so an ascending
+load costs one comparison per value, for 5 to 7%.
+
+So the revised order is:
+
+1. **The varlena write path.** One text column costs more than five integer
+   columns, and that is where the 4.9x lives. Measure before designing: the
+   ablation above did not separate encoding selection from the value stream from
+   the flush for text specifically.
+2. **Column-at-a-time transfer** for the cases where the reader's representation
+   and the writer's already agree, judged per column type rather than per
+   nullability and width combination, since type is what the measurement says
+   dominates.
+3. **A batching entry point**, if anything above still wants one. It is not the
+   place to start and may not be needed at all.
 
 ## Not in scope
 
-`COPY` into a columnar table goes through the same write path and would benefit
-from step 1, but making `COPY` fast is a separate piece of work with its own
-interface questions. Worth noting so the batching entry point is not designed so
-narrowly that only the importers can use it.
+`COPY` into a columnar table goes through the same write path, so it benefits
+from anything that makes per-value work cheaper, which after the measurement
+above is where the win is. Making `COPY` itself fast is a separate piece of work
+with its own interface questions.
 
 ## What must not change
 

--- a/design/IMPORT_THROUGHPUT_PLAN.md
+++ b/design/IMPORT_THROUGHPUT_PLAN.md
@@ -1,0 +1,117 @@
+# Plan: import and bulk-load throughput
+
+`docs/benchmarks.md` records import at about 18x slower than export and calls it
+the clearest optimisation target in the interop path, attributing it to "the full
+insert path including encoding selection and index maintenance". Measuring it says
+that description is wrong in two ways, and the real target is a different one.
+
+## Measured, PostgreSQL 17.10 non-assert, 6,000,000 rows, 5 columns
+
+| step | ms |
+| --- | --- |
+| heap `INSERT INTO ... SELECT` | 2,667.9 |
+| columnar `INSERT INTO ... SELECT`, no file involved | 12,989.6 |
+| `export_arrow` | 881.9 |
+| `import_arrow` | 12,150.2 |
+| `export_parquet` | 1,012.5 |
+| full scan of the Parquet file through `read_parquet` | 1,415.0 |
+| `import_parquet` | 12,956.6 |
+| `read_parquet` feeding `INSERT INTO ... SELECT` | 13,629.9 |
+| columnar `INSERT`, exhaustive encoding selection (`encoding_sample_rows = 0`) | 20,103.2 |
+
+Three things follow.
+
+**Import is not slower than an ordinary insert.** `import_arrow` at 12,150 ms
+against `INSERT INTO ... SELECT` at 12,990 ms for the same rows. There is no
+import-specific overhead to remove. The headline in the benchmark document, "import
+is 18x slower than export", is really "the columnar write path is about 15x slower
+than the read path", and import merely inherits it.
+
+**The readers are not the bottleneck.** Scanning the whole Parquet file through
+`read_parquet` costs 1,415 ms, 11% of the 12,957 ms import. The other 89% is the
+write path.
+
+**Encoding selection is a real cost but not the dominant one.** Turning sampling
+off costs 55% more (20,103 against 12,990), so the selection that remains after
+sampling is a minority of the write path rather than its bulk.
+
+And for scale: the columnar write path is 4.9x slower than a heap insert of the
+same rows, which is the wrong direction for a format that writes about a hundredth
+of the bytes.
+
+## The target
+
+The write path, reached in a way that avoids its per-row shape.
+
+Both readers decode a column-oriented file into per-row `Datum` arrays, hand each
+row to `table_tuple_insert`, and the write path copies each value back into
+per-column buffers. Arrow and PGCN are both columnar; the row is a costume worn
+between two column stores for the length of one function call.
+
+**The main proposal is a column-at-a-time import.** For a column whose Arrow or
+Parquet representation matches what the writer wants, move the values from the
+decoded column buffer into the writer's column buffer directly, once per chunk,
+rather than per row through a slot. Fixed-width non-null columns are the easy and
+common case and can be close to a memcpy. Nullable and varying-length columns need
+the validity bitmap and offsets translated but still avoid the per-row round trip.
+
+That is bounded below by the reader cost of 1,415 ms, so the plausible target is
+somewhere between 3 and 5 seconds against today's 13, not the 1.4 the reader alone
+suggests.
+
+## Order
+
+1. **A batching entry point.** Give the write path a way to accept many rows at
+   once, as `table_multi_insert` does for COPY, and have both importers use it.
+   This is worth doing first even without the column-wise work: it amortises the
+   per-call overhead and it is what the column-wise path needs underneath.
+2. **Column-wise transfer for the simple cases.** Fixed-width, no nulls, type
+   matches exactly. Measure before extending: if this does not move the number,
+   the model above is wrong and the rest should not be built on it.
+3. **Nullable and varying-length columns**, if step 2 pays.
+4. **Encoding selection reuse across chunks of the same column.** The selector
+   re-decides per vector; a column whose first several chunks all chose the same
+   encoding is unlikely to want a different one, and the sample cost could be
+   skipped after a run of agreement. This is the smallest of the four and should
+   be measured on its own, since it is easy to convince oneself it helps.
+
+## Not in scope
+
+`COPY` into a columnar table goes through the same write path and would benefit
+from step 1, but making `COPY` fast is a separate piece of work with its own
+interface questions. Worth noting so the batching entry point is not designed so
+narrowly that only the importers can use it.
+
+## What must not change
+
+Index maintenance is being fixed separately in #153, and whichever resolution that
+takes, this work must not quietly reintroduce the same gap: a batched or
+column-wise path still has to produce index entries, or still has to refuse to run
+on an indexed table. The differential import tests should run against an indexed
+target once #153 adds one.
+
+The importers must also keep raising on malformed input rather than writing
+partial data, which the hardening suites already assert.
+
+## Testing
+
+Throughput work is easy to "prove" with a number that moved for another reason,
+so:
+
+- **Correctness is differential and unchanged**: the existing round-trip suites
+  compare imported tables against their source, and they must pass untouched.
+  Add a target with an index once #153 lands.
+- **The claim is a ratio, not a millisecond count**: assert that importing N rows
+  costs less than some multiple of scanning the same file through `read_parquet`,
+  which is the floor. That is portable across machines in a way a fixed threshold
+  is not, and it is the number the design is actually about.
+- **Every step measured on its own**, against the step before it, on an idle
+  machine, with the figures recorded in the commit. The table above is the
+  baseline to beat.
+
+## Effort
+
+2 to 4 dev-months for two people. Step 1 is well understood; the risk is
+concentrated in step 2, where the number of type and nullability combinations
+decides how much of the win is reachable before the special cases stop being worth
+it.


### PR DESCRIPTION
Two design documents, no code, so no matrix gate. Both were written from measurement and both corrected an assumption on the way, including one of mine that is currently published in `docs/benchmarks.md`.

## Statistics (#154)

The gap is narrower than #130 reads. `columnar_relation_estimate_size` is implemented and returns an accurate live row count from row-group metadata, so the planner already has the right `rel->tuples`; what is missing is distribution. The plan aims at joins, grouping, and correlation, and argues correlation is worth the most here, since `vacuum_sorted` and Z-order exist to create physical locality that nothing currently tells the planner about.

The design risk is the sampling, not the API surface. Mapping a block to a row group is cluster sampling, and on a sorted or Z-ordered table each group holds a narrow slice of the key, so `n_distinct` is underestimated and the MCV list skewed: **the better the clustering, the worse the estimate**. That produces confidently wrong statistics on exactly the tables this engine optimises hardest, which is worse than having none. Spreading the sample across many groups is the answer, and #152 is what made it affordable, since reaching row *r* of a group is now a rank lookup rather than a walk.

The acceptance criteria include a check that only fails for a cluster-sampling implementation, separate from the differential-against-heap check that would pass anyway.

## Throughput (#155)

`docs/benchmarks.md` currently says import is about 18x slower than export because of "the full insert path including encoding selection and index maintenance". Measured on 6,000,000 rows:

| step | ms |
| --- | --- |
| heap `INSERT INTO ... SELECT` | 2,667.9 |
| columnar `INSERT INTO ... SELECT`, no file involved | 12,989.6 |
| `import_arrow` | 12,150.2 |
| full scan of the Parquet file through `read_parquet` | 1,415.0 |
| `import_parquet` | 12,956.6 |

Import is **not** slower than an ordinary insert, so there is no import-specific overhead to remove. The readers are 11% of it. And index maintenance is not in the path at all, which turned out to be #153 rather than a cost.

The honest statement is that the write path is 15x slower than the read path and 4.9x slower than heap, which is the wrong direction for a format writing a hundredth of the bytes. The waste is structural: both readers decode a column-oriented file into per-row Datums and the writer copies them back into per-column buffers. The plan proposes a batching entry point first, then column-at-a-time transfer where representations already agree, with the reader cost as the floor and each step required to justify the next.

I will correct the import sentence in `docs/benchmarks.md` as part of #150 rather than leaving a description in the docs that this measurement contradicts.