### PR TITLE
docs: correct stale names, wrong locking, and missing reference entries

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -20,8 +20,10 @@ bitmap and a value stream encoded in fixed-size vectors. A separate set of
 ordinary heap tables in the `pgcolumnar` schema is the metadata catalog:
 `storage`, `row_group`, and `column_chunk` record the layout, `zone_map` records
 each chunk's and each vector's minimum and maximum for skipping, `bloom` records
-the per-chunk equality filters, `row_mask` records the delete and update marks,
-and `options` holds per-table settings. A storage id links a relation's physical
+the per-chunk equality filters, `delete_vector` records the delete and update
+marks, `projection` records secondary column projections, `free_space` tracks the
+reclaimable byte ranges freed by deletes and compaction, and `options` holds
+per-table settings. A storage id links a relation's physical
 file to its catalog rows.
 
 ## Crash safety
@@ -84,15 +86,20 @@ The physical storage layer: the metapage, the logical-to-physical byte mapping,
 and the append-only reservation model. A logical offset maps to a block number
 and in-page offset by `BYTES_PER_PAGE = BLCKSZ - SizeOfPageHeaderData`. The
 metapage holds three high-water marks (next stripe id, next row number, next
-logical byte offset) advanced under the relation extension lock, so concurrent
-writers serialize their reservations there and then write their data
-independently. This module reads and writes the raw logical buffers through the
+logical byte offset). The stripe id and row number are advanced under an
+exclusive lock on the metapage buffer, taken when a writer begins buffering a
+stripe, so every row gets its stable row number and item pointer at insert time;
+no extension lock is needed there because no data pages are extended. The byte
+offset is advanced separately at flush, once the stripe's size is known, under
+the relation extension lock the caller already holds to extend the data pages.
+Either way concurrent writers serialize their reservations and then write their
+data independently. This module reads and writes the raw logical buffers through the
 buffer manager.
 
 ### columnar_metadata.c
 Access to the `pgcolumnar` catalog tables and the storage-id sequence: the
-`storage`, `row_group`, `column_chunk`, `zone_map`, `bloom`, `row_mask`, and
-`options` tables. Metadata are ordinary heap tables keyed by storage id, read and
+`storage`, `row_group`, `column_chunk`, `zone_map`, `bloom`, `delete_vector`,
+`projection`, `free_space`, and `options` tables. Metadata are ordinary heap tables keyed by storage id, read and
 written with direct catalog access (heap opens, index scans, and inserts) rather
 than SPI, so metadata access does not depend on SPI reentrancy from inside a scan
 or write. Catalog reads use a snapshot whose command id is advanced so a
@@ -157,14 +164,13 @@ the shared counter. The liveness cache (`ColumnarBuildLivenessCache`) reads the
 row-group list and row masks once so a projection scan can test each row's base
 row number cheaply.
 
-### columnar_row_mask.c
+### columnar_delete_vector.c
 Delete and update marking. A delete, and the old side of an update, sets a bit
-in the `pgcolumnar.row_mask` entry for the row's row group rather than rewriting
-the group; an update inserts the new row with a fresh row number. Marks
+in the `pgcolumnar.delete_vector` entry for the row's row group rather than
+rewriting the group; an update inserts the new row with a fresh row number. Marks
 accumulate in a per-subtransaction in-memory buffer and are applied to the
-catalog in one upsert per row group at flush time. The reader loads a row
-group's mask and skips masked rows. This interim mask is replaced by first-class
-delete vectors in a later phase.
+catalog in one upsert per row group at flush time. The reader loads a row group's
+delete vector and skips marked rows.
 
 ### columnar_customscan.c
 Planner and executor integration. A `set_rel_pathlist_hook` replaces a columnar
