### PR TITLE
Gate the partitioned SET ACCESS METHOD control on PostgreSQL 17 (fixes #218)

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -6,7 +6,7 @@ pgColumnar builds from one source tree on PostgreSQL 15, 16, 17, 18, and
 19. Every test suite runs on all five majors. PostgreSQL 13 and 14 still build
 but are out of the tested matrix.
 
-Two behaviors depend on the major:
+Three behaviors depend on the major:
 
 - `ALTER TABLE ... SET ACCESS METHOD` exists on PostgreSQL 15 and later. On 13 and
   14, `pgcolumnar.alter_table_set_access_method` builds a new table, copies rows,
@@ -15,6 +15,13 @@ Two behaviors depend on the major:
   foreign keys.
 - The read stream prefetch path (`pgcolumnar.enable_read_stream`) is effective on
   PostgreSQL 17 and later. On earlier majors the setting has no effect.
+- Setting the access method of a *partitioned* table requires PostgreSQL 17. On
+  15 and 16, core refuses `ALTER TABLE ... SET ACCESS METHOD` on any partitioned
+  table with `cannot change access method of a partitioned table`, so a
+  partitioned parent cannot be made columnar there and its later partitions
+  cannot inherit the choice. Give each partition the access method individually
+  instead. This is core's restriction, not this extension's, and it applies
+  whether or not a foreign key is involved.
 
 ## Host architecture
 

--- a/test/fk_referencing.sh
+++ b/test/fk_referencing.sh
@@ -269,17 +269,38 @@ check "and a partition can still be created the ordinary way" \
 
 # The control, and the one that fails if the rule is keyed on the wrong thing: a
 # partitioned table nobody references converts fine, and its partitions inherit.
+#
+# Core accepts SET ACCESS METHOD on a partitioned table only from PostgreSQL 17.
+# Before that it refuses every such ALTER whether or not a foreign key is
+# involved, so the control cannot be expressed there and these two checks fail on
+# a correct build. They did: added by #206 for issue #201 and gated on 18 and 19
+# only, they went in red on 15 and 16 and stayed red until the next full matrix
+# found them.
+#
+# The older majors get the inverse assertion rather than a silent skip, so the
+# suite still says something on them: the refusal must be core's, by core's
+# message. If this extension ever starts refusing first, or core lifts the
+# restriction, that check fails and this branch gets revisited.
 psql_run "DROP TABLE IF EXISTS fk_free;
 	CREATE TABLE fk_free (id int) PARTITION BY RANGE (id);" >/dev/null
 
-check "a partitioned table with no foreign key still converts" \
-	"$(psql_run "ALTER TABLE fk_free SET ACCESS METHOD pgcolumnar;" 2>&1 | grep -c ERROR)" \
-	"0"
+if [ "$PGC_MAJOR" -ge 17 ]; then
+	check "a partitioned table with no foreign key still converts" \
+		"$(psql_run "ALTER TABLE fk_free SET ACCESS METHOD pgcolumnar;" 2>&1 | grep -c ERROR)" \
+		"0"
 
-check "and its partitions inherit the columnar access method" \
-	"$(psql_run "CREATE TABLE fk_free1 PARTITION OF fk_free FOR VALUES FROM (1) TO (100);" >/dev/null 2>&1;
-	   q "SELECT amname FROM pg_class c JOIN pg_am a ON a.oid = c.relam
-		WHERE c.relname = 'fk_free1';")" \
-	"pgcolumnar"
+	check "and its partitions inherit the columnar access method" \
+		"$(psql_run "CREATE TABLE fk_free1 PARTITION OF fk_free FOR VALUES FROM (1) TO (100);" >/dev/null 2>&1;
+		   q "SELECT amname FROM pg_class c JOIN pg_am a ON a.oid = c.relam
+			WHERE c.relname = 'fk_free1';")" \
+		"pgcolumnar"
+else
+	ferr="$(psql_run "ALTER TABLE fk_free SET ACCESS METHOD pgcolumnar;" 2>&1 || true)"
+
+	check "before 17, core refuses this for every partitioned table" \
+		"$(case "$ferr" in *"cannot change access method of a partitioned table"*) echo yes ;;
+			*) echo "no ($ferr)" ;; esac)" \
+		"yes"
+fi
 
 pgc_summary

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -79,6 +79,11 @@ pgc_cluster_is_ours() {
 pgc_setup() {
 	PGC_PG_CONFIG="${1:-/usr/local/pg17/bin/pg_config}"
 	PGC_BINDIR="$("$PGC_PG_CONFIG" --bindir)"
+	# One definition of the server major, for the suites that must branch on it.
+	# A behavior that exists only from some major is core's, not this extension's,
+	# and a check written against the newer one fails on the older ones for a
+	# reason that is not a defect. Branch on this rather than deriving it again.
+	PGC_MAJOR="$("$PGC_PG_CONFIG" --version | sed -E 's/^[^0-9]*([0-9]+).*/\1/')"
 	# Derived from this process rather than a fixed 54329: two suites run at
 	# once on one box otherwise start on the same port, and the loser reports a
 	# wall of ERROR: database "regress" already exists with no named check


### PR DESCRIPTION
Fixes #218. Test and documentation only. No product code changed.

## What the matrix found

The first full 15 through 19 matrix since `f7adbdb` ran at `5c707d9`. 91 suites,
five majors. PG17, PG18 and PG19 green. PG15 and PG16 red on one suite,
`fk_referencing`, on two checks:

```
FAIL  a partitioned table with no foreign key still converts: got [1] want [0]
FAIL  and its partitions inherit the columnar access method: got [heap] want [pgcolumnar]
```

Both were added by #206 for issue #201, merged earlier today. They are the
control for the new rule: the refusal must be keyed on the foreign key, not on
the table being partitioned.

The control uses `ALTER TABLE ... SET ACCESS METHOD` on a partitioned table.
Core supports that only from PostgreSQL 17; on 15 and 16 it refuses every such
ALTER regardless of foreign keys. So the control cannot be expressed on those
majors and the checks fail on a correct build. #206 was gated on PG18 and PG19,
and the boundary it crossed was 17, below the gate.

## The change

- `test/fk_referencing.sh`: the two controls run from 17. Below 17 the suite
  asserts the inverse instead of skipping, so it still says something there: the
  refusal must be core's, by core's message. If this extension ever refuses
  first, or core lifts the restriction, that check goes red.
- `test/lib.sh`: `PGC_MAJOR` derived once in `pgc_setup`. `unique_conc.sh`
  already derived its own; the next suite that needs it should not derive a
  third.
- `docs/limitations.md`: the major-dependent list had two entries and this was
  not among them, so a reader on 15 or 16 would take the foreign-key section to
  mean a partitioned table converts when nothing references it. It does not.

## Verification

`fk_referencing` on every major in the matrix:

| major | result | checks |
| --- | --- | --- |
| 15.18 | PASS | 25 |
| 16.14 | PASS | 25 |
| 17.10 | PASS | 26 |
| 18.4 | PASS | 26 |
| 19beta2 | PASS | 26 |

26 on 17 and later, so the original controls still run where they can.

Two claims proven rather than assumed:

- **The new check is not vacuous.** Breaking its expected message turns it red on
  PG15 and it reports what core actually said:
  `got [no (ERROR:  cannot change access method of a partitioned table)] want [yes]`
- **The documented workaround works.** Giving a partition the access method
  individually with `CREATE TABLE ... PARTITION OF ... USING pgcolumnar` was run
  on PG15: the partition is columnar, and rows route into it and read back.

The refusal checks were also confirmed to pass on 15 and 16 for the right reason.
This extension's error fires before core's partitioned restriction, so
`and setting the parent's access method is refused as well` still matches
`cannot convert table` rather than passing on core's message.

A full matrix rerun follows this merge, since `test/lib.sh` is shared by every
suite that uses it.