### PR TITLE
Read a bloom filter for the columns a query filters on (#314)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ unreleased. For the forward-looking plan see
 
 ### Changed
 
+- A row group's bloom filter is read for the columns a query filters on, not for
+  every column (#314). A predicate probes one column, so a group that is
+  examined needs the filters of the columns carrying predicates and no others.
+  `bloom_pkey` is `(storage_id, group_number, column_index)`, so naming the
+  column makes the fetch an exact index lookup rather than a range scan whose
+  unwanted rows are discarded. Measured on one group of 200,000 rows over 12
+  columns with one equality predicate: 715 buffers to 323, against a floor of
+  251 with the bloom read deleted outright. With #310 the same probe query falls
+  from 9577 buffers to 1547.
+
 - A row group's bloom filters are read only when a predicate reaches them, not
   before every skip decision (#310). A bloom filter is consulted only for an
   equality predicate whose zone map did not already rule the group out, so a

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -449,6 +449,10 @@ extern List *ColumnarReadZoneMapVectors(uint64 storageId, uint64 groupNumber,
 										Snapshot snapshot);
 extern List *ColumnarReadBloomList(uint64 storageId, uint64 groupNumber,
 								   Snapshot snapshot);
+extern NativeBloomMetadata *ColumnarReadBloomForColumn(uint64 storageId,
+													   uint64 groupNumber,
+													   int columnIndex,
+													   Snapshot snapshot);
 extern void ColumnarDeleteMetadata(uint64 storageId);
 
 /* per-table options catalog (spec 7.4) */

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -1851,6 +1851,65 @@ ColumnarReadBloomList(uint64 storageId, uint64 groupNumber, Snapshot snapshot)
 }
 
 /*
+ * ColumnarReadBloomForColumn
+ *		One column's bloom filter for one row group, or NULL when it has none
+ *		(issue #314).
+ *
+ *		bloom_pkey is (storage_id, group_number, column_index), so naming all
+ *		three makes this an exact index lookup rather than a range scan whose
+ *		unwanted rows are discarded by the caller. That matters because a bloom
+ *		filter is one of the larger things in this catalog: it is sized by the
+ *		group's distinct values, so reading a whole group's worth to probe one
+ *		column reads most of what it fetches for nothing.
+ */
+NativeBloomMetadata *
+ColumnarReadBloomForColumn(uint64 storageId, uint64 groupNumber,
+						   int columnIndex, Snapshot snapshot)
+{
+	Relation	rel = open_columnar_table("bloom", AccessShareLock);
+	TupleDesc	tupdesc = RelationGetDescr(rel);
+	ScanKeyData key[3];
+	SysScanDesc scan;
+	Oid			idxOid;
+	HeapTuple	tuple;
+	NativeBloomMetadata *b = NULL;
+
+	ScanKeyInit(&key[0], Anum_bloom_storage_id, BTEqualStrategyNumber,
+				F_INT8EQ, Int64GetDatum((int64) storageId));
+	ScanKeyInit(&key[1], Anum_bloom_group_number, BTEqualStrategyNumber,
+				F_INT8EQ, Int64GetDatum((int64) groupNumber));
+	ScanKeyInit(&key[2], Anum_bloom_column_index, BTEqualStrategyNumber,
+				F_INT2EQ, Int16GetDatum((int16) columnIndex));
+	idxOid = columnar_index_oid("bloom_pkey");
+	scan = systable_beginscan(rel, idxOid, OidIsValid(idxOid), snapshot,
+							  3, key);
+	tuple = systable_getnext(scan);
+	if (HeapTupleIsValid(tuple))
+	{
+		bool		isnull;
+		Datum		d;
+
+		b = palloc0(sizeof(NativeBloomMetadata));
+		b->storageId = storageId;
+		b->groupNumber = groupNumber;
+		b->columnIndex = (int16) columnIndex;
+		d = heap_getattr(tuple, Anum_bloom_filter, tupdesc, &isnull);
+		if (!isnull)
+		{
+			bytea	   *bf = DatumGetByteaPP(d);
+
+			b->filterLen = VARSIZE_ANY_EXHDR(bf);
+			b->filter = (const char *) memcpy(palloc(b->filterLen + 1),
+											  VARDATA_ANY(bf), b->filterLen);
+		}
+	}
+	systable_endscan(scan);
+	table_close(rel, AccessShareLock);
+
+	return b;
+}
+
+/*
  * ColumnarReadZoneMapVectors
  *		The per-vector zone maps (vector_index >= 0) of one row group, for
  *		per-vector skipping (native spec 7.1, Phase D5b). Only min/max and the

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -697,9 +697,9 @@ static bool
 columnar_native_group_can_match(ColumnarReadState *rs, uint64 groupNumber)
 {
 	List	   *zones;
-	List	   *blooms = NIL;
 	NativeZoneMapMetadata **byCol;
 	NativeBloomMetadata **byColBloom = NULL;
+	bool	   *bloomLookedUp = NULL;
 	ListCell   *lc;
 	int			p;
 
@@ -735,32 +735,36 @@ columnar_native_group_can_match(ColumnarReadState *rs, uint64 groupNumber)
 			NativeBloomMetadata *b;
 
 			/*
-			 * Load this group's bloom filters on first use, not up front. A
-			 * bloom filter is only consulted for an equality predicate whose
-			 * zone map did not already rule the group out, so a group that the
-			 * zone map skips needs none of them. Reading them eagerly charged
-			 * every candidate group for filters that the great majority of them
-			 * never reach (#310).
+			 * Fetch this column's bloom filter on first use: not up front, and
+			 * not the whole group's.
 			 *
-			 * The cost this avoids is not small. A bloom filter holds one
-			 * bitmap per column, sized by the group's distinct values, so the
-			 * eager read scaled with both the column count and the group size.
-			 * Measured on 20 groups of 200,000 rows over 12 columns, it was 466
-			 * buffers per skipped group out of 504, and the whole query fell
-			 * from 9577 buffers to 1946.
+			 * A bloom filter is only consulted for an equality predicate whose
+			 * zone map did not already rule the group out, so a group that the
+			 * zone map skips needs none of them (#310). And a predicate probes
+			 * one column, so a group that is examined needs the filters of the
+			 * columns carrying predicates and no others (#314).
+			 *
+			 * Neither saving is small. A filter holds one bitmap per column
+			 * sized by the group's distinct values, so it is among the larger
+			 * things in the catalog. Reading a whole group's worth cost 466
+			 * buffers per skipped group out of 504 on 20 groups of 200,000 rows
+			 * over 12 columns, and 464 of 715 buffers on a single group scanned
+			 * whole with one predicate.
+			 *
+			 * bloomLookedUp records the fetch, not the result, so a column with
+			 * no filter is looked up once rather than on every predicate.
 			 */
 			if (byColBloom == NULL)
 			{
-				blooms = ColumnarReadBloomList(rs->storageId, groupNumber,
-											   rs->metaSnapshot);
 				byColBloom = palloc0(sizeof(NativeBloomMetadata *) * rs->natts);
-				foreach(lc, blooms)
-				{
-					NativeBloomMetadata *nb = (NativeBloomMetadata *) lfirst(lc);
-
-					if (nb->columnIndex >= 0 && nb->columnIndex < rs->natts)
-						byColBloom[nb->columnIndex] = nb;
-				}
+				bloomLookedUp = palloc0(sizeof(bool) * rs->natts);
+			}
+			if (!bloomLookedUp[pred->attidx])
+			{
+				byColBloom[pred->attidx] =
+					ColumnarReadBloomForColumn(rs->storageId, groupNumber,
+											   pred->attidx, rs->metaSnapshot);
+				bloomLookedUp[pred->attidx] = true;
 			}
 			b = byColBloom[pred->attidx];
 

--- a/test/bloom_lazy.sh
+++ b/test/bloom_lazy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# pgColumnar lazy bloom read (#310): a bloom filter is only consulted for an
+# pgColumnar bloom filter reads (#310, #314): a bloom filter is only consulted for an
 # equality predicate whose zone map did not already rule the group out. The
 # reader used to load every candidate group's bloom filters before evaluating
 # any predicate, so a scan that skipped 19 of 20 groups still paid for the bloom
@@ -15,6 +15,11 @@
 # changed: how much of that catalog the scan touches. The governing property is
 # that bloom reads follow the groups the scan KEEPS, not the groups it examines.
 #
+# The second half covers #314, the same principle across the other axis: a
+# predicate probes one column, so a group that IS examined needs the filters of
+# the columns carrying predicates and no others. The reader used to fetch every
+# column's filter for the group.
+#
 # Usage:  test/bloom_lazy.sh [PG_CONFIG]
 # Written fresh for pgColumnar.
 
@@ -26,7 +31,10 @@ pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
 # monotonic with insertion order, so a zone map alone can exclude every group
 # except the one that holds the value.
 COLS="a int, b int, c int, d int, e int, f int, g1 int, h int, i int, j int, k int"
-VALS="g,g,g,g,g,g,g,g,g,g,g"
+# k repeats every 1000 rows, so every group holds every k value and no zone map
+# can exclude a group on it. That is what lets a single equality predicate keep
+# all the groups, which the control below needs. The rest are unique.
+VALS="g,g,g,g,g,g,g,g,g,g,g % 1000"
 
 build() {			# build(table, rows_per_group, group_count)
 	local t="$1" s="$2" n="$3"
@@ -87,7 +95,15 @@ check "bloom reads do not follow the skipped groups" \
 # A scan that keeps every group still reads bloom filters, so the lazy path is
 # deferring the read and not suppressing it. Without this, a change that simply
 # stopped reading bloom filters would pass the assertion above.
-ALL="SELECT count(*) FROM large WHERE seg >= 0 AND k = 7"
+#
+# One equality predicate in both cases, so the only thing that differs is how
+# many groups survive to reach it: k = 7 is present in every group, seg = 3 in
+# one. An earlier version of this control used a column whose values were unique
+# across the table, so its zone map excluded every group but one and it was
+# measuring the column count instead of the group count.
+ALL="SELECT count(*) FROM large WHERE k = 7"
+check "the control query really does keep every group" \
+	"$(groups_read "$ALL")" "$(groups_total "$ALL")"
 check "a scan that keeps every group reads more" \
 	"$( [ "$(bloom_blocks "$ALL")" -gt "$LARGE_BLK" ] && echo yes || echo no )" "yes"
 
@@ -123,5 +139,47 @@ check "results agree with bloom filters disabled" \
 check "an absent value agrees with bloom filters disabled" \
 	"$(nobloom 'SELECT count(*) FROM large WHERE k = -999;')" \
 	"$(q 'SELECT count(*) FROM h_mirror WHERE k = -999;')"
+
+# ---------------------------------------------------- reads follow the columns
+
+# #314. Twelve columns whose values repeat identically in every group, so no
+# zone map can exclude anything: every group is kept and every equality
+# predicate reaches its bloom filter. The only thing that varies between the two
+# queries is how many columns carry a predicate.
+psql_run "CREATE TABLE wide (p0 int, p1 int, p2 int, p3 int, p4 int, p5 int,
+						   q0 int, q1 int, q2 int, q3 int, q4 int, q5 int) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.set_options('wide', stripe_row_limit => 20000, chunk_group_row_limit => 1024);"
+psql_run "INSERT INTO wide SELECT g % 500, g % 500, g % 500, g % 500, g % 500, g % 500,
+							   g % 500, g % 500, g % 500, g % 500, g % 500, g % 500
+					   FROM generate_series(1, 400000) g;"
+psql_run "ANALYZE wide;"
+
+ONE_PRED="SELECT count(*) FROM wide WHERE p0 = 1"
+SIX_PRED="SELECT count(*) FROM wide WHERE p0 = 1 AND p1 = 1 AND p2 = 1 AND p3 = 1 AND p4 = 1 AND p5 = 1"
+
+check "no group is excluded, so every predicate is reached" \
+	"$(groups_read "$ONE_PRED")" "$(groups_total "$ONE_PRED")"
+
+ONE_BLK="$(bloom_blocks "$ONE_PRED")"
+SIX_BLK="$(bloom_blocks "$SIX_PRED")"
+
+echo "      bloom blocks fetched: 1 predicate -> $ONE_BLK, 6 predicates -> $SIX_BLK"
+
+# The property. Six columns' filters cost more to read than one column's. When
+# the reader fetched the whole group's filters these two were identical, because
+# the work did not depend on the query at all.
+check "bloom reads follow the columns a query filters on" \
+	"$( [ "$SIX_BLK" -gt "$ONE_BLK" ] && echo yes || echo no )" "yes"
+
+# The one-predicate query must not be paying for all twelve columns. Six
+# predicates is half the columns, so reading all twelve would put the single
+# predicate at or above the six-predicate cost rather than well below it.
+check "one predicate costs well less than six" \
+	"$( [ $((ONE_BLK * 2)) -lt "$SIX_BLK" ] && echo yes || echo no )" "yes"
+
+check "the filtered answers agree with a heap mirror" \
+	"$(q "$ONE_PRED;")" "800"
+check "six predicates give the same answer as one here" \
+	"$(q "$SIX_PRED;")" "800"
 
 pgc_summary


### PR DESCRIPTION
Closes #314. Follows #315, and the two compound.

A predicate probes one column, so a group that is examined needs the filters of
the columns carrying predicates and no others. The reader fetched the whole
group's filters and used at most one per predicate, so a single equality
predicate on a twelve column table read twelve bloom bitmaps and probed one.

## Why it is worth removing

A bloom filter holds one bitmap per column sized by the group's distinct values,
which makes it among the larger things in the metadata catalog.

`bloom_pkey` is `(storage_id, group_number, column_index)`, so naming the column
makes the fetch an exact index lookup rather than a range scan whose unwanted
rows the caller discards. All three key columns are equality, so this is a probe,
not a narrowed range.

## Measured

One group of 200,000 rows, twelve int columns, scanned whole with one equality
predicate:

| | buffers |
| --- | --- |
| before | 715 |
| after | 323 |
| bloom read deleted outright | 251 |

The 251 is a floor and not a target: the probed column's filter has to be read.

Compounding with #315, on the 20-group probe from that PR:

| | buffers |
| --- | --- |
| before #315 | 9577 |
| after #315 | 1946 |
| after this | 1547 |

Per-skipped-group cost is unchanged at about 64, as expected. #315 already
removed the bloom read for skipped groups; this is about the groups that are
kept.

## Test

`test/bloom_lazy.sh` gains four checks, taking it to 20.

The property: six columns' filters cost more to read than one column's. With the
whole-group read those two queries were identical, because the work did not
depend on the query at all. Measured 20 blocks against 120. Block reads are
counted against `pgcolumnar.bloom` with `pg_stat_get_blocks_fetched`, so what is
asserted is the thing that changed.

## A correction to the suite this PR builds on

The existing #310 control, "a scan that keeps every group reads more", was
passing for the wrong reason. It used a column whose values are unique across the
table, so its zone map excluded every group but one: it claimed to vary the group
count and actually varied the column count. It went red under the #310 removal
proof, which is why it looked sound.

One column now repeats every 1000 rows, so a single equality predicate keeps
every group, and a new check asserts that the control query really does keep them
all before the property that depends on it is tested.

Worth stating plainly, because it is a limit of the removal-proof discipline
rather than a slip: a removal proof shows a check can go red, not that it goes
red for the stated reason. A fixture that is silently degenerate still responds
to the guard being removed, by a path nobody intended. Fixtures with a
precondition should assert the precondition as its own check.

## Proved by removal, both ways

| restored | result |
| --- | --- |
| the all-column read | 1 and 6 predicates both cost 21 blocks; the two #314 checks red |
| the eager whole-group read | all four checks red |

The two guards fire independently, so the suite covers both properties rather
than one standing in for the other.

## Gates

Five-major matrix (15, 16, 17, 18.4, 19beta2).
