### PR TITLE
docs: document parallel_export_parquet; fix stale superuser claims after #331

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -159,6 +159,10 @@ coverage.
 - Export to Arrow and Parquet: `pgcolumnar.export_arrow(table, path)` and
   `pgcolumnar.export_parquet(table, path)`, both without a libarrow or libparquet
   dependency.
+- Parallel Parquet export: `pgcolumnar.parallel_export_parquet(table, dir, workers)`
+  writes a columnar table to a directory of Parquet files with several read-only
+  background workers, one file each. It gives a near-linear speedup, returns the
+  row count, and `pgcolumnar.read_parquet` reads the directory back.
 - Import from Arrow and Parquet: `pgcolumnar.import_arrow(table, path)` and
   `pgcolumnar.import_parquet(table, path)`, into a target table that exists. The
   import maintains each index on the target. It also applies the unique
@@ -169,7 +173,9 @@ coverage.
   version 1 and version 2.
 - Both directions cover scalar types, one-dimensional arrays, and composite types
   (Arrow List and Struct, Parquet LIST and group), with nulls at every level. The
-  functions require superuser and run on little-endian hosts. See the
+  functions require a server-file role, `pg_read_server_files` to read or
+  `pg_write_server_files` to write, which superusers hold. They run on
+  little-endian hosts. See the
   [SQL reference](sql-reference.md#import-and-export) and the
   [type-coverage table](limitations.md#import-and-export-type-coverage).
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -447,7 +447,9 @@ The results therefore never depend on the pushdown.
 
 ## Import and export type coverage
 
-The import and export functions require superuser and run on little-endian hosts.
+The import and export functions require the `pg_read_server_files` or
+`pg_write_server_files` role, which superusers hold, and run on little-endian
+hosts.
 They support one-dimensional arrays and composite types built from the scalar
 types below, with nulls at every level. Multi-dimensional arrays and types not
 listed are rejected.
@@ -500,8 +502,8 @@ Hadoop-framed LZ4 (codec 5, as distinct from LZ4_RAW) are not read.
 The read-in-place surface (`read_parquet`, `parquet_schema`, and the
 `pgcolumnar_parquet` foreign-data wrapper) has these limits:
 
-- Reads are superuser only and run on little-endian hosts, as import and export
-  do, since they read a server-side path. A file from a different source is input
+- Reads require the `pg_read_server_files` role, which superusers hold, and run on
+  little-endian hosts, as import and export do, since they read a server-side path. A file from a different source is input
   without trust, and the parser for it is code that this project wrote. Refer to
   Security in the administration guide for the trust boundary and the risk that
   stays. Issue #214 tracks the fuzzing.

--- a/docs/sql-reference.md
+++ b/docs/sql-reference.md
@@ -284,9 +284,10 @@ inspection and testing, not for query use.
 
 ## Import and export
 
-These functions read and write Arrow IPC stream files and Parquet files. They
-require superuser, because they read and write files on the server host. They run
-on little-endian hosts only. They support scalar column types, one-dimensional
+These functions read and write Arrow IPC stream files and Parquet files. They read
+and write files on the server host, so a reader needs the `pg_read_server_files`
+role and a writer needs the `pg_write_server_files` role. Superusers hold both.
+They run on little-endian hosts only. They support scalar column types, one-dimensional
 arrays, and composite types, with nulls at every level. The functions refuse multi-dimensional arrays
 and types that they do not support. See
 [Limitations and compatibility](limitations.md).
@@ -364,10 +365,44 @@ SELECT pgcolumnar.parallel_copy('events', '/data/events.txt', 8);   -- returns r
 SELECT pgcolumnar.parallel_copy('events_by_day', '/data/events_sorted.txt', 8);
 ```
 
+### pgcolumnar.parallel_export_parquet(target regclass, path text, workers int DEFAULT NULL) returns bigint
+
+Writes a columnar table to a directory of Parquet files with several read-only
+background workers at once. Returns the number of rows written. The caller needs
+membership in the `pg_write_server_files` role, which superusers hold, and SELECT
+on the target. The output directory must exist and be empty. Each worker writes
+its own `part-NNNN.parquet` file, and `pgcolumnar.read_parquet` reads the whole
+directory back as one relation.
+
+The target may be one of two kinds:
+
+- A single columnar table. The workers split it by row-group ranges, so each
+  worker writes a distinct part of the table.
+- A partitioned table whose partitions are columnar. Each worker takes a distinct
+  set of partitions and writes one file per partition.
+
+The export is read-only and consistent. The dispatcher exports one snapshot and
+every worker imports it. The files together are the committed image of the table
+at call time. This holds even when the call runs inside a transaction with
+uncommitted rows. There is no coordinator and no shared write state. If any worker
+fails the dispatcher removes the files it wrote, so a partial directory is never
+left for `read_parquet` to union.
+
+When `workers` is omitted the function derives a value from the target.
+
+```sql
+-- single columnar table, split across 8 workers
+SELECT pgcolumnar.parallel_export_parquet('events', '/data/events_out', 8);
+-- read the whole directory back as one relation
+SELECT count(*) FROM pgcolumnar.read_parquet('/data/events_out')
+  AS t(id bigint, ts timestamptz, val double precision);
+```
+
 ## Reading external Parquet
 
 These read a server-side Parquet file in place, without importing it. They
-require superuser and operate on little-endian hosts. In each function, `path`
+require the `pg_read_server_files` role, which superusers hold, and operate on
+little-endian hosts. In each function, `path`
 can be one of three things. It can be a single file. It can be a directory, and
 then the function reads all the `*.parquet` files below it at any depth as one
 relation, in sorted order. It can also be a glob pattern.

--- a/docs/sql-reference.md
+++ b/docs/sql-reference.md
@@ -370,7 +370,7 @@ SELECT pgcolumnar.parallel_copy('events_by_day', '/data/events_sorted.txt', 8);
 Writes a columnar table to a directory of Parquet files with several read-only
 background workers at once. Returns the number of rows written. The caller needs
 membership in the `pg_write_server_files` role, which superusers hold, and SELECT
-on the target. The output directory must exist and be empty. Each worker writes
+on the target. The output directory must be empty. It is created if it does not exist. Each worker writes
 its own `part-NNNN.parquet` file, and `pgcolumnar.read_parquet` reads the whole
 directory back as one relation.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -99,7 +99,7 @@ SELECT count(*) FROM pgcolumnar.read_parquet('/data/events_out')
   AS t(id bigint, ts timestamptz, val double precision);
 ```
 
-The output directory must exist and be empty, and the caller needs the
+The output directory must be empty, and is created if it does not exist. The caller needs the
 `pg_write_server_files` role. See [Benchmarks](benchmarks.md#import-and-export)
 for measured numbers.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -85,6 +85,24 @@ count first, because the load prepares one transaction per worker. On a machine
 with many cores this loads several times faster than one `COPY`. See
 [Benchmarks](benchmarks.md#parallel-bulk-ingest) for measured numbers.
 
+### Parallel Parquet export
+
+To write a large columnar table out fast, use
+[`pgcolumnar.parallel_export_parquet`](sql-reference.md#pgcolumnarparallel_export_parquettarget-regclass-path-text-workers-int-default-null-returns-bigint).
+It fans the export across several read-only background workers, each writing one
+file into a directory, and returns the row count. Read the directory back with
+`pgcolumnar.read_parquet`.
+
+```sql
+SELECT pgcolumnar.parallel_export_parquet('events', '/data/events_out', 8);
+SELECT count(*) FROM pgcolumnar.read_parquet('/data/events_out')
+  AS t(id bigint, ts timestamptz, val double precision);
+```
+
+The output directory must exist and be empty, and the caller needs the
+`pg_write_server_files` role. See [Benchmarks](benchmarks.md#import-and-export)
+for measured numbers.
+
 ## Query
 
 Queries need no special syntax. The planner adds columnar scan and aggregate
@@ -154,7 +172,8 @@ INSERT INTO people VALUES (1, ARRAY['a','b'], ROW('Portland','97201')::addr);
 ## Read Parquet files in place
 
 You can query a server-side Parquet file without importing it, either as a
-set-returning function or as a foreign table. Both require superuser.
+set-returning function or as a foreign table. Both require the
+`pg_read_server_files` role, which superusers hold.
 
 ```sql
 -- inspect the file's columns and their inferred types


### PR DESCRIPTION
## What

Follow-up docs audit for the last two days of features. Two gaps.

**1. `parallel_export_parquet` was undocumented in the reference docs.** It shipped
in #329 and appears in `administration.md`'s privilege table, but had no
`sql-reference.md` entry, no `features.md` note, and no `user-guide.md` example,
unlike its sibling `parallel_copy`. Added all three, including the consistency
guarantee (one exported snapshot, so the files are the committed image at call
time) and the partial-output cleanup on failure (#332).

**2. Six stale "require superuser" claims.** #330 and #331 moved the server-file
functions to the `pg_read_server_files` and `pg_write_server_files` roles, which
superusers hold. `administration.md` was updated then, but these were missed:

- `sql-reference.md`: the import/export intro and the read-in-place section
- `features.md`: the interoperability note
- `user-guide.md`: the read-in-place note
- `limitations.md`: the type-coverage note and the read-in-place limits

The two remaining `superuser` mentions in `configuration.md` are GUC-set
permissions, not server-file access, and are correct.

`ste_check.py` and `docs_style.sh` pass on the full docs set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
