### PR TITLE
make installcheck runs something, and a nightly coverage report

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -212,3 +212,68 @@ jobs:
           for f in $(sudo find /tmp -maxdepth 4 -name server.log -path '*pgcolumnar*' 2>/dev/null); do
             echo "===== $f ====="; sudo tail -60 "$f"
           done
+
+  # Line and branch coverage, published as an artifact and nothing else.
+  #
+  # Deliberately not a gate: no threshold, no badge, and a drop cannot fail a
+  # pull request. A coverage threshold creates pressure to write tests that
+  # execute lines rather than tests that prove properties, and the assertions in
+  # this project's suites are the reason its defects get found. The report
+  # answers the question a passing suite cannot: which code does nothing execute
+  # at all.
+  #
+  # The number will look unremarkable and that is correct. A table access method
+  # carries defensive branches that should never be taken, and columnar_compat.h
+  # carries version shims of which one arm compiles per major.
+  coverage:
+    name: coverage report (PG 18)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    if: github.event_name == 'workflow_dispatch' || github.repository == 'jdatcmd/pgcolumnar'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install PostgreSQL 18, codec headers, lcov, and pyarrow
+        run: |
+          set -euo pipefail
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo curl -fsSL -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+            https://www.postgresql.org/media/keys/ACCC4CF8.asc
+          echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] \
+            https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
+            | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            postgresql-18 postgresql-server-dev-18 \
+            liblz4-dev libzstd-dev zlib1g-dev python3-pip lcov
+          # Installed with sudo because the suites run under sudo; a plain
+          # pip3 install lands in ~/.local where root cannot see it, which is how
+          # the Arrow and Parquet suites once reported PASS while skipping.
+          sudo pip3 install --break-system-packages --quiet pyarrow \
+            || sudo pip3 install --quiet pyarrow
+          sudo python3 -c 'import pyarrow, pyarrow.parquet; print("pyarrow as root ok")'
+
+      - name: Stop the packaged cluster
+        run: sudo systemctl stop postgresql || true
+
+      - name: Build instrumented and run the suites
+        run: |
+          set -euo pipefail
+          sudo -E env "PATH=$PATH" \
+            bash test/run_coverage.sh /usr/lib/postgresql/18/bin/pg_config
+
+      - name: Upload the HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-html
+          path: coverage/html
+          retention-days: 14
+
+      - name: Upload the tracefile
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-info
+          path: coverage/coverage.info
+          retention-days: 14

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,18 @@ EXTENSION = pgcolumnar
 DATA = pgcolumnar--1.0-dev.sql
 PGFILEDESC = "pgColumnar - column-oriented table access method"
 
