### PR TITLE
Documentation audit: release status, CI, and the work that has landed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,15 @@ unreleased. For the forward-looking plan see
 - Parquet read type coverage extended to uuid and numeric (from fixed and
   variable DECIMAL, precision up to 38), fixed-length binary, and millisecond,
   microsecond, and nanosecond time units.
+- `pgcolumnar.fsst_min_gain_percent`, a cost margin for the FSST string encoding
+  decision. FSST is kept only when it reduces the compressed chunk by at least
+  this percentage, default 5. Building FSST codes for every vector is one of the
+  larger costs of a text or varlena load, and a sub-margin reduction does not
+  repay it.
+- The on-disk format version is enforced when data is read, not only stamped when
+  it is written. Both the physical metapage version and the native data format
+  version are checked, on every path that decodes columnar data, so a file this
+  build cannot read is refused rather than misread.
 - User and administrator documentation under [docs/](docs/index.md):
   installation, user guide, administration, configuration reference, SQL
   reference, and limitations.
@@ -114,6 +123,12 @@ unreleased. For the forward-looking plan see
 
 ### Changed
 
+- FSST string encoding is now kept only when it reduces the compressed chunk by
+  at least 5 percent, rather than on any reduction at all. On shapes where FSST
+  barely wins, such as high-entropy text, this costs about 2 percent stored size
+  and reduces load time by roughly a third. Where FSST wins by more than the
+  margin the encoding and the stored bytes are unchanged. Set
+  `pgcolumnar.fsst_min_gain_percent` to 0 for the previous behaviour.
 - Renamed the per-table option functions to `pgcolumnar.set_options` and
   `pgcolumnar.reset_options`. The previous names were carried over from an
   earlier compatibility goal that no longer applies. No aliases are kept, since
@@ -125,3 +140,8 @@ unreleased. For the forward-looking plan see
   on all five majors.
 - The Arrow and Parquet import and export functions require superuser and run on
   little-endian hosts.
+- Cross-major `pg_upgrade` is covered by an opt-in gate
+  (`PGC_RUN_UPGRADE=1 test/run_all_versions.sh`), in both copy and link transfer
+  modes.
+- All recorded test results come from x86_64. The suites have not been run on
+  aarch64 or on a big-endian platform.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -76,8 +76,8 @@ Major-version compatibility shims. pgColumnar keeps one source tree that builds
 on PostgreSQL 15 through 19. PostgreSQL changed several of its own API and
 callback contracts across those majors (for example the RelFileNode to
 RelFileLocator rename in 16, the table-AM signature changes in 19, and the
-planner hook that edits the index list -- get_relation_info_hook through 18,
-build_simple_rel_hook in 19 -- used to enable index-only scans). Each shim here
+planner hook that edits the index list, which is get_relation_info_hook through
+18 and build_simple_rel_hook in 19, used to enable index-only scans). Each shim here
 only selects the correct core API for the running major; none of them change
 pgColumnar's behavior.
 

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -155,10 +155,11 @@ the base table and its projections. Projection scans are on by default
 (`pgcolumnar.enable_projection_scan`). Drop a projection with
 `pgcolumnar.drop_projection`.
 
-Projections are not carried by `pg_dump` / `pg_restore` -- they are keyed by
-internal storage ids that a restore regenerates -- so re-declare them with
+Projections are not carried by `pg_dump` and `pg_restore`. They are keyed by
+internal storage ids that a restore regenerates, so re-declare them with
 `pgcolumnar.add_projection` after a logical restore. A physical backup
-(`pg_basebackup`) preserves them.
+(`pg_basebackup`) preserves them, which `test/replication.sh` verifies against a
+standby.
 
 A projection adds write cost and storage, because inserts write it too. Add one
 for a query pattern that a covering, sorted column subset serves, and measure the
@@ -250,7 +251,7 @@ the set of roles that can reach a hand-rolled parser.
 
 A Parquet or Arrow file from a source you did not produce is untrusted input to a
 hand-rolled parser. The metadata in a crafted file drives that parser directly, so
-a malformed or hostile file is a code-execution surface, not just a data-quality
+a malformed or hostile file is a code-execution surface, not only a data-quality
 problem. The superuser boundary means the exposed case is a superuser reading a
 file they did not produce, which is the ordinary data-lake case rather than an
 exotic one: the file is external even though the role is trusted.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -148,9 +148,8 @@ Index-only scan on versus off (covering range count, median ms):
 | --- | --- | --- | --- |
 | covering count, id range (~2%) | 7.53 | 698.95 | 93 |
 
-The "off" column is the fetch-by-row path doing nothing else, which makes it the
-clearest single view of what that path costs, and the clearest measure of what
-#143 changed: this shape was 200.9 s before the decoded-group cache, 31.8 s after
+The "off" column is the fetch-by-row path doing nothing else, which isolates
+what that path costs and what #143 changed: this shape was 200.9 s before the decoded-group cache, 31.8 s after
 it, and 0.69 s once the walk to the row went too.
 
 Projection scan on versus off (covering scan on a scattered sort key, median ms):
