### PR TITLE
Split the Parquet format, Thrift protocol and page codecs into modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ OBJS = \
 	src/columnar_vacuum.o \
 	src/columnar_unique.o \
 	src/columnar_arrow.o \
+	src/columnar_thrift.o \
+	src/columnar_parquet_codec.o \
 	src/columnar_parquet.o \
 	src/columnar_visibilitymap.o \
 	src/columnar_projection.o \

--- a/src/columnar_parquet.c
+++ b/src/columnar_parquet.c
@@ -22,6 +22,8 @@
  *-------------------------------------------------------------------------
  */
 #include "columnar.h"
+#include "columnar_parquet_format.h"
+#include "columnar_thrift.h"
 
 #include "fmgr.h"
 #include "access/htup_details.h"
@@ -50,34 +52,6 @@ PG_FUNCTION_INFO_V1(columnar_export_parquet);
 /* PostgreSQL epoch (2000-01-01) to Unix epoch (1970-01-01) offsets */
 #define PG_TO_UNIX_DAYS		((int64) (POSTGRES_EPOCH_JDATE - UNIX_EPOCH_JDATE))
 #define PG_TO_UNIX_USECS	(PG_TO_UNIX_DAYS * USECS_PER_DAY)
-
-/* Parquet physical types */
-#define PQ_BOOLEAN		0
-#define PQ_INT32		1
-#define PQ_INT64		2
-#define PQ_FLOAT		4
-#define PQ_DOUBLE		5
-#define PQ_BYTE_ARRAY	6
-#define PQ_FIXED_LEN_BYTE_ARRAY 7
-/* ConvertedType */
-#define PQ_CT_UTF8		0
-#define PQ_CT_DECIMAL	5
-#define PQ_CT_DATE		6
-#define PQ_CT_TIME_MICROS 8
-#define PQ_CT_TIMESTAMP_MICROS 10
-#define PQ_CT_INT_16	16
-/* Encoding */
-#define PQ_ENC_PLAIN	0
-#define PQ_ENC_RLE		3
-/* Thrift compact field types */
-#define TC_STOP			0
-#define TC_BOOL_TRUE	1
-#define TC_BOOL_FALSE	2
-#define TC_I32			5
-#define TC_I64			6
-#define TC_BINARY		8
-#define TC_LIST			9
-#define TC_STRUCT		12
 
 typedef enum ParquetKind
 {
@@ -147,88 +121,6 @@ numeric_to_int128(Datum numd, int scale, __int128 *out)
 	return true;
 }
 
-/* ---- Thrift compact-protocol writer (into a StringInfo) ---- */
-
-static void
-tc_varint(StringInfo b, uint64 v)
-{
-	while (v >= 0x80)
-	{
-		appendStringInfoChar(b, (char) ((v & 0x7f) | 0x80));
-		v >>= 7;
-	}
-	appendStringInfoChar(b, (char) v);
-}
-
-static void
-tc_zigzag32(StringInfo b, int32 v)
-{
-	tc_varint(b, (uint32) ((v << 1) ^ (v >> 31)));
-}
-
-static void
-tc_zigzag64(StringInfo b, int64 v)
-{
-	tc_varint(b, (uint64) ((v << 1) ^ (v >> 63)));
-}
-
-/* field header with delta-encoded id */
-static void
-tc_field(StringInfo b, int16 *lastId, int16 id, int type)
-{
-	int			delta = id - *lastId;
-
-	if (delta > 0 && delta <= 15)
-		appendStringInfoChar(b, (char) ((delta << 4) | type));
-	else
-	{
-		appendStringInfoChar(b, (char) type);
-		tc_zigzag32(b, id);
-	}
-	*lastId = id;
-}
-
-static void
-tc_i32_field(StringInfo b, int16 *lastId, int16 id, int32 v)
-{
-	tc_field(b, lastId, id, TC_I32);
-	tc_zigzag32(b, v);
-}
-
-static void
-tc_i64_field(StringInfo b, int16 *lastId, int16 id, int64 v)
-{
-	tc_field(b, lastId, id, TC_I64);
-	tc_zigzag64(b, v);
-}
-
-static void
-tc_string_field(StringInfo b, int16 *lastId, int16 id, const char *s, int len)
-{
-	tc_field(b, lastId, id, TC_BINARY);
-	tc_varint(b, (uint64) len);
-	if (len > 0)
-		appendBinaryStringInfo(b, s, len);
-}
-
-/* list header; caller then appends the elements */
-static void
-tc_list_header(StringInfo b, int size, int elemType)
-{
-	if (size < 15)
-		appendStringInfoChar(b, (char) ((size << 4) | elemType));
-	else
-	{
-		appendStringInfoChar(b, (char) (0xF0 | elemType));
-		tc_varint(b, (uint64) size);
-	}
-}
-
-static void
-tc_stop(StringInfo b)
-{
-	appendStringInfoChar(b, (char) TC_STOP);
-}
 
 /*
  * A leaf column is one Parquet column chunk: a scalar column, an array's element,
@@ -637,7 +529,7 @@ build_rle_levels(StringInfo out, const uint8 *levels, int64 n, int bit_width)
 	int32		len;
 
 	initStringInfo(&h);
-	tc_varint(&h, (uint64) ((ngroups << 1) | 1));	/* one bit-packed run */
+	ColumnarThriftPutVarint(&h, (uint64) ((ngroups << 1) | 1));	/* one bit-packed run */
 	for (i = 0; i < n; i++)
 	{
 		uint32		v = levels[i];
@@ -700,17 +592,17 @@ write_page_header(StringInfo out, int64 nrows, int32 body_size)
 	int16		dlast = 0;
 
 	/* PageHeader */
-	tc_i32_field(out, &last, 1, 0);			/* type = DATA_PAGE */
-	tc_i32_field(out, &last, 2, body_size); /* uncompressed_page_size */
-	tc_i32_field(out, &last, 3, body_size); /* compressed_page_size */
+	ColumnarThriftPutI32Field(out, &last, 1, 0);			/* type = DATA_PAGE */
+	ColumnarThriftPutI32Field(out, &last, 2, body_size); /* uncompressed_page_size */
+	ColumnarThriftPutI32Field(out, &last, 3, body_size); /* compressed_page_size */
 	/* field 5: data_page_header (struct) */
-	tc_field(out, &last, 5, TC_STRUCT);
-	tc_i32_field(out, &dlast, 1, (int32) nrows); /* num_values */
-	tc_i32_field(out, &dlast, 2, PQ_ENC_PLAIN);	/* encoding */
-	tc_i32_field(out, &dlast, 3, PQ_ENC_RLE);	/* def level encoding */
-	tc_i32_field(out, &dlast, 4, PQ_ENC_RLE);	/* rep level encoding */
-	tc_stop(out);								/* end data_page_header */
-	tc_stop(out);								/* end PageHeader */
+	ColumnarThriftPutField(out, &last, 5, TC_STRUCT);
+	ColumnarThriftPutI32Field(out, &dlast, 1, (int32) nrows); /* num_values */
+	ColumnarThriftPutI32Field(out, &dlast, 2, PQ_ENC_PLAIN);	/* encoding */
+	ColumnarThriftPutI32Field(out, &dlast, 3, PQ_ENC_RLE);	/* def level encoding */
+	ColumnarThriftPutI32Field(out, &dlast, 4, PQ_ENC_RLE);	/* rep level encoding */
+	ColumnarThriftPutStop(out);								/* end data_page_header */
+	ColumnarThriftPutStop(out);								/* end PageHeader */
 }
 
 /* ---- FileMetaData footer ---- */
@@ -719,9 +611,9 @@ write_schema_element_root(StringInfo b, int ncols)
 {
 	int16		last = 0;
 
-	tc_string_field(b, &last, 4, "schema", 6);	/* name */
-	tc_i32_field(b, &last, 5, ncols);			/* num_children */
-	tc_stop(b);
+	ColumnarThriftPutStringField(b, &last, 4, "schema", 6);	/* name */
+	ColumnarThriftPutI32Field(b, &last, 5, ncols);			/* num_children */
+	ColumnarThriftPutStop(b);
 }
 
 /* one leaf SchemaElement (a primitive) */
@@ -730,19 +622,19 @@ write_schema_leaf(StringInfo b, const char *name, PqLeaf *leaf, int repetition)
 {
 	int16		last = 0;
 
-	tc_i32_field(b, &last, 1, leaf->ptype);	/* type */
+	ColumnarThriftPutI32Field(b, &last, 1, leaf->ptype);	/* type */
 	if (leaf->ptype == PQ_FIXED_LEN_BYTE_ARRAY)
-		tc_i32_field(b, &last, 2, leaf->typeLength);
-	tc_i32_field(b, &last, 3, repetition);
-	tc_string_field(b, &last, 4, name, (int) strlen(name));
+		ColumnarThriftPutI32Field(b, &last, 2, leaf->typeLength);
+	ColumnarThriftPutI32Field(b, &last, 3, repetition);
+	ColumnarThriftPutStringField(b, &last, 4, name, (int) strlen(name));
 	if (leaf->convType >= 0)
-		tc_i32_field(b, &last, 6, leaf->convType);
+		ColumnarThriftPutI32Field(b, &last, 6, leaf->convType);
 	if (leaf->convType == PQ_CT_DECIMAL)
 	{
-		tc_i32_field(b, &last, 7, leaf->scale);
-		tc_i32_field(b, &last, 8, leaf->precision);
+		ColumnarThriftPutI32Field(b, &last, 7, leaf->scale);
+		ColumnarThriftPutI32Field(b, &last, 8, leaf->precision);
 	}
-	tc_stop(b);
+	ColumnarThriftPutStop(b);
 }
 
 /* one group SchemaElement (no physical type; has num_children) */
