### PR TITLE
CI: automate the sanitizer gate and broaden major coverage (#243)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,17 @@
 # pgColumnar continuous integration.
 #
-# This mirrors the cadence the project already runs locally rather than
-# inventing a second one: a build preflight across every supported major, which
-# is what catches an API break, and the suite run on one major, which is what
-# catches a behaviour break. The full five-major suite matrix stays a local gate
-# (test/run_all_versions.sh) because PostgreSQL 19 is beta and not packaged in
-# PGDG stable, so CI cannot reproduce it honestly.
+# Two per-PR gates, matching the local cadence:
+#   - a build preflight across every packaged major, which catches an API break;
+#   - the suite matrix on the current majors (17 and 18), which catches a
+#     behaviour break -- previously PG17 only (#236), 18 added to close #243.
+#
+# The heavier coverage runs nightly in .github/workflows/nightly.yml, not per-PR:
+# the full packaged suite matrix (15-18) and the ASAN+UBSAN sanitizer gate -- the
+# only gate that catches the non-faulting memory-safety class the assert builds
+# miss. Per-PR stays fast; the deep coverage runs once a day and on demand.
+#
+# PostgreSQL 19 is beta and not packaged in PGDG stable, so it stays a local gate
+# (test/run_all_versions.sh against a source build).
 #
 # Warnings are failures here for the same reason they are in the local matrix.
 
@@ -79,17 +85,22 @@ jobs:
           # here is reported rather than failed on.
           [ -z "$missing" ] && echo "all resolve" || { echo "unresolved (informational):"; echo "$missing"; }
 
-  # Run the suites on one major. This is the behaviour gate; the local
-  # five-major matrix remains the release gate.
+  # Run the suites on the current majors (17 + 18). This is the per-PR behaviour
+  # gate; the full packaged matrix (15-18) runs nightly, and the local five-major
+  # matrix (adding PG19) remains the release gate. The two majors run in parallel.
   suites:
-    name: suites (PG 17)
+    name: suites (PG ${{ matrix.pg }})
     runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        pg: ['17', '18']
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install PostgreSQL 17, codec headers, and pyarrow
+      - name: Install PostgreSQL ${{ matrix.pg }}, codec headers, and pyarrow
         run: |
           set -euo pipefail
           sudo install -d /usr/share/postgresql-common/pgdg
@@ -100,7 +111,7 @@ jobs:
             | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            postgresql-17 postgresql-server-dev-17 \
+            postgresql-${{ matrix.pg }} postgresql-server-dev-${{ matrix.pg }} \
             liblz4-dev libzstd-dev zlib1g-dev python3-pip
           # The Arrow and Parquet suites use pyarrow as an independent reader and
           # skip themselves without it, which would be a silent loss of coverage.
@@ -128,7 +139,7 @@ jobs:
         # packaged one is unused and only competes for shared memory.
         run: sudo systemctl stop postgresql || true
 
-      - name: Run the suite matrix on PG 17
+      - name: Run the suite matrix on PG ${{ matrix.pg }}
         run: |
           set -euo pipefail
           # PGC_SKIP_TIMING drops the three wall-clock suites: a shared runner
@@ -139,17 +150,9 @@ jobs:
           # PGC_REQUIRE_ISOLATION turns a missing pg_isolation_regress into a
           # failure instead of a skip (#247), so the seven columnar race specs
           # cannot report green without executing.
-          #
-          # #247 expected the binary to be absent on a packaged install. On PGDG
-          # and Ubuntu it is present: postgresql-client-NN ships it at
-          # $(pg_config --pgxs)/../test/isolation/pg_isolation_regress, which is
-          # exactly where isolation.sh looks. Verified against the packaged
-          # PostgreSQL 18 in the dev container: the suite runs its specs rather
-          # than skipping. So requiring it here costs nothing and converts an
-          # ambiguous PASS -- which a skip also produces -- into a real one.
           sudo -E env "PATH=$PATH" PGC_SKIP_TIMING=1 PGC_JOBS=4 \
             PGC_REQUIRE_ISOLATION=1 \
-            bash test/run_all_versions.sh /usr/lib/postgresql/17/bin/pg_config
+            bash test/run_all_versions.sh /usr/lib/postgresql/${{ matrix.pg }}/bin/pg_config
 
       - name: Collect logs on failure
         if: failure()

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,150 @@
+# pgColumnar nightly deep gate (issue #243).
+#
+# The per-PR gate (build-and-test.yml) is deliberately fast: build on 15-18, run
+# the suites on 17 and 18. This workflow runs the coverage that is too heavy for
+# every PR, once a day and on demand:
+#
+#   - the full packaged suite matrix (15, 16, 17, 18), so a behaviour, WAL, or
+#     access-method divergence on 15/16 is caught automatically rather than only
+#     by the local by-hand matrix;
+#   - the clang ASAN+UBSAN sanitizer gate, the only gate that catches the
+#     non-faulting memory-safety class the assert builds provably miss (issue
+#     #225). An instrumented PostgreSQL build is expensive, so it is cached and
+#     rebuilt only when test/build_san.sh or the pinned major changes.
+#
+# PostgreSQL 19 is beta and not in PGDG stable, so it stays a local gate.
+
+name: nightly deep gate
+
+on:
+  schedule:
+    - cron: "0 6 * * *" # nightly, 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly
+  cancel-in-progress: false
+
+jobs:
+  # Full packaged suite matrix. Same suites the per-PR gate runs on 17/18, here
+  # across every packaged major so 15 and 16 are covered too.
+  suites:
+    name: suites (PG ${{ matrix.pg }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    if: github.event_name == 'workflow_dispatch' || github.repository == 'jdatcmd/pgcolumnar'
+    strategy:
+      fail-fast: false
+      matrix:
+        pg: ['15', '16', '17', '18']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install PostgreSQL ${{ matrix.pg }}, codec headers, and pyarrow
+        run: |
+          set -euo pipefail
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo curl -fsSL -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+            https://www.postgresql.org/media/keys/ACCC4CF8.asc
+          echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] \
+            https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
+            | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            postgresql-${{ matrix.pg }} postgresql-server-dev-${{ matrix.pg }} \
+            liblz4-dev libzstd-dev zlib1g-dev python3-pip
+          # pyarrow for root (the suites run under sudo); the silent-skip trap the
+          # per-PR workflow documents applies here too.
+          sudo pip3 install --break-system-packages --quiet pyarrow \
+            || sudo pip3 install --quiet pyarrow
+
+      - name: Confirm pyarrow is importable by the suites' interpreter
+        run: |
+          set -euo pipefail
+          python3 -c 'import pyarrow, pyarrow.parquet; print("pyarrow", pyarrow.__version__)'
+          sudo python3 -c 'import pyarrow, pyarrow.parquet; print("pyarrow as root ok")'
+
+      - name: Stop the packaged cluster
+        run: sudo systemctl stop postgresql || true
+
+      - name: Run the suite matrix on PG ${{ matrix.pg }}
+        run: |
+          set -euo pipefail
+          # PGC_REQUIRE_ISOLATION makes a missing pg_isolation_regress fail rather
+          # than skip (#247); timing suites are dropped on shared runners.
+          sudo -E env "PATH=$PATH" PGC_SKIP_TIMING=1 PGC_JOBS=4 \
+            PGC_REQUIRE_ISOLATION=1 \
+            bash test/run_all_versions.sh /usr/lib/postgresql/${{ matrix.pg }}/bin/pg_config
+
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          for f in /tmp/pgcolumnar-matrix-*/*.log; do
+            [ -e "$f" ] || continue
+            echo "===== $f ====="
+            tail -60 "$f"
+          done
+
+  # clang ASAN+UBSAN gate. Builds an instrumented PostgreSQL (cached) and runs the
+  # write/read/encode/import subset against it with sanitizer violations fatal.
+  sanitizer:
+    name: sanitizer gate (ASAN+UBSAN)
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    if: github.event_name == 'workflow_dispatch' || github.repository == 'jdatcmd/pgcolumnar'
+    env:
+      PG_VERSION: "18.4"
+      SAN_PREFIX: /home/runner/pg_san
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install clang, build tools, codec headers, and pyarrow
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            clang llvm bison flex make perl \
+            liblz4-dev libzstd-dev zlib1g-dev python3-pip
+          clang --version | head -1
+          sudo pip3 install --break-system-packages --quiet pyarrow \
+            || sudo pip3 install --quiet pyarrow
+          sudo python3 -c 'import pyarrow, pyarrow.parquet; print("pyarrow as root ok")'
+
+      - name: Cache the instrumented PostgreSQL
+        id: san-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.SAN_PREFIX }}
+          key: san-pg-${{ env.PG_VERSION }}-clang-${{ hashFiles('test/build_san.sh') }}-${{ runner.os }}
+
+      - name: Build the ASAN+UBSAN PostgreSQL (on cache miss)
+        if: steps.san-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /tmp/pg-src.tar.bz2 \
+            "https://ftp.postgresql.org/pub/source/v${PG_VERSION}/postgresql-${PG_VERSION}.tar.bz2"
+          # build_san.sh honours PGC_PG_TARBALL (source) and PGC_SAN_SRC (scratch)
+          # and installs to the prefix argument; point all three at CI-writable
+          # paths instead of its /root defaults.
+          PGC_PG_TARBALL=/tmp/pg-src.tar.bz2 PGC_SAN_SRC=/tmp/pg_san_src \
+            bash test/build_san.sh "$SAN_PREFIX"
+
+      - name: Confirm the build is the expected sanitizer build
+        run: |
+          set -euo pipefail
+          "$SAN_PREFIX/bin/pg_config" --version
+          mkglobal="$("$SAN_PREFIX/bin/pg_config" --pgxs | xargs dirname | xargs dirname)/Makefile.global"
+          grep -q -- '-fsanitize=address,undefined' "$mkglobal"
+          grep -q -- '-fno-sanitize=function' "$mkglobal"
+          echo "sanitizer flags present in Makefile.global"
+
+      - name: Run the sanitizer gate
+        run: |
+          set -euo pipefail
+          # run_san.sh builds the extension instrumented against this server and
+          # runs the subset with ASAN/UBSAN violations fatal. Under sudo because
+          # the suites start their own clusters; -E preserves the sanitizer env.
+          sudo -E env "PATH=$PATH" bash test/run_san.sh "$SAN_PREFIX"


### PR DESCRIPTION
Closes #243.

The two highest-value gates were local / honor-system: the ASAN+UBSAN sanitizer gate ran nowhere in CI, and the behaviour suites ran on PG17 only. A regression in the non-faulting memory-safety class, or a 15/16/18 behaviour divergence, could land green between manual runs.

## What
- **`build-and-test.yml`** — the per-PR suites gate now runs on **17 and 18** (was 17 only). That's the minimum #243 asks for, and it stays fast: two majors, in parallel.
- **`nightly.yml`** (new; `schedule` + `workflow_dispatch`) — the coverage too heavy for every PR:
  - **full packaged suite matrix (15, 16, 17, 18)**, so a 15/16 divergence is caught automatically rather than only by the local by-hand matrix;
  - **clang ASAN+UBSAN sanitizer gate** — builds the instrumented PostgreSQL from a downloaded source tarball via `test/build_san.sh` (**cached**; rebuilt only when `build_san.sh` or the pinned major changes), then runs `test/run_san.sh` with violations fatal.
  - Both jobs `if`-guard so a fork's scheduled run is a no-op, but anyone can `workflow_dispatch` them.

## Fail-loud, per the acceptance criteria
Silent-skip guards kept: `PGC_REQUIRE_ISOLATION` (#247) and the root-interpreter pyarrow import check, so a green run cannot mask dropped coverage.

## Why the split (per-PR vs nightly)
Running the full ~92-suite set × 4 majors on every PR is a lot of runner minutes, and full suites on 15/16 have not been validated before (the local gate bar was full-on-18/19, preflight-on-15/16/17). Putting the unvalidated 15/16 full run nightly means it surfaces any divergence without blocking PRs on it, and keeps per-PR cost at 2 majors. Easy to change: if you'd rather 15/16 be per-PR too, it's a one-line matrix edit. PG19 stays a local gate (beta, not in PGDG stable).

## Verification
- The per-PR change (`suites` on 17+18) is exercised by this PR's own CI run.
- The `nightly` workflow is `schedule`/`dispatch`-only, so it can't run from a fork PR; it needs one `workflow_dispatch` after merge to confirm end-to-end (the instrumented build + gate). I can drive that. YAML validated; the PG 18.4 source tarball URL and `build_san.sh`'s `PGC_PG_TARBALL`/`PREFIX` override contract are confirmed.
