### PR TITLE
feat: price pruning from a measured sample, not from correlation (#461)

### DIFF
--- a/src/columnar.h
+++ b/src/columnar.h
@@ -869,6 +869,19 @@ extern Node *PgColumnarCreateGroupAggScanState(CustomScan *cscan);
 extern ScanKey PgColumnarBuildScanKeys(List *qual, Index scanrelid,
 									 TupleDesc tupdesc, int *nkeys);
 
+/*
+ * How many chunk groups the planner samples when estimating how much a
+ * restriction prunes (#461). Constant work per plan whatever the table's size:
+ * evaluating every group is O(groups) catalog reads on every plan, including
+ * plans that are discarded. Costing compares two plans, so it does not need
+ * three digits of precision.
+ */
+#define PGCOLUMNAR_PRUNE_SAMPLE_GROUPS 32
+
+extern double PgColumnarEstimatePruneSurvival(uint64 storageId, TupleDesc tupdesc,
+											List *qual, Index scanrelid,
+											uint64 ngroups, int sampleTarget);
+
 /* -------------------------------------------------------------------------
  * vectorized aggregation and filtering (pgcolumnar_vector.c, spec 9)
  * ------------------------------------------------------------------------- */

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -781,95 +781,6 @@ pgcolumnar_full_scan_cost(RelOptInfo *rel, Path *seqpath)
 }
 
 /*
- * pgcolumnar_restriction_correlation
- *		The strongest column correlation among the restriction clauses that a
- *		zone map can prune on, as |rho| in [0, 1]. Zero when nothing qualifies.
- *
- *		Only `Var op Const` on an ordered, fixed-width type counts, because that
- *		is what the reader's row-group skip actually evaluates: it compares the
- *		constant against the chunk's stored minimum and maximum. A LIKE, an
- *		expression key or a join clause prunes nothing, and counting one here
- *		would discount a scan that does the full work (#426 is the open issue for
- *		text predicates; until it lands they must not be priced as if they prune).
- */
-static double
-pgcolumnar_restriction_correlation(RelOptInfo *rel, Oid heapRelid)
-{
-	ListCell   *lc;
-	double		best = 0.0;
-
-	foreach(lc, rel->baserestrictinfo)
-	{
-		RestrictInfo *rinfo = lfirst_node(RestrictInfo, lc);
-		OpExpr	   *op;
-		Node	   *leftop;
-		Node	   *rightop;
-		Var		   *var;
-		HeapTuple	st;
-		AttStatsSlot sslot;
-		Oid			sortop;
-
-		if (!IsA(rinfo->clause, OpExpr))
-			continue;
-		op = (OpExpr *) rinfo->clause;
-		if (list_length(op->args) != 2)
-			continue;
-		leftop = (Node *) linitial(op->args);
-		rightop = (Node *) lsecond(op->args);
-
-		/* Var on one side, Const on the other; either order. */
-		if (IsA(leftop, Var) && IsA(rightop, Const))
-			var = (Var *) leftop;
-		else if (IsA(rightop, Var) && IsA(leftop, Const))
-			var = (Var *) rightop;
-		else
-			continue;
-
-		if (var->varno != rel->relid || var->varattno <= 0)
-			continue;
-		/* A zone map stores min and max of a fixed-width ordered value. */
-		if (get_typlen(var->vartype) <= 0 || !get_typbyval(var->vartype))
-			continue;
-
-		/*
-		 * The type's default btree "<", which is the operator ANALYZE keys the
-		 * correlation slot on. Asked of the type cache rather than derived from
-		 * the clause's own operator: get_ordering_op_for_equality_op took two
-		 * arguments through PG17 and three later, and this needs no more than
-		 * the default ordering in any of those majors.
-		 */
-		{
-			TypeCacheEntry *tc = lookup_type_cache(var->vartype,
-												   TYPECACHE_LT_OPR);
-
-			if (tc == NULL || !OidIsValid(tc->lt_opr))
-				continue;
-			sortop = tc->lt_opr;
-		}
-
-		st = SearchSysCache3(STATRELATTINH, ObjectIdGetDatum(heapRelid),
-							 Int16GetDatum(var->varattno), BoolGetDatum(false));
-		if (!HeapTupleIsValid(st))
-			continue;
-		if (get_attstatsslot(&sslot, st, STATISTIC_KIND_CORRELATION, sortop,
-							 ATTSTATSSLOT_NUMBERS))
-		{
-			if (sslot.nnumbers == 1)
-			{
-				double		corr = fabs(sslot.numbers[0]);
-
-				if (corr > best)
-					best = corr;
-			}
-			free_attstatsslot(&sslot);
-		}
-		ReleaseSysCache(st);
-	}
-
-	return (best > 1.0) ? 1.0 : best;
-}
-
-/*
  * pgcolumnar_projected_width_fraction
  *		The share of a row's stored width this scan actually reads, in (0, 1].
  *		One means every column is referenced.
@@ -989,26 +900,12 @@ pgcolumnar_projected_width_fraction(RelOptInfo *rel, Oid heapRelid)
 static double
 pgcolumnar_zonemap_survival(RelOptInfo *rel, Oid heapRelid)
 {
-	double		sel;
-	double		rho;
 	double		survival;
 	double		floorFrac;
 	double		groups;
 
 	if (rel->baserestrictinfo == NIL || rel->tuples <= 0)
 		return 1.0;
-
-	rho = pgcolumnar_restriction_correlation(rel, heapRelid);
-	if (rho <= 0.0)
-		return 1.0;
-
-	sel = rel->rows / rel->tuples;
-	if (sel < 0.0)
-		sel = 0.0;
-	if (sel >= 1.0)
-		return 1.0;
-
-	survival = sel + (1.0 - rho * rho) * (1.0 - sel);
 
 	/*
 	 * One row group's share, from the group size THIS TABLE was written with.
@@ -1040,6 +937,57 @@ pgcolumnar_zonemap_survival(RelOptInfo *rel, Oid heapRelid)
 			return 1.0;
 		groups = ceil(rel->tuples / (double) limit);
 	}
+	if (groups < 1.0)
+		return 1.0;
+
+	/*
+	 * Measure, rather than infer from correlation (#461).
+	 *
+	 * This read pg_stats.correlation and interpolated on rho^2. Correlation is a
+	 * GLOBAL agreement between value order and physical order; pruning is LOCAL,
+	 * needing only each group's own min and max to be narrow. The two come apart
+	 * exactly where this engine is aimed: batch-loaded time-series is globally
+	 * unsorted and locally tight, and #391 measured a TSBS `time` column with
+	 * correlation 0.0133 removing 82 percent of chunk groups. Under the old model
+	 * that column earned nothing. #381 made this same mistake in documentation and
+	 * #391 corrected it; the planner then reintroduced it.
+	 *
+	 * So ask the reader's question with the reader's own code: build the same skip
+	 * predicates and evaluate them against a bounded sample of the groups' zone
+	 * maps. A proxy's error direction is unknowable, a sample's is just sampling
+	 * error, and a discount taken by a different rule than the one that priced it
+	 * is how a plan gets chosen for a saving it never realises.
+	 */
+	{
+		Relation	r = table_open(heapRelid, AccessShareLock);
+
+		/*
+		 * extract_actual_clauses(..., false), NOT get_actual_clauses.
+		 *
+		 * get_actual_clauses carries Assert(!rinfo->pseudoconstant), and a
+		 * pseudoconstant qual is not exotic: `WHERE (SELECT false)` produces one,
+		 * as a one-time filter. On an assert-enabled build that took down two
+		 * native_groupagg checks with a bare QUERY_ERROR. Excluding them is also
+		 * right on the merits -- a one-time filter is evaluated once for the whole
+		 * scan and prunes no chunk group, so it has nothing to contribute here.
+		 */
+		survival = PgColumnarEstimatePruneSurvival(PgColumnarStorageId(r),
+												   RelationGetDescr(r),
+												   extract_actual_clauses(rel->baserestrictinfo,
+																		  false),
+												   rel->relid,
+												   (uint64) groups,
+												   PGCOLUMNAR_PRUNE_SAMPLE_GROUPS);
+		table_close(r, AccessShareLock);
+	}
+
+	/*
+	 * The floor is not decoration, and it matters more now than it did. A sample
+	 * that happens to hit only excluded groups reports a survival of zero, and a
+	 * scan matching anything at all must still read the group its match is in.
+	 * #171 was a full scan priced at 1.00 beating an index scan priced at 174.29,
+	 * turning a point lookup into 1251.88 ms.
+	 */
 	floorFrac = (groups >= 1.0) ? (1.0 / groups) : 1.0;
 	if (survival < floorFrac)
 		survival = floorFrac;

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -393,22 +393,27 @@ PgColumnarBeginReadWithStorage(Relation rel, Snapshot snapshot,
 
 
 /*
- * pgcolumnar_build_predicates
- *		Translate the scan's ScanKeys into skip predicates for chunk-group
- *		filtering (spec 9). Only simple, same-type btree comparison keys on an
- *		orderable column are used; anything else is ignored, so skipping stays
- *		conservative. Runs in readContext.
+ * pgcolumnar_make_predicates
+ *		Translate ScanKeys into skip predicates for chunk-group filtering
+ *		(spec 9), into caller-provided storage. Only simple btree comparison keys
+ *		on an orderable column are used; anything else is ignored, so skipping
+ *		stays conservative. Returns how many were built.
+ *
+ *		Separate from the read state so the PLANNER can build the same predicates
+ *		to estimate how much a scan would prune (#461) without constructing a
+ *		scan. The planner and the executor must decide "can this group match" by
+ *		the same rule -- pricing a discount by one rule and taking it by another
+ *		is how a plan gets chosen for a saving it never realises.
  */
-static void
-pgcolumnar_build_predicates(PgColumnarReadState *readState, int nkeys, ScanKey keys)
+static int
+pgcolumnar_make_predicates(SkipPredicate *out, int nkeys, ScanKey keys,
+						   TupleDesc tupdesc, int natts, MemoryContext cx)
 {
 	int			i;
 	int			n = 0;
 
 	if (nkeys <= 0 || keys == NULL)
-		return;
-
-	readState->predicates = palloc0(sizeof(SkipPredicate) * nkeys);
+		return 0;
 
 	for (i = 0; i < nkeys; i++)
 	{
@@ -423,14 +428,14 @@ pgcolumnar_build_predicates(PgColumnarReadState *readState, int nkeys, ScanKey k
 							 SK_ROW_END | SK_SEARCHNULL | SK_SEARCHNOTNULL |
 							 SK_ORDER_BY))
 			continue;
-		if (key->sk_attno < 1 || key->sk_attno > readState->natts)
+		if (key->sk_attno < 1 || key->sk_attno > natts)
 			continue;
 		if (key->sk_strategy < BTLessStrategyNumber ||
 			key->sk_strategy > BTGreaterStrategyNumber)
 			continue;
 
 		attidx = key->sk_attno - 1;
-		att = TupleDescAttr(readState->tupdesc, attidx);
+		att = TupleDescAttr(tupdesc, attidx);
 
 		crossType = (OidIsValid(key->sk_subtype) &&
 					 key->sk_subtype != att->atttypid);
@@ -475,17 +480,17 @@ pgcolumnar_build_predicates(PgColumnarReadState *readState, int nkeys, ScanKey k
 										key->sk_subtype, BTORDER_PROC);
 			if (!OidIsValid(cmpProc))
 				continue;
-			fmgr_info_cxt(cmpProc, &readState->predicates[n].cmpFn,
-						  readState->readContext);
+			fmgr_info_cxt(cmpProc, &out[n].cmpFn,
+						  cx);
 		}
 		else
-			fmgr_info_copy(&readState->predicates[n].cmpFn, &tce->cmp_proc_finfo,
-						   readState->readContext);
+			fmgr_info_copy(&out[n].cmpFn, &tce->cmp_proc_finfo,
+						   cx);
 
-		readState->predicates[n].attidx = attidx;
-		readState->predicates[n].strategy = key->sk_strategy;
-		readState->predicates[n].compareValue = key->sk_argument;
-		readState->predicates[n].collation = att->attcollation;
+		out[n].attidx = attidx;
+		out[n].strategy = key->sk_strategy;
+		out[n].compareValue = key->sk_argument;
+		out[n].collation = att->attcollation;
 
 		/*
 		 * For an equality predicate on a hashable column with a safe collation,
@@ -501,21 +506,39 @@ pgcolumnar_build_predicates(PgColumnarReadState *readState, int nkeys, ScanKey k
 		 * ever conservative. Cross-type equality therefore keeps min/max pruning
 		 * and forgoes the bloom probe.
 		 */
-		readState->predicates[n].hasHash = false;
+		out[n].hasHash = false;
 		if (!crossType &&
 			key->sk_strategy == BTEqualStrategyNumber &&
 			OidIsValid(tce->hash_proc_finfo.fn_oid) &&
 			PgColumnarCollationIsDeterministic(att->attcollation))
 		{
-			readState->predicates[n].hasHash = true;
-			fmgr_info_copy(&readState->predicates[n].hashFn,
-						   &tce->hash_proc_finfo, readState->readContext);
-			readState->predicates[n].hashCollation = att->attcollation;
+			out[n].hasHash = true;
+			fmgr_info_copy(&out[n].hashFn,
+						   &tce->hash_proc_finfo, cx);
+			out[n].hashCollation = att->attcollation;
 		}
 		n++;
 	}
 