@@ -752,12 +644,12 @@ write_schema_group(StringInfo b, const char *name, int repetition,
 {
 	int16		last = 0;
 
-	tc_i32_field(b, &last, 3, repetition);
-	tc_string_field(b, &last, 4, name, (int) strlen(name));
-	tc_i32_field(b, &last, 5, num_children);
+	ColumnarThriftPutI32Field(b, &last, 3, repetition);
+	ColumnarThriftPutStringField(b, &last, 4, name, (int) strlen(name));
+	ColumnarThriftPutI32Field(b, &last, 5, num_children);
 	if (convType >= 0)
-		tc_i32_field(b, &last, 6, convType);
-	tc_stop(b);
+		ColumnarThriftPutI32Field(b, &last, 6, convType);
+	ColumnarThriftPutStop(b);
 }
 
 /* number of SchemaElements a top column contributes (excluding the root) */
@@ -817,27 +709,27 @@ write_column_chunk(StringInfo b, PqLeaf *c, PqColMeta *m)
 	int16		mlast = 0;
 	int			p;
 
-	tc_i64_field(b, &last, 2, m->dataPageOffset);	/* file_offset */
-	tc_field(b, &last, 3, TC_STRUCT);				/* meta_data */
-	tc_i32_field(b, &mlast, 1, c->ptype);			/* type */
-	tc_field(b, &mlast, 2, TC_LIST);				/* encodings [PLAIN, RLE] */
-	tc_list_header(b, 2, TC_I32);
-	tc_zigzag32(b, PQ_ENC_PLAIN);
-	tc_zigzag32(b, PQ_ENC_RLE);
-	tc_field(b, &mlast, 3, TC_LIST);				/* path_in_schema */
-	tc_list_header(b, c->pathlen, TC_BINARY);
+	ColumnarThriftPutI64Field(b, &last, 2, m->dataPageOffset);	/* file_offset */
+	ColumnarThriftPutField(b, &last, 3, TC_STRUCT);				/* meta_data */
+	ColumnarThriftPutI32Field(b, &mlast, 1, c->ptype);			/* type */
+	ColumnarThriftPutField(b, &mlast, 2, TC_LIST);				/* encodings [PLAIN, RLE] */
+	ColumnarThriftPutListHeader(b, 2, TC_I32);
+	ColumnarThriftPutZigzag32(b, PQ_ENC_PLAIN);
+	ColumnarThriftPutZigzag32(b, PQ_ENC_RLE);
+	ColumnarThriftPutField(b, &mlast, 3, TC_LIST);				/* path_in_schema */
+	ColumnarThriftPutListHeader(b, c->pathlen, TC_BINARY);
 	for (p = 0; p < c->pathlen; p++)
 	{
-		tc_varint(b, (uint64) strlen(c->path[p]));
+		ColumnarThriftPutVarint(b, (uint64) strlen(c->path[p]));
 		appendBinaryStringInfo(b, c->path[p], strlen(c->path[p]));
 	}
-	tc_i32_field(b, &mlast, 4, 0);					/* codec = UNCOMPRESSED */
-	tc_i64_field(b, &mlast, 5, m->numValues);		/* num_values */
-	tc_i64_field(b, &mlast, 6, m->totalSize);		/* total_uncompressed_size */
-	tc_i64_field(b, &mlast, 7, m->totalSize);		/* total_compressed_size */
-	tc_i64_field(b, &mlast, 9, m->dataPageOffset);	/* data_page_offset */
-	tc_stop(b);										/* end ColumnMetaData */
-	tc_stop(b);										/* end ColumnChunk */
+	ColumnarThriftPutI32Field(b, &mlast, 4, 0);					/* codec = UNCOMPRESSED */
+	ColumnarThriftPutI64Field(b, &mlast, 5, m->numValues);		/* num_values */
+	ColumnarThriftPutI64Field(b, &mlast, 6, m->totalSize);		/* total_uncompressed_size */
+	ColumnarThriftPutI64Field(b, &mlast, 7, m->totalSize);		/* total_compressed_size */
+	ColumnarThriftPutI64Field(b, &mlast, 9, m->dataPageOffset);	/* data_page_offset */
+	ColumnarThriftPutStop(b);										/* end ColumnMetaData */
+	ColumnarThriftPutStop(b);										/* end ColumnChunk */
 }
 
 static void
@@ -846,13 +738,13 @@ write_row_group(StringInfo b, PqLeaf *leaves, int nleaves, PqRowGroup *rg)
 	int16		last = 0;
 	int			i;
 
-	tc_field(b, &last, 1, TC_LIST);					/* columns */
-	tc_list_header(b, nleaves, TC_STRUCT);
+	ColumnarThriftPutField(b, &last, 1, TC_LIST);					/* columns */
+	ColumnarThriftPutListHeader(b, nleaves, TC_STRUCT);
 	for (i = 0; i < nleaves; i++)
 		write_column_chunk(b, &leaves[i], &rg->cols[i]);
-	tc_i64_field(b, &last, 2, rg->totalByteSize);
-	tc_i64_field(b, &last, 3, rg->numRows);
-	tc_stop(b);
+	ColumnarThriftPutI64Field(b, &last, 2, rg->totalByteSize);
+	ColumnarThriftPutI64Field(b, &last, 3, rg->numRows);
+	ColumnarThriftPutStop(b);
 }
 
 /* initialize a scalar leaf for a given type; *ok=false if unsupported */
@@ -1174,21 +1066,21 @@ columnar_export_parquet(PG_FUNCTION_ARGS)
 			nschema += schema_count_for_top(&tops[i]);
 
 		initStringInfo(&fmd);
-		tc_i32_field(&fmd, &last, 1, 1);	/* version */
+		ColumnarThriftPutI32Field(&fmd, &last, 1, 1);	/* version */
 		/* schema list (2): root + the (possibly nested) elements per column */
-		tc_field(&fmd, &last, 2, TC_LIST);
-		tc_list_header(&fmd, nschema, TC_STRUCT);
+		ColumnarThriftPutField(&fmd, &last, 2, TC_LIST);
+		ColumnarThriftPutListHeader(&fmd, nschema, TC_STRUCT);
 		write_schema_element_root(&fmd, ntop);
 		for (i = 0; i < ntop; i++)
 			write_top_schema(&fmd, &tops[i], leaves);
-		tc_i64_field(&fmd, &last, 3, total);	/* num_rows */
+		ColumnarThriftPutI64Field(&fmd, &last, 3, total);	/* num_rows */
 		/* row_groups list (4) */
-		tc_field(&fmd, &last, 4, TC_LIST);
-		tc_list_header(&fmd, nrgs, TC_STRUCT);
+		ColumnarThriftPutField(&fmd, &last, 4, TC_LIST);
+		ColumnarThriftPutListHeader(&fmd, nrgs, TC_STRUCT);
 		for (i = 0; i < nrgs; i++)
 			write_row_group(&fmd, leaves, nleaves, &rgs[i]);
-		tc_string_field(&fmd, &last, 6, "pgColumnar", 10);	/* created_by */
-		tc_stop(&fmd);
+		ColumnarThriftPutStringField(&fmd, &last, 6, "pgColumnar", 10);	/* created_by */
+		ColumnarThriftPutStop(&fmd);
 
 		fwrite(fmd.data, 1, fmd.len, f);
 		footerLen = fmd.len;

