### PR TITLE
fix: cost a columnar scan for the columns it reads, not the whole relation (#480)

### DIFF
--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -870,6 +870,92 @@ pgcolumnar_restriction_correlation(RelOptInfo *rel, Oid heapRelid)
 }
 
 /*
+ * pgcolumnar_projected_width_fraction
+ *		The share of a row's stored width this scan actually reads, in (0, 1].
+ *		One means every column is referenced.
+ *
+ *		A columnar scan decodes only the columns the query names (spec 9), which
+ *		is the reason to store data this way at all. The cost model did not know
+ *		it: the path inherits the sequential scan's cost, which prices every page
+ *		of the relation, so reading one int column out of fourteen was quoted the
+ *		same as reading all fourteen. Measured in test/column_projection.sh on
+ *		300,000 rows: 221 buffers against 2,671, priced 1391.08 against 1391.44.
+ *
+ *		The consequence is not a rounding error. On a 200,000-row table with a
+ *		2 KB payload, an index-only scan priced 15,521 ran 373 ms while the
+ *		columnar scan priced 27,682 ran 8 ms -- the plan 44x faster was declined
+ *		because it was quoted as reading a relation it never touches.
+ *
+ *		Width comes from ANALYZE's stored average where there is one, because a
+ *		varlena column's TYPE width says nothing useful (a text column is "we do
+ *		not know"), and the whole point here is the ratio between a fixed-width
+ *		key and a wide payload. get_typavgwidth is the fallback for a column
+ *		never analysed.
+ *
+ *		Both the target list and the restriction clauses count: a qual on a
+ *		column that is not selected still has to be decoded to be evaluated.
+ */
+static double
+pgcolumnar_projected_width_fraction(RelOptInfo *rel, Oid heapRelid)
+{
+	Bitmapset  *needed = NULL;
+	Relation	r;
+	TupleDesc	tupdesc;
+	double		total = 0.0;
+	double		used = 0.0;
+	int			i;
+	ListCell   *lc;
+
+	pull_varattnos((Node *) rel->reltarget->exprs, rel->relid, &needed);
+	foreach(lc, rel->baserestrictinfo)
+	{
+		RestrictInfo *rinfo = lfirst_node(RestrictInfo, lc);
+
+		pull_varattnos((Node *) rinfo->clause, rel->relid, &needed);
+	}
+
+	r = table_open(heapRelid, AccessShareLock);
+	tupdesc = RelationGetDescr(r);
+
+	for (i = 1; i <= tupdesc->natts; i++)
+	{
+		Form_pg_attribute att = TupleDescAttr(tupdesc, i - 1);
+		int32		w;
+
+		if (att->attisdropped)
+			continue;
+
+		w = get_attavgwidth(heapRelid, att->attnum);
+		if (w <= 0)
+			w = get_typavgwidth(att->atttypid, att->atttypmod);
+		if (w <= 0)
+			w = 1;
+
+		total += w;
+		if (bms_is_member(i - FirstLowInvalidHeapAttributeNumber, needed))
+			used += w;
+	}
+
+	table_close(r, AccessShareLock);
+	bms_free(needed);
+
+	if (total <= 0.0)
+		return 1.0;
+
+	/*
+	 * A scan that names no column at all -- `SELECT count(*)` with no
+	 * restriction -- still reads something: the row count comes from metadata,
+	 * but nothing here should price a scan at zero. #171 is what a
+	 * floorless discount does: a full scan priced at 1.00 beat an index scan
+	 * priced at 174.29 and turned a point lookup into 1251.88 ms.
+	 */
+	if (used <= 0.0)
+		return 1.0;
+
+	return (used >= total) ? 1.0 : (used / total);
+}
+
+/*
  * pgcolumnar_zonemap_survival
  *		The fraction of the relation a restricted columnar scan must actually
  *		read, in (0, 1]. One means no pruning is expected.
@@ -1220,9 +1306,31 @@ PgColumnarSetRelPathlist(PlannerInfo *root, RelOptInfo *rel, Index rti,
 	{
 		Cost		full = pgcolumnar_full_scan_cost(rel, seqpath);
 		double		survival = pgcolumnar_zonemap_survival(rel, rte->relid);
+		double		widthFrac = pgcolumnar_projected_width_fraction(rel, rte->relid);
+		Cost		pageCost = seq_page_cost * (double) rel->pages;
+		Cost		run = full - cpath->path.startup_cost;
 
-		cpath->path.total_cost = cpath->path.startup_cost +
-			(full - cpath->path.startup_cost) * survival;
+		/*
+		 * Only the page-read part scales with the projected width: the CPU terms
+		 * are per row and are paid whichever columns are decoded. Subtracting the
+		 * unread share of the I/O rather than scaling the whole run cost keeps a
+		 * narrow projection from being priced below the row-handling it still
+		 * does, which is the shape of #171.
+		 *
+		 * Guarded rather than assumed: rel->pages can exceed what the inherited
+		 * seqscan cost accounts for, and a negative run cost would make a full
+		 * scan free.
+		 */
+		if (pageCost > 0.0 && widthFrac < 1.0)
+		{
+			Cost		saved = pageCost * (1.0 - widthFrac);
+
+			if (saved > run)
+				saved = run;
+			run -= saved;
+		}
+
+		cpath->path.total_cost = cpath->path.startup_cost + run * survival;
 	}
 	cpath->path.pathkeys = NIL;
 	cpath->flags = 0;

