### PR TITLE
Cache the apt archives, and verify the cache is used (#386)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # The packages are ~102 MB, of which ~91 MB is the LLVM toolchain that
+      # postgresql-server-dev-N depends on. That download is what stalls: every
+      # failure of this step sat at the 600s bound while every success finished
+      # in a median of 25s (#386). Caching the debs removes the download on a
+      # hit, and a miss degrades to exactly what happens today.
+      #
+      # ImageOS is in the key because a new runner image can bring a different
+      # LLVM major, and a key that ignored it would serve debs for the wrong one.
+      - name: Cache the PostgreSQL ${{ matrix.pg }} and codec headers packages
+        id: apt-build
+        uses: actions/cache@v4
+        with:
+          path: ~/apt-archives
+          key: apt-pgdev-codecs-pg${{ matrix.pg }}-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS }}-v1
+
       - name: Install PostgreSQL ${{ matrix.pg }} and codec headers
         run: |
           set -euo pipefail
@@ -81,9 +96,21 @@ jobs:
           # Acquire retries cover a flaky mirror; the outer timeout keeps a
           # wedged one from consuming the whole job budget.
           sudo timeout 300 apt-get -o Acquire::Retries=5 update
-          sudo timeout 600 apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
+          mkdir -p "$HOME/apt-archives/partial"
+          sudo timeout 600 apt-get -o Acquire::Retries=5 \
+            -o Dir::Cache::archives="$HOME/apt-archives" install -y --no-install-recommends \
             postgresql-${{ matrix.pg }} postgresql-server-dev-${{ matrix.pg }} \
-            liblz4-dev libzstd-dev zlib1g-dev
+            liblz4-dev libzstd-dev zlib1g-dev 2>&1 | tee /tmp/apt-install.log
+          # A cache that populates but never hits looks identical in the log to one
+          # that works: the job is simply still slow. So assert it. On a hit,
+          # apt must not have fetched anything over the network.
+          sudo chown -R "$USER" "$HOME/apt-archives" || true
+          if [ "${{ steps.apt-build.outputs.cache-hit }}" = "true" ] \
+             && grep -qE '^Get:[0-9]+ https?://' /tmp/apt-install.log; then
+            echo "::error::apt cache reported a hit but packages were downloaded anyway"
+            grep -E '^Get:[0-9]+ https?://' /tmp/apt-install.log
+            exit 1
+          fi
 
       - name: Build, treating warnings as failures
         run: |
@@ -215,6 +242,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # The packages are ~102 MB, of which ~91 MB is the LLVM toolchain that
+      # postgresql-server-dev-N depends on. That download is what stalls: every
+      # failure of this step sat at the 600s bound while every success finished
+      # in a median of 25s (#386). Caching the debs removes the download on a
+      # hit, and a miss degrades to exactly what happens today.
+      #
+      # ImageOS is in the key because a new runner image can bring a different
+      # LLVM major, and a key that ignored it would serve debs for the wrong one.
+      - name: Cache the PostgreSQL ${{ matrix.pg }}, codec headers, and pyarrow packages
+        id: apt-suites
+        uses: actions/cache@v4
+        with:
+          path: ~/apt-archives
+          key: apt-pgdev-codecs-pyarrow-pg${{ matrix.pg }}-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS }}-v1
+
       - name: Install PostgreSQL ${{ matrix.pg }}, codec headers, and pyarrow
         run: |
           set -euo pipefail
@@ -232,9 +274,11 @@ jobs:
           # Acquire retries cover a flaky mirror; the outer timeout keeps a
           # wedged one from consuming the whole job budget.
           sudo timeout 300 apt-get -o Acquire::Retries=5 update
-          sudo timeout 600 apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
+          mkdir -p "$HOME/apt-archives/partial"
+          sudo timeout 600 apt-get -o Acquire::Retries=5 \
+            -o Dir::Cache::archives="$HOME/apt-archives" install -y --no-install-recommends \
             postgresql-${{ matrix.pg }} postgresql-server-dev-${{ matrix.pg }} \
-            liblz4-dev libzstd-dev zlib1g-dev python3-pip
+            liblz4-dev libzstd-dev zlib1g-dev python3-pip 2>&1 | tee /tmp/apt-install.log
           # The Arrow and Parquet suites use pyarrow as an independent reader and
           # skip themselves without it, which would be a silent loss of coverage.
           # Installed with sudo on purpose. The suites run under sudo, so the
@@ -244,6 +288,16 @@ jobs:
           # while skipping themselves.
           sudo pip3 install --break-system-packages --quiet pyarrow \
             || sudo pip3 install --quiet pyarrow
+          # A cache that populates but never hits looks identical in the log to one
+          # that works: the job is simply still slow. So assert it. On a hit,
+          # apt must not have fetched anything over the network.
+          sudo chown -R "$USER" "$HOME/apt-archives" || true
+          if [ "${{ steps.apt-suites.outputs.cache-hit }}" = "true" ] \
+             && grep -qE '^Get:[0-9]+ https?://' /tmp/apt-install.log; then
+            echo "::error::apt cache reported a hit but packages were downloaded anyway"
+            grep -E '^Get:[0-9]+ https?://' /tmp/apt-install.log
+            exit 1
+          fi
 
       - name: Confirm pyarrow is importable by the suites' interpreter
         # Installing pyarrow and having the suites SEE it are different facts. The

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,22 +64,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # The packages are ~102 MB, of which ~91 MB is the LLVM toolchain that
-      # postgresql-server-dev-N depends on. That download is what stalls: every
-      # failure of this step sat at the 600s bound while every success finished
-      # in a median of 25s (#386). Caching the debs removes the download on a
-      # hit, and a miss degrades to exactly what happens today.
-      #
-      # ImageOS is in the key because a new runner image can bring a different
-      # LLVM major, and a key that ignored it would serve debs for the wrong one.
-      - name: Cache the PostgreSQL ${{ matrix.pg }} and codec headers packages
-        id: apt-build
-        uses: actions/cache@v4
-        with:
-          path: ~/apt-archives
-          key: apt-pgdev-codecs-pg${{ matrix.pg }}-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS }}-v1
-
-      - name: Install PostgreSQL ${{ matrix.pg }} and codec headers
+      # The repository and the package lists first, on their own, because the
+      # cache key below is derived from the versions apt resolves and cannot be
+      # computed before the lists exist.
+      - name: Add the PGDG repository and refresh the package lists
         run: |
           set -euo pipefail
           sudo install -d /usr/share/postgresql-common/pgdg
