### PR TITLE
Stream ANALYZE's sample through each row group (closes the second half of #171)

### DIFF
--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -112,9 +112,30 @@ typedef struct ColumnarAnalyzeState
 	uint64		sliceFirstRow;
 	uint64		sliceRows;
 	uint64		sliceNext;		/* next offset within the slice */
+	uint64		sliceGroup;		/* the row group the slice belongs to */
 
 	Datum	   *values;
 	bool	   *nulls;
+
+	/*
+	 * A forward reader over the group the current slice belongs to.
+	 *
+	 * The rows a slice offers are a contiguous run of row numbers, slices within
+	 * a group are visited in ascending order, and groups likewise, so one
+	 * forward scan per group serves every slice in it. Fetching each row by
+	 * number instead -- which this did first -- re-reads the row group list from
+	 * the catalog and re-locates the row on every call, and ANALYZE offers every
+	 * row of every block core samples: 250,000 fetches on a 250,000-row table,
+	 * which ran for over 200 seconds and did not improve when the statistics
+	 * target was lowered, because the work is per row offered rather than per row
+	 * kept.
+	 */
+	ColumnarReadState *rs;		/* NULL until the first slice with rows */
+	uint64		rsGroup;		/* group number rs is restricted to */
+	bool		rsHavePending;	/* pendingRow/values hold an unconsumed row */
+	uint64		pendingRow;
+	Datum	   *pendingValues;
+	bool	   *pendingNulls;
 } ColumnarAnalyzeState;
 
 typedef struct ColumnarScanDescData
@@ -438,7 +459,11 @@ columnar_scan_end(TableScanDesc sscan)
 	ColumnarEndRead(scan->readState);
 
 	if (scan->analyzeState != NULL)
+	{
+		if (scan->analyzeState->rs != NULL)
+			ColumnarEndRead(scan->analyzeState->rs);
 		MemoryContextDelete(scan->analyzeState->cx);
+	}
 
 	/* release a snapshot restored+registered for a parallel worker */
 	if (scan->rs_base.rs_flags & SO_TEMP_SNAPSHOT)
@@ -709,6 +734,8 @@ columnar_analyze_state(ColumnarScanDesc scan)
 											 st->metaSnapshot);
 	st->values = palloc(sizeof(Datum) * RelationGetDescr(rel)->natts);
 	st->nulls = palloc(sizeof(bool) * RelationGetDescr(rel)->natts);
+	st->pendingValues = palloc(sizeof(Datum) * RelationGetDescr(rel)->natts);
+	st->pendingNulls = palloc(sizeof(bool) * RelationGetDescr(rel)->natts);
 	MemoryContextSwitchTo(oldContext);
 
 	scan->analyzeState = st;
@@ -786,6 +813,7 @@ columnar_analyze_set_slice(ColumnarAnalyzeState *st, BlockNumber blockno)
 		st->sliceFirstRow = rg->firstRowNumber + firstOff;
 		st->sliceRows = endOff - firstOff;
 		st->sliceNext = 0;
+		st->sliceGroup = rg->groupNumber;
 		return;
 	}
 }
@@ -836,25 +864,78 @@ columnar_scan_analyze_next_tuple(COLUMNAR_ANALYZE_NEXT_TUPLE_ARGS)
 	ColumnarAnalyzeState *st = columnar_analyze_state(cscan);
 	Relation	rel = scan->rs_rd;
 	TupleDesc	tupdesc = RelationGetDescr(rel);
+	uint64		sliceEnd = st->sliceFirstRow + st->sliceRows;
 	int			i;
 
