### PR TITLE
Finish the plan-shape sweep #203 started

### DIFF
--- a/test/lib.sh
+++ b/test/lib.sh
@@ -300,6 +300,27 @@ check() {
 	fi
 }
 
+# Is this query's plan the columnar custom scan?
+#
+# For a check that reads a counter out of EXPLAIN and asserts on it. Those
+# counters exist only on this node, so if the planner stops choosing it the read
+# returns nothing and the check fails describing skipping, or bloom, or
+# clustering -- anything except the plan change that actually happened.
+#
+# "Columnar Projected Columns" is the node's own marker: no other node reports
+# it, and the vectorized aggregate node reports "Columnar Vectorized Aggregates"
+# instead. A positive grep for the marker is deliberately not an absence test --
+# a plan that fell back to a sequential scan has no Columnar lines to be absent,
+# so an absence test would pass for exactly the case worth catching.
+#
+# EXPLAIN without ANALYZE is enough: the line comes from the plan rather than the
+# run, so the assertion costs a plan and does not execute the query.
+pgc_is_columnar_scan() {	# query -> yes|no
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -At -c "EXPLAIN (COSTS OFF) $1" 2>/dev/null \
+		| grep -q 'Columnar Projected Columns' && echo yes || echo no
+}
+
 # Order-independent set hash of an arbitrary query's result. The row is cast to
 # text as a whole composite so any column list works. No single quotes are used
 # in the wrapper (dollar-quoting + chr(10)) so the inner query may contain its

--- a/test/native_bloom.sh
+++ b/test/native_bloom.sh
@@ -45,6 +45,11 @@ check "bloom rows written" \
 	"$(q "SELECT count(*) FROM pgcolumnar.bloom WHERE storage_id = pgcolumnar.get_storage_id('n') AND column_index = 1;")" \
 	"10"
 
+# The node, before any counter read out of it: the skip counts below come from
+# the columnar custom scan and from nowhere else.
+check "the plan under test is a columnar custom scan" \
+	"$(pgc_is_columnar_scan "SELECT id FROM n WHERE tag = $PROBE")" "yes"
+
 # Equality probe result parity.
 check "equality probe parity" \
 	"$(pgc_set_hash "SELECT id, tag FROM n WHERE tag = $PROBE")" \

--- a/test/native_cluster.sh
+++ b/test/native_cluster.sh
@@ -56,6 +56,11 @@ check "box parity (pre-cluster)" \
 	"$(pgc_set_hash "SELECT id, x, y, payload FROM n WHERE $BOX")" \
 	"$(pgc_set_hash "SELECT id, x, y, payload FROM h WHERE $BOX")"
 
+# The node, before any counter read out of it: the skip counts below are
+# reported by the columnar custom scan and by nothing else.
+check "the plan under test is a columnar custom scan" \
+	"$(pgc_is_columnar_scan "SELECT id FROM n WHERE $BOX")" "yes"
+
 before="$(skipped "SELECT id FROM n WHERE $BOX")"; before="${before:-0}"
 
 # Cluster by (x, y) -- the eager Z-order reorg.

--- a/test/native_recluster.sh
+++ b/test/native_recluster.sh
@@ -50,6 +50,11 @@ check "box parity (pre-recluster)" \
 	"$(pgc_set_hash "SELECT id, x, y, payload FROM n WHERE $BOX")" \
 	"$(pgc_set_hash "SELECT id, x, y, payload FROM h WHERE $BOX")"
 
+# The node, before any counter read out of it: the skip counts below are
+# reported by the columnar custom scan and by nothing else.
+check "the plan under test is a columnar custom scan" \
+	"$(pgc_is_columnar_scan "SELECT id FROM n WHERE $BOX")" "yes"
+
 before="$(skipped "SELECT id FROM n WHERE $BOX")"; before="${before:-0}"
 
 # Online recluster by (x, y).

--- a/test/native_skip.sh
+++ b/test/native_skip.sh
@@ -37,6 +37,11 @@ skipped() {
 }
 gt0() { [ "${1:-0}" -gt 0 ] && echo yes || echo no; }
 
+# The node, before any counter read out of it: every skipped() below returns a
+# number only the columnar custom scan reports.
+check "the plan under test is a columnar custom scan" \
+	"$(pgc_is_columnar_scan 'SELECT id FROM n WHERE id BETWEEN 5000 AND 5100')" "yes"
+
 check "row count" "$(q 'SELECT count(*) FROM n;')" "20480"
 check "no-predicate scan returns all rows" "$(q 'SELECT count(*) FROM n;')" "$(q 'SELECT count(*) FROM h;')"
 

--- a/test/sorted_projection.sh
+++ b/test/sorted_projection.sh
@@ -56,6 +56,11 @@ diff_query "pre order-by"   "SELECT k, v FROM %T ORDER BY k, v"
 diff_query "pre aggregate"  "SELECT k, count(*), sum(v) FROM %T GROUP BY k"
 diff_query "pre star"       "SELECT * FROM %T WHERE id % 997 = 0"
 
