### PR TITLE
Say which maintenance functions stop the table, where they are introduced

### DIFF
--- a/docs/administration.md
+++ b/docs/administration.md
@@ -59,6 +59,11 @@ There are two distinct operations, and the difference matters:
 - **`pgcolumnar.vacuum`** (a function) rewrites the table, combining row groups and
   reclaiming space held by deleted and updated rows.
 
+**`pgcolumnar.vacuum` holds `AccessExclusiveLock` for its whole run.** It rewrites
+the relation, so reads and writes on that table stop until it finishes. Treat it as
+a maintenance window on a large table, not as a routine command. The online
+functions below reclaim space without stopping anything. Use them first.
+
 Run `pgcolumnar.vacuum` after bulk deletes or updates, or after many small load
 transactions have produced many small row groups:
 
@@ -67,7 +72,9 @@ SELECT pgcolumnar.vacuum('events');
 ```
 
 To store rows sorted on a column so range filters on it skip more row groups,
-use `pgcolumnar.vacuum_sorted`:
+use `pgcolumnar.vacuum_sorted`. It also rewrites the relation and also holds
+`AccessExclusiveLock` for its whole run. `pgcolumnar.recluster` does the same
+reordering online:
 
 ```sql
 SELECT pgcolumnar.vacuum_sorted('events', 'customer_id');
@@ -105,6 +112,28 @@ results. They change only the order of the physical storage.
 
 Leave autovacuum on. It maintains visibility-map bits and statistics for columnar
 tables. Schedule `pgcolumnar.vacuum` separately based on delete and update volume.
+
+### Which maintenance functions stop the table
+
+Every maintenance function is one of two kinds. The kind is set by whether it
+rewrites the relation:
+
+| function | lock | table available during it |
+| --- | --- | --- |
+| `pgcolumnar.vacuum` | `AccessExclusiveLock` | no |
+| `pgcolumnar.vacuum_sorted` | `AccessExclusiveLock` | no |
+| `pgcolumnar.cluster` | `AccessExclusiveLock` | no |
+| `pgcolumnar.compact` | `ShareUpdateExclusiveLock` | yes |
+| `pgcolumnar.compact_rewrite` | `ShareUpdateExclusiveLock` | yes |
+| `pgcolumnar.recluster` | `ShareUpdateExclusiveLock` | yes |
+| `pgcolumnar.truncate` | `ShareUpdateExclusiveLock`, plus a conditional `AccessExclusiveLock` | yes |
+| standard `VACUUM` and autovacuum | `ShareUpdateExclusiveLock` | yes |
+
+The three that rewrite need the exclusive lock because they replace the file. The
+others work in place and run beside your queries.
+
+Schedule the exclusive three in a maintenance window. Anything that runs
+unattended, such as a cron entry, should call the online ones.
 
 ### Online maintenance and disk reclaim
 


### PR DESCRIPTION
@ChronicallyJD for review. Docs only, no benchmark needed.

## The gap

`docs/administration.md` already states lock strength for `cluster`, `recluster`,
`compact` and `truncate`. It said nothing for the two functions a DBA reaches for
first.

`pgcolumnar.vacuum` and `pgcolumnar.vacuum_sorted` are introduced with a plain SQL
example about forty lines **above** the section that mentions locks at all:

```sql
SELECT pgcolumnar.vacuum('events');
```

Read in order, that is a routine command. Both hold `AccessExclusiveLock` for their
whole run and stop reads and writes on the table for the duration, which on a large
table is a maintenance window rather than a command you type on a Tuesday.

## What changed

The lock is now stated **at each of those two sites**, next to the example, because
that is where someone about to run it is looking. A correct statement forty lines
later is not much use to them.

Plus a table of every maintenance function and its lock, and the rule that produces
it, so the split is derivable rather than memorised:

| function | lock | table available |
|---|---|---|
| `vacuum`, `vacuum_sorted`, `cluster` | `AccessExclusiveLock` | no |
| `compact`, `compact_rewrite`, `recluster` | `ShareUpdateExclusiveLock` | yes |
| `truncate` | SUEL plus a **conditional** `AccessExclusiveLock` | yes |
| standard `VACUUM` / autovacuum | `ShareUpdateExclusiveLock` | yes |

The three that rewrite replace the file and need the exclusive lock. The rest work in
place. And the practical consequence, since that is the actual question being asked:
schedule the exclusive three in a window, and anything unattended should call the
online ones.

## Verified against the code, not the prose

Audited every lock site in the tree first. There are exactly four `AccessExclusiveLock`
acquisitions, all in `columnar_vacuum.c`, and every one is a rewrite. `truncate` is the
model worth noticing: it holds SUEL for the real work and then tries for the strong
lock **conditionally**, skipping the end truncation if it cannot have it, so it never
queues behind a reader.

That audit came out of the #415 discussion, where the same point becomes a constraint
on any background worker: it should call the online verbs and never escalate.

## Why it is worth a PR on its own

The lazy and eager split is implemented, and documented in the code comments. It was
not where a DBA would find it. That is the shape of gap #395 is about, one directory
over.

`docs_style` passes, including the STE rules, which caught an idiom in my first draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)