### PR TITLE
Add a sanitizer gate, proven by removal (#224)

### DIFF
--- a/test/build_san.sh
+++ b/test/build_san.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Build an AddressSanitizer + UndefinedBehaviorSanitizer PostgreSQL for the
+# sanitizer gate (issue #224). The ordinary matrix is five assert builds, none
+# instrumented, so a memory-safety defect that does not happen to fault -- an
+# unaligned load, an out-of-bounds read that lands inside the process -- is
+# invisible to it. #225 found exactly that class (an unaligned varlena header on
+# the plain write path) only because it was run against an instrumented build by
+# hand. This makes that build reproducible and scriptable.
+#
+# The environment fights back in four specific ways, all handled here:
+#
+#   1. Build in-tree from a FRESH tarball, never VPATH against a configured tree.
+#      /root/postgresql-18.4 already has a config.status; a VPATH build against it
+#      fails to link. We extract a clean copy.
+#   2. clang, not gcc. This looks like a free choice and is not. The defect this
+#      gate exists to catch (#225) is a 4-byte varlena header read at an unaligned
+#      address, and the read sits behind a 1-byte-header branch that tests the same
+#      byte (ColumnarVarSizeAnyUnaligned). gcc's -fsanitize=alignment silently
+#      drops the check on that guarded load at -O1 -- verified: the load happens
+#      45,000 times on a low-cardinality-text INSERT, gcc reports none, clang
+#      reports it. A gcc build here would run clean and prove nothing, which is the
+#      exact vacuous-green shape #224 was filed against. So: clang. Its
+#      -fsanitize=function does flag dynahash's function-pointer casts, which is the
+#      one piece of core noise, so -fno-sanitize=function drops it while keeping the
+#      alignment and bounds checks. (gcc has no `function` check to drop.)
+#   3. ASAN_OPTIONS=detect_leaks=0: the tools built here (pg_config, initdb) are
+#      themselves instrumented and leak by design at exit, so LeakSanitizer would
+#      fire on every invocation and poison the values PGXS reads and the initdb
+#      this build needs.
+#   4. ASAN_OPTIONS=detect_stack_use_after_return=0: without it initdb aborts.
+#
+# Usage:  test/build_san.sh [PREFIX]
+#   PREFIX               install target (default /usr/local/pg18_san)
+#   PGC_PG_TARBALL       source tarball (default /root/postgresql-18.4.tar.bz2)
+#   PGC_SAN_SRC          scratch source dir (default /root/pg18_san_src)
+#
+set -euo pipefail
+
+PREFIX="${1:-/usr/local/pg18_san}"
+TARBALL="${PGC_PG_TARBALL:-/root/postgresql-18.4.tar.bz2}"
+SRC="${PGC_SAN_SRC:-/root/pg18_san_src}"
+
+# The tools invoked during the build are instrumented; keep their by-design exit
+# leaks and stack-use-after-return from aborting the build (traps 3 and 4).
+export ASAN_OPTIONS="detect_leaks=0:detect_stack_use_after_return=0:abort_on_error=1"
+
+# Trap 1: fresh in-tree extraction.
+echo "-- extracting $TARBALL -> $SRC"
+rm -rf "$SRC"
+mkdir -p "$SRC"
+tar -xf "$TARBALL" -C "$SRC" --strip-components=1
+cd "$SRC"
+
+# clang + address,undefined, minus the dynahash function-cast noise.
+SAN="-fsanitize=address,undefined -fno-sanitize=function -fno-omit-frame-pointer"
+echo "-- configure"
+./configure --prefix="$PREFIX" --enable-cassert --enable-debug \
+	--without-icu --without-readline --without-zlib \
+	CC=clang CFLAGS="$SAN -O1 -g" LDFLAGS="$SAN" >/tmp/san-configure.log 2>&1
+
+echo "-- make (this takes a while under instrumentation)"
+make -s -j"$(nproc)" >/tmp/san-make.log 2>&1
+echo "-- make install"
+make -s install >/tmp/san-install.log 2>&1
+
+echo "-- built $PREFIX"
+"$PREFIX/bin/pg_config" --configure

--- a/test/harness_selftest.sh
+++ b/test/harness_selftest.sh
@@ -164,10 +164,12 @@ RUNNER="$TESTDIR/run_all_versions.sh"
 # and is run before merging a change that touches a version guard; it takes no
 # cluster and reports per major, so the matrix cannot run it as a suite. native_scale is a suite but is opt-in by
 # design and says so in its own header: it runs at a row count the matrix should
-# not carry.
+# not carry. build_san builds the ASAN+UBSAN PostgreSQL and run_san is the
+# sanitizer gate (#224): they are a separate instrumented build and its runner,
+# not a suite the ordinary five-major matrix can carry.
 not_a_suite() {
 	case "$1" in
-		lib|portlib|run_all_versions|build_all_versions|devloop|rebuild|native_scale) return 0 ;;
+		lib|portlib|run_all_versions|build_all_versions|devloop|rebuild|native_scale|build_san|run_san) return 0 ;;
 		*) return 1 ;;
 	esac
 }

