### PR TITLE
Harness: run lock, re-exec from a copy, and a database check that decides

### DIFF
--- a/test/lib.sh
+++ b/test/lib.sh
@@ -77,7 +77,12 @@ pgc_cluster_is_ours() {
 pgc_setup() {
 	PGC_PG_CONFIG="${1:-/usr/local/pg17/bin/pg_config}"
 	PGC_BINDIR="$("$PGC_PG_CONFIG" --bindir)"
-	PGC_PORT="${PGC_PORT:-54329}"
+	# Derived from this process rather than a fixed 54329: two suites run at
+	# once on one box otherwise start on the same port, and the loser reports a
+	# wall of ERROR: database "regress" already exists with no named check
+	# failing -- a red that reads exactly like a real one. There is a retry
+	# below for when this still collides; the default should not guarantee it.
+	PGC_PORT="${PGC_PORT:-$(( 40000 + ($$ % 20000) ))}"
 	PGC_DB="${PGC_DB:-regress}"
 	PGC_LIBDIR="$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)")"
 	PGC_SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -185,18 +190,48 @@ pgc_setup() {
 			exit 1
 		fi
 	}
-	# The cluster is up, connectable, and confirmed ours, so CREATE DATABASE cannot
-	# silently land on another suite's server.
+	# The cluster is up, connectable, confirmed ours, and was initdb'd minutes ago
+	# into a private mktemp directory. So PGC_DB cannot legitimately already
+	# exist, and there is nothing here to retry: create it once, and treat
+	# anything else as the problem it is.
+	#
+	# This used to loop ten times, creating the database and then failing to
+	# notice it had. The check asked psql_admin, which does not pass -At, so a
+	# one-row answer came back as a bordered table and "tr -dc 0-9" reduced
+	# "(1 row)" along with the value to "11" -- never equal to "1". The loop
+	# therefore always ran to its limit, and every suite emitted nine
+	# ERROR: database "regress" already exists into the server log on every run,
+	# passing or failing.
+	#
+	# That noise is why a genuine failure was twice read as port contention, by
+	# two different people on the same day: a red result whose log is a wall of
+	# "already exists" looks exactly like a suite that landed on someone else's
+	# cluster. Removing the noise is most of the value here; failing loudly on
+	# the impossible case is the rest.
 	{
-		local _a
+		local _exists
 
-		for _a in $(seq 1 10); do
-			if [ "$(psql_admin "SELECT 1 FROM pg_database WHERE datname = '$PGC_DB';" 2>/dev/null | tr -dc 0-9)" = "1" ]; then
-				break
-			fi
-			psql_admin "CREATE DATABASE $PGC_DB;" >/dev/null 2>&1 || true
-			sleep 1
-		done
+		_exists="$(psql_admin_scalar "SELECT count(*) FROM pg_database WHERE datname = '$PGC_DB';")"
+		case "$_exists" in
+			0)
+				if ! psql_admin "CREATE DATABASE $PGC_DB;" >/dev/null 2>&1; then
+					echo "FATAL: could not create database $PGC_DB on our own cluster" >&2
+					exit 1
+				fi
+				;;
+			1)
+				echo "FATAL: database $PGC_DB already exists on a cluster this suite" >&2
+				echo "       just created from a fresh initdb in $PGC_PGDATA." >&2
+				echo "       That means the server on port $PGC_PORT is not the one we" >&2
+				echo "       started, so nothing this suite reports would be about the" >&2
+				echo "       build under test." >&2
+				exit 1
+				;;
+			*)
+				echo "FATAL: could not determine whether $PGC_DB exists (got '$_exists')" >&2
+				exit 1
+				;;
+		esac
 	}
 	psql_run "CREATE EXTENSION pgcolumnar;" >/dev/null
 }
@@ -227,6 +262,15 @@ psql_run() {
 psql_admin() {
 	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
 		-d postgres -v ON_ERROR_STOP=1 -q -c "$1"
+}
+
+# Scalar form of psql_admin. Separate because psql_admin is used for statements
+# and deliberately keeps psql's ordinary output; -At here means a caller reading
+# a single value gets the value and not a bordered table with "(1 row)" under it,
+# which is the mistake that made the cluster setup retry ten times.
+psql_admin_scalar() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d postgres -At -c "$1" 2>/dev/null
 }
 
 # Scalar query: echo a single value (empty on error).

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -23,7 +23,72 @@
 
 set -uo pipefail
 
-SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# ---------------------------------------------------------------------------
+# Run from a private copy of this script, and refuse to run twice at once.
+#
+# Both guards exist because both failures happened, and neither announced
+# itself as what it was.
+#
+# bash reads a script incrementally as it executes it, so editing this file
+# while a run is in progress corrupts the run in place. A gate died at
+# "line 139: `done'" with the file on disk perfectly valid, because the bytes
+# had moved under the interpreter between one read and the next. Re-executing
+# from a copy makes an in-flight run immune to whatever happens to the original.
+#
+# And two runs at once quietly ruin each other: they contend for clusters and
+# ports, and the symptom is a suite failing with no named check -- a wall of
+# ERROR: database "regress" already exists and a red result that looks exactly
+# like a real one. Three false reds in one day were traced to this. A run now
+# leaves a lock naming its pid, so the second one says so and stops instead of
+# producing a result nobody can trust.
+# ---------------------------------------------------------------------------
+
+PGC_RUN_LOCK="${PGC_RUN_LOCK:-/tmp/pgcolumnar-run_all_versions.lock}"
+
+if [ -z "${PGC_RUN_REEXEC:-}" ]; then
+	# Take the lock before copying, so two starts cannot both decide they are first.
+	if [ -e "$PGC_RUN_LOCK" ]; then
+		_holder="$(sed -n 1p "$PGC_RUN_LOCK" 2>/dev/null)"
+		if [ -n "$_holder" ] && kill -0 "$_holder" 2>/dev/null; then
+			echo "FATAL: a matrix run is already in progress (pid $_holder)" >&2
+			sed -n '2,$p' "$PGC_RUN_LOCK" >&2 2>/dev/null
+			echo "       wait for it, or kill $_holder, or set PGC_RUN_LOCK to run" >&2
+			echo "       against a separate tree on a different port." >&2
+			exit 1
+		fi
+		echo "note: taking over a stale lock from pid ${_holder:-unknown}" >&2
+		rm -f "$PGC_RUN_LOCK"
+	fi
+
+	{
+		echo "$$"
+		echo "       started: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+		echo "       tree:    $(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+		echo "       args:    ${*:-<default matrix>}"
+	} > "$PGC_RUN_LOCK"
+
+	# The lock is removed only by the process that took it, so a stale-lock
+	# takeover cannot have its lock deleted by the run it replaced.
+	trap 'if [ "$(sed -n 1p "$PGC_RUN_LOCK" 2>/dev/null)" = "$$" ]; then rm -f "$PGC_RUN_LOCK"; fi' EXIT
+
+	_self="$(mktemp "/tmp/pgcolumnar-run_all_versions.$$.XXXXXX.sh")"
+	cp "${BASH_SOURCE[0]}" "$_self"
+	chmod +x "$_self"
+	PGC_RUN_REEXEC=1 \
+	PGC_RUN_SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" \
+	PGC_RUN_LOCK="$PGC_RUN_LOCK" \
+	PGC_RUN_OWNER="$$" \
+		bash "$_self" "$@"
+	_rc=$?
+	rm -f "$_self"
+	exit $_rc
+fi
+
+# Re-executed from the copy: the lock belongs to the parent, which removes it,
+# and the tree to test is the original one rather than wherever the copy landed.
+trap - EXIT
+
+SRCDIR="${PGC_RUN_SRCDIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 SUITES=(harness_selftest smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
 	differential recovery fuzz hardening concurrent_diff parallel sorted_projection \
 	arrow_export parquet_export read_stream corruption \
@@ -45,7 +110,12 @@ else
 fi
 
 # A private base port per run, bumped per suite, to avoid clashes.
-BASE_PORT="${PGC_BASE_PORT:-55400}"
+#
+# Derived from the run's own pid rather than fixed, because a fixed default is
+# not private: two runs on one box then start at the same port and fight over
+# every cluster. The lock above makes that refuse rather than happen, but the
+# suites are also run individually, and they should not collide either.
+BASE_PORT="${PGC_BASE_PORT:-$(( 40000 + (${PGC_RUN_OWNER:-$$} % 20000) ))}"
 
 overall=0
 declare -a SUMMARY


### PR DESCRIPTION
Three harness defects, all of which cost real time today. None changes what any suite asserts.

## 1. The `regress` database check never worked

`pgc_setup` looped ten times over "does the database exist, if not create it". The check asked `psql_admin`, which does not pass `-At`, so a one-row answer came back as a bordered table and `tr -dc 0-9` reduced

```
 ?column?
----------
        1
(1 row)
```

to `11` — never equal to `1`. **The loop therefore always ran to its limit**, creating the database on the first pass and failing on the other nine. Every suite has been writing nine

```
ERROR:  database "regress" already exists
```

into the server log on every run, passing or failing, for as long as the loop has been there.

That noise is not cosmetic. It is why the same red result was read as port contention twice today by two different people: a failing suite whose log is a wall of "already exists" looks exactly like one that landed on someone else's cluster. Both readings were wrong, and both cost a re-run to disprove.

**There is also nothing to retry.** By the time this code runs, `pgc_setup` has `mktemp -d`'d a private directory, `initdb`'d into it, started a cluster on its own port, and already confirmed the server answering is the one it started — `pgc_cluster_is_ours` refuses rather than guesses. So the database cannot legitimately exist. It now asks once through a scalar helper that does pass `-At`, creates it once, and **fails loudly with a named reason** if it is already there, because at that point that is the bug rather than a state to recover from.

## 2. Editing the driver corrupts a run in progress

bash reads a script incrementally as it executes it. A gate died at

```
test/run_all_versions.sh: line 139: `done'
```

with the file on disk perfectly valid — the bytes had moved under the interpreter between one read and the next, because I pushed a change to that file while the run was going. The result was not a test failure, but it was reported as one.

`run_all_versions.sh` now re-executes from a private copy of itself, so an in-flight run is immune to whatever happens to the original. The suites were already run from a per-major copy of the tree; the driver was the one file that was not.

## 3. Two runs at once quietly ruin each other

There was no way to ask whether a run was already going. Now a run takes a lock naming its pid, start time, tree and arguments; a second refuses and says who holds it; a lock whose holder is dead is taken over with a note.

`BASE_PORT` and `PGC_PORT` also defaulted to fixed values, so two runs on one box started on the same port by construction. Both now derive from the run's own pid. The existing collision retry stays — the point is that the default should not guarantee a collision it then has to recover from.

## Verified

- a clean run takes the lock and releases it on exit
- a second run while a live pid holds it exits 1 and prints the holder
- a stale lock from a dead pid is taken over, with a note, and released
- a suite that actually goes through `pgc_setup` passes unchanged (`native_dml`, 13/13), and asks for the database once instead of eleven times
- the loud-failure path fires: `PGC_DB` naming a database that does exist exits 1 with `FATAL: database postgres already exists on a cluster this suite just created`
- **the driver survives being overwritten mid-run.** I replaced `run_all_versions.sh` with `GARBAGE ((( unterminated` 25 seconds into a live matrix run: 83 suites completed afterwards, zero syntax errors. That is the failure from this morning, reproduced deliberately and no longer fatal.

## It was also costing ten seconds a suite

The loop slept one second per iteration and always ran all ten. Same suite, same build:

```
before:  12s
after:    2s
```

75 suites call `pgc_setup`, so that is roughly twelve minutes of pure sleep per major, twenty-five across the PG18 and PG19 gates.

Counted in a real matrix log: exactly **nine** `already exists` errors, nine distinct backend pids, 1.03 seconds apart — the first `CREATE` succeeding and the next nine failing, once per suite.

## Not included

The harness still reports "could not obtain a cluster" as a suite failure, which is the thing that makes a false red indistinguishable from a real one at a glance. Failing loudly in `pgc_setup` (1 above) covers the case I could prove; distinguishing the rest belongs with whoever changes the retry logic itself.
