### PR TITLE
Maintain indexes when importing Arrow and Parquet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ OBJS = \
 	src/columnar_compression.o \
 	src/columnar_encoding.o \
 	src/columnar_bloom.o \
+	src/columnar_index.o \
 	src/columnar_reader.o \
 	src/columnar_delete_vector.o \
 	src/columnar_customscan.o \

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -330,6 +330,25 @@ extern bool ColumnarVMIsVisible(Relation rel, BlockNumber blk);
 extern void ColumnarVMSetVisibleForRelation(Relation rel);
 extern void ColumnarDiscardFetchCache(void);
 
+/* index maintenance for callers that insert rows without an executor (#153) */
+typedef struct ColumnarIndexInsertState
+{
+	int			n;
+	Relation   *rels;
+	IndexInfo **infos;
+	ExprState **predicates;		/* partial-index predicate, or NULL */
+	EState	   *estate;
+	TupleTableSlot *slot;
+} ColumnarIndexInsertState;
+
+extern ColumnarIndexInsertState *ColumnarIndexInsertBegin(Relation rel);
+extern void ColumnarIndexInsertRow(ColumnarIndexInsertState *st, Relation rel,
+								   Datum *values, bool *isnull,
+								   uint64 rowNumber, bool enforceUnique);
+extern void ColumnarIndexInsertEnd(ColumnarIndexInsertState *st);
+extern bool ColumnarRelationHasIndexes(Relation rel);
+
+
 /* a contiguous run of all-visible row numbers (gap 28 phase 3) */
 typedef struct ColumnarRowRange
 {

--- a/src/columnar_arrow.c
+++ b/src/columnar_arrow.c
@@ -1905,6 +1905,7 @@ columnar_import_arrow(PG_FUNCTION_ARGS)
 	int			totalBuffers = 0;
 	FILE	   *f;
 	TupleTableSlot *slot;
+	ColumnarIndexInsertState *indexes;
 	CommandId	cid;
 	MemoryContext rowCtx;
 	int64		total = 0;
@@ -1973,6 +1974,8 @@ columnar_import_arrow(PG_FUNCTION_ARGS)
 
 	slot = table_slot_create(rel, NULL);
 	cid = GetCurrentCommandId(true);
+	indexes = ColumnarRelationHasIndexes(rel)
+		? ColumnarIndexInsertBegin(rel) : NULL;
 
 	/*
 	 * Per-row scratch context. Reconstructing a nested value (array/composite)
@@ -2110,6 +2113,19 @@ columnar_import_arrow(PG_FUNCTION_ARGS)
 					}
 					ExecStoreVirtualTuple(slot);
 					table_tuple_insert(rel, slot, cid, 0, NULL);
+
+					/*
+					 * table_tuple_insert writes the row and nothing else: index
+					 * maintenance belongs to the executor and there is none
+					 * here. Without this the imported rows are invisible to
+					 * every index scan and a unique index accepts duplicates
+					 * (issue #153). tts_tid carries the assigned row number.
+					 */
+					if (indexes != NULL)
+						ColumnarIndexInsertRow(indexes, rel, slot->tts_values,
+											   slot->tts_isnull,
+											   ColumnarItemPointerToRowNumber(&slot->tts_tid),
+											   true);
 					MemoryContextSwitchTo(oldCtx);
 					MemoryContextReset(rowCtx);
 					total++;
@@ -2131,6 +2147,9 @@ columnar_import_arrow(PG_FUNCTION_ARGS)
 
 	FreeFile(f);
 	MemoryContextDelete(rowCtx);
+	if (indexes != NULL)
+		ColumnarIndexInsertEnd(indexes);
+
 	ExecDropSingleTupleTableSlot(slot);
 	table_close(rel, RowExclusiveLock);
 	PG_RETURN_INT64(total);

--- a/src/columnar_index.c
+++ b/src/columnar_index.c
@@ -1,0 +1,166 @@
+/*-------------------------------------------------------------------------
+ *
+ * columnar_index.c
+ *		Index maintenance for callers that insert rows without an executor.
+ *
+ * PostgreSQL puts index maintenance in the executor, not in the table access
+ * method: ExecInsertIndexTuples is what puts an entry in each index, and
+ * table_tuple_insert only writes the row. Anything that inserts rows by calling
+ * table_tuple_insert directly therefore has to maintain the indexes itself, or
+ * the indexes silently stop describing the table and an index scan returns rows
+ * that are not there and misses rows that are.
+ *
+ * Two callers are in that position: the online rewrite in columnar_vacuum.c,
+ * which moves live rows into fresh groups, and the Arrow and Parquet importers,
+ * which load rows from a file. The importers did not maintain indexes at all
+ * (issue #153): an index scan over an imported table returned nothing, and a
+ * unique index accepted the same key twice.
+ *
+ * The difference between the two callers is uniqueness. A rewrite moves rows
+ * that already satisfied every constraint, and the row it is replacing is still
+ * visible while it does, so checking uniqueness there would conflict with the
+ * row being replaced; it passes UNIQUE_CHECK_NO. An import inserts genuinely new
+ * rows, so a duplicate has to be caught, and it passes UNIQUE_CHECK_YES for the
+ * unique indexes. That is the only behavioural difference, and it is a
+ * parameter rather than a second implementation.
+ *
+ * Written fresh for pgColumnar from the public PostgreSQL index API.
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "columnar.h"
+
+#include "access/genam.h"
+#include "access/table.h"
+#include "catalog/index.h"
+#include "executor/executor.h"
+#include "nodes/execnodes.h"
+#include "utils/rel.h"
+
+/*
+ * ColumnarIndexInsertBegin
+ *		Open every ready and valid index on the relation and prepare the state
+ *		needed to form index tuples. The caller must hold a lock on rel that
+ *		permits insertion; the indexes are opened with RowExclusiveLock, which is
+ *		what an ordinary insert takes.
+ */
+ColumnarIndexInsertState *
+ColumnarIndexInsertBegin(Relation rel)
+{
+	ColumnarIndexInsertState *st = palloc0(sizeof(ColumnarIndexInsertState));
+	List	   *oids = RelationGetIndexList(rel);
+	int			cap = Max(list_length(oids), 1);
+	ListCell   *lc;
+
+	st->n = 0;
+	st->rels = palloc(cap * sizeof(Relation));
+	st->infos = palloc(cap * sizeof(IndexInfo *));
+	st->predicates = palloc(cap * sizeof(ExprState *));
+	st->estate = CreateExecutorState();
+	st->slot = MakeSingleTupleTableSlot(RelationGetDescr(rel), &TTSOpsVirtual);
+
+	foreach(lc, oids)
+	{
+		Oid			ioid = lfirst_oid(lc);
+		Relation	irel = index_open(ioid, RowExclusiveLock);
+		IndexInfo  *info;
+
+		/*
+		 * An index that is not ready or not valid is one a concurrent build has
+		 * not finished with. That build is responsible for the rows it covers,
+		 * so inserting into it here would double-insert.
+		 */
+		if (!irel->rd_index->indisready || !irel->rd_index->indisvalid)
+		{
+			index_close(irel, RowExclusiveLock);
+			continue;
+		}
+		info = BuildIndexInfo(irel);
+		st->rels[st->n] = irel;
+		st->infos[st->n] = info;
+		st->predicates[st->n] = (info->ii_Predicate != NIL)
+			? ExecPrepareQual(info->ii_Predicate, st->estate)
+			: NULL;
+		st->n++;
+	}
+
+	return st;
+}
+
+/*
+ * ColumnarIndexInsertRow
+ *		Put one row into every open index, under the row number's synthetic item
+ *		pointer. enforceUnique decides whether a unique index checks for a
+ *		conflict: an importer wants that, a rewrite of rows that already exist
+ *		does not.
+ */
+void
+ColumnarIndexInsertRow(ColumnarIndexInsertState *st, Relation rel,
+					   Datum *values, bool *isnull, uint64 rowNumber,
+					   bool enforceUnique)
+{
+	int			natts = RelationGetDescr(rel)->natts;
+	ExprContext *econtext = GetPerTupleExprContext(st->estate);
+	ItemPointerData tid;
+	int			i;
+
+	if (st->n == 0)
+		return;
+
+	ColumnarRowNumberToItemPointer(rowNumber, &tid);
+
+	ExecClearTuple(st->slot);
+	memcpy(st->slot->tts_values, values, natts * sizeof(Datum));
+	memcpy(st->slot->tts_isnull, isnull, natts * sizeof(bool));
+	ExecStoreVirtualTuple(st->slot);
+	econtext->ecxt_scantuple = st->slot;
+
+	for (i = 0; i < st->n; i++)
+	{
+		Datum		ivalues[INDEX_MAX_KEYS];
+		bool		inulls[INDEX_MAX_KEYS];
+		IndexUniqueCheck check = UNIQUE_CHECK_NO;
+
+		/* skip rows a partial index does not cover */
+		if (st->predicates[i] != NULL && !ExecQual(st->predicates[i], econtext))
+			continue;
+
+		if (enforceUnique && st->rels[i]->rd_index->indisunique)
+			check = UNIQUE_CHECK_YES;
+
+		FormIndexDatum(st->infos[i], st->slot, st->estate, ivalues, inulls);
+		index_insert(st->rels[i], ivalues, inulls, &tid, rel,
+					 check, false, st->infos[i]);
+	}
+	ResetPerTupleExprContext(st->estate);
+}
+
+/*
+ * ColumnarIndexInsertEnd
+ *		Close the indexes and free the state. The locks are held until the end of
+ *		the transaction, as index_close with RowExclusiveLock leaves them.
+ */
+void
+ColumnarIndexInsertEnd(ColumnarIndexInsertState *st)
+{
+	int			i;
+
+	for (i = 0; i < st->n; i++)
+		index_close(st->rels[i], RowExclusiveLock);
+
+	if (st->slot != NULL)
+		ExecDropSingleTupleTableSlot(st->slot);
+	if (st->estate != NULL)
+		FreeExecutorState(st->estate);
+}
+
+/*
+ * ColumnarRelationHasIndexes
+ *		Does this relation have any index at all? Used by the importers to skip
+ *		the machinery entirely on the common bulk-load-into-a-bare-table case.
+ */
+bool
+ColumnarRelationHasIndexes(Relation rel)
+{
+	return RelationGetIndexList(rel) != NIL;
+}

--- a/src/columnar_parquet_reader.c
+++ b/src/columnar_parquet_reader.c
@@ -2959,6 +2959,7 @@ typedef struct PqInsertSinkArg
 {
 	Relation	rel;
 	CommandId	cid;
+	ColumnarIndexInsertState *indexes;	/* NULL when the table has none */
 }			PqInsertSinkArg;
 
 static void
@@ -2967,6 +2968,19 @@ pq_insert_sink(TupleTableSlot *slot, void *arg)
 	PqInsertSinkArg *a = (PqInsertSinkArg *) arg;
 
 	table_tuple_insert(a->rel, slot, a->cid, 0, NULL);
+
+	/*
+	 * table_tuple_insert writes the row and nothing else: index maintenance is
+	 * the executor's job, and there is no executor here. Without this the
+	 * imported rows are invisible to every index scan and a unique index accepts
+	 * duplicates (issue #153). tts_tid carries the row number the insert
+	 * assigned.
+	 */
+	if (a->indexes != NULL)
+		ColumnarIndexInsertRow(a->indexes, a->rel, slot->tts_values,
+							   slot->tts_isnull,
+							   ColumnarItemPointerToRowNumber(&slot->tts_tid),
+							   true);
 }
 
 static void
