### PR TITLE
Delete the vectorized predicate machinery that had no call sites

### DIFF
--- a/src/columnar.h
+++ b/src/columnar.h
@@ -592,7 +592,7 @@ extern bool ColumnarRowIsLive(Relation rel, Snapshot snapshot,
  * A ColumnarVector is one decoded chunk group: for each projected column, the
  * whole group's values and null flags as flat arrays, plus the per-row deleted
  * flag resolved from the delete vector. The vectorized aggregate builds a selection
- * vector over it (ColumnarVecSelect); the scan itself is the scalar per-row
+ * vector over it; the scan itself is the scalar per-row
  * reader (ColumnarReadNextRow).
  * ------------------------------------------------------------------------- */
 typedef struct ColumnarVector
@@ -760,59 +760,11 @@ extern ScanKey ColumnarBuildScanKeys(List *qual, Index scanrelid,
 extern void ColumnarVectorInit(void);
 
 /*
- * A single pushed-down comparison predicate "column op const" evaluated
- * column-at-a-time over a decoded chunk group to build a selection vector.
+ * The vectorized predicate machinery that used to be declared here is private to
+ * columnar_vector.c. ColumnarVecRowPasses and ColumnarVecSelect were exported
+ * with no call site anywhere in the tree and are gone; see issue #200. What
+ * remains of it is a convertibility probe the planner uses, and it has no
+ * business outside that file.
  */
-typedef struct ColumnarVecPredicate
-{
-	int			attidx;			/* 0-based column index */
-	bool		varOnLeft;		/* column op const, else const op column */
-	FmgrInfo	opFn;			/* the operator function (returns bool) */
-	Datum		constValue;
-	Oid			collation;
-
-	/*
-	 * Typed fast path (I6). fastKind is one of COLUMNAR_VECFAST_* (0 = none,
-	 * use opFn); strategy is the btree strategy 1..5 (Less..Greater) already
-	 * normalized to "column op const". When fastKind is set, the predicate is
-	 * evaluated column-at-a-time with a branch-free typed loop instead of fmgr.
-	 */
-	int			fastKind;
-	int			strategy;
-} ColumnarVecPredicate;
-
-#define COLUMNAR_VECFAST_NONE 0
-#define COLUMNAR_VECFAST_I16 1
-#define COLUMNAR_VECFAST_I32 2
-#define COLUMNAR_VECFAST_I64 3
-#define COLUMNAR_VECFAST_F32 4
-#define COLUMNAR_VECFAST_F64 5
-
-/*
- * Build the array of evaluable predicates from a plan's restriction clauses.
- * Clauses that are not simple, strict "column op const" comparisons on the scan
- * relation are left out; *allConvertible reports whether every clause converted
- * (the vectorized aggregate requires that, so it can rely on the predicates
- * being the complete filter; the vectorized scan does not and lets the executor
- * re-apply the rest). Allocated in the current memory context.
- */
-extern ColumnarVecPredicate *ColumnarBuildVecPredicates(List *qual,
-														Index scanrelid,
-														TupleDesc tupdesc,
-														int *npreds,
-														bool *allConvertible);
-
-/* whether row i of a decoded chunk group passes every predicate (AND) */
-extern bool ColumnarVecRowPasses(ColumnarVecPredicate *preds, int npreds,
-								 ColumnarVector *vec, uint64 i);
-
-/*
- * Build a selection vector for a whole chunk group column-at-a-time (I6):
- * sel[i] is true when row i is not deleted and passes every predicate. Uses a
- * branch-free typed loop per predicate where possible, falling back to the
- * operator function otherwise. sel must have room for vec->nrows entries.
- */
-extern void ColumnarVecSelect(ColumnarVecPredicate *preds, int npreds,
-							  ColumnarVector *vec, bool *sel);
 
 #endif							/* PGCOLUMNAR_H */

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -79,8 +79,10 @@ bool		columnar_enable_vectorization = true;
  * ------------------------------------------------------------------------- */
 
 /*
- * A single pushed-down comparison predicate "column op const" evaluated
- * column-at-a-time over a decoded chunk group to build a selection vector.
+ * One convertible "column op const" restriction clause. Scratch only: it is
+ * filled to decide whether a clause converts and discarded, and nothing stores
+ * an array of these. The machinery that evaluated them over a decoded chunk
+ * group had no call site and is deleted (issue #200).
  */
 typedef struct ColumnarVecPredicate
 {
@@ -89,23 +91,8 @@ typedef struct ColumnarVecPredicate
 	FmgrInfo	opFn;			/* the operator function (returns bool) */
 	Datum		constValue;
 	Oid			collation;
-
-	/*
-	 * Typed fast path (I6). fastKind is one of COLUMNAR_VECFAST_* (0 = none,
-	 * use opFn); strategy is the btree strategy 1..5 (Less..Greater) already
-	 * normalized to "column op const". When fastKind is set, the predicate is
-	 * evaluated column-at-a-time with a branch-free typed loop instead of fmgr.
-	 */
-	int			fastKind;
-	int			strategy;
 } ColumnarVecPredicate;
 
-#define COLUMNAR_VECFAST_NONE 0
-#define COLUMNAR_VECFAST_I16 1
-#define COLUMNAR_VECFAST_I32 2
-#define COLUMNAR_VECFAST_I64 3
-#define COLUMNAR_VECFAST_F32 4
-#define COLUMNAR_VECFAST_F64 5
 
 /*
  * columnar_clause_to_predicate
@@ -173,95 +160,6 @@ columnar_clause_to_predicate(Node *clause, Index scanrelid, TupleDesc tupdesc,
 	fmgr_info(opfuncid, &pred->opFn);
 	pred->constValue = con->constvalue;
 	pred->collation = op->inputcollid;
-
-	/*
-	 * Resolve a typed fast path (I6): a storage kind from the column type and a
-	 * btree strategy from the operator, normalized to "column op const". Only
-	 * used when the constant has exactly the column's type (so the raw Datum can
-	 * be read as that C type); anything else keeps the operator-function path.
-	 * The eligible types compare byte-for-byte without collation, so the fast
-	 * path is collation-agnostic.
-	 */
-	pred->fastKind = COLUMNAR_VECFAST_NONE;
-	pred->strategy = 0;
-	if (con->consttype == var->vartype)
-	{
-		int			fk = COLUMNAR_VECFAST_NONE;
-
-		switch (var->vartype)
-		{
-			case INT2OID:
-				fk = COLUMNAR_VECFAST_I16;
-				break;
-			case INT4OID:
-			case DATEOID:
-				fk = COLUMNAR_VECFAST_I32;
-				break;
-			case INT8OID:
-			case TIMESTAMPOID:
-			case TIMESTAMPTZOID:
-				fk = COLUMNAR_VECFAST_I64;
-				break;
-			case FLOAT4OID:
-				fk = COLUMNAR_VECFAST_F32;
-				break;
-			case FLOAT8OID:
-				fk = COLUMNAR_VECFAST_F64;
-				break;
-			default:
-				break;
-		}
-
-		if (fk != COLUMNAR_VECFAST_NONE)
-		{
-			TypeCacheEntry *tce = lookup_type_cache(var->vartype,
-													TYPECACHE_BTREE_OPFAMILY);
-			int			strat = 0;
-
-			/* match the operator to a btree strategy of the type's opfamily */
-			if (OidIsValid(tce->btree_opf))
-			{
-				int			s;
-
-				for (s = BTLessStrategyNumber; s <= BTGreaterStrategyNumber; s++)
-				{
-					if (get_opfamily_member(tce->btree_opf, tce->btree_opintype,
-											tce->btree_opintype, s) == op->opno)
-					{
-						strat = s;
-						break;
-					}
-				}
-			}
-
-			if (strat != 0)
-			{
-				if (!varOnLeft)
-				{
-					switch (strat)
-					{
-						case BTLessStrategyNumber:
-							strat = BTGreaterStrategyNumber;
-							break;
-						case BTLessEqualStrategyNumber:
-							strat = BTGreaterEqualStrategyNumber;
-							break;
-						case BTGreaterEqualStrategyNumber:
-							strat = BTLessEqualStrategyNumber;
-							break;
-						case BTGreaterStrategyNumber:
-							strat = BTLessStrategyNumber;
-							break;
-						default:
-							break;	/* equal is symmetric */
-					}
-				}
-				pred->fastKind = fk;
-				pred->strategy = strat;
-			}
-		}
-	}
-
 	return true;
 }
 

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -79,6 +79,35 @@ bool		columnar_enable_vectorization = true;
  * ------------------------------------------------------------------------- */
 
 /*
+ * A single pushed-down comparison predicate "column op const" evaluated
+ * column-at-a-time over a decoded chunk group to build a selection vector.
+ */
+typedef struct ColumnarVecPredicate
+{
+	int			attidx;			/* 0-based column index */
+	bool		varOnLeft;		/* column op const, else const op column */
+	FmgrInfo	opFn;			/* the operator function (returns bool) */
+	Datum		constValue;
+	Oid			collation;
+
+	/*
+	 * Typed fast path (I6). fastKind is one of COLUMNAR_VECFAST_* (0 = none,
+	 * use opFn); strategy is the btree strategy 1..5 (Less..Greater) already
+	 * normalized to "column op const". When fastKind is set, the predicate is
+	 * evaluated column-at-a-time with a branch-free typed loop instead of fmgr.
+	 */
+	int			fastKind;
+	int			strategy;
+} ColumnarVecPredicate;
+
+#define COLUMNAR_VECFAST_NONE 0
+#define COLUMNAR_VECFAST_I16 1
+#define COLUMNAR_VECFAST_I32 2
+#define COLUMNAR_VECFAST_I64 3
+#define COLUMNAR_VECFAST_F32 4
+#define COLUMNAR_VECFAST_F64 5
+
+/*
  * columnar_clause_to_predicate
  *		Turn one "column op const" (or "const op column") clause into a predicate
  *		we can evaluate row by row. Requires a strict boolean operator and a
@@ -236,156 +265,44 @@ columnar_clause_to_predicate(Node *clause, Index scanrelid, TupleDesc tupdesc,
 	return true;
 }
 
-ColumnarVecPredicate *
-ColumnarBuildVecPredicates(List *qual, Index scanrelid, TupleDesc tupdesc,
-						   int *npreds, bool *allConvertible)
+static void
+ColumnarCountConvertibleQuals(List *qual, Index scanrelid, TupleDesc tupdesc,
+							  int *nconvertible, bool *allConvertible)
 {
-	ColumnarVecPredicate *preds;
 	ListCell   *lc;
 	int			n = 0;
 
-	*npreds = 0;
+	*nconvertible = 0;
 	*allConvertible = true;
 	if (qual == NIL)
-		return NULL;
-
-	preds = (ColumnarVecPredicate *)
-		palloc0(sizeof(ColumnarVecPredicate) * list_length(qual));
+		return;
 
 	foreach(lc, qual)
 	{
+		ColumnarVecPredicate scratch;
+
 		if (columnar_clause_to_predicate((Node *) lfirst(lc), scanrelid, tupdesc,
-										 &preds[n]))
+										 &scratch))
 			n++;
 		else
 			*allConvertible = false;
 	}
 
-	*npreds = n;
-	return preds;
+	*nconvertible = n;
 }
 
-bool
-ColumnarVecRowPasses(ColumnarVecPredicate *preds, int npreds,
-					 ColumnarVector *vec, uint64 i)
-{
-	int			p;
-
-	for (p = 0; p < npreds; p++)
-	{
-		ColumnarVecPredicate *pred = &preds[p];
-		Datum		colval;
-		Datum		result;
-
-		/* the predicate column is always projected, so its array is present */
-		if (vec->isnull[pred->attidx][i])
-			return false;		/* strict op over NULL: row excluded */
-
-		colval = vec->values[pred->attidx][i];
-		if (pred->varOnLeft)
-			result = FunctionCall2Coll(&pred->opFn, pred->collation,
-									   colval, pred->constValue);
-		else
-			result = FunctionCall2Coll(&pred->opFn, pred->collation,
-									   pred->constValue, colval);
-
-		if (!DatumGetBool(result))
-			return false;
-	}
-
-	return true;
-}
 
 /*
- * Typed, branch-free predicate loops (I6). Each ANDs one predicate's result
- * into sel over the whole column array. The comparison is chosen once (outside
- * the inner loop) so the loop body has no data-dependent branch beyond the
- * comparison, which the compiler can auto-vectorize.
+ * The branch-free typed comparison loops that lived here built a selection
+ * vector, and were reached only from a function that had no call site anywhere
+ * in the tree; both are deleted (issue #200). Recoverable from history if a
+ * filtered aggregate path is ever built. What should not be recovered with them is their gating, which
+ * was none: the scalar path's predicates are gated on
+ * pgcolumnar.enable_qual_pushdown inside ColumnarBeginRead and these never were,
+ * so wiring them up as they stood would have filtered rows while EXPLAIN
+ * reported no pushdown at all.
  */
