### PR TITLE
Keep varlena columns out of the batch fold's gather (#423)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,10 +104,12 @@ which was true until that script existed.
   projected column with pointer arithmetic on `attlen`, which is -1 for a
   varlena, so the offset and the fetch were both wrong. The eligibility check
   walked the scan keys and asked whether each type was comparable, while the
-  gather walks the projected set and needs each type fixed width. A text column
-  filtered with `LIKE` is projected and is not a scan key, so it arrived
-  unchecked. Such a shape now falls back to the row path, which is what the
-  ALTER TABLE ADD COLUMN case already did. This was ClickBench q21.
+  gather walks the projected set and needs each type passed by value. A text
+  column filtered with `LIKE` is projected and is not a scan key, so it arrived
+  unchecked. `uuid` and `name` failed the same way for a different reason: both
+  are fixed width, 16 and 64 bytes, but passed by reference, and the gather
+  hardcodes by-value. Such a shape now falls back to the row path, which is what
+  the ALTER TABLE ADD COLUMN case already did. This was ClickBench q21.
 
 ### Upgrading
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,18 @@ which was true until that script existed.
   `CREATE PUBLICATION ... WITH (publish = 'insert')`, which does work. See
   [Limitations](docs/limitations.md).
 
+- The ungrouped vectorized aggregate no longer errors on a varlena filter
+  column (#423). `SELECT count(*) FROM t WHERE s LIKE '%x%'` raised
+  "unsupported byval length: -1" with
+  `pgcolumnar.enable_ungrouped_vector_agg` on. The batch fold gathers each
+  projected column with pointer arithmetic on `attlen`, which is -1 for a
+  varlena, so the offset and the fetch were both wrong. The eligibility check
+  walked the scan keys and asked whether each type was comparable, while the
+  gather walks the projected set and needs each type fixed width. A text column
+  filtered with `LIKE` is projected and is not a scan key, so it arrived
+  unchecked. Such a shape now falls back to the row path, which is what the
+  ALTER TABLE ADD COLUMN case already did. This was ClickBench q21.
+
 ### Upgrading
 
 **Run `ALTER EXTENSION pgcolumnar UPDATE;` in every database that has the

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -2733,15 +2733,25 @@ pgcolumnar_batch_shape_eligible(PgColumnarAggScanState *state, TupleDesc tupdesc
 		return false;
 
 	/*
-	 * Every column the fold will GATHER must be fixed width (#423).
+	 * Every column the fold will GATHER must be passed BY VALUE (#423).
 	 *
-	 * The gather does pointer arithmetic on attlen:
+	 * The gather does pointer arithmetic on attlen and hardcodes attbyval:
 	 *
 	 *     cval[col] = fetch_att(cpacked[col] + cpresent[col] * cattlen[col],
 	 *                           true, cattlen[col]);
+	 *                           ^^^^ not the column's real attbyval
 	 *
-	 * A varlena has attlen -1, so the offset is multiplied by -1 and fetch_att is
-	 * asked for a byval of length -1, which raises "unsupported byval length: -1".
+	 * So the requirement is not "fixed width", which was this guard's first and
+	 * wrong form. A varlena has attlen -1 and fails on the arithmetic. But a
+	 * FIXED-WIDTH BY-REFERENCE type passes an attlen > 0 test and still fails,
+	 * because fetch_att will not pass 16 or 64 bytes by value: uuid is attlen 16
+	 * and name is attlen 64, and both raised "unsupported byval length: 16" and
+	 * "... 64" while EXPLAIN still reported the fold as engaged.
+	 *
+	 * attbyval is the property the gather actually depends on, and it implies
+	 * attlen is 1, 2, 4 or 8, so it subsumes the width test rather than adding
+	 * to it. uuid in particular is ordinary in the event-log shapes this fold
+	 * targets.
 	 *
 	 * The type check below is not this check and cannot stand in for it. It walks
 	 * the SCAN KEYS and asks whether each type is comparable, while the gather
@@ -2759,7 +2769,7 @@ pgcolumnar_batch_shape_eligible(PgColumnarAggScanState *state, TupleDesc tupdesc
 		{
 			if (c < 0 || c >= tupdesc->natts)
 				continue;
-			if (TupleDescAttr(tupdesc, c)->attlen <= 0)
+			if (!TupleDescAttr(tupdesc, c)->attbyval)
 				return false;
 		}
 	}

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -1783,8 +1783,39 @@ PgColumnarBeginAggScan(CustomScanState *node, EState *estate, int eflags)
 	 * return so a plain EXPLAIN reports whether the batch fold will run.
 	 */
 	if (state->scanFold)
+	{
+		Bitmapset  *proj = NULL;
+		int			x;
+
+		/*
+		 * Build the projected set BEFORE deciding eligibility, because eligibility
+		 * now depends on it: the fold gathers every projected column and needs each
+		 * one fixed width (#423). It used to be built after the EXPLAIN-only return,
+		 * so a plain EXPLAIN decided eligibility against an empty set and reported
+		 * "Columnar Batch Fold: yes" for a shape that falls back at execution.
+		 *
+		 * Only the set moves. baseSlot and whereState stay below the EXPLAIN return,
+		 * since an EXPLAIN-only node must not initialise executor state.
+		 */
+		pull_varattnos((Node *) state->quals, state->scanrelid, &proj);
+		x = -1;
+		while ((x = bms_next_member(proj, x)) >= 0)
+		{
+			AttrNumber	attno = x + FirstLowInvalidHeapAttributeNumber;
+
+			if (attno > 0)
+				state->projected = bms_add_member(state->projected, attno - 1);
+		}
+		for (a = 0; a < state->naggs; a++)
+			if (state->specs[a].attidx >= 0)
+				state->projected = bms_add_member(state->projected,
+												  state->specs[a].attidx);
+		if (state->projected == NULL)
+			state->projected = bms_make_singleton(0);
+
 		state->batchEligible =
 			pgcolumnar_batch_shape_eligible(state, tupdesc, NULL, NULL);
+	}
 
 	if (eflags & EXEC_FLAG_EXPLAIN_ONLY)
 	{
@@ -1845,30 +1876,12 @@ PgColumnarBeginAggScan(CustomScanState *node, EState *estate, int eflags)
 	 */
 	if (state->scanFold)
 	{
-		Bitmapset  *proj = NULL;
-		int			x;
-
 		state->baseSlot = MakeSingleTupleTableSlot(CreateTupleDescCopy(tupdesc),
 												   &TTSOpsVirtual);
 		state->whereState = (state->quals != NIL)
 			? ExecInitQual(state->quals, &node->ss.ps)
 			: NULL;
 
-		pull_varattnos((Node *) state->quals, state->scanrelid, &proj);
-		x = -1;
-		while ((x = bms_next_member(proj, x)) >= 0)
-		{
-			AttrNumber	attno = x + FirstLowInvalidHeapAttributeNumber;
-
-			if (attno > 0)
-				state->projected = bms_add_member(state->projected, attno - 1);
-		}
-		for (a = 0; a < state->naggs; a++)
-			if (state->specs[a].attidx >= 0)
-				state->projected = bms_add_member(state->projected,
-												  state->specs[a].attidx);
-		if (state->projected == NULL)
-			state->projected = bms_make_singleton(0);
 	}
 
 	table_close(rel, AccessShareLock);
@@ -2718,6 +2731,38 @@ pgcolumnar_batch_shape_eligible(PgColumnarAggScanState *state, TupleDesc tupdesc
 								  &npred, &allConvertible);
 	if (!allConvertible)
 		return false;
+
+	/*
+	 * Every column the fold will GATHER must be fixed width (#423).
+	 *
+	 * The gather does pointer arithmetic on attlen:
+	 *
+	 *     cval[col] = fetch_att(cpacked[col] + cpresent[col] * cattlen[col],
+	 *                           true, cattlen[col]);
+	 *
+	 * A varlena has attlen -1, so the offset is multiplied by -1 and fetch_att is
+	 * asked for a byval of length -1, which raises "unsupported byval length: -1".
+	 *
+	 * The type check below is not this check and cannot stand in for it. It walks
+	 * the SCAN KEYS and asks whether each type is comparable, while the gather
+	 * walks state->projected and needs to know whether each type is fixed width.
+	 * A text column filtered with LIKE is in projected and not in the keys, since
+	 * LIKE is not a pushable scan key, so it reached the gather unchecked. That is
+	 * exactly ClickBench q21, SELECT COUNT(*) FROM hits WHERE URL LIKE '%google%'.
+	 *
+	 * Falling back to the row path is what the ADD COLUMN case already does.
+	 */
+	{
+		int			c = -1;
+
+		while ((c = bms_next_member(state->projected, c)) >= 0)
+		{
+			if (c < 0 || c >= tupdesc->natts)
+				continue;
+			if (TupleDescAttr(tupdesc, c)->attlen <= 0)
+				return false;
+		}
+	}
 
 	keys = PgColumnarBuildScanKeys(state->quals, state->scanrelid, tupdesc, &nkeys);
 	for (k = 0; k < nkeys; k++)

--- a/test/ungrouped_vector_agg.sh
+++ b/test/ungrouped_vector_agg.sh
@@ -158,10 +158,17 @@ check "server still up" "$(q "SELECT 1")" 1
 # Both halves are asserted: the answer is right, AND the plan says it fell back. A fix
 # that returned the right answer while EXPLAIN still claimed "Batch Fold: yes" would be
 # reporting something the execution does not do.
-psql_run "CREATE TABLE vfold (i int, s text) USING pgcolumnar;
-	INSERT INTO vfold SELECT g, 'abc'||g FROM generate_series(1,200000) g;
-	CREATE TABLE vfoldh (i int, s text);
+# uuid and name are the cases a reader assumes are covered once "varlena" is named. They
+# are FIXED WIDTH (16 and 64) and BY REFERENCE, so they pass a width test and still fail:
+# the gather hardcodes attbyval = true. uuid is ordinary in event-log shapes.
+psql_run "CREATE TABLE vfold (i int, s text, uid uuid, nm name) USING pgcolumnar;
+	INSERT INTO vfold SELECT g, 'abc'||g, gen_random_uuid(), ('n'||g)::name
+	  FROM generate_series(1,200000) g;
+	CREATE TABLE vfoldh (i int, s text, uid uuid, nm name);
 	INSERT INTO vfoldh SELECT * FROM vfold;" >/dev/null 2>&1
+check "premise: uuid is fixed width but NOT by value, which is the whole point" \
+	"$(q "SELECT attlen||'/'||attbyval FROM pg_attribute
+	      WHERE attrelid='vfold'::regclass AND attname='uid'")" "16/false"
 check "premise: the varlena fixture really is columnar" \
 	"$(q "SELECT amname FROM pg_class c JOIN pg_am a ON a.oid=c.relam WHERE c.relname='vfold'")" "pgcolumnar"
 
@@ -175,7 +182,9 @@ for shape in "count(*) FROM vfold WHERE s LIKE '%9%'" \
              "count(*) FROM vfold WHERE i > 100 AND s LIKE '%9%'" \
              "sum(i) FROM vfold WHERE s LIKE '%9%'" \
              "count(*) FROM vfold WHERE s = 'abc7'" \
-             "count(*) FROM vfold WHERE length(s) > 4"; do
+             "count(*) FROM vfold WHERE length(s) > 4" \
+             "count(uid) FROM vfold WHERE i > 100" \
+             "count(nm) FROM vfold WHERE i > 100"; do
 	check_text "a varlena shape agrees with heap: ${shape:0:38}" \
 		"$(vq "SELECT $shape")" "$(q "SELECT ${shape//vfold/vfoldh}")"
 done
@@ -184,5 +193,9 @@ check "a fixed-width filter still uses the batch fold" \
 	"$(fold_of "SELECT count(*) FROM vfold WHERE i > 100")" "Columnar Batch Fold: yes"
 check "a varlena filter falls back, and EXPLAIN says so" \
 	"$(fold_of "SELECT count(*) FROM vfold WHERE s LIKE '%9%'")" "Columnar Batch Fold: no"
+check "a fixed-width BY-REFERENCE column also falls back (uuid)" \
+	"$(fold_of "SELECT count(uid) FROM vfold WHERE i > 100")" "Columnar Batch Fold: no"
+check "and name, which is 64 bytes by reference" \
+	"$(fold_of "SELECT count(nm) FROM vfold WHERE i > 100")" "Columnar Batch Fold: no"
 
 pgc_summary

--- a/test/ungrouped_vector_agg.sh
+++ b/test/ungrouped_vector_agg.sh
@@ -143,4 +143,46 @@ check "fold prunes the same groups the row path does" "$FOLD_REMOVED" "$(removed
 ab "clustered filtered agg on==off" "SELECT count(*)::text || '|' || coalesce(sum(y)::text,'z') FROM cl WHERE x > 490000"
 
 check "server still up" "$(q "SELECT 1")" 1
+# ---- varlena columns must not reach the batch fold's gather (#423) ---------
+#
+# The gather does pointer arithmetic on attlen:
+#
+#     cval[col] = fetch_att(cpacked[col] + cpresent[col] * cattlen[col], true, cattlen[col])
+#
+# A varlena has attlen -1, so this raised "unsupported byval length: -1". The old
+# eligibility check walked the SCAN KEYS and asked whether each type was comparable; the
+# gather walks the PROJECTED set and needs each type fixed width. A text column filtered
+# with LIKE is projected and is not a scan key, so it arrived unchecked. That is
+# ClickBench q21.
+#
+# Both halves are asserted: the answer is right, AND the plan says it fell back. A fix
+# that returned the right answer while EXPLAIN still claimed "Batch Fold: yes" would be
+# reporting something the execution does not do.
+psql_run "CREATE TABLE vfold (i int, s text) USING pgcolumnar;
+	INSERT INTO vfold SELECT g, 'abc'||g FROM generate_series(1,200000) g;
+	CREATE TABLE vfoldh (i int, s text);
+	INSERT INTO vfoldh SELECT * FROM vfold;" >/dev/null 2>&1
+check "premise: the varlena fixture really is columnar" \
+	"$(q "SELECT amname FROM pg_class c JOIN pg_am a ON a.oid=c.relam WHERE c.relname='vfold'")" "pgcolumnar"
+
+VAGG="SET pgcolumnar.enable_ungrouped_vector_agg=on;"
+vq() { env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" \
+	-At -q -c "$VAGG" -c "$1" 2>&1 | tail -1; }
+fold_of() { env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" \
+	-At -q -c "$VAGG" -c "EXPLAIN (COSTS OFF) $1" 2>&1 | grep -oE "Columnar Batch Fold: [a-z]+" | head -1; }
+
+for shape in "count(*) FROM vfold WHERE s LIKE '%9%'" \
+             "count(*) FROM vfold WHERE i > 100 AND s LIKE '%9%'" \
+             "sum(i) FROM vfold WHERE s LIKE '%9%'" \
+             "count(*) FROM vfold WHERE s = 'abc7'" \
+             "count(*) FROM vfold WHERE length(s) > 4"; do
+	check_text "a varlena shape agrees with heap: ${shape:0:38}" \
+		"$(vq "SELECT $shape")" "$(q "SELECT ${shape//vfold/vfoldh}")"
+done
+
+check "a fixed-width filter still uses the batch fold" \
+	"$(fold_of "SELECT count(*) FROM vfold WHERE i > 100")" "Columnar Batch Fold: yes"
+check "a varlena filter falls back, and EXPLAIN says so" \
+	"$(fold_of "SELECT count(*) FROM vfold WHERE s LIKE '%9%'")" "Columnar Batch Fold: no"
+
 pgc_summary


### PR DESCRIPTION
Closes #423. @ChronicallyJD for review.

Your diagnosis was exactly right, including the line. I verified the two things that decide
the fix rather than inheriting them, and both hold.

## Your closing question, answered: no

> Worth checking whether `enable_group_vectorization` reaches the same gather

It does not. There is exactly one `fetch_att` in `columnar_vector.c`, at the line you
identified, inside `pgcolumnar_native_batch_fold`. The grouped path has its own gather and
is unaffected. A guard on the ungrouped path alone is therefore sufficient, which is what
this is.

## Why the existing gate could not have caught it

Worth stating precisely, because it is the reusable part: **two different sets, two
different questions.**

- `pgcolumnar_batch_shape_eligible` walks the **scan keys** and asks whether each type is
  **comparable**.
- The gather walks **`state->projected`** and needs each type to be **fixed width**.

`LIKE` is not pushable, so a text column filtered with it is in `projected` and never
appears among the keys. It arrived unchecked. Confirmed that `cneeded` is built from
`state->projected` at the line above the gather.

The guard is now in the eligibility function, on the projected set.

## The part that took a second attempt, and I would not have caught it without looking

My first version returned correct answers on all seven shapes, and `EXPLAIN` still said:

```
Columnar Batch Fold: yes
```

for a shape that now falls back. `state->projected` is built **after** the EXPLAIN-only
return, so a plain EXPLAIN was deciding eligibility against an empty set.

A plan claiming something the execution does not do is the failure class we have both been
chasing all week, so I moved the projected-set computation above that return. **Only the
set moves.** `baseSlot` and `whereState` stay below it, because an EXPLAIN-only node must
not initialise executor state.

Now:

```
int-only filter,  Columnar Batch Fold: yes
varlena filter,   Columnar Batch Fold: no
```

## Removal proof

The same suite against `main`, which reproduces your boundary table exactly:

```
FAIL  count(*) ... WHERE s LIKE '%9%'          : got [ERROR: unsupported byval length: -1] want [81902]
FAIL  count(*) ... WHERE i > 100 AND s LIKE    : got [ERROR: unsupported byval length: -1] want [81883]
FAIL  sum(i)    ... WHERE s LIKE '%9%'         : got [ERROR: unsupported byval length: -1] want [8846252488]
PASS  count(*) ... WHERE s = 'abc7'
PASS  count(*) ... WHERE length(s) > 4
FAIL  a varlena filter falls back, and EXPLAIN says so: got [yes] want [no]
```

The equality and `length(s)` shapes pass on **both** branches, matching what you measured.

## Coverage and regression

Added to `test/ungrouped_vector_agg.sh` rather than a new file, since it already owns this
node. Both halves are asserted: the answer matches heap, **and** the plan says it fell
back. A fix that got the first without the second is the one I nearly shipped.

169 checks across `ungrouped_vector_agg`, `native_agg`, `parallel_vector_agg`,
`native_groupagg` and `native_agg_addcolumn` stay green. Builds clean on 15, 16, 17, 18
and 19. Suite run on 18; happy to take it across the matrix before merge.