### PR TITLE
Record why temporal.sh was asserting nothing, and where else that bites

### DIFF
--- a/design/POSTGRESQL_VERSION_ADOPTION.md
+++ b/design/POSTGRESQL_VERSION_ADOPTION.md
@@ -19,7 +19,7 @@ date it was written. A note without one has not been checked.
 | --- | --- |
 | 1. Read stream and AIO | **shipped**, `pgcolumnar.enable_read_stream` (gap 29) |
 | 2. Virtual generated columns | **done**, read and storage both, `test/generated_columns.sh` |
-| 3. Temporal constraints | **done** on 18 and 19, `test/temporal.sh`. Needs contrib `btree_gist`, or the suite skips (#447) |
+| 3. Temporal constraints | **done** on 18 and 19, `test/temporal.sh`. Needs contrib `btree_gist`; without it the suite fails rather than passing quietly (#447, #448) |
 | 4. btree skip scan | open, no measurement |
 | 5. REPACK | **investigated and the conclusion was wrong**, see below (#399) |
 | 6. Statistics injection | open, no measurement |

--- a/design/POSTGRESQL_VERSION_ADOPTION.md
+++ b/design/POSTGRESQL_VERSION_ADOPTION.md
@@ -19,7 +19,7 @@ date it was written. A note without one has not been checked.
 | --- | --- |
 | 1. Read stream and AIO | **shipped**, `pgcolumnar.enable_read_stream` (gap 29) |
 | 2. Virtual generated columns | **done**, read and storage both, `test/generated_columns.sh` |
-| 3. Temporal constraints | **done**, `test/temporal.sh` |
+| 3. Temporal constraints | **done** on 18 and 19, `test/temporal.sh`. Needs contrib `btree_gist`, or the suite skips (#447) |
 | 4. btree skip scan | open, no measurement |
 | 5. REPACK | **investigated and the conclusion was wrong**, see below (#399) |
 | 6. Statistics injection | open, no measurement |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -136,6 +136,25 @@ All suites pass on PostgreSQL 15 through 19. PostgreSQL 19 is validated against
 19beta2; revalidation against the final PostgreSQL 19 release is pending that
 release.
 
+**Read the skipped count, not only the verdict.** A suite that runs no checks
+reports `SKIPPED (ran no checks)`. The matrix also prints how many suites ran on
+each major. A suite skips for two very different reasons. Only one of them is
+expected. The feature under test may not exist on that major, which is correct.
+Or a tool the suite measures with is missing, which means real coverage was lost
+and the run does not say so anywhere else.
+
+Two dependencies cause the second kind, and both come from outside this
+repository:
+
+| suite | needs | where it comes from |
+| --- | --- | --- |
+| the Arrow and Parquet suites | `pyarrow` | `pip install pyarrow`, as the user the suites run as |
+| `temporal.sh` | `btree_gist` | PostgreSQL **contrib**. A PGDG package ships it; a source build configured without contrib does not |
+
+Build and install `contrib/btree_gist` against each source tree when the matrix
+runs against source builds. Until that was done, `temporal.sh` asserted nothing
+on four of five majors and reported success (#447).
+
 ## Cross-major upgrade
 
 `pg_upgrade` is the path that a user takes to a new major. It is also the point

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -136,15 +136,21 @@ All suites pass on PostgreSQL 15 through 19. PostgreSQL 19 is validated against
 19beta2; revalidation against the final PostgreSQL 19 release is pending that
 release.
 
-**Read the skipped count, not only the verdict.** A suite that runs no checks
-reports `SKIPPED (ran no checks)`. The matrix also prints how many suites ran on
-each major. A suite skips for two very different reasons. Only one of them is
-expected. The feature under test may not exist on that major, which is correct.
-Or a tool the suite measures with is missing, which means real coverage was lost
-and the run does not say so anywhere else.
+**A suite has three outcomes, and two of them are not failures.** Read which one
+you got before deciding whether something is wrong.
 
-Two dependencies cause the second kind, and both come from outside this
-repository:
+| outcome | exit | when |
+| --- | :-: | --- |
+| `PASSED` | 0 | the suite ran its checks and they held |
+| `SKIPPED (ran no checks)` | 2 | the feature under test does not exist on this major |
+| `FAILED` | 1 | a check failed, **or** a tool the suite measures with is missing |
+
+The matrix prints `suites that ran: n of m (skipped: k)` for each major, and names
+the skipped suites. A skip counts in `k`, not in `n`.
+
+**A missing dependency fails rather than skips, and that is deliberate.** The box
+cannot gate that suite. Reporting a pass would claim coverage nobody has. Two
+dependencies come from outside this repository:
 
 | suite | needs | where it comes from |
 | --- | --- | --- |
@@ -152,8 +158,24 @@ repository:
 | `temporal.sh` | `btree_gist` | PostgreSQL **contrib**. A PGDG package ships it; a source build configured without contrib does not |
 
 Build and install `contrib/btree_gist` against each source tree when the matrix
-runs against source builds. Until that was done, `temporal.sh` asserted nothing
-on four of five majors and reported success (#447).
+runs against source builds. To run knowingly without a dependency, waive it:
+
+```sh
+PGC_ALLOW_MISSING_BTREE_GIST=1 test/temporal.sh /path/to/pg_config
+PGC_ALLOW_MISSING=1            test/run_all_versions.sh
+```
+
+A waived suite reports `SKIPPED` and exits 2, so the coverage loss stays visible
+in the skipped count rather than becoming a pass.
+
+Measured on PostgreSQL 18, one suite, four configurations:
+
+| configuration | exit | verdict |
+| --- | :-: | --- |
+| `btree_gist` present | 0 | `PASSED`, 5 checks |
+| `btree_gist` absent | 1 | `FAILED` |
+| `btree_gist` absent, waived | 2 | `SKIPPED` |
+| PostgreSQL 17, feature absent | 2 | `SKIPPED (ran no checks)` |
 
 ## Cross-major upgrade
 

--- a/test/temporal.sh
+++ b/test/temporal.sh
@@ -14,9 +14,15 @@
 # btree_gist is CONTRIB. A PGDG package ships it with postgresql-N, so CI has it. A
 # source build configured without contrib does not, and this suite then asserts nothing.
 # It reported PASSED while doing so until #447, and the local five-major matrix was
-# claiming temporal coverage on every major while running it on one. Build and install
-# contrib/btree_gist against each source tree, or read the SKIPPED line and know what it
-# means.
+# claiming temporal coverage on every major while running it on one.
+#
+# Since #448 a missing btree_gist FAILS rather than skips, because the box cannot gate
+# this suite and a pass would claim coverage nobody has. Build and install
+# contrib/btree_gist against each source tree, or set PGC_ALLOW_MISSING_BTREE_GIST=1 to
+# run knowingly without it, which reports SKIPPED and keeps the loss visible.
+#
+# A skip on 15, 16 and 17 is different and is correct: WITHOUT OVERLAPS does not exist
+# there, so there is nothing to gate.
 #
 # Usage:  test/temporal.sh [PG_CONFIG]
 #

--- a/test/temporal.sh
+++ b/test/temporal.sh
@@ -11,6 +11,13 @@
 # same result set. WITHOUT OVERLAPS needs a GiST index over the scalar key part,
 # so btree_gist must be available; the suite skips with a note if it is not.
 #
+# btree_gist is CONTRIB. A PGDG package ships it with postgresql-N, so CI has it. A
+# source build configured without contrib does not, and this suite then asserts nothing.
+# It reported PASSED while doing so until #447, and the local five-major matrix was
+# claiming temporal coverage on every major while running it on one. Build and install
+# contrib/btree_gist against each source tree, or read the SKIPPED line and know what it
+# means.
+#
 # Usage:  test/temporal.sh [PG_CONFIG]
 #
 # Written fresh for pgColumnar; it does not reuse any upstream test file.


### PR DESCRIPTION
Follow-up to #447/#448 and a correction to my own review of #411. @ChronicallyJD for review.

## What I got wrong

I approved the claim that temporal constraints are "covered by `test/temporal.sh`", having
checked that the file exists and greps for the right things. **On the matrix I would have
quoted, it asserted nothing on four majors out of five.**

Your #448 is what made it visible. Chasing the question you left open:

```
btree_gist in the SOURCE builds        PGDG packages
  pg15 ABSENT                            postgresql-18 ships it
  pg16 ABSENT
  pg17 ABSENT
  pg18 present
  pg19 ABSENT
```

`btree_gist` is **contrib**. CI apt-installs `postgresql-N` and therefore has it, so CI was
running this suite honestly. Our source builds are configured without contrib, so the
five-major matrix, the gate we treat as authoritative, was reporting coverage it never ran.

## What changed after building contrib against each source tree

```
pg15   SKIPPED (ran no checks)     correct: WITHOUT OVERLAPS is 18+
pg17   SKIPPED (ran no checks)     correct: same
pg19   8 checks, PASSED            previously PASSED having run none
```

So the claim was **true on 18 and false on 19**, and nothing said so. The environment fix is
done in the dev container; this PR is the part that belongs in the repository.

## Three changes, no product code

- **`temporal.sh`'s header** records that `btree_gist` is contrib, that a PGDG package has
  it and a source build may not, and what a SKIPPED line then means.
- **`docs/testing.md`** gains a section on reading the skipped count. The distinction worth
  writing down is between *the feature does not exist on this major*, which is expected, and
  *a tool is missing*, which means coverage was lost and nothing else says so. Both external
  dependencies are named: `pyarrow` and `btree_gist`.
- **the version-adoption table** says "done on 18 and 19" and names the dependency, instead
  of "done".

## Why this rather than making the suite fail

`temporal.sh` skipping on 15, 16 and 17 is **correct**: `WITHOUT OVERLAPS` does not exist
there. Turning that into a failure would be wrong, and it is the same reasoning you used for
making skipped a third state rather than a failure. What was missing was not a stricter
suite, it was anyone reading the count. #448 makes the count visible; this makes the reason
findable.

## Worth noting for the wider point

This is the second time today that the thing I approved was a **claim I had not exercised**,
the first being three of my own on #441, #443 and #446. The pattern is not that the code was
wrong. It is that a sentence asserting coverage reads exactly like a sentence reporting it.