### PR TITLE
Parallel bulk ingest into a single columnar table (#300)

### DIFF
--- a/design/PARALLEL_COPY_PLAN.md
+++ b/design/PARALLEL_COPY_PLAN.md
@@ -84,12 +84,15 @@ today's engine. Real parallelism requires each worker to write **distinct storag
   **640.6 s** vs `parallel_copy(16)` **118.6 s** = **5.40×**; both 100,000,000 rows
   with identical `sum(usage_user)`, 0 prepared-xacts leaked. The whole file loads
   atomically and in parallel with byte-identical results.
-- **enhancement — columnar-core bulk.** A bulk-load path in the engine that lets
-  concurrent writers share **one** table without holding the per-storage lock for
-  the whole transaction (e.g. coordinator pre-creates+commits the storage row;
-  writers skip the creation lock when the row already exists committed). Lifts the
-  single-table restriction. Deferred behind v1 because it changes correctness-
-  sensitive core code.
+- **enhancement — columnar-core bulk (built).** A bulk-load path in the engine that
+  lets concurrent writers share **one** table without holding the per-storage lock
+  for the whole transaction: the coordinator pre-creates+commits the storage row,
+  and writers skip the creation lock (default-off `pgcolumnar.bulk_parallel_writer`,
+  set only by loaders) when the row already exists committed. Lifts the single-table
+  restriction. The change to the core write path is gated so ordinary writes are
+  unchanged. **Measured (bench, 20M slice): single COPY ~132.8 s vs
+  `parallel_copy(8)` into one table ~22.0 s = ~6.0×** (vs the 2.01× serialized
+  baseline), byte-identical, 0 leaks.
 
 Together these cover both partitioned targets (v1) and arbitrary single tables
 (enhancement). The rest of this document is being revised to the partition-parallel

--- a/design/PARALLEL_COPY_PLAN.md
+++ b/design/PARALLEL_COPY_PLAN.md
@@ -90,13 +90,23 @@ today's engine. Real parallelism requires each worker to write **distinct storag
   and writers skip the creation lock (default-off `pgcolumnar.bulk_parallel_writer`,
   set only by loaders) when the row already exists committed. Lifts the single-table
   restriction. The change to the core write path is gated so ordinary writes are
-  unchanged. **Measured (bench, 20M slice): single COPY ~132.8 s vs
-  `parallel_copy(8)` into one table ~22.0 s = ~6.0×** (vs the 2.01× serialized
-  baseline), byte-identical, 0 leaks.
+  unchanged. **Measured (bench pg18n, 20M slice, warm/interleaved): single COPY
+  ~132.8 s vs `parallel_copy(8)` into one table ~22.0 s = ~6.0×** (vs the 2.01×
+  serialized baseline). Scaling N=1/2/4/8 = 133/69/37/21 s: 1.93× / 3.59× / 6.33×
+  — sub-linear at N=8 (≈79% of ideal), not "near-linear", but real. The bench signal
+  was a row count plus a `sum(usage_user)` — a float sum is order-dependent, so
+  matching it across a reordered parallel load is a decent signal, not proof. The
+  suite proves the result set is **byte-identical** via `pgc_set_hash`, and a
+  structural witness
+  (>N distinct stripes, no stripe byte-range overlap, complete row coverage) shows
+  the writers genuinely interleaved on the one storage without collision. 0 leaks.
 
 Together these cover both partitioned targets (v1) and arbitrary single tables
-(enhancement). The rest of this document is being revised to the partition-parallel
-design; the "atomic into one table" mechanism below is **retired** by this finding.
+(enhancement). The single-table case is now built via the columnar-core-bulk path
+above (default-off GUC); the **abandoned** approach retired below is the *original*
+"atomic into one table" design that held the per-storage lock across the whole
+transaction and deadlocked under 2PC — not single-table loading itself, which
+succeeds by skipping that lock once the storage row is committed.
 
 ## API
 

--- a/pgcolumnar--1.0-dev.sql
+++ b/pgcolumnar--1.0-dev.sql
@@ -914,10 +914,12 @@ COMMENT ON FUNCTION pgcolumnar.file_split_offsets(text, int)
 -- serialize on the per-storage write lock and, under two-phase commit, deadlock
 -- (single-table parallel load is a planned columnar-core enhancement). Loaders
 -- PREPARE; a coordinator background worker COMMIT PREPAREDs them all, or ROLLBACK
--- PREPAREDs on any failure. Returns rows loaded. Requirements: RANGE-partitioned
--- target (single-column numeric/date-time key, no DEFAULT partition), the file
--- sorted ascending by that key, COPY text format, and max_prepared_transactions >=
--- workers. workers => NULL derives a default from max_parallel_workers.
+-- PREPAREDs on any failure. Returns rows loaded. The target is either a single
+-- columnar table (workers write its one storage concurrently) or a RANGE-partitioned
+-- table (each worker loads a distinct partition; requires a single-column
+-- numeric/date-time key, no DEFAULT partition, and the file sorted ascending by that
+-- key). COPY text format, and max_prepared_transactions >= workers. workers => NULL
+-- derives a default from max_parallel_workers.
 --
 -- Two behaviors to know: (1) the load commits in background workers, INDEPENDENTLY
 -- of the calling transaction, so its rows survive a subsequent ROLLBACK of the

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -177,6 +177,7 @@ extern bool columnar_enable_group_vectorization;	/* GROUP BY vectorized agg (#28
 extern int columnar_groupagg_max_groups;	/* plan-time group-count cap (#289) */
 extern bool columnar_enable_read_stream;	/* stream/prefetch block reads (PG17+) */
 extern bool columnar_enable_index_only_scan;	/* allow index-only scans (gap 28) */
+extern bool columnar_bulk_parallel_writer;	/* internal: parallel_copy loader skips the storage-row creation lock (#300) */
 extern bool columnar_enable_projection_scan;	/* scan a covering projection (gap 26) */
 
 /* issue #5: concurrent unique-key insert serialization */
@@ -320,6 +321,7 @@ extern void ColumnarWriteNewMetapage(const RelFileLocator *newrlocator,
 									 char persistence, uint64 storageId);
 extern void ColumnarReadMetapage(Relation rel, ColumnarMetapage *meta);
 extern uint64 ColumnarStorageId(Relation rel);
+extern void ColumnarEnsureStorageRow(Relation rel);	/* pre-create storage row (#300 parallel_copy) */
 extern void ColumnarReserveRowNumbers(Relation rel, uint64 rowCount,
 									  uint64 *stripeId, uint64 *firstRowNumber);
 extern void ColumnarReserveOffset(Relation rel, uint64 dataLength,

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -1451,6 +1451,15 @@ ColumnarDeleteMetadata(uint64 storageId)
 }
 
 /*
+ * Opt-in, default off. Set for its own session by a pgcolumnar.parallel_copy
+ * loader (backing the pgcolumnar.bulk_parallel_writer GUC, registered in
+ * _PG_init) so ColumnarInsertNativeStorageRow can skip the storage-row creation
+ * advisory lock when the row already exists committed. Ordinary writes never set
+ * it, so the default write path is unchanged.
+ */
+bool		columnar_bulk_parallel_writer = false;
+
+/*
  * ColumnarInsertNativeStorageRow, ColumnarInsertRowGroupRow,
  * ColumnarInsertColumnChunkRow
  *		Record the native-format catalog rows (PGCN v1, native spec 11). Called
@@ -1483,6 +1492,36 @@ ColumnarInsertNativeStorageRow(const NativeStorageMetadata *s)
 	 * skips the insert. The lock is held to transaction end so the winner's row
 	 * is committed and visible before the loser proceeds.
 	 */
+	/*
+	 * Bulk-parallel fast path (opt-in, default off). A pgcolumnar.parallel_copy
+	 * loader sets columnar_bulk_parallel_writer for its own session; when the
+	 * storage row already exists in the latest committed state we skip the advisory
+	 * lock entirely and return. That lock exists ONLY to serialize the first-writer
+	 * creation race -- once the row is committed there is nothing to wait for -- and
+	 * holding it to transaction end is exactly what makes concurrent writers to one
+	 * storage serialize and, under two-phase commit, deadlock. Skipping it (only
+	 * when the row provably exists, and only for an opting-in loader whose
+	 * coordinator pre-created and committed that row) lets N loaders write one
+	 * table's storage concurrently and 2PC-safely. Every ordinary write leaves the
+	 * flag false and takes the unchanged path below.
+	 */
+	if (columnar_bulk_parallel_writer)
+	{
+		PushActiveSnapshot(GetLatestSnapshot());
+		snapshot = ColumnarCatalogSnapshot(GetActiveSnapshot());
+		ScanKeyInit(&key[0], Anum_native_storage_storage_id, BTEqualStrategyNumber,
+					F_INT8EQ, Int64GetDatum((int64) s->storageId));
+		scan = systable_beginscan(rel, InvalidOid, false, snapshot, 1, key);
+		exists = HeapTupleIsValid(systable_getnext(scan));
+		systable_endscan(scan);
+		PopActiveSnapshot();
+		if (exists)
+		{
+			table_close(rel, RowExclusiveLock);
+			return;
+		}
+	}
+
 	SET_LOCKTAG_ADVISORY(tag, MyDatabaseId,
 						 (uint32) (s->storageId >> 32),
 						 (uint32) (s->storageId & 0xFFFFFFFF), 2);

--- a/src/columnar_parallel_copy.c
+++ b/src/columnar_parallel_copy.c
@@ -198,6 +198,26 @@ pcopy_line_offsets(int fd, off_t size, int nranges, const char *path)
 	return offs;
 }
 