@@ -96,15 +84,76 @@ jobs:
           # Acquire retries cover a flaky mirror; the outer timeout keeps a
           # wedged one from consuming the whole job budget.
           sudo timeout 300 apt-get -o Acquire::Retries=5 update
+
+      # The key has to track the package VERSIONS and not only their names.
+      #
+      # actions/cache skips its save step on an exact-key hit, so a fixed key
+      # freezes the archives until a human edits it. On the day PGDG publishes a
+      # new minor, the cache hits with the old debs, apt resolves to the new
+      # ones and downloads them, and the assertion below sees a hit together
+      # with a download and fails the job. Every entry in the matrix goes red on
+      # a routine upstream release, and stays red until someone bumps the key by
+      # hand. That is a false red on a monthly timer.
+      #
+      # Hashing the resolved candidate versions makes an upstream bump a new
+      # key: it misses, downloads, and saves. The restore-keys prefix still
+      # seeds it from the previous archives, so only the changed debs are
+      # fetched. An exact hit then genuinely means nothing should be
+      # downloaded, which is the property worth asserting.
+      - name: Derive the cache key from the versions apt will install
+        id: aptkey
+        run: |
+          set -euo pipefail
+          v=$(apt-cache policy \
+                postgresql-${{ matrix.pg }} postgresql-server-dev-${{ matrix.pg }} \
+                liblz4-dev libzstd-dev zlib1g-dev \
+              | awk '/Candidate:/ {print $2}' | sort | md5sum | cut -c1-12)
+          # A hash of nothing is a constant, which would silently restore the
+          # frozen key this step exists to remove.
+          test -n "$v"
+          echo "k=$v" >> "$GITHUB_OUTPUT"
+          echo "resolved candidate versions hash: $v"
+
+      # The packages are ~102 MB, of which ~91 MB is the LLVM toolchain that
+      # postgresql-server-dev-N depends on. That download is what stalls: every
+      # failure of this step sat at the 600s bound while every success finished
+      # in a median of 25s (#386). Caching the debs removes the download on a
+      # hit, and a miss degrades to exactly what happens today.
+      #
+      # ImageOS is in the key because a new runner image can bring a different
+      # LLVM major, and a key that ignored it would serve debs for the wrong one.
+      - name: Cache the PostgreSQL ${{ matrix.pg }} and codec headers packages
+        id: apt-build
+        uses: actions/cache@v4
+        with:
+          path: ~/apt-archives
+          key: apt-pgdev-codecs-pg${{ matrix.pg }}-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS }}-${{ steps.aptkey.outputs.k }}-v2
+          restore-keys: |
+            apt-pgdev-codecs-pg${{ matrix.pg }}-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS }}-
+
+      - name: Install PostgreSQL ${{ matrix.pg }} and codec headers
+        run: |
+          set -euo pipefail
           mkdir -p "$HOME/apt-archives/partial"
           sudo timeout 600 apt-get -o Acquire::Retries=5 \
             -o Dir::Cache::archives="$HOME/apt-archives" install -y --no-install-recommends \
             postgresql-${{ matrix.pg }} postgresql-server-dev-${{ matrix.pg }} \
             liblz4-dev libzstd-dev zlib1g-dev 2>&1 | tee /tmp/apt-install.log
+          # apt downloads as _apt, so the debs and partial/ are not owned by the
+          # runner user and the post-job save cannot read them. This is not
+          # allowed to fail quietly. A failed chown means the save fails, the
+          # cache is never populated, there is never a hit, and the assertion
+          # below never fires, because it is gated on a hit. Permanently slow
+          # and permanently green is the failure this whole step is about.
+          sudo chown -R "$USER" "$HOME/apt-archives"
+          test -r "$HOME/apt-archives"
           # A cache that populates but never hits looks identical in the log to one
-          # that works: the job is simply still slow. So assert it. On a hit,
-          # apt must not have fetched anything over the network.
-          sudo chown -R "$USER" "$HOME/apt-archives" || true
+          # that works: the job is simply still slow. So assert it. On an exact
+          # hit, apt must not have fetched anything over the network.
+          #
+          # A restore-keys prefix match reports cache-hit false, so a partial
+          # restore that downloads the changed debs is not caught here. That is
+          # correct: it is supposed to download them.
           if [ "${{ steps.apt-build.outputs.cache-hit }}" = "true" ] \
              && grep -qE '^Get:[0-9]+ https?://' /tmp/apt-install.log; then
             echo "::error::apt cache reported a hit but packages were downloaded anyway"
@@ -242,22 +291,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # The packages are ~102 MB, of which ~91 MB is the LLVM toolchain that
-      # postgresql-server-dev-N depends on. That download is what stalls: every
-      # failure of this step sat at the 600s bound while every success finished
-      # in a median of 25s (#386). Caching the debs removes the download on a
-      # hit, and a miss degrades to exactly what happens today.
-      #
-      # ImageOS is in the key because a new runner image can bring a different
-      # LLVM major, and a key that ignored it would serve debs for the wrong one.
-      - name: Cache the PostgreSQL ${{ matrix.pg }}, codec headers, and pyarrow packages
-        id: apt-suites
-        uses: actions/cache@v4
-        with:
-          path: ~/apt-archives
-          key: apt-pgdev-codecs-pyarrow-pg${{ matrix.pg }}-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS }}-v1
-
-      - name: Install PostgreSQL ${{ matrix.pg }}, codec headers, and pyarrow
+      # The repository and the package lists first, on their own, because the
+      # cache key below is derived from the versions apt resolves and cannot be
+      # computed before the lists exist.
+      - name: Add the PGDG repository and refresh the package lists
         run: |
           set -euo pipefail
           sudo install -d /usr/share/postgresql-common/pgdg
