### PR TITLE
Fuzz the Arrow IPC decoder, and fix the OOB read it found (#214)

### DIFF
--- a/src/columnar_arrow.c
+++ b/src/columnar_arrow.c
@@ -1623,6 +1623,102 @@ imp_value_at(ImpNode *n, const uint8 *body, const int64 *bufOff,
 }
 
 /*
+ * imp_check_bounds
+ *		Reject a record batch whose declared row count or offsets do not fit its
+ *		buffers, before any value is read. The buffer (offset, length) pairs are
+ *		already checked against the body length by the caller; this checks the
+ *		other half, that reading `count` elements -- and, for varlena and list,
+ *		the offsets that index the data -- stays inside each buffer.
+ *
+ *		Without it a crafted RecordBatch `length`, or a crafted offset, drives
+ *		imp_scalar_at()/imp_value_at() to memcpy past a buffer and take the
+ *		backend down rather than raising an ERROR (issue #214, found by
+ *		test/fuzz_arrow.sh: a mutated int64 length made the row loop read row
+ *		450,000 of a 200-row buffer). Every read site below reads element i for
+ *		i < count, so bounding count against the buffers here bounds all of them.
+ *		Sizes are compared by division rather than multiplication so a huge
+ *		declared count cannot overflow the check itself.
+ */
+static void
+imp_check_bounds(ImpNode *n, const uint8 *body, const int64 *bufOff,
+				 const int64 *bufLen, int nbuffers, int64 count)
+{
+	if (count < 0)
+		IMPORT_CORRUPT("negative element count");
+
+	/* validity bitmap: count bits, omitted (length 0) when null_count is 0 */
+	if (n->validBuf >= 0)
+	{
+		if (n->validBuf >= nbuffers)
+			IMPORT_CORRUPT("validity buffer index out of range");
+		if (bufLen[n->validBuf] > 0 && bufLen[n->validBuf] < (count + 7) / 8)
+			IMPORT_CORRUPT("validity buffer too small for the row count");
+	}
+
+	if (n->kind == A_STRUCT)
+	{
+		int			a,
+					ci = 0;
+
+		for (a = 0; a < n->structDesc->natts; a++)
+		{
+			if (TupleDescAttr(n->structDesc, a)->attisdropped)
+				continue;
+			imp_check_bounds(&n->children[ci++], body, bufOff, bufLen,
+							 nbuffers, count);
+		}
+		return;
+	}
+
+	if (n->kind == A_LIST || n->kind == A_UTF8 || n->kind == A_BINARY)
+	{
+		int64		oOff;
+		int64		k;
+		int32		prev = 0;
+
+		if (n->offBuf < 0 || n->offBuf >= nbuffers)
+			IMPORT_CORRUPT("offset buffer index out of range");
+		if (count + 1 > bufLen[n->offBuf] / 4)		/* (count+1) int32 offsets */
+			IMPORT_CORRUPT("offset buffer too small for the row count");
+		oOff = bufOff[n->offBuf];
+		for (k = 0; k <= count; k++)
+		{
+			int32		off;
+
+			memcpy(&off, body + oOff + k * 4, 4);
+			if (off < 0 || off < prev)
+				IMPORT_CORRUPT("offsets are not non-negative and non-decreasing");
+			prev = off;
+		}
+		/* prev is now the last offset: the child element count, or the data extent */
+		if (n->kind == A_LIST)
+			imp_check_bounds(&n->children[0], body, bufOff, bufLen, nbuffers, prev);
+		else
+		{
+			if (n->dataBuf < 0 || n->dataBuf >= nbuffers)
+				IMPORT_CORRUPT("data buffer index out of range");
+			if ((int64) prev > bufLen[n->dataBuf])
+				IMPORT_CORRUPT("string/binary data runs past its buffer");
+		}
+		return;
+	}
+
+	/* fixed-width scalar, including A_BOOL which is one bit per value */
+	if (n->dataBuf < 0 || n->dataBuf >= nbuffers)
+		IMPORT_CORRUPT("data buffer index out of range");
+	if (n->kind == A_BOOL)
+	{
+		if (bufLen[n->dataBuf] < (count + 7) / 8)
+			IMPORT_CORRUPT("bool buffer too small for the row count");
+		return;
+	}
+	if (n->width <= 0)
+		IMPORT_CORRUPT("non-positive scalar width");
+	if (count > bufLen[n->dataBuf] / n->width)
+		IMPORT_CORRUPT("value buffer too small for the row count");
+}
+
+/*
  * columnar_import_arrow
  *		SQL: columnar.import_arrow(rel regclass, path text) -> bigint.
  *		Insert the rows of an Arrow IPC stream file into a columnar table;
@@ -1830,6 +1926,14 @@ columnar_import_arrow(PG_FUNCTION_ARGS)
 						(uint64) bufOff[b] + bufLen[b] > (uint64) bodyLength)
 						IMPORT_CORRUPT("buffer out of range");
 				}
+
+				/*
+				 * Reject a batch whose row count or offsets overrun its buffers
+				 * before reading any value from them (issue #214).
+				 */
+				for (i = 0; i < ncols; i++)
+					imp_check_bounds(&tops[i], body, bufOff, bufLen,
+									 (int) nbuffers, nrows);
 
 				for (r = 0; r < nrows; r++)
 				{

--- a/test/arrow_corpus.py
+++ b/test/arrow_corpus.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+#
+# Seed corpus for the Arrow IPC decode fuzzer (test/fuzz_arrow.sh, issue #214).
+#
+# The sibling of test/parquet_corpus.py, for the other hand-rolled parser. Every
+# file here is a VALID Arrow IPC *stream* (as pgcolumnar.export_arrow writes and
+# pgcolumnar.import_arrow reads): a Schema message, one or more RecordBatch
+# messages, and an end-of-stream marker, each message being a 0xFFFFFFFF
+# continuation, a 4-byte little-endian metadata length, a FlatBuffers metadata
+# block, and a body. The fuzzer mutates copies; a seed that is already malformed
+# teaches the mutator nothing because the reader rejects it before the decode.
+#
+# import_arrow accepts a flat schema only -- int2/4/8, float4/8, bool, text
+# (Utf8), bytea (Binary); any other column type is rejected -- so the corpus is
+# flat by design. Breadth here is over the physical decoders the FlatBuffers
+# metadata dispatches to (each width, the validity/offset/data buffer triple, the
+# null and multi-batch shapes), because a mutation is only as interesting as the
+# path the surrounding bytes reach.
+#
+# Each file's line carries the PostgreSQL column list that matches its schema, so
+# the driver can build a target table without a schema-introspection function
+# (Arrow has no parquet_schema equivalent).
+#
+# Usage:  python3 test/arrow_corpus.py OUTDIR
+# Writes OUTDIR/<name>.arrows and prints one "<name> <path> <coldef>" line each.
+#
+import os
+import sys
+
+import pyarrow as pa
+import pyarrow.ipc as ipc
+
+# Arrow array type -> the PostgreSQL column type import_arrow maps it back to.
+PGTYPE = {
+    "int16": "int2",
+    "int32": "int4",
+    "int64": "int8",
+    "float": "float4",
+    "double": "float8",
+    "bool": "bool",
+    "string": "text",
+    "binary": "bytea",
+}
+
+
+def coldef(schema):
+    """The PostgreSQL column list matching an Arrow schema, or None if any field
+    is a type import_arrow does not accept (that seed would only exercise the
+    schema-mismatch check, never the decode)."""
+    parts = []
+    for f in schema:
+        t = str(f.type)
+        pg = PGTYPE.get(t)
+        if pg is None:
+            return None
+        parts.append("%s %s" % (f.name, pg))
+    return ", ".join(parts)
+
+
+def w(outdir, name, batches):
+    """Write one stream seed from a list of RecordBatches (>1 exercises the
+    multi-batch read loop) and report it with its column list."""
+    if not batches:
+        return
+    schema = batches[0].schema
+    cols = coldef(schema)
+    if cols is None:
+        print("SKIP %s (unmapped type)" % name, file=sys.stderr)
+        return
+    path = os.path.join(outdir, name + ".arrows")
+    try:
+        with ipc.new_stream(pa.OSFile(path, "wb"), schema) as writer:
+            for b in batches:
+                writer.write_batch(b)
+    except Exception as e:                  # noqa: BLE001 - report and continue
+        print("SKIP %s (%s)" % (name, type(e).__name__), file=sys.stderr)
+        return
+    print("%s %s %s" % (name, path, cols))
+
+
+def batch(cols):
+    return pa.record_batch({k: v for k, v in cols})
+
+
+def main():
+    outdir = sys.argv[1]
+    os.makedirs(outdir, exist_ok=True)
+    n = 200
+
+    # --- one file per accepted physical type: a mutation lands in a decoder that
+    # is actually reached rather than in a type the file never uses.
+    w(outdir, "int16", [batch([("c0", pa.array(range(n), pa.int16()))])])
+    w(outdir, "int32", [batch([("c0", pa.array(range(n), pa.int32()))])])
+    w(outdir, "int64", [batch([("c0", pa.array(range(n), pa.int64()))])])
+    w(outdir, "float", [batch([("c0", pa.array([i * 0.5 for i in range(n)], pa.float32()))])])
+    w(outdir, "double", [batch([("c0", pa.array([i * 0.25 for i in range(n)], pa.float64()))])])
+    w(outdir, "bool", [batch([("c0", pa.array([i % 2 == 0 for i in range(n)], pa.bool_()))])])
+    w(outdir, "string", [batch([("c0", pa.array(["v%d" % i for i in range(n)]))])])
+    w(outdir, "binary", [batch([("c0", pa.array([b"\x00\x01%d" % i for i in range(n)], pa.binary()))])])
+
+    # --- null shapes: the validity bitmap is a separate buffer and a separate
+    # decode path from the values.
+    w(outdir, "nulls_some", [batch([("c0", pa.array(
+        [None if i % 3 == 0 else i for i in range(n)], pa.int32()))])])
+    w(outdir, "nulls_all", [batch([("c0", pa.array([None] * n, pa.int32()))])])
+    w(outdir, "string_nulls", [batch([("c0", pa.array(
+        [None if i % 2 else "s%d" % i for i in range(n)]))])])
+
+    # --- varlena offsets: the string/binary decoder trusts an offsets buffer and
+    # a data buffer whose lengths have to agree. Empty strings exercise zero-width
+    # offset runs.
+    w(outdir, "string_empty", [batch([("c0", pa.array(["" for _ in range(n)]))])])
+
+    # --- the widest table import_arrow accepts (16 columns), so the schema field
+    # vector and the per-column buffer set are long.
+    wide = [("c%d" % c, pa.array(range(50), pa.int32())) for c in range(16)]
+    w(outdir, "wide16", [batch(wide)])
+
+    # --- several record batches in one stream: the read loop advances message to
+    # message, and a length or continuation error mid-stream is its own case.
+    three = [batch([("c0", pa.array(range(i * 100, i * 100 + 100), pa.int64())),
+                    ("c1", pa.array(["b%d" % j for j in range(100)]))]) for i in range(3)]
+    w(outdir, "multibatch", three)
+
+    # --- an empty batch still has a schema message and a record-batch message
+    # with zero-length buffers.
+    w(outdir, "empty", [batch([("c0", pa.array([], pa.int32()))])])
+
+    # --- mixed columns so the per-column buffer offsets in the record batch have
+    # to be walked in order rather than assumed uniform.
+    w(outdir, "mixed", [batch([
+        ("a", pa.array(range(n), pa.int64())),
+        ("b", pa.array([i * 0.5 for i in range(n)], pa.float64())),
+        ("c", pa.array(["m%d" % (i % 7) for i in range(n)])),
+        ("d", pa.array([i % 2 == 0 for i in range(n)], pa.bool_())),
+    ])])
+
+
+if __name__ == "__main__":
+    main()

--- a/test/arrow_mutate.py
+++ b/test/arrow_mutate.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+#
+# Deterministic byte-level mutator for the Arrow IPC decode fuzzer (issue #214).
+# The sibling of test/parquet_mutate.py, aimed at what a hand-rolled FlatBuffers
+# and Arrow IPC reader gets wrong rather than at uniform byte coverage.
+#
+# Every mutant is a pure function of (seed file, seed integer), so a crash
+# reproduces exactly from the two values printed with it. Nothing is random at
+# run time.
+#
+# An Arrow IPC stream is a sequence of messages, each framed as a 0xFFFFFFFF
+# continuation, a 4-byte little-endian metadata length, a FlatBuffers metadata
+# block, then a body. The reader trusts that length to find the FlatBuffer, and
+# trusts offsets, vector lengths and RecordBatch buffer offset/length pairs inside
+# it; those are the fields with leverage. The generic byte mutations are shared in
+# spirit with the Parquet mutator; the Thrift, PAR1-footer and deep-Thrift-chain
+# mutations do not apply here and are replaced by the two IPC-framing ones.
+#
+# Usage:  python3 test/arrow_mutate.py SEEDFILE SEED OUTFILE
+#
+import os
+import random
+import struct
+import sys
+
+# Values that break arithmetic on a field the reader treats as a size, count or
+# offset: zero, the negatives, the signed and unsigned ceilings, and the ones
+# that overflow a 32-bit multiply by a small element width.
+EXTREMES = [
+    0, 1, -1, 2, -2,
+    0x7F, 0x80, 0xFF,
+    0x7FFF, 0x8000, 0xFFFF,
+    0x7FFFFFFF, 0x80000000, 0xFFFFFFFF,
+    0x40000000, 0x20000000, 0x10000000,
+]
+
+CONT = b"\xff\xff\xff\xff"
+
+
+def _flip_bits(b, rnd):
+    """Classic bit flips: the only mutation that reaches deep into a value buffer
+    where structure is opaque to us."""
+    n = rnd.randint(1, 16)
+    for _ in range(n):
+        i = rnd.randrange(len(b))
+        b[i] ^= 1 << rnd.randrange(8)
+
+
+def _extreme_int(b, rnd):
+    """Overwrite a 4- or 8-byte little-endian window with a boundary value.
+    FlatBuffers offsets and vector lengths are 4 bytes and RecordBatch buffer
+    offset/length pairs are 8, so an unaligned scattershot hits all three."""
+    width = rnd.choice((4, 4, 4, 8))
+    if len(b) < width:
+        return
+    i = rnd.randrange(len(b) - width + 1)
+    v = rnd.choice(EXTREMES)
+    b[i:i + width] = struct.pack("<q" if width == 8 else "<i",
+                                 v if v < 0x80000000 or width == 8 else v - 0x100000000)
+
+
+def _meta_len(b, rnd):
+    """Overwrite the 4-byte metadata length that follows a 0xFFFFFFFF
+    continuation. The reader seeks by it to find the FlatBuffer and to skip to the
+    body, so it is the Arrow analogue of the Parquet footer length: the single
+    field with the most leverage over where parsing lands."""
+    starts = []
+    i = b.find(CONT)
+    while i != -1:
+        starts.append(i)
+        i = b.find(CONT, i + 1)
+    if not starts:
+        return
+    at = rnd.choice(starts) + 4
+    if at + 4 > len(b):
+        return
+    v = rnd.choice(EXTREMES + [len(b), len(b) - at, len(b) * 2])
+    b[at:at + 4] = struct.pack("<I", v & 0xFFFFFFFF)
+
+
+def _continuation(b, rnd):
+    """Corrupt a continuation marker itself, or the end-of-stream that is a
+    0xFFFFFFFF followed by a zero length. Proves the read loop checks the framing
+    rather than trusting the stream to be well formed to its end."""
+    starts = []
+    i = b.find(CONT)
+    while i != -1:
+        starts.append(i)
+        i = b.find(CONT, i + 1)
+    if not starts:
+        return
+    at = rnd.choice(starts)
+    b[at:at + 4] = bytes(rnd.randrange(256) for _ in range(4))
+
+
+def _truncate(b, rnd):
+    """A short read is the commonest malformed file in the wild, and every bound
+    in the reader has to hold when the bytes simply stop."""
+    if len(b) < 16:
+        return
+    keep = rnd.randrange(4, len(b))
+    del b[keep:]
+
+
+def _splice(b, rnd):
+    """Duplicate a byte range in place. Across message framing this can repeat a
+    metadata or body region, so counts and offsets that were consistent no longer
+    are."""
+    if len(b) < 32:
+        return
+    start = rnd.randrange(len(b) - 16)
+    end = min(len(b), start + rnd.randrange(4, 256))
+    chunk = bytes(b[start:end])
+    reps = rnd.choice((2, 4, 8, 32, 128))
+    at = rnd.randrange(len(b))
+    b[at:at] = chunk * reps
+    del b[64 * 1024 * 1024:]        # keep a runaway splice from eating the box
+
+
+def _delete(b, rnd):
+    """Remove a run, shifting every later byte. Offsets and lengths stored earlier
+    then point past where their data now is, which a pure overwrite never
+    produces."""
+    if len(b) < 64:
+        return
+    start = rnd.randrange(len(b) - 32)
+    end = min(len(b), start + rnd.randrange(1, 64))
+    del b[start:end]
+
+
+MUTATIONS = [
+    (_flip_bits, 3),
+    (_extreme_int, 5),
+    (_meta_len, 4),
+    (_continuation, 2),
+    (_truncate, 2),
+    (_splice, 3),
+    (_delete, 2),
+]
+
+
+def mutate(data, seed):
+    rnd = random.Random(seed)
+    b = bytearray(data)
+    pool = []
+    for fn, weight in MUTATIONS:
+        pool.extend([fn] * weight)
+    for _ in range(rnd.randint(1, 3)):
+        rnd.choice(pool)(b, rnd)
+    return bytes(b)
+
+
+def main():
+    src, seed, dst = sys.argv[1], int(sys.argv[2]), sys.argv[3]
+    with open(src, "rb") as f:
+        data = f.read()
+    out = mutate(data, seed)
+    with open(dst, "wb") as f:
+        f.write(out)
+    os.chmod(dst, 0o644)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/fuzz_arrow.sh
+++ b/test/fuzz_arrow.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+#
+# pgColumnar Arrow IPC decode fuzzer (issue #214).
+#
+# The sibling of test/fuzz_parquet.sh, for the other hand-rolled parser.
+# columnar_arrow.c is ~1,900 lines of hand-written FlatBuffers and Arrow IPC
+# decoding with the same shape as the Parquet reader and, until this suite, none
+# of its coverage. It mutates valid Arrow IPC stream files and feeds each to the
+# one entry point that parses one, pgcolumnar.import_arrow, and asserts a single
+# property:
+#
+#     a malformed file makes the backend raise an ERROR, never die.
+#
+# That is the property #210 broke on the Parquet side. The Arrow path has the
+# analogous surface: a metadata length the reader seeks by, FlatBuffers offsets
+# and vector lengths it trusts, and RecordBatch buffer offset/length pairs that
+# say where to read a column's bytes from. A crafted one of those is a
+# memory-safety question, not a data-quality one.
+#
+# Anything that is not a clean ERROR is a finding, in three kinds:
+#   crash   the backend died (signal, or the connection dropped)
+#   san     a sanitizer reported (only on a sanitizer build)
+#   hang    the statement outlived its timeout
+#
+# Every mutant is a pure function of (seed file, seed integer), so a finding
+# reproduces exactly and is saved with the two values that regenerate it.
+#
+# Usage:  test/fuzz_arrow.sh [PG_CONFIG]
+#   PGC_SEED=<int>            base seed (default 20260728)
+#   PGC_ITERS=<int>           mutants to run (default 100)
+#   PGC_FUZZ_KEEP=1           keep every mutant, not only the findings
+#   PGC_FUZZ_FINDINGS=<dir>   save findings outside the workdir, for campaigns
+#
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+if ! python3 -c 'import pyarrow.ipc' 2>/dev/null; then
+	echo "SKIP  pyarrow not available; the Arrow fuzzer needs it to build seeds"
+	pgc_summary
+fi
+
+SEED="${PGC_SEED:-20260728}"
+# 100 in the gate, a bit under a minute. The gate's job is to catch a regression
+# that makes malformed input fatal again; the search for new defects is a
+# campaign, run with PGC_ITERS in the thousands outside CI.
+ITERS="${PGC_ITERS:-100}"
+PGC_FUZZ_KEEP="${PGC_FUZZ_KEEP:-0}"
+CORPUS="$PGC_WORKDIR/corpus"
+FINDINGS="${PGC_FUZZ_FINDINGS:-$PGC_WORKDIR/findings}"
+MUT="$PGC_WORKDIR/mutant.arrows"
+NEWLOG="$PGC_WORKDIR/newlog.txt"
+mkdir -p "$CORPUS" "$FINDINGS"
+chmod 777 "$CORPUS" "$FINDINGS"
+
+echo "-- seed=$SEED iters=$ITERS"
+echo "-- corpus: $CORPUS"
+
+# ---------------------------------------------------------------------------
+# Seeds. Every one is valid; see test/arrow_corpus.py. Each line is
+# "<name> <path> <coldef>", the column list being the schema import_arrow expects,
+# since Arrow has no parquet_schema equivalent to derive it from the file.
+# ---------------------------------------------------------------------------
+mapfile -t SEEDLINES < <(python3 "$PGC_SRCDIR/test/arrow_corpus.py" "$CORPUS" 2>/dev/null)
+if [ "${#SEEDLINES[@]}" -eq 0 ]; then
+	echo "FAIL  the corpus generator produced no files"
+	PGC_FAIL=1
+	pgc_summary
+fi
+echo "-- ${#SEEDLINES[@]} seed files"
+
+# Keep only seeds the reader accepts pristine: create the matching target table
+# and import the untouched seed once. A seed the importer rejects would only ever
+# exercise the schema check and never the decode, and would make the property
+# checks below pass for the wrong reason.
+declare -a SEEDPATH SEEDTAB
+kept=0
+for line in "${SEEDLINES[@]}"; do
+	read -r name path cols <<< "$line"
+	[ -z "$cols" ] && continue
+	tab="arrt_$kept"
+	psql_run "DROP TABLE IF EXISTS $tab; CREATE TABLE $tab ($cols) USING pgcolumnar;" >/dev/null 2>&1 || continue
+	if q "SELECT pgcolumnar.import_arrow('$tab', '$path');" >/dev/null 2>&1; then
+		psql_run "TRUNCATE $tab;" >/dev/null 2>&1
+		SEEDPATH+=("$path")
+		SEEDTAB+=("$tab")
+		kept=$((kept + 1))
+	fi
+done
+echo "-- ${#SEEDPATH[@]} seeds the importer accepts pristine"
+
+if [ "${#SEEDPATH[@]}" -eq 0 ]; then
+	echo "FAIL  no seed imported cleanly; the importer rejects its own corpus"
+	PGC_FAIL=1
+	pgc_summary
+fi
+
+# ---------------------------------------------------------------------------
+# Crash detection. Judged from the server log rather than psql's message: a
+# backend that dies takes the connection with it, so psql reports the symptom.
+# The log is read incrementally from a byte offset so a finding is attributed to
+# the mutant that produced it, not to every mutant after it (the mistake that
+# turned one line into 257 findings in the Parquet fuzzer's first cut).
+# ---------------------------------------------------------------------------
+LOGPOS=0
+crashes=0
+hangs=0
+sanitizer=0
+errors=0
+clean=0
+
+log_since() {
+	local sz
+	sz=$(stat -c %s "$PGC_LOGFILE" 2>/dev/null || echo 0)
+	if [ "$sz" -gt "$LOGPOS" ]; then
+		tail -c +$((LOGPOS + 1)) "$PGC_LOGFILE" > "$NEWLOG" 2>/dev/null
+	else
+		: > "$NEWLOG"
+	fi
+	LOGPOS="$sz"
+}
+
+wait_for_cluster() {
+	local i
+	for i in $(seq 1 60); do
+		if env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" \
+			-U postgres -d "$PGC_DB" -Atc "SELECT 1" >/dev/null 2>&1; then
+			return 0
+		fi
+		sleep 0.5
+	done
+	return 1
+}
+
+save_finding() {
+	local kind="$1" seedfile="$2" mutseed="$3" stmt="$4" detail="$5"
+	local dir="$FINDINGS/${kind}-${mutseed}"
+	mkdir -p "$dir"
+	cp "$MUT" "$dir/mutant.arrows" 2>/dev/null
+	{
+		echo "kind:      $kind"
+		echo "seed file: $(basename "$seedfile")"
+		echo "seed:      $mutseed"
+		echo "statement: $stmt"
+		echo "reproduce:"
+		echo "    python3 test/arrow_corpus.py /tmp/corpus"
+		echo "    python3 test/arrow_mutate.py /tmp/corpus/$(basename "$seedfile") $mutseed /tmp/repro.arrows"
+		echo "    then import /tmp/repro.arrows into a table with the seed's columns"
+		echo "--- detail ---"
+		echo "$detail"
+	} > "$dir/README"
+	echo "  FINDING [$kind] seed=$mutseed from $(basename "$seedfile")"
+	echo "$detail" | head -5 | sed 's/^/      /'
+}
+
+# Runs one statement against one mutant and classifies the outcome. Returns 0
+# when the outcome is acceptable (success or a clean ERROR).
+run_stmt() {
+	local stmt="$1" seedfile="$2" mutseed="$3"
+	local out rc newlog
+
+	log_since
+	out="$(timeout 30 env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" \
+		-U postgres -d "$PGC_DB" -v ON_ERROR_STOP=0 \
+		-c "SET statement_timeout = '20s'; $stmt" 2>&1)"
+	rc=$?
+
+	if echo "$out" | grep -qE 'could not connect|No such file or directory|Connection refused' &&
+	   ! echo "$out" | grep -q '^ERROR:'; then
+		if ! wait_for_cluster; then
+			echo "  FATAL: cluster unreachable and did not return"
+			return 1
+		fi
+	fi
+	log_since
+	newlog="$(cat "$NEWLOG" 2>/dev/null)"
+
+	if echo "$newlog" | grep -qE 'AddressSanitizer|runtime error:|UndefinedBehaviorSanitizer|LeakSanitizer'; then
+		sanitizer=$((sanitizer + 1))
+		save_finding san "$seedfile" "$mutseed" "$stmt" "$newlog"
+		wait_for_cluster || return 1
+		return 1
+	fi
+
+	if echo "$newlog" | grep -qE 'was terminated by signal|server process .* exited with|crashed'; then
+		crashes=$((crashes + 1))
+		save_finding crash "$seedfile" "$mutseed" "$stmt" "$newlog"
+		wait_for_cluster || echo "  (cluster did not come back)"
+		return 1
+	fi
+
+	if [ "$rc" = 124 ]; then
+		hangs=$((hangs + 1))
+		save_finding hang "$seedfile" "$mutseed" "$stmt" "psql wall-clock timeout (30s)"
+		wait_for_cluster
+		return 1
+	fi
+
+	if echo "$out" | grep -q 'canceling statement due to statement timeout'; then
+		hangs=$((hangs + 1))
+		save_finding hang "$seedfile" "$mutseed" "$stmt" "$out"
+		return 1
+	fi
+
+	if echo "$out" | grep -qE 'server closed the connection unexpectedly|connection to server was lost|terminating connection'; then
+		crashes=$((crashes + 1))
+		save_finding crash "$seedfile" "$mutseed" "$stmt" "$out"
+		wait_for_cluster || echo "  (cluster did not come back)"
+		return 1
+	fi
+
+	if echo "$out" | grep -q '^ERROR:'; then
+		errors=$((errors + 1))
+	else
+		clean=$((clean + 1))
+	fi
+	return 0
+}
+
+# Prime the log offset so seed setup above is not attributed to mutant 1.
+log_since
+
+echo "-- fuzzing"
+nseeds="${#SEEDPATH[@]}"
+for ((i = 0; i < ITERS; i++)); do
+	idx=$((i % nseeds))
+	sf="${SEEDPATH[$idx]}"
+	tab="${SEEDTAB[$idx]}"
+	ms=$((SEED + i))
+
+	python3 "$PGC_SRCDIR/test/arrow_mutate.py" "$sf" "$ms" "$MUT" 2>/dev/null || continue
+	chmod 644 "$MUT" 2>/dev/null
+
+	# Empty the target first so an accepted mutant does not accumulate rows across
+	# the run; import_arrow appends.
+	psql_run "TRUNCATE $tab;" >/dev/null 2>&1
+	run_stmt "SELECT pgcolumnar.import_arrow('$tab', '$MUT');" "$sf" "$ms"
+
+	if [ "$PGC_FUZZ_KEEP" = 1 ]; then
+		cp "$MUT" "$PGC_WORKDIR/kept-$ms.arrows" 2>/dev/null
+	fi
+
+	if [ $((i % 50)) = 49 ]; then
+		echo "  $((i + 1))/$ITERS  errors=$errors clean=$clean crashes=$crashes hangs=$hangs san=$sanitizer"
+	fi
+done
+
+echo "-- done: $ITERS mutants, ${errors} rejected with ERROR, ${clean} accepted"
+
+check "no mutant crashed the backend" "$crashes" "0"
+check "no mutant hung the decode" "$hangs" "0"
+check "no mutant tripped a sanitizer" "$sanitizer" "0"
+
+# A corpus rejected outright teaches nothing and would make the three checks above
+# pass for the wrong reason. Some mutants must have reached the decoder and been
+# refused on their merits.
+check "the corpus reached the decoder at all" \
+	"$([ "$errors" -gt 0 ] && echo yes || echo "no (errors=$errors clean=$clean)")" \
+	"yes"
+
+if [ "$crashes" != 0 ] || [ "$hangs" != 0 ] || [ "$sanitizer" != 0 ]; then
+	echo "-- findings kept in $FINDINGS"
+	ls -1 "$FINDINGS"
+fi
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -90,7 +90,7 @@ trap - EXIT
 
 SRCDIR="${PGC_RUN_SRCDIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 SUITES=(harness_selftest smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
-	differential recovery native_backend_crash fuzz fuzz_parquet hardening concurrent_diff parallel sorted_projection \
+	differential recovery native_backend_crash fuzz fuzz_parquet fuzz_arrow hardening concurrent_diff parallel sorted_projection \
 	arrow_export parquet_export read_stream corruption \
 	generated_columns temporal arrow_import index_only projections arrow_nested parquet_import parquet_nested arrow_nested_import parquet_nested_import native_writer native_roundtrip native_encoding native_zonemap write_minmax_fastpath write_fsst_compressed encode_effort native_skip pushdown_report native_agg native_agg_deletes native_agg_addcolumn native_bloom bloom_setting native_vecskip native_index native_fetch_position native_dml alter_column_type native_ios native_projection native_cluster native_compact native_recluster native_reclaim native_ownership drop_cleanup native_reclaim_cycles native_reclaim_frag native_reclaim_reconcile native_gap native_truncate native_rewrite native_rewrite_conc rewrite_group_scan native_parquet_schema native_read_parquet native_parquet_fdw native_parquet_pushdown native_parquet_hardening server_file_privilege native_parquet_stack native_parquet_units native_parquet_flba native_parquet_codecs native_parquet_projection native_parquet_multifile native_parquet_streaming native_parquet_partition native_cancel wal_envelope decode_interrupts import_exclusion import_deferred fk_referencing row_triggers native_lazy_slot native_fetch_cache native_fetch_interrupt analyze_stats analyze_reltuples native_fetch_projection isolation)
 


