### PR TITLE
Isolate the replication suite, and make its failures self-reporting

### DIFF
--- a/test/replication.sh
+++ b/test/replication.sh
@@ -293,4 +293,19 @@ sync_standby
 check "with the module back, the replayed table reads correctly" \
 	"$(hash_standby r2)" "$(hash_primary r2)"
 
+# On failure, restate the evidence at the END of the output.
+#
+# run_all_versions.sh tails the last 20 lines of a failing suite's log, and every
+# diagnostic this suite prints -- sb_start's standby log dump, the port line --
+# happens near the start, so the matrix showed twenty lines of passing scenario-3
+# checks and nothing about what broke. Three separate investigations of an
+# intermittent failure here were spent re-running the matrix with an external
+# snapshotter purely to recover text the suite had already printed.
+if [ "$PGC_FAIL" != 0 ]; then
+	echo "-- replication failed; primary port $PGC_PORT, standby port $SB_PORT"
+	echo "-- standby log tail:"
+	pgc_pg "tail -25 '$SB_LOG'" 2>/dev/null | sed 's/^/     /'
+	echo "-- standby data dir present: $(pgc_pg "test -d '$SB_DIR' && echo yes || echo no" 2>/dev/null | tr -d '[:space:]')"
+fi
+
 pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -159,6 +159,29 @@ is_timing_suite() {
 	esac
 }
 
+# Suites that must not run beside five others, which is a wider set than the
+# timing ones and for a second reason.
+#
+# The timing suites are here because a wall-clock ratio cannot be measured under
+# contention. replication is here because it is heavy rather than because it
+# measures anything: it stands up a SECOND cluster, runs pg_basebackup, and
+# streams between the two, so at PGC_JOBS=6 it is competing with six other
+# clusters for the same box. It failed roughly one full matrix in three, on a
+# different major each time -- PG18, then PG19, then PG16 -- which is the
+# signature of resource contention rather than a defect in the suite or the
+# major.
+#
+# Deliberately NOT the same predicate as is_timing_suite, because
+# PGC_SKIP_TIMING drops those in CI and replication must still run there. Serial
+# and skipped are different properties and were one list until this suite needed
+# one without the other.
+runs_alone() {
+	case "$1" in
+		replication) return 0 ;;
+		*) is_timing_suite "$1" ;;
+	esac
+}
+
 for pgc in "${CONFIGS[@]}"; do
 	if [ ! -x "$pgc" ]; then
 		echo "SKIP  $pgc (not executable)"
@@ -213,7 +236,7 @@ for pgc in "${CONFIGS[@]}"; do
 	results=""
 	maxjobs="${PGC_JOBS:-6}"
 	for s in "${SUITES[@]}"; do
-		if is_timing_suite "$s"; then
+		if runs_alone "$s"; then
 			continue
 		fi
 		# throttle to maxjobs concurrent suites
@@ -236,10 +259,14 @@ for pgc in "${CONFIGS[@]}"; do
 	# running it. They stay in every local run, which is where the numbers mean
 	# something.
 	for s in "${SUITES[@]}"; do
-		if ! is_timing_suite "$s"; then
+		if ! runs_alone "$s"; then
 			continue
 		fi
-		if [ "${PGC_SKIP_TIMING:-0}" = 1 ]; then
+		# PGC_SKIP_TIMING drops the wall-clock suites only. A suite that runs
+		# alone for a resource reason rather than a measurement one -- replication
+		# -- still runs, because there is nothing about a shared runner that makes
+		# its assertions untrustworthy, only slower.
+		if [ "${PGC_SKIP_TIMING:-0}" = 1 ] && is_timing_suite "$s"; then
 			echo "  SKIP  $s (PGC_SKIP_TIMING)"
 			echo 0 >"$builddir/${s}.rc"
 			continue


### PR DESCRIPTION
**This is not a flake fix, and the description previously said it was.** Corrected
before merge, per @ChronicallyJD's note.

## What it actually does

**1. `runs_alone`, separated from `is_timing_suite`.** Two properties had been
sharing one list:

```
is_timing_suite   the three wall-clock ratio suites.
                  PGC_SKIP_TIMING drops these in CI, because a ratio measured
                  under contention is not a measurement.

runs_alone        the timing suites PLUS replication.
                  Excluded from the parallel batch, run serially after it.
```

`replication` belongs in the second and not the first: nothing about a shared
runner makes its assertions untrustworthy, only slower, so it must keep running
in CI. **My first version reused `is_timing_suite` and would have silently dropped
replication from CI while claiming to fix a flake.** Caught by running with
`PGC_SKIP_TIMING=1` and looking for `replication=` in the summary rather than at
the overall green.

Isolating it is right on its own terms: the suite stands up a second cluster,
runs `pg_basebackup`, and streams between them. It should not be doing that beside
six other clusters, whatever the flake turns out to be.

**2. Failures now report themselves.** Every diagnostic this suite printed --
`sb_start`'s standby log dump, the chosen ports -- happened near the start, and
`run_all_versions.sh` tails only the last 20 lines of a failing suite. So a matrix
failure showed twenty lines of passing scenario-3 checks and nothing about what
broke. **Three separate investigations were spent re-running the matrix with an
external snapshotter to recover text the suite had already produced and thrown
away.** It now restates the ports, the standby log tail and the data-dir state at
the end.

## What it does not do

It does not fix the intermittent failure, and I cannot claim it does.

```
with the change in:  FAIL, FAIL, PASS, PASS, PASS, PASS, PASS
```

Two failures in the first two runs, then five consecutive passes. Against a
one-in-three rate, five clean runs has roughly a 13% chance of happening anyway,
so that is suggestive and not proof. A sixth matrix is in flight.

Also measured, and it undercuts the contention theory I started with: **ten
consecutive solo runs on PG16 -- the major that failed -- all passed.** So "six
other clusters are competing with it" cannot be the whole explanation.

**I have still never read the failing check.** That is the honest state, and it is
exactly why change 2 is in here: the next occurrence will say what it was without
another twelve-minute hunt.

## Edge @ChronicallyJD raised

If the failure is before `sb_start` -- `pg_basebackup` itself failing -- `$SB_LOG`
may not exist and the tail prints nothing. The port and data-dir lines still land,
so it degrades to something rather than nothing. Agreed, leaving it.