@@ -274,6 +311,44 @@ jobs:
           # Acquire retries cover a flaky mirror; the outer timeout keeps a
           # wedged one from consuming the whole job budget.
           sudo timeout 300 apt-get -o Acquire::Retries=5 update
+
+      # See the build job for why the key hashes the resolved versions: a fixed
+      # key freezes the archives, and the next routine PGDG minor then turns the
+      # download assertion below into a false red across the whole matrix.
+      - name: Derive the cache key from the versions apt will install
+        id: aptkey
+        run: |
+          set -euo pipefail
+          v=$(apt-cache policy \
+                postgresql-${{ matrix.pg }} postgresql-server-dev-${{ matrix.pg }} \
+                liblz4-dev libzstd-dev zlib1g-dev python3-pip \
+              | awk '/Candidate:/ {print $2}' | sort | md5sum | cut -c1-12)
+          # A hash of nothing is a constant, which would silently restore the
+          # frozen key this step exists to remove.
+          test -n "$v"
+          echo "k=$v" >> "$GITHUB_OUTPUT"
+          echo "resolved candidate versions hash: $v"
+
+      # The packages are ~102 MB, of which ~91 MB is the LLVM toolchain that
+      # postgresql-server-dev-N depends on. That download is what stalls: every
+      # failure of this step sat at the 600s bound while every success finished
+      # in a median of 25s (#386). Caching the debs removes the download on a
+      # hit, and a miss degrades to exactly what happens today.
+      #
+      # ImageOS is in the key because a new runner image can bring a different
+      # LLVM major, and a key that ignored it would serve debs for the wrong one.
+      - name: Cache the PostgreSQL ${{ matrix.pg }}, codec headers, and pyarrow packages
+        id: apt-suites
+        uses: actions/cache@v4
+        with:
+          path: ~/apt-archives
+          key: apt-pgdev-codecs-pyarrow-pg${{ matrix.pg }}-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS }}-${{ steps.aptkey.outputs.k }}-v2
+          restore-keys: |
+            apt-pgdev-codecs-pyarrow-pg${{ matrix.pg }}-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS }}-
+
+      - name: Install PostgreSQL ${{ matrix.pg }}, codec headers, and pyarrow
+        run: |
+          set -euo pipefail
           mkdir -p "$HOME/apt-archives/partial"
           sudo timeout 600 apt-get -o Acquire::Retries=5 \
             -o Dir::Cache::archives="$HOME/apt-archives" install -y --no-install-recommends \
@@ -288,10 +363,21 @@ jobs:
           # while skipping themselves.
           sudo pip3 install --break-system-packages --quiet pyarrow \
             || sudo pip3 install --quiet pyarrow
+          # apt downloads as _apt, so the debs and partial/ are not owned by the
+          # runner user and the post-job save cannot read them. This is not
+          # allowed to fail quietly. A failed chown means the save fails, the
+          # cache is never populated, there is never a hit, and the assertion
+          # below never fires, because it is gated on a hit. Permanently slow
+          # and permanently green is the failure this whole step is about.
+          sudo chown -R "$USER" "$HOME/apt-archives"
+          test -r "$HOME/apt-archives"
           # A cache that populates but never hits looks identical in the log to one
-          # that works: the job is simply still slow. So assert it. On a hit,
-          # apt must not have fetched anything over the network.
-          sudo chown -R "$USER" "$HOME/apt-archives" || true
+          # that works: the job is simply still slow. So assert it. On an exact
+          # hit, apt must not have fetched anything over the network.
+          #
+          # A restore-keys prefix match reports cache-hit false, so a partial
+          # restore that downloads the changed debs is not caught here. That is
+          # correct: it is supposed to download them.
           if [ "${{ steps.apt-suites.outputs.cache-hit }}" = "true" ] \
              && grep -qE '^Get:[0-9]+ https?://' /tmp/apt-install.log; then
             echo "::error::apt cache reported a hit but packages were downloaded anyway"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,12 +107,17 @@ jobs:
           v=$(apt-cache policy \
                 postgresql-${{ matrix.pg }} postgresql-server-dev-${{ matrix.pg }} \
                 liblz4-dev libzstd-dev zlib1g-dev \
-              | awk '/Candidate:/ {print $2}' | sort | md5sum | cut -c1-12)
+              | awk '/Candidate:/ {print $2}' | sort)
+          # $ImageOS, from the shell, where it actually has a value. Reported
+          # rather than only hashed, so an empty one is visible in the log
+          # instead of silently hashing to a constant.
+          echo "runner image: ${ImageOS:-<empty>}   candidates:"; echo "$v" | sed 's/^/  /'
+          h=$(printf '%s\n%s\n' "${ImageOS:-}" "$v" | md5sum | cut -c1-12)
           # A hash of nothing is a constant, which would silently restore the
           # frozen key this step exists to remove.
           test -n "$v"
-          echo "k=$v" >> "$GITHUB_OUTPUT"
-          echo "resolved candidate versions hash: $v"
+          echo "k=$h" >> "$GITHUB_OUTPUT"
+          echo "cache key hash: $h"
 
       # The packages are ~102 MB, of which ~91 MB is the LLVM toolchain that
       # postgresql-server-dev-N depends on. That download is what stalls: every
