### PR TITLE
Assert the node before believing the numbers read from it

### DIFF
--- a/test/native_agg.sh
+++ b/test/native_agg.sh
@@ -59,6 +59,19 @@ plan_par() {
 		EXPLAIN (COSTS OFF) $1" 2>/dev/null
 }
 
+# The node, before any answer read from it.
+#
+# Everything below compares a columnar answer to a heap oracle, and a fallback
+# plan returns exactly the same answers -- that is what makes it a correct
+# fallback. So the parity checks cannot tell the metadata path from the path it
+# replaces, and eleven of them passing says nothing about which one ran. Assert
+# the node first, so that a silent fall back fails here and names itself rather
+# than passing quietly eleven times over.
+check "count(*) uses the metadata agg node" \
+	"$(has_aggnode "$(plan 'SELECT count(*) FROM n')")" "yes"
+check "sum/min/max uses the metadata agg node" \
+	"$(has_aggnode "$(plan 'SELECT sum(id), min(id), max(id) FROM n')")" "yes"
+
 # Supported aggregates answered from zone maps must equal the heap oracle.
 check "count(*)"          "$(q 'SELECT count(*) FROM n;')"        "$(q 'SELECT count(*) FROM h;')"
 check "count(col,nulls)"  "$(q 'SELECT count(s) FROM n;')"       "$(q 'SELECT count(s) FROM h;')"
@@ -72,11 +85,6 @@ check "min(text)"         "$(q 'SELECT min(label) FROM n;')"     "$(q 'SELECT mi
 check "max(text)"         "$(q 'SELECT max(label) FROM n;')"     "$(q 'SELECT max(label) FROM h;')"
 check "multi-agg"         "$(q 'SELECT count(*), sum(id), min(id), max(id) FROM n;')" \
                           "$(q 'SELECT count(*), sum(id), min(id), max(id) FROM h;')"
-
-# The metadata path is actually taken (ColumnarAgg node, no underlying scan).
-check "count(*) uses metadata agg node" "$(has_aggnode "$(plan 'SELECT count(*) FROM n')")" "yes"
-check "sum/min/max uses metadata agg node" \
-	"$(has_aggnode "$(plan 'SELECT sum(id), min(id), max(id) FROM n')")" "yes"
 
 # The path has to win on cost, not only exist. It reads one metadata entry per
 # row group; Gather over Partial Aggregate reads the whole table. Costing this

--- a/test/native_vecskip.sh
+++ b/test/native_vecskip.sh
@@ -34,6 +34,27 @@ counter() {
 }
 gt0() { [ "${1:-0}" -gt 0 ] && echo yes || echo no; }
 
+# The plan text for a query, and whether it is the scalar columnar custom scan.
+# "Columnar Projected Columns" is that node's own marker: the vectorized
+# aggregate node does not report it and no other node reports it at all.
+explain_of() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -At -c "EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) $1" 2>/dev/null
+}
+is_scalar_scan() {
+	explain_of "$1" | grep -q 'Columnar Projected Columns' && echo yes || echo no
+}
+
+# The node, before any counter is read out of it.
+#
+# Every "Columnar Vectors Skipped" and "Chunk Groups Removed by Filter" below is
+# read from this query's plan. If the planner stops choosing the columnar custom
+# scan, counter() returns empty and the comparisons start reporting a skipping
+# regression that is really a plan change. Assert the node first so the failure
+# names the actual cause.
+check "the plan under test is a columnar custom scan" \
+	"$(is_scalar_scan 'SELECT id FROM n WHERE id BETWEEN 100 AND 200')" "yes"
+
 check "row count" "$(q 'SELECT count(*) FROM n;')" "8192"
 check "single row group" \
 	"$(q "SELECT count(*) FROM pgcolumnar.row_group WHERE storage_id = pgcolumnar.get_storage_id('n');")" \