-	while (st->sliceNext < st->sliceRows)
+	if (st->sliceRows == 0)
+		return false;
+
+	/* a slice in a new group needs a reader positioned on that group */
+	if (st->rs == NULL || st->rsGroup != st->sliceGroup)
 	{
-		uint64		rowNumber = st->sliceFirstRow + st->sliceNext++;
+		MemoryContext oldContext = MemoryContextSwitchTo(st->cx);
+
+		if (st->rs != NULL)
+			ColumnarEndRead(st->rs);
+		st->rs = ColumnarBeginRead(rel, scan->rs_snapshot, NULL, NULL, 0, NULL);
+		ColumnarReadRestrictToGroups(st->rs, &st->sliceGroup, 1);
+		st->rsGroup = st->sliceGroup;
+		st->rsHavePending = false;
+		MemoryContextSwitchTo(oldContext);
+	}
+
+	for (;;)
+	{
+		uint64		rowNumber;
 
 		CHECK_FOR_INTERRUPTS();
 
-		/*
-		 * A row the delete vector marks is dead for ANALYZE's purposes, and
-		 * counting it as such is what keeps core's live-row estimate right rather
-		 * than merely keeping it out of the sample.
-		 */
-		if (!ColumnarReadRowByNumber(rel, scan->rs_snapshot, rowNumber,
-									 st->values, st->nulls))
+		if (st->rsHavePending)
 		{
-			*deadrows += 1;
-			continue;
+			rowNumber = st->pendingRow;
+			st->rsHavePending = false;
+			memcpy(st->values, st->pendingValues,
+				   sizeof(Datum) * tupdesc->natts);
+			memcpy(st->nulls, st->pendingNulls, sizeof(bool) * tupdesc->natts);
 		}
+		else if (!ColumnarReadNextRow(st->rs, st->values, st->nulls, &rowNumber))
+		{
+			/*
+			 * The group is exhausted. Any rows of this slice not returned were
+			 * removed by the delete vector, which the reader applies for us.
+			 */
+			*deadrows += (double) (sliceEnd - st->sliceFirstRow - st->sliceNext);
+			st->sliceNext = st->sliceRows;
+			return false;
+		}
+
+		/* rows before the slice belong to a block core has already visited */
+		if (rowNumber < st->sliceFirstRow)
+			continue;
+
+		if (rowNumber >= sliceEnd)
+		{
+			/*
+			 * Past the slice. Hold the row for the next one rather than losing
+			 * it: the reader only goes forward, and re-reading the group per
+			 * slice is what this design exists to avoid.
+			 */
+			memcpy(st->pendingValues, st->values, sizeof(Datum) * tupdesc->natts);
+			memcpy(st->pendingNulls, st->nulls, sizeof(bool) * tupdesc->natts);
+			st->pendingRow = rowNumber;
+			st->rsHavePending = true;
+			*deadrows += (double) (sliceEnd - st->sliceFirstRow - st->sliceNext);
+			st->sliceNext = st->sliceRows;
+			return false;
+		}
+
+		/*
+		 * Rows the reader skipped between the last one and this are deleted; the
+		 * live-row estimate core computes needs them counted, not merely left
+		 * out of the sample.
+		 */
+		*deadrows += (double) (rowNumber - st->sliceFirstRow - st->sliceNext);
+		st->sliceNext = rowNumber - st->sliceFirstRow + 1;
 
 		ExecClearTuple(slot);
 		for (i = 0; i < tupdesc->natts; i++)
@@ -869,15 +950,12 @@ columnar_scan_analyze_next_tuple(COLUMNAR_ANALYZE_NEXT_TUPLE_ARGS)
 		 * by item pointer before computing statistics, and the row-number mapping
 		 * is monotonic, so this is what makes the sorted order the physical order
 		 * -- which in turn is what makes the correlation statistic mean anything.
-		 * Correlation is the one statistic nothing outside this AM can supply.
 		 */
 		ColumnarRowNumberToItemPointer(rowNumber, &slot->tts_tid);
 
 		*liverows += 1;
 		return true;
 	}
-
-	return false;
 }
 
 /* VACUUM: nothing to do in phase 1 (delete vector / compaction arrive later) */

--- a/test/analyze_stats.sh
+++ b/test/analyze_stats.sh
@@ -7,7 +7,7 @@
 # with planner defaults. The sampler maps each block core chooses to the slice of
 # its row group that the block stands for, and offers that slice's live rows.
 #
-# Seven things are asserted.
+# Eight things are asserted.
 #
 # 1. The statistics agree with a heap table on identical data. This is the
 #    differential oracle the rest of the suite uses, and it is what catches a
@@ -259,6 +259,53 @@ echo "-- rows discarded to return one row: ${with_index} with the index, ${no_in
 check "having an index available saves the point lookup real work" \
 	"$(awk -v a="$with_index" -v b="$no_index" \
 		'BEGIN { print (b > 0 && a < b / 2) ? "yes" : "no (" a " with the index, " b " without)" }')" \
