### PR TITLE
Size the index-fetch decode from the attribute prefix (#363)

### DIFF
--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -549,25 +549,90 @@ columnar_index_correlation(IndexOptInfo *index, Oid heapRelid)
 }
 
 /*
- * columnar_scan_nproj
- *		number of distinct base-relation columns a scan of this rel has to
- *		materialize: the ones in the output target plus the ones in the
- *		restriction clauses. Used to size the per-group decode cost, since the
- *		fetch decodes a column at a time. Never returns less than 1.
+ * columnar_scan_decode_shape
+ *		How much a by-row-number fetch of this rel actually decodes: the number of
+ *		columns and their summed width.
+ *
+ *		Not the columns the scan emits. The deferred index-fetch slot decodes the
+ *		attribute *prefix* 0..max-referenced, because slot_getsomeattrs asks for a
+ *		prefix and cannot ask for a set (columnar_tableam.c,
+ *		columnar_slot_decode_upto). A query referencing only a late column therefore
+ *		decodes every column before it, and sizing this from reltarget -- the
+ *		emitted columns -- understates the decode by the ratio of the prefix to the
+ *		projection (issue #363).
+ *
+ *		Measured on a ten-text-column table, same 300 fetched rows, same emitted
+ *		width, same plan: max(a1) 975 ms against max(a10) 194,798 ms. The two sit on
+ *		opposite sides of the fetch cache cap while reltarget->width is identical
+ *		for both, so the cap-crossing branch below could not tell them apart.
+ *
+ *		Widths come from pg_statistic where ANALYZE has run and from the type's
+ *		average width otherwise, the way set_rel_width does it, because the
+ *		unreferenced columns in the prefix are not in reltarget at all.
  */
