### PR TITLE
Derive the port in the suites #184 did not reach

### DIFF
--- a/test/audit.sh
+++ b/test/audit.sh
@@ -48,9 +48,11 @@
 
 set -euo pipefail
 
+. "$(dirname "${BASH_SOURCE[0]}")/portlib.sh"
+
 PG_CONFIG="${1:-/usr/local/pg17/bin/pg_config}"
 BINDIR="$("$PG_CONFIG" --bindir)"
-PORT="${PGC_PORT:-54327}"
+PORT="${PGC_PORT:-$(pgc_pick_port)}"
 SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 WORKDIR="$(mktemp -d /tmp/pgcolumnar-audit.XXXXXX)"

--- a/test/harness_selftest.sh
+++ b/test/harness_selftest.sh
@@ -158,7 +158,8 @@ check "guard rejects a foreign cluster" "$_verdict" "foreign"
 TESTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RUNNER="$TESTDIR/run_all_versions.sh"
 
-# Not suites: the shared library, the two runners, and the two developer helpers
+# Not suites: the two shared libraries (lib.sh, and portlib.sh which lib.sh and
+# the standalone suites source for their port), the two runners, and the two developer helpers
 # that build rather than test. build_all_versions compiles against every major
 # and is run before merging a change that touches a version guard; it takes no
 # cluster and reports per major, so the matrix cannot run it as a suite. native_scale is a suite but is opt-in by
@@ -166,7 +167,7 @@ RUNNER="$TESTDIR/run_all_versions.sh"
 # not carry.
 not_a_suite() {
 	case "$1" in
-		lib|run_all_versions|build_all_versions|devloop|rebuild|native_scale) return 0 ;;
+		lib|portlib|run_all_versions|build_all_versions|devloop|rebuild|native_scale) return 0 ;;
 		*) return 1 ;;
 	esac
 }
@@ -195,5 +196,21 @@ while read -r name; do
 done < <(listed_suites)
 check "every registered suite has a file" \
 	"$([ -z "$missing_file" ] && echo none || echo "missing:$missing_file")" "none"
+
+# ---- no suite hands every run the same default port ------------------------
+
+# #184 derived the port per run in lib.sh and in the matrix runner, which is
+# where the collisions that cost three gates came from. It did not reach the
+# suites that carry their own harness, and they were still starting on fixed
+# 54321 through 54327 -- so two standalone runs of the same suite still collided
+# by construction.
+#
+# This asserts the property rather than the absence of one literal, because a
+# check naming 54329 passed while seven other files still collided. That is how
+# the gap survived the first fix.
+_fixed_ports="$(grep -lE 'PGC_(BASE_)?PORT:-[0-9]+' "$TESTDIR"/*.sh 2>/dev/null | xargs -r -n1 basename | tr '\n' ' ')"
+
+check "no suite hands every run the same default port" \
+	"${_fixed_ports:-none}" "none"
 
 pgc_summary

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -57,6 +57,8 @@ pgc_cluster_datadir() {
 	return 1
 }
 