+/*
+ * pcopy_naive_offsets
+ *		Line-aligned byte offsets partitioning `path` into `workers` even ranges,
+ *		for the single-table load where every worker writes the one storage and any
+ *		record-aligned split is correct (no partition key, so no ordering
+ *		requirement). Returns a palloc'd int64[workers+1].
+ */
+static int64 *
+pcopy_naive_offsets(const char *path, int workers)
+{
+	int			fd;
+	off_t		size;
+	int64	   *offs;
+
+	fd = pcopy_open_regular_file(path, &size);
+	offs = pcopy_line_offsets(fd, size, workers, path);
+	CloseTransientFile(fd);
+	return offs;
+}
+
 PG_FUNCTION_INFO_V1(columnar_file_split_offsets);
 
 /*
@@ -334,8 +354,11 @@ typedef struct PcopyHeader
 {
 	Oid			dbid;
 	Oid			roleid;
-	Oid			relid;			/* target relation */
+	Oid			relid;			/* target relation (partitioned parent, or a single columnar table) */
 	int			nworkers;
+	bool		single_table;	/* target is one columnar table (not partitioned):
+								 * coordinator pre-creates the storage row and loaders
+								 * set columnar_bulk_parallel_writer */
 	char		filename[MAXPGPATH];
 	/* coordinator -> function result channel */
 	pg_atomic_uint32 coord_state;	/* PcopyCoordState */
