### PR TITLE
fix: the ClickBench report claimed a cold run it had not performed

### DIFF
--- a/bench/cb_guards.sh
+++ b/bench/cb_guards.sh
@@ -56,3 +56,33 @@ cb_rows_ok() {
 	case "$want" in '' | *[!0-9]*) return 1 ;; esac
 	[ "$got" = "$want" ]
 }
+
+# cb_cold_tag <drop_how>
+#
+# The protocol tag the report carries, decided from what the page-cache probe
+# actually achieved: "direct" or "sudo" if the drop was performed, anything else
+# if it was not.
+#
+# This exists as a guard rather than as an if/else in the report because the
+# claim is the thing worth testing and the drop is not: whether a given kernel
+# permits the drop cannot be decided by a matrix suite, while whether the report
+# is honest about what happened is pure arithmetic. #506 records the harness
+# printing the cold tag unconditionally, including on hosts where both drop
+# mechanisms had failed.
+#
+# Unknown and empty fall to the warm tag deliberately. A tag that cannot be
+# justified must not be the cold one, because the cold one is the claim that
+# gets quoted.
+cb_cold_tag() {
+	case "${1:-}" in
+		direct | sudo)
+			printf '%s\n' \
+				"tag: lukewarm-cold-run (page cache dropped, server not restarted per query)"
+			;;
+		*)
+			printf '%s\n' \
+				"tag: WARM-RUN (page cache could NOT be dropped on this host; the first-try" \
+				"     column is not a cold number and must not be quoted as one)"
+			;;
+	esac
+}

--- a/bench/run_clickbench.sh
+++ b/bench/run_clickbench.sh
@@ -729,12 +729,7 @@ require "every query in the file ran" "$qn" "$NQUERIES" || fail=1
 # ---------------------------------------------------------------------------
 echo
 echo "================= CLICKBENCH, pgColumnar $EXTVER ================="
-if [ "$CB_DROP_HOW" = none ]; then
-	echo "tag: WARM-RUN (page cache could NOT be dropped on this host; the first-try"
-	echo "     column is not a cold number and must not be quoted as one)"
-else
-	echo "tag: lukewarm-cold-run (page cache dropped, server not restarted per query)"
-fi
+cb_cold_tag "$CB_DROP_HOW"
 printf '%s\n' "${ARMS[@]}" | grep -qx duckdb && \
 	echo "duckdb: PERSISTENT database file, not :memory:, so it stores what it loaded like the others"
 printf '%s\n' "${ARMS[@]}" | grep -qx citus && \

