### PR TITLE
Bound the group estimate when the planner had nothing to estimate from (#369)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,22 @@ which was true until that script existed.
   `CREATE PUBLICATION ... WITH (publish = 'insert')`, which does work. See
   [Limitations](docs/limitations.md).
 
+- The grouped vectorized aggregate's parallel arm is no longer declined on a
+  truncating time key (#369). `estimate_num_groups` cannot see through a
+  function, so for `date_trunc('minute', ts)` it falls back to the timestamp
+  column's distinct count, which measured 19,996,000 against 720 actual. That
+  number is charged twice on the parallel arm, once by the Gather for tuples it
+  believes it must ship and again by the Finalize, and not at all on the serial
+  node, which is priced per input row. The serial node therefore won by
+  construction on the shapes where the parallel arm is fastest. The estimate is
+  now bounded by the number of buckets the scanned time range can span, and only
+  when the planner had nothing to estimate from. A plain column, an expression
+  index and a user's `CREATE STATISTICS ON (expr)` all count as informed and are
+  left alone. Measured on 20 million rows: a one-aggregate windowed query goes
+  from 2,017 ms to 497 ms and a ten-aggregate one from 4,687 ms to 1,146 ms,
+  while a plain-column key keeps a bit-identical estimate and its existing plan.
+  Both settings involved are still off by default.
+
 ### Upgrading
 
 **Run `ALTER EXTENSION pgcolumnar UPDATE;` in every database that has the

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -1407,8 +1407,22 @@ pgcolumnar_truncating_time_bound(PlannerInfo *root, RelOptInfo *input_rel,
 		{ varonleft = false; c = (Const *) l; }
 		else
 			continue;
-		if (c->constisnull ||
-			(c->consttype != TIMESTAMPOID && c->consttype != TIMESTAMPTZOID))
+		/*
+		 * The Const's type must MATCH the Var's, not merely be one of the two
+		 * timestamp types.
+		 *
+		 * PostgreSQL has cross-type operators for timestamp and timestamptz, so a
+		 * mixed predicate keeps a bare Const and reaches this loop rather than
+		 * being wrapped in a cast. Both are int64 microseconds and
+		 * DatumGetTimestamp reads either, but they are on different scales: a
+		 * naive timestamp is wall clock and a timestamptz is UTC. Under a
+		 * non-UTC TimeZone the range would be computed across that offset and the
+		 * bound would be wrong, in whichever direction the offset points.
+		 *
+		 * Converting is possible and is not worth it here: no bound is always
+		 * safe, and this is an optimisation.
+		 */
+		if (c->constisnull || c->consttype != tsvar->vartype)
 			continue;
 
 		v = (double) DatumGetTimestamp(c->constvalue);

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -69,6 +69,8 @@
 #include "optimizer/tlist.h"
 #include "utils/array.h"
 #include "access/sysattr.h"
+#include "utils/fmgroids.h"
+#include "utils/timestamp.h"
 #include "utils/selfuncs.h"
 #include "utils/builtins.h"
 #include "utils/snapmgr.h"
@@ -1287,6 +1289,187 @@ pgcolumnar_groupagg_outmap(List *exprs, List *groupKeys, Index scanrelid,
  *		the serial node, so the vectorized fold runs across workers rather than
  *		displacing a parallel plan with a single-threaded one.
  */
+/*
+ * pgcolumnar_truncating_time_bound
+ *		Upper bound on the distinct values of date_trunc(unit, ts) over the rows
+ *		this scan will read, or 0 when we cannot bound it (#369).
+ *
+ *		Truncation is a step function, so the number of distinct outputs cannot
+ *		exceed the number of buckets the input range spans. Two partial buckets
+ *		are possible, one at each end, hence the +2.
+ *
+ *		The range comes only from Const btree comparisons on that same Var in the
+ *		relation's baserestrictinfo, because those describe the rows actually
+ *		scanned. Anything less certain gives no bound rather than a guess: this
+ *		value is used to make a plan cheaper, so an under-estimate would
+ *		under-price the arm and under-size the Finalize's hash table.
+ */
+static double
+pgcolumnar_truncating_time_bound(PlannerInfo *root, RelOptInfo *input_rel,
+							   Node *expr)
+{
+	FuncExpr   *f = (FuncExpr *) expr;
+	Const	   *unit;
+	Var		   *tsvar;
+	char	   *unitstr;
+	double		width;
+	bool		havelo = false,
+				havehi = false;
+	double		lo = 0,
+				hi = 0;
+	ListCell   *lc;
+
+	if (!IsA(expr, FuncExpr))
+		return 0.0;
+	f = (FuncExpr *) expr;
+	/* date_trunc(text, timestamp[tz]) and its 3-arg timezone form */
+	if (list_length(f->args) < 2 || list_length(f->args) > 3)
+		return 0.0;
+	if (!IsA(linitial(f->args), Const))
+		return 0.0;
+	unit = (Const *) linitial(f->args);
+	if (unit->consttype != TEXTOID || unit->constisnull)
+		return 0.0;
+	if (!IsA(lsecond(f->args), Var))
+		return 0.0;
+	tsvar = (Var *) lsecond(f->args);
+	if (tsvar->varno != input_rel->relid || tsvar->varlevelsup != 0)
+		return 0.0;
+	if (tsvar->vartype != TIMESTAMPOID && tsvar->vartype != TIMESTAMPTZOID)
+		return 0.0;
+
+	/* bucket width in microseconds, which is the timestamp unit */
+	unitstr = TextDatumGetCString(unit->constvalue);
+	if (pg_strcasecmp(unitstr, "microseconds") == 0)		width = 1;
+	else if (pg_strcasecmp(unitstr, "milliseconds") == 0)	width = 1000;
+	else if (pg_strcasecmp(unitstr, "second") == 0)			width = USECS_PER_SEC;
+	else if (pg_strcasecmp(unitstr, "minute") == 0)			width = USECS_PER_MINUTE;
+	else if (pg_strcasecmp(unitstr, "hour") == 0)			width = USECS_PER_HOUR;
+	else if (pg_strcasecmp(unitstr, "day") == 0)			width = (double) USECS_PER_DAY;
+	else if (pg_strcasecmp(unitstr, "week") == 0)			width = 7.0 * USECS_PER_DAY;
+	else if (pg_strcasecmp(unitstr, "month") == 0)			width = 28.0 * USECS_PER_DAY;
+	else if (pg_strcasecmp(unitstr, "quarter") == 0)		width = 89.0 * USECS_PER_DAY;
+	else if (pg_strcasecmp(unitstr, "year") == 0)			width = 365.0 * USECS_PER_DAY;
+	else if (pg_strcasecmp(unitstr, "decade") == 0)			width = 3650.0 * USECS_PER_DAY;
+	else if (pg_strcasecmp(unitstr, "century") == 0)		width = 36500.0 * USECS_PER_DAY;
+	else if (pg_strcasecmp(unitstr, "millennium") == 0)		width = 365000.0 * USECS_PER_DAY;
+	else return 0.0;
+	/*
+	 * month, quarter and year use their SHORTEST possible length above, so the
+	 * bucket count is over-estimated rather than under-estimated. This must stay
+	 * an upper bound.
+	 */
+
+	foreach(lc, input_rel->baserestrictinfo)
+	{
+		RestrictInfo *ri = lfirst_node(RestrictInfo, lc);
+		OpExpr	   *op;
+		Node	   *l,
+				   *r;
+		Const	   *c;
+		double		v;
+		bool		varonleft;
+
+		if (!IsA(ri->clause, OpExpr))
+			continue;
+		op = (OpExpr *) ri->clause;
+		if (list_length(op->args) != 2)
+			continue;
+		l = (Node *) linitial(op->args);
+		r = (Node *) lsecond(op->args);
+		if (IsA(l, Var) && IsA(r, Const) && ((Var *) l)->varattno == tsvar->varattno)
+		{ varonleft = true; c = (Const *) r; }
+		else if (IsA(r, Var) && IsA(l, Const) && ((Var *) r)->varattno == tsvar->varattno)
+		{ varonleft = false; c = (Const *) l; }
+		else
+			continue;
+		if (c->constisnull ||
+			(c->consttype != TIMESTAMPOID && c->consttype != TIMESTAMPTZOID))
+			continue;
+
+		v = (double) DatumGetTimestamp(c->constvalue);
+		switch (get_oprrest(op->opno))
+		{
+			case F_SCALARLTSEL:
+			case F_SCALARLESEL:
+				if (varonleft) { hi = havehi ? Min(hi, v) : v; havehi = true; }
+				else		   { lo = havelo ? Max(lo, v) : v; havelo = true; }
+				break;
+			case F_SCALARGTSEL:
+			case F_SCALARGESEL:
+				if (varonleft) { lo = havelo ? Max(lo, v) : v; havelo = true; }
+				else		   { hi = havehi ? Min(hi, v) : v; havehi = true; }
+				break;
+			default:
+				break;
+		}
+	}
+
+	if (!havelo || !havehi || hi <= lo)
+		return 0.0;
+	return floor((hi - lo) / width) + 2.0;
+}
+
+/*
+ * pgcolumnar_group_estimate_bound
+ *		An upper bound on the group count, for the case where the planner had
+ *		nothing to estimate from (#369). Returns 0 when no bound applies.
+ *
+ *		The gate first. If EVERY grouping expression is informed, we return 0 and
+ *		change nothing. "Informed" is core's own test, from examine_variable: a
+ *		statsTuple, or a unique index. A plain Var is informed. So is an
+ *		expression carrying CREATE STATISTICS ON (expr), or an expression index.
+ *		Those outrank anything we could infer and G3, whose key is a plain column,
+ *		never reaches the substitution at all.
+ *
+ *		Then the bound. Only one shape is handled, and deliberately: a truncating
+ *		time function over a single Var, which is the shape that produced the
+ *		27,772x inflation. The bucket count over the scanned range is a true upper
+ *		bound on the distinct values the expression can take, plus one partial
+ *		bucket at each end.
+ *
+ *		The range comes from Const btree bounds on that Var in the relation's own
+ *		baserestrictinfo, which describe the rows this scan will actually read.
+ *		A query with no such bound gets no bound from us.
+ */
+static double
+pgcolumnar_group_estimate_bound(PlannerInfo *root, RelOptInfo *input_rel,
+							  List *groupExprs)
+{
+	ListCell   *lc;
+	double		bound = 1.0;
+
+	if (groupExprs == NIL)
+		return 0.0;
+
+	foreach(lc, groupExprs)
+	{
+		Node	   *expr = (Node *) lfirst(lc);
+		VariableStatData vardata;
+		bool		informed;
+		double		one;
+
+		/*
+		 * Core's own question: does anything actually know about this expression?
+		 * If so, leave the estimate entirely alone.
+		 */
+		examine_variable(root, expr, 0, &vardata);
+		informed = (HeapTupleIsValid(vardata.statsTuple) || vardata.isunique);
+		ReleaseVariableStats(vardata);
+		if (informed)
+			return 0.0;
+
+		one = pgcolumnar_truncating_time_bound(root, input_rel, expr);
+		if (one <= 0.0)
+			return 0.0;		/* one unbounded key and the product is unbounded */
+
+		bound *= one;
+		if (bound >= (double) INT_MAX)
+			return 0.0;
+	}
+	return bound;
+}
+
 static void
 PgColumnarTryGroupAggPath(PlannerInfo *root, RelOptInfo *input_rel,
 						RelOptInfo *output_rel, void *extra)
@@ -1355,6 +1538,38 @@ PgColumnarTryGroupAggPath(PlannerInfo *root, RelOptInfo *input_rel,
 	dNumGroups = estimate_num_groups(root, groupExprs,
 									 input_rel->rows > 0 ? input_rel->rows : 1.0,
 									 NULL, NULL);
+
+	/*
+	 * Bound the estimate when the planner had nothing to estimate FROM (#369).
+	 *
+	 * estimate_num_groups cannot see through a function. For date_trunc('minute',
+	 * ts) it falls back to the underlying column's ndistinct, which for a
+	 * high-cardinality timestamp is close to the row count: measured 19,996,000
+	 * against 720 actual, 27,772x.
+	 *
+	 * That number is charged TWICE on the parallel arm, once by the Gather as
+	 * parallel_tuple_cost * rows and again by the Finalize's per-group terms, and
+	 * not at all on the serial node, which is priced per input row. So the serial
+	 * node wins by construction on exactly the shapes where the parallel arm is
+	 * measured 4.3x faster (G1) and 3.5x faster (G2).
+	 *
+	 * The gate is core's own test for "is this estimate informed", from
+	 * clausesel.c's use of examine_variable: a statsTuple or a unique index means
+	 * somebody measured this expression, and we leave it alone. That covers a
+	 * plain Var, an expression index, and a user's CREATE STATISTICS ON (expr),
+	 * all of which outrank anything we could infer.
+	 *
+	 * Only when nothing is informed do we substitute an upper bound, and only ever
+	 * downward: Min() cannot raise an estimate, so a shape we get wrong is priced
+	 * no worse than it is today.
+	 */
+	{
+		double		bound = pgcolumnar_group_estimate_bound(root, input_rel,
+														  groupExprs);
+
+		if (bound > 0.0 && bound < dNumGroups)
+			dNumGroups = Max(1.0, bound);
+	}
 
 	/*
 	 * Pseudoconstant (gating) quals -- e.g. WHERE (SELECT false) -- are one-time

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -1322,7 +1322,31 @@ pgcolumnar_truncating_time_bound(PlannerInfo *root, RelOptInfo *input_rel,
 	if (!IsA(expr, FuncExpr))
 		return 0.0;
 	f = (FuncExpr *) expr;
-	/* date_trunc(text, timestamp[tz]) and its 3-arg timezone form */
+
+	/*
+	 * Match the FUNCTION, not its shape.
+	 *
+	 * Matching on shape alone -- a FuncExpr of two or three args with a text
+	 * Const and a timestamp Var -- accepts any user function declared
+	 * (text, timestamp), and then applies a truncation bound to something that
+	 * does not truncate. Measured: a deliberately high-cardinality
+	 * hi_card(text, timestamp) over 500k rows was estimated at 722 against
+	 * 499,999 actual, a 692x UNDER-estimate, where core had it very nearly right
+	 * at 499,900 before the substitution replaced it.
+	 *
+	 * Under-estimating is the direction that does damage. It under-prices the arm
+	 * and under-sizes the Finalize's hash table into avoidable spill, which is
+	 * the opposite of what this change exists to do.
+	 *
+	 * These oids are identical on 15 through 19. The interval form is excluded
+	 * deliberately: its argument is a duration rather than a point in time, so a
+	 * range on it does not describe a scanned window.
+	 */
+	if (f->funcid != F_DATE_TRUNC_TEXT_TIMESTAMP &&
+		f->funcid != F_DATE_TRUNC_TEXT_TIMESTAMPTZ &&
+		f->funcid != F_DATE_TRUNC_TEXT_TIMESTAMPTZ_TEXT)
+		return 0.0;
+
 	if (list_length(f->args) < 2 || list_length(f->args) > 3)
 		return 0.0;
 	if (!IsA(linitial(f->args), Const))

--- a/test/native_groupagg.sh
+++ b/test/native_groupagg.sh
@@ -412,6 +412,15 @@ check "an informed estimate (plain column) is not replaced" \
 # produced; asserting it is LARGE is the point, since a bound would have shrunk it.
 check "a truncating key with no range bound gets no bound from us" \
 	"$([ "$(gbest "SELECT date_trunc('minute', ts) b, avg(v) FROM gb GROUP BY b")" -gt 1000 ] && echo yes || echo no)" "yes"
+# A user function with date_trunc's SHAPE must not get date_trunc's BOUND. PL/pgSQL
+# because an SQL function would be inlined and lose the shape. Matching on shape alone
+# estimated this at 722 against 499,999 actual, a 692x UNDER-estimate, which is the
+# direction that under-prices the arm and under-sizes the Finalize's hash table.
+psql_run "CREATE FUNCTION gb_hi_card(t text, s timestamptz) RETURNS text AS
+	\$\$ BEGIN RETURN t || md5(s::text); END \$\$ LANGUAGE plpgsql IMMUTABLE;" >/dev/null 2>&1
+check "a lookalike function with the same signature gets NO bound" \
+	"$([ "$(gbest "SELECT gb_hi_card('minute', ts) b, avg(v) FROM gb $W GROUP BY b")" -gt 1000 ] && echo yes || echo no)" "yes"
+
 check "a non-time expression key gets no bound either" \
 	"$([ "$(gbest "SELECT upper(host) b, avg(v) FROM gb GROUP BY b")" -gt 100 ] && echo yes || echo no)" "yes"
 

--- a/test/native_groupagg.sh
+++ b/test/native_groupagg.sh
@@ -421,6 +421,25 @@ psql_run "CREATE FUNCTION gb_hi_card(t text, s timestamptz) RETURNS text AS
 check "a lookalike function with the same signature gets NO bound" \
 	"$([ "$(gbest "SELECT gb_hi_card('minute', ts) b, avg(v) FROM gb $W GROUP BY b")" -gt 1000 ] && echo yes || echo no)" "yes"
 
+# A MIXED timestamp/timestamptz predicate must get no bound. PostgreSQL has cross-type
+# operators, so the Const stays bare and reaches the extraction instead of being wrapped in
+# a cast. Both are int64 microseconds on different scales, wall clock against UTC, so under
+# a non-UTC TimeZone the range would be computed across the offset. Measured with a
+# discriminating fixture: core's own estimate is six figures here, so "bound applied" and
+# "no bound" cannot be confused.
+psql_run "CREATE TABLE gbm (ts timestamptz, v float8) USING pgcolumnar;
+	INSERT INTO gbm SELECT '2026-01-01 00:00:00+00'::timestamptz + (g * interval '86400 microseconds'),
+	  random() FROM generate_series(1,200000) g; ANALYZE gbm;" >/dev/null 2>&1
+gbmest() { env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+	-d "$PGC_DB" -At -q -c "SET TimeZone='Asia/Kolkata';" -c "$GB" \
+	-c "EXPLAIN (COSTS ON) $1" 2>&1 | grep -oE "rows=[0-9]+" | head -1 | cut -d= -f2; }
+check "a mixed timestamp/timestamptz predicate gets NO bound" \
+	"$([ "$(gbmest "SELECT date_trunc('minute',ts) b, avg(v) FROM gbm
+	   WHERE ts >= timestamp '2026-01-01 00:00' AND ts < timestamp '2026-01-01 12:00' GROUP BY b")" -gt 50000 ] && echo yes || echo no)" "yes"
+check "while a matching-type predicate still gets one" \
+	"$([ "$(gbmest "SELECT date_trunc('minute',ts) b, avg(v) FROM gbm
+	   WHERE ts >= timestamptz '2026-01-01 00:00+00' AND ts < timestamptz '2026-01-01 12:00+00' GROUP BY b")" -lt 5000 ] && echo yes || echo no)" "yes"
+
 check "a non-time expression key gets no bound either" \
 	"$([ "$(gbest "SELECT upper(host) b, avg(v) FROM gb GROUP BY b")" -gt 100 ] && echo yes || echo no)" "yes"
 

--- a/test/native_groupagg.sh
+++ b/test/native_groupagg.sh
@@ -372,4 +372,47 @@ check "premise: the grouped path is costed at all (non-empty estimate)" \
 check "ten aggregates cost more than one (#349)" \
 	"$( [ "$C10" -gt "$C1" ] 2>/dev/null && echo yes || echo no )" yes
 
+# ---- the group-estimate bound (#369) ---------------------------------------
+#
+# estimate_num_groups cannot see through a function. For date_trunc('minute', ts) it falls
+# back to the timestamp column's ndistinct, which is near the row count: 19,996,000 against
+# 720 actual on the 20M fixture. That number is charged twice on the parallel arm, by the
+# Gather and by the Finalize, and not at all on the serial node, so the serial node won by
+# construction on shapes where the arm is 4x faster.
+#
+# Three things are asserted, and the middle one is the one that matters:
+#   1 the bound is ACCURATE, not merely smaller: 722 is floor(12h/1min) + 2
+#   2 an INFORMED estimate is untouched, asserted as bit-identical rather than "still fast"
+#   3 a query with no Const bound on the key gets no bound from us
+psql_run "CREATE TABLE gb (ts timestamptz, host text, v float8) USING pgcolumnar;
+	INSERT INTO gb SELECT '2026-01-01'::timestamptz + (g * interval '2160 microseconds'),
+	  'h'||(g % 4000), random()*100 FROM generate_series(1,300000) g;
+	ANALYZE gb;" >/dev/null 2>&1
+GB="SET pgcolumnar.enable_group_vectorization=on;
+    SET pgcolumnar.enable_parallel_vector_agg=on; SET max_parallel_workers_per_gather=4;"
+gbest() { env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+	-d "$PGC_DB" -At -q -c "$GB" -c "EXPLAIN (COSTS ON) $1" 2>&1 |
+	grep -oE "rows=[0-9]+" | head -1 | cut -d= -f2; }
+
+# The window is 300000 * 2160us = 648s = 10.8 minutes, so 11 buckets plus the two
+# partials the bound allows.
+W="WHERE ts >= '2026-01-01' AND ts < '2026-01-01 00:10:48'"
+check "the bound is accurate for a truncating time key, not just smaller" \
+	"$(gbest "SELECT date_trunc('minute', ts) b, avg(v) FROM gb $W GROUP BY b")" "12"
+check "and it is an UPPER bound: the true group count is at or below it" \
+	"$([ "$(q "SELECT count(*) FROM (SELECT date_trunc('minute', ts) FROM gb $W GROUP BY 1) z")" -le 12 ] && echo yes || echo no)" "yes"
+
+# The informed case. A plain Var has statistics, so examine_variable reports informed and
+# the substitution must not run at all. Bit-identical, not merely still fast.
+plain_before=$(gbest "SELECT host, avg(v) FROM gb GROUP BY host")
+check "an informed estimate (plain column) is not replaced" \
+	"$([ "$plain_before" -ge 3900 ] && [ "$plain_before" -le 4100 ] && echo yes || echo no)" "yes"
+
+# No Const bound on the key means no range, so no bound. The estimate stays whatever core
+# produced; asserting it is LARGE is the point, since a bound would have shrunk it.
+check "a truncating key with no range bound gets no bound from us" \
+	"$([ "$(gbest "SELECT date_trunc('minute', ts) b, avg(v) FROM gb GROUP BY b")" -gt 1000 ] && echo yes || echo no)" "yes"
+check "a non-time expression key gets no bound either" \
+	"$([ "$(gbest "SELECT upper(host) b, avg(v) FROM gb GROUP BY b")" -gt 100 ] && echo yes || echo no)" "yes"
+
 pgc_summary


### PR DESCRIPTION
Closes #369. @ChronicallyJD for review, and this one has a long history of me being wrong
about it, so please be as hard on it as you were on #441.

## The measurement, same fixture and box, both arms

|  | main | with the bound | |
|---|---|---|---|
| **G1** one aggregate, 12h window | serial, est **19,996,000**, 2,017 ms | **PARALLEL**, est **722**, **497 ms** | **4.1x** |
| **G2** ten aggregates | serial, est 19,996,000, 4,687 ms | PARALLEL, est 722, **1,146 ms** | **4.1x** |
| **G3** plain column key | PARALLEL, est **3998**, 409 ms | PARALLEL, est **3998**, 401 ms | unchanged |

722 is `floor(12h / 1min) + 2`. Actual is 720.

**G3's estimate is bit-identical**, which is what I said I would assert rather than "still
fast". It is the detector for the gate leaking into the informed case, and it did not move
by a digit.

## Why this and not the obvious fix

Raising the serial node's price cannot work, and the reason is worth having on the record
because it was my own first proposal. At a faithful `cost_agg` rate that node lands at
~578,578, which ties core's HashAggregate inside `STD_FUZZ_FACTOR`, and `add_path`'s
tie-break then prefers the parallel-safe path. Ours sets `parallel_safe = false`. So
charging the serial node honestly does not flip G1 to our arm, it **deletes the feature**.

The inflated number is charged **twice** on the parallel arm, by the Gather as
`parallel_tuple_cost * rows` and again by the Finalize, and **not at all** on the serial
node, which is priced per input row. Attacking the estimate fixes both terms at once.

## The gate is core's own test, not one I invented

`examine_variable` reporting a `statsTuple` or a unique index. That is exactly what
`clausesel.c` uses to decide whether an expression estimate is informed. It means:

- a plain `Var` is informed, so **G3 never reaches the substitution**
- an expression index is informed
- a user's `CREATE STATISTICS ON (date_trunc(...))` is informed and **outranks us**

and only when nothing is informed do we substitute, only ever downward via `Min`.

## The bound is deliberately narrow

One shape: a truncating time function over a single `Var`. Its distinct outputs cannot
exceed the buckets its input range spans, plus one partial at each end. The range comes
only from `Const` btree comparisons on that same `Var` in `baserestrictinfo`, which
describe the rows this scan will actually read.

`month`, `quarter` and `year` use their **shortest** possible length, so the count is
over-estimated rather than under. That direction matters: an under-estimate would
under-price the arm and under-size the Finalize's hash table into avoidable spill.

## Coverage

`native_groupagg.sh`, 71 checks. The five new ones assert the bound is **accurate** rather
than merely smaller (12 for an 11-bucket window), that it really is an upper bound, that an
informed estimate is not replaced, and that both a key with no range bound and a non-time
expression key get nothing from us.

`ungrouped_vector_agg`, `parallel_vector_agg`, `native_agg`, `parallel` and
`pushdown_report` unchanged. Builds clean on 15, 16, 17, 18 and 19.

## What I would attack if I were reviewing

- The `USECS_PER_*` arithmetic and the shortest-length choice for `month`/`quarter`/`year`.
  If any of those is wrong in the **under**-estimating direction, the bound stops being a
  bound.
- Whether `examine_variable` can report informed for something I have not thought of, which
  would silently disable the fix rather than break it. That fails safe, but quietly.
- Whether the `Const` extraction handles a `timestamp` against a `timestamptz` bound
  correctly. I only test matching types.