--- a/src/columnar_parquet_codec.c
+++ b/src/columnar_parquet_codec.c
@@ -1,0 +1,239 @@
+/*-------------------------------------------------------------------------
+ *
+ * columnar_parquet_codec.c
+ *		Parquet data-page decompression. See columnar_parquet_codec.h.
+ *
+ * Written fresh for pgColumnar from the public Apache Parquet specification and
+ * the public Snappy format description.
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "lib/stringinfo.h"
+#include "utils/memutils.h"
+
+#include "columnar_parquet_codec.h"
+#include "columnar_parquet_format.h"
+
+#ifdef HAVE_LIBZ
+#include <zlib.h>
+#endif
+#ifdef HAVE_LIBZSTD
+#include <zstd.h>
+#endif
+#ifdef HAVE_LIBLZ4
+#include <lz4.h>
+#endif
+
+/* -------------------------------------------------------------------------
+ * Snappy raw decompression (format spec: preamble varint uncompressed length,
+ * then a stream of literal and copy elements). Clean-room from the format.
+ * ------------------------------------------------------------------------- */
+static bool
+snappy_raw_uncompress(const uint8 *in, size_t inlen, StringInfo out)
+{
+	size_t		pos = 0;
+	uint32		ulen = 0;
+	int			shift = 0;
+
+	/* preamble: uncompressed length as a varint */
+	while (pos < inlen)
+	{
+		uint8		b = in[pos++];
+
+		ulen |= (uint32) (b & 0x7f) << shift;
+		if ((b & 0x80) == 0)
+			break;
+		shift += 7;
+		if (shift > 32)
+			return false;
+	}
+
+	enlargeStringInfo(out, ulen);
+	while (pos < inlen)
+	{
+		uint8		tag = in[pos++];
+		int			type = tag & 0x03;
+
+		if (type == 0)			/* literal */
+		{
+			uint32		len = (tag >> 2) + 1;
+
+			if (len > 60)
+			{
+				int			nb = (tag >> 2) - 59;	/* 1..4 bytes of length */
+				uint32		l = 0;
+				int			i;
+
+				if (pos + nb > inlen)
+					return false;
+				for (i = 0; i < nb; i++)
+					l |= (uint32) in[pos++] << (8 * i);
+				len = l + 1;
+			}
+			if (pos + len > inlen)
+				return false;
+			appendBinaryStringInfo(out, (const char *) in + pos, len);
+			pos += len;
+		}
+		else					/* copy */
+		{
+			uint32		len;
+			uint32		offset;
+			int			i;
+
+			if (type == 1)
+			{
+				len = ((tag >> 2) & 0x07) + 4;
+				if (pos >= inlen)
+					return false;
+				offset = ((uint32) (tag >> 5) << 8) | in[pos++];
+			}
+			else if (type == 2)
+			{
+				len = (tag >> 2) + 1;
+				if (pos + 2 > inlen)
+					return false;
+				offset = (uint32) in[pos] | ((uint32) in[pos + 1] << 8);
+				pos += 2;
+			}
+			else				/* type == 3 */
+			{
+				len = (tag >> 2) + 1;
+				if (pos + 4 > inlen)
+					return false;
+				offset = (uint32) in[pos] | ((uint32) in[pos + 1] << 8) |
+					((uint32) in[pos + 2] << 16) | ((uint32) in[pos + 3] << 24);
+				pos += 4;
+			}
+			if (offset == 0 || offset > (uint32) out->len)
+				return false;
+			/* copies may overlap, so copy byte by byte from the output so far */
+			for (i = 0; i < (int) len; i++)
+			{
+				char		c = out->data[out->len - offset];
+
+				appendBinaryStringInfo(out, &c, 1);
+			}
+		}
+	}
+	return (uint32) out->len == ulen;
+}
+
+/*
+ * Decompress one Parquet page body according to its column-chunk codec.
+ *
+ * On success *out / *outlen point at the decompressed bytes: either straight into
+ * `src` (uncompressed), or into `scratch` (any real codec). `usize` is the
+ * uncompressed size from the page header, which zstd and lz4_raw require up front
+ * (they do not self-describe the output length the way Snappy and gzip do); pass
+ * the value portion's uncompressed size for a v2 data page, where the levels are
+ * stored uncompressed ahead of the compressed values.
+ *
+ * A codec whose library was not built in, or an unknown codec id, returns false
+ * so the caller raises a clean decode error rather than reading garbage.
+ *
+ * srclen and usize are file-declared and otherwise unvalidated (parse_page_header
+ * casts a zigzag int, so a crafted header can present them as negative -- which
+ * arrive here as an enormous size_t -- or absurdly large). Both are bounded to
+ * MaxAllocSize up front so a crafted page yields a clean "return false" rather
+ * than a generic allocation error deep in enlargeStringInfo or a decompressor.
+ * Every codec that consumes usize also caps its output at it, so none can be
+ * driven to allocate or inflate more than the header declares.
+ */
+bool
+ColumnarParquetDecompress(int codec, const uint8 *src, size_t srclen, size_t usize,
+			  StringInfo scratch, const uint8 **out, size_t *outlen)
+{
+	if (srclen > MaxAllocSize || usize > MaxAllocSize)
+		return false;
+
+	switch (codec)
+	{
+		case PQC_UNCOMPRESSED:
+			*out = src;
+			*outlen = srclen;
+			return true;
+
+		case PQC_SNAPPY:
+			/* Snappy self-describes its output length (a leading varint), which
+			 * snappy_raw_uncompress bounds; usize is not consulted. */
+			if (!snappy_raw_uncompress(src, srclen, scratch))
+				return false;
+			*out = (const uint8 *) scratch->data;
+			*outlen = scratch->len;
+			return true;
+
+#ifdef HAVE_LIBZ
+		case PQC_GZIP:
+			{
+				z_stream	zs;
+				int			rc;
+
+				/* Bound the output at the declared size, like zstd and lz4, so a
+				 * small crafted page cannot inflate into a huge allocation. */
+				if (usize == 0)
+					return false;
+				memset(&zs, 0, sizeof(zs));
+				/* 15 + 32: accept a gzip or zlib header (Parquet writes gzip) */
+				if (inflateInit2(&zs, 15 + 32) != Z_OK)
+					return false;
+				enlargeStringInfo(scratch, (int) usize);
+				zs.next_in = (Bytef *) src;
+				zs.avail_in = (uInt) srclen;
+				zs.next_out = (Bytef *) scratch->data;
+				zs.avail_out = (uInt) usize;
+				rc = inflate(&zs, Z_FINISH);
+				inflateEnd(&zs);
+				if (rc != Z_STREAM_END || zs.total_out != usize)
+					return false;
+				scratch->len = (int) usize;
+				scratch->data[scratch->len] = '\0';
+				*out = (const uint8 *) scratch->data;
+				*outlen = scratch->len;
+				return true;
+			}
+#endif
+
+#ifdef HAVE_LIBZSTD
+		case PQC_ZSTD:
+			{
+				size_t		got;
+
+				if (usize == 0)
+					return false;	/* zstd needs the output size */
+				enlargeStringInfo(scratch, (int) usize);
+				got = ZSTD_decompress(scratch->data, usize, src, srclen);
+				if (ZSTD_isError(got) || got != usize)
+					return false;
+				scratch->len = (int) got;
+				*out = (const uint8 *) scratch->data;
+				*outlen = scratch->len;
+				return true;
+			}
+#endif
+
+#ifdef HAVE_LIBLZ4
+		case PQC_LZ4_RAW:
+			{
+				int			got;
+
+				if (usize == 0)
+					return false;	/* lz4 raw needs the output size */
+				enlargeStringInfo(scratch, (int) usize);
+				got = LZ4_decompress_safe((const char *) src, scratch->data,
+										  (int) srclen, (int) usize);
+				if (got < 0 || (size_t) got != usize)
+					return false;
+				scratch->len = got;
+				*out = (const uint8 *) scratch->data;
+				*outlen = scratch->len;
+				return true;
+			}
+#endif
+
+		default:
+			return false;		/* unknown codec, or its library not built in */
+	}
+}

--- a/src/columnar_parquet_codec.h
+++ b/src/columnar_parquet_codec.h
@@ -1,0 +1,37 @@
+/*-------------------------------------------------------------------------
+ *
+ * columnar_parquet_codec.h
+ *		Parquet data-page decompression.
+ *
+ * One entry point that turns a compressed page into bytes, dispatching on the
+ * file's CompressionCodec. Snappy is decoded here from the format itself; gzip,
+ * zstd and lz4_raw go to the system libraries when the build has them and are
+ * refused cleanly when it does not.
+ *
+ * Separated from the import module because it is a property of the file format
+ * and not of how rows are assembled: it can be read against the codec
+ * specifications alone.
+ *
+ * Written fresh for pgColumnar from the public Apache Parquet specification and
+ * the public Snappy format description.
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef PGCOLUMNAR_PARQUET_CODEC_H
+#define PGCOLUMNAR_PARQUET_CODEC_H
+
+#include "postgres.h"
+
+#include "lib/stringinfo.h"
+
+/*
+ * Decompress one page. On success *out points at usize bytes, either into src
+ * (uncompressed) or into scratch, and the caller must not free either. Returns
+ * false on malformed input, on a codec this build cannot decode, and on any
+ * length that disagrees with the page header.
+ */
+extern bool ColumnarParquetDecompress(int codec, const uint8 *src, size_t srclen,
+									  size_t usize, StringInfo scratch,
+									  const uint8 **out, size_t *outlen);
+
+#endif							/* PGCOLUMNAR_PARQUET_CODEC_H */

--- a/src/columnar_parquet_format.h
+++ b/src/columnar_parquet_format.h
@@ -1,0 +1,90 @@
+/*-------------------------------------------------------------------------
+ *
+ * columnar_parquet_format.h
+ *		Parquet and Thrift compact-protocol constants, shared by the reader and
+ *		the writer.
+ *
+ * These are values defined by the file format, not by this implementation, so
+ * there is exactly one correct value for each and both directions must agree on
+ * it. They were previously declared twice, once in columnar_parquet.c and once
+ * in columnar_parquet_reader.c, with 21 names in common. The values did agree,
+ * but nothing made them: a writer and a reader that disagree on a type code
+ * produce a file that is silently wrong rather than one that fails to parse,
+ * which is the worst shape a defect can take here.
+ *
+ * Only format constants belong in this file. A value this implementation chooses
+ * for itself -- a buffer bound, a resolved-unit enum, a sentinel -- stays in the
+ * module that chooses it, because it has no counterpart on the other side.
+ *
+ * Written fresh for pgColumnar from the public Apache Parquet and Apache Thrift
+ * compact-protocol specifications.
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef PGCOLUMNAR_PARQUET_FORMAT_H
+#define PGCOLUMNAR_PARQUET_FORMAT_H
+
+/* Physical types (parquet.thrift Type) */
+#define PQ_BOOLEAN				0
+#define PQ_INT32				1
+#define PQ_INT64				2
+#define PQ_FLOAT				4
+#define PQ_DOUBLE				5
+#define PQ_BYTE_ARRAY			6
+#define PQ_FIXED_LEN_BYTE_ARRAY 7
+
+/* ConvertedType (parquet.thrift ConvertedType); -1 means none */
+#define PQ_CT_UTF8				0
+#define PQ_CT_ENUM				4
+#define PQ_CT_DECIMAL			5
+#define PQ_CT_DATE				6
+#define PQ_CT_TIME_MILLIS		7
+#define PQ_CT_TIME_MICROS		8
+#define PQ_CT_TIMESTAMP_MILLIS	9
+#define PQ_CT_TIMESTAMP_MICROS	10
+#define PQ_CT_INT_8				15
+#define PQ_CT_INT_16			16
+#define PQ_CT_INT_32			17
+#define PQ_CT_INT_64			18
+#define PQ_CT_JSON				19
+
+/* Encoding (parquet.thrift Encoding) */
+#define PQ_ENC_PLAIN			0
+#define PQ_ENC_RLE				3
+
+/* LogicalType union field ids (parquet.thrift LogicalType) */
+#define PQ_LT_TIME				7
+#define PQ_LT_TIMESTAMP			8
+
+/* TimeUnit union field ids (parquet.thrift TimeUnit) */
+#define PQ_TUNIT_MILLIS			1
+#define PQ_TUNIT_MICROS			2
+#define PQ_TUNIT_NANOS			3
+
+/* Page types (parquet.thrift PageType) */
+#define PQ_PAGE_DATA			0
+#define PQ_PAGE_DICTIONARY		2
+#define PQ_PAGE_DATA_V2			3
+
+/* Compression codecs (parquet.thrift CompressionCodec) */
+#define PQC_UNCOMPRESSED		0
+#define PQC_SNAPPY				1
+#define PQC_GZIP				2
+#define PQC_ZSTD				6
+#define PQC_LZ4_RAW				7
+
+/* Thrift compact-protocol field types */
+#define TC_STOP					0
+#define TC_BOOL_TRUE			1
+#define TC_BOOL_FALSE			2
+#define TC_BYTE					3
+#define TC_I16					4
+#define TC_I32					5
+#define TC_I64					6
+#define TC_DOUBLE				7
+#define TC_BINARY				8
+#define TC_LIST					9
+#define TC_SET					10
+#define TC_STRUCT				12
+
+#endif							/* PGCOLUMNAR_PARQUET_FORMAT_H */

