### PR TITLE
Correct the fetch cache's memory bound (#364)

### DIFF
--- a/design/ISSUE_359_FETCH_CACHE_PARTIAL.md
+++ b/design/ISSUE_359_FETCH_CACHE_PARTIAL.md
@@ -70,17 +70,45 @@ A stable resident set of `k` of `n` columns re-decodes `n - k` per fetch. That i
 the proportionality the issue asks for, and it is why "retain what fits" has to
 mean *first-fit, then stop*, not *keep the hottest*.
 
-### Memory bound is preserved
+### Memory bound — as designed, and as it actually turned out
 
-Today the entry transiently exceeds the cap (it is measured after the fetch that
-filled it) and is then dropped. Under this design the entry transiently exceeds
-the cap by one column's decoded stream and is then trimmed back under it, so
-steady-state residency is still <= cap per entry, 4 entries.
+**As designed.** The entry transiently exceeds the cap by one column's decoded
+stream and is then trimmed back under it, so steady-state residency is <= cap per
+entry, 4 entries. If `groupBuffer` *alone* exceeds the cap, every column overflows
+and the entry would hold an unbounded raw buffer, so that case is guarded
+explicitly by not caching the entry at all.
 
-One new case: if `groupBuffer` *alone* exceeds the cap, every column overflows
-and the entry would hold an unbounded raw buffer. Guard that explicitly — do not
-cache the entry at all in that case, which is exactly today's behaviour and keeps
-the bound at 4 x cap.
+**Correction (issue #364).** That is not the bound this achieves, and the claim
+"keeps the bound at 4 x cap" was wrong. The per-column release trims the decoded
+*streams*. It cannot trim `rankPrefix` and `valOffset`, which stay in the entry
+context deliberately so a released column keeps constant-time row reach.
+`valOffset` is four bytes per value per varlena column, ~600 KB per column at the
+default `stripe_row_limit`, so enough varlena columns put the retained indexes
+alone over the cap — after which every newly decoded column is released
+immediately and the entry stops shrinking.
+
+Measured on 150,000 rows x 60 `text` columns, forced index scan over 200 rows:
+
+```
+columnar fetch column | n=2 | total=18 MB     <- the columns that stayed resident
+columnar fetch group  | n=1 | total=44 MB     <- groupBuffer + retained indexes
+ALL columnar fetch contexts total: 62 MB      <- against a 32 MB cap
+```
+
+The real bound is `4 x (cap + retained position indexes + groupBuffer)`. On that
+shape the speedup is also only 1.14x (127,699 ms against 145,132 ms before this
+design), because almost everything overflows.
+
+Releasing `valOffset` alongside the stream was built and measured, and is a worse
+trade: it holds the bound (62 MB -> 28 MB) at a cost of 47% in time
+(127,699 ms -> 187,521 ms). Rebuilding offsets is a second O(values) walk on every
+fetch, not a constant factor on a decode that was happening anyway. The retained
+indexes are what make an overflowed column cheap on its next fetch.
+
+The bound and the speed are in genuine tension on wide varlena tables: holding
+offsets for 60 varlena columns at a 150,000-row group needs ~34 MB and does not fit
+in a 32 MB cap. This design chooses the speed; #364 records the trade rather than
+pretending the bound holds.
 
 ### Two details that will bite
 

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -2479,12 +2479,34 @@ columnar_fetch_row(Relation rel, Snapshot snapshot, uint64 rowNumber,
 	}
 
 	/*
-	 * The per-column release above trims the entry back under the cap, so the
-	 * entry is bounded by it -- except in one case it cannot help: a group whose
-	 * *raw* bytes alone exceed the cap. Every column would overflow and the entry
-	 * would still pin groupBuffer, so four such entries could hold arbitrarily
-	 * much. Drop the entry whole there, which is what this path did for every
-	 * oversized group before, and keeps the cache bounded by 4 x the cap.
+	 * Drop the entry whole when the group's *raw* bytes alone exceed the cap:
+	 * every column would overflow and the entry would still pin groupBuffer, so
+	 * four such entries could hold arbitrarily much.
+	 *
+	 * This does NOT make the cache bounded by 4 x the cap, and #359 said it did.
+	 * Correcting that here rather than leaving it, because it is the kind of claim
+	 * a later change gets designed against (issue #364).
+	 *
+	 * The per-column release trims the *decoded streams* back under the cap. It
+	 * cannot trim what is not releasable: rankPrefix and valOffset stay in the
+	 * entry context by design, so a released column keeps its position indexes.
+	 * valOffset is four bytes per value per varlena column -- ~600 KB per column
+	 * at the default stripe_row_limit -- and enough varlena columns puts the
+	 * retained indexes alone over the cap, at which point every newly decoded
+	 * column is released immediately and the entry stops shrinking.
+	 *
+	 * Measured on 150,000 rows x 60 text columns: one entry held 62 MB against a
+	 * 32 MB cap (44 MB of it retained indexes plus groupBuffer, 18 MB in the two
+	 * columns that stayed resident). The real bound is
+	 *
+	 *     4 x (cap + retained position indexes + groupBuffer)
+	 *
+	 * Releasing valOffset with the stream was tried and is worse: it holds the
+	 * bound (62 MB -> 28 MB) but costs 47% in time (127.7 s -> 187.5 s), because
+	 * rebuilding offsets is a second walk of the value stream on every fetch
+	 * rather than a constant factor on the decode. The retained indexes are what
+	 * makes an overflowed column cheap on its next fetch, which is the whole point
+	 * of keeping them.
 	 */
 	if (rg->byteLength > COLUMNAR_FETCH_CACHE_MAX_BYTES)
 		columnar_fetch_entry_reset(entry);


### PR DESCRIPTION
## What

Closes #364 by correcting the claim rather than changing the behaviour, which is what
you asked for on #367 ("I would like the fix to correct that specific sentence rather
than only the code").

#361 states in its commit message and in `design/ISSUE_359_FETCH_CACHE_PARTIAL.md`
that the per-column release keeps the cache **bounded by 4 x the cap**. It does not.

## Why the bound does not hold

The release trims the decoded *streams*. It cannot trim `rankPrefix` and `valOffset`,
which stay in the entry context deliberately so a released column keeps constant-time
row reach — that part of the design is right and this PR does not touch it.

But `valOffset` is four bytes per value per **varlena** column, ~600 KB per column at
the default `stripe_row_limit`. Enough varlena columns and the retained indexes alone
exceed the cap, after which every newly decoded column is released immediately and the
entry stops shrinking.

Measured, 150,000 rows x 60 `text` columns, forced index scan over 200 rows:

```
columnar fetch column | n=2 | total=18 MB     <- the columns that stayed resident
columnar fetch group  | n=1 | total=44 MB     <- groupBuffer + retained indexes
ALL columnar fetch contexts total: 62 MB      <- against a 32 MB cap
```

Real bound: `4 x (cap + retained position indexes + groupBuffer)`. On that shape the
speedup is also only **1.14x** (127,699 ms against 145,132 ms before #361), because
almost everything overflows.

## Why not fix the bound instead

I built that and measured it, and it is the wrong trade:

| build | memory held | time |
|---|---:|---:|
| before #361 | nothing retained | 145,132 ms |
| #361 as merged | 62 MB vs a 32 MB cap | **127,699 ms** |
| releasing `valOffset` too | 28 MB, under the cap | **187,521 ms** |

47% slower than #361 and 29% slower than the behaviour #361 replaced. My reasoning
that rebuilding offsets was "a constant factor on a decode already happening" was
wrong — it is a second O(values) walk plus a 600 KB allocation, per overflowed column,
per fetch. The retained indexes are precisely what makes an overflowed column cheap on
its next fetch.

Holding offsets for 60 varlena columns at a 150,000-row group needs ~34 MB and does
not fit in a 32 MB cap. The bound and the speed are in real tension; #361 chooses the
speed, and this records that choice instead of asserting a bound that does not hold.

If you would rather the cap be a real ceiling, option (2) on the issue — drop the
entry on its actual footprint rather than on raw bytes — returns this shape to ~145 s
and I will build it. That is a design call and it is yours.

## Scope

Comment and design-doc only. **No behaviour change**, so no new test: there is nothing
new to assert, and the numbers above are reproducible from the fixture described in
the doc. The commit message of #361 is immutable, so the correction lives where a
reader will actually hit it — the code comment at the drop site and the design doc's
memory-bound section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