@@ -3297,6 +3311,8 @@ columnar_import_parquet(PG_FUNCTION_ARGS)
 
 	sinkarg.rel = rel;
 	sinkarg.cid = GetCurrentCommandId(true);
+	sinkarg.indexes = ColumnarRelationHasIndexes(rel)
+		? ColumnarIndexInsertBegin(rel) : NULL;
 	/* insert every resolved file's rows; the per-file decode is bounded by
 	 * fileCtx. Each file is bound against the target's descriptor, so a directory
 	 * whose files disagree with the table errors rather than importing garbage. */
@@ -3313,6 +3329,9 @@ columnar_import_parquet(PG_FUNCTION_ARGS)
 		MemoryContextReset(fileCtx);
 	}
 	MemoryContextDelete(fileCtx);
+
+	if (sinkarg.indexes != NULL)
+		ColumnarIndexInsertEnd(sinkarg.indexes);
 
 	ExecDropSingleTupleTableSlot(slot);
 	table_close(rel, RowExclusiveLock);

--- a/src/columnar_vacuum.c
+++ b/src/columnar_vacuum.c
@@ -110,104 +110,13 @@ uint64_cmp(const void *a, const void *b)
  * ------------------------------------------------------------------------- */
 
 /* the relation's ready+valid indexes, opened once for a rewrite pass */