--- a/src/columnar_parquet_reader.c
+++ b/src/columnar_parquet_reader.c
@@ -18,6 +18,9 @@
  *-------------------------------------------------------------------------
  */
 #include "columnar.h"
+#include "columnar_parquet_format.h"
+#include "columnar_thrift.h"
+#include "columnar_parquet_codec.h"
 
 #include <math.h>
 #include <sys/stat.h>
@@ -87,30 +90,6 @@ PG_FUNCTION_INFO_V1(pgcolumnar_parquet_fdw_validator);
 #define PG_TO_UNIX_DAYS		((int64) (POSTGRES_EPOCH_JDATE - UNIX_EPOCH_JDATE))
 #define PG_TO_UNIX_USECS	(PG_TO_UNIX_DAYS * USECS_PER_DAY)
 
-/* Parquet physical types (parquet.thrift Type) */
-#define PQ_BOOLEAN		0
-#define PQ_INT32		1
-#define PQ_INT64		2
-#define PQ_FLOAT		4
-#define PQ_DOUBLE		5
-#define PQ_BYTE_ARRAY	6
-#define PQ_FIXED_LEN_BYTE_ARRAY 7
-
-/* ConvertedType (parquet.thrift ConvertedType); -1 means none */
-#define PQ_CT_UTF8				0
-#define PQ_CT_ENUM				4
-#define PQ_CT_DECIMAL			5
-#define PQ_CT_DATE				6
-#define PQ_CT_TIME_MILLIS		7
-#define PQ_CT_TIME_MICROS		8
-#define PQ_CT_TIMESTAMP_MILLIS	9
-#define PQ_CT_TIMESTAMP_MICROS	10
-#define PQ_CT_INT_8				15
-#define PQ_CT_INT_16			16
-#define PQ_CT_INT_32			17
-#define PQ_CT_INT_64			18
-#define PQ_CT_JSON				19
-
 /*
  * Resolved time unit for a TIME/TIMESTAMP column. Parquet carries this two ways:
  * the deprecated ConvertedType (TIME_MILLIS ... TIMESTAMP_MICROS) and the current
@@ -131,437 +110,12 @@ PG_FUNCTION_INFO_V1(pgcolumnar_parquet_fdw_validator);
 #define PQ_TU_MICROS	2
 #define PQ_TU_NANOS		3
 
-/* LogicalType union field ids (parquet.thrift LogicalType) */
-#define PQ_LT_TIME		7
-#define PQ_LT_TIMESTAMP	8
-/* TimeUnit union field ids */
-#define PQ_TUNIT_MILLIS	1
-#define PQ_TUNIT_MICROS	2
-#define PQ_TUNIT_NANOS	3
-
 /* Encodings (parquet.thrift Encoding) */
 #define PQE_PLAIN		0
 #define PQE_PLAIN_DICTIONARY 2
 #define PQE_RLE			3
 #define PQE_RLE_DICTIONARY 8
 