--- a/bench/run_clickbench.sh
+++ b/bench/run_clickbench.sh
@@ -166,6 +166,23 @@ require() {  # require <description> <condition-result> <expected>
 BINDIR="$("$PG_CONFIG" --bindir)" || die "no pg_config at $PG_CONFIG"
 PSQL="$BINDIR/psql -h /tmp -p $CB_PORT -U postgres -d clickbench -X -q"
 
+# initdb and the postmaster refuse to run as root; the client tools do not, and
+# they reach the cluster over the socket with trust auth. So only the server side
+# is dropped to postgres and the script itself stays root, which is what keeps
+# drop_caches below reachable. test/lib.sh makes the same split for the suites.
+#
+# Running the whole script as postgres instead looks simpler and is worse: it
+# gives up the page-cache drop silently, which is exactly the failure the probe
+# below exists to stop.
+CB_AS_ROOT=0
+CB_RUNPG=(env)
+if [ "$(id -u)" = 0 ]; then
+	id -u postgres >/dev/null 2>&1 \
+		|| die "running as root and there is no postgres user to run the server as"
+	CB_AS_ROOT=1
+	CB_RUNPG=(runuser -u postgres --)
+fi
+
 # ---------------------------------------------------------------------------
 # 0. Preconditions, once, loudly
 # ---------------------------------------------------------------------------
@@ -177,6 +194,30 @@ mkdir -p "$CB_DATA" || die "cannot write $CB_DATA"
 note "   pg_config: $PG_CONFIG ($("$PG_CONFIG" --version))"
 note "   data dir:  $CB_DATA"
 note "   rows:      $CB_ROWS    tries: $CB_TRIES    arms: $CB_ARMS"
+
+# Whether this host can drop the page cache is established HERE, by doing it,
+# and not at the first query by a test that lies. In an unprivileged container
+# /proc/sys/vm/drop_caches belongs to a uid outside the namespace and refuses
+# even the container's own root, so the old code fell through to a silent no-op
+# while the report went on printing the lukewarm-cold-run tag regardless. A
+# "cold" number that was never cold is worse than an honestly warm one, so the
+# capability is probed once and the tag in section 6 follows what it finds.
+CB_DROP_HOW=none
+sync
+if (echo 3 > /proc/sys/vm/drop_caches) 2>/dev/null; then
+	CB_DROP_HOW=direct
+elif command -v sudo >/dev/null 2>&1 \
+	&& sudo -n sh -c 'sync; echo 3 > /proc/sys/vm/drop_caches' 2>/dev/null; then
+	CB_DROP_HOW=sudo
+fi
+if [ "$CB_DROP_HOW" = none ]; then
+	note "   page cache: CANNOT be dropped here, so the first-try column is WARM"
+	if [ "${PGC_CB_REQUIRE_COLD:-0}" = 1 ]; then
+		die "PGC_CB_REQUIRE_COLD=1 and the page cache cannot be dropped on this host"
+	fi
+else
+	note "   page cache: dropped before each query ($CB_DROP_HOW)"
+fi
 
 # ---------------------------------------------------------------------------
 # 1. The definition, fetched rather than vendored
@@ -294,10 +335,16 @@ NCPU=$(nproc)
 SHARED_MB=$(( MEMKB / 1024 / 4 ))
 CACHE_MB=$(( MEMKB / 1024 * 3 / 4 ))
 if [ -d "$CB_PGDATA" ]; then
-	"$BINDIR/pg_ctl" -D "$CB_PGDATA" -w stop >/dev/null 2>&1
+	"${CB_RUNPG[@]}" "$BINDIR/pg_ctl" -D "$CB_PGDATA" -w stop >/dev/null 2>&1
 	rm -rf "$CB_PGDATA"
 fi
-"$BINDIR/initdb" -D "$CB_PGDATA" --locale=C -U postgres > "$CB_DATA/initdb.log" 2>&1 \
+# initdb accepts an existing empty directory, which is how the data directory
+# comes to belong to postgres when the parent belongs to root.
+mkdir -p "$CB_PGDATA" || die "cannot create $CB_PGDATA"
+if [ "$CB_AS_ROOT" = 1 ]; then
+	chown postgres "$CB_PGDATA" || die "cannot give $CB_PGDATA to postgres"
+fi
+"${CB_RUNPG[@]}" "$BINDIR/initdb" -D "$CB_PGDATA" --locale=C -U postgres > "$CB_DATA/initdb.log" 2>&1 \
 	|| { tail -20 "$CB_DATA/initdb.log"; die "initdb failed"; }
 # Settings follow the shape the upstream PostgreSQL entry uses, scaled to this
 # machine. They are applied to every arm equally, so they cannot favour one.
@@ -320,11 +367,11 @@ max_prepared_transactions = $CB_PCOPY_WORKERS
 listen_addresses = ''
 unix_socket_directories = '/tmp'
 CONF
-"$BINDIR/pg_ctl" -D "$CB_PGDATA" -l "$CB_PGDATA/server.log" -w start >/dev/null 2>&1 \
+"${CB_RUNPG[@]}" "$BINDIR/pg_ctl" -D "$CB_PGDATA" -l "$CB_PGDATA/server.log" -w start >/dev/null 2>&1 \
 	|| { tail -30 "$CB_PGDATA/server.log"; die "cluster did not start"; }
 cleanup() {
 	if [ "$CB_KEEP" != 1 ]; then
-		"$BINDIR/pg_ctl" -D "$CB_PGDATA" -w stop >/dev/null 2>&1
+		"${CB_RUNPG[@]}" "$BINDIR/pg_ctl" -D "$CB_PGDATA" -w stop >/dev/null 2>&1
 	fi
 }
 trap cleanup EXIT
@@ -585,11 +632,11 @@ note "== queries ($NQUERIES x ${#ARMS[@]} arms x $CB_TRIES tries, interleaved)"
 
 drop_caches() {
 	sync
-	if [ -w /proc/sys/vm/drop_caches ]; then
-		echo 3 > /proc/sys/vm/drop_caches 2>/dev/null
-	elif command -v sudo >/dev/null 2>&1; then
-		sudo sh -c 'sync; echo 3 > /proc/sys/vm/drop_caches' 2>/dev/null
-	fi
+	case "$CB_DROP_HOW" in
+		direct) echo 3 > /proc/sys/vm/drop_caches 2>/dev/null ;;
+		sudo)   sudo -n sh -c 'sync; echo 3 > /proc/sys/vm/drop_caches' 2>/dev/null ;;
+		none)   : ;;
+	esac
 }
 
 # Run one query once and return its milliseconds, or ERR.