-typedef struct RewriteIndexState
-{
-	int			n;
-	Relation   *rels;
-	IndexInfo **infos;
-	ExprState **predicates;		/* partial-index predicate, or NULL */
-	EState	   *estate;
-	TupleTableSlot *slot;
-} RewriteIndexState;
-
-static void
-rewrite_index_open(Relation rel, RewriteIndexState *ris)
-{
-	List	   *oids = RelationGetIndexList(rel);
-	int			cap = Max(list_length(oids), 1);
-	ListCell   *lc;
-
-	ris->n = 0;
-	ris->rels = palloc(cap * sizeof(Relation));
-	ris->infos = palloc(cap * sizeof(IndexInfo *));
-	ris->predicates = palloc(cap * sizeof(ExprState *));
-	ris->estate = CreateExecutorState();
-	ris->slot = MakeSingleTupleTableSlot(RelationGetDescr(rel), &TTSOpsVirtual);
-
-	foreach(lc, oids)
-	{
-		Oid			ioid = lfirst_oid(lc);
-		Relation	irel = index_open(ioid, RowExclusiveLock);
-		IndexInfo  *info;
-
-		if (!irel->rd_index->indisready || !irel->rd_index->indisvalid)
-		{
-			index_close(irel, RowExclusiveLock);
-			continue;
-		}
-		info = BuildIndexInfo(irel);
-		ris->rels[ris->n] = irel;
-		ris->infos[ris->n] = info;
-		ris->predicates[ris->n] = (info->ii_Predicate != NIL)
-			? ExecPrepareQual(info->ii_Predicate, ris->estate)
-			: NULL;
-		ris->n++;
-	}
-	list_free(oids);
-}
-
-static void
-rewrite_index_close(RewriteIndexState *ris)
-{
-	int			i;
-
-	for (i = 0; i < ris->n; i++)
-		index_close(ris->rels[i], RowExclusiveLock);
-	ExecDropSingleTupleTableSlot(ris->slot);
-	FreeExecutorState(ris->estate);
-}
-
-/* insert index entries for one rewritten row at its new row number */
-static void
-rewrite_index_insert_row(RewriteIndexState *ris, Relation rel,
-						 Datum *values, bool *isnull, uint64 rowNumber)
-{
-	int			natts = RelationGetDescr(rel)->natts;
-	ExprContext *econtext = GetPerTupleExprContext(ris->estate);
-	ItemPointerData tid;
-	int			i;
-
-	ColumnarRowNumberToItemPointer(rowNumber, &tid);
-
-	ExecClearTuple(ris->slot);
-	memcpy(ris->slot->tts_values, values, natts * sizeof(Datum));
-	memcpy(ris->slot->tts_isnull, isnull, natts * sizeof(bool));
-	ExecStoreVirtualTuple(ris->slot);
-	econtext->ecxt_scantuple = ris->slot;
-
-	for (i = 0; i < ris->n; i++)
-	{
-		Datum		ivalues[INDEX_MAX_KEYS];
-		bool		inulls[INDEX_MAX_KEYS];
-
-		/* skip rows a partial index does not cover */
-		if (ris->predicates[i] != NULL && !ExecQual(ris->predicates[i], econtext))
-			continue;
-
-		FormIndexDatum(ris->infos[i], ris->slot, ris->estate, ivalues, inulls);
-		index_insert(ris->rels[i], ivalues, inulls, &tid, rel,
-					 UNIQUE_CHECK_NO, false, ris->infos[i]);
-	}
-	ResetPerTupleExprContext(ris->estate);
-}
-
 /*
  * Rewrite one group's live rows into a fresh group and retire the old group.
  * Returns the number of live rows moved. Caller holds ShareUpdateExclusiveLock
  * on rel and has opened the indexes in ris.
  */
 static int64
