### PR TITLE
Draw test ports below the ephemeral range, not from inside it

### DIFF
--- a/test/concurrency.sh
+++ b/test/concurrency.sh
@@ -44,6 +44,11 @@
 # PG_CONFIG defaults to /usr/local/pg17/bin/pg_config. Run as a user that may
 # "runuser -u postgres" (e.g. root) when the current user is not postgres.
 
+
+# portlib.sh alone, not lib.sh: this suite carries its own harness, and the port
+# band is needed before any of it runs. Sourcing portlib twice is harmless.
+. "$(dirname "${BASH_SOURCE[0]}")/portlib.sh"
+
 set -uo pipefail
 
 PG_CONFIG="${1:-/usr/local/pg17/bin/pg_config}"
@@ -71,13 +76,16 @@ port_is_free() {  # port -> 0 if nothing is listening on it
 pick_port() {
 	local p i
 	for i in $(seq 1 100); do
-		p=$(( (RANDOM % 20000) + 30000 ))
+		p=$(( PGC_PORT_LO + RANDOM % (PGC_PORT_HI - PGC_PORT_LO) ))
 		if port_is_free "$p"; then
 			echo "$p"
 			return 0
 		fi
 	done
-	echo $(( (RANDOM % 20000) + 30000 ))   # give up probing, use a random one
+	# Inside the band portlib.sh carves below the ephemeral floor: inside the
+	# ephemeral range, a probed-free port can still be taken by an outbound
+	# connection before the cluster binds it.
+	echo $(( PGC_PORT_LO + RANDOM % (PGC_PORT_HI - PGC_PORT_LO) ))   # give up probing
 }
 PORT="${PGC_PORT:-$(pick_port)}"
 

--- a/test/devloop.sh
+++ b/test/devloop.sh
@@ -20,6 +20,10 @@
 #
 # With no suites it just does the clean build (a bare "does it compile + link").
 
+
+# The port band. Sourced directly: devloop runs suites rather than using lib.sh.
+. "$(dirname "${BASH_SOURCE[0]}")/portlib.sh"
+
 set -uo pipefail
 
 PGC="${1:-}"
@@ -55,13 +59,14 @@ for s in "$@"; do
 	echo "===================================================================="
 	echo "== suite: $s"
 	echo "===================================================================="
-	# A distinct high port per suite; lib.sh's own guard corrects a collision.
-	# Below the ephemeral floor (portlib.sh). 50000-58999 sat inside it, so a
-	# devloop cluster could lose its port to an outbound connection between the
-	# choice and the bind, exactly as the matrix clusters did. Left as literals
-	# because this runs before any library is sourced; the range is checked
-	# against portlib's band by harness_selftest.
-	if ! PGC_SKIP_BUILD=1 PGC_PORT=$((12000 + RANDOM % 15000)) \
+	# A distinct port per suite; lib.sh's own guard corrects a collision.
+	# Drawn from portlib's band, which sits below the kernel's ephemeral range:
+	# 50000-58999 sat inside it, so a devloop cluster could lose its port to an
+	# outbound connection between the choice and the bind, exactly as the matrix
+	# clusters did. Sourced rather than duplicated as literals -- an earlier
+	# version of this comment claimed the literals were checked against the band
+	# elsewhere, and no such check existed.
+	if ! PGC_SKIP_BUILD=1 PGC_PORT=$((PGC_PORT_LO + RANDOM % (PGC_PORT_HI - PGC_PORT_LO))) \
 		bash "test/${s}.sh" "$PGC"; then
 		rc=1
 	fi

--- a/test/devloop.sh
+++ b/test/devloop.sh
@@ -56,7 +56,12 @@ for s in "$@"; do
 	echo "== suite: $s"
 	echo "===================================================================="
 	# A distinct high port per suite; lib.sh's own guard corrects a collision.
-	if ! PGC_SKIP_BUILD=1 PGC_PORT=$((50000 + RANDOM % 9000)) \
+	# Below the ephemeral floor (portlib.sh). 50000-58999 sat inside it, so a
+	# devloop cluster could lose its port to an outbound connection between the
+	# choice and the bind, exactly as the matrix clusters did. Left as literals
+	# because this runs before any library is sourced; the range is checked
+	# against portlib's band by harness_selftest.
+	if ! PGC_SKIP_BUILD=1 PGC_PORT=$((12000 + RANDOM % 15000)) \
 		bash "test/${s}.sh" "$PGC"; then
 		rc=1
 	fi

--- a/test/harness_selftest.sh
+++ b/test/harness_selftest.sh
@@ -239,7 +239,10 @@ check "no suite hands every run the same default port" \
 _eph="$(pgc_ephemeral_floor)"
 _offenders=""
 for _f in "$(dirname "${BASH_SOURCE[0]}")"/*.sh; do
-	# Port assignments of the form NAME_PORT=$(( ... )) or PGC_PORT=$(( ... )).
+	# Any *PORT assignment, not only the arithmetic form: a plain
+	# FOO_PORT=45000 would otherwise slip a check whose comment claims to cover
+	# every assignment. Comment lines are excluded so prose about the old ranges
+	# does not read as an offender.
 	while IFS= read -r _line; do
 		# Every integer literal in the expression; flag any at or above the floor.
 		for _n in $(printf '%s\n' "$_line" | grep -oE '[0-9]{4,}'); do
@@ -248,7 +251,7 @@ for _f in "$(dirname "${BASH_SOURCE[0]}")"/*.sh; do
 			fi
 		done
 	done <<-EOF
-		$(grep -hE '^[[:space:]]*[A-Za-z_]*PORT=\$\(\(|PGC_PORT=\$\(\(' "$_f" 2>/dev/null)
+		$(grep -hE '^[[:space:]]*(export[[:space:]]+)?[A-Za-z_]*PORT=' "$_f" 2>/dev/null | grep -vE '^[[:space:]]*#')
 	EOF
 done
 check "no test picks a port from inside the ephemeral range" \

--- a/test/harness_selftest.sh
+++ b/test/harness_selftest.sh
@@ -16,6 +16,11 @@
 # Usage:  test/harness_selftest.sh [PG_CONFIG]
 # Written fresh for pgColumnar.
 
+
+# portlib.sh alone, not lib.sh: this suite carries its own harness, and the port
+# band is needed before any of it runs. Sourcing portlib twice is harmless.
+. "$(dirname "${BASH_SOURCE[0]}")/portlib.sh"
+
 set -uo pipefail
 
 PGC_SELFTEST_PG_CONFIG="${1:-/usr/local/pg17/bin/pg_config}"
@@ -29,7 +34,10 @@ SQ_DIR="$(mktemp -d /tmp/pgc-squatter.XXXXXX)"
 _port_free() { ! (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null; }
 SQ_PORT=0
 for _try in $(seq 1 20); do
-	_cand=$(( 20000 + RANDOM % 20000 ))
+	# Inside the band portlib.sh carves below the ephemeral floor. The squatter
+	# must hold its port for the whole test, which it cannot do reliably from
+	# inside the range the kernel also allocates outbound connections from.
+	_cand=$(( PGC_PORT_LO + RANDOM % (PGC_PORT_HI - PGC_PORT_LO) ))
 	if _port_free "$_cand"; then
 		SQ_PORT=$_cand
 		break

--- a/test/harness_selftest.sh
+++ b/test/harness_selftest.sh
@@ -226,4 +226,32 @@ _fixed_ports="$(grep -lE 'PGC_(BASE_)?PORT:-[0-9]+' "$TESTDIR"/*.sh 2>/dev/null 
 check "no suite hands every run the same default port" \
 	"${_fixed_ports:-none}" "none"
 
+# --- no port picker may draw from inside the ephemeral range --------------
+#
+# The sweep that moved every picker below the kernel's ephemeral floor was a
+# one-time edit, and one-time edits come back. This asserts the property instead
+# of trusting it: any *PORT assignment in test/ whose literals reach into the
+# ephemeral range is a regression of the intermittent bind collision that cost
+# this project several days.
+#
+# An earlier version of the devloop comment claimed exactly this check existed
+# when it did not, which is the reason it exists now.
+_eph="$(pgc_ephemeral_floor)"
+_offenders=""
+for _f in "$(dirname "${BASH_SOURCE[0]}")"/*.sh; do
+	# Port assignments of the form NAME_PORT=$(( ... )) or PGC_PORT=$(( ... )).
+	while IFS= read -r _line; do
+		# Every integer literal in the expression; flag any at or above the floor.
+		for _n in $(printf '%s\n' "$_line" | grep -oE '[0-9]{4,}'); do
+			if [ "$_n" -ge "$_eph" ]; then
+				_offenders="$_offenders $(basename "$_f"):$_n"
+			fi
+		done
+	done <<-EOF
+		$(grep -hE '^[[:space:]]*[A-Za-z_]*PORT=\$\(\(|PGC_PORT=\$\(\(' "$_f" 2>/dev/null)
+	EOF
+done
+check "no test picks a port from inside the ephemeral range" \
+	"$([ -z "$_offenders" ] && echo none || echo "$_offenders")" "none"
+
 pgc_summary

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -182,7 +182,12 @@ pgc_setup() {
 			# Prefer a port nothing is already listening on, so collisions are
 			# avoided rather than merely detected afterwards.
 			for _i in 1 2 3 4 5 6 7 8 9 10; do
-				PGC_PORT=$(( 2048 + (PGC_PORT + 1 + RANDOM % 40000) % 60000 ))
+				# Stays inside the main band. A retry that lands in the
+				# ephemeral range can be stolen between this probe and the bind
+				# below, which is the failure the retry exists to escape; one
+				# that lands in the auxiliary band collides with the extra
+				# clusters replication stands up. See portlib.sh.
+				PGC_PORT=$(( PGC_PORT_LO + (PGC_PORT + 1 + RANDOM % 5000) % (PGC_PORT_HI - PGC_PORT_LO) ))
 				if pgc_port_free "$PGC_PORT"; then
 					break
 				fi

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -59,11 +59,6 @@ pgc_cluster_datadir() {
 
 . "$(dirname "${BASH_SOURCE[0]}")/portlib.sh"
 
-# True when nothing is accepting connections on the given port.
-pgc_port_free() {
-	! (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null
-}
-
 # True when the server answering on PGC_PORT is the cluster at PGC_PGDATA. This is
 # the guard the start loop applies before trusting a started cluster; naming it
 # lets the self-test exercise the decision itself rather than only its inputs. An

--- a/test/pg_upgrade.sh
+++ b/test/pg_upgrade.sh
@@ -24,6 +24,10 @@
 set -uo pipefail
 SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# This suite carries its own harness rather than lib.sh (it drives two majors), so
+# it sources the port library directly for the band and the free-probe.
+. "$(dirname "${BASH_SOURCE[0]}")/portlib.sh"
+
 OLD_PGC="${1:-}"
 NEW_PGC="${2:-}"
 MODE="${3:-copy}"
@@ -68,8 +72,23 @@ WORK="$(mktemp -d /tmp/pgcolumnar-upgrade.XXXXXX)"
 chmod 777 "$WORK"
 OLD_DATA="$WORK/old"
 NEW_DATA="$WORK/new"
-OLD_PORT=$(( 41000 + ($$ % 2000) ))
-NEW_PORT=$(( OLD_PORT + 1 ))
+# Both clusters bind TCP (listen_addresses='127.0.0.1' below), so their ports must
+# come from the band portlib.sh carves BELOW the kernel's ephemeral range. The old
+# 41000-42999 sat squarely inside it, which meant an outbound connection could be
+# assigned the port a cluster was about to bind -- intermittently, with nothing
+# listening before or after. The auxiliary band is the right one: like
+# replication's standby, this suite stands up clusters beyond a suite's own, and
+# it must not walk into the range the matrix is using.
+#
+# Probed rather than assumed free, and the two ports are drawn independently
+# rather than as N and N+1: adjacent-port allocation is its own collision source,
+# which is the bug this project already fixed once in replication.sh.
+OLD_PORT="$(pgc_pick_free_port "$PGC_AUX_PORT_LO" "$PGC_AUX_PORT_HI" "$$")"
+NEW_PORT="$(pgc_pick_free_port "$PGC_AUX_PORT_LO" "$PGC_AUX_PORT_HI" "$(( $$ + 601 ))")"
+if [ -z "$OLD_PORT" ] || [ -z "$NEW_PORT" ] || [ "$OLD_PORT" = "$NEW_PORT" ]; then
+	echo "FAIL  could not find two free ports in [$PGC_AUX_PORT_LO,$PGC_AUX_PORT_HI)" >&2
+	exit 1
+fi
 
 RUNPG=(env)
 if [ "$(id -u)" = "0" ]; then

--- a/test/portlib.sh
+++ b/test/portlib.sh
@@ -129,3 +129,29 @@ pgc_pick_port() {
 	fi
 	printf '%s\n' "$(( PGC_PORT_LO + (${PGC_RUN_OWNER:-$$} % span) ))"
 }
+
+# True when nothing is accepting connections on the given port.
+#
+# Lives here rather than in lib.sh because the band and the probe are one idea:
+# below the ephemeral floor a port that probes free is still free at bind time,
+# and a harness that has the band without the probe is only half-protected.
+# Suites that carry their own harness (pg_upgrade, unique_conc, concurrency,
+# harness_selftest) source this file and get both.
+pgc_port_free() {
+	! (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null
+}
+
+# A free port from a band, verified rather than assumed. Callers pass the band so
+# a suite standing up extra clusters can draw from AUX while the matrix walks MAIN.
+pgc_pick_free_port() {
+	local lo="$1" hi="$2" seed="${3:-$$}" base p
+	base=$(( lo + (seed % (hi - lo)) ))
+	for p in $(seq "$base" $(( base + 300 ))); do
+		[ "$p" -ge "$hi" ] && break
+		if pgc_port_free "$p"; then
+			printf '%s\n' "$p"
+			return 0
+		fi
+	done
+	return 1
+}

--- a/test/portlib.sh
+++ b/test/portlib.sh
@@ -37,6 +37,95 @@
 # its base once per suite per major, several hundred ports, and a base above the
 # ceiling once made every cluster fail with `invalid port number: "66009"`,
 # which presents as a broken tree rather than as a bad constant.
+#
+# It must also stop short of the EPHEMERAL range, which is the harder constraint
+# and was got wrong for a long time. On this box:
+#
+#     /proc/sys/net/ipv4/ip_local_port_range  ->  32768   60999
+#
+# The band was 40000-59999, entirely inside that. An outbound connection -- psql
+# reaching the primary, pg_basebackup, a walsender -- can be assigned any free
+# port in the ephemeral range as its LOCAL port, including the one a cluster is
+# about to bind. Probing that the port is free does not help: the probe and the
+# bind are different instants, and the kernel is free to hand the port out in
+# between.
+#
+# That is not theoretical. It is the intermittent replication failure this project
+# chased across many matrices:
+#
+#     could not bind IPv4 address "127.0.0.1": Address already in use
+#     HINT: Is another postmaster already running on port 33500?
+#
+# with nothing listening on that port before or after. It moved between majors
+# every run, because which connection lands on which port is a race, and it left
+# no evidence behind, because the ephemeral socket that won closed moments later.
+#
+# So the band is derived from the floor rather than hardcoded, and sits entirely
+# below it. A port below the ephemeral floor is never handed to an outbound
+# connection, so "free when probed" and "still free at bind" are the same fact.
+pgc_ephemeral_floor() {
+	local lo
+	lo="$(awk '{print $1}' /proc/sys/net/ipv4/ip_local_port_range 2>/dev/null)"
+	case "$lo" in
+		''|*[!0-9]*) lo=32768 ;;
+	esac
+	printf '%s\n' "$lo"
+}
+
+# Two disjoint bands below the floor.
+#
+#   PGC_PORT_*      the suites' own clusters. The matrix walks upward from a base
+#                   in this band, one port per suite per major.
+#   PGC_AUX_PORT_*  extra clusters a single suite stands up beyond its own -- the
+#                   replication standby and its restore cluster. Separate so that
+#                   the matrix's walk cannot wander into a port a suite is about
+#                   to use, which the free-probe would then have to catch rather
+#                   than the layout preventing.
+#
+# ip_local_port_range's low value is a sysctl. It is 32768 here and on
+# ubuntu-latest, but an image is free to set it lower, and a band derived from a
+# floor that leaves no room beneath it would be tiny, empty, or negative. That
+# must fail loudly: silently falling back into the ephemeral range would reinstate
+# exactly the race this file exists to remove, and a picker that starves is worse
+# than one that says why.
+PGC_EPH_FLOOR="$(pgc_ephemeral_floor)"
+
+# Below this there is no room for two bands plus the matrix's walk.
+PGC_MIN_FLOOR=20000
+
+if [ "$PGC_EPH_FLOOR" -lt "$PGC_MIN_FLOOR" ]; then
+	echo "pgcolumnar: ephemeral floor $PGC_EPH_FLOOR too low to carve a private port band" >&2
+	echo "  /proc/sys/net/ipv4/ip_local_port_range starts at $PGC_EPH_FLOOR; this needs" >&2
+	echo "  at least $PGC_MIN_FLOOR so cluster ports can sit below the range the kernel" >&2
+	echo "  assigns to outbound connections. Raise it:" >&2
+	echo "      sysctl -w net.ipv4.ip_local_port_range=\"32768 60999\"" >&2
+	echo "  Running inside the ephemeral range makes clusters lose ports between the" >&2
+	echo "  free-check and the bind, intermittently and with no evidence left behind." >&2
+	exit 1
+fi
+
+# Auxiliary band: the 2000 ports just under the floor, less a 1000-port guard.
+PGC_AUX_PORT_HI=$(( PGC_EPH_FLOOR - 1000 ))
+PGC_AUX_PORT_LO=$(( PGC_AUX_PORT_HI - 2000 ))
+
+# Main band: from 10000 up to the auxiliary band, less the room the matrix needs
+# to walk upward from its base.
+PGC_PORT_LO=10000
+PGC_PORT_HI=$(( PGC_AUX_PORT_LO - 200 ))
+# Room for one port per suite per major, with slack. The matrix asserts its actual
+# demand against this rather than trusting the constant (see run_all_versions.sh).
+PGC_PORT_WALK=1500
+
+# Kept for callers that only need "the top of the safe range".
+PGC_PORT_CEIL="$PGC_PORT_HI"
+
 pgc_pick_port() {
-	printf '%s\n' "$(( 40000 + (${PGC_RUN_OWNER:-$$} % 20000) ))"
+	local span
+	span=$(( PGC_PORT_HI - PGC_PORT_LO - PGC_PORT_WALK ))
+	if [ "$span" -lt 1000 ]; then
+		echo "pgcolumnar: safe port band [$PGC_PORT_LO,$PGC_PORT_HI) too narrow" >&2
+		echo "  ephemeral floor is $PGC_EPH_FLOOR; need room for $PGC_PORT_WALK ports of walk" >&2
+		exit 1
+	fi
+	printf '%s\n' "$(( PGC_PORT_LO + (${PGC_RUN_OWNER:-$$} % span) ))"
 }

--- a/test/replication.sh
+++ b/test/replication.sh
@@ -40,12 +40,29 @@ SB_LOG="$PGC_WORKDIR/standby.log"
 # construction. It passes standalone and fails in the matrix, which is exactly
 # what it did: green on PG17 alone, red on PG18 inside the matrix.
 #
-# The matrix walks 40000 upward (portlib.sh), so this draws from below that range
-# and still verifies the port is free rather than assuming a range is enough.
+# Draws from below the ephemeral floor, and from a band the matrix's own walk
+# does not reach.
+#
+# The old band was 30000-38999. The ephemeral range on this box starts at 32768,
+# so most of that band was inside it, and this is where that cost the most: the
+# standby is started LATE, long after the port was chosen, which is the widest
+# possible window for an outbound connection to be assigned the same local port.
+# The result was
+#
+#     could not bind IPv4 address "127.0.0.1": Address already in use
+#
+# with nothing listening before or after -- a standby that never started, checks
+# that compared against an empty result, and a failure that moved majors every
+# run. portlib.sh carries the full account.
+#
+# Probing for free is kept, but it is now meaningful: below the floor, a port that
+# probes free is still free when the standby binds it, because the kernel does not
+# allocate from here.
 pick_sb_port() {
 	local base p
-	base=$(( 30000 + ($$ % 9000) ))
+	base=$(( PGC_AUX_PORT_LO + ($$ % (PGC_AUX_PORT_HI - PGC_AUX_PORT_LO)) ))
 	for p in $(seq "$base" $((base + 300))); do
+		[ "$p" -ge "$PGC_AUX_PORT_HI" ] && break
 		if pgc_port_free "$p"; then
 			echo "$p"
 			return 0

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -45,6 +45,39 @@ set -uo pipefail
 
 PGC_RUN_LOCK="${PGC_RUN_LOCK:-/tmp/pgcolumnar-run_all_versions.lock}"
 
+# --stop: the supported way to end a run in progress.
+#
+# It exists because the alternative was pkill, and pkill is wrong here twice: the
+# driver re-executes itself from /tmp under a generated name, so the obvious
+# pattern misses it, and killing postmasters directly bypasses pg_ctl. This reads
+# the lock, signals the owner, and lets the owner's own trap stop the suites and
+# their clusters properly.
+if [ "${1:-}" = "--stop" ]; then
+	if [ ! -e "$PGC_RUN_LOCK" ]; then
+		echo "no matrix run in progress (no lock at $PGC_RUN_LOCK)"
+		exit 0
+	fi
+	_owner="$(sed -n 1p "$PGC_RUN_LOCK" 2>/dev/null)"
+	if [ -z "$_owner" ] || ! kill -0 "$_owner" 2>/dev/null; then
+		echo "stale lock from pid ${_owner:-unknown}; removing it"
+		rm -f "$PGC_RUN_LOCK"
+		exit 0
+	fi
+	echo "stopping matrix run (pid $_owner)"
+	kill -TERM "$_owner" 2>/dev/null
+	for _i in $(seq 1 60); do
+		kill -0 "$_owner" 2>/dev/null || break
+		sleep 1
+	done
+	if kill -0 "$_owner" 2>/dev/null; then
+		echo "pid $_owner did not exit after 60s; sending KILL" >&2
+		kill -KILL "$_owner" 2>/dev/null
+	fi
+	rm -f "$PGC_RUN_LOCK"
+	echo "stopped"
+	exit 0
+fi
+
 if [ -z "${PGC_RUN_REEXEC:-}" ]; then
 	# Take the lock before copying, so two starts cannot both decide they are first.
 	if [ -e "$PGC_RUN_LOCK" ]; then
@@ -69,16 +102,35 @@ if [ -z "${PGC_RUN_REEXEC:-}" ]; then
 
 	# The lock is removed only by the process that took it, so a stale-lock
 	# takeover cannot have its lock deleted by the run it replaced.
-	trap 'if [ "$(sed -n 1p "$PGC_RUN_LOCK" 2>/dev/null)" = "$$" ]; then rm -f "$PGC_RUN_LOCK"; fi' EXIT
+	# INT and TERM as well as EXIT. A bash EXIT trap does not run when the shell
+	# is terminated by an untrapped signal, so without these a killed run left
+	# its lock behind and the next run refused to start against a pid that was
+	# already gone.
+	trap 'if [ "$(sed -n 1p "$PGC_RUN_LOCK" 2>/dev/null)" = "$$" ]; then rm -f "$PGC_RUN_LOCK"; fi' EXIT INT TERM
 
 	_self="$(mktemp "/tmp/pgcolumnar-run_all_versions.$$.XXXXXX.sh")"
 	cp "${BASH_SOURCE[0]}" "$_self"
 	chmod +x "$_self"
+	# Run the copy in the background and forward signals to it, rather than
+	# calling it directly. --stop signals this parent, but the child is the one
+	# holding the suite jobs, so a TERM that stops here and not there is exactly
+	# the orphaning this is meant to prevent.
 	PGC_RUN_REEXEC=1 \
 	PGC_RUN_SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" \
 	PGC_RUN_LOCK="$PGC_RUN_LOCK" \
 	PGC_RUN_OWNER="$$" \
-		bash "$_self" "$@"
+		bash "$_self" "$@" &
+	_child=$!
+	_forward_stop() {
+		kill -TERM "$_child" 2>/dev/null
+		wait "$_child" 2>/dev/null
+		if [ "$(sed -n 1p "$PGC_RUN_LOCK" 2>/dev/null)" = "$$" ]; then
+			rm -f "$PGC_RUN_LOCK"
+		fi
+		exit 130
+	}
+	trap _forward_stop INT TERM
+	wait "$_child"
 	_rc=$?
 	rm -f "$_self"
 	exit $_rc
@@ -87,6 +139,70 @@ fi
 # Re-executed from the copy: the lock belongs to the parent, which removes it,
 # and the tree to test is the original one rather than wherever the copy landed.
 trap - EXIT
+
+# ---------------------------------------------------------------------------
+# Stopping a run
+# ---------------------------------------------------------------------------
+#
+# This driver used to have no cleanup at all -- the line above dropped the
+# parent's EXIT trap and put nothing in its place -- and the suites it starts run
+# as background jobs. So killing the driver did not stop them: they were
+# reparented and carried on, holding their clusters and their ports, writing into
+# the log someone was reading. Both of those cost real time on this branch. One
+# orphaned run's output interleaved into a live run's log and produced a FAIL that
+# belonged to neither; another held the run lock for twenty minutes after it was
+# "killed", so three matrices refused to start and reported nothing.
+#
+# The only way to stop a run was pkill, which is the wrong instrument twice over:
+# it misses this process (re-executed from /tmp under a generated name) and it
+# kills postmasters out from under pg_ctl instead of asking them to stop.
+#
+# So: a signal now stops the suites, then stops their clusters with pg_ctl -- the
+# supported path, using the pg_ctl matching each cluster's own major, read from
+# its PG_VERSION rather than guessed.
+pgc_stop_clusters() {
+	local d sub datadir ver pgctl stopped=0
+	for d in /tmp/pgcolumnar-test.*/; do
+		[ -d "$d" ] || continue
+		for sub in data standby restore; do
+			datadir="$d$sub"
+			[ -f "$datadir/postmaster.pid" ] || continue
+			ver="$(sed -n 1p "$datadir/PG_VERSION" 2>/dev/null)"
+			pgctl="/usr/local/pg${ver}/bin/pg_ctl"
+			# Fall back to any pg_ctl only if the versioned one is absent; a
+			# mismatched pg_ctl refuses rather than corrupting anything.
+			[ -x "$pgctl" ] || pgctl="$(command -v pg_ctl 2>/dev/null)"
+			[ -n "$pgctl" ] && [ -x "$pgctl" ] || continue
+			if [ "$(id -u)" = 0 ] && id postgres >/dev/null 2>&1; then
+				su postgres -c "'$pgctl' -D '$datadir' stop -m immediate -w -t 30" >/dev/null 2>&1
+			else
+				"$pgctl" -D "$datadir" stop -m immediate -w -t 30 >/dev/null 2>&1
+			fi
+			stopped=$((stopped + 1))
+		done
+	done
+	[ "$stopped" -gt 0 ] && echo "stopped $stopped cluster(s) with pg_ctl" >&2
+	return 0
+}
+
+pgc_run_cleanup() {
+	local j
+	trap - INT TERM EXIT
+	echo "" >&2
+	echo "matrix interrupted -- stopping suites and their clusters" >&2
+	# Stop the suites first so they cannot start anything else, then their
+	# clusters. Their own EXIT traps handle the ones they can still reach.
+	for j in $(jobs -p 2>/dev/null); do kill -TERM "$j" 2>/dev/null; done
+	sleep 2
+	for j in $(jobs -p 2>/dev/null); do kill -KILL "$j" 2>/dev/null; done
+	pgc_stop_clusters
+	if [ -n "${PGC_CUR_BUILDDIR:-}" ] && [ -d "$PGC_CUR_BUILDDIR" ]; then
+		rm -rf "$PGC_CUR_BUILDDIR"
+		echo "removed the in-progress build directory" >&2
+	fi
+	exit 130
+}
+trap pgc_run_cleanup INT TERM
 
 SRCDIR="${PGC_RUN_SRCDIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 SUITES=(harness_selftest smoke phase2 phase3 phase4 phase5 phase6 audit concurrency unique_conc \
@@ -232,6 +348,10 @@ for pgc in "${CONFIGS[@]}"; do
 	ver="$("$pgc" --version)"
 	major="$(echo "$ver" | sed -E 's/^[^0-9]*([0-9]+).*/\1/')"
 	builddir="$(mktemp -d "/tmp/pgcolumnar-matrix-${major}.XXXXXX")"
