### PR TITLE
Compile against the PostgreSQL 19 beta in CI, from source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,8 +128,13 @@ jobs:
         run: |
           set -euo pipefail
           sudo apt-get update
+          # gcc-14 explicitly. PostgreSQL 19's configure selects -std=gnu23, and
+          # the runner image's default gcc predates that spelling (it accepts
+          # gnu2x), so PostgreSQL builds and then the extension build inherits a
+          # flag its own compiler rejects. Pinning one compiler for both removes
+          # the mismatch rather than papering over the flag.
           sudo apt-get install -y --no-install-recommends \
-            build-essential flex bison libreadline-dev zlib1g-dev \
+            build-essential gcc-14 flex bison libreadline-dev zlib1g-dev \
             liblz4-dev libzstd-dev pkg-config
 
       - name: Cache the PostgreSQL beta build
@@ -137,7 +142,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/pgbeta
-          key: pgbeta-${{ env.PG_BETA }}-${{ runner.os }}-${{ runner.arch }}
+          key: pgbeta-${{ env.PG_BETA }}-gcc14-${{ runner.os }}-${{ runner.arch }}
 
       - name: Build PostgreSQL ${{ env.PG_BETA }} (on cache miss)
         if: steps.cache-beta.outputs.cache-hit != 'true'
@@ -152,8 +157,8 @@ jobs:
           # Only what PGXS needs: pg_config, the headers, and the makefiles. ICU
           # and readline are dropped to keep the dependency list to what the
           # extension itself already requires.
-          ./configure --prefix="$HOME/pgbeta" --without-icu --without-readline \
-            --without-zlib --enable-debug >/dev/null
+          ./configure CC=gcc-14 --prefix="$HOME/pgbeta" --without-icu \
+            --without-readline --without-zlib --enable-debug >/dev/null
           make -j"$(nproc)" -C src >/dev/null
           make -C src install >/dev/null
           "$HOME/pgbeta/bin/pg_config" --version
@@ -163,7 +168,9 @@ jobs:
           set -euo pipefail
           PG_CONFIG="$HOME/pgbeta/bin/pg_config"
           "$PG_CONFIG" --version
-          make PG_CONFIG="$PG_CONFIG" 2> build.err || { cat build.err; exit 1; }
+          # Same compiler PostgreSQL was configured with, so the flags in
+          # Makefile.global are ones this compiler understands.
+          make CC=gcc-14 PG_CONFIG="$PG_CONFIG" 2> build.err || { cat build.err; exit 1; }
           if grep -q 'warning:' build.err; then
             echo "::error::compiler warnings are failures in this project"
             grep 'warning:' build.err

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,12 @@
 # only gate that catches the non-faulting memory-safety class the assert builds
 # miss. Per-PR stays fast; the deep coverage runs once a day and on demand.
 #
-# PostgreSQL 19 is beta and not packaged in PGDG stable, so it stays a local gate
-# (test/run_all_versions.sh against a source build).
+# PostgreSQL 19 is beta and not packaged in PGDG at all, in stable, testing or
+# snapshot, so it cannot be apt-installed here. It is still built here, from
+# source and cached, because "cannot install" is not "cannot compile against" and
+# the newest major is where header and API tightening lands. See the build-beta
+# job for what that blindness cost. Its suites remain a local gate
+# (test/run_all_versions.sh).
 #
 # Warnings are failures here for the same reason they are in the local matrix.
 
@@ -96,6 +100,76 @@ jobs:
           # server exports a different set than a source build, so a difference
           # here is reported rather than failed on.
           [ -z "$missing" ] && echo "all resolve" || { echo "unresolved (informational):"; echo "$missing"; }