### PR DESCRIPTION
Extends the #214 fuzzer to the Arrow and FlatBuffers path, the half left open after #225, and fixes the crash it found on its first run.

## The harness

The sibling of the Parquet trio, same shape:

- `test/arrow_corpus.py` emits valid Arrow IPC *stream* seeds (via pyarrow), one per accepted physical type plus null, empty, multi-batch, 16-column and mixed layouts. Each line carries the PostgreSQL column list matching its schema, because Arrow has no `parquet_schema` equivalent to derive it from the file.
- `test/arrow_mutate.py` is the deterministic byte mutator: the shared generic mutations (bit flip, extreme int over 4/8-byte windows, truncate, splice, delete) plus two IPC-specific ones -- the message metadata-length prefix (the Arrow analogue of the Parquet footer length) and the continuation marker.
- `test/fuzz_arrow.sh` drives `pgcolumnar.import_arrow`, the one Arrow entry point that parses a file, and asserts the same property: a malformed file makes the backend raise an ERROR, never die. It reuses the Parquet driver's crash-detection machinery (log read incrementally from a byte offset so a finding is attributed to the mutant that produced it, cluster-recovery between mutants, findings saved with the two values that regenerate them).

Registered in the matrix at 100 mutants next to `fuzz_parquet`.

## What it found, on the first run

