### PR TITLE
docs: say which document to believe when the spec and the code disagree

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -16,6 +16,24 @@ question:
 
 This file owns the words.
 
+**Where the spec and the shipped defaults disagree, the defaults are what you
+will observe.** The spec describes the native format as designed, and in two
+known places the code has not moved to meet it. Neither is a defect, and neither
+is going to announce itself:
+
+| the spec says | the code ships |
+| --- | --- |
+| a vector is a fixed 1024 values | a vector holds up to `pgcolumnar.chunk_group_row_limit` rows, default 10000 |
+| the row-group limit is 122880 rows, a multiple of the vector length | `pgcolumnar.stripe_row_limit`, default 150000 |
+
+The first is the sharper trap, because 1024 is not merely aspirational: it is
+written into the native storage catalog row as `vector_length` and then never
+read back by anything. A constant that is recorded and never consulted looks
+exactly like a constant that is enforced.
+
+Read the spec for intent and the code for behaviour. Where a fixture depends on
+one of these numbers, take it from the setting, not from the spec.
+
 There is also a `HANDOFF.md`, the running continuity record: what has happened,
 what is in flight, and what to pick up. **It is deliberately not in the
 repository.** It is excluded per clone through `.git/info/exclude`, so a fresh


### PR DESCRIPTION
The follow-up I committed to on #492, and owed since that review landed.

#492 corrected a line I had taken straight from the spec (a vector is a fixed 1024 values) that the shipped code does not implement. The root cause is structural rather than a one-line slip: the ownership table hands the spec *"what the format and the interface ARE"* and then says nothing about what to do when the code disagrees with it. So the next person copies the next number.

Two known instances, both verified against the tree rather than recalled:

| the spec says | the code ships |
| --- | --- |
| a vector is a fixed 1024 values | a vector holds up to `pgcolumnar.chunk_group_row_limit`, default 10000 |
| the row-group limit is 122880, a multiple of the vector length (section 4) | `pgcolumnar.stripe_row_limit`, default 150000 |

Neither is a defect, and neither announces itself.

**The first is the sharper trap**, for a reason worth stating explicitly: 1024 is not merely aspirational. It is written into the native storage catalog row as `vector_length`, and then never read back. Checked across `src/`, `sql/` and the extension script, the only occurrences are the column definition (whose own comment says "values per vector (1024)"), the attribute number, and the `INSERT` that writes it. A constant that is recorded and never consulted looks exactly like one that is enforced, so both the spec *and* the catalog point a reader at a number the scan does not use.

The operational sentence is the last one: **size a fixture from the setting, not from the spec.** Someone building a fixture for vector-level skipping in 1024-row units gets one vector per row group at the default, sees `Vectors Skipped: 0`, and concludes the mechanism is broken. That is the failure #492 was written to prevent, and it deserved a rule rather than one corrected line.

No em or en dashes, matching the file's own convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)