@@ -682,7 +729,12 @@ require "every query in the file ran" "$qn" "$NQUERIES" || fail=1
 # ---------------------------------------------------------------------------
 echo
 echo "================= CLICKBENCH, pgColumnar $EXTVER ================="
-echo "tag: lukewarm-cold-run (page cache dropped, server not restarted per query)"
+if [ "$CB_DROP_HOW" = none ]; then
+	echo "tag: WARM-RUN (page cache could NOT be dropped on this host; the first-try"
+	echo "     column is not a cold number and must not be quoted as one)"
+else
+	echo "tag: lukewarm-cold-run (page cache dropped, server not restarted per query)"
+fi
 printf '%s\n' "${ARMS[@]}" | grep -qx duckdb && \
 	echo "duckdb: PERSISTENT database file, not :memory:, so it stores what it loaded like the others"
 printf '%s\n' "${ARMS[@]}" | grep -qx citus && \

--- a/bench/run_clickbench.sh
+++ b/bench/run_clickbench.sh
@@ -321,6 +321,28 @@ TSV_ROWS=$(wc -l < "$TSV")
 note "   $TSV: $TSV_ROWS rows, $TSV_BYTES bytes (stride $STRIDE)"
 require "the extracted TSV is not empty" "$([ "$TSV_ROWS" -gt 0 ] && echo yes || echo no)" "yes" || exit 1
 
+# The two ingest arms read this file as DIFFERENT users. `\copy` is client-side
+# and reads as whoever runs this script; pgcolumnar.parallel_copy reads it
+# server-side, through OpenTransientFile, as the user the postmaster runs as.
+# Where those differ -- which is exactly the root case handled above -- a file
+# the client reads happily can be refused to the server, and the refusal arrives
+# at the parallel arm, AFTER the decompress and after the serial arms have
+# loaded. That is the most expensive place in the run to discover it.
+#
+# Asserted as a fact about this file and this user, established by asking that
+# user, rather than inferred from a umask. Root's umask is 0022 on the bench and
+# the arms both read the file there today; a umask is a property of whichever
+# process created the file, and stays true only until the harness runs from cron
+# or from a shell someone configured differently.
+if [ "$CB_AS_ROOT" = 1 ]; then
+	require "the server user can read the extracted TSV" \
+		"$(runuser -u postgres -- test -r "$TSV" && echo yes || echo no)" "yes" || {
+		note "   $TSV is $(stat -c '%A %U:%G' "$TSV"), and the postmaster runs as postgres"
+		note "   pgcolumnar.parallel_copy reads it server-side, so the parallel arm would fail"
+		exit 1
+	}
+fi
+
 # ---------------------------------------------------------------------------
 # 3. A throwaway cluster, sized to this box
 # ---------------------------------------------------------------------------

--- a/test/bench_guards.sh
+++ b/test/bench_guards.sh
@@ -102,6 +102,34 @@ check "a missing count is refused rather than compared with the expectation" \
 check "and a missing expectation is refused too" \
 	"$(cb_rows_ok 2000000 '' && echo ok || echo refused)" "refused"
 
