### PR TITLE
test: make isolation.sh fail-loud when pg_isolation_regress is absent

### DIFF
--- a/test/isolation.sh
+++ b/test/isolation.sh
@@ -28,10 +28,12 @@ if [ ! -x "$ISO" ]; then
 	# packaged server-dev (as on a CI runner) does not ship it, so this suite
 	# would otherwise turn green without running any of the race specs -- a silent
 	# loss of exactly the coverage it exists for. Where the binary is expected to
-	# be present (CI, release gate), set PGC_REQUIRE_ISOLATION=1 to make its
-	# absence a hard failure instead of a skip.
-	if [ "${PGC_REQUIRE_ISOLATION:-0}" = 1 ]; then
-		echo "FAIL  pg_isolation_regress not found at $ISO and PGC_REQUIRE_ISOLATION=1"
+	# be present (CI, release gate), set PGC_REQUIRE_ISOLATION to make its absence
+	# a hard failure instead of a skip. Any non-empty value other than "0" arms
+	# it (1, true, yes, ...), so a truthy-looking value cannot silently disarm the
+	# guard -- the failure direction is safe.
+	if [ -n "${PGC_REQUIRE_ISOLATION:-}" ] && [ "${PGC_REQUIRE_ISOLATION}" != 0 ]; then
+		echo "FAIL  pg_isolation_regress not found at $ISO and PGC_REQUIRE_ISOLATION is set"
 		echo "      install it (built under src/test/isolation) or unset PGC_REQUIRE_ISOLATION"
 		exit 1
 	fi

--- a/test/isolation.sh
+++ b/test/isolation.sh
@@ -24,7 +24,18 @@ PGXS="$("$PGC_PG_CONFIG" --pgxs)"
 ISO="$(dirname "$PGXS")/../test/isolation/pg_isolation_regress"
 
 if [ ! -x "$ISO" ]; then
-	echo "pg_isolation_regress not found at $ISO; SKIP"
+	# pg_isolation_regress is a build artifact under src/test/isolation; a
+	# packaged server-dev (as on a CI runner) does not ship it, so this suite
+	# would otherwise turn green without running any of the race specs -- a silent
+	# loss of exactly the coverage it exists for. Where the binary is expected to
+	# be present (CI, release gate), set PGC_REQUIRE_ISOLATION=1 to make its
+	# absence a hard failure instead of a skip.
+	if [ "${PGC_REQUIRE_ISOLATION:-0}" = 1 ]; then
+		echo "FAIL  pg_isolation_regress not found at $ISO and PGC_REQUIRE_ISOLATION=1"
+		echo "      install it (built under src/test/isolation) or unset PGC_REQUIRE_ISOLATION"
+		exit 1
+	fi
+	echo "pg_isolation_regress not found at $ISO; SKIP (set PGC_REQUIRE_ISOLATION=1 to make this fatal)"
 	pgc_summary
 	exit 0
 fi


### PR DESCRIPTION
## The gap

`test/isolation.sh` silently SKIPs (exit 0) when `pg_isolation_regress` is absent:

```sh
if [ ! -x "$ISO" ]; then
    echo "pg_isolation_regress not found at $ISO; SKIP"
    pgc_summary
    exit 0
fi
```

That binary is a build artifact under `src/test/isolation` and is not shipped by a packaged `server-dev` (as on a CI runner). So on a packaged install the seven columnar race specs — `delete_vs_rewrite`, `old_snapshot_compact`, `compact_vs_reader`, `recluster_vs_delete`, `truncate_vs_{reader,writer,truncate}` — turn green without running. That is a silent loss of exactly the coverage the suite exists for, the same failure mode the CI workflow (#236) guards against for pyarrow, and the same class flagged in the readiness review.

## The change

Add `PGC_REQUIRE_ISOLATION`. Where the binary is expected present (CI, release gate), set it to `1` and a missing binary is a hard failure instead of a skip. Default behaviour is unchanged, so local source-build runs — which do have the binary — are unaffected; the skip message now also names the knob.

Follow-up for #236: set `PGC_REQUIRE_ISOLATION=1` in CI once the isolation binary is available on the runner, so a green suites job means these specs actually ran.

## Gate

Test-harness change touching only the binary-absent branch (the present-binary path is unchanged). Verified locally on PG18 (assert): `isolation.sh` still PASSES with the binary present, and with the binary path removed + `PGC_REQUIRE_ISOLATION=1` it exits non-zero with the FAIL message instead of skipping. `harness_selftest` PASSES.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
