### PR TITLE
Reset the dirty-snapshot out-fields so the row-group read can be indexed (#212)

### DIFF
--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -1815,22 +1815,26 @@ ColumnarReadRowGroupList(uint64 storageId, Snapshot snapshot)
 	SysScanDesc scan;
 	HeapTuple	tuple;
 	List	   *result = NIL;
+	Oid			rgIdx = columnar_index_oid("row_group_pkey");
 
 	ScanKeyInit(&key[0], Anum_row_group_storage_id, BTEqualStrategyNumber,
 				F_INT8EQ, Int64GetDatum((int64) storageId));
 	/*
-	 * Deliberately a heap scan, unlike the per-row-group readers below.
-	 * ColumnarReadRowByNumber() calls this from columnar_index_fetch_tuple(),
-	 * which btree calls from _bt_check_unique() while it holds the index page,
-	 * and it passes the synthesized snapshot from ColumnarCatalogSnapshot(): an
-	 * unregistered copy whose curcid is pushed past the current command. An
-	 * index scan under that combination spins rather than returning, and
-	 * _bt_doinsert() retries forever (test/unique_conc.sh scenario 7).
+	 * Index scan on row_group_pkey, so a fetch reads this storage's groups
+	 * rather than a heap scan of every storage's row groups in the database.
 	 *
-	 * This one is also not where the cost is: it runs once per scan rather than
-	 * once per row group, so it is linear in the row-group count either way.
+	 * This read is on the unique-check path: _bt_check_unique() reaches it
+	 * through columnar_index_fetch_tuple() under its own on-stack SnapshotDirty
+	 * and reads xmin/xmax back out afterwards. A bare index scan here once
+	 * spun the check forever (test/unique_conc.sh scenario 7): when this storage
+	 * has nothing flushed the scan matches no rows, HeapTupleSatisfiesDirty()
+	 * never runs, and the uninitialised out-fields are read as a phantom xact to
+	 * wait on. columnar_index_fetch_tuple() now resets those fields before the
+	 * fetch, the way HeapTupleSatisfiesDirty() does for a heap row, so the index
+	 * scan is safe: an in-progress group still sets xmin here and the check waits
+	 * on the real inserter.
 	 */
-	scan = systable_beginscan(rel, InvalidOid, false, snapshot, 1, key);
+	scan = systable_beginscan(rel, rgIdx, OidIsValid(rgIdx), snapshot, 1, key);
 	while (HeapTupleIsValid(tuple = systable_getnext(scan)))
 	{
 		NativeRowGroupMetadata *rg = palloc0(sizeof(NativeRowGroupMetadata));

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -1132,6 +1132,24 @@ columnar_index_fetch_tuple(struct IndexFetchTableData *scan, ItemPointer tid,
 	ExecClearTuple(slot);
 
 	/*
+	 * Honour the dirty-snapshot contract. _bt_check_unique() hands us its own
+	 * on-stack SnapshotDirty and reads xmin/xmax back out afterwards to pick the
+	 * xact to wait on; InitDirtySnapshot() leaves those fields uninitialised, and
+	 * HeapTupleSatisfiesDirty() -- which never runs on a columnar row -- is what
+	 * would reset and then set them for a heap row. Reset them here exactly as it
+	 * does at entry. The catalog read of the row's containing group below runs
+	 * under this same snapshot, so a group still being inserted by another
+	 * transaction sets xmin to that xact and the unique check waits on it; when
+	 * nothing covers the row the fields stay Invalid and the check does not wait
+	 * on stack garbage.
+	 */
+	if (snapshot != NULL && snapshot->snapshot_type == SNAPSHOT_DIRTY)
+	{
+		snapshot->xmin = snapshot->xmax = InvalidTransactionId;
+		snapshot->speculativeToken = 0;
+	}
+
+	/*
 	 * Settle visibility without decoding anything, then hand the slot the row's
 	 * address rather than its values (issue #157). The columns are decoded when
 	 * the executor asks for them, and it asks for the smallest prefix it needs.


### PR DESCRIPTION
The correctness floor for #212, and the cross-storage half of its cost. Full measurement is on the issue; this is the summary.

## What was wrong

`columnar_index_fetch_tuple` is the tableam entry `_bt_check_unique` calls to test a candidate row, exactly where `heapam_index_fetch_tuple` sits for heap. `_bt_check_unique` passes its own on-stack `SnapshotDirty` and reads `xmin/xmax` back out afterward to decide which transaction to wait on. `InitDirtySnapshot` sets only `snapshot_type`; it never initialises `xmin/xmax`. For a heap row `HeapTupleSatisfiesDirty` resets those fields and then sets them, but it never runs on a columnar row, so columnar left the caller reading whatever the catalog reads happened to leave there.

With the row-group read as a forced heap scan this never bit: the scan visited every storage's committed row groups and each visibility check scrubbed the fields to `Invalid`. It was correct by accident, and cost an O(all-storages-in-the-database) scan on every fetch, once per unique candidate. Turn that read into an index scan and the accident goes away: for a storage with nothing flushed the scan matches zero rows, `HeapTupleSatisfiesDirty` never runs, `xmin/xmax` stay uninitialised stack garbage, and `_bt_doinsert` waits on a phantom xact and retries forever (the #212 spin; `unique_conc` scenario 7). gdb confirms it: the waited-on xid differs every run and the backend has no xid of its own.

## The fix

Honour the dirty-snapshot contract in `columnar_index_fetch_tuple`, the same reset `HeapTupleSatisfiesDirty` does at its entry:

```c
if (snapshot != NULL && snapshot->snapshot_type == SNAPSHOT_DIRTY)
{
    snapshot->xmin = snapshot->xmax = InvalidTransactionId;
    snapshot->speculativeToken = 0;
}
```

The catalog read of the row's containing group still runs under this snapshot, so a group being inserted by a live transaction sets `xmin` to that xact and the unique check waits on it; when nothing covers the row the fields stay `Invalid` and the check raises the violation. With the fields owned, `ColumnarReadRowGroupList` becomes an index scan on `row_group_pkey`, so a fetch reads this storage's groups instead of every storage's.

## Why it is safe

`unique_conc` passes end to end with the index scan: scenario 7 no longer spins, and the concurrent waiters (1b, 8) still block and resolve. Reverting only the reset makes scenario 7 hang again, so the suite discriminates the fix. The reset is guarded to `SNAPSHOT_DIRTY`, so MVCC scans are untouched.

## Scope

Correctness floor plus the cross-storage cost. The `(storage_id, first_row_number)` single-group lookup, and the `delete_vector`/`options` reads, are the next step and compose on top of this one -- that is the O(log n)-per-fetch win. Left out here to keep the correctness change reviewable on its own. #212 stays open for it.

## Gate

Full bar on a clean box, on `ecb0ad9` (the merge base; current `main` is one orthogonal parquet merge ahead, #225, which this does not touch): preflight 15.18 / 16.14 / 17.6 / 18.4 / 19beta2 with 0 warnings each; matrix **ALL VERSIONS PASSED** on PG18 and PG19, with `unique_conc`, `differential`, `harness_selftest`, and `native_fetch_interrupt` all PASS on both majors. `unique_conc` is the one that matters here: it passes with the index scan, and reverting only the reset hangs its scenario 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
