### PR TITLE
Docs site: MkDocs Material, deployed to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,50 @@
+name: docs
+
+# Build the MkDocs (Material) site and publish it to GitHub Pages. Runs on a
+# push to main that touches the docs, and can be run by hand. The build is
+# --strict, so a broken internal link or a missing nav page fails the run rather
+# than shipping a broken page.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - docs/**
+      - mkdocs.yml
+      - .github/workflows/docs.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One deploy at a time; do not cancel an in-progress publish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: pip install -r docs/requirements.txt
+      - run: mkdocs build --strict
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/assets/pgcolumnar-logo-dark.svg
+++ b/docs/assets/pgcolumnar-logo-dark.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 340 80" width="340" height="80" role="img" aria-label="pgColumnar">
+  <defs>
+    <linearGradient id="bar" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#7AA2F7"/>
+      <stop offset="1" stop-color="#3B6FE0"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#F7B733"/>
+      <stop offset="1" stop-color="#F59E0B"/>
+    </linearGradient>
+  </defs>
+  <g transform="translate(16,16)">
+    <rect x="5"  y="30" width="7" height="11" rx="2.5" fill="url(#bar)"/>
+    <rect x="15" y="22" width="7" height="19" rx="2.5" fill="url(#bar)"/>
+    <rect x="25" y="10" width="7" height="31" rx="2.5" fill="url(#accent)"/>
+    <rect x="35" y="16" width="7" height="25" rx="2.5" fill="url(#bar)"/>
+  </g>
+  <g font-family="'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+    <text x="82" y="46" font-size="34" font-weight="700" fill="#F2F4F8">
+      <tspan fill="#7AA2F7">pg</tspan><tspan>Columnar</tspan>
+    </text>
+    <text x="84" y="64" font-size="12.5" letter-spacing="0.5" fill="#9AA4B8">columnar storage for PostgreSQL</text>
+  </g>
+</svg>

--- a/docs/assets/pgcolumnar-logo.svg
+++ b/docs/assets/pgcolumnar-logo.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 340 80" width="340" height="80" role="img" aria-label="pgColumnar">
+  <defs>
+    <linearGradient id="bar" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#5B8DEF"/>
+      <stop offset="1" stop-color="#2B5FD0"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#F7B733"/>
+      <stop offset="1" stop-color="#F59E0B"/>
+    </linearGradient>
+  </defs>
+  <g transform="translate(16,16)">
+    <rect x="5"  y="30" width="7" height="11" rx="2.5" fill="url(#bar)"/>
+    <rect x="15" y="22" width="7" height="19" rx="2.5" fill="url(#bar)"/>
+    <rect x="25" y="10" width="7" height="31" rx="2.5" fill="url(#accent)"/>
+    <rect x="35" y="16" width="7" height="25" rx="2.5" fill="url(#bar)"/>
+  </g>
+  <g font-family="'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+    <text x="82" y="46" font-size="34" font-weight="700" fill="#1F2A44">
+      <tspan fill="#2B5FD0">pg</tspan><tspan>Columnar</tspan>
+    </text>
+    <text x="84" y="64" font-size="12.5" letter-spacing="0.5" fill="#5A6478">columnar storage for PostgreSQL</text>
+  </g>
+</svg>

--- a/docs/assets/pgcolumnar-mark.svg
+++ b/docs/assets/pgcolumnar-mark.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48" height="48" role="img" aria-label="pgColumnar">
+  <defs>
+    <linearGradient id="bar" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#5B8DEF"/>
+      <stop offset="1" stop-color="#2B5FD0"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#F7B733"/>
+      <stop offset="1" stop-color="#F59E0B"/>
+    </linearGradient>
+  </defs>
+  <rect x="5"  y="30" width="7" height="11" rx="2.5" fill="url(#bar)"/>
+  <rect x="15" y="22" width="7" height="19" rx="2.5" fill="url(#bar)"/>
+  <rect x="25" y="10" width="7" height="31" rx="2.5" fill="url(#accent)"/>
+  <rect x="35" y="16" width="7" height="25" rx="2.5" fill="url(#bar)"/>
+</svg>

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -21,7 +21,7 @@ The numbers below are one full run of all three harnesses, measured 2026-07-27 a
 commit `7a9c9f7`: PostgreSQL 17.10 non-assert (18.4 with io_uring for the read
 stream harness), 6,000,000 rows, 8-column table, median of 5, on 8 cores with
 24 GB of memory. Raw output is in