-	readState->numPredicates = n;
+	return n;
+}
+
+/*
+ * pgcolumnar_build_predicates
+ *		Fill a read state's skip predicates from its scan keys. Runs in
+ *		readContext.
+ */
+static void
+pgcolumnar_build_predicates(PgColumnarReadState *readState, int nkeys, ScanKey keys)
+{
+	if (nkeys <= 0 || keys == NULL)
+		return;
+
+	readState->predicates = palloc0(sizeof(SkipPredicate) * nkeys);
+	readState->numPredicates =
+		pgcolumnar_make_predicates(readState->predicates, nkeys, keys,
+								   readState->tupdesc, readState->natts,
+								   readState->readContext);
 }
 
 /*
@@ -891,6 +914,160 @@ pgcolumnar_native_group_can_match(PgColumnarReadState *rs, uint64 groupNumber)
 	}
 
 	return true;
+}
+
+/*
+ * PgColumnarEstimatePruneSurvival
+ *		The fraction of chunk groups a restricted scan would actually read, in
+ *		(0, 1], estimated from a bounded SAMPLE of the groups' zone maps. One
+ *		means nothing prunes; a missing or unusable predicate returns one.
+ *
+ *		Why this exists (#461). The cost model priced pruning from
+ *		pg_stats.correlation, and pruning does not follow correlation.
+ *		Correlation measures agreement between value order and physical order
+ *		across the WHOLE relation; a zone map only needs each GROUP's min and max
+ *		to be narrow, which is local. A table can be globally unsorted and locally
+ *		tight at once, and batch-loaded time-series data -- the shape this engine
+ *		is built for -- is exactly that. Measured on TSBS in #391: the `time`
+ *		column had correlation 0.0133 and removed 82 percent of chunk groups, so a
+ *		model reading rho^2 credited it with nothing. #381 made that mistake in
+ *		documentation and #391 corrected it; the planner then reintroduced it.
+ *
+ *		So this asks the question the reader will ask, using the reader's own
+ *		predicates and the reader's own min/max comparison, rather than inferring
+ *		prunability from a statistic that cannot see it. The error direction of a
+ *		proxy is unknowable; the error of a sample is just sampling error.
+ *
+ *		SAMPLED rather than exact, and the bound is the point. Evaluating every
+ *		group is O(groups) catalog reads on every plan, including plans the
+ *		planner discards -- 10,000 groups on a 100M-row table at the default group
+ *		size. A fixed sample is constant work whatever the table's size, and
+ *		costing does not need three digits: the decision this feeds is which of
+ *		two plans is cheaper, and the floor below already guards the case where
+ *		being wrong is expensive.
+ *
+ *		Group numbers are sampled evenly across [0, ngroups) rather than read from
+ *		the row-group list, because reading that list is the O(groups) cost being
+ *		avoided. A sampled number with no zone map rows (vacuumed away, or a stale
+ *		ngroups estimate) is not counted rather than counted as surviving, so a
+ *		sparse group space narrows the sample instead of biasing it toward 1.0.
+ *
+ *		The bloom filter is deliberately NOT consulted. Filters are among the
+ *		larger things in the catalog and reading them per sampled group would cost
+ *		more than the estimate is worth; min/max is the dominant effect and
+ *		ignoring bloom can only UNDER-credit, which prices the columnar scan high
+ *		and is the safe direction.
+ */
+double
+PgColumnarEstimatePruneSurvival(uint64 storageId, TupleDesc tupdesc, List *qual,
+								Index scanrelid, uint64 ngroups, int sampleTarget)
+{
+	ScanKey		keys;
+	int			nkeys = 0;
+	SkipPredicate *preds;
+	int			npreds;
+	Snapshot	snap;
+	MemoryContext cx;
+	MemoryContext old;
+	int			nsample;
+	int			i;
+	int			examined = 0;
+	int			survived = 0;
+	double		survival;
+
+	if (ngroups == 0 || tupdesc == NULL || qual == NIL)
+		return 1.0;
+	if (!pgcolumnar_enable_qual_pushdown)
+		return 1.0;
+
+	snap = GetActiveSnapshot();
+	if (snap == NULL)
+		return 1.0;
+
+	cx = AllocSetContextCreate(CurrentMemoryContext,
+							   "columnar prune estimate",
+							   ALLOCSET_SMALL_SIZES);
+	old = MemoryContextSwitchTo(cx);
+
+	keys = PgColumnarBuildScanKeys(qual, scanrelid, tupdesc, &nkeys);
+	if (nkeys <= 0)
+	{
+		MemoryContextSwitchTo(old);
+		MemoryContextDelete(cx);
+		return 1.0;
+	}
+
+	preds = palloc0(sizeof(SkipPredicate) * nkeys);
+	npreds = pgcolumnar_make_predicates(preds, nkeys, keys, tupdesc,
+										tupdesc->natts, cx);
+	if (npreds == 0)
+	{
+		MemoryContextSwitchTo(old);
+		MemoryContextDelete(cx);
+		return 1.0;
+	}
+
+	nsample = (ngroups < (uint64) sampleTarget) ? (int) ngroups : sampleTarget;
+	if (nsample <= 0)
+	{
+		MemoryContextSwitchTo(old);
+		MemoryContextDelete(cx);
+		return 1.0;
+	}
+
+	for (i = 0; i < nsample; i++)
+	{
+		uint64		g = (uint64) (((double) i * (double) ngroups) / (double) nsample);
+		List	   *zones;
+		NativeZoneMapMetadata **byCol;
+		ListCell   *lc;
+		bool		canMatch = true;
+		int			p;
+
+		CHECK_FOR_INTERRUPTS();
+
+		zones = PgColumnarReadZoneMapList(storageId, g, snap);
+		if (zones == NIL)
+			continue;			/* no such group: narrow the sample, do not bias it */
+
+		examined++;
+
+		byCol = palloc0(sizeof(NativeZoneMapMetadata *) * tupdesc->natts);
+		foreach(lc, zones)
+		{
+			NativeZoneMapMetadata *z = (NativeZoneMapMetadata *) lfirst(lc);
+
+			if (z->columnIndex >= 0 && z->columnIndex < tupdesc->natts)
+				byCol[z->columnIndex] = z;
+		}
+
+		for (p = 0; p < npreds; p++)
+		{
+			Form_pg_attribute att = TupleDescAttr(tupdesc, preds[p].attidx);
+
+			if (native_zone_excludes(&preds[p], att, byCol[preds[p].attidx], cx))
+			{
+				canMatch = false;
+				break;
+			}
+		}
+
+		if (canMatch)
+			survived++;
+	}
+
+	MemoryContextSwitchTo(old);
+
+	/*
+	 * No group could be examined -- every sampled number was absent. That is a
+	 * failure to measure, not a measurement of "nothing prunes", so say the
+	 * conservative thing rather than inventing a discount.
+	 */
+	survival = (examined > 0) ? ((double) survived / (double) examined) : 1.0;
+
+	MemoryContextDelete(cx);
+
+	return survival;
 }
 
 /*

--- a/test/zonemap_cost.sh
+++ b/test/zonemap_cost.sh
@@ -31,14 +31,44 @@ CUT=$((ROWS * 8 / 10))
 # Two tables, one query shape. `seq` ascends with physical order; `scat` is the
 # same values in an order uncorrelated with it, so its zone maps overlap and
 # prune nothing.
+# `saw` is the third shape, and it is the one correlation cannot see (#461).
+#
+# Correlation measures agreement between value order and physical order across
+# the WHOLE relation. Pruning is local: a group is skipped when its own min and
+# max rule the predicate out. A table can be globally unsorted and locally tight
+# at once, and that is not a corner case -- it is what batch-loaded time-series
+# data looks like, which is the shape this engine exists for.
+#
+# So each group of 10,000 rows covers one narrow band of the value range, and the
+# bands are handed out by (i * 9) mod 20, which is a permutation because 9 and 20
+# are coprime. Group spans come out 0-9999, 90000-99999, 180000-189999 and so on:
+# 5 percent of the range each, in an order that does not follow physical order.
+#
+# The multiplier is chosen, not decorative. Correlation of (i * m) mod 20 with i:
+#
+#     m = 7  ->  +0.3665      m = 9  ->  +0.0376      m = 19 ->  -0.7143
+#
+# m = 7 was the first version and it is the trap this issue is about: 0.3665
+# earns a partial rho^2 discount, so the check below would have PASSED without
+# any fix, for the wrong reason, on the exact defect under test. m = 9 lands at
+# 0.0376, next to the 0.0133 and 0.0463 measured on the TSBS `time` column in
+# #391 -- the case on the record.
+#
+# The within-group order is scrambled too ((g * 7919) mod 10000). Letting values
+# ascend inside a group adds correlation on top of the band ordering, and local
+# tightness only needs min and max to be narrow, never sorted.
+
 psql_run "DROP TABLE IF EXISTS zc;
-	CREATE TABLE zc (seq bigint, scat bigint, tag int, pad text) USING pgcolumnar;
+	CREATE TABLE zc (seq bigint, scat bigint, saw bigint, tag int, pad text) USING pgcolumnar;
 	SELECT pgcolumnar.set_options('zc', stripe_row_limit => 10000);
 	INSERT INTO zc
-	SELECT g, ((g * 7919) % $ROWS), g % 5, md5(g::text)
+	SELECT g, ((g * 7919) % $ROWS),
+	       ((((g - 1) / 10000) * 9) % 20) * 10000 + ((g * 7919) % 10000),
+	       g % 5, md5(g::text)
 	  FROM generate_series(1, $ROWS) g;
 	CREATE INDEX zc_seq ON zc (seq);
 	CREATE INDEX zc_scat ON zc (scat);
+	CREATE INDEX zc_saw ON zc (saw);
 	ANALYZE zc;" >/dev/null 2>&1
 
 check_num "premise: every row loaded" "$(q 'SELECT count(*) FROM zc')" "$ROWS"
@@ -132,6 +162,56 @@ check_num "premise: the scattered columnar cost is a measurement" \
 	"$([ -n "$SCAT_COL" ] && awk "BEGIN{exit !($SCAT_COL > 0)}" && echo 1 || echo 0)" "1"
 check_num "an uncorrelated restriction gets no pruning discount (#434)" \
 	"$(awk "BEGIN{print ($SCAT_COL > $SEQ_COL) ? 1 : 0}")" "1"
+
+# ---- #461: locally tight, globally uncorrelated -----------------------------
+#
+# The gap in the correlation model. Everything physical is measured before
+# anything about price is asserted, because "this column prunes" is the premise
+# the whole arm rests on, and re-deriving it from the model under test would make
+# the check tautological.
+
+CORR_SAW=$(q "SELECT round(abs(correlation)::numeric, 4) FROM pg_stats
+              WHERE tablename = 'zc' AND attname = 'saw'")
+SAW_REMOVED=$(removed_for saw)
+echo "-- sawtooth: |correlation| = ${CORR_SAW:-?}, groups removed = ${SAW_REMOVED:-?}"
+
+check_num "premise: the sawtooth column is uncorrelated, like TSBS time (#391)" \
+	"$([ -n "$CORR_SAW" ] && awk "BEGIN{exit !($CORR_SAW < 0.2)}" && echo 1 || echo 0)" "1"
+
+# The two premises together are the issue in one line: no correlation, and it
+# prunes anyway. Either alone proves nothing.
+check_num "premise: and it prunes as hard as the correlated column, measured" \
+	"$([ -n "$SAW_REMOVED" ] && [ -n "$SEQ_REMOVED" ] &&
+	   awk "BEGIN{exit !($SAW_REMOVED >= $SEQ_REMOVED)}" && echo 1 || echo 0)" "1"
+
+SAW_NODE=$(node_for saw)
+SAW_COL=$(cost_for saw "SET enable_indexscan=off; SET enable_bitmapscan=off;")
+SAW_IDX=$(cost_for saw "SET pgcolumnar.enable_custom_scan=off; SET enable_seqscan=off; SET enable_bitmapscan=off;")
+echo "-- sawtooth: chosen=$SAW_NODE  columnar=$SAW_COL  index=$SAW_IDX"
+
+check_num "premise: the sawtooth columnar cost is a measurement" \
+	"$([ -n "$SAW_COL" ] && awk "BEGIN{exit !($SAW_COL > 0)}" && echo 1 || echo 0)" "1"
+
+# The assertion. A column that demonstrably removes as many groups as the
+# correlated one must be priced like it, not like the one that removes none,
+# because correlation is not what the reader consults when it skips a group.
+#
+# A MARGIN, not merely "less than". Written as a bare `<` this check passed
+# before the fix existed, on 3215.33 against 3222.29 -- a 0.2 percent difference
+# that is rounding in the seq-page term, reported as a discount. The arm removes
+# 16 of 20 groups, so anything worth calling a discount is far larger than the
+# gap between two undiscounted prices.
+check_num "a demonstrably pruning restriction is discounted whatever its correlation (#461)" \
+	"$(awk "BEGIN{print ($SAW_COL < $SCAT_COL * 0.8) ? 1 : 0}")" "1"
+
+# Priced like what it physically resembles. Bounded rather than exact: the model
+# estimates from a sample of groups, so demanding equality with the correlated
+# arm would assert the sampler's precision rather than the behaviour.
+check_num "and priced close to the correlated arm it matches physically (#461)" \
+	"$(awk "BEGIN{print ($SAW_COL < $SEQ_COL * 1.5) ? 1 : 0}")" "1"
+
+check_text "and the planner picks the columnar scan for it" \
+	"$SAW_NODE" "Custom Scan (PgColumnarScan)"
 
 # ---- correctness, which the cost model may not change ----------------------
 check_text "the correlated query returns the same rows either way" \


### PR DESCRIPTION
Closes #461. Depends on #480 (merged as #481) and could not land before it.

## The model measures now, instead of inferring

`pgcolumnar_zonemap_survival` read `pg_stats.correlation` and interpolated on
`rho^2`. Correlation is a **global** agreement between value order and physical
order; pruning is **local**, needing only each group's own min and max to be
narrow. The two come apart exactly where this engine is aimed: batch-loaded
time-series is globally unsorted and locally tight. #391 measured a TSBS `time`
column with correlation **0.0133** removing **82 percent** of chunk groups, and
under the old model it earned nothing.

It now asks the reader's question with the reader's own code: the same skip
predicates, evaluated against a bounded sample of the groups' zone maps.
`pgcolumnar_make_predicates` is factored out of the read state so the planner and
the executor decide "can this group match" by **one** rule. Pricing a discount by
one rule and taking it by another is how a plan gets chosen for a saving it never
realises.

## Result

| column | correlation | groups removed | priced |
| --- | ---: | ---: | ---: |
| correlated | 1.00 | 16 of 20 | 609.66 |
| **sawtooth** | **0.0415** | **16 of 20** | **748.96** |
| scattered | 0.01 | 0 | 2803.24 |

The column correlation cannot see is priced for what it physically does. The
control still earns nothing.

## Three design decisions

**Sampled at 32 groups.** Evaluating every group is O(groups) catalog reads on
every plan, including plans the planner discards -- 10,000 groups on a 100M-row
table. Costing compares two plans; it does not need three digits.

**A sampled group with no zone map rows is not counted**, rather than counted as
surviving, so a sparse group space narrows the sample instead of biasing it
toward "nothing prunes".

**The bloom filter is deliberately not consulted.** Filters are among the larger
things in the catalog and reading them per sampled group would cost more than the
estimate is worth. Omitting them can only *under*-credit, which prices the
columnar scan high -- the safe direction.

## The fixture took four attempts, and every failure was this issue's own trap

A permuted sawtooth: each group covers a narrow band, bands shuffled. The
multiplier is chosen, not decorative -- correlation of `(i * m) mod 20` with `i`:

| m | 7 | **9** | 19 |
| --- | ---: | ---: | ---: |
| corr | +0.3665 | **+0.0376** | -0.7143 |

**The first version used `m = 7`.** At 0.3665 it earns a partial `rho^2`
discount, so the check **passed with no fix applied** -- a vacuous green on the
exact defect under test. `m = 9` lands next to the 0.0133 and 0.0463 measured on
TSBS. Within-group order is scrambled too, since local tightness needs narrow
min/max and never sorting.

**The assertion needed a margin for the same reason.** Written as a bare `<` it
passed before the fix existed, on 3215.33 against 3222.29 -- a 0.2 percent
difference between two undiscounted prices, reported as a discount.

And the first fixture I built reported a prune rate of zero, which I nearly took
as my own error. It was #477.

## Why it could not go first

Removing the correlation model removes a **fictional** discount that was standing
in for the missing column-width discount from #480. On
`planner_choice_quality`'s fixture the executor skips nothing (`Chunk Groups
Total: 2, Removed: 0`) while the old model credited ~0.5, and taking the fiction
away alone regressed plan choice **44x**. With #481 merged, both are right
independently: all three of `zonemap_cost`, `planner_choice_quality` and
`column_projection` pass together, which is the point -- not a new pair that
cancels.

## Verification

RED proven before implementing, on both #461 checks. Full 132-suite matrix green
on **PG18 and PG19** (130 ran / 2 skipped on 18, 132 / 0 on 19).

Rebased onto #481. The conflict was real -- `pgcolumnar_projected_width_fraction`
sits inside the region this deletes -- and the resolution left a duplicated `/*`
that the compiler caught as `'/*' within comment`. Warnings are failures here, so
it would have been a red gate rather than a silent defect, but it is why I did
not verify the resolution by reading the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013sY1RQR5MjZNUixA2um31r
