### PR TITLE
Refuse SET ACCESS METHOD on an FK-referenced partitioned parent

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -127,10 +127,7 @@ Two consequences are worth stating here, because the error surfaces somewhere
 other than where the feature is used:
 
 - **A foreign key cannot reference a columnar table, and is refused when it is
-  created.** Converting an existing table to columnar while a foreign key
-  references it is refused for the same reason, as is setting a columnar access
-  method on a partitioned table that is referenced, since every partition created
-  afterwards would inherit it and be refused in turn. The referential-integrity check reads the parent row with
+  created.** The referential-integrity check reads the parent row with
   `FOR KEY SHARE`, which a columnar table cannot serve, so `CREATE TABLE` and
   `ALTER TABLE ADD CONSTRAINT` reject the constraint rather than accepting one
   that could never be satisfied. A columnar table on the child side of a foreign
@@ -139,9 +136,11 @@ other than where the feature is used:
   for the same reason.** `ALTER TABLE ... SET ACCESS METHOD pgcolumnar`, and
   `pgcolumnar.alter_table_set_access_method`, reach the identical configuration
   from the other side, so they are rejected while any foreign key references the
-  table. Drop the constraint first if the table should be columnar. Converting
-  the referencing side, and converting a table no foreign key points at, are
-  unaffected.
+  table. A partitioned table is refused as well: it has no storage of its own,
+  but it chooses the access method every partition created afterwards inherits,
+  and each of those would then be refused in turn. Drop the constraint first if
+  the table should be columnar. Converting the referencing side, and converting
+  a table no foreign key points at, are unaffected.
 - `INSERT ... ON CONFLICT DO UPDATE` takes a row lock and raises the same error.
   `ON CONFLICT DO NOTHING` does not, and works.
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -127,7 +127,10 @@ Two consequences are worth stating here, because the error surfaces somewhere
 other than where the feature is used:
 
 - **A foreign key cannot reference a columnar table, and is refused when it is
-  created.** The referential-integrity check reads the parent row with
+  created.** Converting an existing table to columnar while a foreign key
+  references it is refused for the same reason, as is setting a columnar access
+  method on a partitioned table that is referenced, since every partition created
+  afterwards would inherit it and be refused in turn. The referential-integrity check reads the parent row with
   `FOR KEY SHARE`, which a columnar table cannot serve, so `CREATE TABLE` and
   `ALTER TABLE ADD CONSTRAINT` reject the constraint rather than accepting one
   that could never be satisfied. A columnar table on the child side of a foreign

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -1872,12 +1872,34 @@ columnar_reject_set_am_to_columnar(AlterTableStmt *stmt)
 		return;
 
 	/*
-	 * Ordinary tables only, matching the constraint-side check. A partitioned
-	 * table takes a different route to the same place -- its access method is
-	 * inherited by partitions created later -- and is not addressed here.
+	 * Ordinary tables and partitioned ones.
+	 *
+	 * A partitioned table has no storage of its own, so setting its access
+	 * method breaks nothing at the time. What it does is choose the access
+	 * method every partition created afterwards inherits -- and if the table is
+	 * referenced by a foreign key, every one of those is then refused by the
+	 * constraint-side check, because core clones the foreign key to each new
+	 * partition:
+	 *
+	 *     ALTER TABLE pp SET ACCESS METHOD pgcolumnar;   -- accepted
+	 *     CREATE TABLE pp9 PARTITION OF pp ...;
+	 *     ERROR: cannot create a foreign key referencing columnar table "pp9"
+	 *
+	 * That error names pp9, a table the user has just written, and says nothing
+	 * about the earlier ALTER that caused it. Refusing here is the same rule
+	 * this check already applies to an ordinary table: a configuration that
+	 * cannot be honoured is refused where it is chosen, not at every later use.
+	 *
+	 * Nothing is lost by refusing. The intent of setting a columnar access
+	 * method on a partitioned table is that its partitions be columnar, and
+	 * while the foreign key exists that is unreachable by any route (#201).
 	 */