+	"yes"
+
+# --- 5. ANALYZE is not proportional to the table ------------------------------
+
+# The sampler offers every row of every block core visits, so its cost is per row
+# OFFERED, not per row kept. Fetching each of those by row number re-read the row
+# group list from the catalog and re-located the row: ANALYZE on a 250,000-row,
+# eight-column table ran over 200 seconds and did not get faster when the
+# statistics target was lowered to 1, because lowering the target does not reduce
+# the rows offered when the table has fewer blocks than the target.
+#
+# A wide table is the shape that shows it, since width drives bytes per row rather
+# than row count, and past a point the decoded row group exceeds the fetch
+# cache's size cap so every offered row re-decodes the whole group. The size
+# below is chosen to sit past that point; measured on the unfixed build:
+#
+#     60,000 rows    526 ms
+#    100,000 rows    705 ms
+#    150,000 rows    over 1800 s        <- the cap is crossed
+#
+# and on the fixed build 341 ms against a 155 ms scan, which is why the threshold
+# has room. The reference is a full scan of the same table: ANALYZE reads a
+# sample and must not cost multiples of reading everything.
+psql_run "DROP TABLE IF EXISTS as_w;
+	CREATE TABLE as_w (a bigint, b int, c int, d int, e timestamptz,
+	                   f text, g text, h text) USING pgcolumnar;
+	INSERT INTO as_w SELECT g, g, g % 1000, g % 7,
+		'2020-01-01'::timestamptz + (g || ' sec')::interval,
+		repeat('x', 200) || g, repeat('y', 200) || g, repeat('z', 200) || g
+	FROM generate_series(1, ${PGC_ANALYZE_WIDE_ROWS:-40000}) g;" >/dev/null
+
+t0=$(date +%s%N)
+psql_run "ANALYZE as_w;" >/dev/null
+t1=$(date +%s%N)
+an_ms=$(( (t1 - t0) / 1000000 ))
+
+t0=$(date +%s%N)
+psql_run "SET pgcolumnar.enable_vectorization = off;
+	SELECT count(h) FROM as_w;" >/dev/null
+t1=$(date +%s%N)
+scan_ms=$(( (t1 - t0) / 1000000 ))
+
+echo "-- wide-table ANALYZE ${an_ms} ms against a ${scan_ms} ms full scan"
+
+check "ANALYZE on a wide table is not many times a full scan of it" \
+	"$(awk -v a="$an_ms" -v s="$scan_ms" \
+		'BEGIN { print (s > 0 && a < s * 20) ? "yes" : "no (" a "ms against a " s "ms scan)" }')" \
 	"yes"
 
 pgc_summary


### PR DESCRIPTION
Closes the second half of #171. The first half is #173, which is merged and which this branch contains — the two are independent, yours in the cost model and this in the sampler.

## The cause

The sampler offers every live row of every block core visits, so **its cost is per row offered, not per row kept**. Each of those went through `ColumnarReadRowByNumber`, which re-reads the row group list from the catalog and re-locates the row on every call. Past the point where a decoded row group exceeds the fetch cache's size cap, the cache stops helping and every offered row re-decodes the whole group as well.

Unfixed, eight columns with three text:

| rows | ANALYZE |
| --- | --- |
| 60,000 | 526 ms |
| 100,000 | 705 ms |
| 150,000 | **over 1800 s** |

The giveaway is that **lowering `default_statistics_target` to 1 changed nothing** — still over 200 s on your 250,000-row shape. `targrows` bounds the rows kept, not the rows offered, and a table with fewer blocks than `targrows` has every block visited whatever the target is. Your 250,000-row table has 98 blocks.

That also explains why it did not reproduce inside the benchmark and why `analyze_stats.sh` never saw it: both use narrow columns, and the cliff is decoded bytes per group, not rows.

## The fix

The rows a slice offers are a contiguous run of row numbers, slices within a group are visited in ascending order, and groups likewise — so one forward reader per group serves every slice in it. A row read past the current slice is held rather than discarded, because the reader only goes forward and re-reading the group per slice is exactly what is being removed.

| | before | after |
| --- | --- | --- |
| 150,000 rows, 8 columns | over 1800 s | **341 ms** |
| 250,000 rows, 8 columns | over 200 s | **1 s** |

Deleted rows needed care: the streaming reader applies the delete mask and simply does not return them, where the per-row fetch returned false and was counted. The gaps are counted as dead so core's live-row estimate is unchanged — `reltuples` still lands within 15% and the suite checks it.

All 14 existing correctness checks still pass, including correlation at 1.0 and the no-double-sampling check.

## The guard, and two fixtures that did not discriminate

The new check references a full scan of the same table rather than a fixed millisecond count.

Its fixture is **40,000 rows of 200-character text columns — sized by decoded bytes, not row count**, because the cliff is the cache cap. Fixed: 396 ms against a 192 ms scan. Unfixed: the suite does not finish.

I got there after two fixtures that proved nothing, and replaced them rather than loosening the threshold to make them "work":

| fixture | unfixed | verdict |
| --- | --- | --- |
| 60,000 narrow rows | 8.5x a scan | passes a 20x threshold — vacuous |
| 100,000 narrow rows | 10x | vacuous |
| 40,000 rows x 200-char text | does not finish | discriminates |

Neither narrow fixture crosses the cap, so on those the defect does not exist to be detected. This is the same lesson as #162 in a new place: a ratio is only as good as the fixture that makes the defect present.

## Gate

Build preflight 17.6, 18.4, 19beta2, zero warnings. Full suite on PG18 and PG19.

One note on the merge: this branch carries `main` including #173, and `analyze_stats.sh` needed a manual resolution because your two checks and my one landed in the same place. Both are present and both pass.