-rewrite_one_group(Relation rel, RewriteIndexState *ris, uint64 storageId,
+rewrite_one_group(Relation rel, ColumnarIndexInsertState *ris, uint64 storageId,
 				  uint64 groupNumber, uint64 firstRow, uint64 rowCount)
 {
 	Oid			relid = RelationGetRelid(rel);
@@ -241,7 +150,7 @@ rewrite_one_group(Relation rel, RewriteIndexState *ris, uint64 storageId,
 
 		newRn = ColumnarWriteRow(ws, rel, values, isnull);
 		ColumnarProjectionFanoutRow(rel, ws, newRn, values, isnull);
-		rewrite_index_insert_row(ris, rel, values, isnull, newRn);
+		ColumnarIndexInsertRow(ris, rel, values, isnull, newRn, false);
 		moved++;
 	}
 	ColumnarFlushWriteStateForRelation(relid);
@@ -281,7 +190,7 @@ columnar_rewrite_partial_groups(Relation rel, double minDeletedFraction,
 	List	   *rgList;
 	ListCell   *lc;
 	List	   *cands = NIL;
-	RewriteIndexState ris;
+	ColumnarIndexInsertState *ris;
 	int64		rewritten = 0;
 
 	/* persist own pending work so the group list and deletes are current */
@@ -325,18 +234,18 @@ columnar_rewrite_partial_groups(Relation rel, double minDeletedFraction,
 	if (cands == NIL)
 		return 0;
 
-	rewrite_index_open(rel, &ris);
+	ris = ColumnarIndexInsertBegin(rel);
 	foreach(lc, cands)
 	{
 		RewriteCandidate *c = (RewriteCandidate *) lfirst(lc);
 
 		if (maxGroups > 0 && rewritten >= maxGroups)
 			break;
-		rewrite_one_group(rel, &ris, storageId, c->groupNumber,
+		rewrite_one_group(rel, ris, storageId, c->groupNumber,
 						  c->firstRow, c->rowCount);
 		rewritten++;
 	}
-	rewrite_index_close(&ris);
+	ColumnarIndexInsertEnd(ris);
 
 	COLUMNAR_ASSERT_NO_OVERLAP(storageId);
 	return rewritten;
@@ -386,7 +295,7 @@ columnar_recluster_online(Relation rel, int ncols, AttrNumber *atts)
 	bool		nullsFirst = false;
 	ColumnarReadState *readState;
 	ColumnarWriteState *writeState;
-	RewriteIndexState ris;
+	ColumnarIndexInsertState *ris;
 	uint64		rowNumber;
 
 	/* persist own pending work so the group list and deletes are current */
@@ -473,7 +382,7 @@ columnar_recluster_online(Relation rel, int ncols, AttrNumber *atts)
 	tuplesort_performsort(tsort);
 
 	/* write the sorted rows back as fresh groups, with online index maintenance */
-	rewrite_index_open(rel, &ris);
+	ris = ColumnarIndexInsertBegin(rel);
 	writeState = ColumnarGetWriteState(rel);
 	while (tuplesort_gettupleslot(tsort, true, false, augSlot, NULL))
 	{
@@ -485,11 +394,11 @@ columnar_recluster_online(Relation rel, int ncols, AttrNumber *atts)
 								 augSlot->tts_isnull);
 		ColumnarProjectionFanoutRow(rel, writeState, newRn, augSlot->tts_values,
 									augSlot->tts_isnull);
-		rewrite_index_insert_row(&ris, rel, augSlot->tts_values,
-								 augSlot->tts_isnull, newRn);
+		ColumnarIndexInsertRow(ris, rel, augSlot->tts_values,
+							   augSlot->tts_isnull, newRn, false);
 	}
 	ColumnarFlushWriteStateForRelation(relid);
-	rewrite_index_close(&ris);
+	ColumnarIndexInsertEnd(ris);
 	tuplesort_end(tsort);
 	ExecDropSingleTupleTableSlot(augSlot);
 

--- a/test/arrow_import.sh
+++ b/test/arrow_import.sh
@@ -129,4 +129,76 @@ PY
 	expect_error "reject dictionary-encoded file" "SELECT pgcolumnar.import_arrow('ri_d', '$DICTF');"
 fi
 
+IXFILE="$PGC_WORKDIR/ix_roundtrip.arrows"
+
+# ---------------------------------------------------------------------------
+# Import into a table that already has indexes (issue #153).
+#
+# table_tuple_insert writes the row and nothing else: index maintenance is the
+# executor's job, and an importer calling it directly has to do that itself.
+# When it did not, the rows landed in the table and in no index, so an index
+# scan returned nothing while a sequential scan returned everything, and a
+# unique index accepted the same key twice. Nothing errored either time.
+#
+# The checks below compare the two access paths against each other on the same
+# predicate, which is the shape that catches it: a count that only ever uses one
+# path passes whether or not the index was maintained.
+# ---------------------------------------------------------------------------
+
+psql_run "CREATE TABLE ix_src (id int, v text) USING pgcolumnar;"
+psql_run "INSERT INTO ix_src SELECT g, 'v' || g FROM generate_series(1, 3000) g;"
+psql_run "SELECT pgcolumnar.export_arrow('ix_src', '$IXFILE');"
+
+psql_run "CREATE TABLE ix_tgt (id int, v text) USING pgcolumnar;"
+psql_run "CREATE INDEX ix_tgt_id ON ix_tgt (id);"
+psql_run "SELECT pgcolumnar.import_arrow('ix_tgt', '$IXFILE');"
+
+# q echoes one line per statement, so take the last: the count, not the SETs.
+#
+# enable_seqscan does not discourage a custom scan, so turning it off on its own
+# leaves the columnar scan the cheapest path and the index is never consulted.
+# That made an earlier version of this check pass against a build with index
+# maintenance deliberately removed. pgcolumnar.enable_custom_scan is what takes
+# the columnar path out of the running, and the plan is asserted below so a
+# future costing change cannot quietly put it back.
+IDX_SETUP="SET enable_seqscan = off; SET pgcolumnar.enable_custom_scan = off;"
+idx_count() {  # force an index scan
+	q "$IDX_SETUP
+	   SELECT count(*) FROM ix_tgt WHERE id BETWEEN 100 AND 199;" | tail -1
+}
+idx_plan_is_index_scan() {
+	q "$IDX_SETUP
+	   EXPLAIN (COSTS OFF) SELECT count(*) FROM ix_tgt WHERE id BETWEEN 100 AND 199;" \
+		| grep -qi 'Index.*Scan' && echo yes || echo no
+}
+seq_count() {  # force a sequential scan
+	q "SET enable_indexscan = off; SET enable_bitmapscan = off;
+	   SET enable_indexonlyscan = off;
+	   SELECT count(*) FROM ix_tgt WHERE id BETWEEN 100 AND 199;" | tail -1
+}
+
+check "the index-scan check really uses the index" "$(idx_plan_is_index_scan)" "yes"
+check "import into an indexed table: both scans agree" "$(idx_count)" "$(seq_count)"
+check "import into an indexed table: the rows are there" "$(seq_count)" "100"
+check "import into an indexed table: a point lookup finds its row" \
+	"$(q "$IDX_SETUP
+	      SELECT count(*) FROM ix_tgt WHERE id = 2222;" | tail -1)" "1"
+
+# A unique index must police the second import rather than take it.
+psql_run "CREATE TABLE ix_uq (id int, v text) USING pgcolumnar;"
+psql_run "CREATE UNIQUE INDEX ix_uq_id ON ix_uq (id);"
+psql_run "SELECT pgcolumnar.import_arrow('ix_uq', '$IXFILE');"
+expect_error "importing the same keys twice raises unique_violation" \
+	"SELECT pgcolumnar.import_arrow('ix_uq', '$IXFILE');"
+check "the failed second import left the row count alone" \
+	"$(q 'SELECT count(*) FROM ix_uq;')" "3000"
+
+# A partial index must receive only the rows its predicate covers.
+psql_run "CREATE TABLE ix_part (id int, v text) USING pgcolumnar;"
+psql_run "CREATE INDEX ix_part_id ON ix_part (id) WHERE id <= 500;"
+psql_run "SELECT pgcolumnar.import_arrow('ix_part', '$IXFILE');"
+check "partial index covers its rows after import" \
+	"$(q "$IDX_SETUP
+	      SELECT count(*) FROM ix_part WHERE id BETWEEN 100 AND 199;" | tail -1)" "100"
+
 pgc_summary

--- a/test/parquet_import.sh
+++ b/test/parquet_import.sh
@@ -131,4 +131,76 @@ expect_error "reject non-parquet file" "SELECT pgcolumnar.import_parquet('pp', '
 psql_run "CREATE TABLE pmismatch (id int, s text, extra int) USING pgcolumnar;"
 expect_error "reject column-count mismatch" "SELECT pgcolumnar.import_parquet('pmismatch', '$PGC_WORKDIR/plain.parquet');"
 
+IXFILE="$PGC_WORKDIR/ix_roundtrip.parquet"
+
+# ---------------------------------------------------------------------------
+# Import into a table that already has indexes (issue #153).
+#
+# table_tuple_insert writes the row and nothing else: index maintenance is the
+# executor's job, and an importer calling it directly has to do that itself.
+# When it did not, the rows landed in the table and in no index, so an index
+# scan returned nothing while a sequential scan returned everything, and a
+# unique index accepted the same key twice. Nothing errored either time.
+#
+# The checks below compare the two access paths against each other on the same
+# predicate, which is the shape that catches it: a count that only ever uses one
+# path passes whether or not the index was maintained.
+# ---------------------------------------------------------------------------
+
+psql_run "CREATE TABLE ix_src (id int, v text) USING pgcolumnar;"
+psql_run "INSERT INTO ix_src SELECT g, 'v' || g FROM generate_series(1, 3000) g;"
+psql_run "SELECT pgcolumnar.export_parquet('ix_src', '$IXFILE');"
+
+psql_run "CREATE TABLE ix_tgt (id int, v text) USING pgcolumnar;"
+psql_run "CREATE INDEX ix_tgt_id ON ix_tgt (id);"
+psql_run "SELECT pgcolumnar.import_parquet('ix_tgt', '$IXFILE');"
+
+# q echoes one line per statement, so take the last: the count, not the SETs.
+#
+# enable_seqscan does not discourage a custom scan, so turning it off on its own
+# leaves the columnar scan the cheapest path and the index is never consulted.
+# That made an earlier version of this check pass against a build with index
+# maintenance deliberately removed. pgcolumnar.enable_custom_scan is what takes
+# the columnar path out of the running, and the plan is asserted below so a
+# future costing change cannot quietly put it back.
+IDX_SETUP="SET enable_seqscan = off; SET pgcolumnar.enable_custom_scan = off;"
+idx_count() {  # force an index scan
+	q "$IDX_SETUP
+	   SELECT count(*) FROM ix_tgt WHERE id BETWEEN 100 AND 199;" | tail -1
+}
+idx_plan_is_index_scan() {
+	q "$IDX_SETUP
+	   EXPLAIN (COSTS OFF) SELECT count(*) FROM ix_tgt WHERE id BETWEEN 100 AND 199;" \
+		| grep -qi 'Index.*Scan' && echo yes || echo no
+}
+seq_count() {  # force a sequential scan
+	q "SET enable_indexscan = off; SET enable_bitmapscan = off;
+	   SET enable_indexonlyscan = off;
+	   SELECT count(*) FROM ix_tgt WHERE id BETWEEN 100 AND 199;" | tail -1
+}
+
+check "the index-scan check really uses the index" "$(idx_plan_is_index_scan)" "yes"
+check "import into an indexed table: both scans agree" "$(idx_count)" "$(seq_count)"
+check "import into an indexed table: the rows are there" "$(seq_count)" "100"
+check "import into an indexed table: a point lookup finds its row" \
+	"$(q "$IDX_SETUP
+	      SELECT count(*) FROM ix_tgt WHERE id = 2222;" | tail -1)" "1"
+
+# A unique index must police the second import rather than take it.
+psql_run "CREATE TABLE ix_uq (id int, v text) USING pgcolumnar;"
+psql_run "CREATE UNIQUE INDEX ix_uq_id ON ix_uq (id);"
+psql_run "SELECT pgcolumnar.import_parquet('ix_uq', '$IXFILE');"
+expect_error "importing the same keys twice raises unique_violation" \
+	"SELECT pgcolumnar.import_parquet('ix_uq', '$IXFILE');"
+check "the failed second import left the row count alone" \
+	"$(q 'SELECT count(*) FROM ix_uq;')" "3000"
+
+# A partial index must receive only the rows its predicate covers.
+psql_run "CREATE TABLE ix_part (id int, v text) USING pgcolumnar;"
+psql_run "CREATE INDEX ix_part_id ON ix_part (id) WHERE id <= 500;"
+psql_run "SELECT pgcolumnar.import_parquet('ix_part', '$IXFILE');"
+check "partial index covers its rows after import" \
+	"$(q "$IDX_SETUP
+	      SELECT count(*) FROM ix_part WHERE id BETWEEN 100 AND 199;" | tail -1)" "100"
+
 pgc_summary


### PR DESCRIPTION
Closes #153.

`import_arrow` and `import_parquet` insert rows with `table_tuple_insert`, which writes the row and nothing else: index maintenance belongs to the executor, and there is no executor on this path. The imported rows landed in the table and in no index, so an index scan returned nothing while a sequential scan returned everything, and a unique index accepted the same key twice. Neither raised.

## The fix

The rewrite path in `columnar_vacuum.c` already had this machinery, because it is in the same position: it inserts rows without an executor and maintains indexes itself. Rather than copy it, it moves to `src/columnar_index.c` and both callers use it.

The one behavioural difference is uniqueness, and it is a parameter rather than a second implementation. A rewrite moves rows that already satisfied every constraint, and the row it replaces is still visible while it does, so checking uniqueness there would conflict with the row being replaced: it passes `UNIQUE_CHECK_NO`. An import inserts genuinely new rows, so it passes `UNIQUE_CHECK_YES` and a duplicate raises. Partial indexes keep their predicate test, and an index that is not yet `indisready`/`indisvalid` is skipped, since the concurrent build that owns it will cover these rows itself.

A table with no indexes does no extra work: the importers skip the machinery rather than opening an empty index list per row.

## Tests, and two ways the first version of them was wrong

`arrow_import` and `parquet_import` now import into a plain index, a unique index and a partial index. Both mistakes are worth recording because the first would have shipped green:

**`enable_seqscan = off` does not discourage a custom scan.** With it off, the columnar path was still cheapest and the index was never consulted, so both index checks passed against a build with this fix deliberately removed. `pgcolumnar.enable_custom_scan = off` is what takes the columnar path out of the running, and the suite now also asserts the plan really is an index scan, so a future costing change cannot quietly defeat the check again.

**The `q` helper echoes one line per statement**, so a count preceded by `SET` statements was compared against the string `SET`.

With those corrected:

| | with the fix | with index maintenance stripped |
| --- | --- | --- |
| `arrow_import` | PASS | **5 failures** |
| `parquet_import` | PASS | **5 failures** |

The failures are the right ones: `both scans agree: got [0] want [100]`, `a point lookup finds its row: got [0] want [1]`, `importing the same keys twice raises unique_violation: got [succeeded] want [error]`, and `the failed second import left the row count alone: got [6000] want [3000]`.

## Gate

PG18 and PG19, full suite, `ALL VERSIONS PASSED`, with `arrow_import`, `parquet_import`, and the three suites that cover the moved helper (`native_rewrite`, `native_recluster`, `native_reclaim`) all green.

## Note on the alternative

#153 offered refusing to import into an indexed table as the cheaper option. I went with maintaining the indexes because refusing is a behaviour change for anyone whose call currently succeeds, and because an access method that leaves indexes disagreeing with the table has no correct state to be in. Import into an indexed table is now slower, which is a real cost and the right one to pay; #155 covers the throughput work separately.