### PR TITLE
ci: bound the build jobs and the package fetches they hang on (#351)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,11 @@ jobs:
   build:
     name: build (PG ${{ matrix.pg }}, ${{ matrix.runner == 'ubuntu-24.04-arm' && 'aarch64' || 'x86_64' }})
     runs-on: ${{ matrix.runner }}
+    # This job normally finishes in about 70 seconds. Without a bound, a stalled
+    # package mirror leaves it running forever and the PR sits at "1 pending"
+    # rather than failing, which pushes a reviewer toward merging on an
+    # incomplete gate (#351). A gate that is routinely bypassed is not a gate.
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       # Two dimensions, so this is a cross product: every major on both
@@ -63,13 +68,20 @@ jobs:
         run: |
           set -euo pipefail
           sudo install -d /usr/share/postgresql-common/pgdg
-          sudo curl -fsSL -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+          # Bounded and retried: plain "curl -fsSL" waits indefinitely on a
+          # stalled connection, which is how this step came to hang for 40
+          # minutes on an otherwise healthy runner (#351).
+          sudo curl -fsSL --connect-timeout 15 --max-time 120 \
+            --retry 5 --retry-delay 5 --retry-all-errors \
+            -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
             https://www.postgresql.org/media/keys/ACCC4CF8.asc
           echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] \
             https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
             | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          # Acquire retries cover a flaky mirror; the outer timeout keeps a
+          # wedged one from consuming the whole job budget.
+          sudo timeout 300 apt-get -o Acquire::Retries=5 update
+          sudo timeout 600 apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
             postgresql-${{ matrix.pg }} postgresql-server-dev-${{ matrix.pg }} \
             liblz4-dev libzstd-dev zlib1g-dev
 
@@ -119,6 +131,7 @@ jobs:
   build-beta:
     name: build (PG 19 beta, from source)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       PG_BETA: 19beta2
     steps:
@@ -206,13 +219,20 @@ jobs:
         run: |
           set -euo pipefail
           sudo install -d /usr/share/postgresql-common/pgdg
-          sudo curl -fsSL -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+          # Bounded and retried: plain "curl -fsSL" waits indefinitely on a
+          # stalled connection, which is how this step came to hang for 40
+          # minutes on an otherwise healthy runner (#351).
+          sudo curl -fsSL --connect-timeout 15 --max-time 120 \
+            --retry 5 --retry-delay 5 --retry-all-errors \
+            -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
             https://www.postgresql.org/media/keys/ACCC4CF8.asc
           echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] \
             https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
             | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          # Acquire retries cover a flaky mirror; the outer timeout keeps a
+          # wedged one from consuming the whole job budget.
+          sudo timeout 300 apt-get -o Acquire::Retries=5 update
+          sudo timeout 600 apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
             postgresql-${{ matrix.pg }} postgresql-server-dev-${{ matrix.pg }} \
             liblz4-dev libzstd-dev zlib1g-dev python3-pip
           # The Arrow and Parquet suites use pyarrow as an independent reader and

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -42,6 +43,7 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -65,13 +65,15 @@ jobs:
         run: |
           set -euo pipefail
           sudo install -d /usr/share/postgresql-common/pgdg
-          sudo curl -fsSL -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+          sudo curl -fsSL --connect-timeout 15 --max-time 120 \
+            --retry 5 --retry-delay 5 --retry-all-errors \
+            -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
             https://www.postgresql.org/media/keys/ACCC4CF8.asc
           echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] \
             https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
             | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          sudo timeout 300 apt-get -o Acquire::Retries=5 update
+          sudo timeout 600 apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
             postgresql-${{ matrix.pg }} postgresql-server-dev-${{ matrix.pg }} \
             liblz4-dev libzstd-dev zlib1g-dev python3-pip
           # pyarrow for root (the suites run under sudo); the silent-skip trap the
@@ -122,8 +124,8 @@ jobs:
       - name: Install clang, build tools, codec headers, pyarrow; create the postgres user
         run: |
           set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          sudo timeout 300 apt-get -o Acquire::Retries=5 update
+          sudo timeout 600 apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
             clang llvm bison flex make perl \
             liblz4-dev libzstd-dev zlib1g-dev python3-pip
           clang --version | head -1
