### PR TITLE
Draft: cost-margin GUC for the FSST keep/drop decision (#155)

### DIFF
--- a/src/columnar.h
+++ b/src/columnar.h
@@ -165,6 +165,7 @@ extern int columnar_chunk_group_row_limit;
 extern int columnar_encoding_sample_rows;
 extern int columnar_compression;		/* one of COLUMNAR_COMPRESSION_* */
 extern int columnar_compression_level;	/* zstd level */
+extern int columnar_fsst_min_gain_percent;	/* min compressed FSST win to keep it (#155) */
 extern bool columnar_enable_qual_pushdown;
 extern bool columnar_enable_custom_scan;
 extern bool columnar_enable_bloom_filter;	/* bloom equality skipping (I7) */

--- a/src/columnar_encoding.c
+++ b/src/columnar_encoding.c
@@ -1781,7 +1781,17 @@ ColumnarFsstHelpsCompressed(const char *corpus, uint32 corpusLen,
 								compressionLevel, &codesComp, &codesCompLen,
 								&usedType, &usedLevel);
 
-	helps = ((uint64) codesCompLen + tableLen < (uint64) plainCompLen);
+	/*
+	 * Keep FSST only when the compressed win clears pgcolumnar.fsst_min_gain_percent,
+	 * not on any win at all. Encoding FSST codes for every vector of the chunk is a
+	 * dominant cost of a text/varlena load (issue #155), and a sub-margin win --
+	 * e.g. FSST ~1% smaller after compression on numeric -- does not repay it. At
+	 * the default 0 this is the original "any win keeps it". The comparison is
+	 * multiplied out rather than subtracting a percentage of plainCompLen, so it
+	 * cannot underflow when plainCompLen is small.
+	 */
+	helps = (((uint64) codesCompLen + tableLen) * 100
+			 < (uint64) plainCompLen * (uint64) (100 - columnar_fsst_min_gain_percent));
 
 	pfree(codes);
 	if (plainComp)

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -62,6 +62,7 @@ int			columnar_encoding_sample_rows = 2048;
 
 int			columnar_compression = COLUMNAR_COMPRESSION_ZSTD;
 int			columnar_compression_level = 3;
+int			columnar_fsst_min_gain_percent = 0;
 bool		columnar_enable_qual_pushdown = true;
 bool		columnar_enable_bloom_filter = true;
 
@@ -2183,6 +2184,22 @@ _PG_init(void)
 							&columnar_compression_level,
 							3,
 							1, 22,
+							PGC_USERSET,
+							0,
+							NULL, NULL, NULL);
+
+	DefineCustomIntVariable("pgcolumnar.fsst_min_gain_percent",
+							"Minimum compressed size reduction, in percent, for FSST "
+							"string encoding to be kept for a column chunk.",
+							"Building FSST codes for every vector is a dominant cost of "
+							"a text or varlena load (issue #155). At 0 FSST is kept on "
+							"any compressed win, however small; a higher value keeps it "
+							"only when it saves at least that percentage after the block "
+							"codec has run, trading a bounded size regression on "
+							"marginal chunks for skipping their per-vector FSST encode.",
+							&columnar_fsst_min_gain_percent,
+							0,
+							0, 99,
 							PGC_USERSET,
 							0,
 							NULL, NULL, NULL);


### PR DESCRIPTION
**Draft — addresses one lever of #155, not the whole fix.** Opening it so the knob and its measured trade are in front of you; the default is yours to set.

## What
The keep-FSST decision (`columnar_encoding.c`, `ColumnarFsstHelpsCompressed`) accepts *any* compressed win:
```c
helps = (codesCompLen + tableLen < plainCompLen);
```
This adds `pgcolumnar.fsst_min_gain_percent`: keep FSST only when it saves at least that percentage after the block codec. **Default 0 is today's behaviour exactly**, so the knob is a no-op until a default is chosen — which is deliberately left to you.

## Why (from the #155 profiles)
The per-vector FSST encode is a dominant write-path cost, and it is paid in full for wins as small as ~1% — the `numeric(12,4)` random case that falsified #237. A per-type skip-list is the wrong instrument (FSST does win on some numeric shapes); a cost-margin on the decision is the right one.

## Measured (pg18n non-assert, 2,000,000 rows, indicative — run under some ambient load)

| shape | margin | load | size | vs 0 |
| --- | --- | --- | --- | --- |
| numeric(12,4) random | 0 | 5,631 ms | 11.39 MB | — |
| numeric(12,4) random | 5 | 5,105 ms | 11.58 MB | **-9% time, +1.6% size** |
| numeric(12,4) random | 10 | 5,207 ms | 11.58 MB | (same; FSST already dropped) |
| low-card text (12 distinct) | 0 | 1,615 ms | 552 KB | — |
| low-card text | 5 / 10 | ~1,650 ms | 552 KB | no change |

The margin drops FSST only on the marginal-win case; where FSST genuinely wins big (low-card text) it is left untouched, so there is no regression there.

## Scope / limitation
It gates the per-vector encode. It does **not** touch the symbol-table *build* cost (`ColumnarFsstBuildChunkTable`), which is paid before the decision and is the 37% you profiled on low-cardinality text — `encode_effort = fast` remains the lever for that.

## Correctness
Assert build, PG18: `native_writer`, `native_roundtrip`, `native_encoding`, `write_fsst_compressed`, `encode_effort` all pass at the default. Since default 0 reproduces the current comparison exactly, no stored bytes change unless the GUC is raised.

## Recommendation
A small non-zero default (≈5%) looks favourable on the marginal case and is a no-op where FSST earns its cost — but this is one numeric shape and one text shape at one volume on a shared box. Before committing a default I'd want your broader sweep (more shapes, larger volumes, idle box); happy to widen it or hand it to your rig. Marked draft pending that and your call on the default.