-/* Compression codecs */
-#define PQC_UNCOMPRESSED 0
-#define PQC_SNAPPY		1
-#define PQC_GZIP		2
-#define PQC_ZSTD		6
-#define PQC_LZ4_RAW		7
-
-/* PageType */
-#define PQ_PAGE_DATA	0
-#define PQ_PAGE_DICTIONARY 2
-#define PQ_PAGE_DATA_V2	3
-
-/* Thrift compact field types */
-#define TC_STOP			0
-#define TC_BOOL_TRUE	1
-#define TC_BOOL_FALSE	2
-#define TC_BYTE			3
-#define TC_I16			4
-#define TC_I32			5
-#define TC_I64			6
-#define TC_DOUBLE		7
-#define TC_BINARY		8
-#define TC_LIST			9
-#define TC_SET			10
-#define TC_STRUCT		12
-
-/* -------------------------------------------------------------------------
- * Snappy raw decompression (format spec: preamble varint uncompressed length,
- * then a stream of literal and copy elements). Clean-room from the format.
- * ------------------------------------------------------------------------- */
-static bool
-snappy_raw_uncompress(const uint8 *in, size_t inlen, StringInfo out)
-{
-	size_t		pos = 0;
-	uint32		ulen = 0;
-	int			shift = 0;
-
-	/* preamble: uncompressed length as a varint */
-	while (pos < inlen)
-	{
-		uint8		b = in[pos++];
-
-		ulen |= (uint32) (b & 0x7f) << shift;
-		if ((b & 0x80) == 0)
-			break;
-		shift += 7;
-		if (shift > 32)
-			return false;
-	}
-
-	enlargeStringInfo(out, ulen);
-	while (pos < inlen)
-	{
-		uint8		tag = in[pos++];
-		int			type = tag & 0x03;
-
-		if (type == 0)			/* literal */
-		{
-			uint32		len = (tag >> 2) + 1;
-
-			if (len > 60)
-			{
-				int			nb = (tag >> 2) - 59;	/* 1..4 bytes of length */
-				uint32		l = 0;
-				int			i;
-
-				if (pos + nb > inlen)
-					return false;
-				for (i = 0; i < nb; i++)
-					l |= (uint32) in[pos++] << (8 * i);
-				len = l + 1;
-			}
-			if (pos + len > inlen)
-				return false;
-			appendBinaryStringInfo(out, (const char *) in + pos, len);
-			pos += len;
-		}
-		else					/* copy */
-		{
-			uint32		len;
-			uint32		offset;
-			int			i;
-
-			if (type == 1)
-			{
-				len = ((tag >> 2) & 0x07) + 4;
-				if (pos >= inlen)
-					return false;
-				offset = ((uint32) (tag >> 5) << 8) | in[pos++];
-			}
-			else if (type == 2)
-			{
-				len = (tag >> 2) + 1;
-				if (pos + 2 > inlen)
-					return false;
-				offset = (uint32) in[pos] | ((uint32) in[pos + 1] << 8);
-				pos += 2;
-			}
-			else				/* type == 3 */
-			{
-				len = (tag >> 2) + 1;
-				if (pos + 4 > inlen)
-					return false;
-				offset = (uint32) in[pos] | ((uint32) in[pos + 1] << 8) |
-					((uint32) in[pos + 2] << 16) | ((uint32) in[pos + 3] << 24);
-				pos += 4;
-			}
-			if (offset == 0 || offset > (uint32) out->len)
-				return false;
-			/* copies may overlap, so copy byte by byte from the output so far */
-			for (i = 0; i < (int) len; i++)
-			{
-				char		c = out->data[out->len - offset];
-
-				appendBinaryStringInfo(out, &c, 1);
-			}
-		}
-	}
-	return (uint32) out->len == ulen;
-}
-
-/*
- * Decompress one Parquet page body according to its column-chunk codec.
- *
- * On success *out / *outlen point at the decompressed bytes: either straight into
- * `src` (uncompressed), or into `scratch` (any real codec). `usize` is the
- * uncompressed size from the page header, which zstd and lz4_raw require up front
- * (they do not self-describe the output length the way Snappy and gzip do); pass
- * the value portion's uncompressed size for a v2 data page, where the levels are
- * stored uncompressed ahead of the compressed values.
- *
- * A codec whose library was not built in, or an unknown codec id, returns false
- * so the caller raises a clean decode error rather than reading garbage.
- *
- * srclen and usize are file-declared and otherwise unvalidated (parse_page_header
- * casts a zigzag int, so a crafted header can present them as negative -- which
- * arrive here as an enormous size_t -- or absurdly large). Both are bounded to
- * MaxAllocSize up front so a crafted page yields a clean "return false" rather
- * than a generic allocation error deep in enlargeStringInfo or a decompressor.
- * Every codec that consumes usize also caps its output at it, so none can be
- * driven to allocate or inflate more than the header declares.
- */
-static bool
-pq_decompress(int codec, const uint8 *src, size_t srclen, size_t usize,
-			  StringInfo scratch, const uint8 **out, size_t *outlen)
-{
-	if (srclen > MaxAllocSize || usize > MaxAllocSize)
-		return false;
-
-	switch (codec)
-	{
-		case PQC_UNCOMPRESSED:
-			*out = src;
-			*outlen = srclen;
-			return true;
-
-		case PQC_SNAPPY:
-			/* Snappy self-describes its output length (a leading varint), which
-			 * snappy_raw_uncompress bounds; usize is not consulted. */
-			if (!snappy_raw_uncompress(src, srclen, scratch))
-				return false;
-			*out = (const uint8 *) scratch->data;
-			*outlen = scratch->len;
-			return true;
-
-#ifdef HAVE_LIBZ
-		case PQC_GZIP:
-			{
-				z_stream	zs;
-				int			rc;
-
-				/* Bound the output at the declared size, like zstd and lz4, so a
-				 * small crafted page cannot inflate into a huge allocation. */
-				if (usize == 0)
-					return false;
-				memset(&zs, 0, sizeof(zs));
-				/* 15 + 32: accept a gzip or zlib header (Parquet writes gzip) */
-				if (inflateInit2(&zs, 15 + 32) != Z_OK)
-					return false;
-				enlargeStringInfo(scratch, (int) usize);
-				zs.next_in = (Bytef *) src;
-				zs.avail_in = (uInt) srclen;
-				zs.next_out = (Bytef *) scratch->data;
-				zs.avail_out = (uInt) usize;
-				rc = inflate(&zs, Z_FINISH);
-				inflateEnd(&zs);
-				if (rc != Z_STREAM_END || zs.total_out != usize)
-					return false;
-				scratch->len = (int) usize;
-				scratch->data[scratch->len] = '\0';
-				*out = (const uint8 *) scratch->data;
-				*outlen = scratch->len;
-				return true;
-			}
-#endif
-
-#ifdef HAVE_LIBZSTD
-		case PQC_ZSTD:
-			{
-				size_t		got;
-
-				if (usize == 0)
-					return false;	/* zstd needs the output size */
-				enlargeStringInfo(scratch, (int) usize);
-				got = ZSTD_decompress(scratch->data, usize, src, srclen);
-				if (ZSTD_isError(got) || got != usize)
-					return false;
-				scratch->len = (int) got;
-				*out = (const uint8 *) scratch->data;
-				*outlen = scratch->len;
-				return true;
-			}
-#endif
-
-#ifdef HAVE_LIBLZ4
-		case PQC_LZ4_RAW:
-			{
-				int			got;
-
-				if (usize == 0)
-					return false;	/* lz4 raw needs the output size */
-				enlargeStringInfo(scratch, (int) usize);
-				got = LZ4_decompress_safe((const char *) src, scratch->data,
-										  (int) srclen, (int) usize);
-				if (got < 0 || (size_t) got != usize)
-					return false;
-				scratch->len = got;
-				*out = (const uint8 *) scratch->data;
-				*outlen = scratch->len;
-				return true;
-			}
-#endif
-
-		default:
-			return false;		/* unknown codec, or its library not built in */
-	}
-}
-
-/* -------------------------------------------------------------------------
- * Thrift compact-protocol reader over an in-memory buffer.
- * ------------------------------------------------------------------------- */
-typedef struct TCReader
-{
-	const uint8 *buf;
-	size_t		len;
-	size_t		pos;
-	bool		error;
-} TCReader;
-
-static uint64
-tcr_varint(TCReader *r)
-{
-	uint64		v = 0;
-	int			shift = 0;
-
-	while (r->pos < r->len)
-	{
-		uint8		b = r->buf[r->pos++];
-
-		v |= (uint64) (b & 0x7f) << shift;
-		if ((b & 0x80) == 0)
-			return v;
-		shift += 7;
-		if (shift > 63)
-			break;
-	}
-	r->error = true;
-	return v;
-}
-
-static int64
-tcr_zigzag(TCReader *r)
-{
-	uint64		u = tcr_varint(r);
-
-	return (int64) (u >> 1) ^ -(int64) (u & 1);
-}
-
-/* read a binary/string field: returns pointer into the buffer and its length */
-static const uint8 *
-tcr_bytes(TCReader *r, uint32 *outlen)
-{
-	uint64		n = tcr_varint(r);
-	const uint8 *p;
-
-	if (r->error || r->pos + n > r->len)
-	{
-		r->error = true;
-		*outlen = 0;
-		return NULL;
-	}
-	p = r->buf + r->pos;
-	r->pos += n;
-	*outlen = (uint32) n;
-	return p;
-}
-
-/*
- * Read a struct field header. Returns the compact field type in *ftype (TC_STOP
- * at end of struct) and the absolute field id in *fid. lastId is updated for the
- * short-form delta encoding.
- */
-static void
-tcr_field(TCReader *r, int *ftype, int *fid, int *lastId)
-{
-	uint8		b;
-
-	if (r->pos >= r->len)
-	{
-		r->error = true;
-		*ftype = TC_STOP;
-		return;
-	}
-	b = r->buf[r->pos++];
-	if (b == 0)
-	{
-		*ftype = TC_STOP;
-		return;
-	}
-	*ftype = b & 0x0f;
-	if ((b >> 4) != 0)
-		*fid = *lastId + (b >> 4);	/* short-form delta */
-	else
-		*fid = (int) tcr_zigzag(r);	/* long form */
-	*lastId = *fid;
-}
-
-/* skip a value of the given compact type (for fields we do not consume) */
-static void
-tcr_skip(TCReader *r, int ftype)
-{
-	switch (ftype)
-	{
-		case TC_BOOL_TRUE:
-		case TC_BOOL_FALSE:
-			break;
-		case TC_BYTE:
-			r->pos += 1;
-			break;
-		case TC_I16:
-		case TC_I32:
-		case TC_I64:
-			(void) tcr_zigzag(r);
-			break;
-		case TC_DOUBLE:
-			r->pos += 8;
-			break;
-		case TC_BINARY:
-			{
-				uint32		n;
-
-				(void) tcr_bytes(r, &n);
-				break;
-			}
-		case TC_LIST:
-		case TC_SET:
-			{
-				uint8		sizeType;
-				uint32		size;
-				int			et;
-				uint32		i;
-
-				if (r->pos >= r->len)
-				{
-					r->error = true;
-					return;
-				}
-				sizeType = r->buf[r->pos++];
-				size = (sizeType >> 4) & 0x0f;
-				et = sizeType & 0x0f;
-				if (size == 0x0f)
-					size = (uint32) tcr_varint(r);
-				for (i = 0; i < size && !r->error; i++)
-					tcr_skip(r, et);
-				break;
-			}
-		case TC_STRUCT:
-			{
-				int			lastId = 0;
-
-				for (;;)
-				{
-					int			ft,
-								fid;
-
-					tcr_field(r, &ft, &fid, &lastId);
-					if (ft == TC_STOP || r->error)
-						break;
-					tcr_skip(r, ft);
-				}
-				break;
-			}
-		default:
-			break;
-	}
-}
-
-/* list header: returns element count and element compact type */
-static uint32
-tcr_list_header(TCReader *r, int *etype)
-{
-	uint8		b;
-	uint32		size;
-
-	if (r->pos >= r->len)
-	{
-		r->error = true;
-		*etype = 0;
-		return 0;
-	}
-	b = r->buf[r->pos++];
-	size = (b >> 4) & 0x0f;
-	*etype = b & 0x0f;
-	if (size == 0x0f)
-		size = (uint32) tcr_varint(r);
-	return size;
-}
 
 /* -------------------------------------------------------------------------
  * Parsed metadata (flat schema only).
@@ -641,7 +195,7 @@ parse_statistics(TCReader *r, PqChunk *ch)
 		int			ft,
 					fid;
 
-		tcr_field(r, &ft, &fid, &lastId);
+		ColumnarThriftField(r, &ft, &fid, &lastId);
 		if (ft == TC_STOP || r->error)
 			break;
 		switch (fid)
@@ -649,7 +203,7 @@ parse_statistics(TCReader *r, PqChunk *ch)
 			case 1:				/* max (deprecated): fallback only */
 				{
 					uint32		n;
-					const uint8 *p = tcr_bytes(r, &n);
+					const uint8 *p = ColumnarThriftBytes(r, &n);
 
 					if (p && !ch->has_max)
 					{
@@ -662,7 +216,7 @@ parse_statistics(TCReader *r, PqChunk *ch)
 			case 2:				/* min (deprecated): fallback only */
 				{
 					uint32		n;
-					const uint8 *p = tcr_bytes(r, &n);
+					const uint8 *p = ColumnarThriftBytes(r, &n);
 
 					if (p && !ch->has_min)
 					{
@@ -675,7 +229,7 @@ parse_statistics(TCReader *r, PqChunk *ch)
 			case 5:				/* max_value (preferred) */
 				{
 					uint32		n;
-					const uint8 *p = tcr_bytes(r, &n);
+					const uint8 *p = ColumnarThriftBytes(r, &n);
 
 					if (p)
 					{
@@ -688,7 +242,7 @@ parse_statistics(TCReader *r, PqChunk *ch)
 			case 6:				/* min_value (preferred) */
 				{
 					uint32		n;
-					const uint8 *p = tcr_bytes(r, &n);
+					const uint8 *p = ColumnarThriftBytes(r, &n);
 
 					if (p)
 					{
@@ -699,7 +253,7 @@ parse_statistics(TCReader *r, PqChunk *ch)
 					break;
 				}
 			default:
-				tcr_skip(r, ft);
+				ColumnarThriftSkip(r, ft);
 				break;
 		}
 	}
@@ -728,34 +282,34 @@ parse_column_meta(TCReader *r, PqChunk *ch)
 		int			ft,
 					fid;
 
-		tcr_field(r, &ft, &fid, &lastId);
+		ColumnarThriftField(r, &ft, &fid, &lastId);
 		if (ft == TC_STOP || r->error)
 			break;
 		switch (fid)
 		{
 			case 4:				/* codec */
-				ch->codec = (int) tcr_zigzag(r);
+				ch->codec = (int) ColumnarThriftZigzag(r);
 				break;
 			case 5:				/* num_values */
-				ch->num_values = tcr_zigzag(r);
+				ch->num_values = ColumnarThriftZigzag(r);
 				break;
 			case 7:				/* total_compressed_size */
-				ch->total_compressed_size = tcr_zigzag(r);
+				ch->total_compressed_size = ColumnarThriftZigzag(r);
 				break;
 			case 9:				/* data_page_offset */
-				ch->data_page_offset = tcr_zigzag(r);
+				ch->data_page_offset = ColumnarThriftZigzag(r);
 				break;
 			case 11:			/* dictionary_page_offset */
-				ch->dict_page_offset = tcr_zigzag(r);
+				ch->dict_page_offset = ColumnarThriftZigzag(r);
 				break;
 			case 12:			/* statistics */
 				if (ft == TC_STRUCT)
 					parse_statistics(r, ch);
 				else
-					tcr_skip(r, ft);
+					ColumnarThriftSkip(r, ft);
 				break;
 			default:
-				tcr_skip(r, ft);
+				ColumnarThriftSkip(r, ft);
 				break;
 		}
 	}
@@ -772,13 +326,13 @@ parse_column_chunk(TCReader *r, PqChunk *ch)
 		int			ft,
 					fid;
 
-		tcr_field(r, &ft, &fid, &lastId);
+		ColumnarThriftField(r, &ft, &fid, &lastId);
 		if (ft == TC_STOP || r->error)
 			break;
 		if (fid == 3 && ft == TC_STRUCT)
 			parse_column_meta(r, ch);
 		else
-			tcr_skip(r, ft);
+			ColumnarThriftSkip(r, ft);
 	}
 }
 
@@ -791,7 +345,7 @@ parse_column_chunk(TCReader *r, PqChunk *ch)
  * This hand-walks nested Thrift unions and assumes the compact-protocol field
  * ordering the spec prescribes. A writer that reorders or partially populates the
  * union could desync the cursor -- but a desync fails the surrounding footer
- * parse (tcr_field / bounds checks catch it), so the blast radius is "file
+ * parse (ColumnarThriftField / bounds checks catch it), so the blast radius is "file
  * rejected", never a wrong value silently returned from a good decode.
  */
 static void
@@ -804,7 +358,7 @@ parse_logical_type(TCReader *r, PqSchemaCol *sc)
 		int			ft,
 					fid;
 
-		tcr_field(r, &ft, &fid, &lastId);
+		ColumnarThriftField(r, &ft, &fid, &lastId);
 		if (ft == TC_STOP || r->error)
 			break;
 		if ((fid == PQ_LT_TIME || fid == PQ_LT_TIMESTAMP) && ft == TC_STRUCT)
@@ -817,7 +371,7 @@ parse_logical_type(TCReader *r, PqSchemaCol *sc)
 				int			ift,
 							ifid;
 
-				tcr_field(r, &ift, &ifid, &innerLast);
+				ColumnarThriftField(r, &ift, &ifid, &innerLast);
 				if (ift == TC_STOP || r->error)
 					break;
 				if (ifid == 2 && ift == TC_STRUCT)	/* unit: union TimeUnit */
@@ -826,7 +380,7 @@ parse_logical_type(TCReader *r, PqSchemaCol *sc)
 					int			uft,
 								ufid;
 
-					tcr_field(r, &uft, &ufid, &uLast);
+					ColumnarThriftField(r, &uft, &ufid, &uLast);
 					if (uft != TC_STOP && !r->error)
 					{
 						switch (ufid)
@@ -842,17 +396,17 @@ parse_logical_type(TCReader *r, PqSchemaCol *sc)
 								break;
 						}
 						sc->is_timestamp = isTs;
-						tcr_skip(r, uft);	/* the unit member is an empty struct */
+						ColumnarThriftSkip(r, uft);	/* the unit member is an empty struct */
 						/* consume the union's STOP */
-						tcr_field(r, &uft, &ufid, &uLast);
+						ColumnarThriftField(r, &uft, &ufid, &uLast);
 					}
 				}
 				else
