### PR TITLE
A vector is chunk_group_row_limit rows, not a fixed 1024 (#491 follow-up)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -45,8 +45,11 @@ Section 2 of the spec is authoritative. The short form:
   across all columns. A relation is a sequence of row groups. It is the write
   unit and the parallel-scan unit.
 - **Column chunk**: one column's data within one row group.
-- **Vector**: a fixed run of 1024 values inside a column chunk. The unit of
-  decode, of data skipping, and of vectorized execution.
+- **Vector**: a run of up to `pgcolumnar.chunk_group_row_limit` rows (default
+  10000) inside a column chunk. The unit of encoding, of data skipping within a
+  row group, and of vectorized execution. The native format fixes this at 1024
+  values; the classic path does not, and `Columnar Vectors Skipped` moves with
+  the setting.
 - **Page**: the on-disk container of one column chunk's encoded vectors. A
   contiguous byte range in the relation's main fork, which is why the buffer
   manager, WAL, and page checksums apply.
@@ -75,6 +78,31 @@ because it is user-facing and it is in dumps.
 **`chunk_group_row_limit` is a different setting and does not control the group
 counters.** It is "maximum number of rows per chunk group", default 10000, from
 the 1.0-dev lineage. Setting it does not change how many groups a scan reports.
+What it does size is the VECTOR, so it moves `Columnar Vectors Skipped` instead.
+Rebuilding the same 200,000 rows and running the same predicate:
+
+| `chunk_group_row_limit` | `Columnar Vectors Skipped` |
+| ---: | ---: |
+| 10000 | 4 |
+| 5000 | 8 |
+| 1024 | 39 |
+
+Each matches the arithmetic for the row group that is read: 50,000 rows at
+10,000 is 5 vectors with 4 below the predicate, at 5,000 it is 10 with 8 below,
+at 1,024 it is about 49 with 39 below. The 1,024 run also grows a
+`Rows Removed by Filter: 64` line, because 190,000 is not a multiple of 1024, so
+the straddling vector is decoded and filtered rather than skipped.
+
+**`projection` names two unrelated things.** A **projection** is the secondary
+physical ordering defined above. `pgcolumnar.enable_column_projection` and
+EXPLAIN's `Columnar Projected Columns` use the same word for reading only the
+columns a query references, which has nothing to do with it. Say **column
+projection** for the second and never the bare word.
+
+**Pruning and filtering are different outcomes, and a plan prints both.**
+`Chunk Groups Removed by Filter` and `Vectors Skipped` are work never done.
+`Rows Removed by Filter` is work done and thrown away. They appear on the same
+node, and which one moved tells you whether a predicate actually helped.
 
 **EXPLAIN's "Chunk Groups" counters count ROW GROUPS.** This is the one most
 likely to produce a wrong conclusion, so it is worth stating plainly.


### PR DESCRIPTION
Follow-up to #491, which merged with my changes-requested review outstanding. No complaint about the merge — the file is good and most of it is better than what I had been writing myself — but this one line is measurably wrong, and it is wrong in the document that now owns the vocabulary.

## The line

```
- **Vector**: a fixed run of 1024 values inside a column chunk.
```

A vector holds up to `pgcolumnar.chunk_group_row_limit` rows: default **10000**, `PGC_USERSET`, range 100 to INT_MAX, per-table overridable. Rebuilding the same 200,000 rows at each setting and running the identical predicate:

| `chunk_group_row_limit` | `Columnar Vectors Skipped` |
| ---: | ---: |
| 10000 | 4 |
| 5000 | **8** |
| 1024 | **39** |

Each matches the arithmetic for the row group that gets read: 50,000 rows at 10,000 is 5 vectors with 4 below the predicate; at 5,000 it is 10 with 8 below; at 1,024 it is about 49 with 39 below. The 1,024 run also grows a `Rows Removed by Filter: 64` line, because 190,000 is not a multiple of 1024 so the straddling vector is decoded and filtered rather than skipped — independent confirmation that the boundary moved rather than the counter changing meaning.

Where 1024 is real: `COLUMNAR_NATIVE_VECTOR_LENGTH` in `columnar.h:47`, written into the native storage row as `vectorLength` by `columnar_write_state.c:529`. That is the native PGCN v1 geometry, which is what spec section 4 describes — along with a 122880-row group limit that is likewise not what ships, since `stripe_row_limit` defaults to 150000. There is no `pgcolumnar.vector_length` GUC in the tree.

## It also removes a contradiction already inside the file

The misleading-words section says `chunk_group_row_limit` "does not control the group counters", which is true. But if a vector were fixed at 1024, that setting would size nothing at all. It sizes the **vector**, so it moves `Columnar Vectors Skipped` instead of the group counters. The table above is now in that section, so the setting has a stated effect rather than only a stated non-effect.

## Why this one matters more than a definition usually would

Someone building a fixture to exercise vector-level skipping would size it in 1024-row units, get a single vector per row group at the default, see `Vectors Skipped: 0`, and conclude the mechanism does not work. That is the same failure the file exists to prevent, which is why I would rather fix it than leave it.

**The root of it is worth a sentence in the file at some point:** the ownership table gives the spec "what the format and the interface ARE", and the spec describes the native format. Where the spec and the shipped defaults disagree, the shipped defaults are what a reader will observe. Not in this PR — it is your call how to phrase it.

## Two other entries in the same section

Both from the same review, both the same shape as the collisions already documented:

- **`projection` names two unrelated things.** A projection is the secondary physical ordering the glossary defines. `pgcolumnar.enable_column_projection` and EXPLAIN's `Columnar Projected Columns` use the word for reading only the referenced columns. Two user-facing surfaces, one word, nothing in common.
- **Pruning and filtering are different outcomes and a plan prints both.** `Chunk Groups Removed by Filter` and `Vectors Skipped` are work never done; `Rows Removed by Filter` is work done and discarded. The 1,024 row above produced both on one node, which is exactly when the distinction is needed.

Happy to drop either of those if you want this PR to be the vector fix alone — say so and I will strip it back.

No em or en dashes, matching the file's own rule. `docs_style.sh` does not glob the repo root, so this is unchecked by the harness either way.
