### PR TITLE
A failed suite ran, so count it as one (#447)

### DIFF
--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -480,6 +480,17 @@ for pgc in "${CONFIGS[@]}"; do
 			# is how the replication failures stayed unreadable.
 			tail -60 "$builddir/${s}.log" | sed 's/^/      /'
 			results+="$s=FAIL "
+			# A failed suite RAN. Counting only passes here made the tally
+			# contradict itself in the one case that matters. The five-major
+			# matrix reported
+			#
+			#     PG19  suites that ran: 121 of 122 (skipped: 0)
+			#
+			# with temporal failing: 121 + 0 is not 122, and the failing suite was
+			# in neither bucket of the count that exists to say what ran. Four
+			# majors hid it, because a tally only disagrees with itself once
+			# something actually fails.
+			suites_ran=$((suites_ran + 1))
 			verfail=1
 		fi
 	done


### PR DESCRIPTION
Follow-up to #448, which I got wrong in a small way that only shows up when something fails.

#448 counts a suite as having **run** when it exits 0 and as **skipped** when it exits 2. A
failure exits 1 and lands in neither, so the per-major tally silently drops it. The first
five-major matrix after it merged said:

```
PG18  suites that ran: 119 of 122 (skipped: 2)    temporal=FAIL
PG19  suites that ran: 121 of 122 (skipped: 0)    temporal=FAIL
```

121 + 0 is not 122. The failing suite disappeared from the count whose whole purpose is to say
what ran, which is a milder version of the confusion #447 was about.

**Four majors hid it.** PG15, 16 and 17 were green, and a tally only contradicts itself once
something actually fails. I did not see it in the arms I ran before opening #448, because none
of them failed, and neither did the review.

### Validated by forcing a failure, both arms

`btree_gist` hidden on pg18a, which since #448 makes `temporal` fail as a missing dependency.
Same major, same box, same forced failure. Only the patch differs.

| arm | line printed | adds up? |
|---|---|---|
| main | `suites that ran: 119 of 122 (skipped: 2)` | 119 + 2 = **121** |
| with the fix | `suites that ran: 120 of 122 (skipped: 2)` | 120 + 2 = **122** |

Both arms report `FAIL temporal`. The verdict never changed; only whether the count admitted
the suite existed.

A failed suite ran. It ran, and it failed. Those are the two facts the line should carry, and
now it does.

### Note on how this was validated

The fix cannot be demonstrated by a green run, because a green run has nothing in the failure
branch. So the check forces one: `btree_gist` is hidden on pg18a, which since #448 makes
`temporal` fail as a missing dependency, and the same major runs both with and without the
patch. If both arms had printed the same tally the fix would be doing nothing.
