### PR TITLE
docs: document the opt-in grouped vectorized aggregate (#289)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,6 +55,8 @@ disk. It never changes the values that a table returns.
 | `pgcolumnar.enable_custom_scan` | boolean | `on` | Use the columnar custom scan path for columnar tables. |
 | `pgcolumnar.enable_qual_pushdown` | boolean | `on` | Push scan qualifiers down so per-chunk min and max values can skip chunk groups. |
 | `pgcolumnar.enable_vectorization` | boolean | `on` | Use the vectorized aggregate path for supported ungrouped aggregates. |
+| `pgcolumnar.enable_group_vectorization` | boolean | `off` | Use the vectorized aggregate path for `GROUP BY` queries on a columnar table. Off by default. |
+| `pgcolumnar.groupagg_max_groups` | integer | `1000000` | Cap on the group count the grouped vectorized aggregate builds. Over the cap the query errors. Range 1 to INT_MAX. |
 | `pgcolumnar.enable_bloom_filter` | boolean | `on` | Skip chunk groups on equality filters using per-chunk bloom filters. |
 | `pgcolumnar.enable_read_stream` | boolean | `on` | Prefetch block reads with the read stream API. Effective on PostgreSQL 17 and later. |
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -53,7 +53,9 @@ settings see the [configuration reference](configuration.md); for constraints se
   Neither path uses the per-tuple executor path. `count(*)` with no filter is one case of
   this: it is answered from each row group's stored row count and reads no column
   data. Set `pgcolumnar.enable_vectorization` to `off` to force an ordinary
-  aggregate over the scan instead.
+  aggregate over the scan instead. An opt-in path vectorizes `GROUP BY` too. Set
+  `pgcolumnar.enable_group_vectorization` to `on` to group and aggregate in one
+  pass over the reader. It is off by default.
 - Column statistics. `ANALYZE` samples rows from across the row groups. It stores
   the null fraction, the distinct counts, the most-common values, the histograms
   and the correlation. The planner then estimates the predicates from the data. Correlation is what lets the planner

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -355,7 +355,7 @@ Each other query uses the scalar plan and stays correct. These include `sum` or
 
 - ordered-set aggregates and string aggregates
 - aggregates with `DISTINCT`
-- `GROUP BY` and `HAVING`, unless the opt-in grouped path below is enabled
+- `GROUP BY` (unless the opt-in grouped path below is enabled) and `HAVING`
 - filters that are not simple
 - joins
 - a reference to a whole row or to a system column

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -355,10 +355,22 @@ Each other query uses the scalar plan and stays correct. These include `sum` or
 
 - ordered-set aggregates and string aggregates
 - aggregates with `DISTINCT`
-- `GROUP BY` and `HAVING`
+- `GROUP BY` and `HAVING`, unless the opt-in grouped path below is enabled
 - filters that are not simple
 - joins
 - a reference to a whole row or to a system column
+
+A separate opt-in path vectorizes `GROUP BY`. It is off by default. Set
+`pgcolumnar.enable_group_vectorization` to `on` to enable it. It covers
+`SELECT <keys>, agg(col) ... [WHERE ...] GROUP BY <keys>` on one columnar
+relation. Each key must be non-volatile, hashable, and computable from that
+relation. A collatable key must use a deterministic collation. Each output must
+be a supported aggregate or a bare key reference. This path also accepts `sum`
+and `avg` on `bigint`, `numeric`, and floating-point columns, which the ungrouped
+path rejects. `pgcolumnar.groupagg_max_groups` caps the group count, default
+1,000,000. The cap is checked at execution against the real count, so a query
+that exceeds it errors rather than switching plans. Raise the cap or turn the
+path off.
 
 ## Skipping and collation
 


### PR DESCRIPTION
#321 added a grouped vectorized aggregate path (#289) but it went undocumented. It is gated by the default-off `pgcolumnar.enable_group_vectorization`, with a `pgcolumnar.groupagg_max_groups` cap, and neither GUC nor the capability appeared in the docs. limitations.md also listed `GROUP BY` as always scalar, which is now only true by default.

## Docs

- **configuration.md** — the two GUCs: `enable_group_vectorization` (off by default) and `groupagg_max_groups` (execution-enforced; over the cap the query errors rather than switching plans).
- **limitations.md** — qualify the `GROUP BY` entry in the vectorized-coverage list, and describe the opt-in path: the shape it fires for, the key requirements (non-volatile, hashable, computable from the relation, deterministic collation), the bare-key output rule, the extra `sum`/`avg` over `bigint`/`numeric`/float it accepts, and the group-count cap.
- **features.md** — note the opt-in grouped path beside the ungrouped one.

Default behavior is unchanged and was already described correctly; this fills in the opt-in feature. Found while auditing docs for the features merged over the last two days (the parallel_copy docs are #326).

## Validation

- `test/ste_check.py` passes on every changed doc; `test/docs_style.sh` passes on the branch.
- No code change.
