### PR TITLE
Cost the columnar scan properly when no seqscan path survives (#171)

### DIFF
--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -555,8 +555,45 @@ ColumnarSetRelPathlist(PlannerInfo *root, RelOptInfo *rel, Index rti,
 	cpath->path.parallel_safe = false;
 	cpath->path.parallel_workers = 0;
 	cpath->path.rows = rel->rows;
-	cpath->path.startup_cost = seqpath ? seqpath->startup_cost : 0;
-	cpath->path.total_cost = seqpath ? seqpath->total_cost : rel->rows;
+
+	/*
+	 * Inherit the sequential scan's cost when there is one, since this path
+	 * reads the same relation and the comparison against every other path
+	 * should turn on what it does differently, not on a different cost model.
+	 *
+	 * When there is none, cost the work: every page read once and the
+	 * restriction evaluated on every row. The fallback used to be rel->rows,
+	 * which is an output row count and not a cost at all.
+	 *
+	 * That fallback was not the rare case it looks like. add_path frees a path
+	 * it finds dominated, so the seqscan is gone from rel->pathlist by the time
+	 * this hook runs exactly when some index path beat it on both cost and
+	 * pathkeys -- which is to say, precisely on the selective lookups where
+	 * using the index matters most. Before ANALYZE the row estimate was a large
+	 * default and the resulting "cost" was accidentally large enough to lose. Once
+	 * ANALYZE supplied real statistics (#159), a selective predicate estimated
+	 * one row, so a full scan of the table was priced at 1.00, beat an index scan
+	 * of the same query costed at 174.29, and the planner stopped using the index.
+	 * That is issue #171: a point lookup went from 23.75 ms to 1251.88 ms the
+	 * moment the table had statistics. Regression-tested in test/analyze_stats.sh.
+	 */
+	if (seqpath != NULL)
+	{
+		cpath->path.startup_cost = seqpath->startup_cost;
+		cpath->path.total_cost = seqpath->total_cost;
+	}
+	else
+	{
+		QualCost	qcost = rel->baserestrictcost;
+		double		ntuples = (rel->tuples >= 0) ? rel->tuples : rel->rows;
+		Cost		run;
+
+		run = seq_page_cost * (double) rel->pages;
+		run += (cpu_tuple_cost + qcost.per_tuple) * ntuples;
+
+		cpath->path.startup_cost = qcost.startup;
+		cpath->path.total_cost = qcost.startup + run;
+	}
 	cpath->path.pathkeys = NIL;
 	cpath->flags = 0;
 	cpath->custom_paths = NIL;

--- a/test/analyze_stats.sh
+++ b/test/analyze_stats.sh
@@ -216,4 +216,49 @@ check "a selective equality is estimated from the data, not the 0.5% default" \
 		'BEGIN { r = e / t; print (r > 0.2 && r < 0.5) ? "yes" : "no (" e " of " t ")" }')" \
 	"yes"
 
+# --- 5. statistics must not cost the index out of a point lookup (#171) --------
+
+# Collecting statistics made one query shape dramatically worse. The custom scan
+# inherits the seqscan's cost, but add_path frees a dominated path, so when an
+# index path beats the seqscan there is no seqscan left to inherit from -- and the
+# fallback was rel->rows, an output row count used as a cost. With real statistics
+# a selective predicate estimates one row, so a full scan was priced at 1.00 and
+# won. Measured on a 6M-row table: 23.75 ms before ANALYZE, 1251.88 ms after.
+#
+# Both checks below are behavioural rather than assertions about a cost number,
+# so neither can be satisfied by a differently-shaped wrong cost.
+
+psql_run "CREATE INDEX IF NOT EXISTS as_c_id ON as_c (id); ANALYZE as_c;" >/dev/null
+
+target=$((ROWS / 2))
+plan="$(q "EXPLAIN (COSTS off) SELECT * FROM as_c WHERE id = $target;")"
+echo "-- point-lookup plan after ANALYZE: $(printf '%s' "$plan" | head -1)"
+
+check "a point lookup on an indexed column still uses the index after ANALYZE" \
+	"$(  grep -qE 'Index (Only )?Scan|Bitmap Heap Scan' <<<"$plan" \
+		&& echo yes || echo "no ($(printf '%s' "$plan" | head -1))")" \
+	"yes"
+
+# The consequence, independent of plan shape: having the index available must
+# actually save work. The comparison is against the same query with the index
+# denied rather than against a fixed number of rows, so it stays discriminating
+# whatever the row group size is -- a fixed threshold would only separate the two
+# for as long as a group happens to be larger than it.
+discarded() {  # extra SET statements -> rows the filter threw away
+	local ea
+	ea="$(q "$1 EXPLAIN (ANALYZE, COSTS off, TIMING off, SUMMARY off)
+		SELECT * FROM as_c WHERE id = $target;")"
+	awk 'match($0, /Rows Removed by Filter: [0-9]+/) {
+		s = substr($0, RSTART, RLENGTH); sub(/[^0-9]+/, "", s); t += s } END { print t + 0 }' <<<"$ea"
+}
+
+with_index="$(discarded "")"
+no_index="$(discarded "SET enable_indexscan = off; SET enable_bitmapscan = off;")"
+echo "-- rows discarded to return one row: ${with_index} with the index, ${no_index} without it"
+
+check "having an index available saves the point lookup real work" \
+	"$(awk -v a="$with_index" -v b="$no_index" \
+		'BEGIN { print (b > 0 && a < b / 2) ? "yes" : "no (" a " with the index, " b " without)" }')" \
+	"yes"
+
 pgc_summary


