### PR TITLE
Link the published documentation site from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 <a href="VERSION"><img src="badges/version.svg" alt="Version 1.0-dev"></a>
 <a href="docs/limitations.md#release-status"><img src="badges/status.svg" alt="Status: pre-release"></a>
 
+<p><strong><a href="https://jdatcmd.github.io/pgcolumnar/">Read the documentation at jdatcmd.github.io/pgcolumnar</a></strong></p>
+
 </div>
 
 A table created `USING pgcolumnar` stores its data by column, with per-column
@@ -26,6 +28,10 @@ is `1.0-dev`, recorded in `VERSION`. A table `USING pgcolumnar` is stored in the
 native on-disk format, PGCN v1.
 
 ## Documentation
+
+The full documentation is published at
+**[jdatcmd.github.io/pgcolumnar](https://jdatcmd.github.io/pgcolumnar/)**. The
+same pages are in this repository under `docs/`:
 
 | | |
 | --- | --- |


### PR DESCRIPTION
The documentation is published at
[jdatcmd.github.io/pgcolumnar](https://jdatcmd.github.io/pgcolumnar/) and nothing
in the repository pointed at it. Every path from the README went to the Markdown
sources under `docs/`, so a reader arriving at the project had no way to know a
rendered, searchable site exists.

Two placements, because they serve different readers:

- the header block, for someone scanning the landing page;
- the Documentation section, for someone who has decided to read and would
  otherwise start clicking individual files.

The table of source files stays. It is useful when reading in the repository or
offline, and it is what the site is built from.

Verified the URL serves `200` rather than assuming it. Advertising a documentation
link that 404s is worse than not linking it.