### PR TITLE
Clean projection declarations when a table is dropped (#304)

### DIFF
--- a/pgcolumnar--1.0-dev.sql
+++ b/pgcolumnar--1.0-dev.sql
@@ -511,6 +511,17 @@ DECLARE
 	d          record;
 	rebuilt    integer := 0;
 BEGIN
+	/*
+	 * Forget a declaration whose relation is gone (#304). The drop hook removes
+	 * these, so a current build does not make them. A database created by a
+	 * build that did not clean up on drop still holds them, and one such row
+	 * used to abort this function for every other table in the database: the
+	 * guard below resolves pd.rel, and resolving a dropped relation raises.
+	 * Deleting them here makes an affected database repair itself.
+	 */
+	DELETE FROM pgcolumnar.projection_declaration pd
+	 WHERE NOT EXISTS (SELECT 1 FROM pg_catalog.pg_class c WHERE c.oid = pd.rel);
+
 	FOR d IN
 		SELECT pd.rel, pd.name, pd.columns, pd.sort_key
 		  FROM pgcolumnar.projection_declaration pd

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -470,6 +470,9 @@ extern void ColumnarRecordProjectionDeclaration(Oid relid, const char *name,
 												ArrayType *columns,
 												ArrayType *sortKey);
 extern void ColumnarDeleteProjectionDeclaration(Oid relid, const char *name);
+/* Every declaration for a relation, for the drop hook: a dropped table must not
+ * leave rows behind whose regclass no longer resolves (#304). */
+extern void ColumnarDeleteProjectionDeclarationsForRel(Oid relid);
 extern void ColumnarDeleteProjectionRow(uint64 storageId, int projectionId);
 
 /* whether a relation uses the columnar table access method */

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -2458,6 +2458,39 @@ ColumnarDeleteProjectionDeclaration(Oid relid, const char *name)
 	CommandCounterIncrement();
 }
 
