### PR TITLE
CI: run the suites on aarch64 (#242)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,3 +130,62 @@ jobs:
             echo "===== $f ====="
             tail -60 "$f"
           done
+
+  # Run the suites on aarch64. This is the leg that matters most for the
+  # alignment class: #225 was an unaligned varlena-header read that is benign on
+  # x86_64 and faults on a strict-alignment target, and until this job existed the
+  # only evidence for the fix was a UBSAN report on the architecture that does not
+  # care. docs/limitations.md claims the extension "runs on any architecture
+  # PostgreSQL supports"; this is the first thing that tests it.
+  #
+  # aarch64 is little-endian, so this covers alignment and not byte order.
+  # Big-endian remains untested and is documented as such.
+  suites-arm:
+    name: suites (PG 17, aarch64)
+    runs-on: ubuntu-24.04-arm
+    needs: build
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install PostgreSQL 17, codec headers, and pyarrow
+        run: |
+          set -euo pipefail
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo curl -fsSL -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+            https://www.postgresql.org/media/keys/ACCC4CF8.asc
+          echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] \
+            https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
+            | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            postgresql-17 postgresql-server-dev-17 \
+            liblz4-dev libzstd-dev zlib1g-dev python3-pip
+          pip3 install --break-system-packages --quiet pyarrow || pip3 install --quiet pyarrow
+
+      - name: Confirm this is actually aarch64
+        # A job that silently ran on x86_64 would report the same green and prove
+        # nothing, which is the whole failure mode this job exists to avoid.
+        run: |
+          set -euo pipefail
+          arch="$(uname -m)"
+          echo "uname -m: $arch"
+          [ "$arch" = "aarch64" ] || { echo "::error::expected aarch64, got $arch"; exit 1; }
+
+      - name: Stop the packaged cluster
+        run: sudo systemctl stop postgresql || true
+
+      - name: Run the suite matrix on aarch64
+        run: |
+          set -euo pipefail
+          sudo -E env "PATH=$PATH" PGC_SKIP_TIMING=1 PGC_JOBS=4 \
+            bash test/run_all_versions.sh /usr/lib/postgresql/17/bin/pg_config
+
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          for f in /tmp/pgcolumnar-matrix-*/*.log; do
+            [ -e "$f" ] || continue
+            echo "===== $f ====="
+            tail -60 "$f"
+          done


### PR DESCRIPTION
Stacked on #236. Targets `ci/github-actions`, not `main`, so it merges after the
base CI workflow lands.

## Why this leg first

#242 lists aarch64 and big-endian together; they are not equally urgent and this
takes only the first.

**aarch64 is the one that tests something we have already claimed and fixed.**
#225 was an unaligned four-byte varlena-header read: benign on x86_64, and a
SIGBUS on a strict-alignment target. The fix was verified by a UBSAN report on
the architecture that cannot fault on it, and `docs/limitations.md` says the
extension "runs on any architecture PostgreSQL supports". Nothing has ever run
there. This is the first evidence either way.

**Big-endian is not in this PR** and is a different question. aarch64 is
little-endian, so this covers alignment and not byte order. The on-disk encoding
descriptor is host-endian by design (`columnar.h:56`), and the Arrow and Parquet
paths are already documented as little-endian only, so byte order is rarer and
better handled as its own change, most likely as a documented "untested" rather
than a gate.

## The job

Same suite set as the x86_64 leg, same `PGC_SKIP_TIMING=1 PGC_JOBS=4`, so a
difference between the two is architectural rather than a difference in what was
run. `ubuntu-24.04-arm` is free for public repositories.

It asserts the architecture before doing anything:

```yaml
arch="$(uname -m)"
[ "$arch" = "aarch64" ] || { echo "::error::expected aarch64, got $arch"; exit 1; }
```

A leg that silently ran on x86_64 would report the same green and prove nothing.
That is the failure mode this whole job exists to rule out, so it is worth one
check rather than an assumption.

## What I do not know yet

This has never run. Specifically unverified: whether PGDG ships arm64 packages
for every component the job installs, whether `pyarrow` has an arm64 wheel or
tries to build from source (which would blow the timeout), and whether any suite
actually fails on aarch64 -- which is the interesting outcome and the reason to
run it.

**If a suite fails here, that is the point of the PR, not a reason to drop it.**
The alignment fix is the first thing I would look at.