--- a/test/column_projection.sh
+++ b/test/column_projection.sh
@@ -195,4 +195,63 @@ check "parallel scan, qual on unselected column" \
 	"$(par "SELECT sum(v) FROM t WHERE k < 500")" \
 	"$(val on "SELECT sum(v) FROM h WHERE k < 500")"
 
+# ---- and the COST MODEL has to know it ---------------------------------------
+#
+# Everything above proves the scan skips the columns it does not need. None of it
+# asks whether the PLANNER knows that, and it did not: the columnar path inherits
+# the sequential scan's cost, which prices every page of the relation, so reading
+# one int column out of fourteen was quoted the same as reading all fourteen.
+#
+# That is not a rounding error on a columnar engine. Column projection is the
+# reason to store data this way at all, and a planner that cannot see it declines
+# the scan precisely where it wins biggest. Measured on a 200,000-row table with
+# a 2 KB payload: an index-only scan priced 15,521 and ran 373 ms, against a
+# columnar scan priced 27,682 that ran 8 ms -- the plan 44x faster was declined
+# because it was quoted as reading a relation it never touches.
+#
+# It stayed hidden because a second error cancelled it. The zone-map discount
+# read pg_stats.correlation and credited a correlated key with skipping half the
+# relation, on a table whose two chunk groups are both read (measured: "Chunk
+# Groups Removed by Filter: 0"). A fictional pruning discount of ~0.5 stood in
+# for the real width discount that was missing, and test/planner_choice_quality.sh
+# passed on the product of the two. #461 removes the fiction, which is why this
+# has to be priced properly first.
+#
+# The oracle is BUFFERS, measured above, not a re-derivation of the cost formula.
+# A cost model checked against its own arithmetic asserts nothing.
+
+# Cost of the columnar scan node itself, not the plan total: the aggregate above
+# it costs the same either way and would dilute the ratio.
+scan_cost() {	# $1 = sql
+	psql_run "SET max_parallel_workers_per_gather=0; EXPLAIN $1;" 2>/dev/null |
+		grep -E 'PgColumnar' | grep -oE 'cost=[0-9.]+\.\.[0-9.]+' |
+		head -1 | sed 's/.*\.\.//'
+}
+
+NARROW_SQL="SELECT count(id) FROM t"
+WIDE_SQL="SELECT count(id), count(txt), count(pad1), count(pad2), count(pad3),
+                 count(pad4), count(pad5), count(pad6), count(pad7), count(pad8) FROM t"
+
+NARROW_BUF=$(bufs on "$NARROW_SQL")
+WIDE_BUF=$(bufs on "$WIDE_SQL")
+NARROW_COST=$(scan_cost "$NARROW_SQL")
+WIDE_COST=$(scan_cost "$WIDE_SQL")
+echo "-- one column of fourteen: buffers $NARROW_BUF vs $WIDE_BUF, cost $NARROW_COST vs $WIDE_COST"
+
+# The physical premise. If the narrow read did not actually touch fewer buffers
+# there would be nothing for the cost model to reflect, and the check below would
+# be demanding a discount that is not owed.
+check_num "premise: the narrow projection really does read far fewer buffers" \
+	"$([ -n "$NARROW_BUF" ] && [ -n "$WIDE_BUF" ] &&
+	   awk "BEGIN{exit !($WIDE_BUF > 0 && $NARROW_BUF < $WIDE_BUF * 0.5)}" && echo 1 || echo 0)" "1"
+
+check_num "premise: both scan costs are measurements" \
+	"$([ -n "$NARROW_COST" ] && [ -n "$WIDE_COST" ] &&
+	   awk "BEGIN{exit !($NARROW_COST > 0 && $WIDE_COST > 0)}" && echo 1 || echo 0)" "1"
+
+# A margin, not a bare "<". Two undiscounted prices differ by rounding, and a
+# bare comparison would report that as the model working.
+check_num "the cost model prices a narrow projection below a wide one" \
+	"$(awk "BEGIN{print ($NARROW_COST < $WIDE_COST * 0.8) ? 1 : 0}")" "1"
+
 pgc_summary