-	if (get_rel_relkind(relid) != RELKIND_RELATION)
-		return;
+	{
+		char		relkind = get_rel_relkind(relid);
+
+		if (relkind != RELKIND_RELATION && relkind != RELKIND_PARTITIONED_TABLE)
+			return;
+	}
 
 	foreach(lc, stmt->cmds)
 	{

--- a/test/fk_referencing.sh
+++ b/test/fk_referencing.sh
@@ -220,4 +220,66 @@ check "converting back to heap is unaffected" \
 	"$(case "$back" in *ERROR*) echo "no ($back)" ;; *) echo yes ;; esac)" \
 	"yes"
 
+# --- 7. a partitioned parent is refused too (#201) -----------------------------
+
+# A partitioned table has no storage, so setting its access method breaks nothing
+# at the time. It chooses what every later partition inherits, and core clones a
+# foreign key to each new partition, so with the constraint in place every
+# ordinary partition creation is then refused -- by an error naming the partition
+# the user just wrote, saying nothing about the ALTER that caused it.
+#
+# The routes that were already covered are asserted first, because they are what
+# makes this a small gap rather than a trap: the constraint-side check fires on
+# the cloned constraint, so a columnar partition is refused however it arrives.
+
+psql_run "DROP TABLE IF EXISTS fk_pc; DROP TABLE IF EXISTS fk_pp;
+	CREATE TABLE fk_pp (id int PRIMARY KEY) PARTITION BY RANGE (id);
+	CREATE TABLE fk_pp1 PARTITION OF fk_pp FOR VALUES FROM (1) TO (100);
+	CREATE TABLE fk_pc (id int REFERENCES fk_pp(id));" >/dev/null
+
+perr="$(psql_run "CREATE TABLE fk_pp2 PARTITION OF fk_pp
+	FOR VALUES FROM (100) TO (200) USING pgcolumnar;" 2>&1 || true)"
+
+check "a columnar partition of an FK-referenced parent is refused" \
+	"$(case "$perr" in *"cannot create a foreign key referencing columnar table"*) echo yes ;;
+		*) echo "no ($perr)" ;; esac)" \
+	"yes"
+
+aerr="$(psql_run "ALTER TABLE fk_pp SET ACCESS METHOD pgcolumnar;" 2>&1 || true)"
+
+check "and setting the parent's access method is refused as well" \
+	"$(case "$aerr" in *"cannot convert table"*) echo yes ;; *) echo "no ($aerr)" ;; esac)" \
+	"yes"
+
+# The consequence that made it worth refusing: without this, the parent keeps a
+# columnar access method and the next ordinary partition creation fails.
+# Asked as "did it become columnar", not "is it heap": a partitioned table that
+# has never been given an access method has relam = 0, so a join against pg_am
+# returns nothing and an equality test against 'heap' fails on a correct build.
+# It did, on the first run of this check.
+check "so the parent did not become columnar" \
+	"$(q "SELECT count(*) FROM pg_class c JOIN pg_am a ON a.oid = c.relam
+		WHERE c.relname = 'fk_pp' AND a.amname = 'pgcolumnar';")" \
+	"0"
+
+check "and a partition can still be created the ordinary way" \
+	"$(psql_run "CREATE TABLE fk_pp3 PARTITION OF fk_pp
+		FOR VALUES FROM (200) TO (300);" 2>&1 | grep -c ERROR)" \
+	"0"
+
+# The control, and the one that fails if the rule is keyed on the wrong thing: a
+# partitioned table nobody references converts fine, and its partitions inherit.
+psql_run "DROP TABLE IF EXISTS fk_free;
+	CREATE TABLE fk_free (id int) PARTITION BY RANGE (id);" >/dev/null
+
+check "a partitioned table with no foreign key still converts" \
+	"$(psql_run "ALTER TABLE fk_free SET ACCESS METHOD pgcolumnar;" 2>&1 | grep -c ERROR)" \
+	"0"
+
+check "and its partitions inherit the columnar access method" \
+	"$(psql_run "CREATE TABLE fk_free1 PARTITION OF fk_free FOR VALUES FROM (1) TO (100);" >/dev/null 2>&1;
+	   q "SELECT amname FROM pg_class c JOIN pg_am a ON a.oid = c.relam
+		WHERE c.relname = 'fk_free1';")" \
+	"pgcolumnar"
+
 pgc_summary


### PR DESCRIPTION
Closes #201, taking the option that issue rated least likely.

## What was left

@ChronicallyJD's write-up is the reason this is small: they went to reproduce the trap they had described, found it already shut, and said so. Core clones a foreign key to each partition, so a columnar partition is refused however it arrives — created explicitly, inherited from the parent's access method, or attached. **This PR asserts all three of those first**, because they are what makes the remainder a gap rather than a trap.

What remained is one accepted command with a consequence elsewhere:

```sql
ALTER TABLE pp SET ACCESS METHOD pgcolumnar;   -- accepted, pp is FK-referenced
CREATE TABLE pp9 PARTITION OF pp FOR VALUES FROM (300) TO (400);
ERROR:  cannot create a foreign key referencing columnar table "pp9"
```

The error names `pp9`, a table the user has just written, and says nothing about the earlier `ALTER` that caused it.

## Why refuse rather than add a hint

The issue preferred leaving the `ALTER` and improving the later error with an `errhint`. I have taken the other option, for consistency rather than because the hint is wrong.

The rule this project already applies, in the constraint-side check, in #199, and in `docs/limitations.md`, is that **a configuration this access method cannot honour is refused where it is chosen, not at every later use of it**. This is that configuration: the intent of setting a columnar access method on a partitioned table is that its partitions be columnar, and while the foreign key exists that is unreachable by every route. Nothing is lost by refusing it.

A hint would still help a table already in that state from an older build. That is a smaller, separate thing and I have not done it here.

## Tests

Six checks added to `test/fk_referencing.sh`, twenty-six in the file. Against the tree with the relkind test put back, three fail:

```
FAIL  and setting the parent's access method is refused as well
FAIL  so the parent did not become columnar: got [1] want [0]
FAIL  and a partition can still be created the ordinary way: got [1] want [0]
```

Controls: a partitioned table nobody references still converts, and its partitions still inherit columnar.

**One of the six was wrong on its first run**, and it is worth recording since it is the same family we keep meeting. It asserted the parent's access method was `heap`. A partitioned table that has never been given one has `relam = 0`, so the join against `pg_am` returns nothing and the check failed **on a correct build**. It now asks whether the parent became columnar, which is the actual question and is right whether `relam` is unset or `heap`.