### PR TITLE
Run the timing-sensitive suites alone instead of beside five others

### DIFF
--- a/test/native_fetch_position.sh
+++ b/test/native_fetch_position.sh
@@ -184,6 +184,12 @@ fetch_once() {  # table, table-rows, count -> milliseconds for one pass
 # itself a function of group size, so more fetches amplify the difference rather
 # than averaging it away.
 #
+# Those figures are from this file's fixture, which carries a varying-length
+# column. A reviewer measured flat ~1.0 across the same fetch counts on a
+# two-integer fixture, which is consistent rather than contradictory: a lighter
+# per-group decode is exactly the condition under which the effect disappears.
+# If this is ever remeasured, remeasure it on a fixture with a text column.
+#
 # What this check actually needed was not to be run beside five other suites;
 # run_all_versions.sh now runs it alone. The two structural checks below are what
 # prove the mechanism, and this one is corroboration.

--- a/test/native_fetch_position.sh
+++ b/test/native_fetch_position.sh
@@ -175,10 +175,18 @@ fetch_once() {  # table, table-rows, count -> milliseconds for one pass
 # even when every per-row lookup is O(1). The defect signature (a walk, so about
 # 2x) and the honest baseline therefore sit near each other by construction, and
 # no tolerance separates them cleanly. Raising the group ratio does not help: it
-# scales the decode with it. If this check needs more headroom, raise the fetch
-# count so per-fetch work dominates the shared decode, rather than moving the
-# threshold. The two structural checks below are what prove the mechanism; this
-# one is corroboration.
+# scales the decode with it.
+#
+# An earlier version of this comment said the way to get headroom was to raise
+# the fetch count, so that per-fetch work dominates the shared decode. That was
+# reasoned from a cost model and it is wrong. Measured, the ratio moves the other
+# way: 1.08 at 6,000 fetches, 1.23 at 20,000, 1.29 at 40,000. Per-fetch cost is
+# itself a function of group size, so more fetches amplify the difference rather
+# than averaging it away.
+#
+# What this check actually needed was not to be run beside five other suites;
+# run_all_versions.sh now runs it alone. The two structural checks below are what
+# prove the mechanism, and this one is corroboration.
 fetch_ms() {  # table, table-rows, count -> median of three passes
 	local a b c
 	a=$(fetch_once "$1" "$2" "$3")

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -120,6 +120,32 @@ BASE_PORT="${PGC_BASE_PORT:-$(( 40000 + (${PGC_RUN_OWNER:-$$} % 20000) ))}"
 overall=0
 declare -a SUMMARY
 
+# Suites whose checks compare wall-clock times, and which therefore cannot be run
+# beside five others.
+#
+# The rest of the matrix runs PGC_JOBS suites at once, each with its own cluster,
+# so every ratio in those suites is measured under six-way contention. That is
+# not a fixture problem and no threshold survives it: the same check on the same
+# build measures 1.11 alone and 2.11 inside the matrix, against a bound of 2.0.
+# Three suites produced red gates that way in one session, each costing a re-run
+# to disprove, which is how a matrix teaches its readers to discount red.
+#
+# Tuning the fixtures was tried first and does not work. On the group-doubling
+# check, raising the fetch count to dilute the shared decode makes the ratio
+# worse rather than better -- 1.08 at 6,000 fetches, 1.23 at 20,000, 1.29 at
+# 40,000 -- because per-fetch cost is itself a function of group size, so more
+# fetches amplify the difference instead of averaging it away. The comment in
+# native_fetch_position.sh that recommended exactly that has been corrected.
+#
+# So they run alone. It costs a few minutes per major and it buys a timing
+# result that means something.
+is_timing_suite() {
+	case "$1" in
+		native_fetch_position|native_cancel|native_agg_deletes) return 0 ;;
+		*) return 1 ;;
+	esac
+}
+
 for pgc in "${CONFIGS[@]}"; do
 	if [ ! -x "$pgc" ]; then
 		echo "SKIP  $pgc (not executable)"
@@ -174,6 +200,9 @@ for pgc in "${CONFIGS[@]}"; do
 	results=""
 	maxjobs="${PGC_JOBS:-6}"
 	for s in "${SUITES[@]}"; do
+		if is_timing_suite "$s"; then
+			continue
+		fi
 		# throttle to maxjobs concurrent suites
 		while [ "$(jobs -rp | wc -l)" -ge "$maxjobs" ]; do wait -n; done
 		port=$((BASE_PORT++))
@@ -184,6 +213,17 @@ for pgc in "${CONFIGS[@]}"; do
 		) &
 	done
 	wait