@@ -120,16 +125,23 @@ jobs:
       # in a median of 25s (#386). Caching the debs removes the download on a
       # hit, and a miss degrades to exactly what happens today.
       #
-      # ImageOS is in the key because a new runner image can bring a different
-      # LLVM major, and a key that ignored it would serve debs for the wrong one.
+      # The runner image is folded into the hash below, not into the literal key.
+      # A new image can bring a different LLVM major, and a key that ignored it
+      # would serve debs for the wrong one. It was in the literal key as
+      # ${{ env.ImageOS }} and expanded to NOTHING every time: ImageOS is a
+      # runner environment variable, and the env context only carries variables
+      # set by the workflow, job, or step. The observed key was
+      # apt-pgdev-codecs-pg15-Linux-X64--v1, with an empty component between the
+      # two dashes. The shell in the hash step can see $ImageOS; an expression
+      # context cannot.
       - name: Cache the PostgreSQL ${{ matrix.pg }} and codec headers packages
         id: apt-build
         uses: actions/cache@v4
         with:
           path: ~/apt-archives
-          key: apt-pgdev-codecs-pg${{ matrix.pg }}-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS }}-${{ steps.aptkey.outputs.k }}-v2
+          key: apt-pgdev-codecs-pg${{ matrix.pg }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.aptkey.outputs.k }}-v3
           restore-keys: |
-            apt-pgdev-codecs-pg${{ matrix.pg }}-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS }}-
+            apt-pgdev-codecs-pg${{ matrix.pg }}-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Install PostgreSQL ${{ matrix.pg }} and codec headers
         run: |
@@ -322,12 +334,17 @@ jobs:
           v=$(apt-cache policy \
                 postgresql-${{ matrix.pg }} postgresql-server-dev-${{ matrix.pg }} \
                 liblz4-dev libzstd-dev zlib1g-dev python3-pip \
-              | awk '/Candidate:/ {print $2}' | sort | md5sum | cut -c1-12)
+              | awk '/Candidate:/ {print $2}' | sort)
+          # $ImageOS, from the shell, where it actually has a value. Reported
+          # rather than only hashed, so an empty one is visible in the log
+          # instead of silently hashing to a constant.
+          echo "runner image: ${ImageOS:-<empty>}   candidates:"; echo "$v" | sed 's/^/  /'
+          h=$(printf '%s\n%s\n' "${ImageOS:-}" "$v" | md5sum | cut -c1-12)
           # A hash of nothing is a constant, which would silently restore the
           # frozen key this step exists to remove.
           test -n "$v"
-          echo "k=$v" >> "$GITHUB_OUTPUT"
-          echo "resolved candidate versions hash: $v"
+          echo "k=$h" >> "$GITHUB_OUTPUT"
+          echo "cache key hash: $h"
 
       # The packages are ~102 MB, of which ~91 MB is the LLVM toolchain that
       # postgresql-server-dev-N depends on. That download is what stalls: every
@@ -335,16 +352,23 @@ jobs:
       # in a median of 25s (#386). Caching the debs removes the download on a
       # hit, and a miss degrades to exactly what happens today.
       #
-      # ImageOS is in the key because a new runner image can bring a different
-      # LLVM major, and a key that ignored it would serve debs for the wrong one.
+      # The runner image is folded into the hash below, not into the literal key.
+      # A new image can bring a different LLVM major, and a key that ignored it
+      # would serve debs for the wrong one. It was in the literal key as
+      # ${{ env.ImageOS }} and expanded to NOTHING every time: ImageOS is a
+      # runner environment variable, and the env context only carries variables
+      # set by the workflow, job, or step. The observed key was
+      # apt-pgdev-codecs-pg15-Linux-X64--v1, with an empty component between the
+      # two dashes. The shell in the hash step can see $ImageOS; an expression
+      # context cannot.
       - name: Cache the PostgreSQL ${{ matrix.pg }}, codec headers, and pyarrow packages
         id: apt-suites
         uses: actions/cache@v4
         with:
           path: ~/apt-archives
-          key: apt-pgdev-codecs-pyarrow-pg${{ matrix.pg }}-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS }}-${{ steps.aptkey.outputs.k }}-v2
+          key: apt-pgdev-codecs-pyarrow-pg${{ matrix.pg }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.aptkey.outputs.k }}-v3
           restore-keys: |
-            apt-pgdev-codecs-pyarrow-pg${{ matrix.pg }}-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS }}-
+            apt-pgdev-codecs-pyarrow-pg${{ matrix.pg }}-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Install PostgreSQL ${{ matrix.pg }}, codec headers, and pyarrow
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,10 +112,14 @@ jobs:
           # rather than only hashed, so an empty one is visible in the log
           # instead of silently hashing to a constant.
           echo "runner image: ${ImageOS:-<empty>}   candidates:"; echo "$v" | sed 's/^/  /'
-          h=$(printf '%s\n%s\n' "${ImageOS:-}" "$v" | md5sum | cut -c1-12)
-          # A hash of nothing is a constant, which would silently restore the
-          # frozen key this step exists to remove.
+          # Both inputs must be non-empty. A hash of nothing is a constant, and a
+          # constant silently restores the frozen key this step exists to remove.
+          # An empty ImageOS is how the runner-image protection went missing the
+          # first time, and folding in a placeholder instead of failing is how it
+          # would go missing again.
           test -n "$v"
+          test -n "${ImageOS:-}"
+          h=$(printf '%s\n%s\n' "$ImageOS" "$v" | md5sum | cut -c1-12)
           echo "k=$h" >> "$GITHUB_OUTPUT"
           echo "cache key hash: $h"
 
@@ -339,10 +343,14 @@ jobs:
           # rather than only hashed, so an empty one is visible in the log
           # instead of silently hashing to a constant.
           echo "runner image: ${ImageOS:-<empty>}   candidates:"; echo "$v" | sed 's/^/  /'
