### PR TITLE
Skip a wall-clock ratio without skipping its suite

### DIFF
--- a/test/lib.sh
+++ b/test/lib.sh
@@ -305,6 +305,31 @@ check() {
 	fi
 }
 
+# A check whose subject is a wall-clock ratio.
+#
+# PGC_SKIP_TIMING exists because a shared runner cannot hold a ratio still, and
+# a gate that reds for reasons unrelated to the change teaches its readers to
+# discount red. Until now it was applied a whole suite at a time, which is too
+# blunt: native_cancel and native_fetch_cache each hold one ratio and several
+# correctness checks, so dropping the suite dropped the correctness with it
+# (#254). native_fetch_cache was not dropped at all, and flaked CI instead:
+#
+#     FAIL  fetching from one big group is not far dearer than from ten small
+#           ones: got [no (one=397ms ten=91ms)]
+#
+# So the ratio is skipped and the rest of the suite runs. A skip is announced
+# rather than silent, and it is not counted as a pass, because a count that
+# includes checks nobody ran is the thing this project keeps having to unlearn.
+check_timing() {
+	local name="$1" got="$2" want="$3"
+
+	if [ "${PGC_SKIP_TIMING:-0}" = 1 ]; then
+		echo "SKIP  $name (PGC_SKIP_TIMING: wall-clock ratio)"
+		return 0
+	fi
+	check "$name" "$got" "$want"
+}
+
 # Is this query's plan the columnar custom scan?
 #
 # For a check that reads a counter out of EXPLAIN and asserts on it. Those

--- a/test/native_cancel.sh
+++ b/test/native_cancel.sh
@@ -65,7 +65,7 @@ check "the short timeout is what fired" \
 
 # Without interrupt checks in the load path the timeout cannot fire until the
 # load finishes, so cancel and full converge. With them it fires during the load.
-check "cancel arrives well before the load completes" \
+check_timing "cancel arrives well before the load completes" \
 	"$( [ "$cancel" -lt $(( full / 2 )) ] && echo yes || echo "no (cancel=${cancel}ms full=${full}ms)")" \
 	"yes"
 

--- a/test/native_fetch_cache.sh
+++ b/test/native_fetch_cache.sh
@@ -69,7 +69,7 @@ echo "-- $UPD fetches: one group of $ROWS took ${one} ms; ten groups took ${many
 
 # Without the cache the single-group case decodes ten times as much per fetch and
 # lands near 10x. With it, both are dominated by the fetches and sit near 1x.
-check "fetching from one big group is not far dearer than from ten small ones" \
+check_timing "fetching from one big group is not far dearer than from ten small ones" \
 	"$( [ "$many" -gt 0 ] && [ $(( one / (many > 0 ? many : 1) )) -lt 3 ] && echo yes ||
 		echo "no (one=${one}ms ten=${many}ms)")" \
 	"yes"


### PR DESCRIPTION
Fixes a CI flake that failed #306 for reasons unrelated to it, and lays the
groundwork for #254 without closing it.

**Five-major matrix: ALL VERSIONS PASSED.**

## The flake

`native_fetch_cache` holds one wall-clock ratio and three correctness checks, and
is **not** in `is_timing_suite`, so CI runs the ratio on a shared runner:

```
FAIL  fetching from one big group is not far dearer than from ten small ones:
      got [no (one=397ms ten=91ms)]
```

The threshold is 3x and it measured 4.4x. Nothing to do with the change under
test.

## Why not just add it to the timing list

Because that is what #254 objects to. `PGC_SKIP_TIMING` drops whole suites, and
both `native_fetch_cache` and `native_cancel` mix a ratio with correctness
checks, so dropping the suite drops the correctness with it.

`check_timing` skips **one assertion**, not one suite. The skip is announced and
is not counted as a pass:

```
PASS  the short timeout is what fired
SKIP  cancel arrives well before the load completes (PGC_SKIP_TIMING: wall-clock ratio)
```

## I am not closing #254, and the reason matters

Its premise does not survive testing. I removed **all four**
`CHECK_FOR_INTERRUPTS` from `columnar_reader.c`, the decode path
`native_cancel` exercises, and both of its assertions still passed:

```
-- full load 198 ms; cancel fired after 65 ms
PASS  the short timeout is what fired
PASS  cancel arrives well before the load completes
```

So running its correctness half in CI would add a check that passes whether or
not the property holds. That is the same shape as the three cache assertions that
passed against a cache with no callers.

The suite has to be able to fail before where it runs matters. Full evidence,
including the run where I proved the wrong thing first by assuming the timed
"load" was the insert when it is actually a `SELECT`, is on #254.

`native_cancel` uses `check_timing` and stays out of CI, so moving it is one line
once it detects something.