### PR TITLE
Hash-accelerate the dictionary distinct search: -18% more on text bulk load (#155)

### DIFF
--- a/src/columnar.h
+++ b/src/columnar.h
@@ -654,6 +654,9 @@ extern const char *ColumnarEncodingName(int encodingType);
 extern bool ColumnarFsstBuildChunkTable(const char *corpus, uint32 corpusLen,
 										Form_pg_attribute att,
 										char **tableOut, uint32 *tableLenOut);
+/* Cheap distinct-count pre-check: true when dictionary encoding wins outright, so
+ * the costly FSST table build can be skipped with byte-identical output (#155). */
+extern bool ColumnarFsstDictWins(const char *corpus, uint32 corpusLen);
 
 /*
  * True when encoding the chunk with the table just built is still a win after

--- a/src/columnar_encoding.c
+++ b/src/columnar_encoding.c
@@ -1629,6 +1629,75 @@ fsst_deserialize_table(const char *p, uint32 len, FsstTable *t)
 	}
 }
 
+/* FNV-1a over a byte range: a cheap, well-mixed 64-bit hash for the distinct
+ * probe below. Our own trivial implementation of the public FNV-1a formula, used
+ * only to bucket values while counting distinct ones. */
+static inline uint64
+columnar_fnv1a(const char *p, uint32 n)
+{
+	uint64		h = UINT64CONST(1469598103934665603);
+	uint32		i;
+
+	for (i = 0; i < n; i++)
+	{
+		h ^= (unsigned char) p[i];
+		h *= UINT64CONST(1099511628211);
+	}
+	return h;
+}
+
+/*
+ * ColumnarFsstDictWins
+ *		Cheap pre-check for the FSST table build (issue #155): would dictionary
+ *		encoding win outright, making the costly FSST symbol-table build wasted
+ *		work? FSST is only attempted per vector when a cheaper encoding has not
+ *		already shrunk the vector well; a low-cardinality column is compressed far
+ *		below that threshold by the dictionary, so the FSST table would be built
+ *		(the single largest cost of a text load, ~22% in profiling) and then never
+ *		used. Count distinct values over the corpus with a small open-addressing
+ *		hash set and stop the instant the count exceeds the dictionary's distinct
+ *		cap: at or below the cap the dictionary is viable for every 1024-row vector
+ *		and wins, so skipping the build produces byte-identical storage; above it
+ *		the column is a genuine FSST candidate and the caller builds the table.
+ *		This is our own heuristic; FSST is the public scheme (VLDB 2020).
+ */
+bool
+ColumnarFsstDictWins(const char *corpus, uint32 corpusLen)
+{
+	/* Open-addressing set of value hashes, capacity a power of two comfortably
+	 * above the distinct cap so the load factor at the early-exit stays low. */
+	enum { FSST_CARD_SLOTS = 4096 };	/* > 2 * DICT_MAX_DISTINCT */
+	uint64		slot[FSST_CARD_SLOTS];
+	bool		used[FSST_CARD_SLOTS];
+	int			distinct = 0;
+	uint32		pos = 0;
+
+	memset(used, 0, sizeof(used));
+	while (pos < corpusLen)
+	{
+		uint32		vlen = ColumnarVarSizeAnyUnaligned(corpus + pos);
+		uint64		h;
+		uint32		s;
+
+		if (vlen == 0 || pos + vlen > corpusLen)
+			return false;		/* malformed run: let the caller build normally */
+
+		h = columnar_fnv1a(corpus + pos, vlen);
+		s = (uint32) (h & (FSST_CARD_SLOTS - 1));
+		while (used[s] && slot[s] != h)
+			s = (s + 1) & (FSST_CARD_SLOTS - 1);
+		if (!used[s])
+		{
+			used[s] = true;
+			slot[s] = h;
+			if (++distinct > DICT_MAX_DISTINCT)
+				return false;	/* high cardinality: a real FSST candidate */
+		}
+		pos += vlen;
+	}
+	return true;				/* dictionary wins; the FSST build is skippable */
+}
+
 /*
  * ColumnarFsstBuildChunkTable
  *		Build one FSST symbol table for a whole column chunk (E3b). The expensive

--- a/src/columnar_encoding.c
+++ b/src/columnar_encoding.c
@@ -1113,6 +1113,8 @@ decode_alp(const char *enc, uint32 encLen, int w, uint32 n, uint32 rawLen,
 
 #define DICT_MAX_DISTINCT 1024
 
+static inline uint64 columnar_fnv1a(const char *p, uint32 n);
+
 static bool
 encode_dict(const char *raw, uint32 rawLen, Form_pg_attribute att, uint32 n,
 			char **out, uint32 *outLen)
@@ -1129,20 +1131,43 @@ encode_dict(const char *raw, uint32 rawLen, Form_pg_attribute att, uint32 n,
 	uint32		i;
 	int			j;
 
+	/*
+	 * Open-addressing hash of value -> distinct index (stored +1; 0 == empty),
+	 * so "have I seen this value?" is O(1) average instead of a memcmp scan over
+	 * every prior distinct value -- the O(n^2) that showed up as ~10% of a text
+	 * load in profiling (issue #155). First-seen assignment order is unchanged,
+	 * so the dictionary and codes are byte-identical to the linear build. Sized a
+	 * power of two above 2 * DICT_MAX_DISTINCT so the load factor stays <= 1/2.
+	 */
+	enum { DICT_HASH_SLOTS = 2048 };
+	uint32		hslot[DICT_HASH_SLOTS];
+
+	memset(hslot, 0, sizeof(hslot));
+
 	for (i = 0; i < n; i++)
 	{
 		const char *vp = raw + pos;
 		uint32		vlen = (w > 0) ? (uint32) w
 			: ColumnarVarSizeAnyUnaligned(vp);
+		uint64		h = columnar_fnv1a(vp, vlen);
+		uint32		s = (uint32) (h & (DICT_HASH_SLOTS - 1));
 		int			code = -1;
 
-		for (j = 0; j < nd; j++)
+		for (;;)
+		{
+			uint32		entry = hslot[s];
+
+			if (entry == 0)
+				break;			/* empty slot: value unseen; insert here below */
+			j = (int) (entry - 1);
 			if (distLen[j] == vlen &&
 				memcmp(raw + distOff[j], vp, vlen) == 0)
 			{
 				code = j;
 				break;
 			}
+			s = (s + 1) & (DICT_HASH_SLOTS - 1);	/* collision: keep probing */
+		}
 
 		if (code < 0)
 		{
@@ -1153,6 +1178,7 @@ encode_dict(const char *raw, uint32 rawLen, Form_pg_attribute att, uint32 n,
 			}
 			distOff[nd] = pos;
 			distLen[nd] = vlen;
+			hslot[s] = (uint32) (nd + 1);	/* record at the empty slot found */
 			code = nd;
 			nd++;
 		}

--- a/src/columnar_write_state.c
+++ b/src/columnar_write_state.c
@@ -967,8 +967,17 @@ columnar_flush_row_group(ColumnarWriteState *writeState)
 			 * costs 2.7% and 12.2% more space, which is why this is a choice
 			 * offered rather than a default changed.
 			 */
+			/*
+			 * Skip the FSST symbol-table build when a cheap distinct probe shows
+			 * the dictionary wins outright (#155): the build is the single largest
+			 * cost of a text load, and for a low-cardinality column the table is
+			 * built and then never used per vector. The probe reads the same corpus
+			 * the keep/drop decision uses, and only skips when the dictionary is
+			 * viable and wins for every vector, so the stored bytes are identical.
+			 */
 			if (corpus.len > 0 &&
-				writeState->encodeEffort != COLUMNAR_ENCODE_EFFORT_FAST)
+				writeState->encodeEffort != COLUMNAR_ENCODE_EFFORT_FAST &&
+				!ColumnarFsstDictWins(corpus.data, (uint32) corpus.len))
 				ColumnarFsstBuildChunkTable(corpus.data, sampleLen, att,
 											&fsstTable, &fsstTableLen);
 


### PR DESCRIPTION
Part of #155. **Stacks on #283** (the FSST-build skip) — its first commit is #283's; review #283 first, and this reduces to just the dict change once #283 lands.

## What the (post-#283) profile showed
After #283 removed the 22% FSST build, re-profiling the same 100M-row text load put `bitpack` (16%) and **`memcmp` (10.5%)** on top. That `memcmp` is `encode_dict`'s distinct search: for every row it scanned **all** prior distinct values with `memcmp` — O(n × distinct) per vector. #283 routes low-cardinality text to the dictionary, so that path now runs on more columns.

## The change
Replace the linear distinct scan with an open-addressing hash of value → distinct index (our own FNV-1a + probe), making the lookup O(1) average. **First-seen assignment order is unchanged**, so the dictionary and bit-packed codes are byte-identical — a pure speedup.

Our own code; no external source referenced (FNV-1a is a public formula).

## Measured (PG18.4 non-assert, 100M rows, shared_buffers=1GB), cumulative with #283
| | load | on-disk data fork |
| --- | --: | --: |
| baseline (main) | 783.1 s | 2,868,682,752 B |
| + #283 (FSST skip) | 607.7 s | 2,868,682,752 B |
| + this (dict hash) | **500.7 s** | **2,868,682,752 B** |

−17.6% on top of #283; **−36% cumulative**, byte-for-byte identical throughout. This narrows the gap to a tuned TimescaleDB columnstore on the same box (414 s to compressed columnar) from ~1.9× to **~1.21×**.

## Gate
Assert builds, **PG18 + PG19**: `harness_selftest`, `native_writer`, `native_roundtrip`, `native_encoding`, `write_fsst_compressed`, `encode_effort`, `native_dml`, `native_skip`, `native_zonemap` — all pass. Nightly ASAN+UBSAN will exercise the new hash probe.

Remaining profile headroom for follow-ups: `bitpack` (16%) and the float encoders (gorilla/ALP).
