### PR TITLE
Fuzz the Parquet decoder, and fix the first defect it found (#214)

### DIFF
--- a/src/columnar.h
+++ b/src/columnar.h
@@ -782,4 +782,51 @@ extern void ColumnarVectorInit(void);
  * business outside that file.
  */
 
+/* -------------------------------------------------------------------------
+ * Reading a varlena header out of a packed value buffer
+ * ------------------------------------------------------------------------- */
+
+/*
+ * VARSIZE_ANY for a pointer that may not be aligned.
+ *
+ * Values in a chunk's raw buffer are packed end to end with no alignment
+ * padding, so a four-byte varlena header starts wherever the previous value
+ * ended. VARSIZE_ANY reads that header by casting to varattrib_4b and loading a
+ * uint32, which is undefined behaviour on an unaligned address: it happens to
+ * work on x86_64 and is a SIGBUS on a strict-alignment target, which
+ * docs/limitations.md promises to support.
+ *
+ * This is not a crafted-input problem. An ordinary INSERT of low-cardinality
+ * text reports it six times under UBSAN, because encode_dict walks exactly such
+ * a buffer. It was found by the #214 fuzzer only in the sense that the fuzzer is
+ * why there was a sanitizer build to see it with.
+ *
+ * A one-byte header carries its length in the first byte, so it needs no
+ * alignment and goes through the ordinary macro.
+ *
+ * The four-byte case decodes the copied header itself rather than handing an
+ * aligned local back to VARSIZE_4B. That was the first attempt and it is also
+ * undefined: VARSIZE_4B casts its argument to varattrib_4b, and a uint32 local
+ * is not large enough for that type, which UBSAN reports as "insufficient space
+ * for an object of type 'varattrib_4b'". Trading an alignment fault for a
+ * type-size fault is not a fix. The shift and mask below mirror varatt.h
+ * exactly, including its endianness split, which is the only part worth
+ * duplicating.
+ */
+static inline uint32
+ColumnarVarSizeAnyUnaligned(const char *p)
+{
+	uint32		hdr;
+
+	if (VARATT_IS_1B(p) || VARATT_IS_1B_E(p))
+		return (uint32) VARSIZE_ANY(p);
+
+	memcpy(&hdr, p, sizeof(hdr));
+#ifdef WORDS_BIGENDIAN
+	return hdr & 0x3FFFFFFF;
+#else
+	return (hdr >> 2) & 0x3FFFFFFF;
+#endif
+}
+
 #endif							/* PGCOLUMNAR_H */

--- a/src/columnar_encoding.c
+++ b/src/columnar_encoding.c
@@ -1132,7 +1132,8 @@ encode_dict(const char *raw, uint32 rawLen, Form_pg_attribute att, uint32 n,
 	for (i = 0; i < n; i++)
 	{
 		const char *vp = raw + pos;
-		uint32		vlen = (w > 0) ? (uint32) w : (uint32) VARSIZE_ANY(vp);
+		uint32		vlen = (w > 0) ? (uint32) w
+			: ColumnarVarSizeAnyUnaligned(vp);
 		int			code = -1;
 
 		for (j = 0; j < nd; j++)

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -258,7 +258,7 @@ ColumnarDecodeValue(Form_pg_attribute att, char **cursor,
 	}
 	else
 	{
-		Size		len = VARSIZE_ANY(p);
+		Size		len = ColumnarVarSizeAnyUnaligned(p);
 		char	   *copy = MemoryContextAlloc(targetContext, len);
 
 		memcpy(copy, p, len);
@@ -1532,7 +1532,7 @@ columnar_build_val_offsets(Form_pg_attribute att, char *rawBuf, uint32 nvalues)
 	for (k = 0; k < nvalues; k++)
 	{
 		offsets[k] = (uint32) (cursor - rawBuf);
-		cursor += VARSIZE_ANY(cursor);
+		cursor += ColumnarVarSizeAnyUnaligned(cursor);
 
 		/*
 		 * A chunk holds as many values as chunk_group_row_limit allows, which is

--- a/test/fuzz_parquet.sh
+++ b/test/fuzz_parquet.sh
@@ -28,9 +28,10 @@
 # a description of one.
 #
 # Usage:  test/fuzz_parquet.sh [PG_CONFIG]
-#   PGC_SEED=<int>   base seed (default 20260728)
-#   PGC_ITERS=<int>  mutants to run (default 300)
-#   PGC_FUZZ_KEEP=1  keep the corpus and every mutant, not only findings
+#   PGC_SEED=<int>            base seed (default 20260728)
+#   PGC_ITERS=<int>           mutants to run (default 100)
+#   PGC_FUZZ_KEEP=1           keep every mutant, not only the findings
+#   PGC_FUZZ_FINDINGS=<dir>   save findings outside the workdir, for campaigns
 #
 # Written fresh for pgColumnar.
 
@@ -51,8 +52,13 @@ SEED="${PGC_SEED:-20260728}"
 ITERS="${PGC_ITERS:-100}"
 PGC_FUZZ_KEEP="${PGC_FUZZ_KEEP:-0}"
 CORPUS="$PGC_WORKDIR/corpus"
-FINDINGS="$PGC_WORKDIR/findings"
+# Findings default into the workdir, which teardown removes. That is fine for the
+# gate, where the console output is the result, and useless for a campaign, where
+# the saved mutant and the full server-log excerpt are the whole point. Point
+# PGC_FUZZ_FINDINGS somewhere durable when running one.
+FINDINGS="${PGC_FUZZ_FINDINGS:-$PGC_WORKDIR/findings}"
 MUT="$PGC_WORKDIR/mutant.parquet"
+NEWLOG="$PGC_WORKDIR/newlog.txt"
 mkdir -p "$CORPUS" "$FINDINGS"
 chmod 777 "$CORPUS" "$FINDINGS"
 
@@ -107,11 +113,24 @@ sanitizer=0
 errors=0
 clean=0
 
+# Writes everything appended since the last call into $NEWLOG, and advances
+# LOGPOS.
+#
+# It writes to a file and is called as a plain command rather than returning the
+# text through $( ), because command substitution runs in a subshell and the
+# LOGPOS assignment there is discarded. That version looked like it worked and
+# did not: LOGPOS stayed 0, every call re-read the log from byte zero, and one
+# matching line anywhere in it was then re-reported against every later mutant.
+# A 500-mutant run produced 257 "findings" that were all the same five lines from
+# the first second of the run, with the seed number being the only thing that
+# differed. Attribution is the whole value of reading the log incrementally.
 log_since() {
 	local sz
 	sz=$(stat -c %s "$PGC_LOGFILE" 2>/dev/null || echo 0)
 	if [ "$sz" -gt "$LOGPOS" ]; then
-		tail -c +$((LOGPOS + 1)) "$PGC_LOGFILE" 2>/dev/null
+		tail -c +$((LOGPOS + 1)) "$PGC_LOGFILE" > "$NEWLOG" 2>/dev/null
+	else
+		: > "$NEWLOG"
 	fi
 	LOGPOS="$sz"
 }
@@ -166,6 +185,7 @@ run_stmt() {
 	# accepted. The suite reported three green checks over a run in which nothing
 	# was ever parsed. That is what the corpus check below exists to catch, and it
 	# is the only reason this was noticed.
+	log_since
 	out="$(timeout 30 env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" \
 		-U postgres -d "$PGC_DB" -v ON_ERROR_STOP=0 \
 		-c "SET statement_timeout = '20s'; $stmt" 2>&1)"
@@ -179,7 +199,8 @@ run_stmt() {
 			return 1
 		fi
 	fi
-	newlog="$(log_since)"
+	log_since
+	newlog="$(cat "$NEWLOG" 2>/dev/null)"
 
 	# A sanitizer report is a finding even when the statement then succeeds.
 	if echo "$newlog" | grep -qE 'AddressSanitizer|runtime error:|UndefinedBehaviorSanitizer|LeakSanitizer'; then
@@ -227,7 +248,7 @@ run_stmt() {
 }
 
 # Prime the log offset so seed setup above is not attributed to mutant 1.
-log_since >/dev/null
+log_since
 
 psql_run "DROP TABLE IF EXISTS fz_target;" >/dev/null 2>&1
 

--- a/test/fuzz_parquet.sh
+++ b/test/fuzz_parquet.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+#
+# pgColumnar Parquet decode fuzzer (issue #214).
+#
+# test/fuzz.sh is a differential suite over data SHAPES with heap as the oracle:
+# it never presents a malformed byte to a decoder. This one is the other half.
+# It mutates valid Parquet files and feeds them to every entry point that parses
+# one, and asserts a single property:
+#
+#     a malformed file makes the backend raise an ERROR, never die.
+#
+# That is the property #210 broke. A crafted footer reached unbounded recursion
+# in ColumnarThriftSkip, and a crafted schema chain reached a second one in
+# walk_schema, either of which takes down the whole cluster rather than the
+# session. Both were found by reading code. This suite is the machine that was
+# missing.
+#
+# Anything that is not a clean ERROR is a finding, and there are three kinds:
+#   crash   the backend died (signal, or the connection dropped)
+#   san     a sanitizer reported (only on a sanitizer build)
+#   hang    the statement outlived its timeout
+# A hang is a finding in its own right and not a nuisance: an unkillable decode
+# loop is #212's shape, and the only way out of one today is kill -9.
+#
+# Every mutant is a pure function of (seed file, seed integer), so a finding
+# reproduces exactly. Findings are saved with the two values that regenerate
+# them, and the file itself is kept because a minimized repro is worth more than
+# a description of one.
+#
+# Usage:  test/fuzz_parquet.sh [PG_CONFIG]
+#   PGC_SEED=<int>   base seed (default 20260728)
+#   PGC_ITERS=<int>  mutants to run (default 300)
+#   PGC_FUZZ_KEEP=1  keep the corpus and every mutant, not only findings
+#
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+if ! python3 -c 'import pyarrow.parquet' 2>/dev/null; then
+	echo "SKIP  pyarrow not available; the Parquet fuzzer needs it to build seeds"
+	pgc_summary
+fi
+
+SEED="${PGC_SEED:-20260728}"
+# 100 in the gate, which is roughly a minute and a half. The gate's job is to
+# catch a regression that makes malformed input fatal again; the search for new
+# defects is a campaign, run with PGC_ITERS in the thousands outside CI.
+ITERS="${PGC_ITERS:-100}"
+PGC_FUZZ_KEEP="${PGC_FUZZ_KEEP:-0}"
+CORPUS="$PGC_WORKDIR/corpus"
+FINDINGS="$PGC_WORKDIR/findings"
+MUT="$PGC_WORKDIR/mutant.parquet"
+mkdir -p "$CORPUS" "$FINDINGS"
+chmod 777 "$CORPUS" "$FINDINGS"
+
+echo "-- seed=$SEED iters=$ITERS"
+echo "-- corpus: $CORPUS"
+
+# ---------------------------------------------------------------------------
+# Seeds. Every one is valid; see test/parquet_corpus.py for why that matters.
+# ---------------------------------------------------------------------------
+mapfile -t SEEDLINES < <(python3 "$PGC_SRCDIR/test/parquet_corpus.py" "$CORPUS" 2>/dev/null)
+if [ "${#SEEDLINES[@]}" -eq 0 ]; then
+	echo "FAIL  the corpus generator produced no files"
+	PGC_FAIL=1
+	pgc_summary
+fi
+echo "-- ${#SEEDLINES[@]} seed files"
+
+# The column definition list read_parquet requires, derived from each pristine
+# seed rather than hard-coded, so adding a seed needs no change here. A seed
+# whose schema will not render is dropped: it would only ever exercise the
+# argument check.
+declare -a SEEDPATH SEEDCOLS
+for line in "${SEEDLINES[@]}"; do
+	p="${line##* }"
+	cols="$(q "SELECT string_agg(format('%I %s', column_name, data_type), ', ')
+		FROM pgcolumnar.parquet_schema('$p');" 2>/dev/null)"
+	[ -z "$cols" ] && continue
+	SEEDPATH+=("$p")
+	SEEDCOLS+=("$cols")
+done
+echo "-- ${#SEEDPATH[@]} seeds with a usable column list"
+
+if [ "${#SEEDPATH[@]}" -eq 0 ]; then
+	echo "FAIL  no seed produced a readable schema; the reader rejects its own corpus"
+	PGC_FAIL=1
+	pgc_summary
+fi
+
+# ---------------------------------------------------------------------------
+# Crash detection.
+#
+# Judged from the server log rather than from psql's message, because a backend
+# that dies takes the connection with it and psql then reports the symptom
+# rather than the cause. The log is read incrementally from a byte offset, so a
+# finding is attributed to the mutant that produced it and not to every mutant
+# after it.
+# ---------------------------------------------------------------------------
+LOGPOS=0
+crashes=0
+hangs=0
+sanitizer=0
+errors=0
+clean=0
+
+log_since() {
+	local sz
+	sz=$(stat -c %s "$PGC_LOGFILE" 2>/dev/null || echo 0)
+	if [ "$sz" -gt "$LOGPOS" ]; then
+		tail -c +$((LOGPOS + 1)) "$PGC_LOGFILE" 2>/dev/null
+	fi
+	LOGPOS="$sz"
+}
+
+wait_for_cluster() {
+	local i
+	for i in $(seq 1 60); do
+		if env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" \
+			-U postgres -d "$PGC_DB" -Atc "SELECT 1" >/dev/null 2>&1; then
+			return 0
+		fi
+		sleep 0.5
+	done
+	return 1
+}
+
+save_finding() {
+	local kind="$1" seedfile="$2" mutseed="$3" stmt="$4" detail="$5"
+	local dir="$FINDINGS/${kind}-${mutseed}"
+	mkdir -p "$dir"
+	cp "$MUT" "$dir/mutant.parquet" 2>/dev/null
+	# The repro is written against a REGENERATED corpus, not against this run's
+	# workdir. The workdir is removed by teardown, so a finding in the matrix
+	# would otherwise print a path that no longer exists by the time anyone reads
+	# it. The corpus generator is deterministic, so the seed's basename is a
+	# stable name for the same bytes.
+	{
+		echo "kind:      $kind"
+		echo "seed file: $(basename "$seedfile")"
+		echo "seed:      $mutseed"
+		echo "statement: $stmt"
+		echo "reproduce:"
+		echo "    python3 test/parquet_corpus.py /tmp/corpus"
+		echo "    python3 test/parquet_mutate.py /tmp/corpus/$(basename "$seedfile") $mutseed /tmp/repro.parquet"
+		echo "    then run the statement above against /tmp/repro.parquet"
+		echo "--- detail ---"
+		echo "$detail"
+	} > "$dir/README"
+	echo "  FINDING [$kind] seed=$mutseed from $(basename "$seedfile")"
+	echo "$detail" | head -5 | sed 's/^/      /'
+}
+
+# Runs one statement against one mutant and classifies the outcome.
+# Returns 0 when the outcome is acceptable (success or a clean ERROR).
+run_stmt() {
+	local stmt="$1" seedfile="$2" mutseed="$3"
+	local out rc newlog
+
+	# Connects exactly as lib.sh does. An earlier version used -h "$PGC_WORKDIR",
+	# and the socket is not there: every statement failed to connect, the message
+	# was neither an ERROR nor a known crash string, and all 180 were counted as
+	# accepted. The suite reported three green checks over a run in which nothing
+	# was ever parsed. That is what the corpus check below exists to catch, and it
+	# is the only reason this was noticed.
+	out="$(timeout 30 env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" \
+		-U postgres -d "$PGC_DB" -v ON_ERROR_STOP=0 \
+		-c "SET statement_timeout = '20s'; $stmt" 2>&1)"
+	rc=$?
+
+	# Never let a connection failure be read as a clean result again.
+	if echo "$out" | grep -qE 'could not connect|No such file or directory|Connection refused' &&
+	   ! echo "$out" | grep -q '^ERROR:'; then
+		if ! wait_for_cluster; then
+			echo "  FATAL: cluster unreachable and did not return"
+			return 1
+		fi
+	fi
+	newlog="$(log_since)"
+
+	# A sanitizer report is a finding even when the statement then succeeds.
+	if echo "$newlog" | grep -qE 'AddressSanitizer|runtime error:|UndefinedBehaviorSanitizer|LeakSanitizer'; then
+		sanitizer=$((sanitizer + 1))
+		save_finding san "$seedfile" "$mutseed" "$stmt" "$newlog"
+		wait_for_cluster || return 1
+		return 1
+	fi
+
+	if echo "$newlog" | grep -qE 'was terminated by signal|server process .* exited with|crashed'; then
+		crashes=$((crashes + 1))
+		save_finding crash "$seedfile" "$mutseed" "$stmt" "$newlog"
+		wait_for_cluster || echo "  (cluster did not come back)"
+		return 1
+	fi
+
+	if [ "$rc" = 124 ]; then
+		hangs=$((hangs + 1))
+		save_finding hang "$seedfile" "$mutseed" "$stmt" "psql wall-clock timeout (30s)"
+		wait_for_cluster
+		return 1
+	fi
+
+	# statement_timeout firing is a hang too: the decode did not finish in 20s
+	# on a file that is at most a few hundred kilobytes.
+	if echo "$out" | grep -q 'canceling statement due to statement timeout'; then
+		hangs=$((hangs + 1))
+		save_finding hang "$seedfile" "$mutseed" "$stmt" "$out"
+		return 1
+	fi
+
+	if echo "$out" | grep -qE 'server closed the connection unexpectedly|connection to server was lost|terminating connection'; then
+		crashes=$((crashes + 1))
+		save_finding crash "$seedfile" "$mutseed" "$stmt" "$out"
+		wait_for_cluster || echo "  (cluster did not come back)"
+		return 1
+	fi
+
+	if echo "$out" | grep -q '^ERROR:'; then
+		errors=$((errors + 1))
+	else
+		clean=$((clean + 1))
+	fi
+	return 0
+}
+
+# Prime the log offset so seed setup above is not attributed to mutant 1.
+log_since >/dev/null
+
+psql_run "DROP TABLE IF EXISTS fz_target;" >/dev/null 2>&1
+
+echo "-- fuzzing"
+nseeds="${#SEEDPATH[@]}"
+for ((i = 0; i < ITERS; i++)); do
+	idx=$((i % nseeds))
+	sf="${SEEDPATH[$idx]}"
+	cols="${SEEDCOLS[$idx]}"
+	ms=$((SEED + i))
+
+	python3 "$PGC_SRCDIR/test/parquet_mutate.py" "$sf" "$ms" "$MUT" 2>/dev/null || continue
+	chmod 644 "$MUT" 2>/dev/null
+
+	run_stmt "SELECT * FROM pgcolumnar.parquet_schema('$MUT');" "$sf" "$ms"
+	run_stmt "SELECT count(*) FROM pgcolumnar.read_parquet('$MUT') AS t($cols);" "$sf" "$ms"
+
+	# import_parquet writes, so it reaches the insert path as well as the decoder.
+	psql_run "DROP TABLE IF EXISTS fz_target; CREATE TABLE fz_target ($cols) USING pgcolumnar;" \
+		>/dev/null 2>&1
+	run_stmt "SELECT pgcolumnar.import_parquet('fz_target', '$MUT');" "$sf" "$ms"
+
+	if [ "$PGC_FUZZ_KEEP" = 1 ]; then
+		cp "$MUT" "$PGC_WORKDIR/kept-$ms.parquet" 2>/dev/null
+	fi
+
+	if [ $((i % 50)) = 49 ]; then
+		echo "  $((i + 1))/$ITERS  errors=$errors clean=$clean crashes=$crashes hangs=$hangs san=$sanitizer"
+	fi
+done
+
+echo "-- done: $ITERS mutants, ${errors} rejected with ERROR, ${clean} accepted"
+
+# The suite asserts the property, not the counts. A mutant that is accepted is
+# not a failure: a bit flip inside a page payload produces a different value,
+# not an invalid file.
+check "no mutant crashed the backend" "$crashes" "0"
+check "no mutant hung the decode" "$hangs" "0"
+check "no mutant tripped a sanitizer" "$sanitizer" "0"
+
+# A corpus that is rejected outright teaches nothing, and would make the three
+# checks above pass for the wrong reason. At least some mutants must have got
+# far enough to be parsed and refused on their merits.
+check "the corpus reached the decoder at all" \
+	"$([ "$errors" -gt 0 ] && echo yes || echo "no (errors=$errors clean=$clean)")" \
+	"yes"
+
+if [ "$crashes" != 0 ] || [ "$hangs" != 0 ] || [ "$sanitizer" != 0 ]; then
+	echo "-- findings kept in $FINDINGS"
+	ls -1 "$FINDINGS"
+fi
+
+pgc_summary

--- a/test/parquet_corpus.py
+++ b/test/parquet_corpus.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+#
+# Seed corpus for the Parquet decode fuzzer (test/fuzz_parquet.sh, issue #214).
+#
+# Every file here is VALID. The fuzzer mutates copies of them; a seed that is
+# already malformed teaches the mutator nothing, because the reader rejects it
+# at the first check and never reaches the code under test.
+#
+# The corpus aims at breadth of decoder state rather than volume: each physical
+# type, each encoding the writer will choose, each supported codec, nesting, and
+# the multi-file and partitioned layouts. A mutation is only as interesting as
+# the path the surrounding bytes reach.
+#
+# Usage:  python3 test/parquet_corpus.py OUTDIR
+# Writes OUTDIR/<name>.parquet and prints one "<name> <path>" line per file.
+#
+import os
+import sys
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+
+def w(outdir, name, table, **kw):
+    """Write one seed and report it. Codec failures are skipped, not fatal:
+    the reader's codec support and this pyarrow's may differ, and a codec we
+    cannot write is one we do not need a seed for."""
+    path = os.path.join(outdir, name + ".parquet")
+    try:
+        pq.write_table(table, path, **kw)
+    except Exception as e:              # noqa: BLE001 - report and continue
+        print("SKIP %s (%s)" % (name, type(e).__name__), file=sys.stderr)
+        return
+    print("%s %s" % (name, path))
+
+
+def main():
+    outdir = sys.argv[1]
+    os.makedirs(outdir, exist_ok=True)
+
+    n = 200
+
+    # --- one file per physical/logical type, so a mutation lands in a decoder
+    # that is actually reached rather than in a type the file never uses.
+    w(outdir, "int32", pa.table({"a": pa.array(range(n), pa.int32())}))
+    w(outdir, "int64", pa.table({"a": pa.array(range(n), pa.int64())}))
+    w(outdir, "int16", pa.table({"a": pa.array(range(n), pa.int16())}))
+    w(outdir, "float", pa.table({"a": pa.array([i * 0.5 for i in range(n)], pa.float32())}))
+    w(outdir, "double", pa.table({"a": pa.array([i * 0.25 for i in range(n)], pa.float64())}))
+    w(outdir, "bool", pa.table({"a": pa.array([i % 2 == 0 for i in range(n)], pa.bool_())}))
+    w(outdir, "string", pa.table({"a": pa.array(["v%d" % i for i in range(n)])}))
+    w(outdir, "binary", pa.table({"a": pa.array([b"\x00\x01%d" % i for i in range(n)], pa.binary())}))
+    w(outdir, "date32", pa.table({"a": pa.array([18000 + i for i in range(n)], pa.date32())}))
+    w(outdir, "ts_us", pa.table({"a": pa.array([1600000000000000 + i for i in range(n)],
+                                               pa.timestamp("us"))}))
+    w(outdir, "ts_tz", pa.table({"a": pa.array([1600000000000000 + i for i in range(n)],
+                                               pa.timestamp("us", tz="UTC"))}))
+    w(outdir, "time64", pa.table({"a": pa.array([i * 1000 for i in range(n)], pa.time64("us"))}))
+    w(outdir, "decimal", pa.table({"a": pa.array([i for i in range(n)], pa.decimal128(18, 4))}))
+
+    # FLBA has its own width handling in the reader and its own bounds.
+    w(outdir, "flba", pa.table({"a": pa.array([b"%04d" % i for i in range(n)],
+                                              pa.binary(4))}))
+
+    # --- null shapes: the definition-level decoder is a separate path.
+    w(outdir, "nulls_some", pa.table({"a": pa.array(
+        [None if i % 3 == 0 else i for i in range(n)], pa.int32())}))
+    w(outdir, "nulls_all", pa.table({"a": pa.array([None] * n, pa.int32())}))
+
+    # --- low cardinality forces dictionary encoding; high entropy forces plain.
+    w(outdir, "dict_text", pa.table({"a": pa.array(["k%d" % (i % 4) for i in range(n)])}))
+    w(outdir, "plain_text", pa.table({"a": pa.array(
+        ["%064x" % (i * 2654435761) for i in range(n)])}), use_dictionary=False)
+
+    # --- nesting: struct and list drive repetition levels and the schema walk,
+    # which is where the second #210 recursion lived.
+    w(outdir, "struct", pa.table({"a": pa.array(
+        [{"x": i, "y": "s%d" % i} for i in range(n)],
+        pa.struct([("x", pa.int32()), ("y", pa.string())]))}))
+    w(outdir, "list", pa.table({"a": pa.array(
+        [[i, i + 1] for i in range(n)], pa.list_(pa.int32()))}))
+    w(outdir, "list_nested", pa.table({"a": pa.array(
+        [[[i], [i + 1]] for i in range(n)], pa.list_(pa.list_(pa.int32())))}))
+    w(outdir, "struct_deep", pa.table({"a": pa.array(
+        [{"b": {"c": {"d": i}}} for i in range(n)],
+        pa.struct([("b", pa.struct([("c", pa.struct([("d", pa.int32())]))]))]))}))
+
+    # --- codecs: each has its own page-decompression path and its own way to
+    # disagree with the declared uncompressed size.
+    wide = pa.table({"a": pa.array(range(n), pa.int32()),
+                     "b": pa.array(["p%d" % (i % 17) for i in range(n)])})
+    for codec in ("snappy", "gzip", "zstd", "lz4", "brotli", "none"):
+        w(outdir, "codec_" + codec, wide, compression=codec)
+
+    # --- multi-row-group and multi-page, so offsets and counts have to agree
+    # across more than one of each.
+    big = pa.table({"a": pa.array(range(20000), pa.int32()),
+                    "b": pa.array(["r%d" % (i % 91) for i in range(20000)])})
+    w(outdir, "rowgroups", big, row_group_size=1000)
+    w(outdir, "pages", big, data_page_size=1024, row_group_size=20000)
+
+    # --- v2 data pages take a different header union member entirely.
+    w(outdir, "pagev2", wide, data_page_version="2.0")
+
+    # --- wide schema: the leaf-count bound and the column-chunk list length are
+    # indexed against each other.
+    w(outdir, "wide64", pa.table(
+        {("c%d" % c): pa.array(range(50), pa.int32()) for c in range(64)}))
+
+    # --- an empty file still has a footer and a schema to walk.
+    w(outdir, "empty", pa.table({"a": pa.array([], pa.int32())}))
+
+
+if __name__ == "__main__":
+    main()

--- a/test/parquet_mutate.py
+++ b/test/parquet_mutate.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+#
+# Deterministic byte-level mutator for the Parquet decode fuzzer (issue #214).
+#
+# Every mutant is a pure function of (seed file, seed integer), so a crash
+# reproduces exactly from the two values printed with it. Nothing here is
+# random at run time.
+#
+# The mutation set is chosen for what a hand-written Thrift and Parquet reader
+# gets wrong, not for uniform coverage of the byte space. A flat bit-flipper
+# spends nearly all of its budget inside page payloads, where the worst outcome
+# is a wrong value; the interesting failures are in the footer, the schema
+# chain, and any field the reader trusts as a length, a count, or an offset.
+#
+# Usage:  python3 test/parquet_mutate.py SEEDFILE SEED OUTFILE
+#
+import os
+import random
+import struct
+import sys
+
+# Values that break arithmetic on a field the reader treats as a size or a
+# count: zero, the negatives, the signed and unsigned ceilings, and the ones
+# that overflow a 32-bit multiply by a small element width.
+EXTREMES = [
+    0, 1, -1, 2, -2,
+    0x7F, 0x80, 0xFF,
+    0x7FFF, 0x8000, 0xFFFF,
+    0x7FFFFFFF, 0x80000000, 0xFFFFFFFF,
+    0x40000000, 0x20000000, 0x10000000,
+]
+
+
+def _flip_bits(b, rnd):
+    """Classic bit flips. Cheap, and the only mutation that reaches deep into a
+    compressed page where structure is opaque to us."""
+    n = rnd.randint(1, 16)
+    for _ in range(n):
+        i = rnd.randrange(len(b))
+        b[i] ^= 1 << rnd.randrange(8)
+
+
+def _extreme_int(b, rnd):
+    """Overwrite a 4- or 8-byte little-endian window with a boundary value.
+    Thrift varints are not aligned, so this is scattershot by design: it hits
+    plain-encoded lengths, page header fields and offsets alike."""
+    width = rnd.choice((4, 4, 4, 8))
+    if len(b) < width:
+        return
+    i = rnd.randrange(len(b) - width + 1)
+    v = rnd.choice(EXTREMES)
+    b[i:i + width] = struct.pack("<q" if width == 8 else "<i",
+                                 v if v < 0x80000000 or width == 8 else v - 0x100000000)
+
+
+def _varint_extreme(b, rnd):
+    """Thrift compact protocol encodes lengths and list sizes as varints, so a
+    boundary value has to be written as a varint to be read as one. Writes a
+    5-byte varint in place, which is what a large count looks like on the wire.
+
+    This is the mutation that reaches list and element counts, and therefore the
+    #210 class: a schema child count is a varint the reader trusts."""
+    if len(b) < 5:
+        return
+    i = rnd.randrange(len(b) - 5 + 1)
+    v = rnd.choice([0x7FFFFFFF, 0xFFFFFFF, 0x1FFFFF, 0xFFFF, 0x7FFF, 0x3FFF])
+    out = bytearray()
+    while True:
+        byte = v & 0x7F
+        v >>= 7
+        if v:
+            out.append(byte | 0x80)
+        else:
+            out.append(byte)
+            break
+    out = (out + bytearray(b"\x00" * 5))[:5]
+    b[i:i + 5] = out
+
+
+def _truncate(b, rnd):
+    """A short read is the commonest malformed file in the wild, and every
+    bound in the reader has to hold when the bytes simply stop."""
+    if len(b) < 16:
+        return
+    keep = rnd.randrange(4, len(b))
+    del b[keep:]
+
+
+def _footer_len(b, rnd):
+    """The last 8 bytes are the 4-byte footer length and the PAR1 magic. The
+    reader seeks backwards by that length, so it is the single field with the
+    most leverage over where parsing starts."""
+    if len(b) < 8:
+        return
+    v = rnd.choice(EXTREMES + [len(b), len(b) - 8, len(b) * 2])
+    b[len(b) - 8:len(b) - 4] = struct.pack("<I", v & 0xFFFFFFFF)
+
+
+def _magic(b, rnd):
+    """Head or tail magic. Cheap, and it proves the reader checks both rather
+    than trusting the file because one end looked right."""
+    if len(b) < 8:
+        return
+    if rnd.random() < 0.5:
+        b[0:4] = bytes(rnd.randrange(256) for _ in range(4))
+    else:
+        b[len(b) - 4:] = bytes(rnd.randrange(256) for _ in range(4))
+
+
+def _splice(b, rnd):
+    """Duplicate a byte range in place. In a Thrift struct chain this can repeat
+    a nesting construct, which is how a deep schema arises from a shallow seed
+    without hand-building one."""
+    if len(b) < 32:
+        return
+    start = rnd.randrange(len(b) - 16)
+    end = min(len(b), start + rnd.randrange(4, 256))
+    chunk = bytes(b[start:end])
+    reps = rnd.choice((2, 4, 8, 32, 128))
+    at = rnd.randrange(len(b))
+    b[at:at] = chunk * reps
+    del b[64 * 1024 * 1024:]        # keep a runaway splice from eating the box
+
+
+def _delete(b, rnd):
+    """Remove a run, shifting every later offset. Offsets stored in the footer
+    then point into the wrong place, which is the bounds case that a pure
+    overwrite mutation never produces."""
+    if len(b) < 64:
+        return
+    start = rnd.randrange(len(b) - 32)
+    end = min(len(b), start + rnd.randrange(1, 64))
+    del b[start:end]
+
+
+def _deep_nest(b, rnd):
+    """Replace the footer with a chain of nested Thrift structs.
+
+    This one is not a random mutation and is not meant to be. Byte-level
+    mutation of a shallow file effectively never produces deep nesting: 250
+    mutants against a build with both #210 guards deliberately removed produced
+    no crash at all, because the depth needed to exhaust the stack does not
+    arise by chance from flipping bits in a 1.5 kB file. The bug class that
+    motivated this whole suite was invisible to it.
+
+    Thrift compact encodes a field header as (delta << 4) | type, and type 0x0C
+    is a struct, so 0x1C opens a nested struct with field delta 1. A run of them
+    is a nesting chain of exactly that length, and skipping an unknown struct
+    recurses once per level.
+
+    The file is rebuilt rather than patched: header magic, the chain as the
+    entire footer, the footer length, and the trailing magic, which is the
+    smallest thing the reader will accept as far as the footer parse.
+    """
+    depth = rnd.choice((1000, 10000, 100000, 400000, 1000000))
+    chain = b"\x1c" * depth
+    out = bytearray(b"PAR1")
+    out += chain
+    out += struct.pack("<I", len(chain))
+    out += b"PAR1"
+    b[:] = out
+
+
+def _deep_schema(b, rnd):
+    """The same idea aimed at the second #210 vector.
+
+    `walk_schema` recurses on num_children read from the footer, and it runs
+    only after the footer parses, so a chain that dies in the footer parse never
+    reaches it. This builds a list-typed field whose elements are structs,
+    nested repeatedly, so the parse has to descend a schema chain rather than
+    skip an unknown one.
+    """
+    depth = rnd.choice((5000, 50000, 200000))
+    # field 1, type struct, repeated: each level re-opens field 1 of its parent.
+    unit = b"\x1c"
+    out = bytearray(b"PAR1")
+    body = unit * depth + b"\x00" * min(depth, 4096)
+    out += body
+    out += struct.pack("<I", len(body))
+    out += b"PAR1"
+    b[:] = out
+
+
+MUTATIONS = [
+    (_flip_bits, 3),
+    (_extreme_int, 4),
+    (_varint_extreme, 4),
+    (_truncate, 2),
+    (_footer_len, 3),
+    (_magic, 1),
+    (_splice, 3),
+    (_delete, 2),
+    (_deep_nest, 2),
+    (_deep_schema, 2),
+]
+
+
+def mutate(data, seed):
+    rnd = random.Random(seed)
+    b = bytearray(data)
+    pool = []
+    for fn, weight in MUTATIONS:
+        pool.extend([fn] * weight)
+    for _ in range(rnd.randint(1, 3)):
+        rnd.choice(pool)(b, rnd)
+    return bytes(b)
+
+
+def main():
+    src, seed, dst = sys.argv[1], int(sys.argv[2]), sys.argv[3]
+    with open(src, "rb") as f:
+        data = f.read()
+    out = mutate(data, seed)
+    with open(dst, "wb") as f:
+        f.write(out)
+    os.chmod(dst, 0o644)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -90,7 +90,7 @@ trap - EXIT
 
 SRCDIR="${PGC_RUN_SRCDIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 SUITES=(harness_selftest smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
-	differential recovery fuzz hardening concurrent_diff parallel sorted_projection \
+	differential recovery fuzz fuzz_parquet hardening concurrent_diff parallel sorted_projection \
 	arrow_export parquet_export read_stream corruption \
 	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap write_minmax_fastpath write_fsst_compressed encode_effort native_skip pushdown_report native_agg native_agg_deletes native_agg_addcolumn native_bloom bloom_setting native_vecskip native_index native_fetch_position native_dml alter_column_type native_ios native_projection native_cluster native_compact native_recluster native_reclaim native_ownership drop_cleanup native_reclaim_cycles native_reclaim_frag native_reclaim_reconcile native_gap native_truncate native_rewrite native_rewrite_conc rewrite_group_scan native_parquet_schema native_read_parquet native_parquet_fdw native_parquet_pushdown native_parquet_hardening native_parquet_stack native_parquet_units native_parquet_flba native_parquet_codecs native_parquet_projection native_parquet_multifile native_parquet_streaming native_parquet_partition native_cancel wal_envelope decode_interrupts import_exclusion import_deferred fk_referencing row_triggers native_lazy_slot native_fetch_cache native_fetch_interrupt analyze_stats analyze_reltuples native_fetch_projection isolation)
 


### PR DESCRIPTION
Stage A of #214, plus the bug it found on its first instrumented run.

## The fuzzer

`test/fuzz.sh` is a differential suite over data *shapes* with heap as the
oracle; it never presents a malformed byte to a decoder. Nothing in this tree
did. `grep -rniE 'LLVMFuzzer|afl-|libfuzzer|-fsanitize=fuzzer'` returned nothing,
and coverage of malformed input was one hand-written case per known defect. #210
was found by reading code and grepping for an absent guard, which is what a
missing machine looks like.

Three files: a valid seed corpus (33 files: every physical type, null shapes,
dictionary and plain, nesting, six codecs, multi-row-group, multi-page, v2 pages,
64-column, empty), a deterministic mutator, and a driver that runs every entry
point that parses a Parquet file and asserts one property -- **a malformed file
raises an ERROR, it never kills the backend**. Crashes, hangs and sanitizer
reports are all findings; a hang counts because an unkillable decode loop is
#212's shape.

Gate cost is 100 mutants, about ninety seconds. Campaigns run with `PGC_ITERS` in
the thousands outside CI.

## The defect it found, which is not a fuzzing defect

```
src/columnar_encoding.c:1135:50: runtime error: load of misaligned address
0x75064ac5813e for type 'uint32', which requires 4 byte alignment
```

Values in a chunk's raw buffer are packed end to end with no alignment padding,
so a four-byte varlena header starts wherever the previous value ended.
`VARSIZE_ANY` reads it by casting to `varattrib_4b` and loading a `uint32`.
Undefined on an unaligned address, fine on x86_64, **SIGBUS on a
strict-alignment target** -- which `docs/limitations.md` promises to support.

I checked whether it needed crafted input. It does not: an ordinary

```sql
INSERT INTO t SELECT 'label' || (i % 5) FROM generate_series(1,5000) i;
```

reports it **six times**. It has been on the plain write path all along. Three
call sites were affected -- `encode_dict`, and the value copy and offset builder
in `columnar_reader.c` -- and all three now go through one helper.

**The first version of that helper was also wrong**, which is worth recording. It
copied the header into a `uint32` local and handed it to `VARSIZE_4B`, which
casts to `varattrib_4b`, a type a four-byte local is too small for. Six reports
became **two**, not zero, reported as "insufficient space for an object of type
'varattrib_4b'". Trading an alignment fault for a type-size fault is not a fix.
The helper now decodes the copied header itself, mirroring `varatt.h` including
its endianness split.

## Three defects in the fuzzer's own harness

All found by using it, all recorded in the files, because each one made it report
green or report nonsense:

1. **The first run reported three green checks over a run in which nothing was
   ever parsed.** `run_stmt` connected with `-h "$PGC_WORKDIR"` and the socket is
   in `/tmp`, so all 180 statements failed to connect; a connection failure is
   neither an `ERROR:` nor a known crash string, so every one counted as
   accepted. The only reason this was caught is the fourth check, *the corpus
   must reach the decoder at all*, which exists for exactly this.
2. **`log_since` advanced its offset inside `$( )`**, which runs in a subshell,
   so `LOGPOS` stayed 0 and every call re-read the log from byte zero. One
   matching line was then re-reported against every later mutant: a 500-mutant
   run produced **257 "findings" that were the same five lines** with different
   seed numbers. A real crash would have been attributed to the wrong input,
   which is worse than not finding it.
3. **Findings were written into the workdir teardown removes**, so a campaign
   destroyed its own evidence, and the saved repro cited a path that no longer
   existed. `PGC_FUZZ_FINDINGS` now points somewhere durable and the repro
   regenerates the corpus, which is deterministic.

## Proof, not assertion

**The fuzzer catches the bug class it was built for.** With **both** #210 stack
guards removed from a copy of the tree, the first version found nothing in 250
mutants -- byte mutation of a 1.5 kB file does not produce a Thrift nesting chain
deep enough to exhaust the stack, so it was blind to exactly what motivated it.
Two structural mutations now build the chain directly, and against the same
guard-removed build it finds the crash within a handful of mutants on all three
entry points, while the guarded build rejects the same inputs cleanly. A fuzzer
never shown to catch a known bug has an unknown detection rate.

**The alignment fix closes the finding.** Same seeds, same ASAN campaign:

| | mutants | findings |
| --- | --- | --- |
| before | 500 | 18 (54 reports, one site) |
| after | 500 | **0** |

And the ordinary insert that reported six now reports zero, with dictionary,
plain and long-varlena paths returning correct values (5000 rows / 5 distinct,
5000 distinct, 200 rows over 3000 bytes).

## Gate

- **Full matrix `ALL VERSIONS PASSED`** on 15.18, 16.14, 17.10, 18.4, 19beta2
  with the fix and the new suite in it.
- Assert-build campaign: **8,000 mutants, 24,000 statements**, zero crashes,
  zero hangs.
- ASAN and UBSAN campaign on 18.4: 500 mutants, zero findings after the fix.
- `harness_selftest` green, including *every suite is registered*.

## What this does not cover, filed as #224

The matrix's five majors are all ordinary assert builds, so the sanitizer check
in this suite **passes vacuously there, every time**. Every one of the 92 suites
passed on all five majors both before and after the fix. Nothing in the gate can
see this class of defect, and that is now its own issue with the whole build
recipe worked out.

Closes the stage A half of #214.