### PR TITLE
Remove merge conflict markers from a published page, and gate against them

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -268,7 +268,6 @@ returning no rows.
 
 ## Vacuum and compaction
 
-<<<<<<< HEAD
 - `autovacuum_parallel_workers`, the per-table storage parameter PostgreSQL 19 adds
   for parallel autovacuum, is accepted on a columnar table and has no effect.
   pgColumnar implements its own vacuum, which marks the visibility map and retires
@@ -276,14 +275,10 @@ returning no rows.
   refused: storage-parameter validation belongs to PostgreSQL and is driven by the
   relation kind rather than by the access method. Setting it is harmless and
   pointless.
-- `VACUUM FULL` and `CLUSTER` are not supported on a columnar table; the
-  copy-for-cluster path raises an error. Use `pgcolumnar.vacuum` or
-=======
 - `REPACK`, `VACUUM FULL` and `CLUSTER` are not supported on a columnar table; the
   copy-for-cluster path raises an error. `REPACK` arrives in PostgreSQL 19 and
   replaces the other two, and it dispatches through the same path, so it is
   refused for the same reason. Use `pgcolumnar.vacuum` or
->>>>>>> origin/main
   `pgcolumnar.vacuum_full` instead.
 - `pgcolumnar.vacuum` always rewrites the whole relation into full row groups. It
   accepts a `stripe_count` argument for compatibility with the interface, but it

--- a/test/docs_style.sh
+++ b/test/docs_style.sh
@@ -79,6 +79,16 @@ check "the roadmap is in the documentation nav" "$([ "$nav_roadmap" -ge 1 ] && e
 check "and the page that nav entry points at exists" \
 	"$([ -f "$SRCDIR/docs/roadmap.md" ] && echo yes || echo no)" "yes"
 
+# Merge conflict markers. These reached main and were published: three of them sat
+# in docs/limitations.md under "Vacuum and compaction", and every other check in
+# this file passed with them there, because they are valid Markdown text.
+#
+# The STE checker reads prose and the nav check reads mkdocs.yml. Neither asks
+# whether the page is a coherent document. This does.
+conflicts=$(grep -rlE '^(<<<<<<< |>>>>>>> )' "$SRCDIR/docs" "$SRCDIR"/*.md 2>/dev/null | tr '\n' ' ')
+check "no document carries a merge conflict marker" \
+	"$([ -z "$conflicts" ] && echo none || echo "$conflicts")" "none"
+
 # CHANGELOG.md: dash characters only. See the scope note above.
 dashes=$(grep -c '—\|–' "$SRCDIR/CHANGELOG.md" || true)
 check "CHANGELOG.md carries no em or en dash" "$dashes" "0"


### PR DESCRIPTION
`docs/limitations.md` has three raw merge conflict markers on `main`, under **Vacuum and
compaction**. They are live on the documentation site right now.

```
<<<<<<< HEAD
- `autovacuum_parallel_workers`, the per-table storage parameter PostgreSQL 19 adds ...
- `VACUUM FULL` and `CLUSTER` are not supported on a columnar table; the
=======
- `REPACK`, `VACUUM FULL` and `CLUSTER` are not supported on a columnar table; the
>>>>>>> origin/main
  `pgcolumnar.vacuum_full` instead.
```

Introduced by the merge at `a0c8189`.

## The resolution is a union, because both arms are right

The `autovacuum_parallel_workers` bullet is **additive**: it documents #398 and is pinned by
`test/pg19_vacuum_options.sh`. The `REPACK` bullet **supersedes** the older `VACUUM FULL`
and `CLUSTER` one, because REPACK dispatches through the same copy-for-cluster path and is
refused for the same reason, which is #399 and is pinned by `test/native_repack.sh`.

Both kept, in that order. No prose invented.

## Why it reached main is the more useful half

**Every check in `docs_style.sh` passed with the markers present.** I ran it myself on main
earlier today and got twelve pages `ok`.

Conflict markers are valid Markdown text. The STE checker reads prose and counts words. The
nav check reads `mkdocs.yml`. `mkdocs build --strict` resolves links and finds nothing wrong
with a paragraph that happens to begin `<<<<<<< HEAD`. Nothing was asking whether the page
is a coherent document.

So `docs_style.sh` now fails on a conflict marker anywhere in `docs/` or in a top-level
Markdown file.

## Removal proof

Same suite, same box, only the page differing:

```
main's docs/limitations.md    FAIL  no document carries a merge conflict marker:
                                    got [docs/limitations.md] want [none]
                                    docs_style.sh: FAILED
resolved                      PASS  no document carries a merge conflict marker
                                    docs_style.sh: PASSED
```

My first attempt at that proof reported FAIL on both arms, because I had edited the file
without committing and `git checkout HEAD --` restored the unfixed version. The proof caught
my own mistake, which is the argument for running it rather than reasoning about it.

## Scope

Deliberately only this. The content work from the external validation report is #440 and I
have kept it separate, since a broken published page should not wait behind a review of new
prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