--- a/test/run_san.sh
+++ b/test/run_san.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# The sanitizer gate (issue #224). The ordinary matrix is five assert builds, none
+# instrumented, so a memory-safety defect that does not fault -- an unaligned load,
+# an out-of-bounds read that lands inside the process -- passes green on all five.
+# #225 was exactly that: an unaligned varlena-header read on the plain write path,
+# benign on x86_64, that every one of the 92 suites passed with and without.
+#
+# This runs a subset of the suites against the ASAN+UBSAN build from
+# test/build_san.sh, with sanitizer violations made fatal (UBSAN_OPTIONS and
+# ASAN_OPTIONS abort_on_error), so a violation kills the backend and turns its
+# suite red rather than printing a line nobody reads. The subset is the write,
+# read, encode, and import/decode paths, where the hand-rolled buffer walks live;
+# all 92 suites on five majors are neither needed nor affordable under
+# instrumentation.
+#
+# Prove it works the way #224 asks: revert the fix it guards (columnar.h,
+# ColumnarVarSizeAnyUnaligned back to the direct 4-byte cast), rebuild, and this
+# gate goes red while the ordinary matrix stays green.
+#
+# Usage:  test/run_san.sh [SAN_PREFIX]      (default /usr/local/pg18_san)
+#   PGC_SAN_SUITES=<list>   override the suite subset
+#   PGC_SAN_FUZZ_ITERS=<n>  fuzzer mutants under sanitizers (default 200)
+#
+set -uo pipefail
+
+SAN="${1:-/usr/local/pg18_san}"
+PGCONF="$SAN/bin/pg_config"
+if [ ! -x "$PGCONF" ]; then
+	echo "FAIL  no sanitizer build at $SAN; run test/build_san.sh first"
+	exit 1
+fi
+
+# A sanitizer violation must abort the backend, not print and continue: that is
+# what turns it into a suite failure. detect_leaks/stack_use_after_return are the
+# by-design tool leaks and initdb trip from build_san.sh, kept off here too.
+export ASAN_OPTIONS="detect_leaks=0:detect_stack_use_after_return=0:abort_on_error=1:print_stacktrace=1"
+export UBSAN_OPTIONS="halt_on_error=1:abort_on_error=1:print_stacktrace=1"
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+echo "-- building the extension instrumented against $SAN"
+make -s clean >/dev/null 2>&1 || true
+if ! make -s PG_CONFIG="$PGCONF" install > /tmp/run-san-ext.log 2>&1; then
+	echo "FAIL  extension build against the sanitizer PostgreSQL"
+	tail -20 /tmp/run-san-ext.log
+	exit 1
+fi
+
+FUZZ_ITERS="${PGC_SAN_FUZZ_ITERS:-200}"
+SUITES="${PGC_SAN_SUITES:-smoke native_writer native_roundtrip native_encoding \
+	native_zonemap write_fsst_compressed write_minmax_fastpath encode_effort \
+	native_dml native_skip native_fetch_position native_fetch_cache \
+	arrow_import arrow_export parquet_import parquet_export native_read_parquet \
+	native_parquet_schema hardening corruption differential fuzz_arrow fuzz_parquet}"
+
+echo "-- running the subset under ASAN+UBSAN (fatal)"
+fail=0
+ran=0
+for s in $SUITES; do
+	if [ ! -f "test/$s.sh" ]; then
+		echo "  SKIP  $s (no such suite)"
+		continue
+	fi
+	ran=$((ran + 1))
+	out="$(PGC_SKIP_BUILD=1 PGC_ITERS="$FUZZ_ITERS" timeout 900 \
+		bash "test/$s.sh" "$PGCONF" 2>&1)"
+	rc=$?
+	# A sanitizer report reaches here two ways: the backend aborts (SIGABRT, so the
+	# suite's own crash checks or a nonzero rc), or the text appears in the output.
+	san="$(printf '%s' "$out" | grep -icE 'runtime error:|AddressSanitizer|UndefinedBehaviorSanitizer|SUMMARY: .*Sanitizer|terminated by signal 6')"
+	if [ "$rc" != 0 ] || [ "$san" != 0 ]; then
+		fail=$((fail + 1))
+		echo "  FAIL  $s  (rc=$rc, sanitizer_lines=$san)"
+		printf '%s\n' "$out" | grep -iE 'runtime error:|AddressSanitizer|SUMMARY: .*Sanitizer|FAIL' | head -4 | sed 's/^/        /'
+	else
+		echo "  PASS  $s"
+	fi
+done
+
+echo "-- $ran suites under sanitizers, $fail failed"
+if [ "$fail" = 0 ]; then
+	echo "SANITIZER GATE PASSED"
+else
+	echo "SANITIZER GATE FAILED"
+fi
+exit "$fail"