+
+  # Compile against the newest major, built from source because PGDG does not
+  # package a beta.
+  #
+  # This exists because of a defect it would have caught. A set-returning function
+  # added to the extension used tuplestore_begin_heap without including
+  # utils/tuplestore.h, which arrives transitively behind funcapi.h through
+  # PostgreSQL 18 and does not on 19. It compiled clean on every major CI could
+  # install and failed only on the one it could not, so the per-PR gate reported
+  # green on a tree that did not build. The local five-major matrix caught it
+  # before merge; nothing in CI would have.
+  #
+  # Build only, not suites. A compile is what catches this class, and it is cheap:
+  # the PostgreSQL build is cached, so a hit costs about as long as compiling the
+  # extension. The suites on 19 stay local, where the beta can be validated
+  # against a full matrix.
+  build-beta:
+    name: build (PG ${{ env.PG_BETA }}, from source)
+    runs-on: ubuntu-latest
+    env:
+      PG_BETA: 19beta2
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential flex bison libreadline-dev zlib1g-dev \
+            liblz4-dev libzstd-dev pkg-config
+
+      - name: Cache the PostgreSQL beta build
+        id: cache-beta
+        uses: actions/cache@v4
+        with:
+          path: ~/pgbeta
+          key: pgbeta-${{ env.PG_BETA }}-${{ runner.os }}-${{ runner.arch }}
+
+      - name: Build PostgreSQL ${{ env.PG_BETA }} (on cache miss)
+        if: steps.cache-beta.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          src=$(mktemp -d)
+          # The beta tarballs live beside the release ones and are not moved when
+          # the next beta appears, so pinning the version pins the bytes.
+          curl -fsSL "https://ftp.postgresql.org/pub/source/v${PG_BETA}/postgresql-${PG_BETA}.tar.bz2" \
+            | tar -xj -C "$src" --strip-components=1
+          cd "$src"
+          # Only what PGXS needs: pg_config, the headers, and the makefiles. ICU
+          # and readline are dropped to keep the dependency list to what the
+          # extension itself already requires.
+          ./configure --prefix="$HOME/pgbeta" --without-icu --without-readline \
+            --without-zlib --enable-debug >/dev/null
+          make -j"$(nproc)" -C src >/dev/null
+          make -C src install >/dev/null
+          "$HOME/pgbeta/bin/pg_config" --version
+
+      - name: Build the extension, treating warnings as failures
+        run: |
+          set -euo pipefail
+          PG_CONFIG="$HOME/pgbeta/bin/pg_config"
+          "$PG_CONFIG" --version
+          make PG_CONFIG="$PG_CONFIG" 2> build.err || { cat build.err; exit 1; }
+          if grep -q 'warning:' build.err; then
+            echo "::error::compiler warnings are failures in this project"
+            grep 'warning:' build.err
+            exit 1
+          fi
+          cat build.err || true
 
   # Run the suites on the current majors (17 + 18). This is the per-PR behaviour
   # gate; the full packaged matrix (15-18) runs nightly, and the local five-major

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
   # extension. The suites on 19 stay local, where the beta can be validated
   # against a full matrix.
   build-beta:
-    name: build (PG ${{ env.PG_BETA }}, from source)
+    name: build (PG 19 beta, from source)
     runs-on: ubuntu-latest
     env:
       PG_BETA: 19beta2

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -232,15 +232,15 @@ the site at
 [jdatcmd.github.io/pgcolumnar](https://jdatcmd.github.io/pgcolumnar/).
 
 PostgreSQL 19 cannot be installed in CI: PGDG does not package it in stable,
-testing or snapshot. It is compiled there anyway, from source and cached, because
-being unable to install a major is not a reason to stop compiling against it, and
-the newest major is where header and API tightening lands.
+testing or snapshot. It is compiled there anyway, from source, and the build stays
+in a cache. To be unable to install a major is not a reason to stop compiling
+against it. The newest major is also where header and API tightening lands.
 
 That distinction was not free. A set-returning function used
 `tuplestore_begin_heap` without including `utils/tuplestore.h`, which arrives
-transitively behind `funcapi.h` through PostgreSQL 18 and does not on 19. It
-compiled on every major CI could install and failed only on the one it could not,
-so a green CI run sat on a tree that did not build. The local matrix caught it
+transitively behind `funcapi.h` through PostgreSQL 18 and does not on 19. It compiled on each major that CI could install. It failed only on
+the one that CI could not install. A green CI run therefore sat on a tree that did
+not build. The local matrix caught it
 before merge; nothing in CI would have.
 
 The suites on 19 remain local. The five-major matrix covers them and stays the

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -208,9 +208,10 @@ shims, and only one arm of each shim compiles for a given major.
 Three workflows run in GitHub Actions.
 
 **On every pull request and push to `main`** (`.github/workflows/ci.yml`): a
-build against PostgreSQL 15, 16, 17 and 18, on x86_64 and on aarch64. Each build
-treats a compiler warning as a failure. The suites run on 17 and 18. The build
-preflight catches an API change between majors. The suite run catches a change in
+build against PostgreSQL 15, 16, 17 and 18, on x86_64 and on aarch64. There is
+also a build against the PostgreSQL 19 beta, from source. Each build treats a
+compiler warning as a failure. The suites run on 17 and 18. The build preflight
+catches an API change between majors. The suite run catches a change in
 behaviour.
 
 **Nightly at 06:00 UTC** (`.github/workflows/nightly.yml`): the full packaged
@@ -230,9 +231,20 @@ defect on the other. The suites that would show it must run.
 the site at
 [jdatcmd.github.io/pgcolumnar](https://jdatcmd.github.io/pgcolumnar/).
 
-PostgreSQL 19 is deliberately absent from CI. It is beta and not packaged in PGDG
-stable, so CI cannot install it honestly. The local five-major matrix covers it,
-and remains the release gate.
+PostgreSQL 19 cannot be installed in CI: PGDG does not package it in stable,
+testing or snapshot. It is compiled there anyway, from source and cached, because
+being unable to install a major is not a reason to stop compiling against it, and
+the newest major is where header and API tightening lands.
+
+That distinction was not free. A set-returning function used
+`tuplestore_begin_heap` without including `utils/tuplestore.h`, which arrives
+transitively behind `funcapi.h` through PostgreSQL 18 and does not on 19. It
+compiled on every major CI could install and failed only on the one it could not,
+so a green CI run sat on a tree that did not build. The local matrix caught it
+before merge; nothing in CI would have.
+
+The suites on 19 remain local. The five-major matrix covers them and stays the
+release gate.
 
 Two suites do not run in CI and run locally instead. The first is the cross-major
 upgrade gate above. The second is the set of timing suites, because a shared


### PR DESCRIPTION
Fixes the gap found while landing #290.

## The gap

CI could build every major PGDG packages, and PGDG packages **no 19 at all**. I
checked stable, testing and snapshot: `postgresql-19` is in none of them. So the
newest major, which is where header and API tightening lands, was the one the
per-PR gate could never see.

That cost something concrete. A set-returning function used
`tuplestore_begin_heap` without including `utils/tuplestore.h`, which arrives
transitively behind `funcapi.h` through PostgreSQL 18 and **does not** on 19. It
compiled clean on 15, 16, 17 and 18 and failed only on 19. **CI reported green on
a tree that did not build.** The local five-major matrix caught it before merge;
nothing in CI would have, and a contributor without that matrix would have merged
it.

## The fix

"Cannot install" is not "cannot compile against". The beta source tarball is
published, and does not move when the next beta appears, so pinning the version
pins the bytes. This repository already builds a PostgreSQL from source in CI for
the sanitizer gate, so the pattern and the caching are precedented.

Build only, not suites: a compile is what catches this class. Cached, so a hit
costs about as long as compiling the extension. The suites on 19 stay local, where
the beta gets a full matrix.

## Verified, with the exact configure flags the job uses

```
PostgreSQL 19beta2 builds
the extension compiles against it, 0 warnings
```

## Proved by removal, which is the part that matters

A job that cannot catch the defect it was written for is decoration, so I put the
defect back:

```
include removed, PG18:      builds OK  <- CI would report green
include removed, PG19beta2: error: implicit declaration of function 'tuplestore_begin_heap'
                            error: assignment to 'Tuplestorestate *' from 'int'
```

## Maintenance note

The version is pinned in one place (`PG_BETA` in the job env) and appears in the
cache key, so bumping to 19beta3 or to the final release is a one-line change that
invalidates the cache by construction. It will need that bump; a pinned beta goes
stale, and going stale is the failure mode to watch for here rather than a
breakage.