-REGRESS =
+# make installcheck. Not the project's gate -- that is test/run_all_versions.sh,
+# which asserts properties with explicit controls -- but the conventional entry
+# point a packager or a new contributor reaches for, and it must not report
+# success while running nothing, which is what an empty REGRESS did.
+REGRESS = pgcolumnar
+
+# The race specs already exist under test/isolation/specs and were reachable only
+# through test/isolation.sh. ISOLATION_OPTS points pg_isolation_regress at that
+# directory rather than moving the specs to the layout PGXS assumes by default,
+# so there is one copy of them and one set of expected files.
+ISOLATION = $(notdir $(basename $(wildcard test/isolation/specs/*.spec)))
+ISOLATION_OPTS = --inputdir=test/isolation
 
 # Optional compression codecs. lz4 and zstd are linked when the system
 # development libraries are present (detected with pkg-config); otherwise

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -164,3 +164,41 @@ build reads back identically on any build of the same format version, across eve
 supported major, and this is the only thing that tests that claim. It is opt-in
 rather than per-PR for cost, not because it is optional: a claim in the
 documentation backed by a suite nobody runs is how coverage rots unnoticed.
+
+## make installcheck
+
+The conventional entry point for a PostgreSQL extension:
+
+```sh
+make installcheck PG_CONFIG=/path/to/pg_config
+```
+
+It runs `sql/pgcolumnar.sql` against `expected/pgcolumnar.out`, then the seven
+isolation specs under `test/isolation/specs`. The target server must have
+`pgcolumnar` in `shared_preload_libraries`; without it the `CREATE EXTENSION` in
+the test fails, which is the correct outcome.
+
+This is a smoke test, not the gate. It compares a columnar table against a heap
+mirror across the main paths and confirms the race specs still hold. The gate is
+the version matrix above, which asserts properties with explicit controls rather
+than comparing output to a recorded file. Expected-output tests are kept
+deliberately thin here: their failure mode is to regenerate the expected file,
+which converts a defect into a new baseline.
+
+## Coverage
+
+```sh
+test/run_coverage.sh /path/to/pg_config
+```
+
+Builds instrumented, runs the suites against that build, and writes an HTML
+report to `coverage/html`. It runs nightly and uploads the report as an artifact.
+
+There is no threshold and nothing fails on the number, deliberately. A coverage
+threshold creates pressure to write tests that execute lines rather than tests
+that prove properties. The report answers the question a passing suite cannot:
+which code does nothing execute at all. Read it for holes rather than for the
+percentage, and expect the percentage to be unremarkable in places that are
+correct: a table access method carries defensive branches that should never be
+taken, and `columnar_compat.h` carries version shims of which one arm compiles per
+major.

--- a/expected/pgcolumnar.out
+++ b/expected/pgcolumnar.out
@@ -1,0 +1,151 @@
+-- pgColumnar installcheck smoke test.
+--
+-- This is the conventional entry point (make installcheck), not the project's
+-- gate. The gate is test/run_all_versions.sh, which asserts properties with
+-- explicit controls; see docs/testing.md. What this file exists for is that
+-- REGRESS was empty, so make installcheck reported success while running
+-- nothing, which is the one failure mode this project refuses everywhere else.
+--
+-- Constraints it is written under:
+--   * idempotent. It drops what it creates, at the start as well as the end, so
+--     running it twice against the same database produces the same output.
+--   * deterministic across PostgreSQL 15 to 19. No plan output, no sizes, no
+--     storage ids, no timings, and every result set is ordered. NOTICEs are
+--     suppressed because DROP IF EXISTS emits one only when the object is
+--     absent, which would differ between the first run and the second.
+--
+-- The server must have pgcolumnar in shared_preload_libraries. Without it the
+-- CREATE EXTENSION below fails, which is the correct and legible outcome.
+SET client_min_messages = warning;
+DROP TABLE IF EXISTS pgc_smoke_c;
+DROP TABLE IF EXISTS pgc_smoke_h;
+CREATE EXTENSION IF NOT EXISTS pgcolumnar;
+-- A columnar table and a heap mirror. Every assertion below compares the two
+-- rather than a literal, so the test states "columnar agrees with heap" instead
+-- of restating values that would have to be maintained by hand.
+CREATE TABLE pgc_smoke_c (id int, v text, n numeric) USING pgcolumnar;
+CREATE TABLE pgc_smoke_h (id int, v text, n numeric);
+INSERT INTO pgc_smoke_c
+    SELECT g, md5(g::text), (g * 1.5)::numeric FROM generate_series(1, 5000) g;
+INSERT INTO pgc_smoke_h
+    SELECT g, md5(g::text), (g * 1.5)::numeric FROM generate_series(1, 5000) g;
+SELECT 'am' AS check,
+       (SELECT a.amname FROM pg_class c JOIN pg_am a ON a.oid = c.relam
+         WHERE c.relname = 'pgc_smoke_c') AS got;
+ check |    got     
+-------+------------
+ am    | pgcolumnar
+(1 row)
+
+SELECT 'count' AS check,
+       (SELECT count(*) FROM pgc_smoke_c) = (SELECT count(*) FROM pgc_smoke_h) AS agrees;
+ check | agrees 
+-------+--------
+ count | t
+(1 row)
+
+SELECT 'aggregates' AS check,
+       (SELECT (min(id), max(id), sum(n)) FROM pgc_smoke_c)
+       = (SELECT (min(id), max(id), sum(n)) FROM pgc_smoke_h) AS agrees;
+   check    | agrees 
+------------+--------
+ aggregates | t
+(1 row)
+
+SELECT 'content' AS check,
+       (SELECT md5(string_agg(t::text, '' ORDER BY t::text)) FROM pgc_smoke_c t)
+       = (SELECT md5(string_agg(t::text, '' ORDER BY t::text)) FROM pgc_smoke_h t) AS agrees;
+  check  | agrees 
+---------+--------
+ content | t
+(1 row)
+
+-- Qualified read, which is the chunk-group skipping path.
+SELECT 'qualified' AS check,
+       (SELECT count(*) FROM pgc_smoke_c WHERE id BETWEEN 100 AND 200)
+       = (SELECT count(*) FROM pgc_smoke_h WHERE id BETWEEN 100 AND 200) AS agrees;
+   check   | agrees 
+-----------+--------
+ qualified | t
+(1 row)
+
+-- Mutation.
+UPDATE pgc_smoke_c SET v = 'updated' WHERE id <= 10;
+UPDATE pgc_smoke_h SET v = 'updated' WHERE id <= 10;
+DELETE FROM pgc_smoke_c WHERE id > 4900;
+DELETE FROM pgc_smoke_h WHERE id > 4900;
+SELECT 'after dml' AS check,
+       (SELECT md5(string_agg(t::text, '' ORDER BY t::text)) FROM pgc_smoke_c t)
+       = (SELECT md5(string_agg(t::text, '' ORDER BY t::text)) FROM pgc_smoke_h t) AS agrees;
+   check   | agrees 
+-----------+--------
+ after dml | t
+(1 row)
+
+-- Index and index scan.
+CREATE INDEX pgc_smoke_c_id ON pgc_smoke_c (id);
+ANALYZE pgc_smoke_c;
+SET enable_seqscan = off;
+SELECT 'index scan' AS check,
+       (SELECT v FROM pgc_smoke_c WHERE id = 4242)
+       = (SELECT v FROM pgc_smoke_h WHERE id = 4242) AS agrees;
+   check    | agrees 
+------------+--------
+ index scan | t
+(1 row)
+
+RESET enable_seqscan;
+-- Per-table options round-trip.
+SELECT pgcolumnar.set_options('pgc_smoke_c', compression => 'pglz');
+ set_options 
+-------------
+ 
+(1 row)
+
+SELECT 'options' AS check, compression AS got
+  FROM pgcolumnar.options WHERE regclass = 'pgc_smoke_c'::regclass;
+  check  | got  
+---------+------
+ options | pglz
+(1 row)
+
+SELECT pgcolumnar.reset_options('pgc_smoke_c');
+ reset_options 
+---------------
+ 
+(1 row)
+
+-- A projection reads what the base table holds.
+SELECT pgcolumnar.add_projection('pgc_smoke_c', 'pgc_smoke_p',
+                                 ARRAY['id','v'], ARRAY['id']) IS NOT NULL AS declared;
+ declared 
+----------
+ t
+(1 row)
+
+SELECT 'projection' AS check,
+       (SELECT count(*) FROM pgcolumnar.read_projection('pgc_smoke_c', 'pgc_smoke_p'))
+       = (SELECT count(*) FROM pgc_smoke_c) AS agrees;
+   check    | agrees 
+------------+--------
+ projection | t
+(1 row)
+
+SELECT pgcolumnar.drop_projection('pgc_smoke_c', 'pgc_smoke_p');
+ drop_projection 
+-----------------
+ 
+(1 row)
+
+-- Maintenance runs and does not change what the table returns.
+VACUUM pgc_smoke_c;
+SELECT 'after vacuum' AS check,
+       (SELECT md5(string_agg(t::text, '' ORDER BY t::text)) FROM pgc_smoke_c t)
+       = (SELECT md5(string_agg(t::text, '' ORDER BY t::text)) FROM pgc_smoke_h t) AS agrees;
+    check     | agrees 
+--------------+--------
+ after vacuum | t
+(1 row)
+
+DROP TABLE pgc_smoke_c;
+DROP TABLE pgc_smoke_h;

--- a/sql/pgcolumnar.sql
+++ b/sql/pgcolumnar.sql
@@ -1,0 +1,95 @@
+-- pgColumnar installcheck smoke test.
+--
+-- This is the conventional entry point (make installcheck), not the project's
+-- gate. The gate is test/run_all_versions.sh, which asserts properties with
+-- explicit controls; see docs/testing.md. What this file exists for is that
+-- REGRESS was empty, so make installcheck reported success while running
+-- nothing, which is the one failure mode this project refuses everywhere else.
+--
+-- Constraints it is written under:
+--   * idempotent. It drops what it creates, at the start as well as the end, so
+--     running it twice against the same database produces the same output.
+--   * deterministic across PostgreSQL 15 to 19. No plan output, no sizes, no
+--     storage ids, no timings, and every result set is ordered. NOTICEs are
+--     suppressed because DROP IF EXISTS emits one only when the object is
+--     absent, which would differ between the first run and the second.
+--
+-- The server must have pgcolumnar in shared_preload_libraries. Without it the
+-- CREATE EXTENSION below fails, which is the correct and legible outcome.
+
+SET client_min_messages = warning;
+
+DROP TABLE IF EXISTS pgc_smoke_c;
+DROP TABLE IF EXISTS pgc_smoke_h;
+CREATE EXTENSION IF NOT EXISTS pgcolumnar;
+
+-- A columnar table and a heap mirror. Every assertion below compares the two
+-- rather than a literal, so the test states "columnar agrees with heap" instead
+-- of restating values that would have to be maintained by hand.
+CREATE TABLE pgc_smoke_c (id int, v text, n numeric) USING pgcolumnar;
+CREATE TABLE pgc_smoke_h (id int, v text, n numeric);
+
+INSERT INTO pgc_smoke_c
+    SELECT g, md5(g::text), (g * 1.5)::numeric FROM generate_series(1, 5000) g;
+INSERT INTO pgc_smoke_h
+    SELECT g, md5(g::text), (g * 1.5)::numeric FROM generate_series(1, 5000) g;
+
+SELECT 'am' AS check,
+       (SELECT a.amname FROM pg_class c JOIN pg_am a ON a.oid = c.relam
+         WHERE c.relname = 'pgc_smoke_c') AS got;
+
+SELECT 'count' AS check,
+       (SELECT count(*) FROM pgc_smoke_c) = (SELECT count(*) FROM pgc_smoke_h) AS agrees;
+SELECT 'aggregates' AS check,
+       (SELECT (min(id), max(id), sum(n)) FROM pgc_smoke_c)
+       = (SELECT (min(id), max(id), sum(n)) FROM pgc_smoke_h) AS agrees;
+SELECT 'content' AS check,
+       (SELECT md5(string_agg(t::text, '' ORDER BY t::text)) FROM pgc_smoke_c t)
+       = (SELECT md5(string_agg(t::text, '' ORDER BY t::text)) FROM pgc_smoke_h t) AS agrees;
+
+-- Qualified read, which is the chunk-group skipping path.
+SELECT 'qualified' AS check,
+       (SELECT count(*) FROM pgc_smoke_c WHERE id BETWEEN 100 AND 200)
+       = (SELECT count(*) FROM pgc_smoke_h WHERE id BETWEEN 100 AND 200) AS agrees;
+
+-- Mutation.
+UPDATE pgc_smoke_c SET v = 'updated' WHERE id <= 10;
+UPDATE pgc_smoke_h SET v = 'updated' WHERE id <= 10;
+DELETE FROM pgc_smoke_c WHERE id > 4900;
+DELETE FROM pgc_smoke_h WHERE id > 4900;
+
+SELECT 'after dml' AS check,
+       (SELECT md5(string_agg(t::text, '' ORDER BY t::text)) FROM pgc_smoke_c t)
+       = (SELECT md5(string_agg(t::text, '' ORDER BY t::text)) FROM pgc_smoke_h t) AS agrees;
+
+-- Index and index scan.
+CREATE INDEX pgc_smoke_c_id ON pgc_smoke_c (id);
+ANALYZE pgc_smoke_c;
+SET enable_seqscan = off;
+SELECT 'index scan' AS check,
+       (SELECT v FROM pgc_smoke_c WHERE id = 4242)
+       = (SELECT v FROM pgc_smoke_h WHERE id = 4242) AS agrees;
+RESET enable_seqscan;
+
+-- Per-table options round-trip.
+SELECT pgcolumnar.set_options('pgc_smoke_c', compression => 'pglz');
+SELECT 'options' AS check, compression AS got
+  FROM pgcolumnar.options WHERE regclass = 'pgc_smoke_c'::regclass;
+SELECT pgcolumnar.reset_options('pgc_smoke_c');
+
+-- A projection reads what the base table holds.
+SELECT pgcolumnar.add_projection('pgc_smoke_c', 'pgc_smoke_p',
+                                 ARRAY['id','v'], ARRAY['id']) IS NOT NULL AS declared;
+SELECT 'projection' AS check,
+       (SELECT count(*) FROM pgcolumnar.read_projection('pgc_smoke_c', 'pgc_smoke_p'))
+       = (SELECT count(*) FROM pgc_smoke_c) AS agrees;
+SELECT pgcolumnar.drop_projection('pgc_smoke_c', 'pgc_smoke_p');
+
+-- Maintenance runs and does not change what the table returns.
+VACUUM pgc_smoke_c;
+SELECT 'after vacuum' AS check,
+       (SELECT md5(string_agg(t::text, '' ORDER BY t::text)) FROM pgc_smoke_c t)
+       = (SELECT md5(string_agg(t::text, '' ORDER BY t::text)) FROM pgc_smoke_h t) AS agrees;
+
+DROP TABLE pgc_smoke_c;
+DROP TABLE pgc_smoke_h;

--- a/test/harness_selftest.sh
+++ b/test/harness_selftest.sh
@@ -180,7 +180,7 @@ RUNNER="$TESTDIR/run_all_versions.sh"
 # not a suite the ordinary five-major matrix can carry.
 not_a_suite() {
 	case "$1" in
-		lib|portlib|run_all_versions|build_all_versions|devloop|rebuild|native_scale|build_san|run_san|pg_upgrade) return 0 ;;
+		lib|portlib|run_all_versions|build_all_versions|devloop|rebuild|native_scale|build_san|run_san|run_coverage|pg_upgrade) return 0 ;;
 		*) return 1 ;;
 	esac
 }

--- a/test/isolation/specs/compact_vs_reader.spec
+++ b/test/isolation/specs/compact_vs_reader.spec
@@ -8,6 +8,11 @@
 
 setup
 {
+	/* Self-contained: pg_isolation_regress under "make installcheck"
+	 * creates a fresh database without the extension, whereas
+	 * test/isolation.sh runs --use-existing against one that has it. */
+	SET client_min_messages = warning;
+	CREATE EXTENSION IF NOT EXISTS pgcolumnar;
 	CREATE TABLE iso (id int, v int) USING pgcolumnar;
 	SELECT pgcolumnar.set_options('iso', stripe_row_limit => 1000);
 	INSERT INTO iso SELECT g, g FROM generate_series(1, 50) g;

--- a/test/isolation/specs/delete_vs_rewrite.spec
+++ b/test/isolation/specs/delete_vs_rewrite.spec
@@ -9,6 +9,11 @@
 
 setup
 {
+	/* Self-contained: pg_isolation_regress under "make installcheck"
+	 * creates a fresh database without the extension, whereas
+	 * test/isolation.sh runs --use-existing against one that has it. */
+	SET client_min_messages = warning;
+	CREATE EXTENSION IF NOT EXISTS pgcolumnar;
 	CREATE TABLE iso (id int, v int) USING pgcolumnar;
 	SELECT pgcolumnar.set_options('iso', stripe_row_limit => 1000);
 	INSERT INTO iso SELECT g, g FROM generate_series(1, 50) g;

--- a/test/isolation/specs/old_snapshot_compact.spec
+++ b/test/isolation/specs/old_snapshot_compact.spec
@@ -7,6 +7,11 @@
 
 setup
 {
+	/* Self-contained: pg_isolation_regress under "make installcheck"
+	 * creates a fresh database without the extension, whereas
+	 * test/isolation.sh runs --use-existing against one that has it. */
+	SET client_min_messages = warning;
+	CREATE EXTENSION IF NOT EXISTS pgcolumnar;
 	CREATE TABLE iso (id int, v int) USING pgcolumnar;
 	SELECT pgcolumnar.set_options('iso', stripe_row_limit => 1000);
 	INSERT INTO iso SELECT g, g FROM generate_series(1, 50) g;

--- a/test/isolation/specs/recluster_vs_delete.spec
+++ b/test/isolation/specs/recluster_vs_delete.spec
@@ -9,6 +9,11 @@
 
 setup
 {
+	/* Self-contained: pg_isolation_regress under "make installcheck"
+	 * creates a fresh database without the extension, whereas
+	 * test/isolation.sh runs --use-existing against one that has it. */
+	SET client_min_messages = warning;
+	CREATE EXTENSION IF NOT EXISTS pgcolumnar;
 	CREATE TABLE iso (id int, v int) USING pgcolumnar;
 	SELECT pgcolumnar.set_options('iso', stripe_row_limit => 1000);
 	INSERT INTO iso SELECT g, g FROM generate_series(1, 50) g;

--- a/test/isolation/specs/truncate_vs_reader.spec
+++ b/test/isolation/specs/truncate_vs_reader.spec
@@ -11,6 +11,11 @@
 
 setup
 {
+	/* Self-contained: pg_isolation_regress under "make installcheck"
+	 * creates a fresh database without the extension, whereas
+	 * test/isolation.sh runs --use-existing against one that has it. */
+	SET client_min_messages = warning;
+	CREATE EXTENSION IF NOT EXISTS pgcolumnar;
 	CREATE TABLE iso (id int, v text) USING pgcolumnar;
 	SELECT pgcolumnar.set_options('iso', stripe_row_limit => 1000, chunk_group_row_limit => 1000);
 	INSERT INTO iso SELECT g, md5(g::text) FROM generate_series(1, 3000) g;

--- a/test/isolation/specs/truncate_vs_truncate.spec
+++ b/test/isolation/specs/truncate_vs_truncate.spec
@@ -7,6 +7,11 @@
 
 setup
 {
+	/* Self-contained: pg_isolation_regress under "make installcheck"
+	 * creates a fresh database without the extension, whereas
+	 * test/isolation.sh runs --use-existing against one that has it. */
+	SET client_min_messages = warning;
+	CREATE EXTENSION IF NOT EXISTS pgcolumnar;
 	CREATE TABLE iso (id int, v text) USING pgcolumnar;
 	SELECT pgcolumnar.set_options('iso', stripe_row_limit => 1000, chunk_group_row_limit => 1000);
 	INSERT INTO iso SELECT g, md5(g::text) FROM generate_series(1, 3000) g;

--- a/test/isolation/specs/truncate_vs_writer.spec
+++ b/test/isolation/specs/truncate_vs_writer.spec
@@ -9,6 +9,11 @@
 
 setup
 {
+	/* Self-contained: pg_isolation_regress under "make installcheck"
+	 * creates a fresh database without the extension, whereas
+	 * test/isolation.sh runs --use-existing against one that has it. */
+	SET client_min_messages = warning;
+	CREATE EXTENSION IF NOT EXISTS pgcolumnar;
 	CREATE TABLE iso (id int, v text) USING pgcolumnar;
 	SELECT pgcolumnar.set_options('iso', stripe_row_limit => 1000, chunk_group_row_limit => 1000);
 	INSERT INTO iso SELECT g, md5(g::text) FROM generate_series(1, 3000) g;

--- a/test/run_coverage.sh
+++ b/test/run_coverage.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# Line and branch coverage over the suites, for one major.
+#
+# A discovery tool, not a gate. There is no threshold here and nothing in CI
+# fails on the number, deliberately. A coverage threshold creates pressure to
+# write tests that execute lines rather than tests that prove properties, and the
+# assertions in this project's suites are the reason its defects get found. What
+# the report answers is the complementary question a passing suite cannot: which
+# code does nothing execute at all. For hand-rolled Parquet and Arrow decoders
+# full of error paths, that is worth knowing.
+#
+# Expect the percentage to look unremarkable and expect that to be correct. A
+# table access method carries defensive branches that should never be taken and
+# columnar_compat.h carries version shims of which only one arm compiles per
+# major. Read the report for holes, not for the number.
+#
+# Why the suites are driven directly rather than through run_all_versions.sh: the
+# matrix builds its own copy of the tree in a temporary directory and removes it
+# when the major finishes, which takes the .gcda counters with it. Coverage has to
+# accumulate next to the objects it was compiled from, so this builds once in the
+# working tree, installs that build, and runs every suite against it with
+# PGC_SKIP_BUILD=1.
+#
+# Usage:  test/run_coverage.sh [PG_CONFIG]
+#   PGC_COV_SUITES=<list>   override the suite list
+#   PGC_COV_OUT=<dir>       output directory (default coverage/)
+#
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+
+PGC="${1:-/usr/local/pg17/bin/pg_config}"
+SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT="${PGC_COV_OUT:-$SRCDIR/coverage}"
+
+command -v lcov >/dev/null || { echo "FAIL  lcov not found" >&2; exit 1; }
+command -v genhtml >/dev/null || { echo "FAIL  genhtml not found" >&2; exit 1; }
+[ -x "$PGC" ] || { echo "FAIL  no pg_config at $PGC" >&2; exit 1; }
+
+echo "== coverage: $("$PGC" --version)"
+
+# COPT reaches both CFLAGS and LDFLAGS through PostgreSQL's Makefile.global, so
+# one variable instruments the compile and links the runtime.
+echo "-- build with --coverage"
+make -C "$SRCDIR" clean >/dev/null 2>&1
+if ! make -C "$SRCDIR" PG_CONFIG="$PGC" COPT="--coverage" >/dev/null 2>"$OUT.build.err"; then
+	echo "FAIL  instrumented build failed" >&2
+	tail -20 "$OUT.build.err" >&2
+	exit 1
+fi
+make -C "$SRCDIR" PG_CONFIG="$PGC" COPT="--coverage" install >/dev/null 2>&1 || {
+	echo "FAIL  install failed" >&2; exit 1; }
+
+# Every suite except the drivers, the libraries, and the ones that build their
+# own server or need two majors. Kept in step with harness_selftest.sh's list.
+not_a_suite() {
+	case "$1" in
+		lib|portlib|run_all_versions|build_all_versions|devloop|rebuild) return 0 ;;
+		native_scale|build_san|run_san|run_coverage|pg_upgrade) return 0 ;;
+		*) return 1 ;;
+	esac
+}
+
+SUITES="${PGC_COV_SUITES:-}"
+if [ -z "$SUITES" ]; then
+	for f in "$SRCDIR"/test/*.sh; do
+		n="$(basename "$f" .sh)"
+		not_a_suite "$n" && continue
+		SUITES="$SUITES $n"
+	done
+fi
+
+mkdir -p "$OUT"
+lcov --directory "$SRCDIR/src" --zerocounters >/dev/null 2>&1
+
+# Below the ephemeral floor, like every other port in this tree (portlib.sh).
+. "$SRCDIR/test/portlib.sh"
+port="$(pgc_pick_port)"
+
+pass=0; fail=0; failed=""
+for s in $SUITES; do
+	port=$((port + 1))
+	if PGC_SKIP_BUILD=1 PGC_PORT="$port" \
+		bash "$SRCDIR/test/${s}.sh" "$PGC" >"$OUT/${s}.log" 2>&1; then
+		pass=$((pass + 1))
+	else
+		fail=$((fail + 1)); failed="$failed $s"
+	fi
+done
+echo "-- suites: $pass passed, $fail failed${failed:+ ($failed)}"
+
+echo "-- collect"
+lcov --directory "$SRCDIR/src" --capture --output-file "$OUT/coverage.info" \
+	--rc branch_coverage=1 --ignore-errors inconsistent >/dev/null 2>&1 || {
+		echo "FAIL  lcov capture produced nothing" >&2; exit 1; }
+# Only this project's sources; PostgreSQL's headers are not what is being measured.
+lcov --extract "$OUT/coverage.info" "$SRCDIR/src/*" \
+	--output-file "$OUT/coverage.info" --rc branch_coverage=1 \
+	--ignore-errors inconsistent >/dev/null 2>&1
+
+# --ignore-errors inconsistent, and only that one. lcov 2.x rejects a tracefile
+# when gcov reports a line as hit while recording no evaluated branches on it,
+# which gcc emits routinely for lines carrying compiler-generated branches. It is
+# an artifact of the two tools' disagreement rather than bad data. "corrupt" is
+# deliberately not bypassed: that one would hide a genuinely unreadable file.
+genhtml "$OUT/coverage.info" --output-directory "$OUT/html" \
+	--branch-coverage --legend --ignore-errors inconsistent >/dev/null 2>&1 || {
+		echo "FAIL  genhtml failed" >&2; exit 1; }
+
+echo
+lcov --summary "$OUT/coverage.info" --rc branch_coverage=1 \
+	--ignore-errors inconsistent 2>&1 | grep -vE "^(Reading|lcov: (WARNING|Note))" | sed 's/^/  /'
+echo
+echo "-- per file, least covered first"
+lcov --list "$OUT/coverage.info" --rc branch_coverage=1 \
+	--ignore-errors inconsistent 2>/dev/null \
+	| awk '/\|/ && !/Total:/ && !/^Filename/ {print}' \
+	| sort -t'|' -k2 -n | head -20 | sed 's/^/  /'
+echo
+echo "report: $OUT/html/index.html"
+
+# The suites failing is worth a non-zero exit; the coverage number never is.
+[ "$fail" = 0 ]


### PR DESCRIPTION
Two additions suggested by a peer. I have implemented both, and pushed back on the
usual shape of the second.

## `REGRESS` was empty

`make installcheck` reported success while running nothing. That is the failure
mode this project refuses everywhere else, sitting in its own Makefile, and it is
the first command a packager or a new contributor reaches for.

`sql/pgcolumnar.sql` compares a columnar table against a **heap mirror** rather
than against literals, so it states "columnar agrees with heap" instead of
restating values someone has to maintain: content hash, aggregates, a qualified
read, update and delete, an index scan, per-table options, a projection, and
`VACUUM`.

`ISOLATION` wires the seven race specs that already existed and were reachable
only through `test/isolation.sh`. `ISOLATION_OPTS` points at their existing
directory rather than moving them, so there is one copy of the specs and one set
of expected files. The specs now create the extension in their own `setup`, which
is what lets them run from either entry point, and is the better property anyway.

**This is not a second gate**, and it is deliberately thin. `run_all_versions.sh`
remains the gate. Porting the suites to expected-output form would trade
anti-vacuity controls for per-major `.out` variants and a failure mode whose
remedy is to regenerate the expected file.

That hazard is not theoretical: my first draft queried `pgcolumnar.options` by a
column name I had guessed rather than checked, and the run produced an `ERROR`.
Had I adopted that output as the expected file, the error would have become the
expected result.

Verified: `installcheck` runs 1 regress test and 7 specs, all pass; the SQL run
twice against one database produces **byte-identical output**; it passes on
**15.18, 17.10 and 19beta2**; and `test/isolation.sh` still passes.

## Coverage: a report, not a gate

`test/run_coverage.sh` builds instrumented, runs the suites, and writes an HTML
report and a per-file listing ordered least-covered first. Nightly uploads it as
an artifact.

**No threshold, no badge, nothing fails on the number.** That is the design
decision, and it is where I would push back on the default shape. A threshold
creates pressure to write tests that execute lines rather than tests that prove
properties, and the assertions in these suites are why defects here get found.
What the report adds is the question a passing suite cannot answer: which code
does nothing execute at all.

First full run, PostgreSQL 17, all suites:

| | |
| --- | --- |
| lines | **93.1%** (10594 of 11381) |
| functions | **94.0%** (489 of 520) |
| branches | **71.2%** (4418 of 6207) |

**And one finding immediately, which is the point:** `columnar_cache.c` is at
**6.7% lines, 2.8% branches**, an order of magnitude below anything else in the
tree. Worth its own issue.

Two implementation notes:

- The suites are driven directly rather than through `run_all_versions.sh`,
  because the matrix builds its own copy in a temporary directory and removes it
  when the major finishes, taking the `.gcda` counters with it.
- lcov 2.x rejects a tracefile when gcov reports a line as hit with no evaluated
  branches on it, which gcc emits routinely. Only that check is bypassed;
  `corrupt` deliberately is not, since it would hide an unreadable file.

`harness_selftest` caught the new driver being unregistered, which is exactly what
that check is for.

Five-major matrix running; I will post it.