### PR DESCRIPTION
Closes the first half of #171.

## The defect

A point lookup on an indexed columnar table went from **23.75 ms to 1251.88 ms the moment the table had statistics**. Collecting statistics, which #159 made work, made this query shape dramatically worse.

The custom scan path inherits the sequential scan's cost. When there was no seqscan path to inherit from, it fell back to `rel->rows` -- an output row count used as a cost.

That fallback is not the rare case it looks like. `add_path` frees a path it finds dominated, so the seqscan is **already gone from `rel->pathlist`** by the time the hook runs exactly when some index path beat it on both cost and pathkeys. Which is to say: precisely on the selective lookups where using the index matters most.

Before ANALYZE the row estimate was a large default, and the resulting "cost" was accidentally large enough to lose. With real statistics a selective predicate estimates one row, so a full scan of the table was priced at `1.00`:

```
== BEFORE ANALYZE ==
 Index Scan using cz_id on cz  (cost=0.42..174.29 rows=1250) (actual rows=1)
== AFTER ANALYZE ==
 Custom Scan (ColumnarScan) on cz  (cost=0.00..1.00 rows=1) (actual rows=1)
   Rows Removed by Filter: 249999
```

A seq scan of that same query costs `2513.00`. The custom scan claimed `1.00` and won.

## The fix

The fallback now costs the work it actually does: every page read once, and the restriction evaluated on every row. That is core's own seqscan formula, which is why the two agree exactly where both can be observed. Where a seqscan path does survive, nothing changes.

After the fix, the same lookup plans `Index Scan using cz_id on cz (cost=0.42..8.44 rows=1)`.

## Tests

Two checks in `test/analyze_stats.sh`, both **behavioural rather than assertions about a cost number**, so neither can be satisfied by a differently-shaped wrong cost.

The second one compares the same query against itself with the index denied, rather than against a fixed number of rows. A fixed threshold would only separate the two cases for as long as a row group happened to be larger than it; this stays discriminating whatever the group size is.

**Proven by removal.** With the fix reverted, both fail and nothing else does:

```
-- point-lookup plan after ANALYZE: Custom Scan (ColumnarScan) on as_c
FAIL  a point lookup on an indexed column still uses the index after ANALYZE
-- rows discarded to return one row: 9999 with the index, 9999 without it
FAIL  having an index available saves the point lookup real work
```

With the fix: `Index Scan using as_c_id`, and `0 with the index, 9999 without it`.

## Gate

- Build preflight: 15, 16, 17, 18, 19, zero warnings.
- Full suite: **79 pass, 0 fail on PG18** and **79 pass, 0 fail on PG19**.

The gate tree predates #170 landing; the two changes touch disjoint files (`columnar_customscan.c` here, `columnar_vector.c` there). I will run the full suite on `main` after this merges to cover the combination.

## Still open on #171

The second half -- ANALYZE itself taking tens of minutes on wide tables -- is not addressed here. It has not reproduced inside the benchmark and needs its own investigation. The issue stays open for it.