### PR TITLE
Measure the cancel guard against the timeout floor, not half the load

### DIFF
--- a/test/native_cancel.sh
+++ b/test/native_cancel.sh
@@ -65,8 +65,34 @@ check "the short timeout is what fired" \
 
 # Without interrupt checks in the load path the timeout cannot fire until the
 # load finishes, so cancel and full converge. With them it fires during the load.
+#
+# The yardstick is the window between the two outcomes, not a bare fraction of
+# `full`. `cancel` cannot go below the timeout itself, so `full / 2` is only a
+# real threshold while `full` is comfortably more than twice the timeout: at
+# full=155 it leaves 27 ms of headroom above a 50 ms floor, and PG17 measured
+# 64-82 ms against PG18's stable 63-64, failing two runs in three on hardware
+# where the cancel worked correctly every time. That is a threshold reporting the
+# box, not the guard.
+#
+# What the guard actually distinguishes: cancel fires *during* the load (just
+# after the timeout) or only *after* it (converging on `full`). So require cancel
+# to land in the lower half of the interval between those two, which is
+# self-calibrating in both directions and cannot be squeezed by a fast box.
+#
+# Which guard this actually proves, established by removing each one rather than
+# from the description above: it is COLUMNAR_DECODE_INTERRUPT in
+# columnar_encoding.c, the per-value decode-loop check on a 65536 stride, not the
+# per-column-chunk CHECK_FOR_INTERRUPTS in columnar_native_load_group(). Deleting
+# the per-chunk check leaves this suite green, because a two-column group reaches
+# it only twice; disabling the decode-loop macro makes cancel converge on full
+# (151 ms against 150) and fails this check, which is the behaviour the paragraph
+# above predicts. Stated so the next person does not remove the cheap guard on the
+# strength of a green run here.
+TIMEOUT_MS=50
+limit=$(( TIMEOUT_MS + (full - TIMEOUT_MS) / 2 ))
 check_timing "cancel arrives well before the load completes" \
-	"$( [ "$cancel" -lt $(( full / 2 )) ] && echo yes || echo "no (cancel=${cancel}ms full=${full}ms)")" \
+	"$( [ "$full" -gt $(( TIMEOUT_MS * 2 )) ] && [ "$cancel" -lt "$limit" ] && echo yes ||
+	    echo "no (cancel=${cancel}ms full=${full}ms limit=${limit}ms)")" \
 	"yes"
 
 pgc_summary


### PR DESCRIPTION
## What

The **full five-major matrix** at `488a2c0` (the first since 2026-07-30, and a
pre-alpha item on #367) came back:

```
PASS  PG15    PASS  PG16    FAIL  PG17    PASS  PG18    PASS  PG19
```

The single red is `native_cancel`, and **it is not a product defect**. The
cancellation worked in every run; the server log shows the statement cancelled by
`statement_timeout` each time. What failed is the threshold.

## Why the threshold was wrong

The check was `cancel < full / 2`. `cancel` cannot go below the timeout itself, so
that is only a real threshold while `full` is comfortably more than twice the
timeout. At `full=155` it leaves **27 ms of headroom above a 50 ms floor**:

| major | cancel latency, repeated runs | result |
|---|---|---|
| PG17 | 82, 80, 64 ms | 2 of 3 fail |
| PG18 | 64, 63, 63 ms | 3 of 3 pass |

`full` is stable at 150-164 ms on both. PG17 is simply slower and more variable on
this measurement and sits on the threshold. That is a gate reporting the box rather
than the guard, which is the specific failure mode this project's own comments say
teaches readers to discount red.

## The fix

Measure against the window the guard actually distinguishes. Cancel either fires
**during** the load (just after the timeout) or only **after** it (converging on
`full`), so require cancel in the lower half of the interval between those two:

```
limit = TIMEOUT_MS + (full - TIMEOUT_MS) / 2
```

Self-calibrating in both directions, and it cannot be squeezed by a fast box.
**PG17 now passes 4 runs of 4**, having passed 1 of 3.

## Proven by removal, and the removal corrected the comment

The suite's header attributes the guard to the per-column-chunk
`CHECK_FOR_INTERRUPTS` in `columnar_native_load_group()`. **That is wrong**, and I
only found out by removing it:

| guard removed | cancel vs full | suite |
|---|---|---|
| per-chunk `CHECK_FOR_INTERRUPTS` (reader) | 64 vs 153 ms | **still PASSES** |
| `COLUMNAR_DECODE_INTERRUPT` (encoding) | **151 vs 150**, **157 vs 154** | **FAILS, both runs** |

A two-column group reaches the per-chunk check twice, which is far too coarse to
matter. The guard that carries this suite is the per-value decode-loop check on a
65536 stride. When it is disabled, cancel converges on full exactly as the header
predicts, and the new threshold catches it.

That correction is written into the suite, so nobody deletes the cheap per-chunk
guard on the strength of a green run here.

## Scope

Test-only. No source change, so the rest of the five-major matrix result stands as
the verification for `488a2c0`: **112 suites on each of five majors, PG15/16/18/19
clean, PG17 clean apart from this threshold.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)