-					tcr_skip(r, ift);	/* isAdjustedToUTC and anything later */
+					ColumnarThriftSkip(r, ift);	/* isAdjustedToUTC and anything later */
 			}
 		}
 		else
-			tcr_skip(r, ft);
+			ColumnarThriftSkip(r, ft);
 	}
 }
 
@@ -878,47 +432,47 @@ parse_schema_element(TCReader *r, PqSchemaCol *sc)
 		int			ft,
 					fid;
 
-		tcr_field(r, &ft, &fid, &lastId);
+		ColumnarThriftField(r, &ft, &fid, &lastId);
 		if (ft == TC_STOP || r->error)
 			break;
 		switch (fid)
 		{
 			case 1:				/* type */
-				sc->phys_type = (int) tcr_zigzag(r);
+				sc->phys_type = (int) ColumnarThriftZigzag(r);
 				break;
 			case 2:				/* type_length */
-				sc->type_length = (int) tcr_zigzag(r);
+				sc->type_length = (int) ColumnarThriftZigzag(r);
 				break;
 			case 3:				/* repetition_type */
-				sc->repetition = (int) tcr_zigzag(r);
+				sc->repetition = (int) ColumnarThriftZigzag(r);
 				break;
 			case 4:				/* name */
 				{
 					uint32		n;
-					const uint8 *p = tcr_bytes(r, &n);
+					const uint8 *p = ColumnarThriftBytes(r, &n);
 
 					if (p)
 						sc->name = pnstrdup((const char *) p, n);
 					break;
 				}
 			case 5:				/* num_children */
-				num_children = (int) tcr_zigzag(r);
+				num_children = (int) ColumnarThriftZigzag(r);
 				sc->num_children = num_children;
 				break;
 			case 6:				/* converted_type */
-				sc->converted_type = (int) tcr_zigzag(r);
+				sc->converted_type = (int) ColumnarThriftZigzag(r);
 				break;
 			case 7:				/* scale (DECIMAL) */
-				sc->scale = (int) tcr_zigzag(r);
+				sc->scale = (int) ColumnarThriftZigzag(r);
 				break;
 			case 8:				/* precision (DECIMAL) */
-				sc->precision = (int) tcr_zigzag(r);
+				sc->precision = (int) ColumnarThriftZigzag(r);
 				break;
 			case 10:			/* logicalType */
 				parse_logical_type(r, sc);
 				break;
 			default:
-				tcr_skip(r, ft);
+				ColumnarThriftSkip(r, ft);
 				break;
 		}
 	}
@@ -1009,14 +563,14 @@ parse_file_metadata(const uint8 *buf, size_t len, PqFile *pf)
 		int			ft,
 					fid;
 
-		tcr_field(&r, &ft, &fid, &lastId);
+		ColumnarThriftField(&r, &ft, &fid, &lastId);
 		if (ft == TC_STOP || r.error)
 			break;
 
 		if (fid == 2 && ft == TC_LIST)	/* schema: list<SchemaElement> */
 		{
 			int			etype;
-			uint32		n = tcr_list_header(&r, &etype);
+			uint32		n = ColumnarThriftListHeader(&r, &etype);
 			uint32		i;
 			PqSchemaCol *tmp = palloc0(sizeof(PqSchemaCol) * Max(n, 1));
 
@@ -1028,7 +582,7 @@ parse_file_metadata(const uint8 *buf, size_t len, PqFile *pf)
 		else if (fid == 4 && ft == TC_LIST)		/* row_groups */
 		{
 			int			etype;
-			uint32		n = tcr_list_header(&r, &etype);
+			uint32		n = ColumnarThriftListHeader(&r, &etype);
 			uint32		i;
 
 			pf->nrowgroups = n;
@@ -1045,13 +599,13 @@ parse_file_metadata(const uint8 *buf, size_t len, PqFile *pf)
 					int			rft,
 								rfid;
 
-					tcr_field(&r, &rft, &rfid, &rgLast);
+					ColumnarThriftField(&r, &rft, &rfid, &rgLast);
 					if (rft == TC_STOP || r.error)
 						break;
 					if (rfid == 1 && rft == TC_LIST)	/* columns */
 					{
 						int			cet;
-						uint32		cn = tcr_list_header(&r, &cet);
+						uint32		cn = ColumnarThriftListHeader(&r, &cet);
 						uint32		ci;
 
 						rg->chunks = palloc0(sizeof(PqChunk) * Max(cn, 1));
@@ -1060,14 +614,14 @@ parse_file_metadata(const uint8 *buf, size_t len, PqFile *pf)
 							parse_column_chunk(&r, &rg->chunks[ci]);
 					}
 					else if (rfid == 3)		/* num_rows */
-						rg->num_rows = tcr_zigzag(&r);
+						rg->num_rows = ColumnarThriftZigzag(&r);
 					else
-						tcr_skip(&r, rft);
+						ColumnarThriftSkip(&r, rft);
 				}
 			}
 		}
 		else
-			tcr_skip(&r, ft);
+			ColumnarThriftSkip(&r, ft);
 	}
 
 	if (r.error || pf->nelems < 1)
@@ -1697,7 +1251,7 @@ parse_data_page_header(TCReader *r, PqPageHeader *h, bool v2)
 		int			ft,
 					fid;
 
