### PR TITLE
Make native_agg_deletes stable on an assert build

### DIFF
--- a/test/native_agg_deletes.sh
+++ b/test/native_agg_deletes.sh
@@ -18,10 +18,10 @@
 #    once from the scan that covers it.
 #
 # 2. count(*) no longer cares. Timed as a ratio against the same query on the
-#    same table with nothing deleted, because a millisecond threshold is not
-#    portable. count(*) over a group is its row count minus its deleted count,
-#    which is exact, so a delete should cost it almost nothing. Before the change
-#    this ratio was in the thousands.
+#    same table scanned in full, because a millisecond threshold is not portable.
+#    count(*) over a group is its row count minus its deleted count, which is
+#    exact, so a delete should not send the query back to reading the table.
+#    Before the change it did exactly that.
 #
 # 3. Only the dirty groups are read. min/max cannot be folded from a zone map
 #    once a row is gone, so those groups are scanned -- but only those. Timed
@@ -116,11 +116,26 @@ clean_ms="$(ms "SELECT count(*) FROM ad_t")"
 psql_run "DELETE FROM ad_t WHERE id = $((ROWS / 2));" >/dev/null 2>&1
 dirty_ms="$(ms "SELECT count(*) FROM ad_t")"
 
-echo "-- count(*): ${clean_ms} ms with no deletes, ${dirty_ms} ms with one"
+# The reference is a full scan of the same table, not the undeleted timing.
+#
+# Comparing the deleted timing against the clean one looked like the obvious
+# ratio and is the wrong shape: the clean figure is a metadata read of about
+# 0.03 ms, so any jitter at all moves the ratio by tens. On an assert-enabled
+# build -- which is what the matrix runs -- that failed about one run in three,
+# at 1.1960/0.0320 against a threshold of 20, while the behaviour under test was
+# perfectly correct.
+#
+# What the issue is actually about is that one deleted row must not send count(*)
+# back to reading the table. So the thing to measure against is reading the
+# table, which is milliseconds rather than microseconds and does not swing.
+scan_ms="$(ms "SELECT count(*) FROM ad_t" \
+	"SET pgcolumnar.enable_vectorization = off;")"
 
-check "one deleted row does not put count(*) into a different class" \
-	"$(awk -v c="$clean_ms" -v d="$dirty_ms" \
-		'BEGIN { print (c > 0 && d / c < 20) ? "yes" : "no (" d "/" c ")" }')" \
+echo "-- count(*): ${clean_ms} ms clean, ${dirty_ms} ms with one deleted, ${scan_ms} ms scanning"
+
+check "one deleted row does not send count(*) back to a full scan" \
+	"$(awk -v d="$dirty_ms" -v s="$scan_ms" \
+		'BEGIN { print (s > 0 && d < s / 4) ? "yes" : "no (" d " against a " s " scan)" }')" \
 	"yes"
 
 # --- 3. only the groups with deletes are read ----------------------------------


### PR DESCRIPTION
A flaky test I merged in #151, found by running the full suite against an assert-enabled build rather than the packaged one.

## The failure

`native_agg_deletes` fails about one run in three on an assert build:

```
FAIL  one deleted row does not put count(*) into a different class:
      got [no (1.1960/0.0320)] want [yes]
```

Nothing is wrong with the code under test. The check compared the deleted timing against the same query with nothing deleted, and the clean figure is a metadata read of about **0.03 ms** — so ordinary jitter moves the ratio by tens. 1.196 ms is still two orders of magnitude below reading the table, which is the thing the check exists to detect.

This is the same trap as a millisecond threshold, one level up: I picked a ratio because a ratio is portable, and then made the denominator a number too small to be stable. A ratio is only as portable as its reference.

## The fix

What #149 is about is that one deleted row must not send `count(*)` back to reading the table, so the reference is now that scan. It is milliseconds rather than microseconds and does not swing:

| run | clean | with one deleted | scanning |
| --- | --- | --- | --- |
| 1 | 0.0320 | 0.3600 | 22.4560 |
| 2 | 0.0370 | **1.1910** | 23.4610 |
| 3 | 0.0330 | 0.3770 | 22.7080 |
| 4 | 0.0330 | 0.3550 | 23.1340 |
| 5 | 0.0330 | 0.3660 | 22.4530 |

Five of five pass on the assert build, including run 2, whose outlier is exactly what failed the old check. The margin is 19x to 63x rather than the old check's 10x-and-hope.

## It still discriminates

Before #151 a deleted row made `count(*)` cost a full scan — 95.07 ms, against a scan of the same order — so the deleted and scanning figures were equal and a quarter-of-a-scan threshold fails by a wide margin. The check has not been weakened, it has been pointed at a reference that means something.

## Why this took a while to surface

I gated #151 on the packaged non-assert server. Assert builds are slower and noisier, which is what exposes a ratio built on a 0.03 ms denominator. It is the same root cause as the #159 blocker: I was not testing what the matrix tests. I have an assert build now and this is the second thing it found.

Worth noting for anyone reading the suite later: the surviving timing checks in that file, and in `native_fetch_position`, all reference a figure the same run measures in milliseconds. The one I got wrong was the only one referencing a sub-millisecond baseline.