### PR TITLE
docs: record the analyze and domain-pruning changes (#414, #483, #485)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,43 @@ which was true until that script existed.
 
 ### Fixed
 
+- `pgcolumnar.analyze()` counts `null_frac` over live rows (#485). It came from
+  the zone maps, which record what was written, so a deleted row kept counting
+  toward the denominator until the table was rewritten. `VACUUM` did not correct
+  it. On 1,000 rows holding 100 nulls, deleting the 301 rows of one value left
+  `null_frac` at 0.100000 against a true 0.143062.
+
+  The size of the error is not the whole of it. `null_frac` came from the zone
+  maps while the most-common frequencies came from a live count, so one
+  `pg_stats` row carried two statistics normalised against different
+  populations: a `null_frac` implying 1,200 rows beside a frequency implying
+  900, with 900 actually present. `null_frac + sum(most_common_freqs) + rest =
+  1` stopped holding, and `eqsel` subtracts both when pricing everything else.
+
+  The null count now comes from the read the function already performs, so this
+  costs no extra pass. It does give up the "null_frac is a metadata read"
+  property claimed for #414 slice 1, which cost nothing in practice because the
+  function always goes on to read the column for `n_distinct`. A metadata-only
+  fast path would need a live-row count, which is that same read. Whether
+  `pgcolumnar.zone_map`'s counts should account for the delete vector, which
+  would also affect pruning, is a wider question and is not addressed.
+
+- A column declared over a domain now prunes chunk groups (#483). The scan key
+  was built and then dropped: a domain column carries the domain's type in
+  `pg_attribute` while the constant beside it carries the base type, so the
+  comparison looked cross-type, and an operator family has no comparison
+  function registered for a domain. Measured on identical values in one table
+  over 20 row groups, `int` and `bigint` each removed 19 groups and a domain
+  over either removed none, while all three reported the filter as pushed down.
+
+  Answers were never wrong, because the executor re-applies the qual. The cost
+  was reading the whole table on ordinary SQL. Both sides of the comparison are
+  now resolved to their base types, so a domain compared against a value of a
+  different domain over the same base type is also recognised. Ordering and
+  hashing are unchanged: the comparison and hash functions were already taken
+  from the column type's resolved entry, which is what the writer used to build
+  the zone maps and bloom filters.
+
 - A `bigint` column compared against an unadorned integer literal now prunes
   chunk groups (#477). The scan key was dropped because the column type's default
   comparison function cannot take an `int4` argument, so predicates of the form
@@ -112,6 +149,19 @@ which was true until that script existed.
   half of the rename is hygiene rather than a visible change.
 
 ### Changed
+
+- `pgcolumnar.analyze()` places `histogram_bounds` at PostgreSQL's own positions
+  (#414). The bounds were evenly spaced quantiles; core places bound i at
+  `values[floor(i * (nvals - 1) / (num_hist - 1))]` among the rows left after
+  the most-common values are removed, and `percentile_disc` resolves a fraction
+  to a different index whenever the two disagree.
+
+  **This changes the emitted array.** The length and both endpoints are the
+  same, so the exactness of the minimum and maximum is unaffected, but an
+  interior bound can move by one position. Both forms are valid equi-depth
+  histograms; core's is the one the planner's selectivity estimators were tuned
+  against. Anyone comparing `pg_stats` across this upgrade should expect
+  interior bounds to differ and that is intended, not a regression.
 
 - The unsupported-rewrite error names `REPACK` on PostgreSQL 19 (#399). `REPACK`
   replaces `CLUSTER` and `VACUUM FULL` in 19 and dispatches through the same


### PR DESCRIPTION
Three merges today changed behaviour a user can observe, and none carried a CHANGELOG entry: #488 (both halves) and #494.

## The one that most needed writing down

Under **Changed**, because #414's histogram work **alters an emitted value the planner consumes**:

> The length and both endpoints are the same, so the exactness of the minimum and maximum is unaffected, but an interior bound can move by one position. Both forms are valid equi-depth histograms; core's is the one the planner's selectivity estimators were tuned against. Anyone comparing `pg_stats` across this upgrade should expect interior bounds to differ and that is intended, not a regression.

The change is right. It is also completely invisible until somebody diffs `pg_stats` across an upgrade, at which point "intended, not a regression" is the sentence that saves them an afternoon. That is the whole reason for the entry.

## Under Fixed

**#485**, with the part that is easy to miss placed above the numbers: the wrong value matters less than the fact that `null_frac` and the most-common frequencies were normalised against *different populations*, so `null_frac + sum(most_common_freqs) + rest = 1` stopped holding and `eqsel` subtracts both. The entry also records what the fix **gives up** — "null_frac is a metadata read" was a stated selling point of #414 slice 1 and is now gone — because a changelog that only lists gains is not a record.

**#483**, placed directly beside #477, since they are the same defect one type-resolution apart and a reader who hits one should find the other. It says explicitly that answers were never wrong and the cost was reading the whole table, because a pruning entry without that sentence invites a correctness scare it does not deserve.

## Not recorded, deliberately

#486 and #487 changed only the test harness. This file covers notable changes to pgColumnar, and a suite that stopped reporting a match as absent is not one. Recorded here so the omission reads as a decision rather than an oversight.

## Verification

`docs_style.sh` passes, including its CHANGELOG-specific check that the file carries no em or en dash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)