### PR TITLE
Rename the custom scan node out of Citus's and TimescaleDB's namespace (#428)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,36 @@ which was true until that script existed.
 
 ## [Unreleased]
 
+### Fixed
+
+- Renamed the custom scan node from `ColumnarScan` to `PgColumnarScan`, and the
+  custom path from `ColumnarAgg` to `PgColumnarAgg` (#428). `ColumnarScan` is
+  also registered by **Citus columnar** and by **TimescaleDB 2.29**.
+  PostgreSQL's registry is one hash table keyed on that name, so two extensions
+  cannot both hold it. Neither failure needed a pgColumnar table; our presence
+  in `shared_preload_libraries` was enough.
+
+  With **Citus columnar** the server refused to start at all, in either load
+  order:
+
+      FATAL:  extensible node type "ColumnarScan" already exists
+
+  With **TimescaleDB** there was no startup error and serial queries returned
+  correct results. TimescaleDB checks the registry first and silently skips
+  registering when the name is taken, so a parallel worker then resolved
+  TimescaleDB's node through pgColumnar's callbacks, and any parallel query over
+  a columnstore hypertable failed with
+  `could not read blocks 0..0 in file ...`. That is the more dangerous of the
+  two, because nothing announces it.
+
+  **This changes `EXPLAIN` output.** Plans that read `Custom Scan (ColumnarScan)`
+  now read `Custom Scan (PgColumnarScan)`. Anything parsing plan text for the old
+  name must be updated. The `Columnar ...` property lines, such as
+  `Columnar Projected Columns`, are a different namespace and are unchanged.
+  `ColumnarAgg` never appeared in `EXPLAIN`: it names a `CustomPathMethods`, and
+  the planned node carries the scan's methods (`columnar_vector.c:717`), so that
+  half of the rename is hygiene rather than a visible change.
+
 ### Changed
 
 - The unsupported-rewrite error names `REPACK` on PostgreSQL 19 (#399). `REPACK`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -190,7 +190,7 @@ reader (projection pushdown), and translates simple `column op const` clauses
 into scan keys so the reader's zone maps remove row groups and vectors that
 cannot match (qual pushdown). The executor always re-applies the full
 restriction clauses as a filter, so skipping never changes results. The scan is
-the scalar per-row path (`ColumnarScanNext`). Through a `create_upper_paths_hook`
+the scalar per-row path (`PgColumnarScanNext`). Through a `create_upper_paths_hook`
 the module adds the vectorized aggregate path for a supported
 `SELECT agg(col) FROM t [WHERE ...]`. EXPLAIN reporting (projected columns, and
 under ANALYZE the row groups and vectors read versus skipped) lives here.

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -133,18 +133,18 @@ static TupleTableSlot *PgColumnarScanNext(ScanState *ss);
 static bool PgColumnarScanRecheck(ScanState *ss, TupleTableSlot *slot);
 
 static const CustomPathMethods pgcolumnar_path_methods = {
-	.CustomName = "ColumnarScan",
+	.CustomName = "PgColumnarScan",
 	.PlanCustomPath = PgColumnarPlanCustomPath,
 	.ReparameterizeCustomPathByChild = NULL,
 };
 
 const CustomScanMethods pgcolumnar_scan_methods = {
-	.CustomName = "ColumnarScan",
+	.CustomName = "PgColumnarScan",
 	.CreateCustomScanState = PgColumnarCreateScanState,
 };
 
 static const CustomExecMethods pgcolumnar_exec_methods = {
-	.CustomName = "ColumnarScan",
+	.CustomName = "PgColumnarScan",
 	.BeginCustomScan = PgColumnarBeginCustomScan,
 	.ExecCustomScan = PgColumnarExecCustomScan,
 	.EndCustomScan = PgColumnarEndCustomScan,

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -720,7 +720,7 @@ PgColumnarPlanAggPath(PlannerInfo *root, RelOptInfo *rel, CustomPath *best_path,
 }
 
 static const CustomPathMethods pgcolumnar_agg_path_methods = {
-	.CustomName = "ColumnarAgg",
+	.CustomName = "PgColumnarAgg",
 	.PlanCustomPath = PgColumnarPlanAggPath,
 	.ReparameterizeCustomPathByChild = NULL,
 };
@@ -3234,7 +3234,7 @@ PgColumnarExplainAggScan(CustomScanState *node, List *ancestors, ExplainState *e
 }
 
 static const CustomExecMethods pgcolumnar_agg_exec_methods = {
-	.CustomName = "ColumnarScan",
+	.CustomName = "PgColumnarScan",
 	.BeginCustomScan = PgColumnarBeginAggScan,
 	.ExecCustomScan = PgColumnarExecAggScan,
 	.EndCustomScan = PgColumnarEndAggScan,
@@ -3307,7 +3307,7 @@ PgColumnarInitializeWorkerAggScan(CustomScanState *node, shm_toc *toc,
 }
 
 static const CustomExecMethods pgcolumnar_agg_parallel_exec_methods = {
-	.CustomName = "ColumnarScan",
+	.CustomName = "PgColumnarScan",
 	.BeginCustomScan = PgColumnarBeginAggScan,
 	.ExecCustomScan = PgColumnarExecAggScan,
 	.EndCustomScan = PgColumnarEndAggScan,
@@ -3910,7 +3910,7 @@ PgColumnarExplainGroupAggScan(CustomScanState *node, List *ancestors,
 }
 
 static const CustomExecMethods pgcolumnar_groupagg_exec_methods = {
-	.CustomName = "ColumnarScan",
+	.CustomName = "PgColumnarScan",
 	.BeginCustomScan = PgColumnarBeginGroupAggScan,
 	.ExecCustomScan = PgColumnarExecGroupAggScan,
 	.EndCustomScan = PgColumnarEndGroupAggScan,
@@ -3991,7 +3991,7 @@ PgColumnarInitializeWorkerGroupAggScan(CustomScanState *node, shm_toc *toc,
 }
 
 static const CustomExecMethods pgcolumnar_groupagg_parallel_exec_methods = {
-	.CustomName = "ColumnarScan",
+	.CustomName = "PgColumnarScan",
 	.BeginCustomScan = PgColumnarBeginGroupAggScan,
 	.ExecCustomScan = PgColumnarExecGroupAggScan,
 	.EndCustomScan = PgColumnarEndGroupAggScan,

--- a/test/analyze_stats.sh
+++ b/test/analyze_stats.sh
@@ -433,7 +433,7 @@ check "without the penalty a selective scattered condition takes the index (#362
 plan_sel_on="$(plan_of "${ord_setup} EXPLAIN (COSTS off) SELECT * FROM o362 WHERE h = 7;")"
 echo "-- selective h = 7, penalty on: $(printf '%s' "$plan_sel_on" | grep -m1 -E 'Scan|Sort')"
 check "the penalty is applied before the columnar path is offered, so it can still win (#362)" \
-	"$(  grep -q 'Custom Scan (ColumnarScan)' <<<"$plan_sel_on" \
+	"$(  grep -q 'Custom Scan (PgColumnarScan)' <<<"$plan_sel_on" \
 		&& ! grep -q 'Index Scan using o362_h' <<<"$plan_sel_on" \
 		&& echo yes || echo "no ($(printf '%s' "$plan_sel_on" | head -1))")" \
 	"yes"

--- a/test/native_agg.sh
+++ b/test/native_agg.sh
@@ -6,7 +6,7 @@
 # counts, count(col) from value_count, sum/avg(int2,int4) from the zone sum, and
 # min/max from the zone min/max. This suite proves the answers equal a heap oracle
 # across the supported aggregates, nulls and an empty table; that the metadata path
-# is actually taken (EXPLAIN shows the ColumnarAgg node with no data scan); and
+# is actually taken (EXPLAIN shows the PgColumnarAgg node with no data scan); and
 # that a filtered or unsupported aggregate falls back and is still correct.
 #
 # Usage:  test/native_agg.sh [PG_CONFIG]

--- a/test/native_agg_deletes.sh
+++ b/test/native_agg_deletes.sh
@@ -177,7 +177,7 @@ check "a dirty group is scanned without scanning the clean ones" \
 # and the path is still the one being measured
 plan="$(q "EXPLAIN (COSTS off) SELECT count(*) FROM ad_t;" | head -1)"
 check "the metadata aggregate path is still chosen with a row deleted" \
-	"$(case "$plan" in *ColumnarScan*) echo yes ;; *) echo "no ($plan)" ;; esac)" \
+	"$(case "$plan" in *"Custom Scan (PgColumnarScan)"*) echo yes ;; *) echo "no ($plan)" ;; esac)" \
 	"yes"
 
 pgc_summary

--- a/test/parallel.sh
+++ b/test/parallel.sh
@@ -31,10 +31,14 @@ setg parallel_setup_cost 0
 setg parallel_tuple_cost 0
 setg min_parallel_table_scan_size 0
 
-# A row-returning scan should plan a Gather over a parallel ColumnarScan.
+# A row-returning scan should plan a Gather over a parallel PgColumnarScan.
 plan="$(q "EXPLAIN (COSTS off) SELECT id, v FROM t_col WHERE k = 5;")"
 check "parallel plan has Gather"        "$(echo "$plan" | grep -c -i 'Gather')" "1"
-check "parallel plan has ColumnarScan"  "$(echo "$plan" | grep -c -i 'ColumnarScan')" "1"
+# The full node name as EXPLAIN prints it, not a substring of it. A bare
+# 'ColumnarScan' also matches 'PgColumnarScan', so this check passed both before
+# and after the #428 rename without ever asserting which name was in the plan.
+check "parallel plan has PgColumnarScan" \
+	"$(echo "$plan" | grep -c 'Custom Scan (PgColumnarScan)')" "1"
 
 # Results must match the heap oracle under the parallel plan.
 diff_query "par filtered scan"  "SELECT id, v, t FROM %T WHERE k = 7"

--- a/test/parallel_vector_agg.sh
+++ b/test/parallel_vector_agg.sh
@@ -3,10 +3,10 @@
 # pgColumnar parallel-aware ungrouped vectorized aggregate (#289 phase 5/6).
 #
 # pgcolumnar.enable_parallel_vector_agg makes the ungrouped batch fold
-# parallel-aware: a parallel partial ColumnarAgg under a core Gather + Finalize.
+# parallel-aware: a parallel partial PgColumnarAgg under a core Gather + Finalize.
 # Each worker claims distinct row groups through the shared gap-23 counter and
 # emits per-worker transition state the Finalize combines. This suite proves:
-#   (1) the plan Finalize Aggregate -> Gather -> parallel partial ColumnarAgg is
+#   (1) the plan Finalize Aggregate -> Gather -> parallel partial PgColumnarAgg is
 #       ACTUALLY chosen with the GUC on and parallelism enabled (premise);
 #   (2) count(*) is exact vs a serial oracle;
 #   (3) avg/sum over float4/float8 match core's OWN parallel aggregate within
@@ -172,7 +172,7 @@ check "premise: grouped Finalize HashAggregate present (#349)" \
    "$(printf '%s' "$GEA" | grep -qi 'Finalize HashAggregate' && echo y || echo n)" y
 # OUR grouped node, and it is the parallel-aware one.
 check "premise: the partial grouped node is under the Gather (#349)" \
-   "$(printf '%s' "$GEA" | grep -qi 'Parallel Custom Scan (ColumnarScan)' &&
+   "$(printf '%s' "$GEA" | grep -qi 'Parallel Custom Scan (PgColumnarScan)' &&
       printf '%s' "$GEA" | grep -qi 'Columnar Vectorized Group Keys' && echo y || echo n)" y
 # Planned is not launched: a leader-only run would satisfy every value check
 # below while never exercising a worker. Assert launch AND our node together, so

--- a/test/phase4.sh
+++ b/test/phase4.sh
@@ -229,12 +229,12 @@ else
 fi
 check "covering value"    "$(q 'SET enable_seqscan=off; SELECT a FROM ios WHERE a = 100;')" "100"
 # a full-table scan is still available when index/bitmap scans are disabled.
-# As of phase 5 the columnar full scan is the custom scan (ColumnarScan); with
+# As of phase 5 the columnar full scan is the custom scan (PgColumnarScan); with
 # the custom scan disabled it is a plain sequential scan. Either is acceptable.
 assert_plan_seq() {
 	local plan
 	plan="$(run_pg "$PSQL -c \"SET enable_indexscan=off; SET enable_bitmapscan=off; EXPLAIN (COSTS OFF) SELECT * FROM ios WHERE a = 100;\"")"
-	if echo "$plan" | grep -qE "Seq Scan|Custom Scan \(ColumnarScan\)"; then
+	if echo "$plan" | grep -qE "Seq Scan|Custom Scan \(PgColumnarScan\)"; then
 		echo "PASS  full-table scan available"
 	else
 		echo "FAIL  full-table scan available: $plan"; fail=1

--- a/test/phase5.sh
+++ b/test/phase5.sh
@@ -120,10 +120,10 @@ q "CREATE TABLE t (a int, b text, c int) USING pgcolumnar;" >/dev/null
 q "SELECT pgcolumnar.set_options('t', stripe_row_limit => 10000);" >/dev/null
 q "INSERT INTO t SELECT g, 'r'||g, g%7 FROM generate_series(1,50000) g;" >/dev/null
 assert_plan "plain select uses custom scan" \
-	"EXPLAIN (COSTS OFF) SELECT * FROM t;" "Custom Scan (ColumnarScan)" "Seq Scan"
+	"EXPLAIN (COSTS OFF) SELECT * FROM t;" "Custom Scan (PgColumnarScan)" "Seq Scan"
 assert_plan "filtered select uses custom scan" \
 	"EXPLAIN (COSTS OFF) SELECT a FROM t WHERE a = 12345;" \
-	"Custom Scan (ColumnarScan)" "Seq Scan"
+	"Custom Scan (PgColumnarScan)" "Seq Scan"
 
 # ---------------------------------------------------------------------------
 # Qual pushdown: a filtered scan skips chunk groups the min/max rule out.
@@ -260,10 +260,10 @@ check "vacuum_full keeps data" "$(q "SELECT count(*) FROM t;")" "50000"
 echo "-- default plan is the serial custom scan"
 assert_plan "columnar default uses custom scan, not seqscan" \
 	"EXPLAIN (COSTS OFF) SELECT count(*) FROM t;" \
-	"Custom Scan (ColumnarScan)" "Seq Scan"
+	"Custom Scan (PgColumnarScan)" "Seq Scan"
 assert_plan "columnar default plan is not parallel" \
 	"EXPLAIN (COSTS OFF) SELECT count(*) FROM t;" \
-	"Custom Scan (ColumnarScan)" "Gather"
+	"Custom Scan (PgColumnarScan)" "Gather"
 
 # ---------------------------------------------------------------------------
 # Disabling the custom scan falls back cleanly to a sequential scan.


### PR DESCRIPTION
Closes #428. @jdatcmd for review.

## The bug is worse than I filed it. Citus makes the server refuse to start.

I filed this against TimescaleDB. Auditing the other extensions on the bench found that
**Citus columnar registers `ColumnarScan` too**, and it does not check first:

```
shared_preload_libraries = 'citus_columnar,pgcolumnar'
FATAL:  extensible node type "ColumnarScan" already exists
```

Either load order. The server does not start. That is a total outage rather than a query
error, and it needs no pgColumnar table, only our presence in `shared_preload_libraries`.

**This is the third Citus collision in this family**, after the twelve symbol collisions
#382 fixed. #382 swept exported symbols and could not have caught this, because
`CustomName` is a string inside a struct rather than a linker symbol.

## Two extensions, two different failure modes

| | registers | failure |
|---|---|---|
| **Citus columnar** 14.1 | unconditionally | **server will not start**, `FATAL: ... already exists` |
| **TimescaleDB** 2.29 | checks first, silently skips | starts clean, serial correct, **parallel breaks** |

TimescaleDB imports `GetCustomScanMethods` as well as the register call, so when we already
own the slot it skips quietly. Nothing announces it. A parallel worker then resolves
TimescaleDB's node through **our** callbacks and reads the wrong relation:

```
ERROR:  could not read blocks 0..0 in file "base/5/17301": read only 0 of 8192 bytes
CONTEXT:  parallel worker
```

That one is the more dangerous, because a user gets correct answers right up until a plan
goes parallel.

## Proved by removal, both ways

Same fixture, only the preload line differing.

**Startup, before and after this change:**

```
--- main (registers ColumnarScan) ---
citus_columnar,pgcolumnar                REFUSED: FATAL: extensible node type "ColumnarScan" already exists
pgcolumnar,citus_columnar                REFUSED: FATAL: extensible node type "ColumnarScan" already exists

--- this branch (registers PgColumnarScan) ---
citus_columnar,pgcolumnar                STARTED
pgcolumnar,citus_columnar                STARTED
timescaledb,citus_columnar,pgcolumnar    STARTED
```

**The TimescaleDB parallel query, before and after**, with the premises asserted so a pass
cannot be vacuous:

```
== BEFORE                                  == AFTER
  ok   both extensions are loaded            ok   both extensions are loaded
  our node: Custom Scan (ColumnarScan)       our node: Custom Scan (PgColumnarScan)
  ok   every chunk is in the columnstore     ok   every chunk is in the columnstore
  ok   the plan is parallel                  ok   the plan is parallel
  serial   : 49.957                          serial   : 50.060
  parallel : CONTEXT: parallel worker        parallel : 50.060
  RESULT: BROKEN                             RESULT: OK (parallel equals serial)
```

The "plan is parallel" premise matters: without it, an "it works now" reading would be
satisfied by a plan that simply stopped going parallel.

## What moved, and what deliberately did not

Only the `.CustomName` **string literals**, eight of them.

- **Not** the C identifiers. `PgColumnarScanNext`, `PgColumnarAggSpec` and the rest were
  already prefixed by #382.
- **Not** the `Columnar ...` EXPLAIN property lines (`Columnar Projected Columns`,
  `Columnar Vectorized Group Keys`, and nine others). Different namespace, no collision,
  and renaming them would have broken a lot of tests for nothing.
- `columnar_vector.c:26` already described the node as `"Custom Scan (PgColumnarScan)"`.
  The comment has been right since #382 and the string was not.

`ColumnarAgg` names a `CustomPathMethods` and **never reached `EXPLAIN`**, because the
planned node carries the scan's methods (`columnar_vector.c:717`). I renamed it anyway for
consistency, but that half is hygiene, not the fix. The CHANGELOG says so rather than
implying two visible changes.

## The two tests that would have hidden this

`grep 'ColumnarScan'` also matches `PgColumnarScan`. Two checks matched a substring, so
they would have passed against either name without ever asserting which was in the plan:

```
parallel.sh            grep -c -i 'ColumnarScan'   ->  grep -c 'Custom Scan (PgColumnarScan)'
native_agg_deletes.sh  *ColumnarScan*              ->  *"Custom Scan (PgColumnarScan)"*
```

Both now match the full node name as `EXPLAIN` prints it. They are the checks a reviewer
should look at hardest, because a rename that silently did nothing is exactly what they
would have failed to catch.

## Gate

Five-major assert matrix, fresh clone, `git clean -fdx`:

```
ALL VERSIONS PASSED       versions run: 5 of 5 configured
  PASS PG15   PASS PG16   PASS PG17   PASS PG18   PASS PG19
  parallel=PASS  parallel_vector_agg=PASS  phase4=PASS  phase5=PASS
  analyze_stats=PASS  native_agg=PASS  native_agg_deletes=PASS   (x5 each)
```

Zero failing suites. The seven suites listed are the ones that read the node name out of a
plan.

The matrix ran at `49bac10`. The pushed tip `087e195` differs from it in `CHANGELOG.md`
only, which I verified with `git diff --name-only`; no source or test file changed after
the gate.

## User-visible

`Custom Scan (ColumnarScan)` becomes `Custom Scan (PgColumnarScan)` in `EXPLAIN`. Anything
parsing plan text for the old name must be updated. CHANGELOG carries it under Fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
