### PR TITLE
Say that the benchmark page measures no joins at all

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -614,16 +614,32 @@ both are larger than anything in it:
 The point lookup is the one number that moved the wrong way, and it moved a long
 way. See the note above it.
 
+## What this page does not measure
+
+**Every query on this page reads one table.** The TSBS workload is time-series
+shaped. All eight of its queries are a scan, a filter and an aggregate over a
+single relation. None of them joins.
+
+So the join-heavy analytical shapes are absent: star schemas, fact tables joined
+to dimensions, and the selective-dimension-join pattern. Those are a large part of
+what columnar storage is usually bought for, and this page says nothing about
+them. Not that we do badly on them. We have not measured them. See #401.
+
+Read the conclusions below as being about single-table scan and aggregate work,
+because that is the evidence behind them.
+
 ## Reading the results
 
-Columnar wins on analytic shapes: aggregates answered from metadata, filtered
-aggregates that minimum, maximum and bloom skipping can prune, wide-table
-projections, and index-only covering scans. The size reduction comes mostly from
+Columnar wins on the analytic shapes measured here. Those are aggregates answered
+from metadata, filtered aggregates that minimum, maximum and bloom skipping can
+prune, wide-table projections, and index-only covering scans. The size reduction comes mostly from
 the encoding layer before zstd. Vectorization adds a large further speedup on
 aggregates, and storing a table sorted on its range key improves skipping.
 
 Heap is better for single-row fetches and for deletes, and by a large margin in
 both. On a table with deletes, the aggregate advantage is not present until a
 vacuum runs.
-Columnar is the wrong choice for write-heavy OLTP and the right choice for
-scan-heavy and aggregate-heavy analytics over wide, append-mostly tables.
+Columnar is the wrong choice for write-heavy OLTP. It is the right choice for
+scan-heavy and aggregate-heavy analytics over wide, append-mostly tables, on the
+single-table shapes measured here. Whether that holds once a join is involved is
+an open question and not a claim this page supports.


### PR DESCRIPTION
`docs/benchmarks.md` draws conclusions about "analytics". Its evidence covers one shape of
analytics.

## The gap

```
$ grep -lci '\bjoin\b' queries/tsbs/*.sql | wc -l
0
$ grep -hiE '^\s*FROM' queries/tsbs/*.sql | sort | uniq -c
      8 FROM %T
```

All eight TSBS queries are a scan, a filter and an aggregate over one relation. The page
then closes with:

> Columnar is the wrong choice for write-heavy OLTP and the right choice for scan-heavy
> and aggregate-heavy analytics over wide, append-mostly tables.

Star schemas and fact-to-dimension joins are a large part of what columnar storage is
bought for. Read as written, that sentence invites a reader to carry a single-table result
into a workload we have never run.

## What changed

A **What this page does not measure** section, placed before the conclusions rather than
after them, saying which shapes are absent and that the absence is **unmeasured rather
than bad**. The two conclusions that said "analytics" now say which analytics, and the
closing line notes that whether the result survives a join is open.

Wording is deliberate on one point. It says we have not measured these shapes, not that we
are slow on them. We do not know either way, and the page should not imply confidence in
either direction.

## Why now rather than with the measurement

#401 covers building a join-heavy fixture and measuring it. That is real work with a real
answer at the end. The disclosure is true today and costs nothing, and the page is linked
from the 1.0-alpha release notes.

Same class as #381 and #391: the page claiming more than the measurement behind it
supports. This one differs in that nothing measured is wrong, only the scope the
conclusions are drawn over.

Docs only.