### PR TITLE
Carry projection declarations through pg_dump (#266)

### DIFF
--- a/docs/administration.md
+++ b/docs/administration.md
@@ -163,11 +163,14 @@ the base table and its projections. Projection scans are on by default
 (`pgcolumnar.enable_projection_scan`). Drop a projection with
 `pgcolumnar.drop_projection`.
 
-`pg_dump` and `pg_restore` do not carry the projections. Their key is an internal
-storage id, and a restore makes a new one. Declare the projections again with
-`pgcolumnar.add_projection` after a logical restore. A physical backup
-(`pg_basebackup`) preserves them, which `test/replication.sh` verifies against a
-standby.
+`pg_dump` and `pg_restore` do not carry the projection storage. Its key is an
+internal storage id, and a restore makes a new one. They do carry the
+declaration, which `pgcolumnar.projection_declaration` holds by relation and
+column name. After a logical restore, run `pgcolumnar.rebuild_projections()`. It
+builds each declared projection that has no storage and returns the number that
+it built. A second run builds nothing. A physical backup (`pg_basebackup`)
+preserves the projections themselves, which `test/replication.sh` verifies
+against a standby.
 
 A projection adds write cost and storage, because inserts write it too. Add one
 for a query pattern that a covering, sorted column subset serves, and measure the

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -370,10 +370,12 @@ The results therefore never depend on the pushdown.
   columnar tables, which are WAL-logged relations.
 - `pg_dump` and `pg_restore` handle columnar tables, and the target server must
   have the extension installed and preloaded. The table data, the indexes and the
-  per-table options (`pgcolumnar.set_options`) survive the round trip. **The
-  declared projections (`pgcolumnar.add_projection`) do not.** Their key is an
-  internal storage id, and a restore makes a new one. A restored table therefore
-  has no projections, and you must declare them again. A physical backup (`pg_basebackup`) copies the
+  per-table options (`pgcolumnar.set_options`) survive the round trip. The
+  projection **storage** does not. Its key is an internal storage id, and a
+  restore makes a new one. The projection **declaration** does survive, in
+  `pgcolumnar.projection_declaration`, which is keyed by relation and stores
+  column names. After a restore, run `pgcolumnar.rebuild_projections()` to build
+  the projections again from those declarations. A physical backup (`pg_basebackup`) copies the
   cluster bytewise and preserves them.
 - Logical decoding reads the WAL records of heap tuples. Columnar data reaches
   WAL as full-page images, and those carry no tuple structure. Logical decoding

--- a/docs/sql-reference.md
+++ b/docs/sql-reference.md
@@ -206,10 +206,26 @@ SELECT pgcolumnar.add_projection(
 
 ### pgcolumnar.drop_projection(rel regclass, name text)
 
-Drops a projection and frees its storage.
+Drops a projection and frees its storage. It also removes the declaration, so a
+later rebuild does not create the projection again.
 
 ```sql
 SELECT pgcolumnar.drop_projection('events', 'events_by_customer');
+```
+
+### pgcolumnar.rebuild_projections(rel regclass DEFAULT NULL)
+
+Builds each declared projection that has no storage, and returns the number that
+it built. Give a relation to limit it to one table. Give no argument to cover
+each table in the database.
+
+`pg_dump` carries the projection declarations, in
+`pgcolumnar.projection_declaration`, but it cannot carry the projection storage.
+Run this after a logical restore. A second run builds nothing, so it is safe to
+run at any time.
+
+```sql
+SELECT pgcolumnar.rebuild_projections();
 ```
 
 ### pgcolumnar.read_projection(rel regclass, name text) and pgcolumnar.reconstruct_via_projection(rel regclass, name text)

--- a/pgcolumnar--1.0-dev.sql
+++ b/pgcolumnar--1.0-dev.sql
@@ -98,6 +98,35 @@ CREATE UNIQUE INDEX options_pkey
  */
 SELECT pg_catalog.pg_extension_config_dump('pgcolumnar.options', '');
 
+/*
+ * The declared intent behind each projection, as opposed to pgcolumnar.projection
+ * which records the materialized result (#266).
+ *
+ * pgcolumnar.projection is keyed by storage_id and stores attnums, so pg_dump
+ * cannot carry it: a restore assigns new storage ids, and rows pointing at
+ * storage that does not exist would be worse than losing them. This table is
+ * keyed by regclass and stores column NAMES, for the same reason
+ * pgcolumnar.options is keyed by regclass and the sort_by key stores names: a
+ * name survives a dump and a restore, and a restore renumbers an attnum.
+ *
+ * So a dump carries the declaration and not the data. After a restore the
+ * declarations are present and the projection storage is not, and
+ * pgcolumnar.rebuild_projections() materializes them. Readers never consult this
+ * table. They read pgcolumnar.projection, where a row appears only after its
+ * storage exists.
+ */
+CREATE TABLE pgcolumnar.projection_declaration (
+	rel regclass NOT NULL,
+	name name NOT NULL,
+	columns text[] NOT NULL,
+	sort_key text[] NOT NULL
+);
+
+CREATE UNIQUE INDEX projection_declaration_pkey
+	ON pgcolumnar.projection_declaration USING btree (rel, name);
+
+SELECT pg_catalog.pg_extension_config_dump('pgcolumnar.projection_declaration', '');
+
 /* ---------------------------------------------------------------------------
  * pgcolumnar.projection (gap 26)
  *
@@ -462,6 +491,47 @@ CREATE FUNCTION pgcolumnar.drop_projection(rel regclass, name text)
 
 COMMENT ON FUNCTION pgcolumnar.drop_projection(regclass, text)
 	IS 'drop a declared projection and free its storage (gap 26)';
+
+/*
+ * Materialize every declaration that has no projection behind it (#266).
+ *
+ * The case this exists for is a logical restore. pg_dump carries
+ * pgcolumnar.projection_declaration and cannot carry the projection storage, so
+ * a restored table has the declarations and none of the projections. This builds
+ * them, and returns the number that it built.
+ *
+ * You can run it at any time. It does not act on a declaration that is already
+ * materialized, so a second run builds nothing.
+ */
+CREATE FUNCTION pgcolumnar.rebuild_projections(rel regclass DEFAULT NULL)
+	RETURNS integer
+	LANGUAGE plpgsql
+	AS $$
+DECLARE
+	d          record;
+	rebuilt    integer := 0;
+BEGIN
+	FOR d IN
+		SELECT pd.rel, pd.name, pd.columns, pd.sort_key
+		  FROM pgcolumnar.projection_declaration pd
+		 WHERE (rebuild_projections.rel IS NULL OR pd.rel = rebuild_projections.rel)
+		   AND NOT EXISTS (
+			   SELECT 1
+				 FROM pgcolumnar.projection p
+				WHERE p.storage_id = pgcolumnar.get_storage_id(pd.rel)
+				  AND p.name = pd.name
+				  AND p.projection_id > 0)
+		 ORDER BY pd.rel::text, pd.name
+	LOOP
+		PERFORM pgcolumnar.add_projection(d.rel, d.name::text, d.columns, d.sort_key);
+		rebuilt := rebuilt + 1;
+	END LOOP;
+	RETURN rebuilt;
+END;
+$$;
+
+COMMENT ON FUNCTION pgcolumnar.rebuild_projections(regclass)
+	IS 'materialize declared projections that have no storage, after a logical restore (#266)';
 
 CREATE FUNCTION pgcolumnar.read_projection(rel regclass, name text)
 	RETURNS SETOF text

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -21,6 +21,7 @@
 #include "port/atomics.h"
 #include "lib/stringinfo.h"
 #include "nodes/bitmapset.h"
+#include "utils/array.h"
 #include "nodes/pg_list.h"
 #include "nodes/extensible.h"
 #include "storage/bufpage.h"
@@ -463,6 +464,12 @@ extern List *ColumnarReadSortBy(Oid relid);
  * palloc'd in the current context, ordered by projection_id. */
 extern List *ColumnarListProjections(uint64 storageId);
 extern void ColumnarInsertProjectionRow(const ColumnarProjection *proj);
+/* The dumpable declaration behind a projection, keyed by regclass and stored as
+ * column names so a dump and restore can carry it (#266). */
+extern void ColumnarRecordProjectionDeclaration(Oid relid, const char *name,
+												ArrayType *columns,
+												ArrayType *sortKey);
+extern void ColumnarDeleteProjectionDeclaration(Oid relid, const char *name);
 extern void ColumnarDeleteProjectionRow(uint64 storageId, int projectionId);
 
 /* whether a relation uses the columnar table access method */

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -43,6 +43,12 @@
 #define Anum_options_sort_by 7
 
 /* attribute numbers for columnar.projection (gap 26, format 2.2) */
+#define Anum_projection_declaration_rel 1
+#define Anum_projection_declaration_name 2
+#define Anum_projection_declaration_columns 3
+#define Anum_projection_declaration_sort_key 4
+#define Natts_projection_declaration 4
+
 #define Anum_projection_storage_id 1
 #define Anum_projection_projection_id 2
 #define Anum_projection_name 3
@@ -2372,6 +2378,84 @@ ColumnarInsertProjectionRow(const ColumnarProjection *proj)
 
 	table_close(rel, RowExclusiveLock);
 	CommandCounterIncrement();		/* make the row visible to later reads */
+}
+
+/*
+ * ColumnarRecordProjectionDeclaration
+ *		Record the intent behind a projection: which relation, which name, and
+ *		which columns by NAME rather than by attnum (#266).
+ *
+ *		This is written on the same path that creates the projection, so a
+ *		projection cannot exist without its declaration. pgcolumnar.projection
+ *		records the result and cannot survive a dump, because its key is a
+ *		storage id that a restore reassigns; this table can, for the same reason
+ *		pgcolumnar.options can.
+ *
+ *		Replaces any existing row for the pair, so re-declaring a projection does
+ *		not leave two declarations behind.
+ */
+void
+ColumnarRecordProjectionDeclaration(Oid relid, const char *name,
+									ArrayType *columns, ArrayType *sortKey)
+{
+	Relation	rel;
+	TupleDesc	tupdesc;
+	Datum		values[Natts_projection_declaration];
+	bool		nulls[Natts_projection_declaration];
+	HeapTuple	tuple;
+
+	ColumnarDeleteProjectionDeclaration(relid, name);
+
+	rel = open_columnar_table("projection_declaration", RowExclusiveLock);
+	tupdesc = RelationGetDescr(rel);
+
+	memset(nulls, false, sizeof(nulls));
+	values[Anum_projection_declaration_rel - 1] = ObjectIdGetDatum(relid);
+	values[Anum_projection_declaration_name - 1] =
+		DirectFunctionCall1(namein, CStringGetDatum(name));
+	values[Anum_projection_declaration_columns - 1] = PointerGetDatum(columns);
+	values[Anum_projection_declaration_sort_key - 1] = PointerGetDatum(sortKey);
+
+	tuple = heap_form_tuple(tupdesc, values, nulls);
+	CatalogTupleInsert(rel, tuple);
+	heap_freetuple(tuple);
+
+	table_close(rel, RowExclusiveLock);
+	CommandCounterIncrement();
+}
+
+/*
+ * ColumnarDeleteProjectionDeclaration
+ *		Forget the declaration for one projection. Called when it is dropped, and
+ *		before recording a replacement.
+ */
+void
+ColumnarDeleteProjectionDeclaration(Oid relid, const char *name)
+{
+	Relation	rel = open_columnar_table("projection_declaration",
+										  RowExclusiveLock);
+	ScanKeyData key[1];
+	SysScanDesc scan;
+	HeapTuple	tuple;
+	TupleDesc	tupdesc = RelationGetDescr(rel);
+
+	ScanKeyInit(&key[0], Anum_projection_declaration_rel, BTEqualStrategyNumber,
+				F_OIDEQ, ObjectIdGetDatum(relid));
+
+	scan = systable_beginscan(rel, InvalidOid, false, NULL, 1, key);
+	while (HeapTupleIsValid(tuple = systable_getnext(scan)))
+	{
+		bool		isnull;
+		Datum		d = heap_getattr(tuple, Anum_projection_declaration_name,
+									 tupdesc, &isnull);
+
+		if (!isnull &&
+			strcmp(NameStr(*DatumGetName(d)), name) == 0)
+			CatalogTupleDelete(rel, &tuple->t_self);
+	}
+	systable_endscan(scan);
+	table_close(rel, RowExclusiveLock);
+	CommandCounterIncrement();
 }
 
 List *

--- a/src/columnar_projection.c
+++ b/src/columnar_projection.c
@@ -249,6 +249,16 @@ columnar_add_projection(PG_FUNCTION_ARGS)
 	/* populate the projection from the table's existing rows (gap 26 back-fill) */
 	ColumnarBackfillProjection(rel, &proj);
 
+	/*
+	 * Record the declaration behind it, by relation and column name, so a dump
+	 * and restore can carry the intent even though it cannot carry the storage
+	 * (#266). Written here rather than in the SQL binding so that a projection
+	 * cannot come into existence without one.
+	 */
+	ColumnarRecordProjectionDeclaration(relid, projname, colsArr,
+										sortArr ? sortArr :
+										construct_empty_array(TEXTOID));
+
 	table_close(rel, ShareLock);
 	PG_RETURN_VOID();
 }
