### PR TITLE
Record what the bloom read actually cost, from profiling (#310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,9 +45,18 @@ unreleased. For the forward-looking plan see
   group the zone map skips needs none of them. The reader loaded them for every
   candidate group, and the cost scaled with the column count and the group size,
   because a filter holds one bitmap per column sized by the group's distinct
-  values. Measured on 20 groups of 200,000 rows over 12 columns: 466 buffers per
-  skipped group out of 504, with the whole query falling from 9577 buffers to
-  1946. Results do not change; the filter was always a pruning step.
+  values.
+
+  The scale of that is easy to understand: on a 100 million row TSBS-cpu table a
+  single filter is 256 kB, and the whole bloom catalog is 3.5 GB, larger than the
+  data it describes. A selective scan copied it per query through 256 kB
+  allocations, and profiling put about 55 percent of the query's CPU in
+  anonymous-page faults under the group-skip check.
+
+  On that table a clustered hostname query falls from 4610 ms to 106 ms, a factor
+  of 43. On a smaller shape, 20 groups of 200,000 rows over 12 columns, the cost
+  is 466 buffers per skipped group out of 504, and the query falls from 9577
+  buffers to 1946. Results do not change; the filter was always a pruning step.
 
 ### Added
 


### PR DESCRIPTION
Rewritten. This PR originally carried the lazy per-column bloom read; that code
is now in main via #315 and #317, which landed first and are the same change.
What is left here is the part of this PR that main does not have: the evidence.

The previous head is preserved in the PR timeline (`aeebe4f`).

## Why the code was dropped

The two implementations were the same. Same exact `bloom_pkey` probe on
`(storage_id, group_number, column_index)`, same guard
(`BTEqualStrategyNumber && columnar_enable_bloom_filter && pred->hasHash`), same
placement inside the predicate loop after the zone map fails to exclude the
group. Diffing the two lookup functions with comments stripped left line-wrapping
and one `(int16)` cast.

Keeping both would have added a second public API doing one job
(`ColumnarReadBloom` beside `ColumnarReadBloomForColumn`), and main additionally
memoizes per group, so a column with no filter is looked up once per group rather
than once per predicate.

## What is left, and why it is worth merging

The merged commits measured this on a 20-group synthetic shape in buffer counts.
That understates the effect and never names its cause. This adds the profiled
figures from the 100M TSBS-cpu run:

- one bloom filter is **256 kB**, and the whole catalog is **3.5 GB**, larger
  than the data it describes;
- a selective scan copied it per query through 256 kB allocations, with about
  **55 percent of the query's CPU in anonymous-page faults** under the group-skip
  check;
- the clustered hostname query falls from **4610 ms to 106 ms, a factor of 43**,
  against the 30.6x that synthetic data showed.

That is the real mechanism and the real number. Losing it because the code landed
by another route would have been the wrong outcome.

## Provenance

Measurement, profiling and the original implementation are ChronicallyJD's, and
the commit carries a `Co-authored-by` trailer. The duplication was mine: #313 was
open at 02:09 and I opened #315 at about 02:33 without re-checking the PR list.

Docs-only. `test/docs_style.sh` passes. No matrix run, because no code changes.