### PR TITLE
Build and test on aarch64 (#242)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,25 @@ concurrency:
 jobs:
   # Build against every supported major. Fast, and it is what an API change
   # between majors trips first.
+  # Both architectures, because a build preflight is cheap and the project has
+  # never compiled anywhere but x86_64 (#242). aarch64 is not covered by the
+  # sanitizer gate's alignment checking, which reports a misaligned load on any
+  # host: what a second architecture adds here is codegen and ABI differences at
+  # compile time, and, in the nightly suite run, a weaker memory model than
+  # x86_64's.
   build:
-    name: build (PG ${{ matrix.pg }})
-    runs-on: ubuntu-latest
+    name: build (PG ${{ matrix.pg }}, ${{ matrix.runner == 'ubuntu-24.04-arm' && 'aarch64' || 'x86_64' }})
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
+      # Two dimensions, so this is a cross product: every major on both
+      # architectures. Expressed as a second dimension rather than as include
+      # entries, because an include entry carrying only new keys is merged into
+      # the existing combinations instead of multiplying them, which would have
+      # produced four jobs on one architecture rather than eight on two.
       matrix:
         pg: ['15', '16', '17', '18']
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,14 +32,32 @@ jobs:
   # Full packaged suite matrix. Same suites the per-PR gate runs on 17/18, here
   # across every packaged major so 15 and 16 are covered too.
   suites:
-    name: suites (PG ${{ matrix.pg }})
-    runs-on: ubuntu-latest
+    name: suites (PG ${{ matrix.pg }}, ${{ matrix.runner == 'ubuntu-24.04-arm' && 'aarch64' || 'x86_64' }})
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     if: github.event_name == 'workflow_dispatch' || github.repository == 'jdatcmd/pgcolumnar'
     strategy:
       fail-fast: false
+      # The full packaged matrix on x86_64, and the current major on aarch64.
+      #
+      # aarch64 runs the suites rather than only building, because the defect
+      # class a second architecture actually adds is one no x86_64 run can show:
+      # x86_64 orders stores more strictly than aarch64, so a missing barrier in
+      # concurrent code is invisible on one and a defect on the other. The suites
+      # that would show it are the concurrent ones, and they need to execute, not
+      # compile.
+      #
+      # One major rather than four, because that defect class is a property of
+      # this extension's own code rather than of a PostgreSQL version boundary,
+      # and a nightly that takes four times as long to say the same thing is a
+      # nightly people start ignoring.
       matrix:
-        pg: ['15', '16', '17', '18']
+        include:
+          - { pg: '15', runner: ubuntu-latest }
+          - { pg: '16', runner: ubuntu-latest }
+          - { pg: '17', runner: ubuntu-latest }
+          - { pg: '18', runner: ubuntu-latest }
+          - { pg: '18', runner: ubuntu-24.04-arm }
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
The project has only ever compiled and run on x86_64.

## Not for the reason it looks like

I first argued for this on alignment grounds and that was wrong. Misaligned reads
are reported on **any** host by `-fsanitize=undefined`, the sanitizer gate builds
with it, and that gate exists precisely because such a read was found and fixed
(#225). The alignment class is covered on x86_64 and aarch64 adds little to it.

What a second architecture adds is what a sanitizer on x86_64 cannot observe:
**x86_64 orders stores more strictly than aarch64**, so a missing barrier in
concurrent code is invisible on one and a defect on the other. This extension has
concurrent paths of its own, including advisory-lock serialization for unique
inserts, parallel scan, concurrent DML, and the visibility map. For that to be
worth anything the suites have to execute, not just compile.

## What runs

| where | coverage |
| --- | --- |
| per PR | build, PG 15-18, **x86_64 and aarch64** (8 jobs) |
| nightly | suites, PG 15-18 x86_64, plus **PG 18 aarch64** |
| nightly | ASAN + UBSAN gate (unchanged) |

One major on aarch64 rather than four, because the defect class is a property of
this extension's code rather than of a PostgreSQL version boundary, and a nightly
that takes four times as long to say the same thing is one people stop reading.

## Two things I checked rather than assumed

Both would have failed on the first run:

- **PGDG publishes arm64 for noble**, `postgresql-18` included (queried the
  binary-arm64 package index).
- **pyarrow ships aarch64 wheels** (12 for the current release), so the Arrow and
  Parquet suites will not skip themselves. The existing import assertion would
  fail the job loudly if that ever stopped being true.

## One implementation note

The build matrix is two dimensions, not `include` entries. An `include` entry
carrying only new keys is merged into existing combinations rather than
multiplying them, which produces four jobs on one architecture instead of eight on
two. My first version had exactly that bug; the second dimension is what makes it
a cross product.

## Scope

**This does not close #242.** aarch64 is little-endian, so the big-endian half of
that issue is untouched.

This PR is its own test: the eight build jobs run against it.