### PR TITLE
State plainly that TimescaleDB leads the cross-engine table

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -374,8 +374,9 @@ columns. The data is loaded byte for byte the same way into each engine.
 The bench host has 16 vCPU and 62 GB. Each engine uses the configuration its own
 users would choose:
 
-- pgColumnar: columnar scan, storage in load order, which is time ascending. One
-  btree on `(hostname, time DESC)`.
+- pgColumnar: columnar scan, storage in load order. One btree on
+  `(hostname, time DESC)`. The load order is not sorted on either key: the measured
+  correlation with physical order is 0.013 for `time` and -0.004 for `hostname`.
 - TimescaleDB: compressed columnstore, segmented by `hostname`, ordered by `time`
   descending. One btree on `(hostname, time DESC)`, and the `(time DESC)` index that
   `create_hypertable` makes, which gives 53 chunk indexes below them.
@@ -464,14 +465,40 @@ across workers. q1, q2 and q3 improve by about five times. q5 and q6 move from b
 heap to ahead of it. The serial table is a measure of the storage format. The parallel
 table is closer to what an installation gets.
 
-**TimescaleDB leads every query that filters one host.** Its columnstore segments by
-`hostname`, so it reads one segment and not the table. pgColumnar stores rows in load
-order, so its zone maps do not skip on `hostname`. A pgColumnar table that is clustered
-on the filter key closes that gap, at the cost of the queries that read all hosts.
+**TimescaleDB is faster than pgColumnar on every query it completes.** That is the
+first thing to take from these tables. In serial it leads by 1.6 times on q4 and q5, and by
+2.1 times on q8. It leads by 2.7 times on q7 and 6.5 times on q6. On q1, q2 and q3 it
+leads by 101, 442 and 679 times. Against heap, pgColumnar wins q4, q5, q6 and q8 by 20
+to 50 percent. It loses q1, q2, q3 and q7.
 
-**pgColumnar leads the wide aggregate shapes with workers.** q5 reads ten metrics for
-all hosts, and q6 scans the table with one filter. pgColumnar is first on both, and q6
-is 2,294 ms against Citus at 8,242 ms.
+**pgColumnar is first on q5 and q6 in the parallel table for one reason: TimescaleDB
+fails there.** Its parallel arm cannot run on this host. The method above records it.
+Where TimescaleDB does run, in serial, it is ahead on both of those queries. Read
+those two cells as "faster than heap and Citus", and not as a win over TimescaleDB.
+
+**Why the one-host queries are so far apart.** pgColumnar skips nothing. Measured on
+q2, with `EXPLAIN (ANALYZE)`:
+
+```
+Columnar Chunk Groups Total: 667
+Columnar Chunk Groups Read: 667
+Columnar Chunk Groups Removed by Filter: 0
+Rows Removed by Filter: 99995680
+```
+
+It reads all 667 row groups and filters 99,995,680 rows to return 4,320. The zone maps cannot help,
+because neither key is sorted in the stored order. Every stripe holds all 4,000 hosts.
+The minimum and maximum `hostname` of each group therefore covers the whole set.
+TimescaleDB answers the same query in about 2 milliseconds. It excludes all but one
+chunk on time, then reads one `hostname` segment through an index.
+
+**So this table measures pgColumnar in the layout that suits it least.** A user with
+this shape would cluster the table on `hostname`. That is what
+TimescaleDB's `segmentby` does for it. That configuration is not measured here. Do not
+read the gap on q1, q2 and q3 as a property of columnar storage until it is. The table
+does show the layout-independent part. pgColumnar reads fewer columns than heap and
+wins the wide scan-bound aggregates. It also stores the same rows in 6,590 MB against
+heap's 22 GB.
 
 **q7 was a planner defect and is now fixed.** The earlier record of this page reported
 133,759 ms for q7 in serial. The cost model charged an index path for the rows the


### PR DESCRIPTION
## What

The narrative I wrote for #377 read more favourably than the numbers support. This
corrects the reading. **No number changes.**

Raised by jd looking at the merged table and asking whether pgColumnar is considerably
slower. It is, and the page did not say so.

## Three things were wrong

**1. The page never stated the headline result.** TimescaleDB is faster than
pgColumnar on *every query it completes*:

| | q1 | q2 | q3 | q4 | q5 | q6 | q7 | q8 |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| TS faster by (serial) | 101x | 442x | 679x | 1.6x | 1.6x | 6.5x | 2.7x | 2.1x |

The page said TimescaleDB "leads every query that filters one host" — true, and it
reads as though the rest were close. Against heap we win q4/q5/q6/q8 by 20-50% and
lose the other four.

**2. One claim rested on a competitor's crash.** "pgColumnar leads the wide aggregate
shapes with workers... first on both" is true at P=4 only because **TimescaleDB's
parallel arm fails on this host**. In serial, where it runs, it beats us on both q5 and
q6. The method section disclosed the failure; the paragraph making the claim did not
repeat it, and that is where a reader forms the impression.

**3. A factual error in the setup list.** It said pgColumnar's storage is "in load
order, which is time ascending". It is not: measured correlation with physical order is
**0.013 for `time` and -0.004 for `hostname`**. Neither key is sorted.

## And that third point is the explanation, which was missing

Measured on q2 with `EXPLAIN (ANALYZE)`:

```
Columnar Chunk Groups Total: 667
Columnar Chunk Groups Read: 667
Columnar Chunk Groups Removed by Filter: 0
Rows Removed by Filter: 99995680
```

**Zero groups skipped.** It reads all 667 and filters 99,995,680 rows to return 4,320.
The zone maps cannot help because every stripe holds all 4,000 hosts, so each group's
`hostname` min/max covers the whole set. TimescaleDB answers the same query in ~2 ms by
excluding all but one chunk on time, then reading one `hostname` segment through an
index.

## What I did not do

**I did not re-measure a clustered pgColumnar table to make the numbers look better.**
The page now says the table measures pgColumnar in the layout that suits it least, that
a user with this shape would cluster on `hostname` (what `segmentby` does for
TimescaleDB), that the configuration is unmeasured, and that the q1-q3 gap should not be
read as a property of columnar storage until it is.

Measuring the clustered variant is worth doing and belongs in its own change, with its
own method, rather than folded into a correction of my own framing.

`test/ste_check.py` passes on every user-facing document.

## Conflict note

#380 also touches `docs/benchmarks.md`. If that merges first I will rebase; the changes
are in different parts of the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