+# ---- a report must not claim a cold run it did not perform (#506) ----------
+#
+# The old harness tested [ -w /proc/sys/vm/drop_caches ], fell back to sudo, and
+# otherwise did nothing at all, silently -- while the report printed the
+# lukewarm-cold-run tag unconditionally. An unprivileged container is exactly
+# such a host: the file belongs to a uid outside the namespace and refuses even
+# the container's own root. So the run published a protocol claim it had not met.
+#
+# The claim is the deliverable being guarded here, not the drop. Whether a given
+# kernel permits the drop is not something a matrix suite can decide; whether the
+# report is honest about what happened is pure arithmetic, and belongs here.
+tag_none="$(cb_cold_tag none 2>/dev/null)"
+# Assert the premise, because the negative check below is vacuous without it: an
+# absent cb_cold_tag yields an empty string, an empty string does not contain
+# "lukewarm-cold-run", and "the run was not called cold" therefore PASSES against
+# no implementation whatever. Seen, not reasoned about -- it passed exactly that
+# way on the first red run of this suite.
+check "premise: the guard exists and emitted a tag to judge" \
+	"$([ -n "$tag_none" ] && echo yes || echo no)" "yes"
+check "a host that could not drop the page cache is not called a cold run" \
+	"$(grep -qi 'lukewarm-cold-run' <<<"$tag_none" && echo claimed || echo not-claimed)" \
+	"not-claimed"
+# Matched case-sensitively and as WARM-RUN rather than as "warm": the string
+# "lukewarm-cold-run" contains "warm", so a loose match would pass on precisely
+# the wrong output this check exists to catch.
+check "and the tag says plainly that the run was warm" \
+	"$(grep -q 'WARM-RUN' <<<"$tag_none" && echo yes || echo no)" "yes"
+
 echo
 echo "checks run: $PGC_CHECKS"
 if [ "$PGC_FAIL" != 0 ]; then


### PR DESCRIPTION
Found while resuming the ClickBench run for #445.

## The defect that matters

`drop_caches()` tested `[ -w /proc/sys/vm/drop_caches ]`, fell back to `sudo`,
and otherwise did nothing — silently. Section 6 then printed

    tag: lukewarm-cold-run (page cache dropped, server not restarted per query)

unconditionally. So on any host where the drop is refused, the run published a
protocol claim it had not met.

That is not hypothetical. In an unprivileged container the file belongs to a uid
outside the namespace and refuses even the container's own root:

    $ ls -l /proc/sys/vm/drop_caches
    --w------- 1 nobody nogroup 0
    $ sync; echo 3 > /proc/sys/vm/drop_caches
    bash: /proc/sys/vm/drop_caches: Permission denied

Both branches of the old code fail there, and the tag printed anyway.

## The fix

The capability is established once, in the preconditions, **by performing the
drop** rather than by testing a permission bit, and the tag follows what the
probe found. A host that cannot drop now says so twice — once up front, once in
the report — and the first-try column is labelled WARM rather than cold.

`PGC_CB_REQUIRE_COLD=1` turns an undroppable cache into a refusal, for anyone
who needs the published protocol rather than an honest warm number. The sudo
fallback gained `-n` so a harness cannot block on a password prompt.

**Proof by removal**, on a host where the drop is refused: the probe reports
`none` and the report prints `WARM-RUN` where the old code printed the cold tag.

Worth noting the published numbers are not affected: the report tabulates only
the *hot* times, and `COLD[]` feeds nothing but the error count. It was the tag
that was false, not the table.

## Second, smaller: privilege

`initdb` and the postmaster refuse to run as root; the client tools do not, and
they reach the cluster over the socket with trust auth. So only the server side
is dropped to `postgres`, the way `test/lib.sh` already splits it for the suites.
The script itself stays root, which is what keeps the page-cache drop reachable —
running the whole thing as `postgres` instead looks simpler and silently gives
that up.

On the bench host, which runs this as `jd`, `CB_AS_ROOT=0` and nothing changes.
This only turns a hard `initdb: cannot be run as root` into a working run.
#505 records that getting the privilege context backwards has already cost runs.

Refs #445, #505