### PR TITLE
Fix an integer-overflow bounds bypass in the Thrift reader (crafted-Parquet OOB read)

### DIFF
--- a/src/columnar_thrift.c
+++ b/src/columnar_thrift.c
@@ -60,7 +60,17 @@ ColumnarThriftBytes(TCReader *r, uint32 *outlen)
 	uint64		n = ColumnarThriftVarint(r);
 	const uint8 *p;
 
-	if (r->error || r->pos + n > r->len)
+	/*
+	 * Overflow-safe bounds check. n is a file-controlled 64-bit varint, so
+	 * "r->pos + n > r->len" can wrap size_t: a crafted n near 2^64 wraps the
+	 * sum back below r->len, passes the guard, and *outlen returns a truncated
+	 * multi-gigabyte length against an in-bounds pointer. That length then flows
+	 * to callers as a read bound (e.g. a column-chunk statistics min/max length
+	 * used as the end sentinel in plain_value_to_datum), producing an
+	 * out-of-bounds read and a backend crash on a hostile Parquet footer.
+	 * r->pos <= r->len is an invariant here, so r->len - r->pos is the safe form.
+	 */
+	if (r->error || n > r->len - r->pos)
 	{
 		r->error = true;
 		*outlen = 0;


### PR DESCRIPTION
## The bug

`ColumnarThriftBytes` (`columnar_thrift.c`) guarded a file-controlled length with:

```c
if (r->error || r->pos + n > r->len)
```

`n` is a 64-bit varint read straight from the file, and `r->pos`/`r->len` are `size_t`. A crafted `n ≈ 2^64 − k` makes `r->pos + n` wrap back below `r->len`, so the guard passes; the function then returns an in-bounds pointer with `*outlen = (uint32) n`, a truncated multi-gigabyte length.

That length is not inert. `parse_statistics` stores it as a column chunk's `stat_min_len`/`stat_max_len`, and `columnar_parquet_reader.c:3600` passes `p + ch->stat_min_len` to `plain_value_to_datum` as the `end` sentinel. A ~4 GB sentinel defeats the decoder's own `cur + blen > end` checks and reads far out of bounds, so a hostile Parquet footer crashes the backend (postmaster-wide restart — a DoS) and can over-read heap.

Surfaced in a release-readiness review; same class as the #210 stack-guard crash.

## The fix

Overflow-safe form, `n > r->len - r->pos` (`r->pos <= r->len` is an invariant at this point) — the same idiom already used for the footer length at `columnar_parquet_reader.c:1472`.

I verified the chain by tracing it in source: the `size_t` wrap, the truncated `*outlen`, its propagation into `stat_min_len`, and its use as the read sentinel at `:3600`. I did **not** build a running PoC. A crafted-footer regression seed that reaches `parse_statistics` (the existing `native_parquet_stack.sh` crafts footers by hand, but for the earlier recursion guards, not the statistics path) is a sensible follow-up.

The sibling adds elsewhere are not the same hazard: `columnar_thrift.c` fixed skips (`+= 1`, `+= 8`) are constants with guarded reads after; `columnar_parquet_reader.c:756` adds a ≤4-byte constant; `:1154` is defeated only by the bogus sentinel this fix prevents. (`:731`'s `ngroups * bit_width` int math is a separate, count-bounded concern worth hardening later.)

## Gate

Full bar on the branch tip:

- **Matrix ALL VERSIONS PASSED** on PG18 and PG19 (assert), every suite — including the malformed-input ones that exercise this path: `fuzz_parquet`, `native_parquet_hardening`, `native_parquet_stack`, `corruption`, `parquet_import`, `native_read_parquet`.
- **Preflight PASSED** on 15/16/17 (assert): build + `smoke native_read_parquet parquet_import native_parquet_hardening native_parquet_stack fuzz_parquet corruption`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
