### PR TITLE
Compare zone min/max directly for integer types, and what the write path actually costs (#155)

### DIFF
--- a/src/columnar_write_state.c
+++ b/src/columnar_write_state.c
@@ -31,12 +31,41 @@
 #include "utils/snapmgr.h"
 #include "utils/typcache.h"
 
+/*
+ * Direct comparison kinds for the zone min/max (issue #155).
+ *
+ * Tracking a chunk's min and max costs two comparisons per value per column, and
+ * routing each through fmgr is most of what they cost: removing min/max tracking
+ * entirely saved 15% of a five-int-column load, where the comparison itself is a
+ * subtraction. These are the types whose stored Datum can be read as a C value
+ * and compared without a collation, which is the same condition, and the same
+ * list, the vectorized filter's fast path uses (COLUMNAR_VECFAST_* in
+ * columnar_vector.c). Anything else keeps the fmgr path.
+ *
+ * float4 and float8 are deliberately NOT here even though the filter fast path
+ * takes them. btree float ordering puts NaN above every other value, which a C
+ * comparison gets wrong: every comparison against NaN is false, so NaN would read
+ * as equal and never become a chunk's maximum. A zone map with a maximum that is
+ * too low makes the reader skip a row group that does hold matching rows, and the
+ * query silently returns fewer rows. The filter path can take the same shortcut
+ * because it compares to answer one predicate, not to build stored bounds that a
+ * later scan trusts.
+ */
+typedef enum ColumnarFastCmp
+{
+	COLUMNAR_FASTCMP_NONE = 0,
+	COLUMNAR_FASTCMP_I16,
+	COLUMNAR_FASTCMP_I32,
+	COLUMNAR_FASTCMP_I64
+} ColumnarFastCmp;
+
 /* per-column, per-write-state facts needed for the min/max skip list */
 typedef struct ColumnarColumnDef
 {
 	bool		orderable;		/* type has a default btree comparison proc */
 	FmgrInfo	cmpFn;			/* the comparison proc, when orderable */
 	Oid			collation;		/* collation to compare under */
+	ColumnarFastCmp fastCmp;	/* direct comparison, when the type allows */
 
 	/*
 	 * int2/int4 column: its exact sum fits an int64 accumulator, so the zone map
@@ -133,6 +162,46 @@ static ChunkGroupBuffer *columnar_start_chunk_group(ColumnarWriteState *writeSta
 static void columnar_init_col_defs(ColumnarWriteState *writeState);
 
 /*
+ * columnar_cmp_value
+ *		Compare two values of a column under its ordering, taking the direct
+ *		route when the type allows one and fmgr otherwise. The integer kinds
+ *		reproduce their btree comparison exactly, so which route is taken can
+ *		never change the answer.
+ */
+static inline int32
+columnar_cmp_value(ColumnarColumnDef *def, Datum a, Datum b)
+{
+	switch (def->fastCmp)
+	{
+		case COLUMNAR_FASTCMP_I16:
+			{
+				int16		x = DatumGetInt16(a);
+				int16		y = DatumGetInt16(b);
+
+				return (x < y) ? -1 : (x > y) ? 1 : 0;
+			}
+		case COLUMNAR_FASTCMP_I32:
+			{
+				int32		x = DatumGetInt32(a);
+				int32		y = DatumGetInt32(b);
+
+				return (x < y) ? -1 : (x > y) ? 1 : 0;
+			}
+		case COLUMNAR_FASTCMP_I64:
+			{
+				int64		x = DatumGetInt64(a);
+				int64		y = DatumGetInt64(b);
+
+				return (x < y) ? -1 : (x > y) ? 1 : 0;
+			}
+		case COLUMNAR_FASTCMP_NONE:
+			break;
+	}
+
+	return DatumGetInt32(FunctionCall2Coll(&def->cmpFn, def->collation, a, b));
+}
+
+/*
  * columnar_init_col_defs
  *		Allocate and fill writeState->colDefs: for each column, resolve the btree
  *		comparison proc (for the per-chunk min/max skip list, spec 7.2) and the
@@ -163,6 +232,31 @@ columnar_init_col_defs(ColumnarWriteState *writeState)
 			fmgr_info_copy(&writeState->colDefs[c].cmpFn,
 						   &tce->cmp_proc_finfo, ColumnarWriteContext);
 			writeState->colDefs[c].collation = att->attcollation;
+
+			/*
+			 * Resolve a direct comparison where the type permits one. These
+			 * compare byte-for-byte under any collation, so the fast path
+			 * cannot disagree with the operator it replaces; the zone map it
+			 * feeds is read back through the same ordering.
+			 */
+			switch (att->atttypid)
+			{
+				case INT2OID:
+					writeState->colDefs[c].fastCmp = COLUMNAR_FASTCMP_I16;
+					break;
+				case INT4OID:
+				case DATEOID:
+					writeState->colDefs[c].fastCmp = COLUMNAR_FASTCMP_I32;
+					break;
+				case INT8OID:
+				case TIMESTAMPOID:
+				case TIMESTAMPTZOID:
+					writeState->colDefs[c].fastCmp = COLUMNAR_FASTCMP_I64;
+					break;
+				default:
+					writeState->colDefs[c].fastCmp = COLUMNAR_FASTCMP_NONE;
+					break;
+			}
 		}
 
 		/* int2/int4: exact sum fits int64, carried in the zone map (D5) */
@@ -414,25 +508,30 @@ ColumnarWriteRow(ColumnarWriteState *writeState, Relation rel,
 				}
 				else
 				{
-					int32		cmpMin = DatumGetInt32(
-						FunctionCall2Coll(&def->cmpFn, def->collation,
-										  values[c], col->minValue));
-					int32		cmpMax = DatumGetInt32(
-						FunctionCall2Coll(&def->cmpFn, def->collation,
-										  values[c], col->maxValue));
+					/*
+					 * A value above the running maximum cannot also be below the
+					 * running minimum, so the second comparison is only needed
+					 * when the first does not settle it. Testing the maximum
+					 * first makes the ascending case -- which is what a bulk load
+					 * of a serial or timestamp column produces -- cost one
+					 * comparison per value instead of two.
+					 */
+					int32		cmpMax = columnar_cmp_value(def, values[c],
+														   col->maxValue);
 
-					if (cmpMin < 0)
-					{
-						if (!att->attbyval)
-							pfree(DatumGetPointer(col->minValue));
-						col->minValue = datumCopy(values[c], att->attbyval,
-												  att->attlen);
-					}
 					if (cmpMax > 0)
 					{
 						if (!att->attbyval)
 							pfree(DatumGetPointer(col->maxValue));
 						col->maxValue = datumCopy(values[c], att->attbyval,
+												  att->attlen);
+					}
+					else if (columnar_cmp_value(def, values[c],
+												col->minValue) < 0)
+					{
+						if (!att->attbyval)
+							pfree(DatumGetPointer(col->minValue));
+						col->minValue = datumCopy(values[c], att->attbyval,
 												  att->attlen);
 					}
 				}

--- a/test/write_minmax_fastpath.sh
+++ b/test/write_minmax_fastpath.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+#
+# pgColumnar zone min/max via the direct comparison path (issue #155).
+#
+# Tracking a chunk's min and max costs two comparisons per value per column, and
+# routing both through fmgr is most of what they cost. Integer-family columns now
+# compare directly, and the maximum is tested first so an ascending load -- what a
+# bulk load of a serial or timestamp column produces -- needs one comparison per
+# value rather than two.
+#
+# The risk this carries is not a crash. A zone map drives row-group skipping, so a
+# minimum that is too high or a maximum that is too low makes the reader skip a
+# group that does hold matching rows and the query silently returns fewer. That is
+# the failure this file is built to catch, so the checks are differential against
+# a heap mirror over predicates that sit exactly on the chunk bounds.
+#
+# The float case has its own check and is the reason floats are deliberately NOT
+# on the fast path. btree float ordering puts NaN above every other value; a C
+# comparison gets that wrong, because every comparison against NaN is false, so
+# NaN would read as equal and never become a chunk's maximum. A later change that
+# adds float4/float8 to the fast list fails here rather than silently losing rows.
+#
+# Usage:  test/write_minmax_fastpath.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+ROWS=${PGC_MINMAX_ROWS:-200000}
+
+# small chunk groups so there are many zone maps to get wrong, and so a predicate
+# can fall inside one group and outside its neighbours
+psql_run "DROP TABLE IF EXISTS mm_c; DROP TABLE IF EXISTS mm_h;
+	SET pgcolumnar.stripe_row_limit = 20000;
+	SET pgcolumnar.chunk_group_row_limit = 5000;
+	CREATE TABLE mm_c (
+		i2 smallint, i4 int, i8 bigint,
+		d date, ts timestamp, tz timestamptz,
+		asc_i int, desc_i int, rand_i int, neg_i int,
+		nullable_i int, t text
+	) USING pgcolumnar;
+	INSERT INTO mm_c SELECT
+		(g % 30000)::smallint,
+		g,
+		g::bigint * 1000000,
+		'2000-01-01'::date + (g % 10000),
+		'2000-01-01'::timestamp + (g || ' sec')::interval,
+		'2000-01-01'::timestamptz + (g || ' sec')::interval,
+		g,
+		$ROWS - g,
+		(g * 7919) % 100000,
+		-g,
+		CASE WHEN g % 5 = 0 THEN NULL ELSE g END,
+		't' || g
+	FROM generate_series(1, $ROWS) g;
+	CREATE TABLE mm_h (LIKE mm_c);
+	INSERT INTO mm_h SELECT * FROM mm_c;" >/dev/null 2>&1
+
+echo "-- $ROWS rows, $(q "SELECT count(*) FROM pgcolumnar.row_group r
+	JOIN pgcolumnar.storage s ON s.storage_id = r.storage_id
+	WHERE s.relation_oid = 'mm_c'::regclass;") row groups"
+
+# --- 1. every column agrees with heap under range predicates -------------------
+
+# Predicates chosen to land on and around chunk-group boundaries, which is where a
+# botched bound shows up: a group is skipped or kept wrongly only at its edges.
+diff_count() {  # label, predicate
+	local c h
+	c="$(q "SELECT count(*) FROM mm_c WHERE $2;")"
+	h="$(q "SELECT count(*) FROM mm_h WHERE $2;")"
+	[ "$c" = "$h" ] || echo "$1(columnar=$c heap=$h)"
+}
+
+bad=""
+bad="$bad $(diff_count i4_eq       "i4 = 5000")"
+bad="$bad $(diff_count i4_bound    "i4 BETWEEN 4999 AND 5001")"
+bad="$bad $(diff_count i4_range    "i4 > $((ROWS / 2)) AND i4 < $((ROWS / 2 + 17))")"
+bad="$bad $(diff_count i2_eq       "i2 = 12345")"
+bad="$bad $(diff_count i2_range    "i2 BETWEEN 100 AND 200")"
+bad="$bad $(diff_count i8_range    "i8 > 4999000000 AND i8 < 5001000000")"
+bad="$bad $(diff_count date_range  "d BETWEEN '2000-06-01' AND '2000-06-03'")"
+bad="$bad $(diff_count ts_range    "ts > '2000-01-01 01:00:00' AND ts < '2000-01-01 01:00:10'")"
+bad="$bad $(diff_count tz_range    "tz > '2000-01-01 01:00:00+00' AND tz < '2000-01-01 01:00:10+00'")"
+bad="$bad $(diff_count asc_range   "asc_i BETWEEN 19999 AND 20001")"
+bad="$bad $(diff_count desc_range  "desc_i BETWEEN 19999 AND 20001")"
+bad="$bad $(diff_count rand_range  "rand_i BETWEEN 500 AND 600")"
+bad="$bad $(diff_count neg_range   "neg_i BETWEEN -20001 AND -19999")"
+bad="$bad $(diff_count null_range  "nullable_i BETWEEN 4999 AND 5001")"
+bad="$bad $(diff_count null_isnull "nullable_i IS NULL")"
+bad="$bad $(diff_count text_eq     "t = 't5000'")"
+
+check "every column returns the same rows as heap under range predicates" \
+	"$(echo $bad | tr -s ' ')" ""
+
+# --- 2. the stored bounds are the true bounds ----------------------------------
+
+# min/max read straight back out, which is what the zone maps hold. An aggregate
+# over a column with no deletes is answered from those zone maps, so this reads
+# the stored bounds rather than the data.
+bad=""
+for col in i2 i4 i8 d ts tz asc_i desc_i rand_i neg_i nullable_i t; do
+	c="$(q "SELECT min($col)::text || '|' || max($col)::text FROM mm_c;")"
+	h="$(q "SELECT min($col)::text || '|' || max($col)::text FROM mm_h;")"
+	[ "$c" = "$h" ] || bad="$bad $col(columnar=$c heap=$h)"
+done
+check "min and max match heap on every column" "${bad:-same}" "same"
+
+# --- 3. skipping still happens -------------------------------------------------
+
+# A fast path that quietly widened every bound would pass checks 1 and 2 while
+# giving up the skipping the zone maps exist for, so assert groups are still
+# ruled out.
+skipped="$(q "EXPLAIN (ANALYZE, COSTS off, TIMING off, SUMMARY off)
+	SELECT count(*) FROM mm_c WHERE asc_i BETWEEN 19999 AND 20001;" \
+	| grep -oE 'Columnar Chunk Groups Removed by Filter: [0-9]+' \
+	| grep -oE '[0-9]+$' | head -1)"
+echo "-- chunk groups skipped for a narrow range: ${skipped:-none reported}"
+
+check "a narrow range still skips row groups" \
+	"$( [ -n "${skipped:-}" ] && [ "$skipped" -gt 0 ] && echo yes || echo "no (${skipped:-unreported})")" \
+	"yes"
+
+# --- 4. floats keep their btree ordering, NaN included -------------------------
+
+psql_run "DROP TABLE IF EXISTS mm_f; DROP TABLE IF EXISTS mm_fh;
+	SET pgcolumnar.stripe_row_limit = 20000;
+	SET pgcolumnar.chunk_group_row_limit = 20000;
+	CREATE TABLE mm_f (f4 real, f8 double precision) USING pgcolumnar;
+	INSERT INTO mm_f SELECT
+		CASE WHEN g = 5001 THEN 'NaN'::real
+		     WHEN g = 5002 THEN 'Infinity'::real
+		     WHEN g = 5003 THEN '-Infinity'::real
+		     ELSE g::real END,
+		CASE WHEN g = 5001 THEN 'NaN'::float8
+		     WHEN g = 5002 THEN 'Infinity'::float8
+		     WHEN g = 5003 THEN '-Infinity'::float8
+		     ELSE g::float8 END
+	FROM generate_series(1, 5003) g;
+	CREATE TABLE mm_fh (LIKE mm_f);
+	INSERT INTO mm_fh SELECT * FROM mm_f;" >/dev/null 2>&1
+
+# The special values sit at the END of a single chunk group, on purpose. NaN
+# arriving first would become that chunk's min and max before any comparison ran,
+# and every check below would pass whatever the comparison did -- which is what an
+# earlier version of this fixture did, and it let a deliberately broken build
+# through.
+check "the float fixture is one chunk group" \
+	"$(q "SELECT count(*) FROM pgcolumnar.row_group r
+		JOIN pgcolumnar.storage s ON s.storage_id = r.storage_id
+		WHERE s.relation_oid = 'mm_f'::regclass;")" "1"
+
+# btree orders NaN above everything, so it is the maximum of both columns. A C
+# comparison would never make it one, and then a query for it can be skipped.
+check "max of a float column with NaN matches heap" \
+	"$(q "SELECT max(f8)::text FROM mm_f;")" "$(q "SELECT max(f8)::text FROM mm_fh;")"
+
+check "max of a real column with NaN matches heap" \
+	"$(q "SELECT max(f4)::text FROM mm_f;")" "$(q "SELECT max(f4)::text FROM mm_fh;")"
+
+check "a row holding NaN is still found by an equality predicate" \
+	"$(q "SELECT count(*) FROM mm_f WHERE f8 = 'NaN';")" \
+	"$(q "SELECT count(*) FROM mm_fh WHERE f8 = 'NaN';")"
+
+check "infinities are found too" \
+	"$(q "SELECT count(*) FROM mm_f WHERE f8 = 'Infinity' OR f8 = '-Infinity';")" \
+	"$(q "SELECT count(*) FROM mm_fh WHERE f8 = 'Infinity' OR f8 = '-Infinity';")"
+
+# --- 5. the fast path is restricted to the types that can take it --------------
+
+SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/src"
+
+check "float types are not on the direct comparison list" \
+	"$(grep -cE 'COLUMNAR_FASTCMP_F(32|64)' "$SRC/columnar_write_state.c")" "0"
+
+pgc_summary


### PR DESCRIPTION
Towards #155. **The measurement below matters more than the patch, because it contradicts the model `design/IMPORT_THROUGHPUT_PLAN.md` is built on.** The patch is a real but modest 5–7%.

## The plan's model does not survive measurement

The plan says the waste is the per-row round trip: both readers decode a columnar file into per-row `Datum` arrays, hand each row to `table_tuple_insert`, and the write path copies each value back into per-column buffers. Step 1 is therefore a batching entry point, "worth doing first even without the column-wise work: it amortises the per-call overhead".

If per-call overhead were the problem, a one-column load would show it as clearly as a five-column one — same rows, same number of `table_tuple_insert` calls. It does not:

18.4, 3,000,000 rows, `INSERT INTO ... SELECT`, no file involved, same machine and session:

| shape | heap | columnar | ratio |
| --- | --- | --- | --- |
| 1 int column | 1272.4 ms | **908.1 ms** | **0.71x** |
| 5 int columns | 1364.1 ms | 3697.0 ms | 2.7x |
| 1 text column | 1284.3 ms | 4680.1 ms | 3.6x |
| 4 numeric columns, no text | 1402.0 ms | 3997.1 ms | 2.9x |
| 5 mixed columns, one text | 1494.7 ms | 8604.8 ms | 5.8x |

**At one integer column the columnar write path is faster than heap.** There is no per-row overhead to amortise; the row-at-a-time interface is not what costs. The cost is per value and roughly additive per column — about 900 ms per numeric column and about 4,600 ms for a text column, which is why the 4.9x in the issue is really "five columns, one of them text".

Two more things the plan does not mention:

- **Compression is not a factor.** `compression = none` is 2% faster than `zstd 3` (8846 ms against 9022), and `lz4` is indistinguishable. Not worth touching.
- **Text is the outlier.** One text column costs more than five integer columns. If effort goes anywhere structural, the varlena write path is where the 4.9x actually lives.

My reading is that step 1 as written would deliver close to nothing, and step 2 should be judged per column type rather than per nullability/width combination. I would rather say that before someone spends the first of the two-to-four dev-months than after.

## Where the remaining per-value cost sits

Ablated by building with each piece disabled, 3,000,000 rows:

| | 1 text column | 5 int columns |
| --- | --- | --- |
| baseline | 4944 ms | 4759 ms |
| without zone min/max tracking | 4113 ms (−17%) | 4060 ms (−15%) |
| without bloom hashing | 4672 ms (−5.5%) | 4039 ms (−15%) |

No single dominant term; min/max is the largest identified piece at 15–17%, and the rest is spread across encoding, the value stream and the flush. That 15% on five *integer* columns, where the comparison itself is a subtraction, says the cost is the fmgr indirection rather than the comparing.

## What this patch does

Two changes to the min/max tracking, which is the one piece with a clean fix:

1. **Integer-family columns compare directly** instead of through fmgr, using the same list of types the vectorized filter's fast path already uses (`COLUMNAR_VECFAST_*`).
2. **The maximum is tested first, the minimum only if the maximum does not settle it.** A value above the running maximum cannot also be below the running minimum, so an ascending load — a serial or timestamp column, which is what bulk loads mostly are — costs one comparison per value instead of two. This is why the text column gains despite not being on the fast list.

Median of three, same machine and session:

| | `1be027b` | this branch | |
| --- | --- | --- | --- |
| 5 int columns | 3587.3 ms | 3395.8 ms | 5.3% |
| 1 text column | 4496.7 ms | 4183.0 ms | 7.0% |
| 1 timestamptz column | 968.2 ms | 924.8 ms | 4.5% |

Individual runs, so the separation can be judged rather than taken on trust: 5 int columns `3635.7 / 3532.2 / 3587.3` against `3395.8 / 3395.2 / 3396.9`; text `4600.9 / 4496.7 / 4399.6` against `4307.5 / 4135.2 / 4183.0`. Non-overlapping.

## floats are deliberately excluded, and I can show why

btree float ordering puts NaN above every other value. A C comparison gets this wrong — every comparison against NaN is false, so NaN reads as equal and never becomes a chunk's maximum, and the zone map then rules out a group that does hold matching rows.

I built that mistake on purpose to see what it costs. With float4/float8 added to the fast list, **a row holding NaN stops being findable**: `WHERE f8 = 'NaN'` returns 0 rows where heap returns 1. Silent row loss, which is the failure mode this project's bar is explicitly about.

The filter fast path can take floats safely because it compares to answer one predicate; this path compares to build stored bounds a later scan trusts. Different obligations, same-looking code.

## Tests

New suite `test/write_minmax_fastpath.sh`, 9 checks: differential against a heap mirror across twelve columns under predicates placed on chunk-group boundaries, the stored bounds themselves, a check that skipping still happens (a fast path that quietly widened every bound would pass the first two), and the float/NaN/infinity cases.

**These are correctness guards, so they pass on `main` too — that is the point of them.** I proved they discriminate by mutation rather than assuming it, and the first attempt did not:

- My initial float fixture inserted `NaN` as the first row of its chunk, so it became both bounds before any comparison ran. **Every behavioural check passed against the deliberately broken build.** Only the source-grep check failed, which would have been a false sense of cover.
- Rebuilt so the special values sit at the end of a single chunk group, the mutation is caught behaviourally: the NaN equality check returns 0 against 1. The fixture comment records why the ordering is load-bearing.

## Gate

Full suite on 18.4: **78 pass, 0 fail.** Non-passing entries are `devloop`, which needs `PGC_SRC` and fails the same way on `main`, and `analyze_stats`, which belongs to #159 and is not part of this branch.

Not run on 17. The two-major gate is yours.

## Scope, honestly

This is not #155. It is 5–7% of a 4.9x gap, plus the measurement that says where the rest is and that step 1 of the plan is aimed at something that is not there. I did not build the batching entry point, because I do not think it would pay and I would rather show you the numbers than write it and find out.

Happy to take the varlena write path next if you agree that is where the 4.9x actually lives.
