### PR TITLE
Skip the FSST table build when the dictionary wins: -22% text bulk load (#155)

### DIFF
--- a/src/columnar.h
+++ b/src/columnar.h
@@ -654,6 +654,9 @@ extern const char *ColumnarEncodingName(int encodingType);
 extern bool ColumnarFsstBuildChunkTable(const char *corpus, uint32 corpusLen,
 										Form_pg_attribute att,
 										char **tableOut, uint32 *tableLenOut);
+/* Cheap distinct-count pre-check: true when dictionary encoding wins outright, so
+ * the costly FSST table build can be skipped with byte-identical output (#155). */
+extern bool ColumnarFsstDictWins(const char *corpus, uint32 corpusLen);
 
 /*
  * True when encoding the chunk with the table just built is still a win after

--- a/src/columnar_encoding.c
+++ b/src/columnar_encoding.c
@@ -1629,6 +1629,75 @@ fsst_deserialize_table(const char *p, uint32 len, FsstTable *t)
 	}
 }
 
+/* FNV-1a over a byte range: a cheap, well-mixed 64-bit hash for the distinct
+ * probe below. Our own trivial implementation of the public FNV-1a formula, used
+ * only to bucket values while counting distinct ones. */
+static inline uint64
+columnar_fnv1a(const char *p, uint32 n)
+{
+	uint64		h = UINT64CONST(1469598103934665603);
+	uint32		i;
+
+	for (i = 0; i < n; i++)
+	{
+		h ^= (unsigned char) p[i];
+		h *= UINT64CONST(1099511628211);
+	}
+	return h;
+}
+
+/*
+ * ColumnarFsstDictWins
+ *		Cheap pre-check for the FSST table build (issue #155): would dictionary
+ *		encoding win outright, making the costly FSST symbol-table build wasted
+ *		work? FSST is only attempted per vector when a cheaper encoding has not
+ *		already shrunk the vector well; a low-cardinality column is compressed far
+ *		below that threshold by the dictionary, so the FSST table would be built
+ *		(the single largest cost of a text load, ~22% in profiling) and then never
+ *		used. Count distinct values over the corpus with a small open-addressing
+ *		hash set and stop the instant the count exceeds the dictionary's distinct
+ *		cap: at or below the cap the dictionary is viable for every 1024-row vector
+ *		and wins, so skipping the build produces byte-identical storage; above it
+ *		the column is a genuine FSST candidate and the caller builds the table.
+ *		This is our own heuristic; FSST is the public scheme (VLDB 2020).
+ */
+bool
+ColumnarFsstDictWins(const char *corpus, uint32 corpusLen)
+{
+	/* Open-addressing set of value hashes, capacity a power of two comfortably
+	 * above the distinct cap so the load factor at the early-exit stays low. */
+	enum { FSST_CARD_SLOTS = 4096 };	/* > 2 * DICT_MAX_DISTINCT */
+	uint64		slot[FSST_CARD_SLOTS];
+	bool		used[FSST_CARD_SLOTS];
+	int			distinct = 0;
+	uint32		pos = 0;
+
+	memset(used, 0, sizeof(used));
+	while (pos < corpusLen)
+	{
+		uint32		vlen = ColumnarVarSizeAnyUnaligned(corpus + pos);
+		uint64		h;
+		uint32		s;
+
+		if (vlen == 0 || pos + vlen > corpusLen)
+			return false;		/* malformed run: let the caller build normally */
+
+		h = columnar_fnv1a(corpus + pos, vlen);
+		s = (uint32) (h & (FSST_CARD_SLOTS - 1));
+		while (used[s] && slot[s] != h)
+			s = (s + 1) & (FSST_CARD_SLOTS - 1);
+		if (!used[s])
+		{
+			used[s] = true;
+			slot[s] = h;
+			if (++distinct > DICT_MAX_DISTINCT)
+				return false;	/* high cardinality: a real FSST candidate */
+		}
+		pos += vlen;
+	}
+	return true;				/* dictionary wins; the FSST build is skippable */
+}
+
 /*
  * ColumnarFsstBuildChunkTable
  *		Build one FSST symbol table for a whole column chunk (E3b). The expensive

--- a/src/columnar_write_state.c
+++ b/src/columnar_write_state.c
@@ -967,8 +967,17 @@ columnar_flush_row_group(ColumnarWriteState *writeState)
 			 * costs 2.7% and 12.2% more space, which is why this is a choice
 			 * offered rather than a default changed.
 			 */
+			/*
+			 * Skip the FSST symbol-table build when a cheap distinct probe shows
+			 * the dictionary wins outright (#155): the build is the single largest
+			 * cost of a text load, and for a low-cardinality column the table is
+			 * built and then never used per vector. The probe reads the same corpus
+			 * the keep/drop decision uses, and only skips when the dictionary is
+			 * viable and wins for every vector, so the stored bytes are identical.
+			 */
 			if (corpus.len > 0 &&
-				writeState->encodeEffort != COLUMNAR_ENCODE_EFFORT_FAST)
+				writeState->encodeEffort != COLUMNAR_ENCODE_EFFORT_FAST &&
+				!ColumnarFsstDictWins(corpus.data, (uint32) corpus.len))
 				ColumnarFsstBuildChunkTable(corpus.data, sampleLen, att,
 											&fsstTable, &fsstTableLen);
 