@@ -740,6 +763,17 @@ pgcolumnar_parallel_copy_worker(Datum main_arg)
 #endif
 	BackgroundWorkerInitializeConnectionByOid(hdr->dbid, hdr->roleid, conn_flags);
 
+	/*
+	 * Single-table load: this loader writes the one shared storage concurrently
+	 * with its siblings. The coordinator has pre-created and committed the storage
+	 * row, so opt this session into skipping the storage-row creation lock -- the
+	 * only transaction-length serializer on the same-storage write path. For a
+	 * partitioned target each loader owns distinct partitions (distinct storage) and
+	 * never contends, so the flag stays off there.
+	 */
+	if (hdr->single_table)
+		columnar_bulk_parallel_writer = true;
+
 	PG_TRY();
 	{
 		Relation	rel;
@@ -964,6 +998,25 @@ pgcolumnar_parallel_copy_coordinator(Datum main_arg)
 #endif
 	BackgroundWorkerInitializeConnectionByOid(hdr->dbid, hdr->roleid, conn_flags);
 
+	/*
+	 * Single-table load: pre-create and COMMIT the storage catalog row before any
+	 * loader starts, in the coordinator's own top-level session (the SQL function
+	 * cannot commit). With the row committed, each loader -- which sets
+	 * columnar_bulk_parallel_writer -- sees it and skips the storage-row creation
+	 * lock, so N loaders write the one storage concurrently and 2PC-safely. The
+	 * coordinator itself leaves the flag off, so this uses the normal create path.
+	 */
+	if (hdr->single_table)
+	{
+		Relation	rel;
+
+		StartTransactionCommand();
+		rel = table_open(hdr->relid, RowExclusiveLock);
+		ColumnarEnsureStorageRow(rel);
+		table_close(rel, NoLock);
+		CommitTransactionCommand();
+	}
+
 	handles = (BackgroundWorkerHandle **)
 		palloc0(sizeof(BackgroundWorkerHandle *) * nworkers);
 
@@ -1149,6 +1202,7 @@ columnar_parallel_copy(PG_FUNCTION_ARGS)
 	char	   *path;
 	int			workers;
 	int			max_prepared;
+	bool		single_table = false;
 	int64	   *offs;
 	shm_toc_estimator est;
 	Size		segsize;
@@ -1192,20 +1246,7 @@ columnar_parallel_copy(PG_FUNCTION_ARGS)
 	 * aligned byte ranges here (this may lower `workers` to the partition count).
 	 */
 	{
-		Relation	parent = table_open(relid, AccessShareLock);
-
-		if (parent->rd_rel->relkind != RELKIND_PARTITIONED_TABLE)
-		{
-			char		nm[NAMEDATALEN];
-
-			strlcpy(nm, RelationGetRelationName(parent), NAMEDATALEN);
-			table_close(parent, AccessShareLock);
-			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("pgcolumnar.parallel_copy requires a partitioned target, but \"%s\" is not partitioned",
-							nm),
-					 errhint("Partition the target so each worker loads a distinct partition. Parallel load into a single non-partitioned table is a planned enhancement.")));
-		}
+		Relation	target = table_open(relid, AccessShareLock);
 
 		/*
 		 * The loaders run as this role and INSERT into the target, so the caller
@@ -1220,14 +1261,42 @@ columnar_parallel_copy(PG_FUNCTION_ARGS)
 			{
 				char		nm[NAMEDATALEN];
 
-				strlcpy(nm, RelationGetRelationName(parent), NAMEDATALEN);
-				table_close(parent, AccessShareLock);
+				strlcpy(nm, RelationGetRelationName(target), NAMEDATALEN);
+				table_close(target, AccessShareLock);
 				aclcheck_error(aclresult, OBJECT_TABLE, nm);
 			}
 		}
 
-		offs = pcopy_partition_aligned_offsets(parent, path, &workers);
-		table_close(parent, AccessShareLock);
+		if (target->rd_rel->relkind == RELKIND_PARTITIONED_TABLE)
+		{
+			/* each worker loads a DISTINCT partition (distinct storage) */
+			offs = pcopy_partition_aligned_offsets(target, path, &workers);
+			single_table = false;
+		}
+		else if (ColumnarIsColumnarRelation(relid))
+		{
+			/*
+			 * A single columnar table: workers write the ONE storage concurrently
+			 * (distinct stripe/row-number reservations; the coordinator pre-creates
+			 * the storage row and the loaders skip its creation lock via
+			 * columnar_bulk_parallel_writer). Any record-aligned byte split is
+			 * correct -- no partition key, so no sorted-input requirement.
+			 */
+			offs = pcopy_naive_offsets(path, workers);
+			single_table = true;
+		}
+		else
+		{
+			char		nm[NAMEDATALEN];
+
+			strlcpy(nm, RelationGetRelationName(target), NAMEDATALEN);
+			table_close(target, AccessShareLock);
+			ereport(ERROR,
+					(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+					 errmsg("\"%s\" is not a pgcolumnar table or a partitioned table",
+							nm)));
+		}
+		table_close(target, AccessShareLock);
 	}
 
 	/*
@@ -1269,6 +1338,7 @@ columnar_parallel_copy(PG_FUNCTION_ARGS)
 	hdr->roleid = GetUserId();
 	hdr->relid = relid;
 	hdr->nworkers = workers;
+	hdr->single_table = single_table;
 	strlcpy(hdr->filename, path, sizeof(hdr->filename));
 	hdr->total_rows = 0;
 	hdr->failed_worker = -1;

--- a/src/columnar_parallel_copy.c
+++ b/src/columnar_parallel_copy.c
@@ -80,6 +80,7 @@
 #include "utils/memutils.h"
 #include "utils/partcache.h"
 #include "utils/rel.h"
+#include "utils/snapmgr.h"
 
 /* 2PC global-transaction-id buffer size; core defines this, guard in case a
  * given major puts it in a header we don't reach here. */