-		tcr_field(r, &ft, &fid, &lastId);
+		ColumnarThriftField(r, &ft, &fid, &lastId);
 		if (ft == TC_STOP || r->error)
 			break;
 		if (!v2)
@@ -1705,13 +1259,13 @@ parse_data_page_header(TCReader *r, PqPageHeader *h, bool v2)
 			switch (fid)
 			{
 				case 1:
-					h->num_values = (int) tcr_zigzag(r);
+					h->num_values = (int) ColumnarThriftZigzag(r);
 					break;
 				case 2:
-					h->encoding = (int) tcr_zigzag(r);
+					h->encoding = (int) ColumnarThriftZigzag(r);
 					break;
 				default:
-					tcr_skip(r, ft);
+					ColumnarThriftSkip(r, ft);
 					break;
 			}
 		}
@@ -1720,22 +1274,22 @@ parse_data_page_header(TCReader *r, PqPageHeader *h, bool v2)
 			switch (fid)
 			{
 				case 1:
-					h->num_values = (int) tcr_zigzag(r);
+					h->num_values = (int) ColumnarThriftZigzag(r);
 					break;
 				case 4:
-					h->encoding = (int) tcr_zigzag(r);
+					h->encoding = (int) ColumnarThriftZigzag(r);
 					break;
 				case 5:
-					h->def_levels_len = (int) tcr_zigzag(r);
+					h->def_levels_len = (int) ColumnarThriftZigzag(r);
 					break;
 				case 6:
-					h->rep_levels_len = (int) tcr_zigzag(r);
+					h->rep_levels_len = (int) ColumnarThriftZigzag(r);
 					break;
 				case 7:
 					h->is_compressed = (ft == TC_BOOL_TRUE);
 					break;
 				default:
-					tcr_skip(r, ft);
+					ColumnarThriftSkip(r, ft);
 					break;
 			}
 		}
@@ -1755,19 +1309,19 @@ parse_page_header(TCReader *r, PqPageHeader *h)
 		int			ft,
 					fid;
 
-		tcr_field(r, &ft, &fid, &lastId);
+		ColumnarThriftField(r, &ft, &fid, &lastId);
 		if (ft == TC_STOP || r->error)
 			break;
 		switch (fid)
 		{
 			case 1:
-				h->type = (int) tcr_zigzag(r);
+				h->type = (int) ColumnarThriftZigzag(r);
 				break;
 			case 2:
-				h->uncompressed_size = (int) tcr_zigzag(r);
+				h->uncompressed_size = (int) ColumnarThriftZigzag(r);
 				break;
 			case 3:
-				h->compressed_size = (int) tcr_zigzag(r);
+				h->compressed_size = (int) ColumnarThriftZigzag(r);
 				break;
 			case 5:				/* DataPageHeader (v1) */
 				parse_data_page_header(r, h, false);
@@ -1781,13 +1335,13 @@ parse_page_header(TCReader *r, PqPageHeader *h)
 						int			dft,
 									dfid;
 
-						tcr_field(r, &dft, &dfid, &dl);
+						ColumnarThriftField(r, &dft, &dfid, &dl);
 						if (dft == TC_STOP || r->error)
 							break;
 						if (dfid == 1)
-							h->num_values = (int) tcr_zigzag(r);
+							h->num_values = (int) ColumnarThriftZigzag(r);
 						else
-							tcr_skip(r, dft);
+							ColumnarThriftSkip(r, dft);
 					}
 					break;
 				}
@@ -1795,7 +1349,7 @@ parse_page_header(TCReader *r, PqPageHeader *h)
 				parse_data_page_header(r, h, true);
 				break;
 			default:
-				tcr_skip(r, ft);
+				ColumnarThriftSkip(r, ft);
 				break;
 		}
 	}
