### PR TITLE
fix: keep the by-row-number decode's scratch out of the fetch cache (#353)

### DIFF
--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -563,6 +563,7 @@ columnar_native_decode_chunk(MemoryContext cx, Form_pg_attribute att,
 	char	   *rawBuf;
 	char	   *rawCursor;
 	uint32	   *vecRawLen;
+	MemoryContext decodeScratch;
 
 	if (descLen < COLUMNAR_NATIVE_ENCDESC_HEADER_LEN ||
 		(uint8) desc[0] != COLUMNAR_NATIVE_ENCDESC_VERSION)
@@ -605,11 +606,25 @@ columnar_native_decode_chunk(MemoryContext cx, Form_pg_attribute att,
 		dp += COLUMNAR_NATIVE_ENCDESC_ENTRY_LEN;
 	}
 
+	/*
+	 * The decode's intermediates -- the decompressed encoded region and each
+	 * vector's decoded buffer (memcpy'd into rawBuf below) -- are scratch, not
+	 * results, but were allocated in cx. On the scan path cx is a group context
+	 * reset every group so it did not matter; on the by-row-number fetch path cx
+	 * is the statement-scoped cache entry that is NOT reset, so the scratch stayed
+	 * live and roughly tripled the entry's measured size, pushing a wide group's
+	 * projected prefix over the 32 MB fetch cap and forcing a re-decode on every
+	 * fetch (#353). Put the scratch in a child context and delete it before
+	 * returning, so cx keeps only rawBuf and vecRawLen.
+	 */
+	decodeScratch = AllocSetContextCreate(cx, "columnar decode scratch",
+										  ALLOCSET_DEFAULT_SIZES);
+
 	/* reverse the block codec to recover the concatenated encoded region */
 	if (blockCodec != COLUMNAR_COMPRESSION_NONE)
 		encRegion = ColumnarDecompressValueStream(values, valuesLen, blockCodec,
 												  (uint32) encTotal,
-												  cx);
+												  decodeScratch);
 	else
 	{
 		if ((uint64) valuesLen != encTotal)
@@ -645,7 +660,7 @@ columnar_native_decode_chunk(MemoryContext cx, Form_pg_attribute att,
 			char	   *rawVec = ColumnarDecodeChunk(encCursor, encLen, encType,
 													 att, valueCount, rawLen,
 													 sharedTable, sharedTableLen,
-													 cx);
+													 decodeScratch);
 
 			memcpy(rawCursor, rawVec, rawLen);
 			rawCursor += rawLen;
@@ -658,6 +673,8 @@ columnar_native_decode_chunk(MemoryContext cx, Form_pg_attribute att,
 	if (outVecCount != NULL)
 		*outVecCount = (int) vectorCount;
 
+	/* rawBuf and vecRawLen live in cx; the scratch above does not */
+	MemoryContextDelete(decodeScratch);
 	return rawBuf;
 }
 

--- a/test/native_fetch_cache.sh
+++ b/test/native_fetch_cache.sh
@@ -96,4 +96,43 @@ check "a hit re-checks the group geometry it was filled with" \
 check "the cache is released at executor end, not only at transaction end" \
 	"$(grep -c 'ColumnarDiscardFetchCache' "$SRC/columnar_tableam.c")" "2"
 
+# --- #353: a wide group's decode scratch must not blow the fetch cap ----------
+# The by-row-number decode allocated its intermediates -- the decompressed region
+# and each vector's decoded buffer -- in the cached entry, ~3x the result. A wide
+# group's projected prefix then exceeded the 32MB cap and was re-decoded on every
+# fetch (measured ~200x). The scratch now lives in a transient context, so the
+# entry keeps only the result. Test: a wide table at the default stripe (one big
+# group, large decoded prefix) vs a small-stripe control; the wide case must not
+# be far dearer per fetch, and must return the same answer.
+wbuild() {  # table, stripe
+	psql_run "DROP TABLE IF EXISTS $1;
+		CREATE TABLE $1 (id int, h text, c1 int,c2 int,c3 int,c4 int,c5 int,c6 int,
+		                 c7 int,c8 int,c9 int,c10 int, u float8,
+		                 t1 text,t2 text,t3 text,t4 text,t5 text,t6 text,t7 text,t8 text)
+		    USING pgcolumnar;
+		SELECT pgcolumnar.set_options('$1', stripe_row_limit => $2);
+		INSERT INTO $1 SELECT g, 'h' || (g % 500), g,g,g,g,g,g,g,g,g,g, (g % 100)::float8,
+		    repeat('x',40),repeat('y',40),repeat('z',40),'a'||g,'b'||g,'c'||g,'d'||g,'e'||g
+		    FROM generate_series(1, 300000) g;
+		CREATE INDEX ${1}_h ON $1 (h);"
+}
+w_ms() {  # index-driven point query over one host: many fetches into few groups
+	local start end
+	start=$(date +%s%N)
+	psql_run "SET max_parallel_workers_per_gather=0; SET enable_seqscan=off; SET enable_bitmapscan=off;
+		SELECT count(*), max(u) FROM $1 WHERE h='h1';" >/dev/null 2>&1
+	end=$(date +%s%N); echo $(( (end - start) / 1000000 ))
+}
+wbuild fc_wide 150000      # default stripe: one/two big groups, wide decoded prefix
+wbuild fc_wnarrow 20000    # smaller groups that fit under the cap regardless
+bigw="$(w_ms fc_wide)"; smallw="$(w_ms fc_wnarrow)"
+echo "-- #353 wide point query: default-stripe ${bigw} ms, small-stripe ${smallw} ms"
+check_timing "a wide group's fetch is not far dearer than a small group's (#353)" \
+	"$( [ "$smallw" -gt 0 ] && [ $(( bigw / (smallw > 0 ? smallw : 1) )) -lt 5 ] && echo yes ||
+		echo "no (wide=${bigw}ms small=${smallw}ms)")" \
+	"yes"
+check "the wide-group point query is correct (#353)" \
+	"$(q "SELECT count(*) || '|' || coalesce(max(u)::text,'z') FROM fc_wide WHERE h='h1'")" \
+	"$(q "SELECT count(*) || '|' || coalesce(max(u)::text,'z') FROM fc_wnarrow WHERE h='h1'")"
+
 pgc_summary


