### PR TITLE
Skip the FSST symbol-table build for numeric columns

### DIFF
--- a/src/columnar_write_state.c
+++ b/src/columnar_write_state.c
@@ -967,8 +967,20 @@ columnar_flush_row_group(ColumnarWriteState *writeState)
 			 * costs 2.7% and 12.2% more space, which is why this is a choice
 			 * offered rather than a default changed.
 			 */
+			/*
+			 * Numeric never wins FSST: its value stream is base-10000 digit
+			 * words with little substring redundancy, so the symbol table built
+			 * here is always dropped by the shrink check below, after the build
+			 * has already cost the time. Skip the build for numeric, exactly as
+			 * encode_effort = fast does for every type. Measured on 8,000,000
+			 * rows, one numeric column, monotonic and high-entropy alike:
+			 * byte-for-byte identical storage and about 3.3x faster to load, and
+			 * a -p profile of the loading backend put ~37% of on-CPU time in the
+			 * FSST build this skips (issue #155).
+			 */
 			if (corpus.len > 0 &&
-				writeState->encodeEffort != COLUMNAR_ENCODE_EFFORT_FAST)
+				writeState->encodeEffort != COLUMNAR_ENCODE_EFFORT_FAST &&
+				att->atttypid != NUMERICOID)
 				ColumnarFsstBuildChunkTable(corpus.data, sampleLen, att,
 											&fsstTable, &fsstTableLen);
 


### PR DESCRIPTION
Closes the numeric value-stream thread on #155.

## The cost

The per-chunk FSST symbol table is built for every varlena column, then dropped by the shrink check when it does not reduce on-disk size. For numeric it is dropped **every time**: the value stream is base-10000 digit words with little substring redundancy, and the block codec already captures what redundancy exists, so FSST never wins. Building it is pure cost.

A `-p` perf profile of a numeric load (optimized build, current `main`) put **~37% of on-CPU time** in the FSST build, `encode_fsst_shared` (`fsst_hash` / `fsst_lookup_find` / `fsst_longest_match`), for monotonic and high-entropy data alike.

## The measurement

Identical deterministic values, N = 8,000,000, one numeric column, default `encode_effort` vs `fast` (which skips the FSST search):

| shape | `full` | `fast` | size delta | speedup |
| --- | --- | --- | --- | --- |
| monotonic | 10255 ms / 3112960 B | 3061 ms / 3112960 B | **0 B** | **3.35x** |
| high-entropy scramble | 11669 ms / 33185792 B | 3497 ms / 33185792 B | **0 B** | **3.34x** |

Byte-for-byte identical storage, ~3.3x faster to load.

## The change

One condition at `columnar_write_state.c:983`: skip `ColumnarFsstBuildChunkTable` for `atttypid == NUMERICOID`, exactly as `encode_effort = fast` already does for every type.

**Output is unchanged by construction.** The change makes numeric-default take the same path as numeric-`fast`, which the measurement above shows is byte-for-byte identical, and which the `encode_effort` suite already exercises. So existing numeric round-trip, encoding, and zone-map suites cover correctness; the win is write time. Narrowed to numeric because that is what is measured; the same method can weigh other varlena types later.

## Gate

Full bar on the branch tip (`bc41e34`):

- **Matrix ALL VERSIONS PASSED** on PG18 and PG19 (assert), every suite including `harness_selftest`, `native_encoding`, `native_roundtrip`, `native_zonemap`, `write_fsst_compressed`, `encode_effort`, `native_dml`.
- **Preflight PASSED** on 15/16/17 (assert): build + `smoke native_writer native_roundtrip native_encoding native_zonemap write_fsst_compressed encode_effort native_dml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