-          h=$(printf '%s\n%s\n' "${ImageOS:-}" "$v" | md5sum | cut -c1-12)
-          # A hash of nothing is a constant, which would silently restore the
-          # frozen key this step exists to remove.
+          # Both inputs must be non-empty. A hash of nothing is a constant, and a
+          # constant silently restores the frozen key this step exists to remove.
+          # An empty ImageOS is how the runner-image protection went missing the
+          # first time, and folding in a placeholder instead of failing is how it
+          # would go missing again.
           test -n "$v"
+          test -n "${ImageOS:-}"
+          h=$(printf '%s\n%s\n' "$ImageOS" "$v" | md5sum | cut -c1-12)
           echo "k=$h" >> "$GITHUB_OUTPUT"
           echo "cache key hash: $h"
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -61,6 +61,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # The packages are ~102 MB, of which ~91 MB is the LLVM toolchain that
+      # postgresql-server-dev-N depends on. That download is what stalls: every
+      # failure of this step sat at the 600s bound while every success finished
+      # in a median of 25s (#386). Caching the debs removes the download on a
+      # hit, and a miss degrades to exactly what happens today.
+      #
+      # ImageOS is in the key because a new runner image can bring a different
+      # LLVM major, and a key that ignored it would serve debs for the wrong one.
+      - name: Cache the PostgreSQL ${{ matrix.pg }}, codec headers, and pyarrow packages
+        id: apt-nightly
+        uses: actions/cache@v4
+        with:
+          path: ~/apt-archives
+          key: apt-pgdev-codecs-pyarrow-pg${{ matrix.pg }}-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS }}-v1
+
       - name: Install PostgreSQL ${{ matrix.pg }}, codec headers, and pyarrow
         run: |
           set -euo pipefail
@@ -73,13 +88,25 @@ jobs:
             https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
             | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
           sudo timeout 300 apt-get -o Acquire::Retries=5 update
-          sudo timeout 600 apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
+          mkdir -p "$HOME/apt-archives/partial"
+          sudo timeout 600 apt-get -o Acquire::Retries=5 \
+            -o Dir::Cache::archives="$HOME/apt-archives" install -y --no-install-recommends \
             postgresql-${{ matrix.pg }} postgresql-server-dev-${{ matrix.pg }} \
-            liblz4-dev libzstd-dev zlib1g-dev python3-pip
+            liblz4-dev libzstd-dev zlib1g-dev python3-pip 2>&1 | tee /tmp/apt-install.log
           # pyarrow for root (the suites run under sudo); the silent-skip trap the
           # per-PR workflow documents applies here too.
           sudo pip3 install --break-system-packages --quiet pyarrow \
             || sudo pip3 install --quiet pyarrow
+          # A cache that populates but never hits looks identical in the log to one
+          # that works: the job is simply still slow. So assert it. On a hit,
+          # apt must not have fetched anything over the network.
+          sudo chown -R "$USER" "$HOME/apt-archives" || true
+          if [ "${{ steps.apt-nightly.outputs.cache-hit }}" = "true" ] \
+             && grep -qE '^Get:[0-9]+ https?://' /tmp/apt-install.log; then
+            echo "::error::apt cache reported a hit but packages were downloaded anyway"
+            grep -E '^Get:[0-9]+ https?://' /tmp/apt-install.log
+            exit 1
+          fi
 
       - name: Confirm pyarrow is importable by the suites' interpreter
         run: |
@@ -237,6 +264,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # The packages are ~102 MB, of which ~91 MB is the LLVM toolchain that
+      # postgresql-server-dev-N depends on. That download is what stalls: every
+      # failure of this step sat at the 600s bound while every success finished
+      # in a median of 25s (#386). Caching the debs removes the download on a
+      # hit, and a miss degrades to exactly what happens today.
+      #
+      # ImageOS is in the key because a new runner image can bring a different
+      # LLVM major, and a key that ignored it would serve debs for the wrong one.
+      - name: Cache the PostgreSQL 18, codec headers, lcov, and pyarrow packages
+        id: apt-coverage
+        uses: actions/cache@v4
+        with:
+          path: ~/apt-archives
+          key: apt-pgdev-codecs-lcov-pyarrow-pg18-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS }}-v1
+
       - name: Install PostgreSQL 18, codec headers, lcov, and pyarrow
         run: |
           set -euo pipefail
@@ -249,15 +291,27 @@ jobs:
             https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
             | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
           sudo timeout 300 apt-get -o Acquire::Retries=5 update
-          sudo timeout 600 apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
+          mkdir -p "$HOME/apt-archives/partial"
+          sudo timeout 600 apt-get -o Acquire::Retries=5 \
+            -o Dir::Cache::archives="$HOME/apt-archives" install -y --no-install-recommends \
             postgresql-18 postgresql-server-dev-18 \
-            liblz4-dev libzstd-dev zlib1g-dev python3-pip lcov
+            liblz4-dev libzstd-dev zlib1g-dev python3-pip lcov 2>&1 | tee /tmp/apt-install.log
           # Installed with sudo because the suites run under sudo; a plain
           # pip3 install lands in ~/.local where root cannot see it, which is how
           # the Arrow and Parquet suites once reported PASS while skipping.
           sudo pip3 install --break-system-packages --quiet pyarrow \
             || sudo pip3 install --quiet pyarrow
           sudo python3 -c 'import pyarrow, pyarrow.parquet; print("pyarrow as root ok")'