-static int
-columnar_scan_nproj(RelOptInfo *rel, Index rti)
+static void
+columnar_scan_decode_shape(RelOptInfo *rel, Index rti, Oid relid,
+						   int *nprefix, double *prefixWidth)
 {
 	Bitmapset  *attrs = NULL;
 	ListCell   *lc;
-	int			n;
+	int			maxatt = 0;
+	int			x;
+	double		width = 0.0;
+	int			i;
 
 	pull_varattnos((Node *) rel->reltarget->exprs, rti, &attrs);
 	foreach(lc, rel->baserestrictinfo)
 		pull_varattnos((Node *) lfirst_node(RestrictInfo, lc)->clause, rti, &attrs);
-	n = bms_num_members(attrs);
+
+	x = -1;
+	while ((x = bms_next_member(attrs, x)) >= 0)
+	{
+		AttrNumber	att = x + FirstLowInvalidHeapAttributeNumber;
+
+		/*
+		 * A whole-row reference reads every column, so the prefix is the whole
+		 * tuple. System columns cost no decode and are ignored.
+		 */
+		if (att == InvalidAttrNumber)
+		{
+			maxatt = rel->max_attr;
+			break;
+		}
+		if (att > maxatt)
+			maxatt = att;
+	}
 	bms_free(attrs);
-	return (n > 0) ? n : 1;
+
+	if (maxatt < 1)
+	{
+		*nprefix = 1;
+		*prefixWidth = (rel->reltarget->width > 0) ? rel->reltarget->width : 1.0;
+		return;
+	}
+
+	for (i = 1; i <= maxatt; i++)
+	{
+		int32		w = get_attavgwidth(relid, i);
+
+		if (w <= 0)
+		{
+			Oid			typid;
+			int32		typmod;
+			Oid			collid;
+
+			get_atttypetypmodcoll(relid, i, &typid, &typmod, &collid);
+
+			/* a dropped column occupies its place in the prefix but decodes nothing */
+			if (!OidIsValid(typid))
+				continue;
+			w = get_typavgwidth(typid, typmod);
+		}
+		width += (double) w;
+	}
+
+	*nprefix = maxatt;
+	*prefixWidth = (width > 0.0) ? width : 1.0;
 }
 
 /*
@@ -599,7 +664,7 @@ columnar_scan_nproj(RelOptInfo *rel, Index rti)
  */
 static Cost
 columnar_index_fetch_penalty(RelOptInfo *rel, double rows, double rho,
-							 int nproj, bool tid_ordered)
+							 int nproj, double decodedWidth, bool tid_ordered)
 {
 	double		R = (double) columnar_stripe_row_limit;
 	double		N = (rel->tuples > 0) ? rel->tuples : rows;
@@ -647,7 +712,7 @@ columnar_index_fetch_penalty(RelOptInfo *rel, double rows, double rho,
 	 * it the same way: blend between decoding each group once and decoding one
 	 * per fetch, by how much of the decoded group does not fit.
 	 */
-	decoded_width = (double) rel->reltarget->width * R;
+	decoded_width = decodedWidth * R;
 	if (decoded_width > (double) COLUMNAR_FETCH_CACHE_MAX_BYTES)
 	{
 		double		resident = (double) COLUMNAR_FETCH_CACHE_MAX_BYTES /
@@ -722,13 +787,14 @@ static void
 columnar_penalize_index_fetches(RelOptInfo *rel, Index rti, Oid relid)
 {
 	int			nproj;
+	double		decodedWidth;
 	bool		mutated = false;
 	ListCell   *lc;
 
 	if (!columnar_enable_index_fetch_penalty)
 		return;
 
-	nproj = columnar_scan_nproj(rel, rti);
+	columnar_scan_decode_shape(rel, rti, relid, &nproj, &decodedWidth);
 
 	foreach(lc, rel->pathlist)
 	{
@@ -742,12 +808,14 @@ columnar_penalize_index_fetches(RelOptInfo *rel, Index rti, Oid relid)
 			IndexPath  *ip = castNode(IndexPath, p);
 			double		rho = columnar_index_correlation(ip->indexinfo, relid);
 
-			add = columnar_index_fetch_penalty(rel, p->rows, rho, nproj, false);
+			add = columnar_index_fetch_penalty(rel, p->rows, rho, nproj,
+											   decodedWidth, false);
 		}
 		else if (p->pathtype == T_BitmapHeapScan)
 		{
 			/* a bitmap heap scan fetches in TID (row-number) order */
-			add = columnar_index_fetch_penalty(rel, p->rows, 1.0, nproj, true);
+			add = columnar_index_fetch_penalty(rel, p->rows, 1.0, nproj,
+											   decodedWidth, true);
 		}
 		/* T_IndexOnlyScan and the custom scans do no heap fetch */
 

--- a/test/analyze_stats.sh
+++ b/test/analyze_stats.sh
@@ -438,4 +438,48 @@ check "the penalty is applied before the columnar path is offered, so it can sti
 		&& echo yes || echo "no ($(printf '%s' "$plan_sel_on" | head -1))")" \
 	"yes"
 
+# --- 8. the decode is the attribute prefix, not the emitted columns (#363) -------
+#
+# The checks above vary how many rows a plan fetches. This varies *which column* it
+# references, holding everything else fixed -- same row count, same emitted width,
+# same plan shape. The deferred index-fetch slot decodes the attribute prefix
+# 0..max-referenced (columnar_tableam.c, columnar_slot_decode_upto), so referencing
+# a late column decodes every column before it.
+#
+# Sizing that decode from rel->reltarget->width cannot see the difference: it is
+# identical for the two queries below. Measured on the 100M-era fixture, same 300
+# fetched rows, same emitted width, same plan: max(a1) 975 ms, max(a10) 194,798 ms.
+#
+# Here a1's prefix decodes ~15 MB per group and stays under the fetch cache cap,
+# while a10's decodes ~156 MB and does not. So the early column should keep its
+# index and the late one should not. On a build that sizes from the emitted width
+# the two are indistinguishable and this check fails.
+O363_ROWS=${PGC_O363_ROWS:-150000}
+psql_run "DROP TABLE IF EXISTS o363;
+	CREATE TABLE o363 (id int, a1 text, a2 text, a3 text, a4 text, a5 text,
+	                   a6 text, a7 text, a8 text, a9 text, a10 text)
+		USING pgcolumnar;
+	INSERT INTO o363 SELECT g, repeat('a',100), repeat('b',100), repeat('c',100),
+		repeat('d',100), repeat('e',100), repeat('f',100), repeat('g',100),
+		repeat('h',100), repeat('i',100), repeat('j',100)
+		FROM generate_series(1, $O363_ROWS) g;
+	CREATE INDEX o363_id ON o363 (id);
+	ANALYZE o363;" >/dev/null
+
+plan_early="$(plan_of "${ord_setup} EXPLAIN (COSTS off)
+	SELECT max(a1) FROM o363 WHERE id BETWEEN 1 AND 2000;")"
+echo "-- max(a1), prefix is 2 columns: $(printf '%s' "$plan_early" | grep -m1 -E 'Scan|Sort')"
+check "an early column's short decode prefix leaves it on the index (#363)" \
+	"$(grep -q 'Index Scan using o363_id' <<<"$plan_early" && echo yes \
+		|| echo "no ($(printf '%s' "$plan_early" | head -1))")" \
+	"yes"
+
+plan_late="$(plan_of "${ord_setup} EXPLAIN (COSTS off)
+	SELECT max(a10) FROM o363 WHERE id BETWEEN 1 AND 2000;")"
+echo "-- max(a10), prefix is 11 columns: $(printf '%s' "$plan_late" | grep -m1 -E 'Scan|Sort')"
+check "a late column's wide decode prefix costs it off the index (#363)" \
+	"$(  ! grep -q 'Index Scan using o363_id' <<<"$plan_late" && echo yes \
+		|| echo "no ($(printf '%s' "$plan_late" | head -1))")" \
+	"yes"
+
 pgc_summary


### PR DESCRIPTION
## What

Closes #363. The index-fetch cost model sized the per-fetch decode from the columns
the scan **emits**. The deferred index-fetch slot decodes the attribute **prefix**
`0..max-referenced` — `slot_getsomeattrs` asks for a prefix and cannot ask for a set
— so a query referencing a late column decodes every column before it.

Both of the model's inputs understated it:

- `decoded_width` came from `rel->reltarget->width`, which gates the cap-crossing
  branch;
- `nproj` was the count of *referenced* columns rather than the length of the prefix.

Measured on a ten-`text`-column table, same 300 fetched rows, same emitted width,
same plan, varying only which column is referenced:

```
max(a1):     975 ms
max(a10): 194,798 ms
```

200x, and `rel->reltarget->width` is identical for both — the two queries sit on
opposite sides of the 32 MB fetch cache cap while the model computed the same
`decoded_width` for each.

`columnar_scan_decode_shape()` returns the prefix length and its summed width.

## Why it matters more now than when it was filed

Before #365 the penalty could not change a plan at all, so a wrong input to it was
inert. It is load-bearing for plan choice now, which is jdatcmd's argument on #367 for
not deferring this past alpha, and I agree with it — I had it as post-alpha and was
wrong.

## Design decisions worth a reviewer's eye

- **Widths come from `pg_statistic`, falling back to the type average**, the way
  `set_rel_width` does. The unreferenced columns in the prefix are not in `reltarget`
  at all, so there is nothing else to read them from.
- **A whole-row reference widens the prefix to the whole tuple.** `pull_varattnos`
  reports it as attribute 0; treating that as "no columns" would understate by the
  entire table.
- **A dropped column holds its place and decodes nothing** — it stays in the prefix
  length, contributes no width.
- **System columns are ignored**: they cost no decode.
- The penalty arithmetic is untouched; only what is fed into it changed.

## Tests

`test/analyze_stats.sh` gains a case that holds row count, emitted width and plan
shape fixed and varies only *which* column is referenced — `a1` versus `a10` on an
eleven-column table. `a1`'s prefix decodes ~15 MB per group and stays under the cap;
`a10`'s decodes ~156 MB and does not.

**Proven by removal.** Same test file, PG18 assert:

| build | `max(a1)` — must keep the index | `max(a10)` — must lose it |
|---|---|---|
| unfixed `702d125` | PASS `Index Scan using o363_id` | **FAIL `Index Scan using o363_id`** |
| this branch | PASS `Index Scan using o363_id` | **PASS `Custom Scan (ColumnarScan)`** |

and every existing #355 and #362 check passes on both builds, so the change does not
over-fire into the cases #171/#159 protect: the clustered `ORDER BY`, the selective
point lookup, and the early-column query all keep their indexes.

## Gate

Five-major build: BUILD_OK, **0 warnings** on PG15/16/17/18/19. Full matrix on
PG18 + PG19 running; I will post it as a comment.

The one expected red is the pre-existing wide-table ANALYZE timing ratio in
`analyze_stats`, which fails identically on clean main and is unrelated to the
planner (see #359 — ANALYZE never enters `columnar_fetch_row`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
