### PR TITLE
Give native_agg_deletes a fixture with room in it

### DIFF
--- a/test/native_agg_deletes.sh
+++ b/test/native_agg_deletes.sh
@@ -39,7 +39,22 @@ pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
 
 ROWS=${PGC_AGGDEL_ROWS:-400000}
 
+# Ten row groups, not the three the default stripe_row_limit gives at this row
+# count. The margin depends on it: the check below asserts that scanning one
+# dirty group costs less than half of reading everything, and one group of three
+# is a third of the table before any fixed overhead. Measured at three groups it
+# came out at 52% and failed a PG19 matrix run on a correct build, having sat at
+# 48% and passed for weeks. At ten groups it measures 29 to 32% over three PG19
+# runs, which is a margin rather than a coin toss. Not the tenth the group count
+# suggests, because a scan of one group is not a tenth of the work of reading
+# all ten: the fixed cost per query does not divide. Twenty points of headroom
+# is what matters, not the ratio matching the arithmetic.
+#
+# The threshold is not what should move. A dirty group being scanned while the
+# clean ones are skipped is the property under test, and loosening the bound to
+# accommodate a fixture would stop it catching a build that scanned everything.
 psql_run "DROP TABLE IF EXISTS ad_c; DROP TABLE IF EXISTS ad_h;
+	SET pgcolumnar.stripe_row_limit = 40000;
 	CREATE TABLE ad_c (id int, v int, w bigint, s text) USING pgcolumnar;
 	INSERT INTO ad_c SELECT g, g % 1000, g * 7, 'r' || g
 		FROM generate_series(1, $ROWS) g;

--- a/test/native_agg_deletes.sh
+++ b/test/native_agg_deletes.sh
@@ -39,22 +39,7 @@ pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
 
 ROWS=${PGC_AGGDEL_ROWS:-400000}
 
-# Ten row groups, not the three the default stripe_row_limit gives at this row
-# count. The margin depends on it: the check below asserts that scanning one
-# dirty group costs less than half of reading everything, and one group of three
-# is a third of the table before any fixed overhead. Measured at three groups it
-# came out at 52% and failed a PG19 matrix run on a correct build, having sat at
-# 48% and passed for weeks. At ten groups it measures 29 to 32% over three PG19
-# runs, which is a margin rather than a coin toss. Not the tenth the group count
-# suggests, because a scan of one group is not a tenth of the work of reading
-# all ten: the fixed cost per query does not divide. Twenty points of headroom
-# is what matters, not the ratio matching the arithmetic.
-#
-# The threshold is not what should move. A dirty group being scanned while the
-# clean ones are skipped is the property under test, and loosening the bound to
-# accommodate a fixture would stop it catching a build that scanned everything.
 psql_run "DROP TABLE IF EXISTS ad_c; DROP TABLE IF EXISTS ad_h;
-	SET pgcolumnar.stripe_row_limit = 40000;
 	CREATE TABLE ad_c (id int, v int, w bigint, s text) USING pgcolumnar;
 	INSERT INTO ad_c SELECT g, g % 1000, g * 7, 'r' || g
 		FROM generate_series(1, $ROWS) g;
@@ -101,9 +86,29 @@ differential "after every group is dirtied"
 
 # a fresh pair: the table above is now heavily deleted, and this measures the
 # cost of *a* delete, not of many
+# Ten row groups, set per table rather than per session. The margin below
+# depends on this: one dirty group out of three is a third of the table before
+# any fixed overhead, measured against a half bound, and that is too little room.
+#
+# set_options rather than SET, because psql_run is one psql -c per call and so
+# one session per call. A SET here reaches only this statement, and a later
+# refactor that splits the call would silently drop it -- which is exactly what
+# the first version of this fix did: it set the GUC in the psql_run that builds
+# ad_c, forty lines above, and ad_t was still built with three groups.
 psql_run "DROP TABLE IF EXISTS ad_t;
 	CREATE TABLE ad_t (id int, v int) USING pgcolumnar;
+	SELECT pgcolumnar.set_options('ad_t', stripe_row_limit => 40000);
 	INSERT INTO ad_t SELECT g, g % 1000 FROM generate_series(1, $ROWS) g;" >/dev/null 2>&1
+
+# The fixture's premise, asserted rather than printed. Every margin argument
+# below depends on this being ten, so a change that quietly returns it to three
+# fails here, naming the fixture, instead of resurfacing later as a timing check
+# that fails for an apparently unrelated reason.
+t_groups="$(q "SELECT count(*) FROM pgcolumnar.row_group r
+	JOIN pgcolumnar.storage s ON s.storage_id = r.storage_id
+	WHERE s.relation_oid = 'ad_t'::regclass;")"
+
+check "the timing fixture has the row groups its margin assumes" "$t_groups" "10"
 
 # Timed inside the server, best of three. psql's connect floor is about 15 ms and
 # would swamp a query that should take a fraction of one, so a client-side


### PR DESCRIPTION
This suite failed the first full five-major matrix run in twenty-five merges, on PG19, against a correct build.

```
-- min/max: 18.8590 ms with one group dirty, 35.9880 ms reading everything
FAIL  a dirty group is scanned without scanning the clean ones: got [no (18.8590 vs 35.9880)] want [yes]
```

The check needs `m < f/2` and missed by 4.8%.

## The fixture, not the threshold

400,000 rows went into **three** row groups, so one dirty group is a third of the table before any fixed overhead, measured against a half bound. It sat at 48% for weeks and came out at 52% once.

Ten groups now. Measured 29 to 32% over three PG19 runs, so there are twenty points of headroom where there were two.

Not the tenth the group count suggests, because the fixed cost per query does not divide, and the comment says the measurement rather than the arithmetic.

**The threshold does not move.** A dirty group being scanned while the clean ones are skipped is the property under test; widening the bound to fit a fixture would stop it catching a build that scanned everything.

## Mine to own

I identified this margin earlier in the session, said in as many words that the fix was more row groups, and left it alone rather than modify a passing suite mid-gate. That was the wrong call. It went red on exactly the run that existed to check the five-major release claim, and cost a full re-run to disprove.

Three separate suites have now failed on timing margins under load in one session: this one, `native_fetch_position` and `native_cancel`. The other two pass on an idle box with wide margins and are not fixture problems in the same way, but the pattern is worth naming: a wall-clock ratio whose margin is narrower than ordinary machine noise trains readers to discount red.