+. "$(dirname "${BASH_SOURCE[0]}")/portlib.sh"
+
 # True when nothing is accepting connections on the given port.
 pgc_port_free() {
 	! (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null
@@ -82,7 +84,7 @@ pgc_setup() {
 	# wall of ERROR: database "regress" already exists with no named check
 	# failing -- a red that reads exactly like a real one. There is a retry
 	# below for when this still collides; the default should not guarantee it.
-	PGC_PORT="${PGC_PORT:-$(( 40000 + ($$ % 20000) ))}"
+	PGC_PORT="${PGC_PORT:-$(pgc_pick_port)}"
 	PGC_DB="${PGC_DB:-regress}"
 	PGC_LIBDIR="$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)")"
 	PGC_SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/test/phase2.sh
+++ b/test/phase2.sh
@@ -15,9 +15,11 @@
 
 set -euo pipefail
 
+. "$(dirname "${BASH_SOURCE[0]}")/portlib.sh"
+
 PG_CONFIG="${1:-/usr/local/pg17/bin/pg_config}"
 BINDIR="$("$PG_CONFIG" --bindir)"
-PORT="${PGC_PORT:-54322}"
+PORT="${PGC_PORT:-$(pgc_pick_port)}"
 SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 WORKDIR="$(mktemp -d /tmp/pgcolumnar-phase2.XXXXXX)"

--- a/test/phase3.sh
+++ b/test/phase3.sh
@@ -17,9 +17,11 @@
 
 set -euo pipefail
 
+. "$(dirname "${BASH_SOURCE[0]}")/portlib.sh"
+
 PG_CONFIG="${1:-/usr/local/pg17/bin/pg_config}"
 BINDIR="$("$PG_CONFIG" --bindir)"
-PORT="${PGC_PORT:-54323}"
+PORT="${PGC_PORT:-$(pgc_pick_port)}"
 SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 WORKDIR="$(mktemp -d /tmp/pgcolumnar-phase3.XXXXXX)"

--- a/test/phase4.sh
+++ b/test/phase4.sh
@@ -20,9 +20,11 @@
 
 set -euo pipefail
 
+. "$(dirname "${BASH_SOURCE[0]}")/portlib.sh"
+
 PG_CONFIG="${1:-/usr/local/pg17/bin/pg_config}"
 BINDIR="$("$PG_CONFIG" --bindir)"
-PORT="${PGC_PORT:-54324}"
+PORT="${PGC_PORT:-$(pgc_pick_port)}"
 SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 WORKDIR="$(mktemp -d /tmp/pgcolumnar-phase4.XXXXXX)"

--- a/test/phase5.sh
+++ b/test/phase5.sh
@@ -23,9 +23,11 @@
 
 set -euo pipefail
 
+. "$(dirname "${BASH_SOURCE[0]}")/portlib.sh"
+
 PG_CONFIG="${1:-/usr/local/pg17/bin/pg_config}"
 BINDIR="$("$PG_CONFIG" --bindir)"
-PORT="${PGC_PORT:-54325}"
+PORT="${PGC_PORT:-$(pgc_pick_port)}"
 SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 WORKDIR="$(mktemp -d /tmp/pgcolumnar-phase5.XXXXXX)"

--- a/test/phase6.sh
+++ b/test/phase6.sh
@@ -27,9 +27,11 @@
 
 set -euo pipefail
 
+. "$(dirname "${BASH_SOURCE[0]}")/portlib.sh"
+
 PG_CONFIG="${1:-/usr/local/pg17/bin/pg_config}"
 BINDIR="$("$PG_CONFIG" --bindir)"
-PORT="${PGC_PORT:-54326}"
+PORT="${PGC_PORT:-$(pgc_pick_port)}"
 SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 WORKDIR="$(mktemp -d /tmp/pgcolumnar-phase6.XXXXXX)"

--- a/test/portlib.sh
+++ b/test/portlib.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# One definition of the port a run starts on.
+#
+# Every suite stands up its own throwaway cluster, so every suite needs a port,
+# and each one used to carry a different fixed default: 54321 for smoke, 54322
+# for phase2, and so on. Distinct within a run, which is what made the matrix
+# work, and identical across runs, which made two runs on one machine contend by
+# construction rather than by accident.
+#
+# #184 fixed that for lib.sh and for the matrix runner, and explained the cost
+# better than this comment can: the collision surfaces as a wall of
+# `database "regress" already exists` with no named check failing, which reads
+# exactly like a real failure and was twice misread as one. It did not reach the
+# ten suites that carry their own harness instead of using lib.sh, which is what
+# this file is for -- they were still starting on 54321 through 54327.
+#
+# The retry in lib.sh stays. The point is that a default should not guarantee the
+# collision it then has to recover from.
+#
+# run_all_versions.sh keeps its own copy of this arithmetic rather than sourcing
+# this file, and that is deliberate. It re-executes itself from a private copy in
+# /tmp so that editing the driver cannot corrupt a run in progress (#184), and at
+# that point it is detached from the tree: a tree-relative source would be
+# exactly the fragility the re-exec exists to remove. Two copies of one
+# expression is the smaller cost. If the range here changes, change it there.
+#
+# Written fresh for pgColumnar.
+
+# The port this run starts on. Derived from the pid, matching #184's derivation
+# in lib.sh and run_all_versions.sh exactly, so there is one range and not two.
+# PGC_RUN_OWNER is set by the matrix runner when it re-executes itself, so a
+# re-executed driver keeps the port block its parent picked rather than drawing
+# a second one.
+#
+# The range stops well short of 65535 on purpose: the matrix walks upward from
+# its base once per suite per major, several hundred ports, and a base above the
+# ceiling once made every cluster fail with `invalid port number: "66009"`,
+# which presents as a broken tree rather than as a bad constant.
+pgc_pick_port() {
+	printf '%s\n' "$(( 40000 + (${PGC_RUN_OWNER:-$$} % 20000) ))"
+}

--- a/test/smoke.sh
+++ b/test/smoke.sh
@@ -15,9 +15,11 @@
 
 set -euo pipefail
 
+. "$(dirname "${BASH_SOURCE[0]}")/portlib.sh"
+
 PG_CONFIG="${1:-/usr/local/pg17/bin/pg_config}"
 BINDIR="$("$PG_CONFIG" --bindir)"
-PORT="${PGC_PORT:-54321}"
+PORT="${PGC_PORT:-$(pgc_pick_port)}"
 SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # A scratch area the postgres user can read and write.


### PR DESCRIPTION
#184 derived the port per run in `lib.sh` and in the matrix runner. Ten suites carry their own harness rather than using `lib.sh`, and seven of those still opened on a fixed port — `smoke` on 54321, the phases on 54322 through 54326, `audit` on 54327 — so two standalone runs of the same suite still collided by construction. That is a real case: re-verifying one suite while a matrix run is going is exactly what someone does after a red gate.

Measured against current `main`, two concurrent standalone runs of one suite:

| | exit codes | passed |
| --- | --- | --- |
| `main` | 1 and 0 | 1 of 2 |
| this branch | **0 and 0** | **2 of 2** |

## Deliberate choices

**The derivation is #184's, character for character**, so there is one range rather than two competing ones. Picking up `PGC_RUN_OWNER` as it does also means a re-executed driver keeps the port block its parent chose instead of drawing a second one.

**`run_all_versions.sh` keeps its own copy** rather than sourcing the helper. It re-executes itself from `/tmp` so that editing the driver cannot corrupt a run in progress, and at that point it is detached from the tree — a tree-relative source would reintroduce exactly the fragility the re-exec removes. `portlib.sh` records that, and says to change both if the range changes.

**`harness_selftest` asserts the property**, not the absence of a literal: *no suite hands every run the same default port*. That distinction is not academic. It is how this gap survived the first fix — a check naming 54329 passed while seven other files still collided.

## Gate

Build preflight 15.18, 16.14, 17.10, 18.4, 19beta2, zero warnings. Full suite **ALL VERSIONS PASSED on PG18 and PG19**, no named failures. Plus `harness_selftest` 13/13 standalone including the new check.