### PR DESCRIPTION
## What
Fixes **#353**: an indexed point query on a wide table at the default `stripe_row_limit` ran at ~33 ms **per row** (186× slower than one stripe size down, ~1700× vs heap) — the by-row-number fetch cache dropped the decoded group on every fetch and re-decoded it, because the entry exceeded `COLUMNAR_FETCH_CACHE_MAX_BYTES` (32 MB).

## Root cause (measured, not assumed)
It was **not** the decoded result and **not** the whole-group buffer — it was the decode's **scratch**. `columnar_native_decode_chunk` allocates its intermediates (the decompressed encoded region, and each vector's decoded buffer that's `memcpy`'d into `rawBuf` then never freed) in the caller's context. On the scan path that context is a group context reset every group, so it never mattered. On the fetch path it's the statement-scoped cache entry, which is **not** reset — so the scratch stayed live and roughly tripled the entry: a 13-column projected prefix whose tight decoded size was ~11 MB measured ~34 MB, over the cap.

Instrumented: `entry->cx` 33.8 MB, of which raw chunk bytes were **0.25 MB** and decoded+scratch **33.6 MB**; unchanged under `ALLOCSET_SMALL_SIZES`, so it was live scratch, not aset block reservation. (Ruled out along the way: per-column caching — the deferred index fetch decodes a *prefix*, not the touched columns, so it doesn't shrink below the cap; narrowing to projected columns — infeasible, the standard tableam + deferred slot only knows the prefix; raising the cap / lowering the stripe — moves the cliff rather than removing it.)

## Fix
Put the decode's scratch in a transient child context and delete it before returning, so the caller's context keeps only `rawBuf` and `vecRawLen`. **19 lines, one function.** The scan path is unaffected (its context was already reset per group). This removes the inflation rather than raising the cap or lowering the default stripe.

Default-stripe wide-table indexed point query: **~19,800 ms → ~98 ms (~200×)**, identical result.

## Tests / gate
`test/native_fetch_cache.sh` gains a wide-table point query asserting it's not far dearer than the small-group control (a skippable timing ratio: ~2× now vs ~200× before) and returns the same answer. Gate: preflight all 5 majors, full assert matrix **PG18 + PG19**, and **pg18_san** across the decode/fetch path (native_fetch_cache/projection, native_index, native_agg, native_dml) — all clean (only red is the pre-existing `analyze_stats` wall-clock flake, which fails identically on clean main).

Note: this addresses the *fetch cost* half; the *planner cost-modelling* gap (#355) — the planner picking an index scan for ordering without pricing the per-row fetch — is separate and still open, though this makes it far less severe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