@@ -148,7 +150,9 @@ jobs:
         if: steps.san-cache.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
-          curl -fsSL -o /tmp/pg-src.tar.bz2 \
+          curl -fsSL --connect-timeout 15 --max-time 600 \
+            --retry 5 --retry-delay 5 --retry-all-errors \
+            -o /tmp/pg-src.tar.bz2 \
             "https://ftp.postgresql.org/pub/source/v${PG_VERSION}/postgresql-${PG_VERSION}.tar.bz2"
           # build_san.sh honours PGC_PG_TARBALL (source) and PGC_SAN_SRC (scratch)
           # and installs to the prefix argument; point all three at CI-writable
@@ -237,13 +241,15 @@ jobs:
         run: |
           set -euo pipefail
           sudo install -d /usr/share/postgresql-common/pgdg
-          sudo curl -fsSL -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+          sudo curl -fsSL --connect-timeout 15 --max-time 120 \
+            --retry 5 --retry-delay 5 --retry-all-errors \
+            -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
             https://www.postgresql.org/media/keys/ACCC4CF8.asc
           echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] \
             https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
             | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          sudo timeout 300 apt-get -o Acquire::Retries=5 update
+          sudo timeout 600 apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
             postgresql-18 postgresql-server-dev-18 \
             liblz4-dev libzstd-dev zlib1g-dev python3-pip lcov
           # Installed with sudo because the suites run under sudo; a plain


### PR DESCRIPTION
Fixes #351.

## What was wrong

`build (PG 15, x86_64)` hung indefinitely on `Install PostgreSQL 15 and codec headers` on two consecutive PRs -- #347 for 40 minutes, #350 for 18 -- against a normal runtime of ~70 seconds. Both times every other build passed, including **PG 15 on aarch64**: same major, same compiler, different runner. The step that wedges is package installation, before any project code compiles, so it cannot be a property of the change under test.

Three separate gaps, all of which had to be closed:

| gap | effect |
|---|---|
| `build` and `build-beta` had **no `timeout-minutes`** (only `suites` did) | a stall produced a check pending *forever* rather than failing |
| `curl -fsSL` with **no connect or total timeout** | waits indefinitely on a stalled connection instead of failing and retrying |
| `apt-get` with **no retries and no outer bound** | a wedged mirror consumes the entire job |

The missing job timeout is the one that matters most. A check stuck at pending is worse than a red one: the PR shows "1 pending" and a reviewer either waits or merges on an incomplete gate. That temptation arose on two consecutive PRs here, and a gate that is routinely bypassed stops being a gate.

## What changed

- `timeout-minutes` on `build` (15) and `build-beta` (20). Normal runtime is ~70s, so these bound a hang without being tight enough to fail a slow-but-working runner.
- `curl` now sets `--connect-timeout 15 --max-time 120` and retries with `--retry 5 --retry-delay 5 --retry-all-errors`.
- `apt-get` runs with `-o Acquire::Retries=5` under an outer `timeout`.
- The same unbounded `curl`/`apt` in `nightly.yml` hardened identically -- same defect, slower fuse, since its jobs at least have timeouts and so fail after up to two hours rather than never.
- `docs.yml` had no job timeouts either; added.

Every job across the three workflows is now bounded, and every network fetch is retried and time-limited:

```
ci.yml       build       timeout=15
ci.yml       build-beta  timeout=20
ci.yml       suites      timeout=60
docs.yml     build       timeout=20
docs.yml     deploy      timeout=20
nightly.yml  suites      timeout=60
nightly.yml  sanitizer   timeout=120
nightly.yml  coverage    timeout=90
```

## A trap worth knowing about

When the hung run is cancelled, GitHub may retry the job as a new attempt, and the PR check then shows **green from the retry** while the cancelled attempt sits at `conclusion=cancelled` with `Build: skipped`. On #350 that produced a green-looking `build (PG 15, x86_64)` check over a job that compiled nothing -- I caught it only by inspecting the job's steps rather than the check mark.

This PR does not fix that (it is GitHub's behaviour), but with the timeout in place the cancel-and-retry dance should stop being necessary.

## Verification

All three workflow files parse (`yaml.safe_load`). The real proof is this PR's own CI: it exercises the changed `build` and `build-beta` jobs on all majors and both architectures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011miCFRSatixeNRw3w5yNq8