--- a/test/pushdown_report.sh
+++ b/test/pushdown_report.sh
@@ -43,8 +43,31 @@ plan() {
 
 field() { echo "$1" | grep -oE "$2: [0-9]+" | head -1 | grep -oE '[0-9]+$'; }
 
+# Is this plan the scalar columnar custom scan, and not something else?
+#
+# "Columnar Projected Columns" is that node's own marker: the vectorized
+# aggregate node does not report it, and no other node reports it at all. A
+# positive grep for the node's marker is a stronger test than an absence test,
+# because a plan that fell back to a seq scan has no Columnar lines to be absent.
+is_scalar_scan() {
+	echo "$1" | grep -q 'Columnar Projected Columns' && echo yes || echo no
+}
+
 on="$(plan on)"
 off="$(plan off)"
+
+# --- 0. the node, before any number read from it --------------------------------
+
+# Every check below reads a counter out of these two plans and believes it. If
+# the planner ever stops choosing the columnar custom scan here -- a costing
+# change, a new path, a GUC default -- those counters go missing or come from
+# somewhere else, and a suite that only compared numbers would report a fix
+# where there was a plan change. This has to fail before anything is read.
+check "the plan under test is a columnar custom scan" "$(is_scalar_scan "$on")" "yes"
+
+# The setting under test must not be changing which node runs; if it did, every
+# comparison between the two plans below would be comparing different things.
+check "and it is still one with pushdown off" "$(is_scalar_scan "$off")" "yes"
 
 # --- 1. the reported number follows the setting ---------------------------------
 


### PR DESCRIPTION
Taking the node-marker instrument you asked for on #198, with your placement requirement: the assertion is the **first** check in each section, before any number is read.

## The failure this instruments

Your own suite, from the #198 thread: a section headed "the aggregate path reports through a different function" ran a query with a qual. The vectorized aggregate path declines those, so the base custom scan answered instead. Both halves of the file measured the same code path, one of them under a heading saying otherwise, both passed, and the mutation run failed exactly the checks it was expected to fail — so nothing in the process caught it.

That is the gap worth closing generally: **a mutation run proves a check discriminates, not that it discriminates on the thing in its name.**

## The instrument

Each node reports its own marker in `EXPLAIN`, and the two are disjoint:

| node | marker |
| --- | --- |
| scalar custom scan | `Columnar Projected Columns`, `Columnar Total Columns` |
| vectorized aggregate | `Columnar Vectorized Aggregates` |

So each assertion is a single positive grep rather than an absence test. That matters: an absence test passes for a plan that fell back to a seq scan, which has no `Columnar` lines to be absent.

## `native_agg.sh` is the one that most needed it

Eleven parity checks compare a columnar answer against a heap oracle. **A fallback plan returns exactly the same answers** — that is what makes it a correct fallback. So those eleven cannot tell the metadata path from the path that replaces it, and eleven of them passing says nothing about which one ran.

The node assertion already existed in that file. It ran twelfth. It now runs first.

`pushdown_report.sh` and `native_vecskip.sh` read counters straight out of a plan they never checked. Both now assert the node first. `pushdown_report.sh` additionally asserts that the setting under test is not itself changing which node runs, since every comparison in that file is between two plans and a plan change would make them incomparable.

## Verified by taking the node away, not by argument

A GUC rather than a code edit, because the failure being guarded against *is* a plan change and a GUC is the most faithful way to produce one.

`enable_custom_scan = off`:

```
===== pushdown_report =====
FAIL  the plan under test is a columnar custom scan: got [no] want [yes]
FAIL  and it is still one with pushdown off: got [no] want [yes]
FAIL  pushdown on reports a pushed-down filter: got [] want [1]

===== native_vecskip =====
FAIL  the plan under test is a columnar custom scan: got [no] want [yes]
PASS  row count
PASS  single row group
PASS  range parity          <-- still passes with the node gone
FAIL  vectors removed > 0: got [no] want [yes]
```

`enable_vectorization = off`:

```
===== native_agg =====
FAIL  count(*) uses the metadata agg node: got [no] want [yes]
FAIL  sum/min/max uses the metadata agg node: got [no] want [yes]
PASS  count(*)
PASS  count(col,nulls)
PASS  sum(int4)
PASS  sum(int4,nulls)
```

Those four passes are the point. They agree with the heap oracle because the fallback is correct, and before this change they were the first thing the file reported — four green lines describing a path that was not running.

## Gate

- Build preflight: **15.18, 16.14, 17.6, 18.4, 19beta2 — zero warnings.**
- Full suite on the `-O2 --enable-cassert` build: **`ALL VERSIONS PASSED` on PG18 and PG19**, with `pushdown_report=PASS`, `native_vecskip=PASS` and `native_agg=PASS` in both.

Test-only change; no source touched.

## Not done here

I stopped at the three files you named. Other suites read `EXPLAIN` counters — the parquet pushdown and index-only ones at least — and the same argument applies to any check that names a path. Worth a sweep, but a sweep is a different review from this one, and I would rather you see the shape on three files first.