@@ -845,10 +846,20 @@ pgcolumnar_parallel_copy_worker(Datum main_arg)
 
 		options = list_make1(makeDefElem("format",
 										 (Node *) makeString("text"), -1));
+		/*
+		 * Core runs COPY FROM inside a portal that pushes an active snapshot
+		 * (PortalRunUtility) before CopyFrom. We call CopyFrom directly, so we
+		 * push one ourselves: the columnar insert path reads pgcolumnar.options
+		 * via a visibility-checked systable scan, which requires a registered or
+		 * active snapshot. Pop it before PREPARE (a prepared transaction must
+		 * carry no active snapshot).
+		 */
+		PushActiveSnapshot(GetTransactionSnapshot());
 		cstate = BeginCopyFrom(pstate, rel, NULL, NULL, false,
 							   pcopy_range_read, NIL, options);
 		processed = CopyFrom(cstate);
 		EndCopyFrom(cstate);
+		PopActiveSnapshot();
 		free_parsestate(pstate);
 		table_close(rel, NoLock);
 		CloseTransientFile(fd);
@@ -1011,9 +1022,21 @@ pgcolumnar_parallel_copy_coordinator(Datum main_arg)
 		Relation	rel;
 
 		StartTransactionCommand();
+		/*
+		 * StartTransactionCommand does not push an active snapshot, but
+		 * ColumnarEnsureStorageRow reads pgcolumnar.options/storage via
+		 * systable scans, and those visibility checks require a registered or
+		 * active snapshot. A normal backend has one from the executor; this
+		 * bgworker does not, so push one explicitly. Without it the scan runs
+		 * on an unregistered GetTransactionSnapshot() and aborts an assert
+		 * build the moment the options relation has a matching row (i.e. when
+		 * the target has custom options set).
+		 */
+		PushActiveSnapshot(GetTransactionSnapshot());
 		rel = table_open(hdr->relid, RowExclusiveLock);
 		ColumnarEnsureStorageRow(rel);
 		table_close(rel, NoLock);
