### PR TITLE
Clean projection_declaration on DROP TABLE (#304)

### DIFF
--- a/src/columnar.h
+++ b/src/columnar.h
@@ -470,6 +470,7 @@ extern void ColumnarRecordProjectionDeclaration(Oid relid, const char *name,
 												ArrayType *columns,
 												ArrayType *sortKey);
 extern void ColumnarDeleteProjectionDeclaration(Oid relid, const char *name);
+extern void ColumnarDeleteProjectionDeclarationsForRel(Oid relid);
 extern void ColumnarDeleteProjectionRow(uint64 storageId, int projectionId);
 
 /* whether a relation uses the columnar table access method */

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -2458,6 +2458,33 @@ ColumnarDeleteProjectionDeclaration(Oid relid, const char *name)
 	CommandCounterIncrement();
 }
 
+/*
+ * ColumnarDeleteProjectionDeclarationsForRel
+ *		Forget every declaration for a relation. Called when the whole table is
+ *		dropped, so no declaration is left behind pointing at a relation that no
+ *		longer exists. This mirrors ColumnarDeleteOptions on the drop path: both
+ *		are relid-keyed config that a dropped table must not outlive.
+ */
+void
+ColumnarDeleteProjectionDeclarationsForRel(Oid relid)
+{
+	Relation	rel = open_columnar_table("projection_declaration",
+										  RowExclusiveLock);
+	ScanKeyData key[1];
+	SysScanDesc scan;
+	HeapTuple	tuple;
+
+	ScanKeyInit(&key[0], Anum_projection_declaration_rel, BTEqualStrategyNumber,
+				F_OIDEQ, ObjectIdGetDatum(relid));
+
+	scan = systable_beginscan(rel, InvalidOid, false, NULL, 1, key);
+	while (HeapTupleIsValid(tuple = systable_getnext(scan)))
+		CatalogTupleDelete(rel, &tuple->t_self);
+	systable_endscan(scan);
+	table_close(rel, RowExclusiveLock);
+	CommandCounterIncrement();
+}
+
 List *
 ColumnarListProjections(uint64 storageId)
 {

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -2017,6 +2017,7 @@ columnar_object_access(ObjectAccessType access, Oid classId, Oid objectId,
 
 			ColumnarDeleteMetadata(storageId);
 			ColumnarDeleteOptions(objectId);
+			ColumnarDeleteProjectionDeclarationsForRel(objectId);
 		}
 
 		relation_close(rel, NoLock);

--- a/test/drop_cleanup.sh
+++ b/test/drop_cleanup.sh
@@ -28,7 +28,11 @@ set -uo pipefail
 
 pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
 
-# every catalog that hangs off a storage id, as one comparable string
+# every catalog a dropped table must take with it, as one comparable string.
+# projection_declaration is keyed by relid rather than storage id, but it is
+# still per-table config that must not outlive the table: leaving it behind
+# orphans a regclass that no longer resolves, which poisons rebuild_projections
+# and dumps a dangling regclass. It belongs in this count for the same reason.
 snapshot() {
 	q "SELECT (SELECT count(*) FROM pgcolumnar.storage) || '/' ||
 		(SELECT count(*) FROM pgcolumnar.projection) || '/' ||
@@ -36,7 +40,8 @@ snapshot() {
 		(SELECT count(*) FROM pgcolumnar.column_chunk) || '/' ||
 		(SELECT count(*) FROM pgcolumnar.zone_map) || '/' ||
 		(SELECT count(*) FROM pgcolumnar.bloom) || '/' ||
-		(SELECT count(*) FROM pgcolumnar.delete_vector);" | tail -1
+		(SELECT count(*) FROM pgcolumnar.delete_vector) || '/' ||
+		(SELECT count(*) FROM pgcolumnar.projection_declaration);" | tail -1
 }
 
 # --- 1. a plain table, which already cleaned up ------------------------------
@@ -92,6 +97,32 @@ check "no storage row refers to a missing relation" \
 	"$(q "SELECT count(*) FROM pgcolumnar.storage s
 		WHERE NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.oid = s.relation_oid);" | tail -1)" \
 	"0"
+
+# --- 5b. no declaration may outlive its relation, and rebuild survives a drop -
+#
+# A declaration left behind is worse than debris: rebuild_projections walks
+# every declaration and calls get_storage_id(rel) on it, so one orphan with a
+# dropped rel aborts rebuild for every table in the database. Keep a live table
+# with a projection standing while a sibling with a projection is dropped, then
+# require rebuild to still succeed.
+
+psql_run "DROP TABLE IF EXISTS dcl_keep;
+	CREATE TABLE dcl_keep (id int, a int) USING pgcolumnar;" >/dev/null
+psql_run "SELECT pgcolumnar.add_projection('dcl_keep','kp',ARRAY['a'],ARRAY['a']);" >/dev/null
+psql_run "INSERT INTO dcl_keep SELECT g, g % 7 FROM generate_series(1, 2000) g;" >/dev/null
+psql_run "CREATE TABLE dcl_gone (id int, a int) USING pgcolumnar;" >/dev/null
+psql_run "SELECT pgcolumnar.add_projection('dcl_gone','gp',ARRAY['a'],ARRAY['a']);" >/dev/null
+psql_run "INSERT INTO dcl_gone SELECT g, g FROM generate_series(1, 2000) g;" >/dev/null
+psql_run "DROP TABLE dcl_gone;" >/dev/null
+
+check "no declaration refers to a missing relation" \
+	"$(q "SELECT count(*) FROM pgcolumnar.projection_declaration d
+		WHERE NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.oid = d.rel);" | tail -1)" \
+	"0"
+rb="$(q "SELECT 'RB=' || pgcolumnar.rebuild_projections();" 2>&1 | tail -1)"
+check "rebuild_projections succeeds after a projected table was dropped" \
+	"$(case "$rb" in RB=*) echo ok ;; *) echo "$rb" ;; esac)" \
+	"ok"
 
 # --- 6. the table still works, which a too-eager cleanup would break ---------
 