+# The node, before any counter read out of it: "Columnar Vectors Skipped" is
+# reported by the columnar custom scan and by nothing else.
+check "the plan under test is a columnar custom scan" \
+	"$(pgc_is_columnar_scan "SELECT sum(v) FROM t_col WHERE k BETWEEN 100 AND 120")" "yes"
+
 removed_before="$(groups_removed "SELECT sum(v) FROM t_col WHERE k BETWEEN 100 AND 120")"
 
 echo "-- sort the columnar table on k"

--- a/test/write_minmax_fastpath.sh
+++ b/test/write_minmax_fastpath.sh
@@ -112,6 +112,10 @@ check "min and max match heap on every column" "${bad:-same}" "same"
 # A fast path that quietly widened every bound would pass checks 1 and 2 while
 # giving up the skipping the zone maps exist for, so assert groups are still
 # ruled out.
+# The node, before the counter read out of it.
+check "the plan under test is a columnar custom scan" \
+	"$(pgc_is_columnar_scan "SELECT count(*) FROM mm_c WHERE asc_i BETWEEN 19999 AND 20001")" "yes"
+
 skipped="$(q "EXPLAIN (ANALYZE, COSTS off, TIMING off, SUMMARY off)
 	SELECT count(*) FROM mm_c WHERE asc_i BETWEEN 19999 AND 20001;" \
 	| grep -oE 'Columnar Chunk Groups Removed by Filter: [0-9]+' \


### PR DESCRIPTION
#203 asserted the node in the three files you named and I flagged the rest as a sweep left undone. This is the rest of it.

## What was exposed

I surveyed all 28 suites that read `EXPLAIN`, narrowed to the 13 that pull a **numeric counter** out of it and assert on the number, and found six with no node assertion at all:

`native_skip`, `native_bloom`, `native_cluster`, `native_recluster`, `sorted_projection`, `write_minmax_fastpath`

`Columnar Chunk Groups Removed by Filter` and `Columnar Vectors Skipped` are reported by the columnar custom scan and by nothing else. When the planner stops choosing it, the read returns nothing and the check fails describing skipping, or bloom, or clustering — anything except the plan change that actually happened.

## The helper

In `test/lib.sh` as `pgc_is_columnar_scan`, once rather than copied six times.

It uses `EXPLAIN` **without** `ANALYZE`: the marker line comes from the plan rather than the run, which I confirmed rather than assumed, so the assertion costs a plan and does not execute the query. And it greps positively for the node's own marker rather than testing for absence — a plan that fell back to a sequential scan has no `Columnar` lines to be absent, so an absence test would pass for exactly the case worth catching.

## Two suites deliberately left alone

- **`analyze_stats`** reads `Rows Removed by Filter`, a generic executor counter, and compares the same query with and without an index. Its own comment says the comparison is independent of plan shape, and it is. An assertion there would contradict what the check is for.
- **`audit`** greps for `Pushed-Down Filters: 1` and requires the value, so it cannot pass without the node. Only the failure message would improve, and not enough to justify touching that file.

## Verified by taking the node away

With `enable_custom_scan=off`, every one of the six fails its node assertion ahead of the counter checks that assertion guards, while the parity checks around them keep passing — which is the point, since parity cannot see a plan change:

```
===== native_cluster =====
PASS  row count
PASS  box parity (pre-cluster)
FAIL  the plan under test is a columnar custom scan
PASS  row count after cluster
PASS  box parity (post-cluster)
PASS  full-table parity after cluster
FAIL  clustering increases 2D skipping
FAIL  clustering skips most groups
```

## Gate — read this part

- Build preflight: **15.18, 16.14, 17.6, 18.4, 19beta2 — zero warnings.**
- Full suite: **PG19 all pass. PG18 FAILED**, on `native_fetch_position` and nothing else.
- All six swept suites: **PASS on both majors.**

I am not going to describe that as green. The failing check is `doubling the row group does not double the cost of the same fetches`, at `small=97ms big=205ms` — a ratio of 2.11 against a 2.0 bound. Nothing of mine was running alongside it; I had stopped everything for the gate.

It is not this change — this is test-only and does not touch that suite — and here is that claim measured rather than asserted. The same check, run on its own, four times on each side:

```
alone, main:    1.11  1.32  1.13  1.12
alone, branch:  1.13  1.08  1.15  1.17
inside the matrix:  2.11
```

## The root cause, which is worth more than this PR

`run_all_versions.sh` runs six suites concurrently:

```
maxjobs="${PGC_JOBS:-6}"
while [ "$(jobs -rp | wc -l)" -ge "$maxjobs" ]; do wait -n; done
```

So every wall-clock ratio in the matrix is measured against five other suites and their clusters. **"Passes on an idle box" is not a property the gate can ever observe** — the gate is never idle, by design.

That reframes the three flaky timing suites of this session. They are not three thin fixtures that met three unlucky boxes; they are three wall-clock ratios measured under six-way concurrency, and the ~1.8x inflation above is the harness measuring itself. #204 fixes one of them properly by giving the fixture forty points of headroom instead of arguing about the box. The other two want the same treatment, and I would rather that be a deliberate follow-up than something I bolt onto a test-only sweep.

Happy to take `native_fetch_position` and `native_cancel` next on the same principle if you want them.