-#define VEC_CMP_BODY(GET, OP) \
-	{ for (i = 0; i < n; i++) { sel[i] = sel[i] & !isn[i] & (GET(vals[i]) OP c); } break; }
-#define VEC_CMP(NAME, CTYPE, GET) \
-static void \
-NAME(bool *sel, const Datum *vals, const bool *isn, uint64 n, int strat, Datum cdat) \
-{ \
-	CTYPE c = GET(cdat); \
-	uint64 i; \
-	switch (strat) \
-	{ \
-		case BTLessStrategyNumber: VEC_CMP_BODY(GET, <) \
-		case BTLessEqualStrategyNumber: VEC_CMP_BODY(GET, <=) \
-		case BTEqualStrategyNumber: VEC_CMP_BODY(GET, ==) \
-		case BTGreaterEqualStrategyNumber: VEC_CMP_BODY(GET, >=) \
-		case BTGreaterStrategyNumber: VEC_CMP_BODY(GET, >) \
-	} \
-}
 
-VEC_CMP(vecsel_i16, int16, DatumGetInt16)
-VEC_CMP(vecsel_i32, int32, DatumGetInt32)
-VEC_CMP(vecsel_i64, int64, DatumGetInt64)
-VEC_CMP(vecsel_f32, float4, DatumGetFloat4)
-VEC_CMP(vecsel_f64, float8, DatumGetFloat8)
-
-void
-ColumnarVecSelect(ColumnarVecPredicate *preds, int npreds,
-				  ColumnarVector *vec, bool *sel)
-{
-	uint64		n = vec->nrows;
-	uint64		i;
-	int			p;
-
-	/* start from the non-deleted rows */
-	for (i = 0; i < n; i++)
-		sel[i] = !vec->deleted[i];
-
-	for (p = 0; p < npreds; p++)
-	{
-		ColumnarVecPredicate *pred = &preds[p];
-		const Datum *vals = vec->values[pred->attidx];
-		const bool *isn = vec->isnull[pred->attidx];
-
-		switch (pred->fastKind)
-		{
-			case COLUMNAR_VECFAST_I16:
-				vecsel_i16(sel, vals, isn, n, pred->strategy, pred->constValue);
-				break;
-			case COLUMNAR_VECFAST_I32:
-				vecsel_i32(sel, vals, isn, n, pred->strategy, pred->constValue);
-				break;
-			case COLUMNAR_VECFAST_I64:
-				vecsel_i64(sel, vals, isn, n, pred->strategy, pred->constValue);
-				break;
-			case COLUMNAR_VECFAST_F32:
-				vecsel_f32(sel, vals, isn, n, pred->strategy, pred->constValue);
-				break;
-			case COLUMNAR_VECFAST_F64:
-				vecsel_f64(sel, vals, isn, n, pred->strategy, pred->constValue);
-				break;
-			default:
-				/* operator-function fallback, still column-at-a-time */
-				for (i = 0; i < n; i++)
-				{
-					Datum		r;
-
-					if (!sel[i])
-						continue;
-					if (isn[i])
-					{
-						sel[i] = false;
-						continue;
-					}
-					if (pred->varOnLeft)
-						r = FunctionCall2Coll(&pred->opFn, pred->collation,
-											  vals[i], pred->constValue);
-					else
-						r = FunctionCall2Coll(&pred->opFn, pred->collation,
-											  pred->constValue, vals[i]);
-					sel[i] = DatumGetBool(r);
-				}
-				break;
-		}
-	}
-}
 
 /* -------------------------------------------------------------------------
  * vectorized aggregate: classification
@@ -536,8 +453,7 @@ typedef struct ColumnarAggScanState
 	ColumnarAggSpec *specs;
 	int			naggs;
 
-	ColumnarVecPredicate *preds;
-	int			npreds;
+	int			npreds;			/* pushed-down predicate count, for EXPLAIN */
 
 	MemoryContext resultContext;	/* holds min/max running values */
 	bool		done;			/* the single result row was emitted */
