### PR TITLE
Instructional and reference docs in Simplified Technical English (#291)

### DIFF
--- a/docs/administration.md
+++ b/docs/administration.md
@@ -7,14 +7,15 @@ monitoring, backup, and security.
 ## Storage layout
 
 A columnar table is one PostgreSQL relation plus rows in the `pgcolumnar` catalog
-tables. Data is organized as follows:
+tables. pgColumnar puts data in this order:
 
 - A **row group** is the unit of write. Each write transaction appends one or
   more row groups of up to `pgcolumnar.stripe_row_limit` rows.
-- Within a row group, each column is stored and compressed separately as a
-  chunk. A chunk's values are encoded in **vectors** of up to
-  `pgcolumnar.chunk_group_row_limit` rows, the unit of the encoding cascade and
-  of minimum and maximum skipping.
+- In a row group, pgColumnar keeps each column as a chunk and compresses each
+  chunk separately. pgColumnar encodes the values of a chunk in **vectors**. A vector
+  holds a maximum of `pgcolumnar.chunk_group_row_limit` rows. The vector is the
+  unit of the encoding cascade. It is also the unit of minimum and maximum
+  skipping.
 - Each chunk records its minimum and maximum and an optional bloom filter, and a
   per-vector zone map records the finer minimum and maximum ranges.
 
@@ -75,21 +76,23 @@ SELECT pgcolumnar.vacuum_sorted('events', 'customer_id');
 To compact every columnar table in a schema, use `pgcolumnar.vacuum_full`.
 
 `pgcolumnar.vacuum_sorted` sorts ascending on its columns, which tightens the
-minimum and maximum of the leading column. To tighten several columns at once,
-use `pgcolumnar.cluster`, which orders rows by a Z-order (Morton) curve over the
-columns given, so multi-column range and point filters skip more:
+minimum and maximum of the leading column. To make several columns tighter at the
+same time, use `pgcolumnar.cluster`. It puts the rows in the order of a Z-order
+(Morton) curve on the columns that you give. Range filters and point filters on
+more than one column then skip more groups:
 
 ```sql
 SELECT pgcolumnar.cluster('events', 'customer_id', 'ts');
 ```
 
-**`pgcolumnar.cluster` holds `AccessExclusiveLock` for its whole run**, like
-PostgreSQL's own `CLUSTER` and `VACUUM FULL`: it rewrites the relation and swaps
-the file, so reads and writes on the table block until it finishes. Use it for an
-initial bulk reorganisation, on a table you can take offline.
-`pgcolumnar.recluster` is the online form of the same idea and is described
-below; prefer it on a live table. Neither changes query results. Both only
-reorder physical storage.
+**`pgcolumnar.cluster` holds `AccessExclusiveLock` until it completes.** The
+PostgreSQL commands `CLUSTER` and `VACUUM FULL` do the same. It rewrites the
+relation and replaces the file. Thus reads and writes on the table stop until it
+completes. Use it for a first bulk reorganisation, on a table that you can make
+unavailable.
+`pgcolumnar.recluster` does the same operation online. The text below describes
+it. Use it on a table that stays available. The two functions do not change query
+results. They change only the order of the physical storage.
 
 Leave autovacuum on. It maintains visibility-map bits and statistics for columnar
 tables. Schedule `pgcolumnar.vacuum` separately based on delete and update volume.
@@ -114,32 +117,37 @@ SELECT pgcolumnar.truncate('events');
 ```
 
 `pgcolumnar.truncate` is opt-in. Set `pgcolumnar.enable_end_truncation` to `on`
-first (see Configuration). It is best-effort: it takes a brief AccessExclusiveLock
-only when it is immediately available and returns 0 without waiting otherwise, so
-it does not block a busy table. It cannot run inside a transaction block. Run it
+first. Refer to Configuration. The function does what it can. It takes a short
+`AccessExclusiveLock`, but only if the lock is available immediately. If the lock
+is not available, the function returns 0 and does not wait. Thus it does not
+block a table that is busy. It cannot run inside a transaction block. Run it
 after a large delete followed by `pgcolumnar.compact`, when the freed space is at
 the end of the file.
 
 ## Index-only scans
 
-An index-only scan answers a query from the index without reading the table, when
-the index covers the query and the rows are marked all-visible. pgColumnar serves
-this through a columnar visibility-map fork:
+An index-only scan reads the index and not the table. pgColumnar can use one when
+two conditions are true. First, the index contains all the columns of the query.
+Second, the rows have the all-visible mark. A columnar visibility-map fork
+supplies this:
 
 - `VACUUM` marks a row group all-visible when its inserting transaction is old
   enough and the group has no deletes.
 - Any insert, update, or delete clears the bit for the affected group.
 
 Index-only scans are on by default (`pgcolumnar.enable_index_only_scan`). To make a
-covering query use one, ensure the table has been vacuumed since its last write.
+covering query use an index-only scan, run `VACUUM` on the table after the last
+write.
 Check with `EXPLAIN (ANALYZE)`: an index-only scan reports `Heap Fetches: 0`.
 
 ## Projections
 
 A projection stores a subset of a table's columns a second time, optionally
-sorted on a key. The planner scans a projection instead of the base table when it
-covers the query and serves it better, for example a range query on a key that is
-scattered in the base table but is the projection's sort key.
+sorted on a key. The planner reads a projection and not the base table when two
+conditions are true. First, the projection contains all the columns of the query.
+Second, the projection gives a better result. An example is a range query on a
+key. The key is in a random order in the base table, but it is the sort key of
+the projection.
 
 Declare a projection:
 
@@ -150,13 +158,13 @@ SELECT pgcolumnar.add_projection(
     sort_key => ARRAY['customer_id']);
 ```
 
-Existing rows are back-filled when the projection is added. New inserts write to
+When you add the projection, pgColumnar fills it with the rows that exist. New inserts write to
 the base table and its projections. Projection scans are on by default
 (`pgcolumnar.enable_projection_scan`). Drop a projection with
 `pgcolumnar.drop_projection`.
 
-Projections are not carried by `pg_dump` and `pg_restore`. They are keyed by
-internal storage ids that a restore regenerates, so re-declare them with
+`pg_dump` and `pg_restore` do not carry the projections. Their key is an internal
+storage id, and a restore makes a new one. Declare the projections again with
 `pgcolumnar.add_projection` after a logical restore. A physical backup
 (`pg_basebackup`) preserves them, which `test/replication.sh` verifies against a
 standby.
@@ -185,19 +193,20 @@ A high deleted-row percentage or a large number of small row groups indicates th
 
 ## Concurrent unique inserts
 
-When a columnar table has a unique index, `pgcolumnar.enable_unique_insert_lock`
-(on by default) serializes concurrent inserts of the same key with a
-transaction-scoped advisory lock, so overlapping same-key inserts conflict
-correctly. `pgcolumnar.unique_lock_buckets` (default 128) bounds how many advisory
+A columnar table can have a unique index. For such a table,
+`pgcolumnar.enable_unique_insert_lock` puts concurrent inserts of the same key in
+sequence. It uses an advisory lock with the scope of the transaction. Thus two
+inserts of the same key conflict correctly. The setting is on by default. `pgcolumnar.unique_lock_buckets` (default 128) bounds how many advisory
 locks a transaction holds per unique index. Leave the lock on unless you have a
 specific reason to change it.
 
 ## Column cache
 
-`pgcolumnar.enable_column_cache` (off by default) caches decompressed chunk groups
-so they can be reused across reads, sized by `pgcolumnar.column_cache_size` (default
-200 MB). Enable it for repeated scans over the same recently read data, and size
-the cache to the working set.
+`pgcolumnar.enable_column_cache` keeps chunk groups after decompression. Other
+reads can then use them again. `pgcolumnar.column_cache_size` sets the size, and
+the default is 200 MB. The cache is off by default. Enable it if you scan the
+same recent data more than one time. Set the size to the size of the working
+set.
 
 ## Backup and restore
 
@@ -230,33 +239,35 @@ the point of use:
 | `pgcolumnar.export_parquet(rel, path)` | writes a server file | superuser |
 | `pgcolumnar.export_arrow(rel, path)` | writes a server file | superuser |
 
-Two layers keep a non-superuser out. The functions carry the default grant to
-`PUBLIC`, but the `pgcolumnar` schema does not grant `USAGE` to `PUBLIC`, so a
-role that was never given schema access cannot reach them at all; and even with
-schema access, the superuser check refuses the call. `test/server_file_privilege.sh`
-asserts every entry point above refuses a non-superuser, and holds that list as
-data so a new file-reading function is added to one place.
+Two layers keep a non-superuser out. The functions have the default grant to
+`PUBLIC`. But the `pgcolumnar` schema does not grant `USAGE` to `PUBLIC`. Thus a
+role without access to the schema cannot reach the functions. If a role does have
+access to the schema, the superuser check refuses the call. `test/server_file_privilege.sh`
+checks that each entry point above refuses a non-superuser. It holds that list as
+data. Thus you add a new file-reading function in one place only.
 
 Every other `pgcolumnar.*` function runs with ordinary table privileges.
 
 This is stricter than core's convention: `COPY FROM 'file'` needs membership in
 `pg_read_server_files`, not superuser, so a DBA can delegate file reading without
-handing over the cluster. pgColumnar keeps superuser for the pre-release: loosening
-to `pg_read_server_files` and `pg_write_server_files` later is backward compatible,
-while tightening later would break working setups. The looser roles are worth
-reconsidering once the parsers are fully fuzzed (see below), because they widen
-the set of roles that can reach a hand-rolled parser.
+handing over the cluster. pgColumnar keeps superuser for the pre-release. A change to
+`pg_read_server_files` and `pg_write_server_files` later is backward compatible.
+A change to a more strict rule later would stop installations that operate
+correctly. Examine the less strict roles again after the fuzzing of the parsers
+is complete. Refer to the text below. These roles increase the number of roles
+that can reach a parser that this project wrote.
 
 ### The file is untrusted input
 
-A Parquet or Arrow file from a source you did not produce is untrusted input to a
-hand-rolled parser. The metadata in a crafted file drives that parser directly, so
-a malformed or hostile file is a code-execution surface, not only a data-quality
-problem. The superuser boundary means the exposed case is a superuser reading a
-file they did not produce, which is the ordinary data-lake case rather than an
-exotic one: the file is external even though the role is trusted.
+A Parquet file or an Arrow file from a different source is input without trust.
+The parser for these formats is code that this project wrote. The metadata in the
+file controls that parser directly. Thus a file that is incorrect or hostile is a
+surface for code execution. It is not only a problem of data quality. Because of the superuser boundary, the exposed condition is a superuser
+who reads a file that a different person made. This is the usual data-lake
+condition and not an unusual one. The role has trust, but the file is external.
 
 The mitigation for that residual risk is fuzzing the parsers, tracked in #214,
-which so far covers the Parquet path. Until the Arrow path is fuzzed as well,
-treat an Arrow file from an untrusted source with the same caution, and prefer
-importing only files you generated or obtained from a source you trust.
+which covers the Parquet path at this time. The fuzzing does not cover the Arrow
+path yet. Until it does, give the same care to an Arrow file from a source
+without trust. Import only the files that you made, or that you got from a source
+that you trust.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,13 +2,15 @@
 
 pgColumnar has two kinds of settings:
 
-- Server settings under the `pgcolumnar.` prefix, listed below. Most can be set in
-  `postgresql.conf`, per session with `SET`, per role, or per database, without
-  special privileges. Two are not: `pgcolumnar.enable_end_truncation` requires
-  superuser, and `pgcolumnar.unique_lock_buckets` can only be set at server start.
-  Each exception is noted in its own row below.
-- Per-table storage options, set with `pgcolumnar.set_options`. These
-  apply to one table and are used when that table writes new data.
+- Server settings. These settings use the `pgcolumnar.` prefix. The list is
+  below. For almost all of them, you do not need a special privilege. You can set
+  them in `postgresql.conf`, for one session with `SET`, for one role, or for one
+  database. There are two exceptions. `pgcolumnar.enable_end_truncation` needs
+  superuser. You can set `pgcolumnar.unique_lock_buckets` only at server start.
+  The row for each exception gives this condition again.
+- Per-table storage options. You set these options with
+  `pgcolumnar.set_options`. They apply to one table. That table uses them when it
+  writes new data.
 
 ## Server settings
 
@@ -18,7 +20,7 @@ pgColumnar has two kinds of settings:
 | --- | --- | --- | --- |
 | `pgcolumnar.stripe_row_limit` | integer | `150000` | Maximum rows per row group. The row group is the unit of write and the granularity at which whole segments are appended. Range 1000 to INT_MAX. |
 | `pgcolumnar.chunk_group_row_limit` | integer | `10000` | Maximum rows per vector. The vector is the unit of encoding and of min/max skipping. Range 100 to INT_MAX. |
-| `pgcolumnar.encoding_sample_rows` | integer | `2048` | Rows sampled to choose a vector's value encoding. Candidates are estimated on a windowed sample (evenly spread windows of consecutive values, so both global shape and local runs are visible) and only the best two are applied to the whole vector. `0` applies every candidate to every vector, which is what earlier versions did, and any value below 128 is treated as `0` because a smaller sample cannot rank candidates. Affects write speed and, in principle, compression ratio; never correctness. |
+| `pgcolumnar.encoding_sample_rows` | integer | `2048` | The number of rows that the writer samples to select the value encoding of a vector. The writer estimates each candidate on a sample of windows. The windows contain consecutive values and have an equal distance between them. Thus the sample shows the global shape and also the local runs. The writer then applies only the two best candidates to the full vector. A value of `0` applies each candidate to each vector. This is the behaviour of earlier versions. The writer changes a value below 128 to `0`, because a smaller sample cannot put the candidates in order. This setting changes the write speed. It can also change the compression ratio. It does not change correctness. |
 
 ### Compression
 
@@ -28,20 +30,23 @@ pgColumnar has two kinds of settings:
 | `pgcolumnar.compression_level` | integer | `3` | Level for the `zstd` codec. Range 1 to 22. Higher levels compress more and write more slowly. |
 | `pgcolumnar.fsst_min_gain_percent` | integer | `5` | Minimum size reduction, in percent, for FSST string encoding to be kept for a column chunk. Range 0 to 99. See below. |
 
-Building FSST codes for every vector is one of the larger costs of a text or
-varlena load. At `0`, FSST is kept whenever it produces any reduction after
-the block codec, however small, and that reduction does not always repay the
-encode. The default of `5` keeps FSST only where it saves at least 5 percent.
+To build the FSST codes for each vector is one of the larger costs of a load of
+text data. A value of `0` keeps FSST if it makes any reduction after the block
+codec. A small reduction does not always pay for the cost of the encode. The
+default of `5` keeps FSST only if it saves 5 percent or more.
 
-On measured workloads this costs about 2 percent stored size on shapes where
-FSST barely wins, such as high-entropy text, and reduces their load time by
-roughly a third. Where FSST wins by more than the margin, such as low-cardinality text, the
-setting changes nothing: the encoding chosen and the bytes written are the same.
-Wide values are also unaffected.
+Measurements show the effect of the default. For the data shapes where FSST wins
+by a small quantity, such as high-entropy text, the stored size increases by
+approximately 2 percent. The load time of the same data decreases by
+approximately one third. For the data shapes where FSST wins by more than the
+margin, such as low-cardinality text, the setting changes nothing. The writer
+selects the same encoding and writes the same bytes. Wide values also stay the
+same.
 
-Set it to `0` for the previous behaviour of keeping FSST on any reduction. The
-setting applies when data is written, so it affects new chunks rather than
-existing ones, and it never changes the values a table returns.
+To get the behaviour of earlier versions, set the value to `0`. Then FSST stays
+if it makes any reduction. The setting applies when the writer writes data. Thus
+it changes new chunks, but it does not change the chunks that are already on
+disk. It never changes the values that a table returns.
 
 ### Scan and execution
 
@@ -83,9 +88,10 @@ existing ones, and it never changes the values a table returns.
 
 ## Per-table storage options
 
-`pgcolumnar.set_options` sets storage options on one table. New data
-written after the change uses the new values; data already written is unchanged
-until the table is rewritten (for example by `pgcolumnar.vacuum`).
+`pgcolumnar.set_options` sets the storage options of one table. The new values
+apply to the data that the writer writes after the change. The data that is
+already on disk does not change. It changes only when a command rewrites the
+table, for example `pgcolumnar.vacuum`.
 
 ```sql
 SELECT pgcolumnar.set_options(
@@ -105,19 +111,21 @@ SELECT pgcolumnar.set_options(
 | `compression_level` | integer | Level for the `zstd` codec, 1 to 22. |
 | `encode_effort` | name | `full` (default) or `fast`. How much work the writer spends choosing an encoding. See below. |
 
-Arguments left at their default (`NULL`) are not changed. A value outside the
-valid range for a limit or level is rejected.
+The function does not change an argument that keeps its default value of
+`NULL`. The function refuses a value that is outside the permitted range of a
+limit or a level.
 
 ### Encode effort
 
-`encode_effort = fast` skips the FSST substring search when writing text and
-other variable-length columns. Everything else is unchanged: dictionary,
-run-length, the numeric schemes and the block codec all still run, and a table
-written either way is read back by the same code, so the setting is a cost
-choice and never a compatibility one.
+`encode_effort = fast` does not do the FSST substring search. This applies when
+the writer writes text columns and other columns of variable length. All other
+parts stay the same. The dictionary, the run-length encoding, the numeric
+schemes and the block codec all continue to operate. The same code reads a table
+that the writer wrote with either value. Thus this setting controls cost only.
+It does not control compatibility.
 
-It trades compression ratio for load speed, and how much of each depends
-entirely on the data:
+The setting decreases the compression ratio and increases the load speed. The
+quantity of each effect depends fully on the data:
 
 | Text shape (1,000,000 rows, one column) | Load speed-up with `fast` | Extra space |
 | --- | --- | --- |
@@ -127,20 +135,20 @@ entirely on the data:
 | 256-char high-entropy | 2.4x | none |
 | Short low-entropy text | 1.2x to 2.7x | none |
 
-On five of the seven shapes measured, `fast` produced byte-for-byte identical
-storage, so the work it skipped had bought nothing. On the two where the search
-does pay, it pays properly. There is no way to know which case a column is
-without trying it, which is why this is a per-table choice and why the default
-keeps the full search.
+The measurements used seven data shapes. For five of them, `fast` wrote storage
+that is identical byte for byte. Thus the work that it did not do gave no
+benefit. For the other two shapes, the search gives a large benefit. You cannot
+know which condition applies to a column until you try it. For this reason the
+option applies to one table, and the default keeps the full search.
 
-`fast` is worth considering for a bulk load you intend to compact later:
+Use `fast` for a bulk load if you will compact the table later.
 `pgcolumnar.vacuum`, `pgcolumnar.compact_rewrite` and `pgcolumnar.recluster`
-rewrite the data under whatever effort is set at the time, so a table can be
-loaded cheaply and compressed properly afterwards.
+rewrite the data. They use the effort value that applies at that time. Thus you
+can load a table at a low cost, then compress it fully after the load.
 
-The option is per table rather than a session setting on purpose: the same data
-written through two sessions with different settings would otherwise be stored
-two different ways depending on which session loaded it.
+The option applies to one table and is not a session setting. This is
+deliberate. If it were a session setting, two sessions with different values
+would store the same data in two different forms.
 
 `pgcolumnar.reset_options` returns options to the server defaults:
 
@@ -151,4 +159,4 @@ SELECT pgcolumnar.reset_options(
     compression           => true);
 ```
 
-Each boolean argument, when true, resets that option on the table.
+If a boolean argument is true, the function resets that option on the table.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,7 +1,7 @@
 # Installation
 
 pgColumnar builds with PGXS against an installed PostgreSQL server. The supported
-versions are 15 through 18. Version 19 is validated against 19beta2. Validation
+versions are 15 through 18. The project validates version 19 against 19beta2. Validation
 against the final 19 release is not done yet. PostgreSQL 13 and 14 build, but
 they are not in the tested matrix.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,66 +1,71 @@
 # Installation
 
-pgColumnar builds with PGXS against an installed PostgreSQL server, versions 15
-through 18, with 19 validated against 19beta2 and pending re-validation against
-the final release. PostgreSQL 13 and 14 still build but are out of the tested
-matrix.
+pgColumnar builds with PGXS against an installed PostgreSQL server. The supported
+versions are 15 through 18. Version 19 is validated against 19beta2. Validation
+against the final 19 release is not done yet. PostgreSQL 13 and 14 build, but
+they are not in the tested matrix.
 
 ## Requirements
 
-- A PostgreSQL server and its development headers, reachable through `pg_config`.
+- A PostgreSQL server and its development headers. The build finds them through
+  `pg_config`.
 - A C compiler and `make`.
-- `pkg-config`. It is used to detect the optional compression libraries.
-- Optional: `liblz4` and `libzstd` development libraries. When present, the `lz4`
-  and `zstd` codecs are compiled in. When absent, those codecs are compiled out
-  and a request for them on a columnar table falls back to a codec that is
-  present.
-- Optional: `zlib` development libraries. When present, the Parquet reader
-  decodes GZIP-compressed pages. It is not used by the native table format.
-- The fallback above applies to the native table format only. When an external
-  Parquet file holds a page compressed with a codec that was not built in, the
-  read fails with a decode error rather than falling back. See
-  [limitations.md](limitations.md) for the codecs the reader supports.
-- A little-endian host is required for the Arrow and Parquet import and export
-  functions and for reading external Parquet files (`read_parquet`,
-  `parquet_schema`, and the `pgcolumnar_parquet` foreign-data wrapper). The rest
-  of the extension runs on any host PostgreSQL supports.
+- `pkg-config`. The build uses it to find the optional compression libraries.
+- Optional: the `liblz4` and `libzstd` development libraries. If they are
+  available, the build includes the `lz4` and `zstd` codecs. If they are not
+  available, the build removes those codecs. A columnar table that requests a
+  removed codec then uses a codec that is available.
+- Optional: the `zlib` development library. If it is available, the Parquet
+  reader decodes GZIP-compressed pages. The native table format does not use
+  `zlib`.
+- A little-endian host, for the Arrow and Parquet functions only. These functions
+  are `read_parquet`, `parquet_schema`, the import and export functions, and the
+  `pgcolumnar_parquet` foreign-data wrapper. All other parts of the extension
+  operate on each host that PostgreSQL supports.
+
+The replacement of a removed codec applies to the native table format only. If an
+external Parquet file contains a page that uses a codec that the build removed,
+the read fails with a decode error. The read does not use a different codec. For
+the codecs that the reader supports, refer to [limitations.md](limitations.md).
 
 ## Build and install
 
-Point the build at the `pg_config` of the target server:
+Set the build to the `pg_config` of the target server:
 
 ```sh
 make PG_CONFIG=/path/to/pg_config
 make install PG_CONFIG=/path/to/pg_config
 ```
 
-`make install` copies `pgcolumnar.so`, the control file, and the SQL script into
-the server's library and extension directories.
+`make install` copies `pgcolumnar.so`, the control file, and the SQL script. It
+puts them in the library directory and the extension directory of the server.
 
 ## Load the library
 
-pgColumnar installs planner and executor hooks at library load time. Add it to
-`shared_preload_libraries` and restart the server:
+pgColumnar installs planner hooks and executor hooks when the server loads the
+library. Add the extension to `shared_preload_libraries`, then start the server
+again:
 
 ```
 shared_preload_libraries = 'pgcolumnar'
 ```
 
-Set this in `postgresql.conf` (or with `ALTER SYSTEM SET shared_preload_libraries
-= 'pgcolumnar'`), then restart. If other libraries are already preloaded, add
-`pgcolumnar` to the comma-separated list.
+Set this parameter in `postgresql.conf`. As an alternative, use `ALTER SYSTEM SET
+shared_preload_libraries = 'pgcolumnar'`. Then start the server again. If the
+parameter contains other libraries, add `pgcolumnar` to the list. Commas divide
+the items in the list.
 
 ## Create the extension
 
-In each database that will hold columnar tables:
+Do this in each database that will contain columnar tables:
 
 ```sql
 CREATE EXTENSION pgcolumnar;
 ```
 
-This creates the `pgcolumnar` schema, the `pgcolumnar` table access method, the
-catalog tables, and the `pgcolumnar.*` functions. The extension is not
-relocatable; its objects stay in the `pgcolumnar` schema.
+This command creates the `pgcolumnar` schema, the `pgcolumnar` table access
+method, the catalog tables, and the `pgcolumnar.*` functions. The extension is
+not relocatable. Its objects stay in the `pgcolumnar` schema.
 
 ## Verify
 
@@ -68,7 +73,7 @@ relocatable; its objects stay in the `pgcolumnar` schema.
 -- the access method is registered
 SELECT amname FROM pg_am WHERE amname = 'pgcolumnar';
 
--- a columnar table can be created and read
+-- you can create a columnar table and read it
 CREATE TABLE install_check (id int, v text) USING pgcolumnar;
 INSERT INTO install_check VALUES (1, 'ok');
 SELECT * FROM install_check;
@@ -80,22 +85,23 @@ DROP TABLE install_check;
 To install a new build of the extension:
 
 1. Run `make install` with the same `PG_CONFIG`.
-2. Restart the server so the new library is loaded.
+2. Start the server again, so that it loads the new library.
 
-The on-disk format version is recorded in the source and in
-[../design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md](https://github.com/jdatcmd/pgcolumnar/blob/main/design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md).
-A build that keeps the same format version reads tables written by earlier builds
-of that version without conversion.
+The source records the on-disk format version. The specification also records it,
+in [../design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md](https://github.com/jdatcmd/pgcolumnar/blob/main/design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md).
+A build that keeps the same format version reads the tables that earlier builds
+of that version wrote. A conversion is not necessary.
 
 ## Remove
 
-Drop the extension from a database, then remove the files if no database still
-uses it:
+First drop the extension from a database. Then remove the files, but only if no
+database uses the extension:
 
 ```sql
 DROP EXTENSION pgcolumnar;   -- fails if columnar tables still exist; drop them first
 ```
 
-Removing `pgcolumnar` from `shared_preload_libraries` and restarting unloads the
-library. Do this only after no database contains columnar tables, because reading
-a columnar table requires the access method to be present.
+To unload the library, remove `pgcolumnar` from `shared_preload_libraries` and
+start the server again. Do this only after you drop all columnar tables. A read
+of a columnar table needs the access method, and the access method is not
+available when the library is not loaded.

--- a/docs/sql-reference.md
+++ b/docs/sql-reference.md
@@ -11,10 +11,9 @@ Converts a table to another access method, for example from the default heap to
 `pgcolumnar` or back.
 
 On PostgreSQL 15 and later this runs `ALTER TABLE ... SET ACCESS METHOD`, which
-rewrites the table in place and preserves its identity and dependents. On
-PostgreSQL 13 and 14, which have no such command, it builds a sibling table with
-`LIKE ... INCLUDING ALL`, copies every row through the target method, and swaps
-names. On those two majors the conversion does not preserve the original table's
+rewrites the table in place and preserves its identity and dependents. PostgreSQL 13 and 14 do not have that command. On those two versions, the
+function makes a second table with `LIKE ... INCLUDING ALL`. It then copies each
+row through the target method and exchanges the names. On those two majors the conversion does not preserve the original table's
 OID or objects that depend on it, such as views and foreign keys.
 
 ```sql
@@ -63,10 +62,11 @@ SELECT pgcolumnar.vacuum_sorted('events', 'customer_id');
 ### pgcolumnar.cluster(tablename regclass, VARIADIC columns name[])
 
 Rewrites a columnar table with its rows ordered by a Z-order (Morton)
-space-filling curve over the given columns. Where `vacuum_sorted` sorts ascending
-and so tightens the minimum and maximum of its leading column, Z-order tightens
-every clustered column at once, so multi-column range and point filters skip more
-vectors and chunk groups. Results are unchanged; only physical order is.
+space-filling curve on the columns that you give. `vacuum_sorted` sorts in
+ascending order. Thus it makes the minimum and maximum of its first column
+tighter. Z-order makes each clustered column tighter at the same time. Range
+filters and point filters on more than one column then skip more vectors and more
+chunk groups. The results do not change. Only the physical order changes.
 
 **Holds `AccessExclusiveLock` for the duration**, like PostgreSQL's own `CLUSTER`
 and `VACUUM FULL`, because it rewrites the relation and swaps its file. Reads and
@@ -112,10 +112,11 @@ SELECT pgcolumnar.compact_rewrite('events', 0.3);
 
 ### pgcolumnar.truncate(tablename regclass) returns bigint
 
-Returns trailing reclaimed blocks to the operating system. Best-effort: it takes
-`AccessExclusiveLock` conditionally for the brief physical step and returns 0
-without waiting if the table is busy, and it only removes space freed before the
-oldest-xmin horizon. Gated by `pgcolumnar.enable_end_truncation`, which is off by
+Gives the reclaimed blocks at the end of the file back to the operating system.
+The function does what it can. It takes `AccessExclusiveLock` for the short
+physical step, but only if the lock is available. If the table is busy, the
+function returns 0 and does not wait. It removes only the space that became free
+before the oldest-xmin horizon. Gated by `pgcolumnar.enable_end_truncation`, which is off by
 default. Returns the number of blocks truncated.
 
 ```sql
@@ -125,7 +126,7 @@ SELECT pgcolumnar.truncate('events');
 ### pgcolumnar.vacuum_full(schema name DEFAULT 'public', sleep_time real DEFAULT 0.0, stripe_count int DEFAULT 0)
 
 Runs `pgcolumnar.vacuum` on every columnar table in a schema. `sleep_time` is a
-pause in seconds between tables. `stripe_count` is passed through to each call.
+pause in seconds between tables. Each call receives the same `stripe_count`.
 
 ```sql
 SELECT pgcolumnar.vacuum_full('public');
@@ -162,7 +163,7 @@ than the base table, the planner scans the projection instead. See
 ### pgcolumnar.add_projection(rel regclass, name text, columns text[], sort_key text[] DEFAULT '{}')
 
 Declares a projection on `rel` named `name`, storing `columns`, sorted on
-`sort_key`. Existing rows are back-filled when the projection is added.
+`sort_key`. When you add the projection, pgColumnar fills it with the rows that exist.
 
 ```sql
 SELECT pgcolumnar.add_projection(
@@ -189,8 +190,8 @@ inspection and testing, not for query use.
 These functions read and write Arrow IPC stream files and Parquet files. They
 require superuser, because they read and write files on the server host. They run
 on little-endian hosts only. They support scalar column types, one-dimensional
-arrays, and composite types, with nulls at every level. Multi-dimensional arrays
-and unsupported types are rejected. See
+arrays, and composite types, with nulls at every level. The functions refuse multi-dimensional arrays
+and types that they do not support. See
 [Limitations and compatibility](limitations.md).
 
 ### pgcolumnar.export_arrow(rel regclass, path text) returns bigint
@@ -206,7 +207,7 @@ rows written.
 ### pgcolumnar.import_arrow(rel regclass, path text) returns bigint
 
 Inserts the rows of an Arrow IPC stream file at `path` into the existing table
-`rel`. The table's column types define what is expected. Returns the number of
+`rel`. The column types of the table define the types that the function accepts. Returns the number of
 rows inserted.
 
 ### pgcolumnar.import_parquet(rel regclass, path text) returns bigint
@@ -231,23 +232,25 @@ SELECT pgcolumnar.import_parquet('events_copy', '/data/events/');
 ## Reading external Parquet
 
 These read a server-side Parquet file in place, without importing it. They
-require superuser and run on little-endian hosts. In every case `path` may be a
-single file, a directory (all `*.parquet` files below it at any depth, read as
-one relation
-in sorted order), or a glob pattern.
+require superuser and operate on little-endian hosts. In each function, `path`
+can be one of three things. It can be a single file. It can be a directory, and
+then the function reads all the `*.parquet` files below it at any depth as one
+relation, in sorted order. It can also be a glob pattern.
 
 ### pgcolumnar.read_parquet(path text) returns setof record
 
-Returns the rows of a Parquet file. The caller supplies a column definition list
-that names the output columns and their types; the reader binds it against the
-file's leaf columns by position, with the same type-compatibility rules as
-import.
+Returns the rows of a Parquet file. You must supply a column definition list. It
+gives the names of the output columns and their types. The reader connects the
+list to the leaf columns of the file by position. It uses the same rules for type
+compatibility as the import functions.
 
-The list must cover every leaf column in the file. Declaring a subset is an
-error, not a projection: the read stops with a message reporting the file's leaf
-count and the count the target expands to. The same rule applies to a foreign
-table's column definitions. Projection pushdown decides which of the declared
-columns are decoded, which is separate from how many must be declared. Use
+The list must contain each leaf column in the file. A list with fewer columns is
+an error and not a projection. The read stops and gives a message. The message
+contains the number of leaf columns in the file and the number that the target
+expands to. The same rule applies to a foreign
+table's column definitions. Projection pushdown selects the declared columns
+that the reader decodes. This is a separate question from the number of columns
+that you must declare. Use
 `parquet_schema` to generate the full list.
 
 ```sql
@@ -281,9 +284,10 @@ A scan that skips nothing still returns correct rows.
 
 Table options: `path`, and `partition_columns` for a Hive-style layout. The
 latter names the columns whose values come from `col=value` directory components
-rather than from the files. They are declared rather than inferred, since a wrong
-guess would silently change which rows a query returns. A predicate on a
-partition column drops whole files before they are opened, reported as
+rather than from the files. You declare these columns. pgColumnar does not infer
+them, because an incorrect value would change the rows that a query returns, with
+no message. A predicate on a partition column removes complete files before the
+reader opens them. The plan shows this as
 `Files Pruned`.
 
 ```sql
@@ -309,7 +313,7 @@ index-only scans. They are for diagnostics.
 
 ### pgcolumnar.vm_is_visible(rel regclass, blk int)
 
-Returns whether the given block (chunk group) is marked all-visible.
+Tells you if the block (chunk group) has the all-visible mark.
 
 ### pgcolumnar.vm_selftest(rel regclass, blk int)
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,7 +1,8 @@
 # User guide
 
-This guide covers creating columnar tables, loading data, and querying them. It
-assumes the extension is installed and loaded (see [Installation](installation.md)).
+This guide tells you how to create columnar tables, how to load data, and how to
+query the tables. It assumes that you installed the extension and that the server
+loads it. Refer to [Installation](installation.md).
 
 ## Create a columnar table
 
@@ -42,15 +43,16 @@ To convert back to the default heap, use `heap` as the method.
 
 ## Load data
 
-Columnar storage is built for append-mostly data. Rows are buffered and written
-in row groups of up to `pgcolumnar.stripe_row_limit` rows. Each transaction writes
-its own row groups, so a load's shape affects the result:
+Columnar storage is for data that you mostly append. The writer holds rows in a
+buffer, then writes them in row groups. A row group contains a maximum of
+`pgcolumnar.stripe_row_limit` rows. Each transaction writes its own row groups.
+Thus the shape of a load changes the result:
 
 - Prefer `COPY` or multi-row `INSERT` over many single-row `INSERT` statements. A
   `COPY` of N rows writes about N divided by `stripe_row_limit` row groups.
-- Many small transactions produce many small row groups. If a table was loaded that
-  way, run [`pgcolumnar.vacuum`](sql-reference.md#pgcolumnarvacuumtablename-regclass-stripe_count-int-default-0)
-  to combine row groups.
+- Many small transactions make many small row groups. If a load used that method,
+  run [`pgcolumnar.vacuum`](sql-reference.md#pgcolumnarvacuumtablename-regclass-stripe_count-int-default-0)
+  to combine the row groups.
 
 ```sql
 COPY events FROM '/data/events.csv' WITH (FORMAT csv, HEADER);
@@ -90,8 +92,8 @@ controlled by a setting in the [Configuration reference](configuration.md):
 - Chunk-group skipping: per-chunk minimum and maximum values drop groups of rows
   that cannot satisfy a filter.
 - Bloom filters: per-chunk filters drop groups for equality filters.
-- Vectorized aggregate: an ungrouped count, sum, avg, min, or max over a
-  supported type is answered from the zone-map metadata.
+- Vectorized aggregate. The zone-map metadata answers an ungrouped count, sum,
+  avg, min, or max on a supported type.
 - `count(*)` answered from catalog metadata when there is no filter.
 
 ### Point lookups and indexes
@@ -103,10 +105,11 @@ CREATE INDEX ON events (id);
 SELECT * FROM events WHERE id = 12345;
 ```
 
-An index supports point lookups and range scans. When a query's columns are all
-in the index and the table's rows are marked all-visible, pgColumnar can answer
-from the index alone with an index-only scan, served by its visibility-map fork.
-Visibility bits are set by `VACUUM`. See
+An index supports point lookups and range scans. An index-only scan reads the
+index and not the table. pgColumnar can use one when two conditions are true.
+First, the index contains all the columns of the query. Second, the
+visibility-map fork marks the rows of the table as all-visible. `VACUUM` sets the
+visibility bits. Refer to
 [Administration](administration.md#index-only-scans).
 
 ## Arrays and composite types
@@ -229,18 +232,18 @@ table public.events_cdc: INSERT: seq[bigint]:4 op[text]:'DELETE' id[bigint]:2 ki
 
 Four properties of this arrangement are worth knowing.
 
-An `UPDATE` arrives as one `UPDATE`. A columnar update is a delete of the old row
-and an insert of a new one internally, but the trigger fires once per row event,
-so the capture table records what the statement did rather than how the storage
-did it.
+An `UPDATE` arrives as one `UPDATE`. Internally, a columnar update deletes the
+old row and inserts a new row. The trigger operates one time for each row event.
+Thus the capture table records the operation of the statement. It does not record
+the operation of the storage.
 
-The capture is transactional. The trigger runs in the same transaction as the
-statement, so a rolled back transaction leaves no captured rows, and the captured
-rows commit with the data.
+The capture is transactional. The trigger operates in the transaction of the
+statement. Thus a transaction that rolls back captures no rows. The captured rows
+commit together with the data.
 
-It costs a heap row per changed row, in write time and in space. Bulk loads are
-the case to think about before enabling it: a load of ten million rows writes ten
-million heap rows as well.
+The capture writes one heap row for each changed row. This has a cost in write
+time and in space. Examine bulk loads before you enable the capture. A load of
+ten million rows also writes ten million heap rows.
 
 The capture table needs pruning. Nothing deletes from it. Delete rows once the
 consumer has confirmed them, and remember that the deletes are themselves


### PR DESCRIPTION
Part of #291, scoped to the instructional and reference documents: `installation`,
`configuration`, `user-guide`, `administration`, `sql-reference`. The analytical
documents and the code comments are not in this change.

## Measured

Code blocks and tables excluded from the counts:

| | sentences | over 25 words | idiom | em/en dash |
| --- | ---: | ---: | ---: | ---: |
| before | 303 | **27** | 2 | 0 |
| after | 434 | **0** | **0** | 0 |

The sentence count rises 43 percent for the same content. That is the trade STE
makes: more sentences, fewer ideas held at once in each.

## What changed, beyond sentence length

Idiom was the larger edit and the less obvious one. It is the part a fluent
reader does not notice and a non-native reader cannot resolve. "Falls back to",
"best-effort", "point the build at", "take a table offline" and "worth
reconsidering" are all gone, said plainly instead. Passive constructions became
active where an actor exists: "space is reclaimed by compaction" became
"compaction makes the space available again".

## What this does not claim

Full ASD-STE100 compliance is defined against the **licensed ASD Dictionary**, roughly
900 approved words each with one approved meaning and part of speech. I do not
have that dictionary, so **vocabulary compliance is not verified and is not
claimed here**. What is verified is the measurable structural rules, checked
against every sentence in the five files by a small script.

If you want real compliance rather than rule-following, that needs the dictionary
and ideally a checker, and it is worth deciding before more documents are
converted.

## Verification

- Every fact checked as still present: setting names, defaults, ranges, function
  names, version numbers, the measured figures in the encode-effort table, the
  security roles.
- Every relative link resolves.
- No content dropped: the diff adds 186 lines and removes 160, and the additions
  are sentence splits rather than new claims.

Documentation only; no code paths touched.