### PR TITLE
fix: push scan keys in the batch fold to prune row groups (#349 item 2)

### DIFF
--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -2552,12 +2552,21 @@ columnar_native_batch_fold(ColumnarAggScanState *state, Relation rel,
 			cneeded[col] = true;
 
 	/*
-	 * No scan keys are pushed to the reader: the WHERE is applied inline per value
-	 * below. For a zone-map-selective filter, pushing keys would also prune whole
-	 * vectors; that is a later refinement (it needs present-index skipping) and
-	 * only helps a filter the vector min/max can rule out.
+	 * Push the scan keys so the reader prunes whole row groups its zone maps rule
+	 * out (#349). The fold walks every surviving group in full and still rechecks
+	 * the WHERE inline per value below, so pruning is a pure win: on clustered or
+	 * range-partitioned data -- the workload this fold targets -- it skips groups
+	 * no row can match instead of decoding and folding them. (Before this the fold
+	 * read every group, 100x more than the row path on a selective clustered scan.)
+	 *
+	 * Per-vector skipping WITHIN a surviving group is a separate refinement the
+	 * fold does not take: it would need to step the present index past a skipped
+	 * vector. That is safe to leave out because columnar_native_load_group builds
+	 * the packed present-value stream whole regardless of the skip vector, so
+	 * walking all rows and advancing the present index over each is correct.
 	 */
-	rs = ColumnarBeginRead(rel, estate->es_snapshot, NULL, state->projected, 0, NULL);
+	rs = ColumnarBeginRead(rel, estate->es_snapshot, NULL, state->projected,
+						   nkeys, keys);
 
 	/*
 	 * Parallel arm (#289 phase 5/6): route group claiming through the shared

--- a/test/ungrouped_vector_agg.sh
+++ b/test/ungrouped_vector_agg.sh
@@ -119,5 +119,28 @@ psql_run "DELETE FROM t WHERE id IN (5, 2005, 40001)" >/dev/null
 ab "filtered avg after deletes"     "SELECT coalesce(avg(v)::text,'z') FROM t WHERE k > 500"
 ab "count(*) filter after deletes"  "SELECT count(*) FROM t WHERE k > 500"
 
+# ---- the fold prunes row groups its zone maps rule out (#349 item 2) ---------
+# On clustered data a selective filter lets the reader skip whole groups. The
+# fold used to open the reader with no scan keys and read every group; now it
+# pushes the keys, so it prunes like the row path -- while still rechecking the
+# WHERE inline, so the answer is unchanged. Assert it removes groups, removes the
+# same ones the row path does, and returns the row path's value.
+psql_run "DROP TABLE IF EXISTS cl;
+          CREATE TABLE cl (x float8, y float8) USING pgcolumnar;
+          SELECT pgcolumnar.set_options('cl'::regclass, stripe_row_limit => 10000);
+          INSERT INTO cl SELECT g::float8, (g % 100)::float8
+              FROM generate_series(1, 500000) g ORDER BY g;" >/dev/null
+removed() {  # removed <on|off> -- chunk groups removed by filter, via EXPLAIN ANALYZE
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -Atq -c "$NOPAR" -c "SET $GUC=$1" \
+		-c "EXPLAIN (ANALYZE, TIMING OFF, SUMMARY OFF, COSTS OFF) SELECT count(*), sum(y) FROM cl WHERE x > 490000" 2>&1 |
+		grep -oiE 'Removed by Filter: [0-9]+' | grep -oE '[0-9]+' | head -1
+}
+FOLD_REMOVED="$(removed on)"
+check "fold prunes groups on a clustered filter (removed>0)" \
+	"$([ "${FOLD_REMOVED:-0}" -gt 0 ] 2>/dev/null && echo yes || echo no)" yes
+check "fold prunes the same groups the row path does" "$FOLD_REMOVED" "$(removed off)"
+ab "clustered filtered agg on==off" "SELECT count(*)::text || '|' || coalesce(sum(y)::text,'z') FROM cl WHERE x > 490000"
+
 check "server still up" "$(q "SELECT 1")" 1
 pgc_summary


### PR DESCRIPTION
## What
Fixes **#349 item 2**: the ungrouped batch fold opened the reader with no scan keys, so it read and decoded **every** row group even when the query's zone maps could rule most out. On clustered / range-partitioned data — the workload the fold targets — a selective indexed-column filter that the row path prunes to a couple of groups made the fold decode all of them.

## Measured
Clustered fixture, selective filter:

| | chunk groups read | removed by filter |
|---|---:|---:|
| before (fold) | 200 / 200 | 0 |
| after (fold) | **2 / 200** | **198** |

Same as the row path, identical answer.

## How
The fold *already builds* the scan keys (for its inline per-value recheck); it just passed `0, NULL` to `ColumnarBeginRead`. Pass them, and `columnar_native_load_group` prunes whole groups its zone maps rule out. The fold still walks every surviving group in full and rechecks the WHERE inline, so the result is unchanged. Per-vector skipping *within* a surviving group is deliberately left out — it would need to step the present index past a skipped vector, and the packed present-value stream is built whole regardless of the skip vector, so walking all rows stays correct.

## Tests / gate
`test/ungrouped_vector_agg.sh` gains a clustered fixture asserting the fold removes groups by filter, removes the *same* groups the row path does, and returns the row path's value. Gate: **preflight all 5 majors, full assert matrix PG18+PG19, pg18_san** (ungrouped/parallel/native_agg/native_index) — all green (the only red is the pre-existing `analyze_stats` wall-clock flake, which fails identically on clean main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
