### PR TITLE
CI: refuse to let pyarrow or the isolation specs skip silently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,13 @@ jobs:
             liblz4-dev libzstd-dev zlib1g-dev python3-pip
           # The Arrow and Parquet suites use pyarrow as an independent reader and
           # skip themselves without it, which would be a silent loss of coverage.
-          pip3 install --break-system-packages --quiet pyarrow || pip3 install --quiet pyarrow
+          # Installed with sudo on purpose. The suites run under sudo, so the
+          # interpreter that must find pyarrow is root's. A plain "pip3 install"
+          # as the runner lands in ~/.local and root cannot see it, which is
+          # exactly how the Arrow and Parquet suites came to report PASS in CI
+          # while skipping themselves.
+          sudo pip3 install --break-system-packages --quiet pyarrow \
+            || sudo pip3 install --quiet pyarrow
 
       - name: Confirm pyarrow is importable by the suites' interpreter
         # Installing pyarrow and having the suites SEE it are different facts. The

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,17 @@ jobs:
           # skip themselves without it, which would be a silent loss of coverage.
           pip3 install --break-system-packages --quiet pyarrow || pip3 install --quiet pyarrow
 
+      - name: Confirm pyarrow is importable by the suites' interpreter
+        # Installing pyarrow and having the suites SEE it are different facts. The
+        # Arrow and Parquet suites skip themselves when the import fails, so a
+        # pip/interpreter skew turns those suites green without running them --
+        # a silent loss of exactly the coverage they exist for. The suites run
+        # under sudo, so check the import as root too, not only as the runner.
+        run: |
+          set -euo pipefail
+          python3 -c 'import pyarrow, pyarrow.parquet; print("pyarrow", pyarrow.__version__)'
+          sudo python3 -c 'import pyarrow, pyarrow.parquet; print("pyarrow as root ok")'
+
       - name: Stop the packaged cluster
         # The suites start their own throwaway clusters on private ports; the
         # packaged one is unused and only competes for shared memory.
@@ -119,7 +130,19 @@ jobs:
           # to the change is worse than one that does not run. They stay in the
           # local matrix, which is where those numbers mean anything.
           # PGC_JOBS is sized for a 4-core runner rather than the local 8.
+          # PGC_REQUIRE_ISOLATION turns a missing pg_isolation_regress into a
+          # failure instead of a skip (#247), so the seven columnar race specs
+          # cannot report green without executing.
+          #
+          # #247 expected the binary to be absent on a packaged install. On PGDG
+          # and Ubuntu it is present: postgresql-client-NN ships it at
+          # $(pg_config --pgxs)/../test/isolation/pg_isolation_regress, which is
+          # exactly where isolation.sh looks. Verified against the packaged
+          # PostgreSQL 18 in the dev container: the suite runs its specs rather
+          # than skipping. So requiring it here costs nothing and converts an
+          # ambiguous PASS -- which a skip also produces -- into a real one.
           sudo -E env "PATH=$PATH" PGC_SKIP_TIMING=1 PGC_JOBS=4 \
+            PGC_REQUIRE_ISOLATION=1 \
             bash test/run_all_versions.sh /usr/lib/postgresql/17/bin/pg_config
 
       - name: Collect logs on failure


### PR DESCRIPTION
@ChronicallyJD both follow-ups from your #236 review, and one correction to #247.

## pyarrow

You were right that this is worth doing and right that it was not a merge
blocker. Installing pyarrow and the suites **seeing** it are different facts: the
Arrow and Parquet suites skip themselves on import failure, so a pip/interpreter
skew turns them green without running.

Asserted as the runner user **and as root**, because the suites run under `sudo`
and root's interpreter is the one that matters. Checking only the runner's would
have been the same class of mistake one level down.

## Isolation, and a correction

`PGC_REQUIRE_ISOLATION=1` is now set, so a missing `pg_isolation_regress` fails
instead of skipping.

**#247's premise about packaged installs is wrong**, at least for PGDG and
Ubuntu. The binary is not absent: `postgresql-client-NN` ships it at
`$(pg_config --pgxs)/../test/isolation/pg_isolation_regress`, which is precisely
where `isolation.sh` looks:

```
dpkg -S pg_isolation_regress
postgresql-client-18: /usr/lib/postgresql/18/lib/pgxs/src/test/isolation/pg_isolation_regress
```

I verified rather than assuming, because if it had been absent this change would
have turned CI red with no fix available — and I would have been trading a silent
skip for a broken gate. Against the packaged PostgreSQL 18 in the dev container,
with the flag set, `isolation.sh` runs its specs and passes.

So requiring it costs nothing and buys something specific: `isolation=PASS` was
**ambiguous**, because the skip path also exits 0 and reports PASS. It is now a
real result.

## Not changed

Neither knob alters local behaviour. `PGC_SKIP_TIMING` is untouched here; the
`native_cancel` carve-out you identified is filed as **#254** with your design
(cancel from another session, generous bound, no ratio) and an acceptance
criterion that removing a `CHECK_FOR_INTERRUPTS` must turn it red.