### PR DESCRIPTION
Fixes #304.

`DROP TABLE` deleted a columnar relation's `options` but not its new `projection_declaration` rows (added in #299), so a dropped projected table left the declaration behind with a `regclass` that no longer resolves. That orphan is worse than debris:

- **`rebuild_projections()` breaks database-wide.** It walks every declaration and calls `get_storage_id(pd.rel)`; on an orphaned row `pd.rel` is a dropped relation, so the cache lookup errors and the whole call aborts. One dropped projected table poisons rebuild for every table.
- **`pg_dump` restores a dangling regclass.** `projection_declaration` is `config_dump`-registered, so the orphan is dumped and restored as a bare OID pointing at nothing.

## Fix

Symmetric to `options`. New `ColumnarDeleteProjectionDeclarationsForRel(relid)` deletes every declaration for a relation, called next to `ColumnarDeleteOptions(objectId)` in the `OAT_DROP` hook (`columnar_tableam.c`). The existing name-keyed `ColumnarDeleteProjectionDeclaration` is unchanged.

## Test

`drop_cleanup.sh`'s `snapshot()` counted every catalog **except** `projection_declaration`, which is exactly why the leak passed its assertions. This adds it to the count (so the existing drop checks now cover it) plus two direct checks: no declaration outlives its relation, and `rebuild_projections()` survives a dropped projected table.

## Verified — new test fails on unfixed main, passes with the fix (pg18a, assert)

A test that does not fail on the bug proves nothing, so both halves were run.

**Unfixed `main` + this test:**
```
FAIL  dropping it takes the projection's metadata too: got [.../1] want [.../0]
FAIL  ten create-and-drop cycles leave nothing: got [.../12] want [.../2]   <- unbounded, 1 orphan/drop
FAIL  no declaration refers to a missing relation: got [13] want [0]
FAIL  rebuild_projections succeeds after a projected table was dropped: got [] want [ok]
  ERROR: cache lookup failed for relation 16534
  CONTEXT: ... pgcolumnar.rebuild_projections(regclass)
```

**This branch (fix + test): all 10 checks PASS.**

Broader projection/drop-path regression subset on pg18a assert to follow in a comment.
