### PR TITLE
Assert that pg_basebackup preserves projections (#266 follow-up)

### DIFF
--- a/test/replication.sh
+++ b/test/replication.sh
@@ -33,6 +33,10 @@ pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
 
 SB_DIR="$PGC_WORKDIR/standby"
 SB_LOG="$PGC_WORKDIR/standby.log"
+# A second, restore-only cluster. See the "restore in isolation" block: it exists
+# to take streaming out of the picture entirely.
+RS_DIR="$PGC_WORKDIR/restore"
+RS_LOG="$PGC_WORKDIR/restore.log"
 
 # The standby needs a port of its own, and PGC_PORT + 1 is the one choice that
 # cannot work. run_all_versions.sh hands each suite a port by walking upward from
@@ -76,6 +80,11 @@ if [ -z "$SB_PORT" ]; then
 	PGC_FAIL=1
 	pgc_summary
 fi
+RS_PORT="$(pick_sb_port)"
+while [ "$RS_PORT" = "$SB_PORT" ] || ! pgc_port_free "$RS_PORT"; do
+	RS_PORT=$((RS_PORT + 1))
+	[ "$RS_PORT" -gt 39000 ] && { echo "FAIL  no free port for the restore"; PGC_FAIL=1; pgc_summary; }
+done
 echo "-- primary port $PGC_PORT, standby port $SB_PORT"
 
 # ---------------------------------------------------------------------------
@@ -111,8 +120,29 @@ sb_start() {
 	return 1
 }
 
-# Stop the standby before the ordinary teardown takes the primary away.
-sb_teardown() { sb_stop; pgc_teardown; }
+rs_q() {   # query the RESTORE-ONLY cluster
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$RS_PORT" -U postgres \
+		-d "$PGC_DB" -At -c "$1" 2>/dev/null || true
+}
+
+rs_stop() {
+	pgc_pg "pg_ctl -D '$RS_DIR' stop -m immediate -w" >/dev/null 2>&1 || true
+}
+
+rs_start() {
+	local i
+	pgc_pg "pg_ctl -D '$RS_DIR' -l '$RS_LOG' -t 120 start -w" >/dev/null 2>&1
+	for i in $(seq 1 120); do
+		[ "$(rs_q 'SELECT 1')" = 1 ] && return 0
+		sleep 0.5
+	done
+	echo "  restore cluster did not accept connections; last 15 lines of its log:"
+	pgc_pg "tail -15 '$RS_LOG'" 2>/dev/null | sed 's/^/    /'
+	return 1
+}
+
+# Stop both extra clusters before the ordinary teardown takes the primary away.
+sb_teardown() { sb_stop; rs_stop; pgc_teardown; }
 trap sb_teardown EXIT
 
 # Wait until the standby has replayed at least the primary's current LSN.
@@ -144,6 +174,20 @@ hash_standby() { sb_q "SELECT md5(string_agg(t::text, '' ORDER BY t::text)) FROM
 psql_run "CREATE TABLE r (id int, v text) USING pgcolumnar;
 	INSERT INTO r SELECT g, 'row' || g FROM generate_series(1,20000) g;" >/dev/null 2>&1
 
+# Declared BEFORE the backup on purpose. docs/limitations.md (#267) tells users a
+# physical backup preserves projections where pg_dump does not, and the claim is
+# about the bytewise copy containing them -- so the projection has to exist at
+# backup time or the test exercises streaming replay instead and the assertion
+# names a mechanism it never ran.
+psql_run "SELECT pgcolumnar.add_projection('r', 'r_pre', ARRAY['id','v'], ARRAY['id']);" >/dev/null 2>&1
+proj_sql="SELECT count(*) FROM pgcolumnar.projection
+	WHERE storage_id = pgcolumnar.get_storage_id('r') AND projection_id > 0"
+pri_proj="$(q "$proj_sql;")"
+check "the primary has a projection to preserve, before the backup runs" \
+	"$pri_proj" "1"
+pri_pre_rows="$(q "SELECT count(*) FROM pgcolumnar.read_projection('r','r_pre');")"
+check "and it reads on the primary" "$pri_pre_rows" "20000"
+
 echo "-- pg_basebackup"
 pgc_pg "pg_basebackup -h 127.0.0.1 -p $PGC_PORT -U postgres -D '$SB_DIR' -R -X stream -c fast" \
 	>/dev/null 2>&1
@@ -172,25 +216,104 @@ sync_standby
 check "the base backup carried the initial rows" \
 	"$(hash_standby r)" "$(hash_primary r)"
 
-# Projections survive a physical backup, which docs/limitations.md now claims.
+# The claim docs/limitations.md makes: a physical backup preserves projections
+# where pg_dump does not.
 #
-# #266 and #267 established that pg_dump does NOT carry projections: they are
-# keyed by storage_id, which a logical restore regenerates, so the rows cannot be
-# carried and are pinned as lost in pg_dump_roundtrip.sh. The docs contrast that
-# with a physical backup preserving them, and that half was reasoning rather than
-# a test. pg_basebackup is a bytewise copy, so the projection rows and the storage
-# ids they reference both come across unchanged -- which is exactly the kind of
-# claim worth asserting rather than arguing, since it is the recovery path the
-# documentation sends people to.
-psql_run "SELECT pgcolumnar.add_projection('r', 'r_proj', ARRAY['id','v'], ARRAY['id']);" >/dev/null 2>&1
-proj_sql="SELECT count(*) FROM pgcolumnar.projection
-	WHERE storage_id = pgcolumnar.get_storage_id('r') AND projection_id > 0"
-pri_proj="$(q "$proj_sql;")"
-check "the primary has a projection to preserve" "$pri_proj" "1"
+# #266 and #267 established the negative half with a test -- projections are keyed
+# by storage_id, which a logical restore regenerates, so pg_dump cannot carry them
+# and pg_dump_roundtrip.sh pins the loss. The positive half was reasoning: the
+# backup is a bytewise copy, so the projection rows and the storage ids they name
+# both come across unchanged. r_pre was declared before pg_basebackup ran, so it
+# is genuinely in the backup and this asserts the documented mechanism.
+check "pg_basebackup carried the projection catalog row, unlike pg_dump (#266)" \
+	"$(sb_q "$proj_sql;")" "$pri_proj"
+
+# Existence is not usability. The catalog row can arrive while the projection's
+# own storage did not, which would read as preserved and behave as lost -- the
+# same existence-versus-function gap the index point-lookup covers in
+# pg_dump_roundtrip.sh. Read it on the standby and compare content, not counts.
+check "and the projection's storage came across intact and readable" \
+	"$(sb_q "SELECT count(*) FROM pgcolumnar.read_projection('r','r_pre');")" \
+	"$pri_pre_rows"
+check "with the same content the primary reads" \
+	"$(sb_q "SELECT md5(string_agg(x, '' ORDER BY x)) FROM pgcolumnar.read_projection('r','r_pre') x;")" \
+	"$(q "SELECT md5(string_agg(x, '' ORDER BY x)) FROM pgcolumnar.read_projection('r','r_pre') x;")"
+
+# A distinct property, worth keeping now that it is no longer mislabelled as the
+# backup one: a projection created AFTER the backup reaches the standby by WAL
+# replay of the DDL and its back-fill -- the sibling of the SMGR-truncate replay
+# this suite covers further down.
+psql_run "SELECT pgcolumnar.add_projection('r', 'r_post', ARRAY['id','v'], ARRAY['id']);" >/dev/null 2>&1
+check "the primary now has a second, post-backup projection" "$(q "$proj_sql;")" "2"
 
 sync_standby
-check "pg_basebackup preserved the projection, unlike pg_dump (#266)" \
-	"$(sb_q "$proj_sql;")" "$pri_proj"
+check "streaming replay carried a projection created after the backup" \
+	"$(sb_q "$proj_sql;")" "2"
+check "and that one reads on the standby too" \
+	"$(sb_q "SELECT count(*) FROM pgcolumnar.read_projection('r','r_post');")" \
+	"$pri_pre_rows"
+
+# ---------------------------------------------------------------------------
+# The same claim, with streaming taken out of the picture
+# ---------------------------------------------------------------------------
+#
+# Everything above runs against a streaming standby, which would hold a
+# projection whether it arrived in the backup or by replay afterwards. Declaring
+# r_pre before the backup means the backup must contain it, but the assertion
+# still cannot see which mechanism delivered it, so on its own it argues rather
+# than proves -- the exact failing this PR set out to fix.
+#
+# So take a second backup and bring it up as a standalone cluster: no -R, no
+# standby.signal, no primary_conninfo. It recovers to consistency from its own
+# WAL and opens read-write, never connecting to the primary. Anything present in
+# it came from the backup bytes, and nothing else. That is the documented claim
+# with nothing left to attribute it to.
+echo "-- restore in isolation (no streaming)"
+pgc_pg "pg_basebackup -h 127.0.0.1 -p $PGC_PORT -U postgres -D '$RS_DIR' -X fetch -c fast" \
+	>/dev/null 2>&1
+pgc_pg "sed -i 's/^port=.*/port=$RS_PORT/' '$RS_DIR/postgresql.conf'" >/dev/null 2>&1
+rs_start
+check "the restored cluster accepts connections" "$(rs_q 'SELECT 1')" "1"
+
+# The control that makes the rest mean anything: if this were still following the
+# primary, or were the primary, "the projection is there" would prove nothing.
+check "the restored cluster is not in recovery (it is not following anyone)" \
+	"$(rs_q 'SELECT pg_is_in_recovery()')" "f"
+check "and has no upstream configured" \
+	"$(rs_q "SELECT count(*) FROM pg_stat_wal_receiver")" "0"
+check "and is a different cluster from the primary and the standby" \
+	"$([ "$(rs_q 'SHOW data_directory')" != "$(q 'SHOW data_directory')" ] && \
+	   [ "$(rs_q 'SHOW data_directory')" != "$(sb_q 'SHOW data_directory')" ] && \
+	   echo yes || echo no)" \
+	"yes"
+
+# Both of the next two compare the restored cluster against the primary, and a
+# comparison of two empty results passes while proving nothing -- so pin the
+# primary side to a literal first. Without these, dropping both projections on the
+# primary would turn the pair below green rather than red.
+rs_pri_count="$(q "$proj_sql;")"
+rs_pri_hash="$(q "SELECT md5(string_agg(x, '' ORDER BY x)) FROM pgcolumnar.read_projection('r','r_pre') x;")"
+check "the primary still has both projections when the backup is taken" \
+	"$rs_pri_count" "2"
+check "and a non-empty projection to compare against" \
+	"$([ -n "$rs_pri_hash" ] && echo yes || echo no)" "yes"
+
+# Compared against the primary's count now, not a literal: this backup is a
+# snapshot of the primary taken at this point, so both r_pre and r_post are in it.
+check "a physical backup alone preserves the projections, unlike pg_dump (#266)" \
+	"$(rs_q "$proj_sql;")" "$rs_pri_count"
+check "and its storage, readable with the same content" \
+	"$(rs_q "SELECT md5(string_agg(x, '' ORDER BY x)) FROM pgcolumnar.read_projection('r','r_pre') x;")" \
+	"$rs_pri_hash"
+
+# r_post was declared after the FIRST backup but before this one, so it is in
+# these bytes too. Its presence is not the point; its absence would mean this
+# backup predates it and the check above was reading a stale copy.
+check "and the later projection is in this backup as well, so it is not stale" \
+	"$(rs_q "SELECT count(*) FROM pgcolumnar.read_projection('r','r_post');")" \
+	"$pri_pre_rows"
+
+rs_stop
 
 # Positive control: with replay paused, a change on the primary must NOT appear.
 # This is the check that proves the comparison can fail. Everything after it is

--- a/test/replication.sh
+++ b/test/replication.sh
@@ -188,8 +188,23 @@ check "the primary has a projection to preserve, before the backup runs" \
 pri_pre_rows="$(q "SELECT count(*) FROM pgcolumnar.read_projection('r','r_pre');")"
 check "and it reads on the primary" "$pri_pre_rows" "20000"
 
+# -C -S creates a physical replication slot and writes primary_slot_name into the
+# standby's config, so the primary retains WAL until the standby has consumed it.
+#
+# Without a slot the primary is free to recycle a segment the standby still needs,
+# and the standby then loops on
+#     ERROR: requested WAL segment ... has already been removed
+# until sync_standby gives up, after which every comparison below reads an empty
+# result and the suite reports a cascade of failures that say nothing about what
+# broke. That is the intermittent replication failure this suite has shown in the
+# matrix: it was never a columnar defect, it was WAL retention left to chance and
+# decided by checkpoint timing under parallel load.
+#
+# The restore-only backup further down requests a checkpoint (-c fast), which is
+# precisely the event that recycles those segments, so the isolation cluster made
+# a latent hole reproducible rather than introducing one.
 echo "-- pg_basebackup"
-pgc_pg "pg_basebackup -h 127.0.0.1 -p $PGC_PORT -U postgres -D '$SB_DIR' -R -X stream -c fast" \
+pgc_pg "pg_basebackup -h 127.0.0.1 -p $PGC_PORT -U postgres -D '$SB_DIR' -R -C -S pgc_standby -X stream -c fast" \
 	>/dev/null 2>&1
 check "pg_basebackup produced a data directory" \
 	"$(pgc_pg "test -f '$SB_DIR/PG_VERSION' && echo yes || echo no" 2>/dev/null | tr -d '[:space:]')" \
@@ -200,6 +215,16 @@ check "pg_basebackup produced a data directory" \
 pgc_pg "sed -i 's/^port=.*/port=$SB_PORT/' '$SB_DIR/postgresql.conf'" >/dev/null 2>&1
 sb_start
 check "the standby accepts connections" "$(sb_q 'SELECT 1')" "1"
+
+# The retention fix, asserted rather than assumed: a slot that was not created, or
+# that the standby is not using, leaves WAL recycling to chance again and the
+# failure comes back as an unexplained flake.
+check "a physical slot exists to hold WAL for the standby" \
+	"$(q "SELECT count(*) FROM pg_replication_slots WHERE slot_name = 'pgc_standby' AND slot_type = 'physical'")" \
+	"1"
+check "and the standby is actually connected through it" \
+	"$(q "SELECT active FROM pg_replication_slots WHERE slot_name = 'pgc_standby'")" \
+	"t"
 
 # ---------------------------------------------------------------------------
 # The controls. Without these the rest can pass while proving nothing.

--- a/test/replication.sh
+++ b/test/replication.sh
@@ -322,10 +322,33 @@ check "and that one reads on the standby too" \
 # it came from the backup bytes, and nothing else. That is the documented claim
 # with nothing left to attribute it to.
 echo "-- restore in isolation (no streaming)"
-pgc_pg "pg_basebackup -h 127.0.0.1 -p $PGC_PORT -U postgres -D '$RS_DIR' -X fetch -c fast" \
-	>/dev/null 2>&1
+# -X stream, not -X fetch. fetch collects the required WAL at the END of the
+# backup, so if the primary recycled a segment while the backup ran, the backup
+# itself fails -- the same retention problem the standby had, one layer up, and it
+# does fail under the parallel matrix. stream opens a second connection and takes
+# WAL as it is produced, using a temporary slot, so nothing it needs can be
+# recycled underneath it.
+#
+# This is still a restore, not a standby: no -R, so no standby.signal and no
+# primary_conninfo. The temporary slot exists only for the duration of the backup.
+pgc_pg "pg_basebackup -h 127.0.0.1 -p $PGC_PORT -U postgres -D '$RS_DIR' -X stream -c fast" \
+	>"$PGC_WORKDIR/rs_backup.log" 2>&1
+
+# Distinguish "the backup failed" from "the cluster would not start". Without
+# this they are the same empty result, and the previous matrix could not tell
+# them apart.
+rs_backup_ok="$(pgc_pg "test -f '$RS_DIR/PG_VERSION' && echo yes || echo no" 2>/dev/null | tr -d '[:space:]')"
+if [ "$rs_backup_ok" != yes ]; then
+	echo "  the restore backup failed; pg_basebackup said:"
+	sed 's/^/    /' "$PGC_WORKDIR/rs_backup.log" 2>/dev/null | tail -15
+fi
+check "the second base backup produced a data directory" "$rs_backup_ok" "yes"
+
 pgc_pg "sed -i 's/^port=.*/port=$RS_PORT/' '$RS_DIR/postgresql.conf'" >/dev/null 2>&1
-rs_start
+if ! rs_start; then
+	echo "FAIL  the restored cluster did not start"
+	PGC_FAIL=1
+fi
 check "the restored cluster accepts connections" "$(rs_q 'SELECT 1')" "1"
 
 # The control that makes the rest mean anything: if this were still following the

--- a/test/replication.sh
+++ b/test/replication.sh
@@ -148,10 +148,18 @@ trap sb_teardown EXIT
 # Wait until the standby has replayed at least the primary's current LSN.
 # Polls rather than sleeping a fixed amount: a fixed sleep is either flaky or
 # slow, and on a loaded box it is both.
+# The return value is deliberately not ignored by callers -- see sync_or_fail.
+#
+# 360 half-second attempts (3 minutes), not 60 seconds. Under the six-way matrix
+# this box has been observed taking a 34-second checkpoint, and a standby that is
+# merely slow is not a standby that is broken. A too-short budget here does not
+# report "the standby was slow"; it silently returns 1, every comparison after it
+# reads pre-sync state, and the suite fails on a content mismatch that names the
+# wrong thing entirely.
 sync_standby() {
 	local target i replayed
 	target="$(q "SELECT pg_current_wal_lsn()")"
-	for i in $(seq 1 120); do
+	for i in $(seq 1 360); do
 		replayed="$(sb_q "SELECT pg_last_wal_replay_lsn()")"
 		if [ -n "$replayed" ] && [ -n "$target" ] && \
 		   [ "$(sb_q "SELECT '$replayed'::pg_lsn >= '$target'::pg_lsn")" = t ]; then
@@ -159,6 +167,26 @@ sync_standby() {
 		fi
 		sleep 0.5
 	done
+	return 1
+}
+
+# Every caller goes through this. sync_standby returning 1 used to be discarded,
+# so a standby that never caught up produced a cascade of downstream content
+# mismatches instead of one line saying it never caught up -- the same discarded
+# exit status that sb_start had, in the same suite.
+sync_or_fail() {
+	if sync_standby; then
+		return 0
+	fi
+	echo "FAIL  the standby did not catch up (${1:-unnamed sync point})"
+	echo "      primary lsn: $(q "SELECT pg_current_wal_lsn()")"
+	echo "      standby replayed: $(sb_q "SELECT pg_last_wal_replay_lsn()")"
+	echo "      standby in recovery: $(sb_q "SELECT pg_is_in_recovery()")"
+	echo "      walreceiver: $(sb_q "SELECT count(*) FROM pg_stat_wal_receiver")"
+	echo "      slot active: $(q "SELECT active FROM pg_replication_slots WHERE slot_name='pgc_standby'")"
+	echo "      last 15 lines of the standby log:"
+	pgc_pg "tail -15 '$SB_LOG'" 2>/dev/null | sed 's/^/        /'
+	PGC_FAIL=1
 	return 1
 }
 
@@ -237,7 +265,7 @@ check "the standby is a different cluster from the primary" \
 	"$([ "$(sb_q 'SHOW data_directory')" != "$(q 'SHOW data_directory')" ] && echo yes || echo no)" \
 	"yes"
 
-sync_standby
+sync_or_fail "sync 1"
 check "the base backup carried the initial rows" \
 	"$(hash_standby r)" "$(hash_primary r)"
 
@@ -271,7 +299,7 @@ check "with the same content the primary reads" \
 psql_run "SELECT pgcolumnar.add_projection('r', 'r_post', ARRAY['id','v'], ARRAY['id']);" >/dev/null 2>&1
 check "the primary now has a second, post-backup projection" "$(q "$proj_sql;")" "2"
 
-sync_standby
+sync_or_fail "sync 2"
 check "streaming replay carried a projection created after the backup" \
 	"$(sb_q "$proj_sql;")" "2"
 check "and that one reads on the standby too" \
@@ -349,7 +377,7 @@ sleep 1
 check "with replay paused the standby does NOT see the new rows" \
 	"$(sb_q "SELECT count(*) FROM r WHERE v LIKE 'paused%'")" "0"
 sb_q "SELECT pg_wal_replay_resume()" >/dev/null
-sync_standby
+sync_or_fail "sync 3"
 check "after resuming, the standby sees them" \
 	"$(sb_q "SELECT count(*) FROM r WHERE v LIKE 'paused%'")" "100"
 
@@ -360,7 +388,7 @@ check "after resuming, the standby sees them" \
 psql_run "INSERT INTO r SELECT g, 'more' || g FROM generate_series(20001,40000) g;
 	DELETE FROM r WHERE id % 7 = 0;
 	UPDATE r SET v = v || '-u' WHERE id % 11 = 0;" >/dev/null 2>&1
-sync_standby
+sync_or_fail "sync 4"
 
 check "insert, delete and update replay identically" \
 	"$(hash_standby r)" "$(hash_primary r)"
@@ -372,11 +400,11 @@ check "and the row counts agree" \
 # ---------------------------------------------------------------------------
 
 psql_run "SELECT pgcolumnar.vacuum('r');" >/dev/null 2>&1
-sync_standby
+sync_or_fail "sync 5"
 check "vacuum replays identically" "$(hash_standby r)" "$(hash_primary r)"
 
 psql_run "SELECT pgcolumnar.compact('r');" >/dev/null 2>&1
-sync_standby
+sync_or_fail "sync 6"
 check "compact replays identically" "$(hash_standby r)" "$(hash_primary r)"
 
 # ColumnarTruncateMainFork is the one direct XLogInsert in the tree
@@ -405,7 +433,7 @@ psql_run "DROP TABLE IF EXISTS t;" >/dev/null 2>&1
 psql_run "CREATE TABLE t (id int, v text) USING pgcolumnar;" >/dev/null 2>&1
 psql_run "SELECT pgcolumnar.set_options('t', stripe_row_limit => 1000, chunk_group_row_limit => 1000);" >/dev/null 2>&1
 psql_run "INSERT INTO t SELECT g, md5(g::text) FROM generate_series(1,30000) g;" >/dev/null 2>&1
-sync_standby
+sync_or_fail "sync 7"
 
 psql_run "DELETE FROM t WHERE id > 15000;" >/dev/null 2>&1
 psql_run "SELECT pgcolumnar.compact('t');" >/dev/null 2>&1
@@ -419,7 +447,7 @@ check "the primary actually truncated (record was emitted)" \
 	"yes"
 
 pri_after="$(q "SELECT pg_relation_size('t')")"
-sync_standby
+sync_or_fail "sync 8"
 sb_after="$(sb_q "SELECT pg_relation_size('t')")"
 
 check "the standby's main fork shrank to match the primary" \
@@ -473,7 +501,7 @@ sb_stop
 pgc_pg "sed -i \"s/^shared_preload_libraries=.*/shared_preload_libraries='pgcolumnar'/\" '$SB_DIR/postgresql.conf'" \
 	>/dev/null 2>&1
 sb_start
-sync_standby
+sync_or_fail "sync 9"
 
 check "with the module back, the replayed table reads correctly" \
 	"$(hash_standby r2)" "$(hash_primary r2)"

--- a/test/replication.sh
+++ b/test/replication.sh
@@ -83,7 +83,7 @@ fi
 RS_PORT="$(pick_sb_port)"
 while [ "$RS_PORT" = "$SB_PORT" ] || ! pgc_port_free "$RS_PORT"; do
 	RS_PORT=$((RS_PORT + 1))
-	[ "$RS_PORT" -gt 39000 ] && { echo "FAIL  no free port for the restore"; PGC_FAIL=1; pgc_summary; }
+	[ "$RS_PORT" -ge "$PGC_AUX_PORT_HI" ] && { echo "FAIL  no free port for the restore"; PGC_FAIL=1; pgc_summary; }
 done
 echo "-- primary port $PGC_PORT, standby port $SB_PORT"
 
@@ -131,13 +131,20 @@ rs_stop() {
 
 rs_start() {
 	local i
-	pgc_pg "pg_ctl -D '$RS_DIR' -l '$RS_LOG' -t 120 start -w" >/dev/null 2>&1
-	for i in $(seq 1 120); do
+	# pg_ctl's own output is kept, not discarded: when it is the thing that
+	# failed, sending it to /dev/null leaves nothing to read but an empty query
+	# result, and "the cluster did not answer" is not a diagnosis.
+	pgc_pg "pg_ctl -D '$RS_DIR' -l '$RS_LOG' -t 180 start -w" >"$PGC_WORKDIR/rs_ctl.log" 2>&1
+	for i in $(seq 1 240); do
 		[ "$(rs_q 'SELECT 1')" = 1 ] && return 0
 		sleep 0.5
 	done
-	echo "  restore cluster did not accept connections; last 15 lines of its log:"
-	pgc_pg "tail -15 '$RS_LOG'" 2>/dev/null | sed 's/^/    /'
+	echo "  restore cluster did not accept connections on port $RS_PORT"
+	echo "  pg_ctl said:"
+	sed 's/^/    /' "$PGC_WORKDIR/rs_ctl.log" 2>/dev/null | tail -10
+	echo "  is anything listening on $RS_PORT: $(pgc_port_free "$RS_PORT" && echo no || echo yes)"
+	echo "  restore cluster log:"
+	pgc_pg "tail -25 '$RS_LOG'" 2>/dev/null | sed 's/^/    /'
 	return 1
 }
 

--- a/test/replication.sh
+++ b/test/replication.sh
@@ -172,6 +172,26 @@ sync_standby
 check "the base backup carried the initial rows" \
 	"$(hash_standby r)" "$(hash_primary r)"
 
+# Projections survive a physical backup, which docs/limitations.md now claims.
+#
+# #266 and #267 established that pg_dump does NOT carry projections: they are
+# keyed by storage_id, which a logical restore regenerates, so the rows cannot be
+# carried and are pinned as lost in pg_dump_roundtrip.sh. The docs contrast that
+# with a physical backup preserving them, and that half was reasoning rather than
+# a test. pg_basebackup is a bytewise copy, so the projection rows and the storage
+# ids they reference both come across unchanged -- which is exactly the kind of
+# claim worth asserting rather than arguing, since it is the recovery path the
+# documentation sends people to.
+psql_run "SELECT pgcolumnar.add_projection('r', 'r_proj', ARRAY['id','v'], ARRAY['id']);" >/dev/null 2>&1
+proj_sql="SELECT count(*) FROM pgcolumnar.projection
+	WHERE storage_id = pgcolumnar.get_storage_id('r') AND projection_id > 0"
+pri_proj="$(q "$proj_sql;")"
+check "the primary has a projection to preserve" "$pri_proj" "1"
+
+sync_standby
+check "pg_basebackup preserved the projection, unlike pg_dump (#266)" \
+	"$(sb_q "$proj_sql;")" "$pri_proj"
+
 # Positive control: with replay paused, a change on the primary must NOT appear.
 # This is the check that proves the comparison can fail. Everything after it is
 # only meaningful because this one showed a difference is detectable.

--- a/test/replication.sh
+++ b/test/replication.sh
@@ -81,6 +81,15 @@ if [ -z "$SB_PORT" ]; then
 	pgc_summary
 fi
 RS_PORT="$(pick_sb_port)"
+# An empty pick would reach pgc_port_free "" below and probe nothing. Not
+# reachable with a dedicated 2000-port band and one replication run at a time,
+# but an unreachable branch that silently probes the empty string is the kind of
+# thing that stops being unreachable when the band is resized.
+if [ -z "$RS_PORT" ]; then
+	echo "FAIL  no free port for the restore cluster in [$PGC_AUX_PORT_LO,$PGC_AUX_PORT_HI)"
+	PGC_FAIL=1
+	pgc_summary
+fi
 while [ "$RS_PORT" = "$SB_PORT" ] || ! pgc_port_free "$RS_PORT"; do
 	RS_PORT=$((RS_PORT + 1))
 	[ "$RS_PORT" -ge "$PGC_AUX_PORT_HI" ] && { echo "FAIL  no free port for the restore"; PGC_FAIL=1; pgc_summary; }


### PR DESCRIPTION
@ChronicallyJD closing the asymmetry I flagged on #267.

That PR pinned the **negative** claim with a test — `pg_dump` does not carry
projections — and stated the **positive** one in `docs/limitations.md` as
reasoning:

> A physical backup (`pg_basebackup`) preserves them.

The reasoning is right: `pg_basebackup` is a bytewise copy, so the
`pgcolumnar.projection` rows and the storage ids they reference both come across
unchanged. But that line is now the recovery path the documentation sends people
to when they care about keeping projections, and an unverified claim in
user-facing docs is exactly where an argument does damage.

`test/replication.sh` already ran `pg_basebackup` and stood up a standby, so it
asserts it directly:

```
PASS  the primary has a projection to preserve
PASS  pg_basebackup preserved the projection, unlike pg_dump (#266)
```

The first is the control. Without it the second passes trivially if
`add_projection` silently did nothing — the same false-pass shape you guarded
against on your side with `the base table has a projection to preserve`.

23 checks, up from 21. Full five-major matrix running; I will post the result.