### PR TITLE
q2 on TimescaleDB is 5 ms, not about 2

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -489,7 +489,7 @@ Rows Removed by Filter: 99995680
 It reads all 667 row groups and filters 99,995,680 rows to return 4,320. The zone maps cannot help,
 because neither key is sorted in the stored order. Every stripe holds all 4,000 hosts.
 The minimum and maximum `hostname` of each group therefore covers the whole set.
-TimescaleDB answers the same query in about 2 milliseconds. It excludes all but one
+TimescaleDB answers the same query in 5 milliseconds. It excludes all but one
 chunk on time, then reads one `hostname` segment through an index.
 
 **So this table measures pgColumnar in the layout that suits it least.** A user with


### PR DESCRIPTION
One-word correction to #381.

The paragraph explaining why the one-host queries are far apart said TimescaleDB answers q2 "in about 2 milliseconds". The serial table in the same file says **5**, and the 442x figure quoted three paragraphs above is exactly `2,211 / 5`. There is no 2 ms cell in that row; the nearest is q1 at 4.

A number in the prose that disagrees with the table it explains is the specific failure #381 was written to correct.

Everything else in #381 I verified on the bench and it holds: the correlations (0.0133 for `time`, -0.0036 for `hostname`), the zero group skipping (667 of 667 read, 0 removed, 0 vectors skipped, 99,995,680 rows filtered to return 4,320), and all eight multipliers against the table.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)