### PR TITLE
Gate test/pg_upgrade.sh behind PGC_RUN_UPGRADE (#257)

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -134,3 +134,33 @@ test/run_all_versions.sh /usr/local/pg15/bin/pg_config ... /usr/local/pg19/bin/p
 All suites pass on PostgreSQL 15 through 19. PostgreSQL 19 is validated against
 19beta2; revalidation against the final PostgreSQL 19 release is pending that
 release.
+
+## Cross-major upgrade
+
+`pg_upgrade` is the path a user takes to a new major, and it is where an access
+method with its own catalog is most likely to break: the relation forks carry the
+data, the `pgcolumnar.*` tables carry the metadata, and both have to survive the
+transfer with the extension present on the new side. `test/pg_upgrade.sh` runs it
+and asserts the rows, the content hash, the access method and the per-table
+options all come across.
+
+It takes two majors at once and runs the upgrade twice per pair, so it is not part
+of the per-PR gate and not on by default. Ask for it:
+
+```sh
+PGC_RUN_UPGRADE=1 test/run_all_versions.sh
+```
+
+That runs each adjacent pair of the majors being tested, in both transfer modes.
+`link` shares the data files with the old cluster and `copy` does not, and they
+fail differently, so both are run. A single pair can also be run directly:
+
+```sh
+test/pg_upgrade.sh /usr/local/pg17/bin/pg_config /usr/local/pg18/bin/pg_config link
+```
+
+Run it before a release. `docs/limitations.md` states that data written by one
+build reads back identically on any build of the same format version, across every
+supported major, and this is the only thing that tests that claim. It is opt-in
+rather than per-PR for cost, not because it is optional: a claim in the
+documentation backed by a suite nobody runs is how coverage rots unnoticed.

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -470,6 +470,66 @@ for pgc in "${CONFIGS[@]}"; do
 	rm -rf "$builddir"
 done
 
+# ---------------------------------------------------------------------------
+# Cross-major upgrade (opt-in: PGC_RUN_UPGRADE=1)
+# ---------------------------------------------------------------------------
+#
+# Off by default and deliberately not part of the per-PR gate. pg_upgrade needs
+# two majors at once, runs the upgrade twice per pair (copy and link), and is
+# expensive -- the same reason run_san.sh sits beside the matrix rather than in
+# it.
+#
+# It is here rather than only in a checklist because docs/limitations.md now makes
+# a cross-major claim -- that data written by one build reads back identically on
+# any build of the same format version, across every supported major -- and
+# test/pg_upgrade.sh is the only thing that tests it. A claim backed by a suite
+# nobody runs is the failure mode that left native_scale dark (#257).
+#
+# Adjacent pairs of the majors being tested, both transfer modes: link shares the
+# data files with the old cluster and copy does not, and they fail differently.
+if [ "${PGC_RUN_UPGRADE:-0}" = 1 ]; then
+	echo "==================================================================="
+	echo "== cross-major upgrade (PGC_RUN_UPGRADE=1)"
+	echo "==================================================================="
+
+	_ucount=0
+	for _i in $(seq 0 $(( ${#CONFIGS[@]} - 2 ))); do
+		_old="${CONFIGS[$_i]}"
+		_new="${CONFIGS[$((_i + 1))]}"
+		[ -x "$_old" ] && [ -x "$_new" ] || continue
+		_omaj="$("$_old" --version | sed -E 's/^[^0-9]*([0-9]+).*/\1/')"
+		_nmaj="$("$_new" --version | sed -E 's/^[^0-9]*([0-9]+).*/\1/')"
+		for _mode in copy link; do
+			_ucount=$((_ucount + 1))
+			_ulog="$(mktemp "/tmp/pgcolumnar-upgrade-${_omaj}-${_nmaj}-${_mode}.XXXXXX.log")"
+			if bash "$SRCDIR/test/pg_upgrade.sh" "$_old" "$_new" "$_mode" \
+				>"$_ulog" 2>&1; then
+				echo "  PASS  pg_upgrade PG$_omaj -> PG$_nmaj ($_mode)"
+				SUMMARY+=("PASS   upgrade PG$_omaj->PG$_nmaj ($_mode)")
+				rm -f "$_ulog"
+			else
+				echo "  FAIL  pg_upgrade PG$_omaj -> PG$_nmaj ($_mode)"
+				if grep -qE '^FAIL' "$_ulog"; then
+					grep -E '^FAIL' "$_ulog" | sed 's/^/      >> /'
+				fi
+				tail -40 "$_ulog" | sed 's/^/      /'
+				echo "      full log: $_ulog"
+				SUMMARY+=("FAIL   upgrade PG$_omaj->PG$_nmaj ($_mode)")
+				overall=1
+			fi
+		done
+	done
+
+	# Asked for the gate and got nothing: that is a failure, not a quiet pass.
+	# One pg_config short of a pair, or a typo in the list, would otherwise report
+	# green having upgraded nothing.
+	if [ "$_ucount" = 0 ]; then
+		echo "  FAIL  PGC_RUN_UPGRADE=1 but no adjacent pair of majors was runnable"
+		SUMMARY+=("FAIL   upgrade (no runnable pair)")
+		overall=1
+	fi
+fi
+
 echo
 echo "===================== MATRIX SUMMARY ============================"
 for line in "${SUMMARY[@]}"; do


### PR DESCRIPTION
Closes #257.

`docs/limitations.md` (via #270) states that data written by one build reads back
identically on any build of the same format version, **across every supported
major**. `test/pg_upgrade.sh` is the only thing that tests that, and it was in no
`SUITES` list and no gate. The claim rested on a suite nobody ran, which is how
`native_scale` went dark.

## What this does

```sh
PGC_RUN_UPGRADE=1 test/run_all_versions.sh
```

Runs each **adjacent pair** of the majors being tested, in **both transfer modes**.
`link` shares the data files with the old cluster and `copy` does not, and they
fail differently, so both run.

Off by default and deliberately not per-PR: it needs two majors at once and runs
the upgrade twice per pair. Same reason `run_san.sh` sits beside the matrix rather
than in it. Written into `docs/testing.md` so the invocation is recorded rather
than remembered, which was half of #257's acceptance.

## Proved, not assumed

**It runs and reports:**
```
PASS  pg_upgrade PG17 -> PG18 (copy)
PASS  pg_upgrade PG17 -> PG18 (link)
```

**A failure propagates.** With one assertion inside the upgrade suite broken:
```
FAIL  pg_upgrade PG17 -> PG18 (copy)
    >> FAIL  row count preserved: got [DELIBERATELY-WRONG] want [46154]
SOME VERSIONS FAILED
```
with the failing check surfaced and the log kept rather than deleted.

**Asking for the gate and getting nothing is a failure, not a quiet pass.** That
guard earned itself immediately: my first run pointed at a `pg_config` path that
does not exist on this box, and it reported
```
FAIL  PGC_RUN_UPGRADE=1 but no adjacent pair of majors was runnable
```
instead of green.

**Off by default is verified**, not assumed: a matrix run without the variable
contains no upgrade phase at all and passes.

## Note on ordering

#269 moves `pg_upgrade.sh`'s ports out of the ephemeral range. That matters more
once this lands, because the suite stops being manual-only. This branch is cut
from `main` and does not conflict; either order works, but #269 first is the
better one.