### PR TITLE
Guard the analyze block callback at PG17, where the signature actually changed

### DIFF
--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -31,7 +31,8 @@
 #include "optimizer/plancat.h"
 #include "port/atomics.h"
 #include "storage/bufmgr.h"
-#if PG_VERSION_NUM >= 180000
+#if PG_VERSION_NUM >= 170000
+/* the read-stream ANALYZE rework landed in PG17, and so did this header */
 #include "storage/read_stream.h"
 #endif
 #include "storage/lmgr.h"
@@ -581,7 +582,14 @@ columnar_analyze_set_slice(ColumnarAnalyzeState *st, BlockNumber blockno)
 	}
 }
 
-#if PG_VERSION_NUM >= 180000
+/*
+ * The block comes from a read stream from PG17 and as a plain BlockNumber
+ * before that. columnar_compat.h supplies the parameter list and splits at the
+ * same major; these two must agree, and when they did not, PG17 took the
+ * pre-17 branch and failed to compile on a `blockno` its signature does not
+ * have.
+ */
+#if PG_VERSION_NUM >= 170000
 static bool
 columnar_scan_analyze_next_block(COLUMNAR_ANALYZE_NEXT_BLOCK_ARGS)
 {


### PR DESCRIPTION
**`main` does not build on PostgreSQL 17.** Found re-reviewing #159 after merging it.

```
src/columnar_tableam.c: In function 'columnar_scan_analyze_next_block':
error: 'blockno' undeclared (first use in this function)
```

## Why

`scan_analyze_next_block` took `(BlockNumber, BufferAccessStrategy)` through PG16 and `(ReadStream *)` from **PG17**, which is the read-stream ANALYZE rework. `columnar_compat.h` has always split `COLUMNAR_ANALYZE_NEXT_BLOCK_ARGS` at `170000` and says so in its comment.

#159 guarded the callback body at `180000`. So on PG17 the pre-17 branch was compiled against a PG17 signature and referenced a parameter that signature does not have.

PG15 and PG16 build because they really are pre-17. PG18 and PG19 build because they are past both guards. **PG17 is the only major where the mismatch can appear**, which is exactly why the PG18-and-PG19 gate I approved #159 on reported it green.

## Fix

Both guards now agree with the compat macro at `170000`, with a comment saying the two must stay in step and what happens when they do not.

## Verification

Builds clean, zero warnings, on all five majors:

```
pg15: BUILD OK (0 warnings)    pg17: BUILD OK (0 warnings)    pg19: BUILD OK (0 warnings)
pg16: BUILD OK (0 warnings)    pg18: BUILD OK (0 warnings)
```

Full 15 through 19 matrix: `ALL VERSIONS PASSED`, with `analyze_stats` passing on all five majors.

## What this says about the gating rule

The per-PR cadence is PG18 and PG19, with a full matrix once per feature. That is cheap and it is usually right, but it cannot see a defect that exists only on a major it does not build. Any change touching a version-guarded callback should build all five before merge even if it only gates two, which costs about a minute. I approved #159 without doing that.