### PR TITLE
Probe for the C23 spelling instead of hardcoding gnu23 (#294)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,11 +128,20 @@ jobs:
         run: |
           set -euo pipefail
           sudo apt-get update
-          # gcc-14 explicitly. PostgreSQL 19's configure selects -std=gnu23, and
-          # the runner image's default gcc predates that spelling (it accepts
-          # gnu2x), so PostgreSQL builds and then the extension build inherits a
-          # flag its own compiler rejects. Pinning one compiler for both removes
-          # the mismatch rather than papering over the flag.
+          # gcc-14 explicitly, so one compiler configures PostgreSQL and builds
+          # the extension.
+          #
+          # PGXS hands the extension the CFLAGS the server was configured with,
+          # and PostgreSQL's configure adapts those to its compiler. Configuring
+          # with a newer GCC and building with an older one therefore feeds the
+          # older compiler warning flags it does not have: gcc-15 adds
+          # -Wmissing-variable-declarations, which gcc-13 rejects outright.
+          # Pinning one compiler for both removes the mismatch.
+          #
+          # This is NOT where -std=gnu23 came from. That flag is set by this
+          # project's own Makefile for PostgreSQL 19, whose headers use C23
+          # constructs, and the Makefile now probes for the spelling the
+          # compiler accepts. See #294.
           sudo apt-get install -y --no-install-recommends \
             build-essential gcc-14 flex bison libreadline-dev zlib1g-dev \
             liblz4-dev libzstd-dev pkg-config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ unreleased. For the forward-looking plan see
 
 ### Changed
 
+- The C standard flag for PostgreSQL 19 is probed rather than hardcoded (#294).
+  This project sets `-std=gnu23` for PostgreSQL 19, whose headers use C23
+  constructs. GCC 13 accepts only the older `gnu2x` spelling of the same
+  language and rejects `gnu23` outright, so building against PostgreSQL 19 with
+  GCC 13 failed on a flag the user never set. The Makefile now asks the compiler
+  which spelling it takes. Every source file compiles under GCC 13 with `gnu2x`
+  against PostgreSQL 19 headers.
+
 - `pgcolumnar.recluster` records its ordered extent, so `pgcolumnar.sort_status`
   no longer reports a reclustered table as entirely unsorted (#311). It runs
   under a lock that permits concurrent inserts, and the mark is a boundary, so

--- a/Makefile
+++ b/Makefile
@@ -70,18 +70,44 @@ endif
 
 PG_CONFIG ?= pg_config
 
+# Build note for source-built servers: PGXS hands this extension the CFLAGS the
+# server was configured with, and PostgreSQL's configure adapts those to its own
+# compiler. Build the extension with the compiler that configured the server, or
+# it can be handed warning flags it does not recognise. That is a toolchain
+# mismatch and not something this Makefile can paper over.
+#
 # Select the C standard by PostgreSQL major version. PostgreSQL 13 through 18
 # are written to compile as C17 (their headers predate C23), so pin gnu17 there
 # for a deterministic build regardless of the compiler's default. PostgreSQL 19
 # uses C23 constructs in its headers (for example typeof_unqual in nodes.h), so
-# it needs gnu23. The value is appended to CFLAGS through PG_CFLAGS, which PGXS
-# honors.
+# it needs C23.
 PG_MAJORVERSION := $(shell $(PG_CONFIG) --version | sed -E 's/^[^0-9]*([0-9]+).*/\1/')
+
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+
+# The compiler PGXS will use, for the probe below. CC has to be settled before
+# the include, because PG_CFLAGS is only honored if it is set before it, so the
+# value is read out of the server's Makefile.global unless the caller named one
+# on the command line. Probing with make's default cc instead would test a
+# compiler that may not be the one that does the build.
+PG_MAKEFILE_GLOBAL := $(patsubst %/makefiles/pgxs.mk,%/Makefile.global,$(PGXS))
+PROBE_CC := $(if $(filter command line,$(origin CC)),$(CC),\
+	$(shell sed -n 's/^CC = //p' $(PG_MAKEFILE_GLOBAL) 2>/dev/null | head -1))
+PROBE_CC := $(if $(strip $(PROBE_CC)),$(PROBE_CC),cc)
+
 ifeq ($(shell test "$(PG_MAJORVERSION)" -ge 19 && echo yes),yes)
-PG_CFLAGS += -std=gnu23
+# GCC 14 and later spell C23 "gnu23"; GCC 13 accepts only "gnu2x" and rejects
+# the newer spelling outright. Both name the same language, and GCC 13 compiles
+# PostgreSQL 19's C23 headers under gnu2x, so ask the compiler which spelling it
+# takes rather than hardcode one (#294). Hardcoding gnu23 failed on GCC 13 with
+# an error naming a flag the user never set, which reads as a defect in this
+# project rather than a toolchain difference.
+C23_STD := $(shell echo 'int main(void){return 0;}' \
+	| $(PROBE_CC) -std=gnu23 -x c -c -o /dev/null - >/dev/null 2>&1 \
+	&& echo gnu23 || echo gnu2x)
+PG_CFLAGS += -std=$(C23_STD)
 else
 PG_CFLAGS += -std=gnu17
 endif
 
-PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -40,6 +40,30 @@ make install PG_CONFIG=/path/to/pg_config
 `make install` copies `pgcolumnar.so`, the control file, and the SQL script. It
 puts them in the library directory and the extension directory of the server.
 
+### Servers built from source
+
+Build the extension with the compiler that configured the server.
+
+PGXS gives the extension the compiler flags the server was configured with, and
+PostgreSQL's `configure` adapts those flags to its compiler. A server configured
+with a newer GCC therefore records flags an older GCC does not accept. GCC 15
+records `-Wmissing-variable-declarations`, which GCC 13 rejects. The build then
+stops on a flag you did not set:
+
+```
+gcc-13: error: unrecognized command-line option '-Wmissing-variable-declarations'
+```
+
+Name the compiler explicitly when the server was configured with one that is not
+your default:
+
+```sh
+make CC=gcc-14 PG_CONFIG=/path/to/pg_config
+```
+
+This does not apply to packaged servers. Their flags come from the package
+build, and the distribution compiler accepts them.
+
 ## Load the library
 
 pgColumnar installs planner hooks and executor hooks when the server loads the


### PR DESCRIPTION
Closes #294, and corrects its diagnosis.

## The diagnosis in the issue is wrong

The issue states:

> `-std=gnu23` is not something this project sets. It comes out of PostgreSQL's
> `src/Makefile.global`, which PGXS applies to extension builds.

Neither half holds.

- `gnu23` appears nowhere in the PostgreSQL 19beta2 source tree. Not in
  `configure`, not in `configure.ac`, not in `meson.build`.
- Configuring 19beta2 with GCC 13, 14 or 15 puts **no** `-std` flag in
  `Makefile.global` at all. Checked all three.
- The flag is set by this project, in its own `Makefile`, for PostgreSQL 19,
  because 19's headers use C23 constructs such as `typeof_unqual`.

So the question the issue leaves open, how a `Makefile.global` carrying `gnu23`
came to be paired with a compiler that rejects it, has no answer because no
`Makefile.global` ever carried it.

## The real bug, which is still live

Hardcoding `gnu23` breaks the build for anyone using GCC 13, against their own
correctly configured PostgreSQL 19. GCC 13 accepts only `gnu2x`, the older
spelling of the same language, and rejects `gnu23` outright. The error names a
flag the user never set, which reads as a defect in this project.

| compiler | default `__STDC_VERSION__` | accepts `-std=gnu23` |
| --- | --- | --- |
| GCC 13 | 201710L | no |
| GCC 14 | 201710L | yes |
| GCC 15 | 202311L | yes |

The Makefile now asks the compiler which spelling it takes. The probe runs
against the compiler PGXS will actually use: `CC` is read from the server's
`Makefile.global` unless the caller names one on the command line, because
`PG_CFLAGS` is only honored when set before the PGXS include, and make's default
`cc` may not be the compiler that does the build.

Verified against PostgreSQL 19 headers, using the CFLAGS a GCC 13 `configure`
produces: **all 22 source files compile under GCC 13 with `gnu2x`**. GCC 15 still
selects `gnu23`. PostgreSQL 17 still selects `gnu17` under both.

## The mechanism the issue described is real, for a different flag

PostgreSQL's `configure` adapts its warning flags to its compiler, and PGXS
passes them to the extension. A server configured with GCC 15 records
`-Wmissing-variable-declarations`, which GCC 13 rejects. That is the **only**
CFLAGS difference between a GCC 13 and a GCC 15 configure of 19beta2, measured by
diffing the two.

That is the genuine reason CI must use one compiler for both steps, so the pin
stays. The `ci.yml` comment claiming configure selects `gnu23` is corrected to
say what actually requires the pin.

`docs/installation.md` gains a short section telling source builders to build
with the compiler that configured their server, with the error they will see if
they do not. It does not apply to packaged servers.

## Gates

Five-major matrix (15, 16, 17, 18.4, 19beta2). `test/docs_style.sh` passes.

No test suite is added. The change is a build-system flag selection, and the
thing that exercises it is the build itself: the per-PR CI matrix compiles
against every packaged major on two architectures, plus 19 from source.