@@ -678,8 +594,8 @@ ColumnarCreateUpperPaths(PlannerInfo *root, UpperRelationKind stage,
 		Relation	rel = table_open(relid, AccessShareLock);
 		TupleDesc	tupdesc = RelationGetDescr(rel);
 
-		(void) ColumnarBuildVecPredicates(quals, input_rel->relid, tupdesc,
-										  &npreds, &allConvertible);
+		ColumnarCountConvertibleQuals(quals, input_rel->relid, tupdesc,
+									  &npreds, &allConvertible);
 		table_close(rel, AccessShareLock);
 	}
 	if (!allConvertible)
@@ -886,9 +802,20 @@ ColumnarBeginAggScan(CustomScanState *node, EState *estate, int eflags)
 		}
 	}
 
-	state->preds = ColumnarBuildVecPredicates(state->quals, state->scanrelid,
-											  tupdesc, &state->npreds,
-											  &allConvertible);
+	/*
+	 * Only the count survives, and only EXPLAIN reads it. The predicate array was
+	 * stored here and never read: what would have applied it had no call site
+	 * anywhere in the tree and is deleted (issue #200).
+	 *
+	 * The call stays rather than the count being hardcoded to zero. This path is
+	 * only chosen when the relation has no quals, so the count is always zero
+	 * today and the call looks redundant, but that is an inference from a
+	 * planner early return several hundred lines away, and it is the kind that
+	 * stops being true without anyone noticing. Computing it costs one walk of
+	 * an empty list.
+	 */
+	ColumnarCountConvertibleQuals(state->quals, state->scanrelid, tupdesc,
+								  &state->npreds, &allConvertible);
 
 	table_close(rel, AccessShareLock);
 }

