### PR TITLE
Point at commandprompt/pgcolumnar after the org move

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,7 +35,7 @@ jobs:
     name: suites (PG ${{ matrix.pg }}, ${{ matrix.runner == 'ubuntu-24.04-arm' && 'aarch64' || 'x86_64' }})
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
-    if: github.event_name == 'workflow_dispatch' || github.repository == 'jdatcmd/pgcolumnar'
+    if: github.event_name == 'workflow_dispatch' || github.repository == 'commandprompt/pgcolumnar'
     strategy:
       fail-fast: false
       # The full packaged matrix on x86_64, and the current major on aarch64.
@@ -114,7 +114,7 @@ jobs:
     name: sanitizer gate (ASAN+UBSAN)
     runs-on: ubuntu-latest
     timeout-minutes: 120
-    if: github.event_name == 'workflow_dispatch' || github.repository == 'jdatcmd/pgcolumnar'
+    if: github.event_name == 'workflow_dispatch' || github.repository == 'commandprompt/pgcolumnar'
     env:
       PG_VERSION: "18.4"
       SAN_PREFIX: /home/runner/pg_san
@@ -233,7 +233,7 @@ jobs:
     name: coverage report (PG 18)
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    if: github.event_name == 'workflow_dispatch' || github.repository == 'jdatcmd/pgcolumnar'
+    if: github.event_name == 'workflow_dispatch' || github.repository == 'commandprompt/pgcolumnar'
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <a href="VERSION"><img src="badges/version.svg" alt="Version 1.0-dev"></a>
 <a href="docs/limitations.md#release-status"><img src="badges/status.svg" alt="Status: pre-release"></a>
 
-<p><strong><a href="https://jdatcmd.github.io/pgcolumnar/">Read the documentation at jdatcmd.github.io/pgcolumnar</a></strong></p>
+<p><strong><a href="https://commandprompt.github.io/pgcolumnar/">Read the documentation at commandprompt.github.io/pgcolumnar</a></strong></p>
 
 </div>
 
@@ -30,7 +30,7 @@ native on-disk format, PGCN v1.
 ## Documentation
 
 The full documentation is published at