+          # A cache that populates but never hits looks identical in the log to one
+          # that works: the job is simply still slow. So assert it. On a hit,
+          # apt must not have fetched anything over the network.
+          sudo chown -R "$USER" "$HOME/apt-archives" || true
+          if [ "${{ steps.apt-coverage.outputs.cache-hit }}" = "true" ] \
+             && grep -qE '^Get:[0-9]+ https?://' /tmp/apt-install.log; then
+            echo "::error::apt cache reported a hit but packages were downloaded anyway"
+            grep -E '^Get:[0-9]+ https?://' /tmp/apt-install.log
+            exit 1
+          fi
 
       - name: Stop the packaged cluster
         run: sudo systemctl stop postgresql || true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -104,8 +104,11 @@ jobs:
           # rather than only hashed, so an empty one is visible in the log
           # instead of silently hashing to a constant.
           echo "runner image: ${ImageOS:-<empty>}   candidates:"; echo "$v" | sed 's/^/  /'
-          h=$(printf '%s\n%s\n' "${ImageOS:-}" "$v" | md5sum | cut -c1-12)
+          # Both inputs must be non-empty; see ci.yml's build job for why a
+          # placeholder instead of a failure is how this protection goes missing.
           test -n "$v"
+          test -n "${ImageOS:-}"
+          h=$(printf '%s\n%s\n' "$ImageOS" "$v" | md5sum | cut -c1-12)
           echo "k=$h" >> "$GITHUB_OUTPUT"
           echo "cache key hash: $h"
 
@@ -345,8 +348,11 @@ jobs:
           # rather than only hashed, so an empty one is visible in the log
           # instead of silently hashing to a constant.
           echo "runner image: ${ImageOS:-<empty>}   candidates:"; echo "$v" | sed 's/^/  /'
-          h=$(printf '%s\n%s\n' "${ImageOS:-}" "$v" | md5sum | cut -c1-12)
+          # Both inputs must be non-empty; see ci.yml's build job for why a
+          # placeholder instead of a failure is how this protection goes missing.
           test -n "$v"
+          test -n "${ImageOS:-}"
+          h=$(printf '%s\n%s\n' "$ImageOS" "$v" | md5sum | cut -c1-12)
           echo "k=$h" >> "$GITHUB_OUTPUT"
           echo "cache key hash: $h"
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,8 +67,15 @@ jobs:
       # in a median of 25s (#386). Caching the debs removes the download on a
       # hit, and a miss degrades to exactly what happens today.
       #
-      # ImageOS is in the key because a new runner image can bring a different
-      # LLVM major, and a key that ignored it would serve debs for the wrong one.
+      # The runner image is folded into the hash below, not into the literal key.
+      # A new image can bring a different LLVM major, and a key that ignored it
+      # would serve debs for the wrong one. It was in the literal key as
+      # ${{ env.ImageOS }} and expanded to NOTHING every time: ImageOS is a
+      # runner environment variable, and the env context only carries variables
+      # set by the workflow, job, or step. The observed key was
+      # apt-pgdev-codecs-pg15-Linux-X64--v1, with an empty component between the
+      # two dashes. The shell in the hash step can see $ImageOS; an expression
+      # context cannot.
       - name: Add the PGDG repository and refresh the package lists
         run: |
           set -euo pipefail
@@ -92,19 +99,24 @@ jobs:
           v=$(apt-cache policy \
                 postgresql-${{ matrix.pg }} postgresql-server-dev-${{ matrix.pg }} \
                 liblz4-dev libzstd-dev zlib1g-dev python3-pip \
-              | awk '/Candidate:/ {print $2}' | sort | md5sum | cut -c1-12)
+              | awk '/Candidate:/ {print $2}' | sort)
+          # $ImageOS, from the shell, where it actually has a value. Reported
+          # rather than only hashed, so an empty one is visible in the log
+          # instead of silently hashing to a constant.
+          echo "runner image: ${ImageOS:-<empty>}   candidates:"; echo "$v" | sed 's/^/  /'
+          h=$(printf '%s\n%s\n' "${ImageOS:-}" "$v" | md5sum | cut -c1-12)
           test -n "$v"
-          echo "k=$v" >> "$GITHUB_OUTPUT"
-          echo "resolved candidate versions hash: $v"
+          echo "k=$h" >> "$GITHUB_OUTPUT"
+          echo "cache key hash: $h"
 
       - name: Cache the PostgreSQL ${{ matrix.pg }}, codec headers, and pyarrow packages
         id: apt-nightly
         uses: actions/cache@v4
         with:
           path: ~/apt-archives
-          key: apt-pgdev-codecs-pyarrow-pg${{ matrix.pg }}-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS }}-${{ steps.aptkey.outputs.k }}-v2
+          key: apt-pgdev-codecs-pyarrow-pg${{ matrix.pg }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.aptkey.outputs.k }}-v3
           restore-keys: |
-            apt-pgdev-codecs-pyarrow-pg${{ matrix.pg }}-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS }}-
+            apt-pgdev-codecs-pyarrow-pg${{ matrix.pg }}-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Install PostgreSQL ${{ matrix.pg }}, codec headers, and pyarrow
         run: |
@@ -296,8 +308,15 @@ jobs:
       # in a median of 25s (#386). Caching the debs removes the download on a
       # hit, and a miss degrades to exactly what happens today.
       #
-      # ImageOS is in the key because a new runner image can bring a different
-      # LLVM major, and a key that ignored it would serve debs for the wrong one.
+      # The runner image is folded into the hash below, not into the literal key.
+      # A new image can bring a different LLVM major, and a key that ignored it
+      # would serve debs for the wrong one. It was in the literal key as
+      # ${{ env.ImageOS }} and expanded to NOTHING every time: ImageOS is a
+      # runner environment variable, and the env context only carries variables
+      # set by the workflow, job, or step. The observed key was
+      # apt-pgdev-codecs-pg15-Linux-X64--v1, with an empty component between the
+      # two dashes. The shell in the hash step can see $ImageOS; an expression
+      # context cannot.
       - name: Add the PGDG repository and refresh the package lists
         run: |
           set -euo pipefail