+/*
+ * ColumnarDeleteProjectionDeclarationsForRel
+ *		Forget every declaration for a relation. Called when the relation is
+ *		dropped (#304).
+ *
+ *		Without this a dropped table leaves declaration rows whose regclass no
+ *		longer resolves, and the damage is not confined to that table: the
+ *		orphan is dumped by config_dump as a bare OID pointing at nothing, and
+ *		rebuild_projections() aborts on it, which stops every other table in the
+ *		database being rebuilt. pgcolumnar.options avoids this by being cleaned in
+ *		the same hook; this catalog needs the same treatment.
+ */
+void
+ColumnarDeleteProjectionDeclarationsForRel(Oid relid)
+{
+	Relation	rel = open_columnar_table("projection_declaration",
+										  RowExclusiveLock);
+	ScanKeyData key[1];
+	SysScanDesc scan;
+	HeapTuple	tuple;
+
+	ScanKeyInit(&key[0], Anum_projection_declaration_rel, BTEqualStrategyNumber,
+				F_OIDEQ, ObjectIdGetDatum(relid));
+
+	scan = systable_beginscan(rel, InvalidOid, false, NULL, 1, key);
+	while (HeapTupleIsValid(tuple = systable_getnext(scan)))
+		CatalogTupleDelete(rel, &tuple->t_self);
+	systable_endscan(scan);
+
+	table_close(rel, RowExclusiveLock);
+	CommandCounterIncrement();
+}
+
 List *
 ColumnarListProjections(uint64 storageId)
 {

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -2017,6 +2017,14 @@ columnar_object_access(ObjectAccessType access, Oid classId, Oid objectId,
 
 			ColumnarDeleteMetadata(storageId);
 			ColumnarDeleteOptions(objectId);
+			/*
+			 * And the projection declarations, for the same reason and in the
+			 * same place (#304). A declaration left behind holds a regclass that
+			 * no longer resolves, which config_dump then dumps as a bare OID and
+			 * rebuild_projections() aborts on, taking every other table in the
+			 * database with it.
+			 */
+			ColumnarDeleteProjectionDeclarationsForRel(objectId);
 		}
 
 		relation_close(rel, NoLock);

--- a/test/projections.sh
+++ b/test/projections.sh
@@ -289,4 +289,40 @@ check "new snapshot projection scan sees both batches" "$final" "20000"
 exec 9>&-
 wait "$A_PID" 2>/dev/null || true
 
+# --- DROP TABLE must not orphan a declaration (#304) -------------------------
+#
+# pgcolumnar.projection_declaration is keyed by regclass and dumped, so a row
+# left behind by a dropped table holds a regclass that no longer resolves. That
+# is not confined to the dropped table: rebuild_projections() resolves pd.rel for
+# every declaration, and resolving a dropped relation raises, so one orphan used
+# to abort the rebuild for every other table in the database.
+
+psql_run "DROP TABLE IF EXISTS od1; DROP TABLE IF EXISTS od2;" >/dev/null 2>&1
+for t in od1 od2; do
+	psql_run "CREATE TABLE $t (id int, v text) USING pgcolumnar;
+		INSERT INTO $t SELECT g, md5(g::text) FROM generate_series(1,500) g;
+		SELECT pgcolumnar.add_projection('$t','${t}_p',ARRAY['id','v'],ARRAY['id']);" >/dev/null 2>&1
+done
+decl="SELECT count(*) FROM pgcolumnar.projection_declaration WHERE rel::text IN ('od1','od2')"
+check "two declared projections to start" "$(q "$decl;")" "2"
+
+psql_run "DROP TABLE od1;" >/dev/null 2>&1
+check "DROP TABLE removes its declaration (#304)" "$(q "$decl;")" "1"
+check "and leaves the other table's declaration alone" \
+	"$(q "SELECT name FROM pgcolumnar.projection_declaration WHERE rel::text = 'od2';")" "od2_p"
+check "so a rebuild still works for the rest of the database" \
+	"$(q 'SELECT pgcolumnar.rebuild_projections();')" "0"
+
+# A database created by the build that shipped without the drop hook already
+# holds orphans, so the rebuild repairs them rather than aborting on them.
+psql_run "INSERT INTO pgcolumnar.projection_declaration
+	VALUES (2147483647::oid::regclass, 'ghost', ARRAY['id'], ARRAY['id']);" >/dev/null 2>&1
+check "an orphan left by an older build is present" \
+	"$(q "SELECT count(*) FROM pgcolumnar.projection_declaration WHERE name = 'ghost';")" "1"
+check "the rebuild does not abort on it" \
+	"$(q 'SELECT pgcolumnar.rebuild_projections();')" "0"
+check "and it removed the orphan" \
+	"$(q "SELECT count(*) FROM pgcolumnar.projection_declaration WHERE name = 'ghost';")" "0"
+psql_run "DROP TABLE IF EXISTS od2;" >/dev/null 2>&1
+
 pgc_summary


### PR DESCRIPTION
Fixes #304. @ChronicallyJD's analysis was correct in every particular, including
the root cause and the fix, and they raised it in review before #299 merged. The
comment landed after the merge. The review was right and my merge was too quick.

**Five-major matrix: ALL VERSIONS PASSED.**

## Reproduced first

```
declarations before drop: 2
declarations after DROP TABLE t: 2      <- orphaned
rebuild_projections(): ERROR:  cache lookup failed for relation 16481
```

## Two changes, because the first alone does not help an affected database

**The cause.** `ColumnarDeleteProjectionDeclarationsForRel(relid)`, called from
the object-access hook on `OAT_DROP`, beside the existing
`ColumnarDeleteOptions(objectId)`. `options` never had this problem because it is
cleaned there; the new catalog needed the same treatment.

**The blast radius.** `rebuild_projections()` now deletes declarations whose
relation no longer exists before resolving anything. This matters because **#299
is already on `main`**, so databases created by the build without the hook
already hold orphans, and the hook fix does nothing for them. The repair has to
happen somewhere the user will actually run, so the function heals the database
it is called on.

That second part is why the fix is not just the one line the issue suggested.

## Why it was worse than a stray row, which the issue got exactly right

`rebuild_projections()` resolves `pd.rel` for **every** declaration, so one
orphan aborted the rebuild for every other table in the database. And the orphan
is `config_dump`-registered, so a dump restores a bare OID pointing at nothing,
which is the state the declaration design existed to avoid.

## Tests

Seven checks added to `test/projections.sh`, now 64: the drop cleans its own
declaration, other tables are untouched, a rebuild still works afterwards, and an
injected orphan is repaired rather than fatal.

The orphan injection is deliberate. Without it the suite would only prove the hook
works on a database that never had the bug, and the users who need the repair are
exactly the ones the hook cannot help.