### PR DESCRIPTION
The sanitizer gate, and it is proven by removal.

## What this is

- `test/build_san.sh` -- a reproducible ASAN+UBSAN PostgreSQL 18.4 build, replacing the by-hand container artifact `pg18_san` was. All four environment traps from the issue are scripted: fresh in-tree extraction (not VPATH against the configured `/root/postgresql-18.4`), the sanitizer toolchain, `detect_leaks=0`, `detect_stack_use_after_return=0`.
- `test/run_san.sh` -- the gate. It builds the extension instrumented, then runs a subset of the suites (write, read, encode, import and decode paths, where the hand-rolled buffer walks live) with sanitizer violations made **fatal**, so a violation aborts the backend and turns its suite red rather than printing a line into a log nobody reads. A second gate beside the matrix, not a sixth matrix major, because it needs a different build.
- `harness_selftest` learns that `build_san` and `run_san` are not suites, the way it already knows `lib` and the runners are not.

## The one real finding: it has to be clang, not gcc

The issue says "gcc works too, via libasan". For this defect class it does not, and this cost me the afternoon the traps were supposed to save, so it is worth stating plainly. The #225 defect is a 4-byte varlena-header read at an unaligned address, and the read sits behind a 1-byte-header branch that tests the same byte (`ColumnarVarSizeAnyUnaligned`). gcc's `-fsanitize=alignment` silently drops the check on that guarded load at `-O1`. Measured, not inferred: instrumenting the function to log every unaligned 4-byte read, a low-cardinality-text INSERT does **45,000** of them; a gcc `-fsanitize=address,undefined` build reports **zero**; clang reports them. A gcc gate here would build, run clean, and prove nothing, which is the exact vacuous-green shape this issue was filed against. `build_san.sh` uses clang, and drops the one piece of core noise clang adds (dynahash's function-pointer casts) with `-fno-sanitize=function`, which gcc has no equivalent to need.

## Proven by removal, which is the todo that matters

With the fix present, `run_san.sh` is green: 23 suites under fatal ASAN+UBSAN, 0 failures, no core noise.

Revert `ColumnarVarSizeAnyUnaligned` to the direct 4-byte cast and rebuild:

```
FAIL  native_writer ...   src/columnar.h:824:8: runtime error: load of misaligned
FAIL  native_encoding     address ... for type 'const uint32', which requires 4 byte alignment
FAIL  fuzz_arrow / fuzz_parquet / differential / arrow_* / parquet_* / native_* ...
-- 23 suites under sanitizers, 20 failed
SANITIZER GATE FAILED
```

20 of 23 red, on the exact defect, at the exact line. The ordinary five-major matrix stays **green** through the same revert, because the misaligned load is benign on x86_64 -- which is the whole reason the matrix could not see it and this gate has to exist. That is the gate turned on and off, not a green run asserted to be meaningful.

## Gate

Two gates, both green. **Ordinary matrix** on `80786e1` (current `main`): preflight 15.18 / 16.14 / 17.6 / 18.4 / 19beta2 with 0 warnings each; matrix ALL VERSIONS PASSED on PG18 and PG19 with `harness_selftest=PASS` on both (it now excludes `build_san` and `run_san` as non-suites). **Sanitizer gate** (`run_san.sh` on the clang ASAN+UBSAN build): 23 suites, 0 failures with the fix present; 20 failures on the exact misalignment with it reverted.

The sanitizer campaign that #214 deferred here (the Arrow corpus under ASAN) now has a build and a runner to run on; `fuzz_arrow` and `fuzz_parquet` are already in the subset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