@@ -198,8 +197,8 @@ So the target is bulk load in general rather than the interop path. Tracked as
 [issue #155](https://github.com/jdatcmd/pgcolumnar/issues/155) with a plan in
 `design/IMPORT_THROUGHPUT_PLAN.md`.
 
-The plan attributes the cost to the row/column transposition -- both readers
-decode a column-oriented file into per-row values, and the writer copies them
+The plan attributes the cost to the row/column transposition, since both readers
+decode a column-oriented file into per-row values and the writer copies them
 back into per-column buffers. Measurement does not support that as the main
 term. A single integer column already writes faster than heap, and on a text
 column the write path is dominated by the FSST substring search: skipping it

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,14 +28,14 @@ pgColumnar has two kinds of settings:
 | `pgcolumnar.compression_level` | integer | `3` | Level for the `zstd` codec. Range 1 to 22. Higher levels compress more and write more slowly. |
 | `pgcolumnar.fsst_min_gain_percent` | integer | `5` | Minimum size reduction, in percent, for FSST string encoding to be kept for a column chunk. Range 0 to 99. See below. |
 
-Building FSST codes for every vector is a significant part of the cost of a text
-or varlena load. At `0`, FSST is kept whenever it produces any reduction after
+Building FSST codes for every vector is one of the larger costs of a text or
+varlena load. At `0`, FSST is kept whenever it produces any reduction after
 the block codec, however small, and that reduction does not always repay the
 encode. The default of `5` keeps FSST only where it saves at least 5 percent.
 
 On measured workloads this costs about 2 percent stored size on shapes where
 FSST barely wins, such as high-entropy text, and reduces their load time by
-roughly a third. Where FSST wins clearly, such as low-cardinality text, the
+roughly a third. Where FSST wins by more than the margin, such as low-cardinality text, the
 setting changes nothing: the encoding chosen and the bytes written are the same.
 Wide values are also unaffected.
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -27,11 +27,18 @@ format version is enforced on read rather than only stamped on write
 What that testing does not cover is worth stating alongside it. Every result
 recorded in this repository comes from x86_64. The suites have not been run on
 aarch64 or on a big-endian platform
-([issue #242](https://github.com/jdatcmd/pgcolumnar/issues/242)). That matters
-more here than it would in most extensions: the code reads values out of packed
-on-disk buffers, and an unaligned read of that kind has already had to be fixed
-once, on a platform that tolerates it. Another architecture is untested rather
-than known to be broken, and building there should be treated accordingly.
+([issue #242](https://github.com/jdatcmd/pgcolumnar/issues/242)).
+
+Unaligned reads, one class that would be expected to differ by architecture, are
+covered independent of it: the sanitizer gate builds with clang's address and
+undefined-behaviour checks, which report a misaligned load on any host, and that
+gate exists because such a read was found and fixed once. What remains untested on
+another architecture is what a sanitizer on x86_64 cannot observe, principally
+memory ordering. x86_64 orders stores more strictly than aarch64 does, so a
+missing barrier in concurrent code can be invisible on one and a defect on the
+other. Another architecture is untested rather than known to be broken, and
+building there should be treated accordingly.
+
 PostgreSQL 19 coverage is against 19beta2, not a final release.
 
 The sections below are the standing functional limitations, separate from that

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -11,14 +11,31 @@ tables that can be rebuilt from an external source, and for development, testing
 and measurement. It is not yet recommended for a production system of record or
 for data that cannot be reloaded.
 
-Hardening tracked before a first alpha is in the issue tracker: fuzzing the
-hand-rolled Parquet and Arrow parsers
-([issue #214](https://github.com/jdatcmd/pgcolumnar/issues/214)), a stated and
-tested boundary for untrusted input files
-([issue #216](https://github.com/jdatcmd/pgcolumnar/issues/216)), and a statement
-of the blast radius of a single backend crash
-([issue #217](https://github.com/jdatcmd/pgcolumnar/issues/217)). The sections
-below are the standing functional limitations, separate from that work.
+The hardening that was tracked before a first alpha is complete. The hand-rolled
+Parquet and Arrow parsers are fuzzed, both by byte mutation and by structural
+mutation of the container format
+([issue #214](https://github.com/jdatcmd/pgcolumnar/issues/214)). The boundary for
+untrusted input files is stated and tested
+([issue #216](https://github.com/jdatcmd/pgcolumnar/issues/216)). The blast radius
+of a single backend crash is asserted and documented
+([issue #217](https://github.com/jdatcmd/pgcolumnar/issues/217)). The on-disk
+format version is enforced on read rather than only stamped on write
+([issue #240](https://github.com/jdatcmd/pgcolumnar/issues/240)), and cross-major
+`pg_upgrade` is covered by a gate rather than by a suite nobody runs
+([issue #257](https://github.com/jdatcmd/pgcolumnar/issues/257)).
+
+What that testing does not cover is worth stating alongside it. Every result
+recorded in this repository comes from x86_64. The suites have not been run on
+aarch64 or on a big-endian platform
+([issue #242](https://github.com/jdatcmd/pgcolumnar/issues/242)). That matters
+more here than it would in most extensions: the code reads values out of packed
+on-disk buffers, and an unaligned read of that kind has already had to be fixed
+once, on a platform that tolerates it. Another architecture is untested rather
+than known to be broken, and building there should be treated accordingly.
+PostgreSQL 19 coverage is against 19beta2, not a final release.
+
+The sections below are the standing functional limitations, separate from that
+work.
 
 ## On-disk format stability
 
@@ -27,11 +44,11 @@ format version (currently PGCN v1) and a physical metapage version, and both are
 checked on read. The metapage version guards the physical block layout; the
 native format version guards the data encoding, so a future version that changes
 the encoding while keeping the metapage layout is still caught. A version this
-build does not understand is rejected -- `unsupported columnar format version` for
-the metapage, `unsupported columnar native format version` for the data format --
-and the read fails cleanly rather than misinterpreting bytes written by a
-different layout. The check runs on every decode path -- sequential scan,
-vectorized aggregate, and index-scan fetch -- so a version this build cannot read
+build does not understand is rejected, reporting `unsupported columnar format
+version` for the metapage or `unsupported columnar native format version` for the
+data format, and the read fails rather than misinterpreting bytes written by a
+different layout. The check runs on every decode path, including sequential scan,
+vectorized aggregate, and index-scan fetch, so a version this build cannot read
 is refused whichever way the query reaches the data. Both guards are pinned by
 `test/native_format.sh`.
 
@@ -43,14 +60,14 @@ stamps every object it writes, base and projections together.
 Within a version the format round-trips faithfully: data written and read back on
 the same build is byte-for-byte identical, which `test/native_format.sh` proves on
 every supported PostgreSQL major. Byte-for-byte preservation across a PostgreSQL
-major upgrade is asserted separately by `test/pg_upgrade.sh`; wiring that suite
-into the gate is tracked in
-[issue #257](https://github.com/jdatcmd/pgcolumnar/issues/257).
+major upgrade is asserted separately by `test/pg_upgrade.sh`, which runs as an
+opt-in gate (`PGC_RUN_UPGRADE=1 test/run_all_versions.sh`) over each adjacent pair
+of majors in both copy and link transfer modes.
 
-There is no in-place upgrade across an incompatible format version yet. The format
-has not changed during the pre-release, so no migration has been needed; but until
-an upgrade path and a compatibility guarantee are committed to, treat the format
-as reload-required across an incompatible bump. This is the same posture as the
+There is no in-place upgrade across an incompatible format version. The format has
+not changed during the pre-release, so no migration has been needed. Until an
+upgrade path and a compatibility guarantee are committed to, treat the format as
+reload-required across an incompatible bump. This is the same posture as the
 release-status note above: keep the source a columnar table was loaded from, so it
 can be rebuilt if a future version changes the layout. A physical copy
 (`pg_basebackup`, file-system snapshot, replication) preserves the exact bytes and
@@ -285,7 +302,7 @@ on whether the filter was pushed down.
 - `pg_dump` and `pg_restore` handle columnar tables, and the target server must
   have the extension installed and preloaded. Table data, indexes, and per-table
   options (`pgcolumnar.set_options`) survive the round trip; **declared
-  projections (`pgcolumnar.add_projection`) do not** -- they are keyed by internal
+  projections (`pgcolumnar.add_projection`) do not**. They are keyed by internal
   storage ids that a restore regenerates, so a restored table has no projections
   and they must be re-declared. A physical backup (`pg_basebackup`) copies the
   cluster bytewise and preserves them.
@@ -402,8 +419,8 @@ The read-in-place surface (`read_parquet`, `parquet_schema`, and the
   raw file data is one page, not one file, so file size is not a limit. What does
   scale with the data is the decoded form of one row group for the columns the
   query reads, since a row group is decoded before its rows are produced. A file
-  written with very large row groups therefore costs more memory than the same
-  data written with smaller ones.
+  written with larger row groups therefore costs more memory than the same data
+  written with smaller ones.
 - The column definition list, or a foreign table's column list, must cover every
   leaf column in the file. A shorter list is an error rather than a projection.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -107,7 +107,7 @@ test/pbt/run.sh [seed] [iterations]
 test/build_all_versions.sh
 ```
 
-No clusters and no suites, just a compile against each installed major, about a
+No clusters and no suites, only a compile against each installed major, about a
 minute for all five. Run it before merging anything that touches a version guard,
 a table access method callback signature, or `columnar_compat.h`.
 
@@ -202,3 +202,53 @@ percentage, and expect the percentage to be unremarkable in places that are
 correct: a table access method carries defensive branches that should never be
 taken, and `columnar_compat.h` carries version shims of which one arm compiles per
 major.
+## Continuous integration
+
+Three workflows run in GitHub Actions.
+
+**On every pull request and push to `main`** (`.github/workflows/ci.yml`): a build
+against PostgreSQL 15, 16, 17 and 18 on both x86_64 and aarch64, treating compiler
+warnings as failures, and the suites on 17 and 18. The build preflight is what
+catches an API change between majors; the suite run is what catches a behaviour
+change.
+
+**Nightly at 06:00 UTC** (`.github/workflows/nightly.yml`): the full packaged
+suite matrix across 15 to 18 on x86_64, the current major on aarch64, the ASAN and
+UBSAN sanitizer gate against an instrumented PostgreSQL, and the coverage report.
+The sanitizer build is cached, since building it takes longer than running the
+suites against it.
+
+The aarch64 run executes the suites rather than only building them. Misaligned
+reads, the class most often expected to differ by architecture, are already
+reported by the sanitizer gate on any host. What a second architecture adds is
+what a sanitizer on x86_64 cannot observe: x86_64 orders stores more strictly than
+aarch64, so a missing barrier in concurrent code can be invisible on one and a
+defect on the other, and the suites that would show it have to run.
+
+**On documentation changes** (`.github/workflows/docs.yml`): builds and publishes
+the site at
+[jdatcmd.github.io/pgcolumnar](https://jdatcmd.github.io/pgcolumnar/).
+
+PostgreSQL 19 is deliberately absent from CI. It is beta and not packaged in PGDG
+stable, so CI cannot install it honestly. The local five-major matrix covers it,
+and remains the release gate.
+
+Two suites are not reachable from CI and are run locally: the cross-major upgrade
+gate above, and the timing suites, whose wall-clock ratios a shared runner cannot
+hold still. Skipping them there is a deliberate trade. A gate that goes red for
+reasons unrelated to the change teaches its readers to discount red, which is
+worse than not running it.
+
+## Stopping a run
+
+The matrix re-executes itself from a private copy in `/tmp` and runs its suites as
+background jobs, so signalling it by pattern does not reach the right process and
+leaves the suites running with their clusters and ports held. Use:
+
+```sh
+test/run_all_versions.sh --stop
+```
+
+That reads the run lock, signals the owner, and lets it stop the suites and then
+their clusters through `pg_ctl`. It also clears a lock left by a run that is no
+longer alive. Interrupting a run with Ctrl-C does the same cleanup.


### PR DESCRIPTION
Two corrections of substance, one gap, and a style pass.

## The release-status section said the alpha gate was unmet

It listed fuzzing the Parquet and Arrow parsers (#214), the untrusted-input
boundary (#216) and the crash blast radius (#217) as hardening tracked *before* a
first alpha. **All three are closed.** A reader would have concluded the gate was
unmet when it is met. It now states what was done, and adds the format-version
enforcement (#240) and the cross-major upgrade gate (#257).

## A stale claim in the format section

It said wiring `test/pg_upgrade.sh` into the gate was tracked in #257. That is
closed and the gate exists, so the text gives the invocation instead of pointing
at future work.

## What the testing does not cover, stated alongside what it does

Every recorded result comes from x86_64. The suites have never run on aarch64 or
on a big-endian platform (#242). That belongs in a release-status section rather
than being left to inference: this code reads values out of packed on-disk
buffers, and an unaligned read of exactly that kind has already had to be fixed
once, on an architecture that tolerates it. Untested is not the same as broken,
and saying which costs one sentence.

## `docs/testing.md` did not mention CI at all

It described only local invocation. CI is now three workflows: per-PR builds on
15 to 18 with suites on 17 and 18, a nightly full matrix plus the ASAN and UBSAN
gate, and the documentation publish. Also documents `--stop`, since the matrix
re-executes itself from `/tmp` and signalling it by pattern leaves its suites
running with their clusters held.

## CHANGELOG

`fsst_min_gain_percent` and the read-side format-version enforcement under Added;
the FSST default under Changed, because it alters stored bytes; the upgrade gate
and the architecture coverage under Compatibility.

## Style

Prose dashes replaced with sentences, SQL comments in code blocks left alone.
Vague adjectives removed. "A significant part of the cost" and "where FSST wins
clearly" were mine, and both now state what was measured.

Verified mechanically: no em or en dashes in `docs/`, `README.md` or
`CHANGELOG.md`, no prose double-hyphens, every relative link resolves.

Documentation only; no code paths touched.