### PR TITLE
fix: a domain column must prune like its base type (#483)

### DIFF
--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -421,6 +421,8 @@ pgcolumnar_make_predicates(SkipPredicate *out, int nkeys, ScanKey keys,
 		int			attidx;
 		Form_pg_attribute att;
 		TypeCacheEntry *tce;
+		Oid			colType;
+		Oid			argType;
 		bool		crossType;
 
 		/* only plain "column op const" comparison keys are usable */
@@ -437,8 +439,42 @@ pgcolumnar_make_predicates(SkipPredicate *out, int nkeys, ScanKey keys,
 		attidx = key->sk_attno - 1;
 		att = TupleDescAttr(tupdesc, attidx);
 
-		crossType = (OidIsValid(key->sk_subtype) &&
-					 key->sk_subtype != att->atttypid);
+		/*
+		 * Compare BASE types when deciding whether this key is cross-type
+		 * (#483).
+		 *
+		 * A domain is not a different type for comparison purposes: it shares
+		 * its base type's ordering, its comparison proc, and its physical
+		 * representation. But a column declared over a domain has the domain's
+		 * OID in atttypid while the constant beside it has the base type's, so
+		 * comparing the OIDs directly called every such key cross-type, and the
+		 * opfamily has no ordering proc for (domain, base). #478's fallback then
+		 * dropped the key, which is right for a genuinely uncomparable pair and
+		 * wrong here.
+		 *
+		 * The effect was that a domain column pruned NOTHING. Measured on
+		 * identical values in one table over 20 row groups: int and bigint each
+		 * removed 19 groups, a domain over either removed 0, and all three
+		 * reported the filter as pushed down. The answers stayed correct because
+		 * the executor re-applies the qual; the table was simply read whole.
+		 *
+		 * Both sides are resolved, not just the column, so that a domain
+		 * compared against a value of a DIFFERENT domain over the same base type
+		 * is also recognised as same-type rather than falling into the
+		 * opfamily lookup that has no entry for either OID.
+		 *
+		 * This changes no comparison semantics. The cmp and hash procs come from
+		 * lookup_type_cache(att->atttypid) below, which already resolves a domain
+		 * through GetDefaultOpClass to its base type's procs, and the WRITER
+		 * builds zone maps and bloom filters from that same expression
+		 * (columnar_write_state.c). Reader and writer therefore agree on the
+		 * ordering and the hash by construction, before and after this change.
+		 */
+		colType = getBaseType(att->atttypid);
+		argType = OidIsValid(key->sk_subtype)
+			? getBaseType(key->sk_subtype) : InvalidOid;
+
+		crossType = (OidIsValid(argType) && argType != colType);
 
 		tce = lookup_type_cache(att->atttypid,
 								TYPECACHE_CMP_PROC_FINFO |
@@ -469,15 +505,15 @@ pgcolumnar_make_predicates(SkipPredicate *out, int nkeys, ScanKey keys,
 		 */
 		if (crossType)
 		{
-			Oid			opclass = GetDefaultOpClass(att->atttypid, BTREE_AM_OID);
+			Oid			opclass = GetDefaultOpClass(colType, BTREE_AM_OID);
 			Oid			opfamily;
 			Oid			cmpProc;
 
 			if (!OidIsValid(opclass))
 				continue;
 			opfamily = get_opclass_family(opclass);
-			cmpProc = get_opfamily_proc(opfamily, att->atttypid,
-										key->sk_subtype, BTORDER_PROC);
+			cmpProc = get_opfamily_proc(opfamily, colType, argType,
+										BTORDER_PROC);
 			if (!OidIsValid(cmpProc))
 				continue;
 			fmgr_info_cxt(cmpProc, &out[n].cmpFn,

--- a/test/native_skip.sh
+++ b/test/native_skip.sh
@@ -20,11 +20,17 @@ pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
 # 20480 rows, 2048-row groups -> 10 row groups with contiguous, non-overlapping
 # id ranges (group k holds ids k*2048+1 .. (k+1)*2048), so range and equality
 # predicates on id are highly skippable.
-GEN="SELECT g, (g * 10)::bigint, 'lbl-' || (g % 100)
+GEN="SELECT g, (g * 10)::bigint, 'lbl-' || (g % 100),
+         g::nsk_acct4, (g * 10)::nsk_acct8
   FROM generate_series(1, 20480) g"
 
-psql_run "CREATE TABLE h (id int, k bigint, label text);"
-psql_run "CREATE TABLE n (id int, k bigint, label text) USING pgcolumnar;"
+# d4 and d8 are domains over int and bigint holding the same values as id and k.
+# A domain is ordinary modelling, and it must prune exactly as its base type does
+# (#483).
+psql_run "CREATE DOMAIN nsk_acct4 AS int;"
+psql_run "CREATE DOMAIN nsk_acct8 AS bigint;"
+psql_run "CREATE TABLE h (id int, k bigint, label text, d4 nsk_acct4, d8 nsk_acct8);"
+psql_run "CREATE TABLE n (id int, k bigint, label text, d4 nsk_acct4, d8 nsk_acct8) USING pgcolumnar;"
 psql_run "SELECT pgcolumnar.set_options('n', stripe_row_limit => 2048, chunk_group_row_limit => 1024);"
 psql_run "INSERT INTO h $GEN;"
 psql_run "INSERT INTO n $GEN;"
@@ -87,6 +93,63 @@ check "bigint vs integer literal returns the same rows as heap (#477)" \
 
 check "and it skips groups, which the cast version already did (#477)" \
 	"$(gt0 "$(skipped 'SELECT id FROM n WHERE k BETWEEN 100000 AND 101000')")" "yes"
+
+# ---- a domain column must prune like its base type (#483) --------------------
+#
+# Found while building #479's fixture, which needed a predicate the reader could
+# not use. This was that predicate, and it should not have been one.
+#
+# pgcolumnar_clause_to_scankey and pgcolumnar_make_predicates resolved a domain
+# differently, so the key passed the first and was dropped by the second. The key
+# is built because lookup_type_cache reaches GetDefaultOpClass, which resolves a
+# domain to its base type, so the domain finds integer_ops and a valid strategy.
+# It was then dropped because the column type is the domain while sk_subtype is
+# the base type, making the key cross-type, and integer_ops has no ordering proc
+# for (domain, int4). #478's fallback is right for a genuinely uncomparable pair
+# and a domain is not one.
+#
+# Measured before the fix, same values in one table, 20 groups: int and bigint
+# pruned 19, a domain over either pruned 0, and all three reported
+# "Columnar Pushed-Down Filters: 1". Ordinary SQL silently reading the whole
+# table.
+#
+# Parity first, and not as decoration. Comparing a domain's stored values with
+# the wrong comparison proc risks a WRONG answer, not a slow one, so rows are
+# asserted before skipping in every arm below.
+check "domain over int returns the same rows as heap (#483)" \
+	"$(pgc_set_hash 'SELECT id FROM n WHERE d4 BETWEEN 5000 AND 5100')" \
+	"$(pgc_set_hash 'SELECT id FROM h WHERE d4 BETWEEN 5000 AND 5100')"
+check "and it skips groups, as the same predicate on int does (#483)" \
+	"$(gt0 "$(skipped 'SELECT id FROM n WHERE d4 BETWEEN 5000 AND 5100')")" "yes"
+
+check "domain over bigint returns the same rows as heap (#483)" \
+	"$(pgc_set_hash 'SELECT id FROM n WHERE d8 BETWEEN 100000 AND 101000')" \
+	"$(pgc_set_hash 'SELECT id FROM h WHERE d8 BETWEEN 100000 AND 101000')"
+check "and it skips groups too (#483)" \
+	"$(gt0 "$(skipped 'SELECT id FROM n WHERE d8 BETWEEN 100000 AND 101000')")" "yes"
+
+# One-sided and equality take different branches of native_zone_excludes, and
+# equality additionally gates the bloom probe, which is where a wrong answer
+# would come from if the domain resolved to a different hash than the writer used.
+check "one-sided domain predicate skips groups (#483)" \
+	"$(gt0 "$(skipped 'SELECT id FROM n WHERE d4 > 15000')")" "yes"
+check "one-sided domain parity" \
+	"$(q 'SELECT count(*) FROM n WHERE d4 > 15000;')" \
+	"$(q 'SELECT count(*) FROM h WHERE d4 > 15000;')"
+
+check "domain equality skips groups (#483)" \
+	"$(gt0 "$(skipped 'SELECT id FROM n WHERE d4 = 12345')")" "yes"
+check "domain equality parity" \
+	"$(q 'SELECT count(*) FROM n WHERE d4 = 12345;')" \
+	"$(q 'SELECT count(*) FROM h WHERE d4 = 12345;')"
+
+# An absent value must still come back empty. This is the arm a wrong bloom probe
+# breaks: the filter hashes the values the writer stored, and a probe that hashed
+# under a different type would skip a group that holds the row.
+check "domain equality on an absent value returns nothing" \
+	"$(q 'SELECT count(*) FROM n WHERE d4 = 20481;')" "0"
+check "domain equality on a present boundary value finds it" \
+	"$(q 'SELECT count(*) FROM n WHERE d4 = 20480;')" "1"
 
 # One-sided and equality too, because they take different branches of
 # native_zone_excludes and equality additionally gates the bloom probe.

--- a/test/pushdown_report.sh
+++ b/test/pushdown_report.sh
@@ -128,8 +128,8 @@ check "two quals report two pushed-down filters" \
 # --- 6. a filter that is pushed down but cannot exclude anything (#479) ---------
 #
 # "Columnar Pushed-Down Filters" counts the scan keys the reader was HANDED.
-# The reader then converts each into a skip predicate and can drop it -- and a
-# dropped key excludes no chunk group at all, while the line above still reports
+# The reader then converts each into a skip predicate and can drop one, and a
+# dropped key excludes no chunk group at all while the line above still reports
 # it as pushed down. That is how #477 stayed invisible for a year: a bigint
 # column against a bare integer literal reported
 #
@@ -138,68 +138,108 @@ check "two quals report two pushed-down filters" \
 #
 # which reads as "pushdown works, this predicate is just not selective" and
 # actually meant "the predicate was never usable". test/zonemap_cost.sh sat in
-# exactly that state for its whole life, and #460's cost discount was validated
-# against it.
+# exactly that state for its whole life.
 #
-# "Columnar Usable Skip Predicates" is the second number: how many predicates
-# the reader built and can exclude with. The two together say which case you are
-# in.
+# "Columnar Usable Skip Predicates" is the second number: how many predicates the
+# reader built and can exclude with. The two together say which case you are in.
 #
-# The fixture is a DOMAIN column, which the issue's own Test section did not
-# propose and which is the shape that survives #478. A domain resolves to its
-# base type in GetDefaultOpClass, so pgcolumnar_clause_to_scankey finds a btree
-# opfamily and a strategy and builds the key; but in pgcolumnar_make_predicates
-# the column type is the domain while the constant's type is the base, so the
-# key is cross-type, and integer_ops has no BTORDER proc for (domain, int4).
-# #478's fallback drops it. Ordinary SQL, and it prunes nothing.
+# THE UNUSABLE ARM IS CONSTRUCTED, AND HAS TO BE. This suite first used a domain
+# column, which was unusable because of a defect (#483) rather than by nature.
+# That defect is fixed, so a domain now prunes exactly as its base type does and
+# is no use here. Nothing in core replaces it: asked directly, the catalog has NO
+# cross-type btree operator lacking an ordering proc for its pair, which the
+# premise below asserts rather than assumes.
 #
-# (The fixture the issue DOES propose -- a same-type predicate on a column with
-# no btree comparison -- cannot show this at all: clause_to_scankey rejects such
-# a column outright, so no scan key is built and both numbers read 0.)
+# So the condition is built on purpose, out of one operator and one opfamily
+# entry, and it reproduces precisely the shape #477 had in production: a
+# cross-type btree operator whose family has no BTORDER proc for the pair, so
+# pgcolumnar_clause_to_scankey builds a key and pgcolumnar_make_predicates drops
+# it.
 #
-# Both columns hold the same values in the same table, so the two arms differ
-# only in the declared type of the column being compared: the physical layout,
-# the row groups and their min/max are identical by construction.
+# Two details are load-bearing and were each found by the fixture failing:
+#
+#   The right-hand type must be NON-COLLATABLE. With `text` on the right, the
+#   operator's inputcollid is the default collation while a bigint column's
+#   attcollation is 0, and clause_to_scankey refuses the clause on that mismatch
+#   before any key is built. Both counters then read 0 and there is nothing to
+#   tell apart. `oid` has no collation, so the clause survives that guard.
+#
+#   The function must NOT be inlinable. Written in SQL it was inlined, and the
+#   qual the planner handed the scan was the built-in `>` against a bigint
+#   constant, which prunes perfectly well. The EXPLAIN said
+#   `Filter: (dz.b > '190000'::bigint)` and the arm quietly tested nothing.
+#   plpgsql is not inlined.
 psql_run "DROP TABLE IF EXISTS pdr_u;
-	DROP DOMAIN IF EXISTS pdr_acct;
-	CREATE DOMAIN pdr_acct AS int;
-	CREATE TABLE pdr_u (plain int, dom pdr_acct) USING pgcolumnar;
+	CREATE TABLE pdr_u (plain int, b bigint) USING pgcolumnar;
 	SELECT pgcolumnar.set_options('pdr_u', stripe_row_limit => 10000);" >/dev/null
-psql_run "INSERT INTO pdr_u
-	SELECT g, g::pdr_acct FROM generate_series(1, $ROWS) g;" >/dev/null
+psql_run "INSERT INTO pdr_u SELECT g, g FROM generate_series(1, $ROWS) g;" >/dev/null
 
-uplan() {  # uplan <column>
+cat > "$PGC_SQLDIR/pdr_unusable.sql" <<'SQL'
+CREATE FUNCTION pdr_gt_oid(bigint, oid) RETURNS boolean
+  LANGUAGE plpgsql IMMUTABLE AS $b$ BEGIN RETURN $1 > ($2::bigint); END $b$;
+CREATE OPERATOR >>> (LEFTARG = bigint, RIGHTARG = oid, FUNCTION = pdr_gt_oid);
+ALTER OPERATOR FAMILY integer_ops USING btree ADD OPERATOR 5 >>> (bigint, oid);
+SQL
+env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+	-d "$PGC_DB" -At -f "$PGC_SQLDIR/pdr_unusable.sql" >/dev/null 2>&1
+
+# The premise the whole section rests on: the family really has no ordering proc
+# for this pair, which is WHY the reader must drop the key. Without this, "0
+# usable" could be any other cause and the section would be naming the wrong one.
+check "premise: integer_ops has no ordering proc for (bigint, oid)" \
+	"$(q "SELECT count(*) FROM pg_amproc ap
+		JOIN pg_opfamily f ON f.oid = ap.amprocfamily
+		WHERE f.opfname = 'integer_ops'
+		  AND ap.amproclefttype = 'int8'::regtype
+		  AND ap.amprocrighttype = 'oid'::regtype
+		  AND ap.amprocnum = 1")" "0"
+
+# And the reason this had to be constructed at all. If core ever ships a
+# cross-type btree operator without an ordering proc, an ordinary fixture exists
+# again and this section should use it instead of the operator above.
+check "premise: and core has no such pair of its own, which is why this is built" \
+	"$(q "SELECT count(*) FROM pg_amop ao
+		JOIN pg_am am ON am.oid = ao.amopmethod AND am.amname = 'btree'
+		WHERE ao.amoplefttype <> ao.amoprighttype
+		  AND ao.amopstrategy BETWEEN 1 AND 5
+		  AND ao.amopfamily <> (SELECT oid FROM pg_opfamily WHERE opfname = 'integer_ops'
+		                        AND opfmethod = am.oid)
+		  AND NOT EXISTS (SELECT 1 FROM pg_amproc ap
+		                   WHERE ap.amprocfamily = ao.amopfamily
+		                     AND ap.amproclefttype = ao.amoplefttype
+		                     AND ap.amprocrighttype = ao.amoprighttype
+		                     AND ap.amprocnum = 1)")" "0"
+
+uplan() {  # uplan <qual>
 	q "SET pgcolumnar.enable_qual_pushdown = on;
 	   EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
-	   SELECT count(*) FROM pdr_u WHERE $1 > $((ROWS - 10000));"
+	   SELECT count(*) FROM pdr_u WHERE $1;"
 }
 
-usable="$(uplan plain)"
-unusable="$(uplan dom)"
+usable="$(uplan "plain > $((ROWS - 10000))")"
+unusable="$(uplan "b >>> $((ROWS - 10000))::oid")"
 
-# The node again, before any number is read out of either plan. Neither of these
-# queries is the one checked above and the planner is free to choose differently.
+# The node again, before any number is read out of either plan.
 check "the usable arm is a columnar custom scan" "$(is_scalar_scan "$usable")" "yes"
 check "the unusable arm is a columnar custom scan" "$(is_scalar_scan "$unusable")" "yes"
 
-# The premise that makes the whole section mean something: these two arms really
-# do prune differently. Without this, "1 usable" against "0 usable" could be two
-# labels on identical behaviour -- which is the #477 failure repeated one level
-# up, asserting a derived number with no physical fact under it.
+# The premise that makes the rest mean something: these two arms really do prune
+# differently. Without it, "1 usable" against "0 usable" could be two labels on
+# identical behaviour.
 check "the usable arm removes chunk groups" \
 	"$([ "$(field "$usable" 'Columnar Chunk Groups Removed by Filter')" -gt 0 ] \
 		&& echo yes || echo no)" "yes"
-# This one pins a KNOWN-WRONG behaviour deliberately. A domain column ought to
-# prune exactly as its base type does, and it does not (#483). This suite needs
-# some predicate the reader cannot use, and that is the only one available on
-# current main; when #483 is fixed, this check goes red and whoever fixed it must
-# supply a new unusable fixture rather than delete the section. Pinned as an
-# assertion and not an echo, because nobody reads a passing suite's output.
 check "the unusable arm removes none" \
 	"$(field "$unusable" 'Columnar Chunk Groups Removed by Filter')" "0"
 
-# Both are reported as pushed down. This is the defect: the old line alone
-# cannot tell these two plans apart.
+# A dropped predicate must cost speed and nothing else. The executor re-applies
+# the qual, so the answer is the same either way, and if it were not this suite
+# would be reporting a correctness bug as a reporting one.
+check "and the unusable arm still returns the right answer" \
+	"$(q "SELECT count(*) FROM pdr_u WHERE b >>> $((ROWS - 10000))::oid;")" "10000"
+
+# Both are reported as pushed down. This is the defect: the old line alone cannot
+# tell these two plans apart.
 check "both arms report the filter as pushed down" \
 	"$(field "$usable" 'Columnar Pushed-Down Filters')/$(field "$unusable" 'Columnar Pushed-Down Filters')" \
 	"1/1"
@@ -211,8 +251,8 @@ check "the unusable arm reports none" \
 	"$(field "$unusable" 'Columnar Usable Skip Predicates')" "0"
 
 # With pushdown off the reader builds no predicates at all, so the new line must
-# follow the setting too -- otherwise it would report a capability the run did
-# not have, which is the #191 complaint about the old line.
+# follow the setting too, or it would report a capability the run did not have,
+# which is the #191 complaint about the old line.
 check "pushdown off reports no usable skip predicates" \
 	"$(field "$off" 'Columnar Usable Skip Predicates')" "0"
 
@@ -221,26 +261,23 @@ check "pushdown off reports no usable skip predicates" \
 # "Columnar Pushed-Down Filters" is printed by three nodes, not one: the scalar
 # scan above, and both vectorized aggregate nodes, which fill it from
 # PgColumnarCountConvertibleQuals -- the same built-key count, with the same gap
-# under it. Measured on this same domain fixture before the fix, all three
-# reported "1" while removing 0 of 20 chunk groups.
-#
-# Leaving two of the three unfixed would make one line of plan text mean two
-# different things depending on which node ran, which is worse than the defect.
+# under it. Leaving two of the three unfixed would make one line of plan text
+# mean two different things depending on which node ran.
 #
 # Both nodes are opt-in, so each arm asserts its own node fired FIRST. Without
 # that, a query the node quietly declines falls back to core Agg over the scalar
-# scan -- which now reports the new line correctly, so the check would pass while
+# scan, which reports the new line correctly, so the check would pass while
 # testing the node it was written for not at all.
 aggplan() {  # aggplan <guc> <sql>
 	q "SET pgcolumnar.enable_qual_pushdown = on;
 	   SET $1 = on;
 	   EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) $2;"
 }
-has() { grep -q "$2" <<<"$1" && echo yes || echo no; }
+has() { case "$1" in *"$2"*) echo yes ;; *) echo no ;; esac; }
 
 UAGG=pgcolumnar.enable_ungrouped_vector_agg
-u_usable="$(aggplan $UAGG "SELECT count(*), sum(plain) FROM pdr_u WHERE plain > $((ROWS - 10000))")"
-u_unusable="$(aggplan $UAGG "SELECT count(*), sum(plain) FROM pdr_u WHERE dom > $((ROWS - 10000))")"
+u_usable="$(aggplan $UAGG "SELECT count(*), sum(b) FROM pdr_u WHERE plain > $((ROWS - 10000))")"
+u_unusable="$(aggplan $UAGG "SELECT count(*), sum(b) FROM pdr_u WHERE b >>> $((ROWS - 10000))::oid")"
 
 check "the ungrouped vectorized aggregate node ran (usable arm)" \
 	"$(has "$u_usable" 'Columnar Vectorized Aggregates')" "yes"
@@ -253,16 +290,28 @@ check "ungrouped: the usable arm removes chunk groups" \
 check "ungrouped: the unusable arm removes none" \
 	"$(field "$u_unusable" 'Columnar Chunk Groups Removed by Filter')" "0"
 
-check "ungrouped: both arms report the filter as pushed down" \
-	"$(field "$u_usable" 'Columnar Pushed-Down Filters')/$(field "$u_unusable" 'Columnar Pushed-Down Filters')" \
+# NOTE, and it is a finding rather than a detail: on these two nodes
+# "Columnar Pushed-Down Filters" is NOT the quantity the scalar node prints. It
+# comes from PgColumnarCountConvertibleQuals, which asks
+# pgcolumnar_clause_to_predicate (convertible to a VECTOR predicate), while the
+# scalar node counts pgcolumnar_clause_to_scankey results (scan keys). The two
+# tests do not accept the same clauses, so one label reports two different
+# quantities depending on which node ran. Filed separately; #479's own complaint
+# in a new place.
+#
+# The practical consequence here is that the constructed operator is not
+# convertible to a vector predicate either, so this arm reads 0 on BOTH counters
+# and cannot discriminate on these nodes the way it does on the scalar scan.
+# Asserted as what it is rather than dressed up as a comparison that works.
+check "ungrouped: the usable arm reports one of each, agreeing" \
+	"$(field "$u_usable" 'Columnar Pushed-Down Filters')/$(field "$u_usable" 'Columnar Usable Skip Predicates')" \
 	"1/1"
-check "ungrouped: and the usable skip predicates tell them apart" \
-	"$(field "$u_usable" 'Columnar Usable Skip Predicates')/$(field "$u_unusable" 'Columnar Usable Skip Predicates')" \
-	"1/0"
+check "ungrouped: and the unusable arm builds no skip predicate" \
+	"$(field "$u_unusable" 'Columnar Usable Skip Predicates')" "0"
 
 GAGG=pgcolumnar.enable_group_vectorization
-g_usable="$(aggplan $GAGG "SELECT dom, count(*) FROM pdr_u WHERE plain > $((ROWS - 10000)) GROUP BY 1")"
-g_unusable="$(aggplan $GAGG "SELECT plain, count(*) FROM pdr_u WHERE dom > $((ROWS - 10000)) GROUP BY 1")"
+g_usable="$(aggplan $GAGG "SELECT b, count(*) FROM pdr_u WHERE plain > $((ROWS - 10000)) GROUP BY 1")"
+g_unusable="$(aggplan $GAGG "SELECT plain, count(*) FROM pdr_u WHERE b >>> $((ROWS - 10000))::oid GROUP BY 1")"
 
 # "Columnar Vectorized Group Keys" is this node's own marker; no other node emits
 # it, so a positive grep proves the node rather than an absence a fallback would
@@ -278,11 +327,13 @@ check "grouped: the usable arm removes chunk groups" \
 check "grouped: the unusable arm removes none" \
 	"$(field "$g_unusable" 'Columnar Chunk Groups Removed by Filter')" "0"
 
-check "grouped: both arms report the filter as pushed down" \
-	"$(field "$g_usable" 'Columnar Pushed-Down Filters')/$(field "$g_unusable" 'Columnar Pushed-Down Filters')" \
+# Same caveat as the ungrouped node above: this label is a different quantity
+# here, so the arms assert agreement on the usable side and an absent skip
+# predicate on the unusable one, which is what is actually true.
+check "grouped: the usable arm reports one of each, agreeing" \
+	"$(field "$g_usable" 'Columnar Pushed-Down Filters')/$(field "$g_usable" 'Columnar Usable Skip Predicates')" \
 	"1/1"
-check "grouped: and the usable skip predicates tell them apart" \
-	"$(field "$g_usable" 'Columnar Usable Skip Predicates')/$(field "$g_unusable" 'Columnar Usable Skip Predicates')" \
-	"1/0"
+check "grouped: and the unusable arm builds no skip predicate" \
+	"$(field "$g_unusable" 'Columnar Usable Skip Predicates')" "0"
 
 pgc_summary


### PR DESCRIPTION
Closes #483. Surfaced #493 along the way.

A column declared over a domain skipped **no row groups at all**. Measured on identical values in one table over 20 row groups, PG17:

| column | predicate | groups removed |
| --- | --- | ---: |
| `int` | `> 190000` | 19 of 20 |
| `bigint` | `> 190000` | 19 of 20 |
| `DOMAIN AS int` | `> 190000` | **0 of 20** |
| `DOMAIN AS bigint` | `> 190000` | **0 of 20** |

All four reported `Columnar Pushed-Down Filters: 1`. Answers stayed correct, because the executor re-applies the qual, so the only symptom was reading the whole table, silently, on ordinary SQL.

## Cause

`clause_to_scankey` and `make_predicates` resolved a domain differently, so the key passed the first and was dropped by the second. The key is built because `lookup_type_cache` reaches `GetDefaultOpClass`, which resolves a domain to its base type. It was then dropped because `att->atttypid` is the domain while `key->sk_subtype` is the base type, which made the key look cross-type, and `integer_ops` has no ordering proc for `(domain, int4)`. #478's fallback is right for a genuinely uncomparable pair, and a domain is not one.

## Fix

Compare base types when deciding `crossType`, and use them for the opfamily lookup. **Both** sides are resolved, so a domain compared against a value of a *different* domain over the same base type is also same-type.

**This changes no comparison semantics, and that had to be checked rather than assumed.** The cmp and hash procs come from `lookup_type_cache(att->atttypid)`, which already resolves a domain to its base type's procs, and the **writer** builds zone maps and bloom filters from that same expression in `columnar_write_state.c`. Reader and writer agree by construction, before and after. The equality arms are what would catch it otherwise: a bloom probe hashing differently from the writer skips a group holding the row, so the suite asserts both that an absent value returns nothing and that a present boundary value is still found.

Parity is asserted before skipping in every arm, because the risk of resolving a comparison wrongly is a **wrong answer**, not a slow one.

The planner's prunability estimate (#461) goes through the same function, so it now prices domain columns the way execution prunes them.

**Proved by removal:** with only the two `getBaseType` calls reverted and everything else identical, the four skipping checks fail and the parity checks still pass. Fingerprinted: `6daa675` fixed, `da90ae8` armed, `6daa675` restored byte-identical.

## This costs #479 its fixture, handled here rather than left

`pushdown_report.sh` pinned "the unusable arm removes none" as a deliberate assertion so this fix would go red rather than change silently. It did — `got [19] want [0]`, which is the fix working.

**Nothing in core replaces it.** Asked directly, the catalog has *no* cross-type btree operator lacking an ordering proc for its pair. The suite now asserts that rather than assuming it, so if PostgreSQL ever ships one, an ordinary fixture exists again and the suite says so.

So the unusable arm is **constructed**: one plpgsql function, one operator, one `ALTER OPERATOR FAMILY`, reproducing exactly the shape #477 had in production. Two details are load-bearing, and each was found by the fixture failing rather than by design:

- **The right-hand type must be non-collatable.** With `text`, the operator's `inputcollid` is the default collation while a `bigint` column's `attcollation` is 0, and `clause_to_scankey` refuses the clause on that mismatch before any key is built — both counters read 0 and there is nothing to tell apart. `oid` has no collation.
- **The function must not be inlinable.** Written in SQL it was inlined, and the qual reaching the scan was the built-in `>` against a bigint constant, which prunes perfectly well. EXPLAIN read `Filter: (dz.b > '190000'::bigint)` and the arm tested nothing. plpgsql is not inlined.

## And it surfaced a separate defect: #493

On the two vectorized aggregate nodes, `Columnar Pushed-Down Filters` is **not** the quantity the scalar node prints. It comes from `PgColumnarCountConvertibleQuals` → `pgcolumnar_clause_to_predicate` (convertible to a *vector predicate*), while the scalar node counts `pgcolumnar_clause_to_scankey` results. The two tests accept different clauses, so one label reports two different things depending on which node ran. That is #479's own complaint, one node over. Filed, not fixed here; those arms now assert what is actually true on those nodes rather than a comparison that only holds on the scalar scan.

## Verification

19 suites re-run, **all clean, zero failures**: `native_skip` (29), `pushdown_report` (34), `zonemap_cost`, `native_bloom`, `native_vecskip`, `phase5`, `write_minmax_fastpath`, `column_projection`, `planner_choice_quality`, `native_agg`, `native_groupagg`, `ungrouped_vector_agg`, `parallel_vector_agg`, `native_zonemap`, `native_sort_by`, `native_cluster`, `differential` (201), `audit`, `harness_selftest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)