+	# Recorded so an interrupted run can remove it. A completed major removes
+	# its own at the bottom of the loop; one that is stopped part-way used to
+	# leave a full source tree and install behind in /tmp.
+	PGC_CUR_BUILDDIR="$builddir"
 
 	echo "==================================================================="
 	echo "== $ver"

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -115,7 +115,47 @@ fi
 # not private: two runs on one box then start at the same port and fight over
 # every cluster. The lock above makes that refuse rather than happen, but the
 # suites are also run individually, and they should not collide either.
-BASE_PORT="${PGC_BASE_PORT:-$(( 40000 + (${PGC_RUN_OWNER:-$$} % 20000) ))}"
+#
+# Below the ephemeral floor, deliberately. This is the second copy of the
+# arithmetic in portlib.sh, kept because the driver re-executes itself from /tmp
+# and a tree-relative source would be the fragility that re-exec removes.
+#
+# The old band, 40000-59999, was entirely inside /proc/sys/net/ip_local_port_range
+# (32768-60999 here), so the kernel could hand a cluster's port to an outbound
+# connection between the free-check and the bind. See portlib.sh for the full
+# account; it is the cause of the intermittent replication failure.
+_pgc_eph_floor="$(awk '{print $1}' /proc/sys/net/ipv4/ip_local_port_range 2>/dev/null)"
+case "$_pgc_eph_floor" in ''|*[!0-9]*) _pgc_eph_floor=32768 ;; esac
+if [ "$_pgc_eph_floor" -lt 20000 ]; then
+	echo "FATAL: ephemeral floor $_pgc_eph_floor too low to carve a private port band" >&2
+	echo "       /proc/sys/net/ipv4/ip_local_port_range starts at $_pgc_eph_floor; this" >&2
+	echo "       needs at least 20000 so cluster ports sit below the range the kernel" >&2
+	echo "       assigns to outbound connections. Raise it:" >&2
+	echo "           sysctl -w net.ipv4.ip_local_port_range=\"32768 60999\"" >&2
+	exit 1
+fi
+# Mirrors portlib.sh: main band below the auxiliary band, both below the floor.
+_pgc_aux_hi=$(( _pgc_eph_floor - 1000 ))
+_pgc_aux_lo=$(( _pgc_aux_hi - 2000 ))
+PGC_PORT_LO=10000
+PGC_PORT_HI=$(( _pgc_aux_lo - 200 ))
+_pgc_walk=1500
+_pgc_span=$(( PGC_PORT_HI - PGC_PORT_LO - _pgc_walk ))
+BASE_PORT="${PGC_BASE_PORT:-$(( PGC_PORT_LO + (${PGC_RUN_OWNER:-$$} % _pgc_span) ))}"
+
+# The band must hold one port per suite per major, plus the auxiliary clusters a
+# suite stands up beyond its own. Asserted rather than assumed: the walk is a
+# constant here and the suite list grows, so a silent overrun would put a cluster
+# back inside the ephemeral range -- the exact failure this layout removes, and
+# one that costs days to recognise.
+_pgc_need=$(( ${#SUITES[@]} * ${#CONFIGS[@]} + 16 ))
+if [ $(( BASE_PORT + _pgc_need )) -ge "$PGC_PORT_HI" ]; then
+	echo "FATAL: port band too small for this run" >&2
+	echo "       ${#SUITES[@]} suites x ${#CONFIGS[@]} majors needs $_pgc_need ports from $BASE_PORT," >&2
+	echo "       which passes the top of the band ($PGC_PORT_HI)." >&2
+	echo "       Raise net.ipv4.ip_local_port_range's floor, or set PGC_BASE_PORT lower." >&2
+	exit 1
+fi
 
 overall=0
 declare -a SUMMARY
@@ -292,7 +332,10 @@ for pgc in "${CONFIGS[@]}"; do
 			if grep -qE '^FAIL' "$builddir/${s}.log"; then
 				grep -E '^FAIL' "$builddir/${s}.log" | sed 's/^/      >> /'
 			fi
-			tail -20 "$builddir/${s}.log" | sed 's/^/      /'
+			# 60, not 20: a suite that prints a failure diagnostic and a
+			# server-log dump needs more room than 20 lines, and truncating it
+			# is how the replication failures stayed unreadable.
+			tail -60 "$builddir/${s}.log" | sed 's/^/      /'
 			results+="$s=FAIL "
 			verfail=1
 		fi

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -284,6 +284,14 @@ for pgc in "${CONFIGS[@]}"; do
 			results+="$s=PASS "
 		else
 			echo "  FAIL  $s"
+			# The failing check first, then the tail. A suite that prints a
+			# diagnostic and a server-log dump on failure pushes its own FAIL
+			# lines out of a 20-line tail, which is how an intermittent
+			# replication failure stayed unreadable across many matrices: the
+			# evidence was in the log and the summary showed everything but.
+			if grep -qE '^FAIL' "$builddir/${s}.log"; then
+				grep -E '^FAIL' "$builddir/${s}.log" | sed 's/^/      >> /'
+			fi
 			tail -20 "$builddir/${s}.log" | sed 's/^/      /'
 			results+="$s=FAIL "
 			verfail=1

--- a/test/unique_conc.sh
+++ b/test/unique_conc.sh
@@ -52,6 +52,10 @@
 # PG_CONFIG defaults to /usr/local/pg17/bin/pg_config. Run as a user that may
 # "runuser -u postgres" (e.g. root) when the current user is not postgres.
 
+
+# Own harness rather than lib.sh; portlib carries the port band.
+. "$(dirname "${BASH_SOURCE[0]}")/portlib.sh"
+
 set -uo pipefail
 
 PG_CONFIG="${1:-/usr/local/pg17/bin/pg_config}"
@@ -70,13 +74,17 @@ port_is_free() {
 		! (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null
 	fi
 }
+# This cluster listens on a unix socket only (listen_addresses='' below), so the
+# number never binds a TCP port and the ephemeral race cannot reach it. Drawn from
+# portlib's band regardless: a port picker that is safe by accident, in a file
+# that says nothing about why, is one edit away from being unsafe.
 pick_port() {
 	local p i
 	for i in $(seq 1 100); do
-		p=$(( (RANDOM % 20000) + 30000 ))
+		p=$(( PGC_PORT_LO + RANDOM % (PGC_PORT_HI - PGC_PORT_LO) ))
 		if port_is_free "$p"; then echo "$p"; return 0; fi
 	done
-	echo $(( (RANDOM % 20000) + 30000 ))
+	echo $(( PGC_PORT_LO + RANDOM % (PGC_PORT_HI - PGC_PORT_LO) ))
 }
 PORT="${PGC_PORT:-$(pick_port)}"
 


### PR DESCRIPTION
@ChronicallyJD split out of #268 as you asked. This is the shared port-picking
infrastructure and the harness diagnostics, on their own SHAs, with nothing about
projections in the way. #268 is back to being the projection assertion it started
as, rebased on top of this.

## The defect

Every port-picking site drew from inside the kernel's ephemeral range. Here and on
`ubuntu-latest`, `/proc/sys/net/ipv4/ip_local_port_range` is `32768 60999`:

| site | band | |
|---|---|---|
| `portlib.sh` | 40000-59999 | entirely inside |
| `run_all_versions.sh` | 40000-59999 | entirely inside |
| `devloop.sh` | 50000-58999 | entirely inside |
| `replication.sh` | 30000-38999 | mostly inside |
| `lib.sh` retry | 2048-62047 | mostly inside |
| `concurrency.sh` | 30000-49999 | mostly inside |
| `harness_selftest.sh` | 20000-39999 | partly inside |

An outbound connection is assigned a free port from that range as its **local**
port, and it can be the one a cluster is about to bind. Probing that the port is
free does not help: the probe and the bind are different instants.

It cost the most in replication because its standby binds late, the widest window
between choosing a port and using it:

```
could not bind IPv4 address "127.0.0.1": Address already in use
HINT:  Is another postmaster already running on port 33500?
```

with nothing listening on 33500 before or after.

**Measured, not assumed**, since the fix rests on it: of 501 outbound connections
on this kernel, **501** were allocated a local port inside 32768-60999 and **0**
below it.

## Your robustness note

You were right that the guard was the weak point, and it was weaker than you
could see from the diff -- with a low enough floor my arithmetic went *negative*
rather than merely narrow.

- A floor below 20000 is now a **hard failure** naming the sysctl to run, not a
  fallback into the range this exists to avoid and not a picker that starves in
  silence.
- Two **disjoint bands**: `PGC_PORT_*` for suite clusters, `PGC_AUX_PORT_*` for
  the extra clusters one suite stands up beyond its own. My first cut had the
  auxiliary band overlapping the top of the matrix's walk, so the free-probe was
  covering for the layout.
- The matrix **asserts its real demand** (`suites x majors`) against the band
  rather than trusting the walk constant, because the suite list grows and a
  silent overrun would put a cluster back inside the ephemeral range.

Chasing that also turned up a latent bug: `concurrency.sh` and
`harness_selftest.sh` carry their own harness, and one of them used the band 49
lines before `lib.sh` was sourced. Left as-is that would have divided by zero.
Both now source `portlib.sh` directly.

## Also here

**The harness printed `tail -20` on failure.** A suite that prints its own
diagnostic and a server-log dump pushes its `FAIL` lines out of that window --
which is why this flake went unread across many matrices. The evidence was in
every log and nothing displayed it. `FAIL` lines first now, then the tail.

**`--stop`.** The driver re-executes itself from `/tmp` under a generated name and
runs suites as background jobs, so killing it orphaned them: they kept their
clusters and ports and wrote into the log someone was reading. That produced a
phantom `FAIL` belonging to no run, and a "killed" run that held the lock for
twenty minutes while three matrices refused to start. `INT`/`TERM` now stop the
suites and then their clusters via `pg_ctl` -- the supported path, using the
`pg_ctl` matching each cluster's own `PG_VERSION`. Measured: before `suites=2
postmasters=3 builddirs=1`, after `0/0/0`, lock removed.

## Gate

Five-major matrix on this branch: **ALL VERSIONS PASSED**. Before the split, four
consecutive matrices green (20 replication runs) against the same fix.