### PR TITLE
Document pgcolumnar.cluster, which appears in no document at all

### DIFF
--- a/docs/administration.md
+++ b/docs/administration.md
@@ -74,6 +74,23 @@ SELECT pgcolumnar.vacuum_sorted('events', 'customer_id');
 
 To compact every columnar table in a schema, use `pgcolumnar.vacuum_full`.
 
+`pgcolumnar.vacuum_sorted` sorts ascending on its columns, which tightens the
+minimum and maximum of the leading column. To tighten several columns at once,
+use `pgcolumnar.cluster`, which orders rows by a Z-order (Morton) curve over the
+columns given, so multi-column range and point filters skip more:
+
+```sql
+SELECT pgcolumnar.cluster('events', 'customer_id', 'ts');
+```
+
+**`pgcolumnar.cluster` holds `AccessExclusiveLock` for its whole run**, like
+PostgreSQL's own `CLUSTER` and `VACUUM FULL`: it rewrites the relation and swaps
+the file, so reads and writes on the table block until it finishes. Use it for an
+initial bulk reorganisation, on a table you can take offline.
+`pgcolumnar.recluster` is the online form of the same idea and is described
+below; prefer it on a live table. Neither changes query results — both only
+reorder physical storage.
+
 Leave autovacuum on. It maintains visibility-map bits and statistics for columnar
 tables. Schedule `pgcolumnar.vacuum` separately based on delete and update volume.
 

--- a/docs/sql-reference.md
+++ b/docs/sql-reference.md
@@ -60,6 +60,24 @@ but are often queried by range.
 SELECT pgcolumnar.vacuum_sorted('events', 'customer_id');
 ```
 
+### pgcolumnar.cluster(tablename regclass, VARIADIC columns name[])
+
+Rewrites a columnar table with its rows ordered by a Z-order (Morton)
+space-filling curve over the given columns. Where `vacuum_sorted` sorts ascending
+and so tightens the minimum and maximum of its leading column, Z-order tightens
+every clustered column at once, so multi-column range and point filters skip more
+vectors and chunk groups. Results are unchanged; only physical order is.
+
+**Holds `AccessExclusiveLock` for the duration**, like PostgreSQL's own `CLUSTER`
+and `VACUUM FULL`, because it rewrites the relation and swaps its file. Reads and
+writes on the table block until it completes. Use it for an initial bulk
+reorganisation; use [`pgcolumnar.recluster`](administration.md#online-maintenance-and-disk-reclaim)
+to reorder a live table without an exclusive lock.
+
+```sql
+SELECT pgcolumnar.cluster('events', 'customer_id', 'ts');
+```
+
 ### pgcolumnar.vacuum_full(schema name DEFAULT 'public', sleep_time real DEFAULT 0.0, stripe_count int DEFAULT 0)
 
 Runs `pgcolumnar.vacuum` on every columnar table in a schema. `sleep_time` is a


### PR DESCRIPTION
`pgcolumnar.cluster` is defined in `pgcolumnar--1.0.sql`, tested by `test/native_cluster.sh`, and **mentioned in no document at all.**

Every other user-facing maintenance function is described somewhere — `vacuum`, `vacuum_sorted` and `vacuum_full` in the SQL reference; `compact`, `compact_rewrite`, `recluster` and `truncate` in the administration guide. This one is reachable only by reading the extension SQL.

It is also the one that most needs saying, because **it is the only maintenance function that takes `AccessExclusiveLock` for its whole run.** Someone finding it in `\df pgcolumnar.*` and trying it on a live table has no way to learn that first.

## Verified rather than transcribed

I did not take the lock level from the `COMMENT ON FUNCTION`, since that is exactly the kind of claim this project has repeatedly found to be true-when-written:

```
columnar_cluster:    rel = table_open(relid, AccessExclusiveLock);   /* held to end of transaction */
columnar_recluster:  rel = table_open(relid, ShareUpdateExclusiveLock);
```

The Z-order claim is what `native_cluster.sh` already asserts — *clustering increases 2D skipping* and *clustering skips most groups* — so the description says what the suite measures rather than what the design intends. The example's argument shape matches the suite's own call, `pgcolumnar.cluster('n', 'x', 'y')`.

## Where it went

Both places its siblings live, since they serve different readers:

- **`docs/administration.md`**, next to `vacuum_sorted` — because that is where someone deciding *which* reorganisation to run is looking, and the useful sentence there is the contrast: `cluster` tightens several columns at once where `vacuum_sorted` tightens the leading one, and `recluster` is the online form of the same idea.
- **`docs/sql-reference.md`**, next to the other rewrite functions, with the lock warning in bold.

## Not done here, deliberately

`compact`, `compact_rewrite`, `recluster` and `truncate` are in the administration guide but absent from the SQL reference's Maintenance section. The reference opens with "Every function is in the `pgcolumnar` schema", which is about namespacing and not a claim of completeness, so I read that as an editorial question about what the reference is for rather than a gap like this one. Happy to add them if you want it exhaustive.

Docs only — no code, no tests, nothing for the matrix to exercise. I have not run a gate for that reason rather than by omission.

Found during the docs-versus-code audit a while back; I flagged it then and did not come back to it, which is why it is only landing now.
