### PR TITLE
Joins work; it is their speed that is unmeasured (#402 follow-up)

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -625,6 +625,12 @@ to dimensions, and the selective-dimension-join pattern. Those are a large part 
 what columnar storage is usually bought for, and this page says nothing about
 them. Not that we do badly on them. We have not measured them. See #401.
 
+Joins themselves work. A columnar table joins a heap table in either direction,
+and a columnar table, under hash, merge and nested-loop strategies, returning the
+same rows as the all-heap equivalent, with column projection surviving the join so
+the columnar side reads only the columns the join and the target list need. What is
+absent is a measurement of how fast that is, not evidence that it works.
+
 Read the conclusions below as being about single-table scan and aggregate work,
 because that is the evidence behind them.
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -626,8 +626,8 @@ what columnar storage is usually bought for, and this page says nothing about
 them. Not that we do badly on them. We have not measured them. See #401.
 
 Joins themselves work. A columnar table joins a heap table in either direction,
-and a columnar table, under hash, merge and nested-loop strategies, returning the
-same rows as the all-heap equivalent, with column projection surviving the join so
+and joins another columnar table. Hash, merge and nested-loop strategies all return
+the same rows as the all-heap equivalent. Column projection survives the join, so
 the columnar side reads only the columns the join and the target list need. What is
 absent is a measurement of how fast that is, not evidence that it works.
 


### PR DESCRIPTION
Follow-up to #402, as I said on the review.

#402 correctly says the join-heavy shapes are absent from the page. It leaves one thing ambiguous: it says nothing about whether joins **work**, so a reader can come away unsure whether a columnar table joins at all. That is a worse impression than the truth.

Measured on a 200,000-row fixture:

| shape | result |
|---|---|
| columnar fact JOIN heap dimension, inner + aggregate | identical to heap/heap |
| LEFT JOIN with nulls | identical |
| heap on the outer side | identical |
| columnar JOIN columnar | identical |
| semijoin (`EXISTS`) / anti-join (`NOT EXISTS`) | identical |
| hash / merge / nested loop, each forced | all correct, all chosen |

Column projection also survives the join (`Columnar Projected Columns: 1` of 4), so the columnar side reads only what the join and target list need rather than losing the advantage at the boundary.

So the accurate claim is narrower and stronger than an absence: **the speed is unmeasured, the correctness is not in question.** #401 still owns the measurement.

Docs only, no em or en dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)