### PR TITLE
Roadmap: #310 is closed, selective-scan page reads are done

### DIFF
--- a/design/ROADMAP.md
+++ b/design/ROADMAP.md
@@ -93,10 +93,12 @@ unchanged, across background workers: partition-parallel in #323, single-table i
 was rejected on its own measurement, since parse is a minority of the load. Read
 the #300 thread for the profile and the two write-path findings it produced.
 
-Not work, but still open: **#310, selective-scan page reads**. Both causes are
-fixed and merged (#315 and #317) and the effect was re-measured at 100M by both
-parties, on synthetic and on real TSBS data; the figures are in the issue. It
-stays open pending the reporter's sign-off, not further engineering.
+Selective-scan page reads are done and #310 is closed. A query skipping to 1 of
+667 chunk groups used to fault about 85 percent of the table's pages; it now
+touches 3.5 percent. Both causes were bloom filters being read when nothing would
+consult them: for groups a scan skips (#315) and for columns no predicate probes
+(#317). Confirmed on the real 100M TSBS-cpu dataset with the same on-disk table
+and only the library swapped.
 
 Formerly deferred, now built and on main. All three items this paragraph used to
 list as "not yet built" are built: end-truncation ships as


### PR DESCRIPTION
#310 closed after confirmation on the real 100M TSBS-cpu dataset. The roadmap
paragraph said it was open pending exactly that confirmation, so it went stale the
moment the issue closed.

Replaced with a closing statement: what the problem was (85 percent of the table's
pages faulted to decode one group), what it is now (3.5 percent), and the two
causes, both of them bloom filters being read when nothing would consult them.

## The pattern, now with enough data points to state

Seven entries in this file have gone stale. The split is clean:

- Statements about **work in progress** rot: "in flight", "first slice",
  "not merged", "waiting on confirmation". Four of the seven.
- Statements about **finished work** do not. Zero of the seven.

#322 removed restated measurements, which fixed numbers drifting. This is the
other half of the same problem, and the fix is the same shape: prefer a sentence
that stays true. An entry describing something that finished cannot go stale; an
entry describing something in motion is perishable by construction and needs
re-checking whenever the work moves.

Docs-only. `test/docs_style.sh` passes. No matrix run, no code changes.