@@ -219,7 +225,7 @@ storage id.
 Concurrent unique-key insert serialization (issue #5). Before a freshly inserted
 row is handed back to the executor's index maintenance, the table-AM insert
 paths call `ColumnarLockUniqueKeys`, which takes a transaction-scoped advisory
-lock (the same `SET_LOCKTAG_ADVISORY` primitive as the `columnar_row_mask`
+lock (the same `SET_LOCKTAG_ADVISORY` primitive as the `columnar_delete_vector`
 chunk-group lock) keyed by the row's unique key value(s). Because a columnar
 row's data is invisible to other backends until its stripe flushes at statement
 end, the btree dirty-snapshot uniqueness check can miss a conflict against a row
@@ -338,10 +344,10 @@ Scan: the planner installs the custom scan (`columnar_customscan`) with a column
 projection and scan keys -> the reader (`columnar_reader`) walks row groups, uses
 the zone maps in `columnar_metadata` to skip groups and vectors, decodes
 projected chunks through `columnar_encoding` / `columnar_compression` (optionally
-via `columnar_cache`), applies the row mask (`columnar_row_mask`), and returns
+via `columnar_cache`), applies the delete vector (`columnar_delete_vector`), and returns
 rows one at a time -> the executor re-applies the full qual as a filter. An
 ungrouped aggregate is answered by `columnar_vector` from the zone-map metadata.
 
 Delete or update: the custom scan supplies each row's item pointer ->
-`columnar_row_mask` marks the old row; an update also inserts the new row through
+`columnar_delete_vector` marks the old row; an update also inserts the new row through
 the writer.

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -88,7 +88,7 @@ PostgreSQL's own `CLUSTER` and `VACUUM FULL`: it rewrites the relation and swaps
 the file, so reads and writes on the table block until it finishes. Use it for an
 initial bulk reorganisation, on a table you can take offline.
 `pgcolumnar.recluster` is the online form of the same idea and is described
-below; prefer it on a live table. Neither changes query results — both only
+below; prefer it on a live table. Neither changes query results. Both only
 reorder physical storage.
 
 Leave autovacuum on. It maintains visibility-map bits and statistics for columnar

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -308,7 +308,7 @@ both are larger than anything in it:
 - **A wide table is no longer unusable for index-driven access.** 2,000 index
   fetches reading one column of a 41-column table went from 1,001,374 ms to
   614 ms when the lazily-decoding slot landed (#169), and an 11-column table from
-  284,148 ms to 159 ms. That is the cliff [issue #157] described, and it is gone.
+  284,148 ms to 159 ms. That is the cliff #157 described, and it is gone.
 - **`ANALYZE` now collects statistics** (#159), including correlation, which is
   what lets the planner see the locality `vacuum_sorted` and Z-ordering create.
   Its cost is unmeasured here and is part of #171.

--- a/docs/features.md
+++ b/docs/features.md
@@ -38,9 +38,12 @@ settings see the [configuration reference](configuration.md); for constraints se
 - Chunk-group skipping: a per-chunk minimum and maximum skip list lets a filtered
   scan skip chunk groups that cannot match a pushed-down `column op const`
   qualifier. A per-chunk bloom filter additionally skips groups on an equality
-  probe whose value is provably absent, for hashable, non-collatable columns such
-  as ids and uuids. The executor always re-applies the full qualifier, so skipping
-  never changes results.
+  probe whose value is provably absent, for hashable columns whose collation is
+  deterministic. That covers non-collatable types such as ids and uuids as well
+  as text under an ordinary deterministic collation; only nondeterministic
+  collations are excluded, since there equal values need not share a hash. The
+  executor always re-applies the full qualifier, so skipping never changes
+  results.
 - Vectorized aggregate: an ungrouped `count`, `sum`, `avg`, `min`, or `max` over
   a supported column type is answered from the zone-map metadata, or by a
   column-at-a-time fold over the decoded values when the group has deletes,
@@ -168,7 +171,7 @@ coverage.
 - uuid and numeric columns are read from their Parquet representations, and the
   reader handles millisecond, microsecond, and nanosecond time units.
 - Files are read on demand rather than loaded whole. The footer is read first,
-  then pages as the scan reaches them, so memory does not scale with file size
-  and there is no practical limit on how large a file can be. A row group that
+  then pages as the scan reaches them, so memory use does not scale with file
+  size; a file is bounded by available disk rather than by memory. A row group that
   predicate pushdown excludes is never read from disk at all, and
   `parquet_schema` reads only the footer.

--- a/docs/sql-reference.md
+++ b/docs/sql-reference.md
@@ -78,6 +78,50 @@ to reorder a live table without an exclusive lock.
 SELECT pgcolumnar.cluster('events', 'customer_id', 'ts');
 ```
 
+### pgcolumnar.recluster(tablename regclass, VARIADIC columns name[]) returns bigint
+
+The online counterpart to `cluster`. Re-establishes the same Z-order clustering
+over the given columns, but under `ShareUpdateExclusiveLock`, so concurrent reads
+and writes continue instead of blocking. Returns the number of row groups
+reclustered.
+
+```sql
+SELECT pgcolumnar.recluster('events', 'customer_id', 'ts');
+```
+
+### pgcolumnar.compact(tablename regclass) returns bigint
+
+Retires row groups that are fully deleted, dropping their metadata so scans skip
+them. Holds only `ShareUpdateExclusiveLock`, so it runs against a live table.
+Returns the number of groups retired.
+
+```sql
+SELECT pgcolumnar.compact('events');
+```
+
+### pgcolumnar.compact_rewrite(tablename regclass, min_deleted_fraction float8 DEFAULT 0.2, max_groups int DEFAULT 0) returns bigint
+
+Rewrites partially-deleted row groups, those whose deleted fraction is at least
+`min_deleted_fraction`, to drop their dead rows and reclaim the space, under
+`ShareUpdateExclusiveLock`. `max_groups` caps how many groups a single call
+rewrites; 0 means no cap. Returns the number of groups rewritten.
+
+```sql
+SELECT pgcolumnar.compact_rewrite('events', 0.3);
+```
+
+### pgcolumnar.truncate(tablename regclass) returns bigint
+
+Returns trailing reclaimed blocks to the operating system. Best-effort: it takes
+`AccessExclusiveLock` conditionally for the brief physical step and returns 0
+without waiting if the table is busy, and it only removes space freed before the
+oldest-xmin horizon. Gated by `pgcolumnar.enable_end_truncation`, which is off by
+default. Returns the number of blocks truncated.
+
+```sql
+SELECT pgcolumnar.truncate('events');
+```
+
 ### pgcolumnar.vacuum_full(schema name DEFAULT 'public', sleep_time real DEFAULT 0.0, stripe_count int DEFAULT 0)
 
 Runs `pgcolumnar.vacuum` on every columnar table in a schema. `sleep_time` is a

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -146,10 +146,10 @@ groups and columns the query does not need:
 
 ```sql
 CREATE SERVER pq FOREIGN DATA WRAPPER pgcolumnar_parquet;
-CREATE FOREIGN TABLE events (id int, ts timestamp, amount numeric(12,2))
+CREATE FOREIGN TABLE events_parquet (id int, ts timestamp, amount numeric(12,2))
   SERVER pq OPTIONS (path '/data/events/');   -- a directory of *.parquet files
 
-SELECT sum(amount) FROM events WHERE ts >= '2026-01-01';
+SELECT sum(amount) FROM events_parquet WHERE ts >= '2026-01-01';
 ```
 
 A `path` may name one file, a directory (all `*.parquet` files below it, at any


### PR DESCRIPTION
Adversarial pass over `docs/` checking every claim against `src/*.c` and `pgcolumnar--1.0.sql`. Nine fixes, each verified against the code it describes.

## Accuracy defects (wrong, not just incomplete)

- **`row_mask` -> `delete_vector` throughout `ARCHITECTURE.md`.** The delete/update-marking mechanism is `columnar_delete_vector.c` / `pgcolumnar.delete_vector` / `DeleteVectorBuffer` everywhere in the code; `row_mask` appears nowhere in `src/` or the SQL. Renamed all seven occurrences (prose, the module heading, the reader/update flow, and the advisory-lock cross-reference) and removed the line claiming the "interim mask" is "replaced by first-class delete vectors in a later phase" -- delete vectors are the shipped mechanism.
- **Reservation locking was wrong.** The doc put all three metapage high-water marks under the relation extension lock. In the source, `ColumnarReserveRowNumbers` advances the stripe id and row number under an exclusive lock on the metapage buffer ("no relation extension lock is needed here because no data pages are extended"); only `ColumnarReserveOffset` runs under the extension lock. Rewritten to match.
- **Bloom scope too narrow (`features.md`).** `columnar_bloom.c` gates on collation determinism (`collisdeterministic || InvalidOid`), so deterministic-collation text qualifies, not just non-collatable ids/uuids. Only nondeterministic collations are excluded. Reworded.

## Missing reference entries

- **Four maintenance functions undocumented in `sql-reference.md`:** `compact`, `compact_rewrite`, `recluster`, `truncate`. All ship in `pgcolumnar--1.0.sql` (lines 470/478/486/497). Added, with signatures and lock behavior taken from each function's `COMMENT ON FUNCTION`.
- **Two catalog tables missing from `ARCHITECTURE.md`:** `projection` and `free_space`. Both catalog lists named seven of the nine tables. Added.

## Overclaim / formatting

- **`features.md`:** "no practical limit on how large a file can be" softened to the accurate claim (memory does not scale with file size; a file is bounded by disk).
- **`benchmarks.md`:** fixed the broken `[issue #157]` markdown reference (rendered literally).
- **`user-guide.md`:** renamed the Parquet foreign-table example off `events`, which is already a columnar table earlier in the same guide (name collision on a top-to-bottom read).
- **`administration.md`:** removed an em-dash.

## What I deliberately left

The `encode_effort` speed-up table in `configuration.md` and the wide-table figures in `benchmarks.md` are framed as point measurements, not reproduced by the shipping suites. They read honestly as measurements and I have no evidence they are wrong, so I fixed only the broken link and left the numbers rather than delete accurate content. Say the word if you would rather they carry a reproduction path or come out.

Docs-only; no code, no suite behavior changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)