+
+	# Then the timing-sensitive suites, one at a time, with nothing else running.
+	for s in "${SUITES[@]}"; do
+		if ! is_timing_suite "$s"; then
+			continue
+		fi
+		port=$((BASE_PORT++))
+		PGC_SKIP_BUILD=1 PGC_PORT="$port" \
+			bash "$builddir/test/${s}.sh" "$pgc" >"$builddir/${s}.log" 2>&1
+		echo $? >"$builddir/${s}.rc"
+	done
 
 	# collect results in suite order for a stable, readable summary
 	for s in "${SUITES[@]}"; do

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -137,6 +137,19 @@ declare -a SUMMARY
 # fetches amplify the difference instead of averaging it away. The comment in
 # native_fetch_position.sh that recommended exactly that has been corrected.
 #
+# Not every wall-clock ratio belongs here, and the distinction is measurable
+# rather than a matter of taste. native_fetch_cache asserts one on the same
+# index-driven fetch with the same stopwatch, and is deliberately absent: it
+# compares one big group against ten small ones, and the cache equalises
+# per-fetch cost across both sides, so contention is common-mode and cancels in
+# the ratio. Measured, six-way: absolute times roughly doubled and the ratio
+# stayed near 1 against a bound of 3, worst case 1.15.
+#
+# The three below measure quantities whose per-fetch or per-query cost is itself
+# a function of the thing being varied, so contention is differential and does
+# not cancel. That is the test for membership: does the load move both sides of
+# the ratio together?
+#
 # So they run alone. It costs a few minutes per major and it buys a timing
 # result that means something.
 is_timing_suite() {


### PR DESCRIPTION
Taking the timing-margin class, following @ChronicallyJD's finding on #204 that the matrix generates its own contention.

## The root cause is the harness, not three fixtures

```bash
maxjobs="${PGC_JOBS:-6}"
```

Six suites at once, each with its own cluster, so every wall-clock ratio in the matrix is measured against five others. Your measurement made it concrete: the same check, same build, **1.11 alone and 2.11 inside the matrix**, against a 2.0 bound. "Passes on an idle box" is not a property the gate can observe, and three suites produced red gates this way in one session.

`native_fetch_position`, `native_cancel` and `native_agg_deletes` now run **serially, after the parallel batch**. Coverage is unchanged — every major, every run — they are simply not measured against five competitors.

## Fixture tuning was tried first and does not work

This is the part I would have got wrong without measuring, and the source of the error was my own comment.

The group-doubling check shares one decode of the group across its fetches, and that decode is O(group size). So the obvious lever is raising the fetch count until per-fetch work dominates it — which is what `native_fetch_position.sh` told me to do, in a comment I wrote in the median-of-three PR. Measured:

| fetch count | ratio |
| --- | --- |
| 6,000 | 1.08 |
| 20,000 | 1.23 |
| 40,000 | **1.29** |

**It moves the wrong way.** Per-fetch cost is itself a function of group size, so more fetches amplify the difference rather than averaging it away. That comment is corrected in this PR with the numbers that disprove it — it was reasoned from a cost model and never checked, which makes it the fifth stale comment we have found this week and the first that was wrong on arrival rather than overtaken by events.

## Verified

PG18, full matrix: `ALL VERSIONS PASSED`, with `native_fetch_position=PASS`, `native_cancel=PASS` and `native_agg_deletes=PASS` — all three having run in the serial phase.

## One thing I did not do

`native_cancel` is thin for a different reason and this does not address it: it compares a 50 ms timeout's firing against a ~300 ms full load, so `full/2` is a small absolute number and the interrupt's scheduling latency is a large fraction of it. Serializing removes the contention that made it fail, but the check would still be tight on a slow machine. Worth its own look if it recurs; I would rather see it recur than guess at a fixture now, having just been wrong about exactly that on the other suite.