### PR DESCRIPTION
Part of #155. Cuts bulk-load time by profiling the write path and removing its single largest cost.

## What the profile showed
A text-heavy bulk load (TSBS-cpu, 100M rows, PG18) is **CPU-bound on encoding**, not on the write mechanism (buffer manager / WAL / smgr were ~0% — the backend sits in `R`, not I/O wait). The top cost by far:

| cost | % of load CPU |
| --- | --- |
| `ColumnarFsstBuildChunkTable` (FSST symbol-table build) | **22.2%** |
| `bitpack` | 12.5% |
| `encode_gorilla` / `encode_dict` / `encode_alp` | ~14% |
| COPY text parsing (`strtod`, `CopyRead*`) | ~8% |

The FSST table is built **unconditionally per text chunk**, then `ColumnarFsstHelpsCompressed` decides keep/drop. For a low-cardinality column the dictionary compresses far below the threshold at which FSST is even attempted per vector, so the table is built and **never used** — 22% of the load spent on wasted work. The #276 cost-margin gates keep/drop but the build runs *before* that.

## The change
`ColumnarFsstDictWins`: a cheap distinct-count over the corpus (bounded open-addressing set, FNV-1a, **early-exit** the instant the count exceeds `DICT_MAX_DISTINCT`). At or below the cap the dictionary is viable for every 1024-row vector and wins, so the FSST build is skipped; above it the column is a genuine FSST candidate and the table is built as before. The probe reads the same corpus the keep/drop decision uses and only skips when the dictionary wins for every vector — so **stored bytes are identical**.

Our own heuristic; FSST itself is the public scheme (VLDB 2020). No competitor or core code referenced.

## Measured (PG18.4 non-assert, 100M rows, shared_buffers=1GB)
| | before | after |
| --- | --: | --: |
| load time | 783.1 s | **607.7 s (−22.4%)** |
| on-disk data fork | 2,868,682,752 B | **2,868,682,752 B (identical)** |

Byte-for-byte identical output; 175 s saved on 100M rows. (Context: this narrows the gap to a tuned TimescaleDB columnstore on the same box from ~1.9× to ~1.47×.)

## Gate
Assert builds, **PG18 + PG19**: `harness_selftest`, `native_writer`, `native_roundtrip`, `native_encoding`, `write_fsst_compressed`, `encode_effort`, `native_dml`, `native_skip` — all pass. `write_fsst_compressed` is the one that matters most here: it exercises the shapes where FSST *wins*, confirming the skip does not fire on them. The ASAN+UBSAN nightly gate will exercise the new byte-walk; happy to run the sanitizer locally first if you'd like it before merge.

More headroom remains in the profile (`bitpack`, the float encoders) for follow-up PRs.