-[../bench/sample_output_all_2026_07_27.txt](../bench/sample_output_all_2026_07_27.txt).
+[../bench/sample_output_all_2026_07_27.txt](https://github.com/jdatcmd/pgcolumnar/blob/main/bench/sample_output_all_2026_07_27.txt).
 They show the shape of the tradeoff, not a precise score. The dataset is synthetic
 and deliberately mixes column shapes that suit different encodings, so a table of
 purely random values will look worse and a repetitive one better.

--- a/docs/features.md
+++ b/docs/features.md
@@ -10,7 +10,7 @@ settings see the [configuration reference](configuration.md); for constraints se
 - Column-oriented storage in the relation's main fork, so the buffer manager,
   WAL, and page checksums apply. Data is stored in the native format, PGCN v1,
   specified in
-  [../design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md](../design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md).
+  [../design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md](https://github.com/jdatcmd/pgcolumnar/blob/main/design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md).
 - Value encodings are chosen per vector by estimating each candidate on a strided
   sample and applying only the best two, rather than applying every candidate to
   the whole vector. On a 6,000,000-row load this cuts write time by about a third

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,8 +58,8 @@ WAL, replication, indexes, `COPY`, and `pg_dump`. The extension adds:
 The documents above are for users and administrators. The design and format
 specifications are separate:
 
-- [../design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md](../design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md):
+- [../design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md](https://github.com/jdatcmd/pgcolumnar/blob/main/design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md):
   on-disk format and SQL interface specification.
 - [ARCHITECTURE.md](ARCHITECTURE.md): source layout and how the pieces connect.
-- [../design/ROADMAP.md](../design/ROADMAP.md): completed work and remaining items.
-- [../PROVENANCE.md](../PROVENANCE.md): clean-room implementation method.
+- [../design/ROADMAP.md](https://github.com/jdatcmd/pgcolumnar/blob/main/design/ROADMAP.md): completed work and remaining items.
+- [../PROVENANCE.md](https://github.com/jdatcmd/pgcolumnar/blob/main/PROVENANCE.md): clean-room implementation method.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -83,7 +83,7 @@ To install a new build of the extension:
 2. Restart the server so the new library is loaded.
 
 The on-disk format version is recorded in the source and in
-[../design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md](../design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md).
+[../design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md](https://github.com/jdatcmd/pgcolumnar/blob/main/design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md).
 A build that keeps the same format version reads tables written by earlier builds
 of that version without conversion.
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+# Documentation site build (MkDocs + Material). Pinned so a rebuild is
+# reproducible and a theme release cannot silently change the rendered site.
+mkdocs-material==9.7.7

--- a/docs/stylesheets/brand.css
+++ b/docs/stylesheets/brand.css
@@ -1,0 +1,160 @@
+/*
+ * pgColumnar documentation theme.
+ * Palette taken from the logo: ink navy #1F2A44, brand blue #2B5FD0 / #5B8DEF,
+ * amber accent #F59E0B / #F7B733, slate #5A6478. A dark navy header carries the
+ * mark; links are brand blue; interactive/hover states are amber.
+ */
+
+:root {
+  --pgc-navy:        #1F2A44;
+  --pgc-navy-deep:   #16203a;
+  --pgc-blue:        #2B5FD0;
+  --pgc-blue-light:  #5B8DEF;
+  --pgc-amber:       #F59E0B;
+  --pgc-amber-light: #F7B733;
+  --pgc-slate:       #5A6478;
+}
+
+/* ---- light scheme ------------------------------------------------------- */
+[data-md-color-scheme="default"] {
+  --md-primary-fg-color:        var(--pgc-navy);
+  --md-primary-fg-color--light: var(--pgc-blue);
+  --md-primary-fg-color--dark:  var(--pgc-navy-deep);
+  --md-primary-bg-color:        #ffffff;
+  --md-primary-bg-color--light: rgba(255, 255, 255, 0.75);
+
+  --md-accent-fg-color:         var(--pgc-amber);
+  --md-accent-fg-color--transparent: rgba(245, 158, 11, 0.1);
+
+  --md-typeset-a-color:         var(--pgc-blue);
+
+  /* a neutral with a faint navy bias rather than a flat grey */
+  --md-default-bg-color:        #fbfcfe;
+  --md-footer-bg-color:         var(--pgc-navy-deep);
+  --md-footer-bg-color--dark:   #0f1729;
+}
+
+/* ---- dark scheme -------------------------------------------------------- */
+[data-md-color-scheme="slate"] {
+  --md-hue: 222; /* bias the slate dark ground toward the brand navy */
+
+  --md-primary-fg-color:        var(--pgc-navy-deep);
+  --md-primary-fg-color--light: var(--pgc-blue-light);
+  --md-primary-fg-color--dark:  #0f1729;
+  --md-primary-bg-color:        #e7edf4;
+
+  --md-accent-fg-color:         var(--pgc-amber-light);
+  --md-typeset-a-color:         #7aa4f5;
+
+  --md-footer-bg-color:         #0f1729;
+}
+
+/* ---- header: keep the mark and title crisp on the navy bar -------------- */
+.md-header {
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.06), 0 2px 8px rgba(15, 23, 41, 0.25);
+}
+.md-header__button.md-logo img {
+  height: 1.5rem;
+  width: auto;
+}
+.md-header__title {
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+/* Active/hover nav tab gets an amber underline: one clear accent, used sparingly */
+.md-tabs__link {
+  opacity: 0.85;
+  transition: opacity 120ms;
+}
+.md-tabs__link:hover,
+.md-tabs__link--active {
+  opacity: 1;
+}
+.md-tabs__item--active .md-tabs__link {
+  position: relative;
+}
+.md-tabs__item--active .md-tabs__link::after {
+  content: "";
+  position: absolute;
+  left: 0.6rem;
+  right: 0.6rem;
+  bottom: -2px;
+  height: 2px;
+  background: var(--pgc-amber);
+  border-radius: 2px;
+}
+
+/* ---- typography: give body copy room, headings a touch of weight -------- */
+.md-typeset {
+  font-feature-settings: "kern", "liga", "tnum";
+}
+.md-typeset h1 {
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+.md-typeset h2 {
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin-top: 2.2em;
+}
+.md-typeset h2::after {
+  content: "";
+  display: block;
+  width: 2.25rem;
+  height: 2px;
+  margin-top: 0.35rem;
+  background: var(--pgc-amber);
+  border-radius: 2px;
+  opacity: 0.8;
+}
+
+/* ---- tables: readable, with a quiet navy header row --------------------- */
+.md-typeset table:not([class]) th {
+  background: color-mix(in srgb, var(--pgc-blue) 8%, transparent);
+  font-weight: 600;
+}
+[data-md-color-scheme="slate"] .md-typeset table:not([class]) th {
+  background: color-mix(in srgb, var(--pgc-blue-light) 14%, transparent);
+}
+.md-typeset table:not([class]) {
+  font-variant-numeric: tabular-nums;
+}
+
+/* ---- code: brand-tinted inline code, comfortable blocks ----------------- */
+.md-typeset code {
+  border-radius: 4px;
+}
+.md-typeset :not(pre) > code {
+  background: color-mix(in srgb, var(--pgc-blue) 8%, transparent);
+}
+[data-md-color-scheme="slate"] .md-typeset :not(pre) > code {
+  background: color-mix(in srgb, var(--pgc-blue-light) 12%, transparent);
+}
+
+/* ---- links: amber underline on hover, brand blue otherwise ------------- */
+.md-typeset a {
+  text-underline-offset: 0.15em;
+}
+.md-typeset a:hover {
+  color: var(--md-accent-fg-color);
+}
+
+/* ---- home page: lift the intro table into cards-ish rows ---------------- */
+.md-typeset .md-button {
+  border-radius: 6px;
+}
+.md-typeset .md-button--primary {
+  background: var(--pgc-blue);
+  border-color: var(--pgc-blue);
+}
+.md-typeset .md-button--primary:hover {
+  background: var(--pgc-amber);
+  border-color: var(--pgc-amber);
+  color: var(--pgc-navy-deep);
+}
+
+/* Footer: a calm dark navy, generator line removed via config */
+.md-footer-meta {
+  background: var(--md-footer-bg-color--dark, var(--pgc-navy-deep));
+}

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -251,6 +251,6 @@ decoded unless the consumer filters them.
 - Operate tables in production: [Administration](administration.md).
 - Improve range scans on a scattered key or serve a query from a column subset:
   [projections](administration.md#projections) and
-  [`pgcolumnar.vacuum_sorted`](sql-reference.md#pgcolumnarvacuum_sortedtablename-regclass-variadic-sort_columns-namel).
+  [`pgcolumnar.vacuum_sorted`](sql-reference.md#pgcolumnarvacuum_sortedtablename-regclass-variadic-sort_columns-name).
 - Move data in and out of the Arrow and Parquet ecosystem:
   [import and export](sql-reference.md#import-and-export).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,113 @@
+site_name: pgColumnar
+site_description: Analytic column storage for PostgreSQL, built as a native table access method.
+site_url: https://jdatcmd.github.io/pgcolumnar/
+site_author: pgColumnar contributors
+
+repo_url: https://github.com/jdatcmd/pgcolumnar
+repo_name: jdatcmd/pgcolumnar
+edit_uri: edit/main/docs/
+
+copyright: >
+  pgColumnar is released under the MIT License. PostgreSQL is a trademark of the
+  PostgreSQL Community Association of Canada.
+
+theme:
+  name: material
+  logo: assets/pgcolumnar-mark.svg
+  favicon: assets/pgcolumnar-mark.svg
+  icon:
+    repo: fontawesome/brands/github
+  font:
+    text: IBM Plex Sans
+    code: IBM Plex Mono
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.sections
+    - navigation.top
+    - navigation.tracking
+    - navigation.footer
+    - navigation.indexes
+    - toc.follow
+    - search.suggest
+    - search.highlight
+    - search.share
+    - content.code.copy
+    - content.code.annotate
+    - content.tabs.link
+
+extra_css:
+  - stylesheets/brand.css
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/jdatcmd/pgcolumnar
+      name: pgColumnar on GitHub
+  generator: false
+
+markdown_extensions:
+  - abbr
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+      slugify: !!python/object/apply:pymdownx.slugs.slugify
+        kwds:
+          case: lower
+  - pymdownx.betterem
+  - pymdownx.caret
+  - pymdownx.tilde
+  - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+
+plugins:
+  - search
+
+nav:
+  - Home: index.md
+  - Getting started:
+      - Installation: installation.md
+      - User guide: user-guide.md
+  - Concepts:
+      - Features: features.md
+      - Architecture: ARCHITECTURE.md
+  - Operations:
+      - Administration: administration.md
+      - Configuration: configuration.md
+      - Benchmarks: benchmarks.md
+  - Reference:
+      - SQL reference: sql-reference.md
+      - Limitations & compatibility: limitations.md
+  - Development:
+      - Testing: testing.md


### PR DESCRIPTION
Renders the `docs/` Markdown set as a branded documentation site and publishes it to GitHub Pages.

## What
- **MkDocs + Material**, branded to the logo palette: an ink-navy header carrying the mark, brand-blue links, a single amber accent used sparingly (section rules, tab underline, hover). Light and slate-dark schemes with a toggle; IBM Plex Sans / Mono.
- **Nav** grouped into Getting started / Concepts / Operations / Reference / Development, with tabs, instant search, code-copy, and per-page TOC.
- **Anchor compatibility:** `toc` uses pymdownx's GitHub-style slugify, so the existing intra-doc `#anchor` links resolve on the site exactly as they do on GitHub.
- **CI deploy:** `.github/workflows/docs.yml` builds with `mkdocs build --strict` (a broken link or missing nav page fails the run) and deploys with the first-party Pages actions. `docs/requirements.txt` pins `mkdocs-material` for reproducible builds.

## Content touched (minimal)
- Rewrote six links that pointed at repo files outside `docs/` (`design/…`, `PROVENANCE.md`, `bench/…`) to absolute GitHub URLs, so they resolve on the site and on GitHub both.
- Fixed one stale `vacuum_sorted` anchor in `user-guide.md`.

## Verified
Clean `mkdocs build --strict` locally (mkdocs-material 9.7.7), 11 pages, brand CSS + logo + fonts wired.

Once merged with Pages enabled (source: GitHub Actions), the site is live at **https://jdatcmd.github.io/pgcolumnar/**.