-**[jdatcmd.github.io/pgcolumnar](https://jdatcmd.github.io/pgcolumnar/)**. The
+**[commandprompt.github.io/pgcolumnar](https://commandprompt.github.io/pgcolumnar/)**. The
 same pages are in this repository under `docs/`:
 
 | | |

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -30,7 +30,7 @@ The previous record of this section was 2026-07-27 at commit `7a9c9f7`, on
 PostgreSQL 17.10 and a machine with 24 GB. The harness itself did not change
 between the two runs. The major version and the machine did, so read the ratios
 and not the absolute values. The old raw output is in
-[../bench/sample_output_all_2026_07_27.txt](https://github.com/jdatcmd/pgcolumnar/blob/main/bench/sample_output_all_2026_07_27.txt).
+[../bench/sample_output_all_2026_07_27.txt](https://github.com/commandprompt/pgcolumnar/blob/main/bench/sample_output_all_2026_07_27.txt).
 
 The read stream section is not re-measured. It needs a PostgreSQL 18 build with
 `--with-liburing`, and no such build exists on this machine. Its numbers are from
@@ -93,7 +93,7 @@ milliseconds.
 
 The point lookup was a regression when the previous version of this page was
 written, at 1251.88 ms, and it was reported as
-[issue #171](https://github.com/jdatcmd/pgcolumnar/issues/171). That issue is
+[issue #171](https://github.com/commandprompt/pgcolumnar/issues/171). That issue is
 closed. The planner chose a full columnar scan for a point lookup once statistics
 existed. It now keeps the index, and the same query takes 11.90 ms.
 
@@ -126,7 +126,7 @@ needs the data.
 
 This behaviour used to apply to the whole storage. One deleted row then put
 `count(*)` at 222 ms and `min/max` at 317 ms, instead of the figures above
-([issue #149](https://github.com/jdatcmd/pgcolumnar/issues/149), fixed). Vacuuming
+([issue #149](https://github.com/commandprompt/pgcolumnar/issues/149), fixed). Vacuuming
 still helps, since it returns the dirty group to the clean path.
 
 ## Mutation
@@ -159,7 +159,7 @@ baseline that this run failed to meet.
 
 The delete figure was the weakest number in this document, at 1509 ms. At that
 time, to reach a row, the code went through each earlier row in the group. Both
-halves of [issue #143](https://github.com/jdatcmd/pgcolumnar/issues/143) are now
+halves of [issue #143](https://github.com/commandprompt/pgcolumnar/issues/143) are now
 complete. The code decodes the group one time and keeps it in a cache. It then
 reaches the value of a row by rank, and not by a walk. Deleting 1000 rows costs 22.8 ms rather than 1509.
 
@@ -275,7 +275,7 @@ costs 1,415 ms, 11% of the import. The other 89% is the write path, which is als
 4.9x slower than a heap insert of the same rows.
 
 So the target is bulk load in general rather than the interop path. Tracked as
-[issue #155](https://github.com/jdatcmd/pgcolumnar/issues/155) with a plan in
+[issue #155](https://github.com/commandprompt/pgcolumnar/issues/155) with a plan in
 `design/IMPORT_THROUGHPUT_PLAN.md`.
 
 The plan gives the cost to the transposition between rows and columns. Both
@@ -289,7 +289,7 @@ shapes measured, it also produced storage that is identical byte for byte. `enco
 trade per table.
 
 Index maintenance is not in this path at all, which is a correctness bug rather
-than a cost: see [issue #153](https://github.com/jdatcmd/pgcolumnar/issues/153).
+than a cost: see [issue #153](https://github.com/commandprompt/pgcolumnar/issues/153).
 
 Nested round-trip, 1,000,000 rows, one `int[3]` array column and one composite
 column:
@@ -479,9 +479,9 @@ path returns, and not for the rows the query reads. A `DISTINCT ON` reads one ro
 host. The model therefore priced the index path far above every
 alternative. No consumer could recover it, not even one that reads 3,998 rows of
 100,000,000. That is
-[issue #376](https://github.com/jdatcmd/pgcolumnar/issues/376), found by this
+[issue #376](https://github.com/commandprompt/pgcolumnar/issues/376), found by this
 benchmark pass and fixed in
-[#378](https://github.com/jdatcmd/pgcolumnar/pull/378), which bounds the penalty at a
+[#378](https://github.com/commandprompt/pgcolumnar/pull/378), which bounds the penalty at a
 multiple of one scan. The query now takes 767 ms.
 
 Citus is slow on this shape for its own reasons, at 124,537 ms.

--- a/docs/features.md
+++ b/docs/features.md
@@ -10,7 +10,7 @@ settings see the [configuration reference](configuration.md); for constraints se
 - Column-oriented storage in the relation's main fork, so the buffer manager,
   WAL, and page checksums apply. Data is stored in the native format, PGCN v1,
   specified in
-  [../design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md](https://github.com/jdatcmd/pgcolumnar/blob/main/design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md).
+  [../design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md](https://github.com/commandprompt/pgcolumnar/blob/main/design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md).
 - The writer selects the value encoding for each vector. It estimates each
   candidate on a strided sample and then applies only the best two. It does not
   apply each candidate to the whole vector. On a load of 6,000,000 rows this

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,8 +59,8 @@ WAL, replication, indexes, `COPY`, and `pg_dump`. The extension adds:
 The documents above are for users and administrators. The design and format
 specifications are separate:
 
-- [../design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md](https://github.com/jdatcmd/pgcolumnar/blob/main/design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md):
+- [../design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md](https://github.com/commandprompt/pgcolumnar/blob/main/design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md):
   on-disk format and SQL interface specification.
 - [ARCHITECTURE.md](ARCHITECTURE.md): source layout and how the pieces connect.
-- [../design/ROADMAP.md](https://github.com/jdatcmd/pgcolumnar/blob/main/design/ROADMAP.md): completed work and remaining items.
-- [../PROVENANCE.md](https://github.com/jdatcmd/pgcolumnar/blob/main/PROVENANCE.md): clean-room implementation method.
+- [../design/ROADMAP.md](https://github.com/commandprompt/pgcolumnar/blob/main/design/ROADMAP.md): completed work and remaining items.
+- [../PROVENANCE.md](https://github.com/commandprompt/pgcolumnar/blob/main/PROVENANCE.md): clean-room implementation method.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -112,7 +112,7 @@ To install a new build of the extension:
 2. Start the server again, so that it loads the new library.
 
 The source records the on-disk format version. The specification also records it,
-in [../design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md](https://github.com/jdatcmd/pgcolumnar/blob/main/design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md).
+in [../design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md](https://github.com/commandprompt/pgcolumnar/blob/main/design/NATIVE_FORMAT_AND_INTERFACE_SPEC.md).
 A build that keeps the same format version reads the tables that earlier builds
 of that version wrote. A conversion is not necessary.
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -14,20 +14,20 @@ for data that cannot be reloaded.
 The hardening that was tracked before a first alpha is complete. The
 Parquet and Arrow parsers, which this project wrote, are fuzzed, both by byte mutation and by structural
 mutation of the container format
-([issue #214](https://github.com/jdatcmd/pgcolumnar/issues/214)). The boundary for
+([issue #214](https://github.com/commandprompt/pgcolumnar/issues/214)). The boundary for
 untrusted input files is stated and tested
-([issue #216](https://github.com/jdatcmd/pgcolumnar/issues/216)). The blast radius
+([issue #216](https://github.com/commandprompt/pgcolumnar/issues/216)). The blast radius
 of a single backend crash is asserted and documented
-([issue #217](https://github.com/jdatcmd/pgcolumnar/issues/217)). The build checks the on-disk format version
+([issue #217](https://github.com/commandprompt/pgcolumnar/issues/217)). The build checks the on-disk format version
 on read. It does not only stamp the version on write
-([issue #240](https://github.com/jdatcmd/pgcolumnar/issues/240)). A gate covers
+([issue #240](https://github.com/commandprompt/pgcolumnar/issues/240)). A gate covers
 cross-major `pg_upgrade`. Before, only a suite that nobody ran covered it
-([issue #257](https://github.com/jdatcmd/pgcolumnar/issues/257)).
+([issue #257](https://github.com/commandprompt/pgcolumnar/issues/257)).
 
 What that testing does not cover is worth stating alongside it. Every result
 recorded in this repository comes from x86_64. The suites have not been run on
 aarch64 or on a big-endian platform
-([issue #242](https://github.com/jdatcmd/pgcolumnar/issues/242)).
+([issue #242](https://github.com/commandprompt/pgcolumnar/issues/242)).
 
 Unaligned reads are one class that a reader could expect to differ by
 architecture. The tests cover that class on each architecture. The sanitizer gate
@@ -192,7 +192,7 @@ the same rows. There is no import-specific overhead; the cost is the columnar
 write path either way.
 
 Work on load throughput is tracked in
-[issue #155](https://github.com/jdatcmd/pgcolumnar/issues/155). One realized lever
+[issue #155](https://github.com/commandprompt/pgcolumnar/issues/155). One realized lever
 is [`pgcolumnar.parallel_copy`](#parallel-bulk-ingest). It loads a text file
 across several cores at once.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -229,7 +229,7 @@ defect on the other. The suites that would show it must run.
 
 **On documentation changes** (`.github/workflows/docs.yml`): builds and publishes
 the site at
-[jdatcmd.github.io/pgcolumnar](https://jdatcmd.github.io/pgcolumnar/).
+[commandprompt.github.io/pgcolumnar](https://commandprompt.github.io/pgcolumnar/).
 
 PostgreSQL 19 cannot be installed in CI: PGDG does not package it in stable,
 testing or snapshot. It is compiled there anyway, from source, and the build stays

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,10 +1,10 @@
 site_name: pgColumnar
 site_description: Analytic column storage for PostgreSQL, built as a native table access method.
-site_url: https://jdatcmd.github.io/pgcolumnar/
+site_url: https://commandprompt.github.io/pgcolumnar/
 site_author: pgColumnar contributors
 
-repo_url: https://github.com/jdatcmd/pgcolumnar
-repo_name: jdatcmd/pgcolumnar
+repo_url: https://github.com/commandprompt/pgcolumnar
+repo_name: commandprompt/pgcolumnar
 edit_uri: edit/main/docs/
 
 copyright: >
@@ -57,7 +57,7 @@ extra_css:
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/jdatcmd/pgcolumnar
+      link: https://github.com/commandprompt/pgcolumnar
       name: pgColumnar on GitHub
   generator: false
 


### PR DESCRIPTION
## What

The repository moved from `jdatcmd` to the **commandprompt** organisation. GitHub
redirects the old paths, so nothing breaks immediately, but a release should carry
canonical URLs.

## The one that would have broken quietly

`.github/workflows/nightly.yml` gated three jobs on:

```yaml
if: github.event_name == 'workflow_dispatch' || github.repository == 'jdatcmd/pgcolumnar'
```

After the transfer that condition is false, so **every nightly would have skipped
itself and reported success by not running**. Found by reading the diff, which is the
only way that class of thing gets found: a job that skips is green.

## Also

GitHub Pages follows the owner, so `jdatcmd.github.io/pgcolumnar` becomes
`commandprompt.github.io/pgcolumnar` (confirmed live). Updated in `mkdocs.yml`
`site_url`, `README.md` and `docs/testing.md`.

27 URL references across `docs/`, `mkdocs.yml` and the workflow.

## Deliberately not changed

`.mailmap` and `PROVENANCE.md` keep their `jdatcmd` references. Those name a
commit-author identity and the clean-room record, not a repository location, and
rewriting them would falsify history.

`HANDOFF.md` is gitignored and untracked.

## Verification

`docs_style.sh` passes. No source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)