100 mutants, seven crashes, all on `import_arrow`. Root cause, from the one gdb caught before the others took the connection down:

```
#0  imp_scalar_at   (i=450000) at src/columnar_arrow.c:1528   memcpy(&v, vp, 8)
#1  imp_value_at    at src/columnar_arrow.c:1622
#2  columnar_import_arrow
```

The seed had 200 rows. A mutated RecordBatch `length` field drove the row loop to read row 450,000 of a 200-row buffer: `vp = body + bufOff + 450000 * 8`, roughly 3.6 MB into a 1.6 kB buffer, out of bounds, SIGSEGV, whole-cluster reinit. The buffer `(offset, length)` pairs were already validated against the body length, but nothing checked that reading element *i* stayed inside a buffer -- and `length`, and the varlena/list offsets, are trusted straight from the FlatBuffers metadata. `imp_scalar_at`, the varlena offset reads, and even `imp_is_null` all index by *i* without a bound.

## The fix

`imp_check_bounds`, an up-front recursive validator run once per RecordBatch before any value is read. It rejects a batch whose declared row count or offsets do not fit its buffers: validity bitmap sized for the row count, fixed-width value buffers sized for count x width, bool buffers sized for the bit count, varlena offsets non-negative and non-decreasing with the last offset inside the data buffer, and list offsets recursed into the child element count. Struct recurses at the same count. Sizes are compared by division, not multiplication, so a huge declared count cannot overflow the check itself. On failure it raises the existing `IMPORT_CORRUPT` ERROR, so a malformed file is rejected rather than fatal.

