### PR TITLE
The release-status page said no release was tagged (#383 follow-up)

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -2,11 +2,11 @@
 
 ## Release status
 
-pgColumnar is pre-release. The version marker is `1.0-dev`, recorded in `VERSION`,
-and there has been no tagged release.
+pgColumnar is pre-release. The version marker is `1.0-alpha`, recorded in `VERSION`,
+and `v1.0-alpha` is tagged and published as a pre-release.
 
-Until there is, treat a columnar table as reloadable and keep the source the data
-was loaded from. The extension is appropriate today for evaluation, for analytical
+An alpha is still an alpha: treat a columnar table as reloadable and keep the source
+the data was loaded from. The extension is appropriate today for evaluation, for analytical
 tables that can be rebuilt from an external source, and for development, testing,
 and measurement. It is not yet recommended for a production system of record or
 for data that cannot be reloaded.


### PR DESCRIPTION
Follow-up to #383, which pointed the README at 1.0-alpha.

The status badge two lines above the one #383 edited links to `docs/limitations.md#release-status`, and that section still read:

> The version marker is `1.0-dev`, recorded in `VERSION`, and there has been no tagged release.

Both halves were wrong after v1.0-alpha shipped, and the second is the one that matters: a reader following the badge from a README that says 1.0-alpha landed on a page telling them no release exists.

The guidance below it is unchanged, because it is still true of an alpha: reloadable tables, appropriate for evaluation and analytical rebuilds, not yet a production system of record. Only the "until there is" premise, which assumed no release existed, is reworded.

**Deliberately not restating the extension's `default_version` here.** #389 moves it to `1.0-alpha` with an upgrade script, so a paragraph pinning it at `1.0-dev` would be false on merge. The CHANGELOG already carries that distinction.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)