### PR TITLE
Carry per-table options through pg_dump (fixes #248)

### DIFF
--- a/pgcolumnar--1.0-dev.sql
+++ b/pgcolumnar--1.0-dev.sql
@@ -60,6 +60,29 @@ CREATE TABLE pgcolumnar.options (
 CREATE UNIQUE INDEX options_pkey
 	ON pgcolumnar.options USING btree (regclass);
 
+/*
+ * Carry the per-table options through pg_dump (#248).
+ *
+ * Rows in an extension's own tables are not dumped unless the extension says so.
+ * Without this, pg_dump emitted the table definition and its data but never the
+ * options row, so a restored columnar table silently reverted to default
+ * stripe/chunk limits, compression and encode_effort. Silent, because nothing
+ * fails: the data is all there and only the settings are gone.
+ *
+ * This table and ONLY this table. Every other pgcolumnar catalog table is keyed
+ * by storage_id, which is assigned when the relation is created, so a restore
+ * generates new ones -- dumping those rows would restore metadata pointing at
+ * storage that no longer exists, which is worse than losing it. options is keyed
+ * by regclass, a name that survives dump and restore, and it holds user intent
+ * rather than physical layout, which is the same reason it is the only one worth
+ * carrying.
+ *
+ * Projections are user intent too and are still lost across a dump, for the
+ * storage_id reason above; re-emitting pgcolumnar.add_projection() calls is a
+ * different mechanism and its own problem.
+ */
+SELECT pg_catalog.pg_extension_config_dump('pgcolumnar.options', '');
+
 /* ---------------------------------------------------------------------------
  * pgcolumnar.projection (gap 26)
  *

--- a/test/pg_dump_roundtrip.sh
+++ b/test/pg_dump_roundtrip.sh
@@ -60,18 +60,17 @@ verify() {  # label db
 	check "$label: access method is pgcolumnar"  "$(on "$db" "$am_sql;")" "pgcolumnar"
 	# tail -1: the two SET statements each emit a command tag before the result.
 	check "$label: restored index answers a point lookup" "$(on "$db" "$idx_sql;" | tail -1)" "12345"
-	# Pinned as an assertion of the CURRENT, WRONG behaviour rather than echoed.
+	# Per-table options survive the round trip (#248). They did not until the
+	# extension registered pgcolumnar.options with pg_extension_config_dump:
+	# rows in an extension's own tables are not dumped unless the extension asks,
+	# so a restored table silently reverted to default limits, compression and
+	# encode_effort.
 	#
-	# An echo in a passing suite is read by nobody, so a known gap recorded that
-	# way is a gap that gets forgotten. Asserting what happens today keeps the
-	# round-trip gate green while #248 is open, and makes fixing #248 turn this
-	# check RED -- which is exactly when someone needs reminding that this line
-	# and its expectation have to change. A known-wrong behaviour that is pinned
-	# cannot be fixed silently.
-	#
-	# When #248 lands: flip the expectation to "$before_opt" and delete this note.
-	check "$label: encode_effort is NOT preserved (pinned; see #248)" \
-		"$(on "$db" "$opt_sql;")" "<none>"
+	# This check was pinned to the broken behaviour while #248 was open, which is
+	# what turned it red the moment the fix landed and forced this line to be
+	# updated deliberately rather than a green run hiding the change.
+	check "$label: per-table options survive" \
+		"$(on "$db" "$opt_sql;")" "$before_opt"
 	on postgres "DROP DATABASE IF EXISTS $db;" >/dev/null 2>&1
 }
 


### PR DESCRIPTION
@ChronicallyJD your #249 finding, fixed rather than documented.

## The cause

Rows in an extension's own tables are not dumped unless the extension registers
them. `pgcolumnar.options` never was, so `pg_dump` emitted the table and its data
but not the options row:

```sql
SELECT pg_catalog.pg_extension_config_dump('pgcolumnar.options', '');
```

Silent is what made it worth fixing rather than caveating. Nothing errors: every
row is present, only the settings are gone, so a restored table quietly writes in
a different shape than the one it was tuned for.

## Only this table, and the reason is the interesting part

Every other `pgcolumnar` catalog table is keyed by **storage_id**, assigned when a
relation is created, so a restore generates new ones. Dumping those rows would
restore metadata pointing at storage that no longer exists — worse than losing it.

`options` is keyed by **regclass**, a name that survives dump and restore, and it
records user intent rather than physical layout. That is what makes it both safe
to carry and the only one worth carrying.

**Projections are still lost**, for exactly that storage_id reason — they are user
intent but keyed by storage. Re-emitting `add_projection()` calls is a different
mechanism; worth its own issue if you agree.

## Your pinned check earned its place immediately

The assertion I pinned to the broken behaviour on #249 went red the moment this
fix landed:

```
FAIL  custom: encode_effort is NOT preserved (pinned; see #248): got [fast] want [<none>]
```

That is the design working. It forced the expectation to be updated deliberately
instead of a green run quietly absorbing a behaviour change. Now flipped to assert
the option survives.

## Gate

Full five-major matrix **ALL VERSIONS PASSED**, 495 suite runs.

One pre-release note: this lives in `pgcolumnar--1.0-dev.sql`, so an already
installed extension does not gain it until reinstalled. No upgrade script exists
yet by design; when 1.0 ships, `1.0-dev--1.0` carries it.