+		PopActiveSnapshot();
 		CommitTransactionCommand();
 	}
 

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -2331,8 +2331,10 @@ _PG_init(void)
 							 "Internal. Set by pgcolumnar.parallel_copy loader workers "
 							 "so they skip the storage-row creation lock when the row "
 							 "already exists committed, allowing concurrent atomic writers "
-							 "to one table (#300). Not for manual use; off by default "
-							 "leaves the write path unchanged.",
+							 "to one table (#300). Safe even if set by hand: the skip fires "
+							 "only when the storage row is already committed, which is exactly "
+							 "when the creation lock guards nothing, so an ordinary write still "
+							 "behaves correctly. Off by default leaves the write path unchanged.",
 							 NULL,
 							 &columnar_bulk_parallel_writer,
 							 false,

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -2327,6 +2327,19 @@ _PG_init(void)
 							 0,
 							 NULL, NULL, NULL);
 
+	DefineCustomBoolVariable("pgcolumnar.bulk_parallel_writer",
+							 "Internal. Set by pgcolumnar.parallel_copy loader workers "
+							 "so they skip the storage-row creation lock when the row "
+							 "already exists committed, allowing concurrent atomic writers "
+							 "to one table (#300). Not for manual use; off by default "
+							 "leaves the write path unchanged.",
+							 NULL,
+							 &columnar_bulk_parallel_writer,
+							 false,
+							 PGC_USERSET,
+							 GUC_NOT_IN_SAMPLE,
+							 NULL, NULL, NULL);
+
 	DefineCustomBoolVariable("pgcolumnar.enable_unique_insert_lock",
 							 "Serialize concurrent inserts of the same unique key.",
 							 "Takes a transaction-scoped advisory lock per unique "

--- a/src/columnar_write_state.c
+++ b/src/columnar_write_state.c
@@ -504,6 +504,34 @@ ColumnarGetWriteState(Relation rel)
 }
 
 /*
+ * ColumnarEnsureStorageRow
+ *		Create the native storage catalog row for `rel` if it does not exist,
+ *		with exactly the metadata a normal flush would record. Used by
+ *		pgcolumnar.parallel_copy's coordinator to pre-create and commit the storage
+ *		row before launching concurrent loaders, so each loader (with
+ *		columnar_bulk_parallel_writer set) sees it committed and skips the
+ *		storage-row creation lock. Idempotent -- ColumnarInsertNativeStorageRow
+ *		returns if the row already exists.
+ */
+void
+ColumnarEnsureStorageRow(Relation rel)
+{
+	NativeStorageMetadata s;
+	ColumnarOptions opts;
+	int			stripeRowLimit = columnar_stripe_row_limit;
+
+	if (ColumnarReadOptions(RelationGetRelid(rel), &opts) && opts.stripeRowLimitSet)
+		stripeRowLimit = opts.stripeRowLimit;
+
+	s.storageId = ColumnarStorageId(rel);
+	s.relationOid = RelationGetRelid(rel);
+	s.formatVersion = COLUMNAR_NATIVE_VERSION_MAJOR;
+	s.vectorLength = COLUMNAR_NATIVE_VECTOR_LENGTH;
+	s.rowGroupLimit = stripeRowLimit;
+	ColumnarInsertNativeStorageRow(&s);
+}
+
+/*
  * buffered_note_offset
  *		Record where the next row's value begins, if this column is tracking
  *		offsets at all.

--- a/test/parallel_copy.sh
+++ b/test/parallel_copy.sh
@@ -399,8 +399,8 @@ done
 # storage-row lock was skipped -- with it held, loader 2 blocks on loader 1's
 # prepared xact forever -- so a passing run is itself evidence the skip fired.
 F_W=$(make_file 40000)
-psql_run "DROP TABLE IF EXISTS t_wit_heap; CREATE TABLE t_wit_heap (id int, txt text);
-          \copy t_wit_heap FROM '$F_W' WITH (FORMAT text)" >/dev/null
+psql_run "DROP TABLE IF EXISTS t_wit_heap; CREATE TABLE t_wit_heap (id int, txt text);" >/dev/null
+psql_run "\copy t_wit_heap FROM '$F_W' WITH (FORMAT text)" >/dev/null
 psql_run "DROP TABLE IF EXISTS t_wit; CREATE TABLE t_wit (id int, txt text) USING pgcolumnar;
           SELECT pgcolumnar.set_options('t_wit'::regclass,
                                         chunk_group_row_limit => 1000,

--- a/test/parallel_copy.sh
+++ b/test/parallel_copy.sh
@@ -356,10 +356,36 @@ check "missing file: errors, not crashes" \
 check "missing file: server still up (no worker crash)" "$(q "SELECT 1")" 1
 check "missing file: nothing loaded" "$(q "SELECT count(*) FROM t_pcp")" 0
 
-# ---- a non-partitioned target is rejected (would serialize/deadlock) ----------
-psql_run "DROP TABLE IF EXISTS t_plain; CREATE TABLE t_plain (id int, txt text) USING pgcolumnar;" >/dev/null
-np_err="$(err_of "SELECT pgcolumnar.parallel_copy('t_plain'::regclass, '$F', 2)")"
-check "non-partitioned target is rejected" \
-	"$(printf '%s' "$np_err" | grep -qi "not partitioned" && echo ok || echo no)" ok
+# ---- a non-columnar (heap) target is rejected --------------------------------
+psql_run "DROP TABLE IF EXISTS t_heaptgt; CREATE TABLE t_heaptgt (id int, txt text);" >/dev/null
+nc_err="$(err_of "SELECT pgcolumnar.parallel_copy('t_heaptgt'::regclass, '$F', 2)")"
+check "non-columnar target is rejected" \
+	"$(printf '%s' "$nc_err" | grep -qi "not a pgcolumnar table" && echo ok || echo no)" ok
+
+# ---- single columnar table: workers write ONE storage concurrently -----------
+# The storage-row creation lock is skipped by the loaders (the coordinator
+# pre-creates the row committed), so N loaders write the one storage in parallel and
+# 2PC-atomically. The result must equal a single COPY -- a concurrency race on the
+# shared storage would diverge from the oracle. The GUC that gates the engine's
+# skip must default off, so an ordinary write never takes that path.
+check "bulk_parallel_writer GUC defaults off (core write path unchanged)" \
+	"$(q "SHOW pgcolumnar.bulk_parallel_writer")" off
+for W in 1 2 4; do
+	psql_run "DROP TABLE IF EXISTS t_single; CREATE TABLE t_single (id int, txt text) USING pgcolumnar;" >/dev/null
+	check "parallel_copy(single table, $W workers): rows returned = 5000" \
+		"$(q "SELECT pgcolumnar.parallel_copy('t_single'::regclass, '$F', $W)")" 5000
+	check "parallel_copy(single table, $W workers): result == single-COPY oracle" \
+		"$(pgc_set_hash "SELECT * FROM t_single")" "$(pgc_set_hash "SELECT * FROM t_heap")"
+	check "parallel_copy(single table, $W workers): no prepared-transaction leak" \
+		"$(q "SELECT count(*) FROM pg_prepared_xacts")" 0
+done
+
+# single-table atomicity: a bad row rolls back the whole load, no leak
+psql_run "DROP TABLE IF EXISTS t_single; CREATE TABLE t_single (id int, txt text) USING pgcolumnar;" >/dev/null
+st_bad="$(err_of "SELECT pgcolumnar.parallel_copy('t_single'::regclass, '$F_BADKEY', 4)")"
+check "single table: a bad row fails the whole load" \
+	"$(printf '%s' "$st_bad" | grep -qiE 'invalid input syntax|failed' && echo ok || echo no)" ok
+check "single table: failed load leaves the target empty" "$(q "SELECT count(*) FROM t_single")" 0
+check "single table: no prepared-transaction leak after failure" "$(q "SELECT count(*) FROM pg_prepared_xacts")" 0
 
 pgc_summary

--- a/test/parallel_copy.sh
+++ b/test/parallel_copy.sh
@@ -380,6 +380,51 @@ for W in 1 2 4; do
 		"$(q "SELECT count(*) FROM pg_prepared_xacts")" 0
 done
 
+# ---- concurrency witness: prove the writers actually shared the storage -------
+# The oracle-equality checks above pass even if the loaders serialised by accident,
+# in which case they exercise nothing a single COPY did not. This block forces real
+# concurrent writing and asserts the structural fingerprint of it, so the guarantee
+# is visible in the suite rather than incidental. A small stripe_row_limit (set on
+# the table, so every loader reads it) makes each of N workers flush SEVERAL stripes
+# from a 40k-row file; then:
+#   (a) MORE distinct stripe ids than workers  -> many stripe reservations happened
+#       against the one shared metapage (each worker wrote more than one group);
+#   (b) no two stripes' byte ranges [fileoffset, fileoffset+datalength) overlap, and
+#       the per-stripe rowcounts cover every input row exactly  -> the concurrent
+#       writers neither collided on disk nor lost/duplicated a row. This is the
+#       SQL-visible form of COLUMNAR_ASSERT_NO_OVERLAP, which the assert gate also
+#       enforces from C. Row-number uniqueness is implied: a collision would drop or
+#       duplicate rows and fail (b)'s coverage and the oracle below.
+# And structurally: N 2PC-prepared loaders can only COMMIT together if the
+# storage-row lock was skipped -- with it held, loader 2 blocks on loader 1's
+# prepared xact forever -- so a passing run is itself evidence the skip fired.
+F_W=$(make_file 40000)
+psql_run "DROP TABLE IF EXISTS t_wit_heap; CREATE TABLE t_wit_heap (id int, txt text);
+          \copy t_wit_heap FROM '$F_W' WITH (FORMAT text)" >/dev/null
+psql_run "DROP TABLE IF EXISTS t_wit; CREATE TABLE t_wit (id int, txt text) USING pgcolumnar;
+          SELECT pgcolumnar.set_options('t_wit'::regclass,
+                                        chunk_group_row_limit => 1000,
+                                        stripe_row_limit => 2000);" >/dev/null
+WN=4
+check "witness: parallel_copy(single table, $WN workers, 40000 rows) loads every row" \
+	"$(q "SELECT pgcolumnar.parallel_copy('t_wit'::regclass, '$F_W', $WN)")" 40000
+check "witness: result == single-COPY oracle" \
+	"$(pgc_set_hash "SELECT * FROM t_wit")" "$(pgc_set_hash "SELECT * FROM t_wit_heap")"
+# (a) more distinct stripes than workers: concurrent reservations, >1 group per worker
+check "witness: >$WN distinct stripe ids (each worker reserved several stripes)" \
+	"$(q "SELECT count(DISTINCT stripeid) > $WN FROM pgcolumnar.stats('t_wit'::regclass)")" t
+# (b) no two stripe byte ranges overlap (each overlap counted twice; want 0)
+check "witness: no stripe byte-range overlaps another (no on-disk collision)" \
+	"$(q "WITH s AS (SELECT stripeid, fileoffset AS lo, fileoffset+datalength AS hi
+	                 FROM pgcolumnar.stats('t_wit'::regclass))
+	      SELECT count(*) FROM s a JOIN s b
+	        ON a.stripeid <> b.stripeid AND a.lo < b.hi AND b.lo < a.hi")" 0
+# (b) per-stripe rowcounts cover every input row exactly (no lost/duplicated rows)
+check "witness: stripe rowcounts sum to every input row (complete coverage)" \
+	"$(q "SELECT sum(rowcount) FROM pgcolumnar.stats('t_wit'::regclass)")" 40000
+check "witness: no prepared-transaction leak" \
+	"$(q "SELECT count(*) FROM pg_prepared_xacts")" 0
+
 # single-table atomicity: a bad row rolls back the whole load, no leak
 psql_run "DROP TABLE IF EXISTS t_single; CREATE TABLE t_single (id int, txt text) USING pgcolumnar;" >/dev/null
 st_bad="$(err_of "SELECT pgcolumnar.parallel_copy('t_single'::regclass, '$F_BADKEY', 4)")"


### PR DESCRIPTION
Completes #300: `pgcolumnar.parallel_copy` can now load a **single, non-partitioned columnar table** in parallel and atomically. Partitioned targets already landed in #323 (each worker a distinct partition); this covers the one-table case, which the partition-parallel work deliberately deferred as the "columnar-core bulk" follow-up.

## The blocker

The only transaction-length serializer on the same-storage bulk-write path is the per-storage advisory `ExclusiveLock` in `ColumnarInsertNativeStorageRow` (`columnar_metadata.c`), held to transaction end. It exists **only** to serialize the first-writer race for the storage catalog row, but holding it that long made concurrent writers to one table serialize (measured **2.01×** for 2 concurrent) and **deadlock under 2PC**. Everything else on the write path is already concurrency-safe: row-number/stripe/offset reservation is a short metapage buffer lock (`ColumnarReserveRowNumbers`), and the `row_group`/`column_chunk`/`zone_map`/`bloom` inserts key on the distinct reserved stripe ids.

## The change (conditional — the default write path is byte-for-byte unchanged)

- A **default-off** session GUC `pgcolumnar.bulk_parallel_writer` (backing var `columnar_bulk_parallel_writer`, `GUC_NOT_IN_SAMPLE`). When set, `ColumnarInsertNativeStorageRow` skips the advisory lock **iff** the storage row already exists in the latest committed state — the lock only guards creation, so once the row is committed there is nothing to wait for. Every ordinary write leaves the flag off and takes the existing path; the guard is dead code for them.
- `ColumnarEnsureStorageRow(rel)` pre-creates the storage row with exactly the metadata a normal flush records (reused, no drift).
- `parallel_copy` now accepts a single columnar table: the **coordinator** pre-creates and COMMITs the storage row in its own session (the SQL function can't commit), then the **loaders** set the flag and write the one storage concurrently — disjoint stripe reservations, no shared xact-length lock → parallel **and** 2PC-safe. A naive byte split is used (any record-aligned split is correct; no partition key, so no sorted-input requirement). A non-columnar target is rejected; a partitioned target keeps the partition-aligned path.

## Validation

- **Gate:** 71 checks green on pg18a and pg19a (assert) and pg18_san (ASan/UBSan); clean preflight compile on all five majors (15–19). New tests: single-table `parallel_copy` == single-COPY oracle for 1/2/4 workers (the oracle equality is the concurrency-correctness check on the shared storage), no prepared-xact leak, atomic rollback on a bad row, and that the GUC defaults off. The default write path stays covered, unchanged, by the existing concurrent differential suites (flag off).
- **Bench (pg18n, 20M-row TSBS slice, warm, interleaved 3 rounds):** single COPY ~132.8 s vs `parallel_copy(8)` into ONE columnar table ~22.0 s = **~6.0×**; scaling N=1/2/4/8 = 133/69/37/21 s (near-linear); byte-identical result (both 20,000,000 rows, `sum(usage_user)=1004254779.771`), 0 prepared-xacts leaked. Compare the same-table baseline *before* this change: **2.01× serialized** (2 concurrent writers took 2× a single load).

## Note on the core write path

The one change to the shared write path (`ColumnarInsertNativeStorageRow`) is a single default-off-gated early-return. A plain COPY, INSERT, or any non-parallel-copy write never enters it. Flagged for review regardless — it's your engine.
