### PR TITLE
Fuzz the Arrow list and struct decode paths too (#214)

### DIFF
--- a/test/arrow_corpus.py
+++ b/test/arrow_corpus.py
@@ -57,13 +57,16 @@ def coldef(schema):
     return ", ".join(parts)
 
 
-def w(outdir, name, batches):
+def w(outdir, name, batches, cols=None):
     """Write one stream seed from a list of RecordBatches (>1 exercises the
-    multi-batch read loop) and report it with its column list."""
+    multi-batch read loop) and report it with its column list. Pass cols
+    explicitly for list and struct schemas, whose PostgreSQL type (an array or a
+    named composite) cannot be derived from the Arrow schema alone."""
     if not batches:
         return
     schema = batches[0].schema
-    cols = coldef(schema)
+    if cols is None:
+        cols = coldef(schema)
     if cols is None:
         print("SKIP %s (unmapped type)" % name, file=sys.stderr)
         return
@@ -134,6 +137,35 @@ def main():
         ("c", pa.array(["m%d" % (i % 7) for i in range(n)])),
         ("d", pa.array([i % 2 == 0 for i in range(n)], pa.bool_())),
     ])])
+
+    # --- list and struct: the recursive decode paths. import_arrow builds an
+    # A_LIST node for an array-typed target column and an A_STRUCT node for a
+    # composite one, recursively, and decodes with offset-driven child reads --
+    # the higher-risk shape a flat corpus never reaches. Their PostgreSQL types
+    # are passed explicitly; the driver pre-creates the composite type the struct
+    # seeds name (pgc_fuzz_xy) before it builds the target tables.
+    w(outdir, "list_int", [batch([("a", pa.array(
+        [[i, i + 1] for i in range(n)], pa.list_(pa.int32())))])], cols="a int4[]")
+    w(outdir, "list_text", [batch([("a", pa.array(
+        [["k%d" % (i % 5), "v%d" % i] for i in range(n)], pa.list_(pa.string())))])],
+      cols="a text[]")
+    w(outdir, "list_nulls", [batch([("a", pa.array(
+        [None if i % 4 == 0 else [i, None, i + 1] for i in range(n)],
+        pa.list_(pa.int32())))])], cols="a int4[]")
+    w(outdir, "list_empty", [batch([("a", pa.array(
+        [[] for _ in range(n)], pa.list_(pa.int32())))])], cols="a int4[]")
+
+    xy = pa.struct([("x", pa.int32()), ("y", pa.string())])
+    w(outdir, "struct_xy", [batch([("a", pa.array(
+        [{"x": i, "y": "s%d" % i} for i in range(n)], xy))])],
+      cols="a pgc_fuzz_xy")
+    w(outdir, "struct_nulls", [batch([("a", pa.array(
+        [None if i % 3 == 0 else {"x": i, "y": None} for i in range(n)], xy))])],
+      cols="a pgc_fuzz_xy")
+    # list of struct: both recursions at once (offsets into a struct child).
+    w(outdir, "list_struct", [batch([("a", pa.array(
+        [[{"x": i, "y": "e%d" % i}] for i in range(n)], pa.list_(xy)))])],
+      cols="a pgc_fuzz_xy[]")
 
 
 if __name__ == "__main__":

--- a/test/fuzz_arrow.sh
+++ b/test/fuzz_arrow.sh
@@ -72,6 +72,12 @@ if [ "${#SEEDLINES[@]}" -eq 0 ]; then
 fi
 echo "-- ${#SEEDLINES[@]} seed files"
 
+# The composite type the struct seeds name in their column list. Created once here
+# so a struct-target table can be built; the corpus references it by name because
+# a composite column type cannot be written inline the way an array can.
+psql_run "DROP TYPE IF EXISTS pgc_fuzz_xy CASCADE;
+	CREATE TYPE pgc_fuzz_xy AS (x int, y text);" >/dev/null 2>&1
+
 # Keep only seeds the reader accepts pristine: create the matching target table
 # and import the untouched seed once. A seed the importer rejects would only ever
 # exercise the schema check and never the decode, and would make the property


### PR DESCRIPTION
A coverage follow-up to #228, from re-reviewing #214: the Arrow fuzzer only exercised flat schemas, and left the recursive decode path unfuzzed.

## The gap

`import_arrow` builds an `A_LIST` node for an array-typed target column and an `A_STRUCT` node for a composite one, recursively (`imp_build_node`), then decodes them with offset-driven child reads (`imp_value_at`), and the bounds validator #228 added (`imp_check_bounds`) recurses over the same tree. None of that was reached: `arrow_corpus.py` produced only flat scalar and varlena schemas, so every list, struct and nested-offset branch went unfuzzed. That is the higher-risk shape -- offsets that index a child, recursion -- and it is exactly the path the #228 review singled out as the one to watch.

## The change

Test-only, no C change. `arrow_corpus.py` gains seven seeds: `list<int>`, `list<text>`, list with null lists and null elements, empty lists, `struct<int,text>`, struct with nulls, and a `list<struct>` that exercises both recursions at once (offsets into a struct child). `fuzz_arrow.sh` pre-creates the one composite type the struct seeds name (`pgc_fuzz_xy`), since a composite column type cannot be written inline the way an array can, and the corpus carries each seed's column list as before.

## Result

The corpus went from 16 seeds to 23, all seven new ones importing pristine, and the fuzzer now drives `pgcolumnar.import_arrow` through the list, struct and list-of-struct decoders on every run. It found nothing: about 3,800 mutants across the recursive seeds (a 3,000 soak plus the standalone runs), zero crashes, zero hangs, zero sanitizer, with the usual split of mutants rejected with ERROR and accepted. So this is coverage, not a fix: the recursive path holds under the #228 bounds validator, and now a regression in it would be caught rather than surviving because no seed reached it.

## Gate

Full bar on `80786e1` (current `main`): preflight 15.18 / 16.14 / 17.6 / 18.4 / 19beta2 with 0 warnings each; matrix ALL VERSIONS PASSED on PG18 and PG19, `fuzz_arrow=PASS` and `harness_selftest=PASS` on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
