### PR TITLE
fix: a suite must not report checks against the previously installed .so

### DIFF
--- a/test/lib.sh
+++ b/test/lib.sh
@@ -117,6 +117,26 @@ pgc_setup() {
 	echo "version=$("$PGC_PG_CONFIG" --version)"
 	echo "workdir=$PGC_WORKDIR"
 
+	# initdb and pg_ctl cannot run as root; use postgres when we are root.
+	#
+	# Settled BEFORE the build, and before the trap below, because pgc_teardown
+	# reaches pg_ctl through pgc_pg, which expands PGC_RUNPG. Installing the trap
+	# while that array is still unset would turn any early failure into an
+	# unbound-variable error under `set -u` instead of a cleanup.
+	if [ "$(id -u)" = "0" ]; then
+		PGC_RUNPG=(runuser -u postgres --)
+		chown -R postgres "$PGC_WORKDIR"
+		chmod 777 "$PGC_WORKDIR" "$PGC_SQLDIR"
+	else
+		PGC_RUNPG=(env)
+	fi
+
+	# Armed here rather than after the build: the build below can exit, and
+	# between mktemp above and this line there is nothing to remove the workdir.
+	# Stopping a cluster that was never started is a no-op, so arming it early
+	# costs nothing and covers every failure path after the directory exists.
+	trap pgc_teardown EXIT
+
 	# The matrix runner builds and installs once per version and sets
 	# PGC_SKIP_BUILD so parallel suites do not each rebuild (a no-op relink) or
 	# race on writing the shared .so during "make install". A suite run on its own
@@ -143,17 +163,6 @@ pgc_setup() {
 			exit 1
 		fi
 	fi
-
-	# initdb and pg_ctl cannot run as root; use postgres when we are root.
-	if [ "$(id -u)" = "0" ]; then
-		PGC_RUNPG=(runuser -u postgres --)
-		chown -R postgres "$PGC_WORKDIR"
-		chmod 777 "$PGC_WORKDIR" "$PGC_SQLDIR"
-	else
-		PGC_RUNPG=(env)
-	fi
-
-	trap pgc_teardown EXIT
 
 	echo "-- initdb"
 	pgc_pg "initdb -D '$PGC_PGDATA' -A trust" >/dev/null 2>&1

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -121,11 +121,27 @@ pgc_setup() {
 	# PGC_SKIP_BUILD so parallel suites do not each rebuild (a no-op relink) or
 	# race on writing the shared .so during "make install". A suite run on its own
 	# still builds and installs.
+	#
+	# Both steps are status-checked. lib.sh sets `set -uo pipefail` but not -e, so
+	# an unchecked make that fails to compile does not stop the suite: it carries
+	# on and runs every check against the PREVIOUSLY INSTALLED .so, then prints a
+	# full PASS/FAIL report for code that does not exist. That is indistinguishable
+	# from a real result, and it was caught only because someone fingerprinted the
+	# installed .so and saw the same hash either side of a source change that could
+	# not have produced it.
 	if [ -z "${PGC_SKIP_BUILD:-}" ]; then
 		echo "-- building"
-		make -C "$PGC_SRCDIR" PG_CONFIG="$PGC_PG_CONFIG" >/dev/null
+		if ! make -C "$PGC_SRCDIR" PG_CONFIG="$PGC_PG_CONFIG" >/dev/null; then
+			echo "FATAL: the build failed, so there is nothing new to test" >&2
+			echo "       (refusing to report checks against the previously installed .so)" >&2
+			exit 1
+		fi
 		echo "-- installing"
-		make -C "$PGC_SRCDIR" install PG_CONFIG="$PGC_PG_CONFIG" >/dev/null
+		if ! make -C "$PGC_SRCDIR" install PG_CONFIG="$PGC_PG_CONFIG" >/dev/null; then
+			echo "FATAL: the install failed, so the .so under test is not the one just built" >&2
+			echo "       (refusing to report checks against the previously installed .so)" >&2
+			exit 1
+		fi
 	fi
 
 	# initdb and pg_ctl cannot run as root; use postgres when we are root.


### PR DESCRIPTION
Reported by @ChronicallyJD, who caught it the only way it can be caught from the
outside: by fingerprinting the installed `.so` across a source change and seeing
the same hash twice.

## The defect

`pgc_setup` ran both make steps with no status check:

```sh
make -C "$PGC_SRCDIR" PG_CONFIG="$PGC_PG_CONFIG" >/dev/null
make -C "$PGC_SRCDIR" install PG_CONFIG="$PGC_PG_CONFIG" >/dev/null
```

`lib.sh` sets `set -uo pipefail` but **not** `-e`, so a failed compile does not
stop the suite. It carries straight on and runs every check against whatever
`.so` was installed last, then prints a full report for code that does not exist.

## Scope: the matrix was never at risk, only the standalone path

The obvious reviewer objection, checked rather than assumed:
`run_all_versions.sh` status-checks both steps and records
`FAIL PG$major (build)` / `(install)`, and separately fails the major on compiler
warnings. Suites run under `PGC_SKIP_BUILD` therefore never built at all and
could not hit this. The gap was exactly and only the standalone
`test/<suite>.sh` path — which is what a person runs while iterating, i.e. the
case where the source most often does not compile.

## Proof by removal

`this is not valid C and cannot compile;` appended to `src/columnar_bloom.c`.

**With the guard:**

```
-- building
src/columnar_bloom.c:260:1: error: unknown type name 'this'
make: *** [<builtin>: src/columnar_bloom.o] Error 1
FATAL: the build failed, so there is nothing new to test
       (refusing to report checks against the previously installed .so)
```

No checks run.

**With the guard removed, same broken tree:**

```
PASS  the filter still skips groups it can prove empty (#467)
PASS  premise: one row group holds more than the refusal threshold
PASS  a column above the distinct cap is refused a filter, not given a bad one
PASS  and the load itself succeeded, rather than erroring on the way

checks run: 19
bloom_sizing.sh: PASSED
```

Nineteen green checks, including four premise assertions, against a source file
that cannot compile. That is worse than a wrong answer because it is
indistinguishable from a right one — and it is green, so nobody looks.

## Second commit: the trap had to move too

Review caught that the new `exit 1` sat between `mktemp -d` and
`trap pgc_teardown EXIT`, leaking a workdir on every failed build — precisely
when someone is iterating on code that does not compile. Fixed, proven by
removal:

| trap position | suite exit | workdirs left |
| --- | --- | --- |
| above the build (now) | 1 | **0** |
| below the build (first commit) | 1 | **1** |

Moving the trap alone would have been wrong: `pgc_teardown` reaches `pg_ctl`
through `pgc_pg`, which expands `PGC_RUNPG`, set *after* the build. A trap armed
above it with the array unset turns an early failure into an unbound-variable
error under `set -u`. The privilege block moved up with it.

Passing path unchanged: clean `bloom_sizing.sh` gives 19 checks, PASSED, 0
workdirs, 0 leftover clusters.

## Class

Third instance of the same shape found this week: a step that fails silently and
a report that speaks anyway. #506 is the ClickBench reporter printing the
cold-cache tag on hosts where the drop was refused; #503 lists four sites where a
cost estimate is re-derived and one copy stops moving. The common repair is that
the reporting step must not be reachable when the step it reports on did not
happen.