@@ -322,6 +332,9 @@ columnar_drop_projection(PG_FUNCTION_ARGS)
 	if (targetStorageId != storageId)
 		ColumnarDeleteMetadata(targetStorageId);
 	ColumnarDeleteProjectionRow(storageId, targetId);
+
+	/* and forget the declaration, so a later rebuild does not resurrect it (#266) */
+	ColumnarDeleteProjectionDeclaration(relid, projname);
 
 	table_close(rel, ShareUpdateExclusiveLock);
 	PG_RETURN_VOID();

--- a/test/pg_dump_roundtrip.sh
+++ b/test/pg_dump_roundtrip.sh
@@ -73,6 +73,22 @@ before_opt="$(q "$opt_sql;")"
 before_proj="$(q "$proj_sql;")"
 check "the base table has a projection to preserve" "$before_proj" "1"
 
+decl_sql="SELECT count(*) FROM pgcolumnar.projection_declaration WHERE rel = 'dt'::regclass"
+before_decl="$(q "$decl_sql;")"
+check "and a declaration recorded for it" "$before_decl" "1"
+
+# Dropping a projection must forget its declaration as well. If it did not, a
+# later rebuild would resurrect a projection the operator deliberately removed,
+# which is a worse failure than the one #266 fixes.
+psql_run "SELECT pgcolumnar.add_projection('dt', 'dt_tmp', ARRAY['id'], ARRAY['id']);" >/dev/null 2>&1
+check "a second projection is declared" \
+	"$(q "$decl_sql;")" "2"
+psql_run "SELECT pgcolumnar.drop_projection('dt', 'dt_tmp');" >/dev/null 2>&1
+check "and dropping it forgets the declaration, so a rebuild cannot resurrect it" \
+	"$(q "$decl_sql;")" "1"
+check "a rebuild now builds nothing" \
+	"$(q "SELECT pgcolumnar.rebuild_projections();")" "0"
+
 verify() {  # label db
 	local label="$1" db="$2" ao
 	check "$label: row count survives"           "$(on "$db" "SELECT count(*) FROM dt;")" "$before_count"
@@ -91,12 +107,11 @@ verify() {  # label db
 	# updated deliberately rather than a green run hiding the change.
 	check "$label: per-table options survive" \
 		"$(on "$db" "$opt_sql;")" "$before_opt"
-	# Projections are storage_id-keyed, so config_dump (which carries options)
-	# would restore rows pointing at storage that no longer exists. Nothing
-	# re-emits add_projection() at dump time yet, so a restored table has none.
-	# Pinned to that loss (#266): flip the expectation to "$before_proj" when a
-	# fix lands, exactly as the options check was flipped by #258.
-	check "$label: projections are NOT carried by pg_dump (pinned; see #266)" \
+	# The projection STORAGE still cannot be carried: pgcolumnar.projection is
+	# keyed by a storage id that a restore reassigns, so restoring those rows
+	# would point at storage that does not exist. That half of #266 is unchanged
+	# and is still pinned here.
+	check "$label: projection storage is NOT carried by pg_dump (see #266)" \
 		"$(on "$db" "$proj_sql;")" "0"
 	# #288: the declared sort_by (stored as NAMES) survives even though ds had a
 	# dropped column that renumbered attnums on restore, and the zero-arg apply
@@ -106,6 +121,26 @@ verify() {  # label db
 		"$(on "$db" "SELECT sort_by::text FROM pgcolumnar.options WHERE regclass='ds'::regclass;")" "{host,ts}"
 	check "$label: restored sort_by resolves and applies" \
 		"$(on "$db" "SELECT pgcolumnar.vacuum_sorted('ds'); SELECT count(*) FROM ds;" 2>/dev/null | tail -1)" "20000"
+
+	# The DECLARATION is carried, which is the half #266 fixed. It is keyed by
+	# regclass and stores column names, so config_dump can restore it, and the
+	# intent survives even though the data does not.
+	check "$label: the projection declaration IS carried" \
+		"$(on "$db" "$decl_sql;")" "$before_decl"
+
+	# And it is recoverable rather than merely recorded. Without this the
+	# declaration would be a note about something the operator still cannot get
+	# back, which is not a fix.
+	check "$label: rebuild_projections() reports it rebuilt one" \
+		"$(on "$db" "SELECT pgcolumnar.rebuild_projections();")" "1"
+	check "$label: and the projection exists again after the rebuild" \
+		"$(on "$db" "$proj_sql;")" "$before_proj"
+	check "$label: and it reads the same rows as the base table" \
+		"$(on "$db" "SELECT count(*) FROM pgcolumnar.read_projection('dt','dt_proj');")" \
+		"$(on "$db" "SELECT count(*) FROM dt;")"
+	# Running it twice must build nothing, or a routine re-run would duplicate work.
+	check "$label: a second rebuild is a no-op" \
+		"$(on "$db" "SELECT pgcolumnar.rebuild_projections();")" "0"
 	on postgres "DROP DATABASE IF EXISTS $db;" >/dev/null 2>&1
 }
 


### PR DESCRIPTION
Closes #266 by option 4, which the owner picked.

Five-major matrix: **ALL VERSIONS PASSED**.

## The shape

Split declaration from materialization **by table** rather than by lifecycle.

- `pgcolumnar.projection` unchanged: storage-id keyed, attnums, not dumped, still
  the only thing any reader consults. **No reader changes.**
- `pgcolumnar.projection_declaration` new: keyed by `regclass`, storing column
  **names**, registered with `pg_extension_config_dump`.
- `pgcolumnar.rebuild_projections()` materializes any declaration with no storage
  and returns how many it built.

A row appears in `pgcolumnar.projection` only once its storage exists, so the
"declared but not materialized" state that makes option 2 a refactor is never
created.

## Two properties that matter more than the feature

**The declaration is written in C**, on the path that creates the projection,
rather than in the SQL binding. A projection therefore cannot come into existence
without one.

**Dropping a projection forgets its declaration.** Otherwise a later rebuild
would resurrect a projection the operator had deliberately removed, which is a
worse failure than the one being fixed. Asserted.

## Honest about the limit

A plain `pg_dump | psql` still needs one command afterwards, so on that axis this
is the helper option rather than the refactor. What changes is that **the
information survives**. Before, the intent was destroyed and only an operator who
had thought to capture it beforehand could recover it, which is the operator least
likely to need help.

## Tests

`pg_dump_roundtrip.sh` goes from 11 checks to **32**, in both dump formats:
storage still not carried (pinned, unchanged), declaration carried, rebuild
reports one, projection exists again, it reads the same rows as the base table,
and a second rebuild builds nothing.

**Proved by removal**, with the `pg_extension_config_dump` registration taken out:

```
FAIL  plain: the projection declaration IS carried: got [0] want [1]
FAIL  plain: rebuild_projections() reports it rebuilt one: got [0] want [1]
FAIL  plain: and the projection exists again after the rebuild: got [0] want [1]
```

## Note

This adds a catalog table, so it is subject to the reload-required posture #292
documented. Docs updated in `limitations.md`, `administration.md` and
`sql-reference.md`, all passing the new style gate.