@@ -321,19 +340,24 @@ jobs:
           v=$(apt-cache policy \
                 postgresql-18 postgresql-server-dev-18 \
                 liblz4-dev libzstd-dev zlib1g-dev python3-pip lcov \
-              | awk '/Candidate:/ {print $2}' | sort | md5sum | cut -c1-12)
+              | awk '/Candidate:/ {print $2}' | sort)
+          # $ImageOS, from the shell, where it actually has a value. Reported
+          # rather than only hashed, so an empty one is visible in the log
+          # instead of silently hashing to a constant.
+          echo "runner image: ${ImageOS:-<empty>}   candidates:"; echo "$v" | sed 's/^/  /'
+          h=$(printf '%s\n%s\n' "${ImageOS:-}" "$v" | md5sum | cut -c1-12)
           test -n "$v"
-          echo "k=$v" >> "$GITHUB_OUTPUT"
-          echo "resolved candidate versions hash: $v"
+          echo "k=$h" >> "$GITHUB_OUTPUT"
+          echo "cache key hash: $h"
 
       - name: Cache the PostgreSQL 18, codec headers, lcov, and pyarrow packages
         id: apt-coverage
         uses: actions/cache@v4
         with:
           path: ~/apt-archives
-          key: apt-pgdev-codecs-lcov-pyarrow-pg18-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS }}-${{ steps.aptkey.outputs.k }}-v2
+          key: apt-pgdev-codecs-lcov-pyarrow-pg18-${{ runner.os }}-${{ runner.arch }}-${{ steps.aptkey.outputs.k }}-v3
           restore-keys: |
-            apt-pgdev-codecs-lcov-pyarrow-pg18-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS }}-
+            apt-pgdev-codecs-lcov-pyarrow-pg18-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Install PostgreSQL 18, codec headers, lcov, and pyarrow
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -69,14 +69,7 @@ jobs:
       #
       # ImageOS is in the key because a new runner image can bring a different
       # LLVM major, and a key that ignored it would serve debs for the wrong one.
-      - name: Cache the PostgreSQL ${{ matrix.pg }}, codec headers, and pyarrow packages
-        id: apt-nightly
-        uses: actions/cache@v4
-        with:
-          path: ~/apt-archives
-          key: apt-pgdev-codecs-pyarrow-pg${{ matrix.pg }}-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS }}-v1
-
-      - name: Install PostgreSQL ${{ matrix.pg }}, codec headers, and pyarrow
+      - name: Add the PGDG repository and refresh the package lists
         run: |
           set -euo pipefail
           sudo install -d /usr/share/postgresql-common/pgdg
@@ -88,6 +81,34 @@ jobs:
             https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
             | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
           sudo timeout 300 apt-get -o Acquire::Retries=5 update
+
+      # See ci.yml's build job for why the key hashes the resolved versions: a
+      # fixed key freezes the archives, and the next routine PGDG minor then
+      # turns the download assertion below into a false red.
+      - name: Derive the cache key from the versions apt will install
+        id: aptkey
+        run: |
+          set -euo pipefail
+          v=$(apt-cache policy \
+                postgresql-${{ matrix.pg }} postgresql-server-dev-${{ matrix.pg }} \
+                liblz4-dev libzstd-dev zlib1g-dev python3-pip \
+              | awk '/Candidate:/ {print $2}' | sort | md5sum | cut -c1-12)
+          test -n "$v"
+          echo "k=$v" >> "$GITHUB_OUTPUT"
+          echo "resolved candidate versions hash: $v"
+
+      - name: Cache the PostgreSQL ${{ matrix.pg }}, codec headers, and pyarrow packages
+        id: apt-nightly
+        uses: actions/cache@v4
+        with:
+          path: ~/apt-archives
+          key: apt-pgdev-codecs-pyarrow-pg${{ matrix.pg }}-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS }}-${{ steps.aptkey.outputs.k }}-v2
+          restore-keys: |
+            apt-pgdev-codecs-pyarrow-pg${{ matrix.pg }}-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS }}-
+
+      - name: Install PostgreSQL ${{ matrix.pg }}, codec headers, and pyarrow
+        run: |
+          set -euo pipefail
           mkdir -p "$HOME/apt-archives/partial"
           sudo timeout 600 apt-get -o Acquire::Retries=5 \
             -o Dir::Cache::archives="$HOME/apt-archives" install -y --no-install-recommends \
@@ -97,10 +118,15 @@ jobs:
           # per-PR workflow documents applies here too.
           sudo pip3 install --break-system-packages --quiet pyarrow \
             || sudo pip3 install --quiet pyarrow
+          # Not "|| true": a failed chown means the save fails, the cache is
+          # never populated, there is never a hit, and the assertion below never
+          # fires because it is gated on a hit. See ci.yml for the long form.
+          sudo chown -R "$USER" "$HOME/apt-archives"
+          test -r "$HOME/apt-archives"
           # A cache that populates but never hits looks identical in the log to one
-          # that works: the job is simply still slow. So assert it. On a hit,
-          # apt must not have fetched anything over the network.
-          sudo chown -R "$USER" "$HOME/apt-archives" || true
+          # that works: the job is simply still slow. So assert it. On an exact
+          # hit, apt must not have fetched anything over the network. A
+          # restore-keys prefix match reports false here and is meant to.
           if [ "${{ steps.apt-nightly.outputs.cache-hit }}" = "true" ] \
              && grep -qE '^Get:[0-9]+ https?://' /tmp/apt-install.log; then
             echo "::error::apt cache reported a hit but packages were downloaded anyway"
@@ -272,14 +298,7 @@ jobs:
       #
       # ImageOS is in the key because a new runner image can bring a different
       # LLVM major, and a key that ignored it would serve debs for the wrong one.
