### PR TITLE
Roadmap: #300 is closed, bulk ingest is done

### DIFF
--- a/design/ROADMAP.md
+++ b/design/ROADMAP.md
@@ -81,20 +81,17 @@ is and where the current numbers are; follow the link for figures.
    dictionary-coded grouping on the high-cardinality text key. The shapes where
    pgColumnar is furthest behind, and the two where it is slower than heap, are
    q6 and q8 in #289's table; nothing in flight addresses either.
-2. **Parallel bulk ingest** (#300). Bulk load itself is closed (#155): four
-   encoder levers landed via #290.
-   The remaining lever is not a COPY parser bypass. #300's own profile attributes
-   most of the columnar load to encode rather than to parse, so bypassing the
-   parser alone cannot close the gap to heap, and the measured lever is
-   parallelism over the existing encoder with core COPY unchanged. #323 is the
-   design and first slice. `IMPORT_THROUGHPUT_PLAN.md` is *not* the reference: it
-   predates the #283 to #286 work and puts COPY under "Not in scope". Read the
-   #300 thread.
-3. **Code comment audit** (#291) to the ASD-STE100 standard. The documentation
+2. **Code comment audit** (#291) to the ASD-STE100 standard. The documentation
    half landed in #298, which added `test/docs_style.sh` to the matrix as a
    durable gate. The code comments remain, and no gate covers them: the licensed
    ASD-STE100 vocabulary list cannot be checked mechanically, so any claim of
    compliance there is unverifiable by construction.
+
+Bulk ingest is done and #300 is closed. `pgcolumnar.parallel_copy` fans core COPY,
+unchanged, across background workers: partition-parallel in #323, single-table in
+#324, both atomic via two-phase commit. The parser bypass the issue was named for
+was rejected on its own measurement, since parse is a minority of the load. Read
+the #300 thread for the profile and the two write-path findings it produced.
 
 Not work, but still open: **#310, selective-scan page reads**. Both causes are
 fixed and merged (#315 and #317) and the effect was re-measured at 100M by both


### PR DESCRIPTION
`parallel_copy` landed in two slices, #323 (partition-parallel) and #324
(single-table), and #300 closed with them.

The open list still had it as item 2, pointing at #323 as "the design and first
slice" — true when written, false once the second slice merged. Replaced with a
closing statement: what shipped, that the parser bypass the issue was named for was
rejected on its own measurement, and where to read the profile.

## Note on the pattern

This is the sixth stale entry in this file. The discipline introduced in #322,
carrying no restated measurements, was aimed at numbers drifting, and it works for
that. It does not cover **status** drift: "in flight", "first slice", "not merged"
rot the moment work moves, and three of the six were that kind, including one you
caught within an hour.

The entry replacing this one is a statement about finished work rather than a plan,
which is the only shape here that cannot go stale. Worth keeping in mind that the
open list is inherently the perishable part of this document, and the closed
statements are not.

Docs-only. `test/docs_style.sh` passes. No matrix run, no code changes.