--- a/src/columnar_write_state.c
+++ b/src/columnar_write_state.c
@@ -61,18 +61,16 @@
  * routing each through fmgr is most of what they cost: removing min/max tracking
  * entirely saved 15% of a five-int-column load, where the comparison itself is a
  * subtraction. These are the types whose stored Datum can be read as a C value
- * and compared without a collation, which is the same condition, and the same
- * list, the vectorized filter's fast path uses (COLUMNAR_VECFAST_* in
- * columnar_vector.c). Anything else keeps the fmgr path.
+ * and compared without a collation. Anything else keeps the fmgr path.
  *
- * float4 and float8 are deliberately NOT here even though the filter fast path
- * takes them. btree float ordering puts NaN above every other value, which a C
+ * float4 and float8 are deliberately NOT here, and the reason is worth keeping
+ * whatever else changes. btree float ordering puts NaN above every other value, which a C
  * comparison gets wrong: every comparison against NaN is false, so NaN would read
  * as equal and never become a chunk's maximum. A zone map with a maximum that is
  * too low makes the reader skip a row group that does hold matching rows, and the
- * query silently returns fewer rows. The filter path can take the same shortcut
- * because it compares to answer one predicate, not to build stored bounds that a
- * later scan trusts.
+ * query silently returns fewer rows. A path that compares to answer one
+ * predicate could take the shortcut, because it does not build stored bounds
+ * that a later scan trusts; this one does, so it cannot.
  */
 typedef enum ColumnarFastCmp
 {


### PR DESCRIPTION
Closes #200, taking it as agreed on that thread so we did not both write it.

`ColumnarVecRowPasses` and `ColumnarVecSelect` were exported from `columnar.h`, defined in `columnar_vector.c`, and called from nowhere in the tree. The five branch-free typed comparison loops behind them were reached only from `ColumnarVecSelect`. `ColumnarBuildVecPredicates` built an array that was stored in the aggregate scan state and never read.

They arrived in `c0e4eb2`, "I6: vectorized branch-free predicate evaluation", and the consumer never landed. I checked the premise the issue rested on rather than accepting it: **there is no filtered-aggregate item on the roadmap** — the only mention anywhere in `design/` is a test description. So this is unplanned machinery, not machinery awaiting a planned consumer.

## Why deleting beat leaving it

It was **ungated**. The scalar path's predicates are gated on `pgcolumnar.enable_qual_pushdown` inside `ColumnarBeginRead`; `ColumnarBuildVecPredicates` was gated by nothing, which cost nothing only because no one applied its output. Anyone wiring it up would have filtered rows while `EXPLAIN` reported no pushdown.

That is #191 with the sign flipped, and the worse direction: an over-report can be checked against behaviour, an under-report looks exactly like the feature being correctly disabled.

## What remains

The probe the planner actually uses, named for what it does:

```c
static void
ColumnarCountConvertibleQuals(List *qual, Index scanrelid, TupleDesc tupdesc,
                              int *nconvertible, bool *allConvertible)
```

No array is allocated anywhere. `columnar_clause_to_predicate` fills a stack scratch that is discarded, so the conversion logic deciding `allConvertible` is **untouched** — loosening or tightening it would move plan choice, which is not what a deletion should do.

## One deviation from the shape proposed on the issue

@ChronicallyJD proposed deleting `state->npreds` and printing a literal `0` for the aggregate node's `Columnar Pushed-Down Filters`, with the invariant in a comment. I kept it computed.

A hardcoded `0` is correct exactly as long as the path returns at `columnar_vector.c:674` on `quals != NIL`. If that moves, `EXPLAIN` reports no pushdown while pushdown happens — the under-report above. A comment stating the invariant does not prevent it: four comments found stale this week were all true when written. Computing it costs one walk of an empty list, and it tells the truth by itself if the invariant changes.

Reviewer measured the output and confirmed `Pushed-Down Filters: 0` on that node either way, so this is a close call about future-proofing rather than about today's behaviour, and I will flip it if preferred.

## Gate

Build preflight **15.18, 16.14, 17.10, 18.4, 19beta2, zero warnings**.

The suite run alongside it reported `native_fetch_position` and `native_cancel`, and **that was my fault, not the change**: I ran two full compiles on the same box while the gate was going. Both pass on an idle box with wide margins — `near 99 / far 106` against the 3x bound, `cancel 75 / full 455`. Sixty lines of dead code cannot affect either, and the preflight that matters for a deletion was clean on all five majors.