### PR TITLE
Record what the ClickBench licence actually forbids (#421)

### DIFF
--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -551,11 +551,38 @@ oracle, so none changes query results.
   this repository. The runner fetches `postgresql/create.sql` and
   `postgresql/queries.sql` from upstream at run time, into the benchmark data
   directory, and feeds them to `psql` unmodified. The comparison oracle is the
-  heap arm of the same run, not any upstream expected output. **Proposed
-  2026-08-05: keep the run-time fetch rather than take a durable in-tree copy.
-  Owner decision pending, and the NonCommercial term's effect on publishing
-  benchmark numbers is a separate question that a run-time fetch does not
-  address.** The measured numbers published in
+  heap arm of the same run, not any upstream expected output.
+
+  **Both open questions were decided by the owner on 2026-08-06.**
+
+  *Run-time fetch:* keep it, and re-fetch on every run rather than caching, so a
+  run measures the current upstream definition rather than whatever was current
+  the first time the harness ran on that machine.
+
+  *NonCommercial:* the owner read the licence and determined that **publishing our
+  own test results is permitted**. We measure to compare, not to sell. What the
+  term forbids, and what this project must therefore not do with ClickBench or
+  anything derived from it:
+
+  - selling copies of the material, or of a remix of it
+  - placing the material on a website or platform monetised by ads where the
+    primary goal is revenue generation
+  - using the material in promotional materials, corporate brochures, or paid
+    advertisements for a business
+  - charging a fee to access, download, or view a derivative work built on it
+
+  The third is the one to watch, because it is the one a well-meaning reader walks
+  into. The numbers in `docs/benchmarks.md` are documentation: they exist so a user
+  can decide whether this engine suits their workload, and so we can see our own
+  regressions. **Lifting them into a brochure, a sales deck, a conference booth
+  panel or a paid campaign is the prohibited use**, and the fact that we produced
+  the numbers ourselves does not change that, because the benchmark definition
+  they were produced with is the licensed material.
+
+  Recorded as the owner's determination and its reasoning. No legal opinion was
+  sought. It is written down so it can be revisited rather than re-derived.
+
+  The measured numbers published in
   `docs/benchmarks.md` are our own, produced on our own hardware. The dataset
   (`hits.tsv.gz`) is downloaded for local measurement and is not redistributed;
   its own licensing is unestablished and it must not be added to the tree without

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -762,13 +762,15 @@ run was on 2026-08-05, and upstream carried the digests above a day later. That
 is an inference and not a measurement. The next run is the first that will state
 it.
 
-**These numbers are documentation, and the NonCommercial term governs what else
-they may be used for.** Publishing our own test results here is permitted: we
-measure to compare, and to catch our own regressions. Reusing them in promotional
-material, a corporate brochure, a sales deck or a paid advertisement is not, and
-producing the numbers ourselves does not change that, because the benchmark
-definition they came from is the licensed material. The full list of prohibited
-uses is in `PROVENANCE.md` beside the owner's determination of 2026-08-06.
+**These numbers are documentation**, and the NonCommercial term governs their
+reuse. Publishing our own test results here is permitted. We measure to compare,
+and to catch our own regressions.
+
+Reuse in promotional material, a corporate brochure, a sales deck or a paid
+advertisement is not permitted. Producing the numbers ourselves does not change
+that. The benchmark definition they came from is the licensed material. The full
+list of prohibited uses is in `PROVENANCE.md`, beside the owner's determination
+of 2026-08-06.
 
 The numbers below are one run on 2026-08-05. The conditions were PostgreSQL 18.4
 non-assert, 16 cores, 62 GB of memory, and 11,110,833 rows. That row count is

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -739,6 +739,17 @@ project's MIT license does not carry. The harness fetches the definition from
 upstream at run time and copies nothing. Our comparison oracle is the heap arm of
 the same run.
 
+The definition is re-fetched on every run, so a result is only comparable to
+another taken against the same upstream definition.
+
+**These numbers are documentation, and the NonCommercial term governs what else
+they may be used for.** Publishing our own test results here is permitted: we
+measure to compare, and to catch our own regressions. Reusing them in promotional
+material, a corporate brochure, a sales deck or a paid advertisement is not, and
+producing the numbers ourselves does not change that, because the benchmark
+definition they came from is the licensed material. The full list of prohibited
+uses is in `PROVENANCE.md` beside the owner's determination of 2026-08-06.
+
 The numbers below are one run on 2026-08-05. The conditions were PostgreSQL 18.4
 non-assert, 16 cores, 62 GB of memory, and 11,110,833 rows. That row count is
 every ninth row of the real 100 million row table. The reported time is the best


### PR DESCRIPTION
**Owner determination, 2026-08-06, after reading CC BY-NC-SA: publishing our own test results is
permitted.** We measure to compare, not to sell.

### I had this wrong and this PR now says the opposite of what it opened with

The first version removed the load-and-size table and the per-query speedup ratios from
`docs/benchmarks.md`, on the reading that no ClickBench-derived numbers could be published. That
reading was wrong. **The removal is reverted** and `docs/benchmarks.md` is byte-identical to
`main` apart from one added caution.

Nothing about those measurements was ever in doubt. Only what we were entitled to do with them.

### What the term actually forbids

Now written down rather than left to inference:

- selling copies of the material, or of a remix of it
- placing it on a website or platform monetised by ads where revenue generation is the primary goal
- using it in promotional materials, corporate brochures, or paid advertisements for a business
- charging a fee to access, download, or view a derivative work built on it

**The third is the one worth guarding**, because it is the one a well-meaning reader walks into. A
benchmark table in documentation exists so a user can decide whether this engine suits their
workload, and so we can see our own regressions. The same table in a sales deck, a conference
booth panel or a paid campaign is the prohibited use — and having produced the numbers ourselves
does not change that, because the benchmark definition they were produced with is the licensed
material.

### Where each piece lives

- **`docs/benchmarks.md`** gains a short caution beside the numbers, where someone about to lift
  them will actually see it. Everything else in that file is unchanged.
- **`PROVENANCE.md`** carries the full list, the determination, and its reasoning. No legal
  opinion was sought, and it is recorded so it can be revisited rather than re-derived.

It also records the run-time fetch decision from the same day, which #453 implements.

### On #453

Its `PROVENANCE.md` paragraph reached the opposite conclusion on this question before the owner
had made one, and I held it for that reason. The owner has now ruled, and the substance of that
paragraph is closer to right than my first attempt was — but it was still recording a
determination that had not been taken. Both of us should let that file follow the owner rather
than lead them.