### PR DESCRIPTION
Closes #480. Found while working #461, which is parked until this lands.

## The measurement

`test/column_projection.sh`'s fixture: 300,000 rows, fourteen columns.

| query | buffers | cost before | cost after |
| --- | ---: | ---: | ---: |
| `SELECT count(id)` | **221** | 1391.08 | **796.03** |
| ten columns incl. `txt` + eight `float8` | **2671** | 1391.44 | **1257.08** |

Twelve times the data, priced 0.03 percent apart. That suite has always asserted
the buffer counts. Nothing asserted that the planner knew.

## Cause

`pgcolumnar_full_scan_cost` inherits the sequential scan's cost, and a seqscan
reads every page of the relation. Column projection is the reason to store data
columnar at all, and the cost model could not see it.

On `planner_choice_quality`'s fixture -- 200,000 rows, 2 KB incompressible
payload -- that meant:

```
SELECT count(*) FROM pq WHERE k > 100000
  Index Only Scan   priced 15,521   ran 373 ms   <- chosen
  Custom Scan       priced 27,682   ran   8 ms
```

A plan **44x faster** declined, because the columnar scan was quoted as reading a
400 MB relation when it touches one 8-byte column.

## Why it was invisible: two errors cancelling

`planner_choice_quality` passes on `main`. It passes because #460's zone-map
discount credits a correlated key with skipping about half the relation -- and on
that fixture the executor skips **nothing**:

```
Columnar Chunk Groups Total: 2
Columnar Chunk Groups Removed by Filter: 0
```

Two chunk groups, both read; `k > 100000` excludes neither. **A fictional pruning
discount of ~0.5 was standing in for the real width discount that is missing**,
and the suite asserted the product of the two.

This is the same shape as #477 one layer up, and it is the reason #461 cannot go
first: replacing correlation with a measured prune rate is individually correct,
removes the fiction, and regresses plan choice 44x. That branch is parked at
`3ba9b09`.

## The three judgment calls

**Only the page-read component scales.** The CPU terms are per row and are paid
whichever columns are decoded. Scaling the whole run cost would price a narrow
projection below the row handling it still does, which is the shape of #171 --
a full scan priced at 1.00 beating an index scan priced at 174.29.

**The saving is clamped to the run cost.** `rel->pages` can exceed what an
inherited seqscan cost accounts for, and a negative run cost makes a full scan
free.

**Width comes from ANALYZE's stored average**, falling back to `get_typavgwidth`.
A varlena column's type width says nothing useful and the ratio between a
fixed-width key and a wide payload is the entire point. Restriction clauses count
alongside the target list: a qual on an unselected column still has to be
decoded.

## Verification

RED before implementing: the new check failed at 1391.08 against 1391.44. The
oracle is the **measured buffer count**, not the cost formula -- a cost model
checked against its own arithmetic asserts nothing.

`planner_choice_quality` now passes on its own merits rather than by
cancellation: this branch is cut from `main`, so the correlation model is
untouched, and the columnar scan at 8.4 ms is chosen over the index-only scan at
214 ms.

Full 132-suite matrix green on **PG18 and PG19** (130 ran / 2 skipped on 18,
132 / 0 on 19).

## Scope

Only the base columnar path's width factor. The projection scan path is costed as
a flat `0.5x` of the base path and I have not touched that -- it is a separate
guess that deserves its own look, but it is not what declined the plan here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013sY1RQR5MjZNUixA2um31r