-      - name: Cache the PostgreSQL 18, codec headers, lcov, and pyarrow packages
-        id: apt-coverage
-        uses: actions/cache@v4
-        with:
-          path: ~/apt-archives
-          key: apt-pgdev-codecs-lcov-pyarrow-pg18-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS }}-v1
-
-      - name: Install PostgreSQL 18, codec headers, lcov, and pyarrow
+      - name: Add the PGDG repository and refresh the package lists
         run: |
           set -euo pipefail
           sudo install -d /usr/share/postgresql-common/pgdg
@@ -291,6 +310,34 @@ jobs:
             https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
             | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
           sudo timeout 300 apt-get -o Acquire::Retries=5 update
+
+      # See ci.yml's build job for why the key hashes the resolved versions: a
+      # fixed key freezes the archives, and the next routine PGDG minor then
+      # turns the download assertion below into a false red.
+      - name: Derive the cache key from the versions apt will install
+        id: aptkey
+        run: |
+          set -euo pipefail
+          v=$(apt-cache policy \
+                postgresql-18 postgresql-server-dev-18 \
+                liblz4-dev libzstd-dev zlib1g-dev python3-pip lcov \
+              | awk '/Candidate:/ {print $2}' | sort | md5sum | cut -c1-12)
+          test -n "$v"
+          echo "k=$v" >> "$GITHUB_OUTPUT"
+          echo "resolved candidate versions hash: $v"
+
+      - name: Cache the PostgreSQL 18, codec headers, lcov, and pyarrow packages
+        id: apt-coverage
+        uses: actions/cache@v4
+        with:
+          path: ~/apt-archives
+          key: apt-pgdev-codecs-lcov-pyarrow-pg18-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS }}-${{ steps.aptkey.outputs.k }}-v2
+          restore-keys: |
+            apt-pgdev-codecs-lcov-pyarrow-pg18-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS }}-
+
+      - name: Install PostgreSQL 18, codec headers, lcov, and pyarrow
+        run: |
+          set -euo pipefail
           mkdir -p "$HOME/apt-archives/partial"
           sudo timeout 600 apt-get -o Acquire::Retries=5 \
             -o Dir::Cache::archives="$HOME/apt-archives" install -y --no-install-recommends \
@@ -302,10 +349,15 @@ jobs:
           sudo pip3 install --break-system-packages --quiet pyarrow \
             || sudo pip3 install --quiet pyarrow
           sudo python3 -c 'import pyarrow, pyarrow.parquet; print("pyarrow as root ok")'
+          # Not "|| true": a failed chown means the save fails, the cache is
+          # never populated, there is never a hit, and the assertion below never
+          # fires because it is gated on a hit. See ci.yml for the long form.
+          sudo chown -R "$USER" "$HOME/apt-archives"
+          test -r "$HOME/apt-archives"
           # A cache that populates but never hits looks identical in the log to one
-          # that works: the job is simply still slow. So assert it. On a hit,
-          # apt must not have fetched anything over the network.
-          sudo chown -R "$USER" "$HOME/apt-archives" || true
+          # that works: the job is simply still slow. So assert it. On an exact
+          # hit, apt must not have fetched anything over the network. A
+          # restore-keys prefix match reports false here and is meant to.
           if [ "${{ steps.apt-coverage.outputs.cache-hit }}" = "true" ] \
              && grep -qE '^Get:[0-9]+ https?://' /tmp/apt-install.log; then
             echo "::error::apt cache reported a hit but packages were downloaded anyway"


### PR DESCRIPTION
Closes #386, implementing the plan from the issue.

## What this does

apt writes its archives to `~/apt-archives`, which `actions/cache` keys on the PG major,
runner OS and arch, and `ImageOS`. Four install steps across `ci.yml` and `nightly.yml`.

`ImageOS` is in the key deliberately: a new runner image can bring a different LLVM major,
and a key that ignored it would serve debs for the wrong one.

## The half I care about more

**On a reported cache hit, the step fails if apt fetched anything over the network.**

```yaml
if [ "${{ steps.apt-build.outputs.cache-hit }}" = "true" ] \
   && grep -qE '^Get:[0-9]+ https?://' /tmp/apt-install.log; then
  echo "::error::apt cache reported a hit but packages were downloaded anyway"
```

A cache that populates and never hits looks identical in the log to one that works. The job
is simply still slow and nothing says so. That is the same shape as #396, where the suite
had the exemption and not the invocation, and it is the failure I would otherwise be
shipping here.

## What I did not do

**Raise the bound.** At 30 kB/s the fetch needs about 50 minutes, so that trades a red check
for a runner held most of an hour.

**Pin a mirror.** The runner picks from its own mirrorlist. Betting on a different one is
the bet we are already losing.

**Drop the toolchain.** `apt-cache depends postgresql-server-dev-18` shows
`Depends: clang-21` and `Depends: llvm-21-dev`, hard, so no apt flag removes them. jd's view
and mine is that there is no reason to want to: it is a legitimate dependency of
`postgresql-server-dev-N`.

## What I could not verify, and how it fails

**I cannot run GitHub Actions locally, so the first CI run on this PR is the test.** I have
validated what I can: both workflows still parse as YAML, all four install steps route
their archives and tee their output, and no package was dropped from any list.

That last one is not rhetorical. My first patch attempt inserted the tee mid-list:

```
liblz4-dev libzstd-dev zlib1g-dev 2>&1 | tee /tmp/apt-install.log python3-pip lcov
```

which would have silently stopped installing `lcov` and `python3-pip` in the coverage job.
Caught by reading the generated file rather than trusting the script. Fixed, and every
package list is asserted intact in the diff.

The failure modes are benign by construction. A miss degrades to exactly today's behaviour.
A stale entry is re-fetched by apt rather than used, because apt validates what is in the
archive directory. So the downside is a slow job, not a wrong one.

Worth watching the first few runs for the hit rate rather than assuming it.