### PR TITLE
Stop the publisher cluster as well as the subscriber (#470)

### DIFF
--- a/test/logical_subscriber.sh
+++ b/test/logical_subscriber.sh
@@ -61,7 +61,18 @@ pgc_pg "initdb -D '$SUB_DIR' -A trust" >/dev/null 2>&1
   pgc_pg "printf 'port=%s\nlisten_addresses=%s\nwal_level=logical\nmax_locks_per_transaction=256\nshared_preload_libraries=%s\n' \
 	'$SUB_PORT' \"'127.0.0.1'\" \"'pgcolumnar'\" >> '$SUB_DIR/postgresql.conf'"
 pgc_pg "pg_ctl -D '$SUB_DIR' -l '$SUB_LOG' start -w" >/dev/null 2>&1
-sub_cleanup() { pgc_pg "pg_ctl -D '$SUB_DIR' -m immediate stop" >/dev/null 2>&1 || true; }
+# Ends in pgc_teardown, which is not optional. pgc_setup installs
+# `trap pgc_teardown EXIT`, and a second `trap ... EXIT` REPLACES it rather than
+# adding to it, so this used to stop the subscriber and leave the publisher
+# cluster running: measured at one orphaned postmaster per run, from a box with
+# none. Orphans hold ports, the band is finite, and a suite that cannot get one
+# fails after 8 start attempts with "could not create any TCP/IP sockets" -- a red
+# that is indistinguishable from a real one and lands on whichever suite drew that
+# port. replication.sh's sb_teardown has always chained this way (#470).
+sub_cleanup() {
+	pgc_pg "pg_ctl -D '$SUB_DIR' -m immediate stop" >/dev/null 2>&1 || true
+	pgc_teardown
+}
 trap sub_cleanup EXIT
 
 SUB() { env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$SUB_PORT" -U postgres \


### PR DESCRIPTION
Closes #470.

## The defect

`pgc_setup` installs `trap pgc_teardown EXIT`. `test/logical_subscriber.sh` then installed its own:

```sh
sub_cleanup() { pgc_pg "pg_ctl -D '$SUB_DIR' -m immediate stop" >/dev/null 2>&1 || true; }
trap sub_cleanup EXIT
```

A second `trap ... EXIT` **replaces** the first. So the subscriber cluster was stopped and the suite's own cluster never was. The suite passed, every run, and left a live postmaster behind.

## Measured, not argued

PG17, from a box reaped to zero orphaned postmasters:

```
before fix:  logical_subscriber  rc=0  before=0 after=1 delta=1  PASSED
after fix:   logical_subscriber  rc=0  before=0 after=0 delta=0  PASSED
```

Gated on PG18 and PG19, with `replication.sh` alongside because it is the suite that already chained correctly and must keep doing so:

```
PG18  logical_subscriber  rc=0  checks run: 20  PASSED
PG18  replication         rc=0  checks run: 41  PASSED
PG19  logical_subscriber  rc=0  checks run: 20  PASSED
PG19  replication         rc=0  checks run: 41  PASSED
```

## Why it is not cosmetic

The port band is finite. A suite that cannot get a port fails after 8 start attempts with `could not create any TCP/IP sockets`, which is **indistinguishable from a real red** and is attributed to whichever suite drew the exhausted port, not to the one that leaked. 37 orphans had accumulated on the dev container and turned two majors of a gate red for reasons unrelated to the code under test.

## The audit behind it

`objstore_module` had the identical defect and was fixed in #446. This is the other one.

The audit had to be **measured rather than read**, and that mattered: `harness_selftest` installs its own EXIT trap at line 73, *before* `pgc_setup` at line 90, so by inspection `pgc_setup` should clobber it and the squatter cluster should leak. Measured, it does not.

| suite | delta | verdict |
| --- | --- | --- |
| `harness_selftest` | 0 | no leak, despite the ordering |
| `logical_subscriber` | 1 -> 0 | this PR |
| `replication` | 0 | already correct, chains `pgc_teardown` |
| `objstore_module` | 1 -> 0 | fixed in #446 |

## Left open deliberately

Nothing in the harness detects this class. A suite can leak a cluster and still report PASSED, which is how both instances survived unnoticed. #470 records that a before/after postmaster count around each suite would catch the whole category rather than these two instances; that is a harness change and not this PR.