## Proof

Same standard as the Parquet side: the fuzzer is proven against the bug class, not just run once.

- **Unfixed build, 100 mutants:** 7 crashes on `import_arrow`.
- **With the fix, 8,000 mutants (soak):** 0 crashes, 0 hangs, 0 sanitizer reports; 6,917 rejected with ERROR (reached the decoder and refused on merits), 1,083 accepted (a value-buffer bit flip is a different value, not an invalid file). An earlier 2,000-mutant run at the default seed was also clean.
- **No valid-file regression:** `arrow_import` 17/17, `arrow_export` 10/10, and every corpus seed still imports pristine.

## Sanitizer, soak, and stage B

An OOB read does not always SIGSEGV, so the assert build understates this class; the defect here happened to be far enough out of bounds to fault every time. A `pg18_san` build is not present in this container (it is #224's deliverable and carries the recipe), so the ASAN/UBSAN campaign belongs there; the driver's `san` detection is already wired for it, and it is worth a 500-mutant ASAN pass on the Arrow corpus once #224 lands, exactly as #225 did for Parquet.

Stage B (coverage-guided in-process) stays deferred on the same reasoning as the Parquet side: stage A found a real memory-safety bug on the Arrow path on day one too, which argues for more stage-A breadth before paying the decoupling cost.

## Gate

Full bar on `c9e89b0` (current `main`): preflight 15.18 / 16.14 / 17.6 / 18.4 / 19beta2 with 0 warnings each; matrix **ALL VERSIONS PASSED** on PG18 and PG19, with `fuzz_arrow=PASS`, `fuzz_parquet=PASS`, `arrow_import=PASS` and `harness_selftest=PASS` on both. Warnings-clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