@@ -2092,7 +1646,7 @@ decode_leaf_entries(PqSource *src, PqChunk *ch,
 			const uint8 *end;
 			int			i;
 
-			if (!pq_decompress(ch->codec, praw, h.compressed_size,
+			if (!ColumnarParquetDecompress(ch->codec, praw, h.compressed_size,
 							   h.uncompressed_size, &dec, &db, &dblen))
 				return false;
 			dictCount = h.num_values;
@@ -2157,7 +1711,7 @@ decode_leaf_entries(PqSource *src, PqChunk *ch,
 					size_t		vusize = (h.uncompressed_size > levLen)
 						? (size_t) (h.uncompressed_size - levLen) : 0;
 
-					if (!pq_decompress(ch->codec, vraw, vrawlen, vusize,
+					if (!ColumnarParquetDecompress(ch->codec, vraw, vrawlen, vusize,
 									   &dec, &valbuf, &vallen))
 						return false;
 				}
@@ -2173,7 +1727,7 @@ decode_leaf_entries(PqSource *src, PqChunk *ch,
 				size_t		pblen;
 				size_t		off = 0;
 
-				if (!pq_decompress(ch->codec, praw, h.compressed_size,
+				if (!ColumnarParquetDecompress(ch->codec, praw, h.compressed_size,
 								   h.uncompressed_size, &dec, &pb, &pblen))
 					return false;
 				/* v1: repetition levels first, then definition levels, both

--- a/src/columnar_thrift.c
+++ b/src/columnar_thrift.c
@@ -1,0 +1,276 @@
+/*-------------------------------------------------------------------------
+ *
+ * columnar_thrift.c
+ *		Thrift compact-protocol reader and writer.
+ *
+ * See columnar_thrift.h. Nothing here knows about Parquet or about pgColumnar.
+ * The two directions were previously in separate files, the reader inside the
+ * Parquet import module and the writer inside the export module, which put the
+ * encode and decode of the same wire format a thousand lines apart.
+ *
+ * Written fresh for pgColumnar from the public Apache Thrift compact-protocol
+ * specification.
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "lib/stringinfo.h"
+
+#include "columnar_thrift.h"
+
+/* -------------------------------------------------------------------------
+ * Thrift compact-protocol reader over an in-memory buffer.
+ * ------------------------------------------------------------------------- */
+
+uint64
+ColumnarThriftVarint(TCReader *r)
+{
+	uint64		v = 0;
+	int			shift = 0;
+
+	while (r->pos < r->len)
+	{
+		uint8		b = r->buf[r->pos++];
+
+		v |= (uint64) (b & 0x7f) << shift;
+		if ((b & 0x80) == 0)
+			return v;
+		shift += 7;
+		if (shift > 63)
+			break;
+	}
+	r->error = true;
+	return v;
+}
+
+int64
+ColumnarThriftZigzag(TCReader *r)
+{
+	uint64		u = ColumnarThriftVarint(r);
+
+	return (int64) (u >> 1) ^ -(int64) (u & 1);
+}
+
+/* read a binary/string field: returns pointer into the buffer and its length */
+const uint8 *
+ColumnarThriftBytes(TCReader *r, uint32 *outlen)
+{
+	uint64		n = ColumnarThriftVarint(r);
+	const uint8 *p;
+
+	if (r->error || r->pos + n > r->len)
+	{
+		r->error = true;
+		*outlen = 0;
+		return NULL;
+	}
+	p = r->buf + r->pos;
+	r->pos += n;
+	*outlen = (uint32) n;
+	return p;
+}
+
+/*
+ * Read a struct field header. Returns the compact field type in *ftype (TC_STOP
+ * at end of struct) and the absolute field id in *fid. lastId is updated for the
+ * short-form delta encoding.
+ */
+void
+ColumnarThriftField(TCReader *r, int *ftype, int *fid, int *lastId)
+{
+	uint8		b;
+
+	if (r->pos >= r->len)
+	{
+		r->error = true;
+		*ftype = TC_STOP;
+		return;
+	}
+	b = r->buf[r->pos++];
+	if (b == 0)
+	{
+		*ftype = TC_STOP;
+		return;
+	}
+	*ftype = b & 0x0f;
+	if ((b >> 4) != 0)
+		*fid = *lastId + (b >> 4);	/* short-form delta */
+	else
+		*fid = (int) ColumnarThriftZigzag(r);	/* long form */
+	*lastId = *fid;
+}
+
+/* skip a value of the given compact type (for fields we do not consume) */
+void
+ColumnarThriftSkip(TCReader *r, int ftype)
+{
+	switch (ftype)
+	{
+		case TC_BOOL_TRUE:
+		case TC_BOOL_FALSE:
+			break;
+		case TC_BYTE:
+			r->pos += 1;
+			break;
+		case TC_I16:
+		case TC_I32:
+		case TC_I64:
+			(void) ColumnarThriftZigzag(r);
+			break;
+		case TC_DOUBLE:
+			r->pos += 8;
+			break;
+		case TC_BINARY:
+			{
+				uint32		n;
+
+				(void) ColumnarThriftBytes(r, &n);
+				break;
+			}
+		case TC_LIST:
+		case TC_SET:
+			{
+				uint8		sizeType;
+				uint32		size;
+				int			et;
+				uint32		i;
+
+				if (r->pos >= r->len)
+				{
+					r->error = true;
+					return;
+				}
+				sizeType = r->buf[r->pos++];
+				size = (sizeType >> 4) & 0x0f;
+				et = sizeType & 0x0f;
+				if (size == 0x0f)
+					size = (uint32) ColumnarThriftVarint(r);
+				for (i = 0; i < size && !r->error; i++)
+					ColumnarThriftSkip(r, et);
+				break;
+			}
+		case TC_STRUCT:
+			{
+				int			lastId = 0;
+
+				for (;;)
+				{
+					int			ft,
+								fid;
+
+					ColumnarThriftField(r, &ft, &fid, &lastId);
+					if (ft == TC_STOP || r->error)
+						break;
+					ColumnarThriftSkip(r, ft);
+				}
+				break;
+			}
+		default:
+			break;
+	}
+}
+
+/* list header: returns element count and element compact type */
+uint32
+ColumnarThriftListHeader(TCReader *r, int *etype)
+{
+	uint8		b;
+	uint32		size;
+
+	if (r->pos >= r->len)
+	{
+		r->error = true;
+		*etype = 0;
+		return 0;
+	}
+	b = r->buf[r->pos++];
+	size = (b >> 4) & 0x0f;
+	*etype = b & 0x0f;
+	if (size == 0x0f)
+		size = (uint32) ColumnarThriftVarint(r);
+	return size;
+}
+
+/* ---- Thrift compact-protocol writer (into a StringInfo) ---- */
+
+void
+ColumnarThriftPutVarint(StringInfo b, uint64 v)
+{
+	while (v >= 0x80)
+	{
+		appendStringInfoChar(b, (char) ((v & 0x7f) | 0x80));
+		v >>= 7;
+	}
+	appendStringInfoChar(b, (char) v);
+}
+
+void
+ColumnarThriftPutZigzag32(StringInfo b, int32 v)
+{
+	ColumnarThriftPutVarint(b, (uint32) ((v << 1) ^ (v >> 31)));
+}
+
+void
+ColumnarThriftPutZigzag64(StringInfo b, int64 v)
+{
+	ColumnarThriftPutVarint(b, (uint64) ((v << 1) ^ (v >> 63)));
+}
+
+/* field header with delta-encoded id */
+void
+ColumnarThriftPutField(StringInfo b, int16 *lastId, int16 id, int type)
+{
+	int			delta = id - *lastId;
+
+	if (delta > 0 && delta <= 15)
+		appendStringInfoChar(b, (char) ((delta << 4) | type));
+	else
+	{
+		appendStringInfoChar(b, (char) type);
+		ColumnarThriftPutZigzag32(b, id);
+	}
+	*lastId = id;
+}
+
+void
+ColumnarThriftPutI32Field(StringInfo b, int16 *lastId, int16 id, int32 v)
+{
+	ColumnarThriftPutField(b, lastId, id, TC_I32);
+	ColumnarThriftPutZigzag32(b, v);
+}
+
+void
+ColumnarThriftPutI64Field(StringInfo b, int16 *lastId, int16 id, int64 v)
+{
+	ColumnarThriftPutField(b, lastId, id, TC_I64);
+	ColumnarThriftPutZigzag64(b, v);
+}
+
+void
+ColumnarThriftPutStringField(StringInfo b, int16 *lastId, int16 id, const char *s, int len)
+{
+	ColumnarThriftPutField(b, lastId, id, TC_BINARY);
+	ColumnarThriftPutVarint(b, (uint64) len);
+	if (len > 0)
+		appendBinaryStringInfo(b, s, len);
+}
+
+/* list header; caller then appends the elements */
+void
+ColumnarThriftPutListHeader(StringInfo b, int size, int elemType)
+{
+	if (size < 15)
+		appendStringInfoChar(b, (char) ((size << 4) | elemType));
+	else
+	{
+		appendStringInfoChar(b, (char) (0xF0 | elemType));
+		ColumnarThriftPutVarint(b, (uint64) size);
+	}
+}
+
+void
+ColumnarThriftPutStop(StringInfo b)
+{
+	appendStringInfoChar(b, (char) TC_STOP);
+}

--- a/src/columnar_thrift.h
+++ b/src/columnar_thrift.h
@@ -1,0 +1,56 @@
+/*-------------------------------------------------------------------------
+ *
+ * columnar_thrift.h
+ *		Thrift compact-protocol reader and writer.
+ *
+ * The protocol is the container Parquet uses for its file metadata, and nothing
+ * here knows anything about Parquet or about pgColumnar: it moves varints,
+ * zigzag integers, field headers and list headers in and out of a buffer. It is
+ * separated for that reason, so the two directions sit together and can be read
+ * against the protocol specification rather than against a Parquet file.
+ *
+ * Written fresh for pgColumnar from the public Apache Thrift compact-protocol
+ * specification.
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef PGCOLUMNAR_THRIFT_H
+#define PGCOLUMNAR_THRIFT_H
+
+#include "postgres.h"
+
+#include "lib/stringinfo.h"
+
+#include "columnar_parquet_format.h"
+
+/* ---- reader: a cursor over an in-memory buffer ---- */
+
+typedef struct TCReader
+{
+	const uint8 *buf;
+	size_t		len;
+	size_t		pos;
+	bool		error;
+} TCReader;
+
+extern uint64 ColumnarThriftVarint(TCReader *r);
+extern int64 ColumnarThriftZigzag(TCReader *r);
+extern const uint8 *ColumnarThriftBytes(TCReader *r, uint32 *outlen);
+extern void ColumnarThriftField(TCReader *r, int *ftype, int *fid, int *lastId);
+extern void ColumnarThriftSkip(TCReader *r, int ftype);
+extern uint32 ColumnarThriftListHeader(TCReader *r, int *etype);
+
+/* ---- writer: appends into a StringInfo ---- */
+
+extern void ColumnarThriftPutVarint(StringInfo b, uint64 v);
+extern void ColumnarThriftPutZigzag32(StringInfo b, int32 v);
+extern void ColumnarThriftPutZigzag64(StringInfo b, int64 v);
+extern void ColumnarThriftPutField(StringInfo b, int16 *lastId, int16 id, int type);
+extern void ColumnarThriftPutI32Field(StringInfo b, int16 *lastId, int16 id, int32 v);
+extern void ColumnarThriftPutI64Field(StringInfo b, int16 *lastId, int16 id, int64 v);
+extern void ColumnarThriftPutStringField(StringInfo b, int16 *lastId, int16 id,
+										 const char *s, int len);
+extern void ColumnarThriftPutListHeader(StringInfo b, int size, int elemType);
+extern void ColumnarThriftPutStop(StringInfo b);
+
+#endif							/* PGCOLUMNAR_THRIFT_H */


### PR DESCRIPTION
Pure moves. **No behaviour change**, and the code that moved is covered by the fourteen Parquet suites, which pass unchanged.

## Why

`columnar_parquet_reader.c` was seven concerns in one 4,527-line file, delimited by its own banner comments:

| lines | concern | knows about pgColumnar? |
| --- | --- | --- |
| 174-385 | Snappy decompression | no |
| 386-565 | Thrift compact-protocol reader | no |
| 566-1123 | parsed metadata / flat schema | yes |
| 1124-1214 | RLE / bit-packing decoder | no |
| 1215-2502 | per-column import plan | yes |
| 2503-3496 | nested import assembly | yes |
| 3497-4527 | Parquet FDW | separate feature |

This takes out the concerns that are properties of the **file format** rather than of how rows are assembled. Each can now be read against its specification instead of against a Parquet file, and exercised without one.

## What moved

**`columnar_parquet_format.h`** -- 21 constants were defined twice, once in the reader and once in the writer: physical types, converted types, Thrift field types. I compared every duplicated value before removing either copy and they did agree, so this is provably a no-op today.

Nothing *made* them agree, though, and that is the reason to do it: a writer and a reader that disagree on a type code produce a file that is silently wrong rather than one that fails to parse. Compression codecs and page types moved here too, being equally format constants.

Only format constants live there. A value this implementation chooses for itself -- a buffer bound, the resolved-unit enum, a sentinel -- stays in the module that chooses it, because it has no counterpart on the other side.

**`columnar_thrift.{c,h}`** -- the compact-protocol reader *and* writer, which were a thousand lines apart in two different files: the reader inside Parquet import, the writer inside Parquet export. Encode and decode of one wire format now sit together.

**`columnar_parquet_codec.{c,h}`** -- Snappy, decoded from the format itself, plus the page-decompression dispatch that hands gzip, zstd and lz4_raw to the system libraries.

```
columnar_parquet_reader.c   4527 -> 4081
columnar_parquet.c          1210 -> 1102
new                         columnar_thrift.c 276, columnar_parquet_codec.c 239,
                            three headers
```

## Not included, deliberately

The **Parquet FDW**, which is the largest remaining concern in that file at about a thousand lines. It reaches back into thirteen symbols, and two of them (`ImpLeaf` and `ImpTop`, the recursive nested-assembly types) would have to become a public interface. That is a design decision and deserves its own review, rather than being carried inside a refactor whose whole value is that it changes nothing.

## Gate

- Build preflight: 15.18, 16.14, 17.10, 18.4, 19beta2, **zero warnings**.
- Full suite: **ALL VERSIONS PASSED on PG19**. All fourteen Parquet suites pass: `fdw`, `codecs`, `units`, `flba`, `streaming`, `partition`, `projection`, `multifile`, `pushdown`, `hardening`, `schema`, `read_parquet`, `import`, `export`.
- I built after each individual extraction rather than once at the end, so any breakage was attributable to a single move.

PG18 reported `native_fetch_position`. That is the harness's cluster-ownership retry giving up against a competing job on the box -- a wall of `ERROR: database "regress" already exists` with **no named check failure** -- and it passes 7/7 standalone, twice, with the timing ratios comfortable (1.05 and 1.08 near/far). This change touches no code that suite exercises.

## Related

That false red is now the third this session, and its cause is structural rather than luck: `test/lib.sh` defaults every run to `PGC_PORT=54329`, so two gates on one box contend by default. Worth fixing separately, since a harness change is a different kind of risk from a provably-no-op refactor.