### PR TITLE
fix: a vacuumed columnar table is priced as if nothing were all-visible (#507)

### DIFF
--- a/src/columnar.h
+++ b/src/columnar.h
@@ -376,7 +376,7 @@ extern void PgColumnarVMSetVisible(Relation rel, BlockNumber blk);
 extern void PgColumnarVMClearVisible(Relation rel, BlockNumber blk);
 extern void PgColumnarVMClearForRow(Relation rel, uint64 rowNumber);
 extern bool PgColumnarVMIsVisible(Relation rel, BlockNumber blk);
-extern void PgColumnarVMSetVisibleForRelation(Relation rel);
+extern uint64 PgColumnarVMSetVisibleForRelation(Relation rel);
 extern void PgColumnarDiscardFetchCache(void);
 
 /* index maintenance for callers that insert rows without an executor (#153) */

--- a/src/columnar_compat.h
+++ b/src/columnar_compat.h
@@ -288,6 +288,24 @@ PgColumnarOpInterpStrategy(const OpBtreeInterpretation *o)
 #endif
 
 /* -------------------------------------------------------------------------
+ * vac_update_relstats() gained a num_all_frozen_pages argument in PG18, between
+ * num_all_visible_pages and hasindex. We pass zero for it: nothing here computes
+ * an all-frozen count, and claiming pages are frozen when they have not been
+ * examined is the one direction that would be unsafe.
+ * ------------------------------------------------------------------------- */
+#if PG_VERSION_NUM >= 180000
+#define COLUMNAR_VAC_UPDATE_RELSTATS(rel, pages, tuples, allvis, hasindex, \
+									 fxid, mxid, fupd, mupd, inxact) \
+	vac_update_relstats((rel), (pages), (tuples), (allvis), 0, (hasindex), \
+						(fxid), (mxid), (fupd), (mupd), (inxact))
+#else
+#define COLUMNAR_VAC_UPDATE_RELSTATS(rel, pages, tuples, allvis, hasindex, \
+									 fxid, mxid, fupd, mupd, inxact) \
+	vac_update_relstats((rel), (pages), (tuples), (allvis), (hasindex), \
+						(fxid), (mxid), (fupd), (mupd), (inxact))
+#endif
+
+/* -------------------------------------------------------------------------
  * Oldest-xmin horizon for all-visible determination. GetOldestXmin(rel, flags)
  * was replaced by GetOldestNonRemovableTransactionId(rel) in PG14. A stripe
  * whose insert xid precedes this is visible to every current and future

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -1087,6 +1087,24 @@ pgcolumnar_relation_vacuum(Relation rel, COLUMNAR_VACUUM_PARAMS params,
 		double		frac = (double) visibleRows / (double) rel->rd_rel->reltuples;
 		BlockNumber allvis;
 
+		/*
+		 * When the clamp can bind, and why it is not hiding an overshoot.
+		 *
+		 * visibleRows counts rows in blocks lying ENTIRELY within an all-visible
+		 * run, so it is bounded by the true all-visible row count, which is
+		 * bounded by the true live row count. The denominator is not a count at
+		 * all -- reltuples is ANALYZE's estimate -- so the only way frac exceeds
+		 * one is that the estimate sits below the rows actually there. The clamp
+		 * therefore fires when the two inputs disagree, never when both are
+		 * accurate, and the value it produces in that case (every page
+		 * all-visible) is the right answer for a relation whose rows are all
+		 * visible. It cannot mask a miscounted numerator, because a numerator
+		 * that could overshoot on its own would have to count rows that do not
+		 * exist.
+		 *
+		 * test/native_ios.sh asserts the outcome either way: relallvisible must
+		 * not exceed relpages, and must still be most of the relation.
+		 */
 		if (frac > 1.0)
 			frac = 1.0;
 		/* truncating cast, not floor(): both are non-negative here, and this

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -783,7 +783,35 @@ pgcolumnar_relation_estimate_size(Relation rel, int32 *attr_widths,
 
 	*pages = Max(nblocks, 1);
 	*tuples = Max(liveRows, 0);
-	*allvisfrac = 0.0;
+
+	/*
+	 * The all-visible fraction, from the catalog rather than hardcoded (#507).
+	 *
+	 * This callback is the ONLY place the planner learns it: core's
+	 * estimate_rel_size delegates to the AM, so a hardcoded zero here overrides
+	 * pg_class entirely and no amount of VACUUM recording the truth can reach
+	 * cost_index. That is worth stating plainly because it is not visible from
+	 * either end -- the catalog looks right and the plan stays wrong, and a test
+	 * that asserts relallvisible is green while the defect is untouched.
+	 *
+	 * Zero is not a safe default here either. cost_index scales an index-only
+	 * scan's heap-fetch estimate by (1 - allvisfrac), so zero prices every
+	 * index-only scan as though it fetched every row -- on a 500,000-row fixture
+	 * that is the difference between an index-only scan priced 5,505 and the same
+	 * scan priced as high as 21,284, and it decides the plan.
+	 *
+	 * Same derivation core uses for a heap: the recorded all-visible pages over
+	 * the pages we are reporting, clamped, since the two are read at different
+	 * moments and a relation that shrank between them could otherwise exceed one.
+	 */
+	if (nblocks > 0 && rel->rd_rel->relallvisible > 0)
+	{
+		double		frac = (double) rel->rd_rel->relallvisible / (double) nblocks;
+
+		*allvisfrac = (frac > 1.0) ? 1.0 : frac;
+	}
+	else
+		*allvisfrac = 0.0;
 }
 
 /*

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -803,6 +803,16 @@ pgcolumnar_relation_estimate_size(Relation rel, int32 *attr_widths,
 	 * Same derivation core uses for a heap: the recorded all-visible pages over
 	 * the pages we are reporting, clamped, since the two are read at different
 	 * moments and a relation that shrank between them could otherwise exceed one.
+	 *
+	 * The two ends deliberately use different page counts, and it is not an
+	 * oversight: vacuum scales the numerator by the CATALOG relpages when it
+	 * records it, and this divides by the LIVE block count at plan time. Heap has
+	 * the same property -- vac_update_relstats writes relallvisible against the
+	 * pages it counted, and estimate_rel_size divides by curpages -- and both
+	 * directions are safe. A relation that grew since its vacuum divides an old
+	 * numerator by a larger denominator, so the fraction decays exactly where the
+	 * new pages are the ones not yet all-visible; one that shrank is caught by
+	 * the clamp. test/analyze_stats.sh pins the growth direction.
 	 */
 	if (nblocks > 0 && rel->rd_rel->relallvisible > 0)
 	{
@@ -1448,6 +1458,28 @@ pgcolumnar_tuple_update(COLUMNAR_TUPLE_UPDATE_ARGS)
 
 	rowNumber = PgColumnarWriteRow(writeState, rel, slot->tts_values,
 								 slot->tts_isnull);
+
+	/*
+	 * The new row version makes its block not all-visible, exactly as a plain
+	 * insert does (gap 28). This half of update-as-delete-plus-insert was the
+	 * only write path not clearing the bit, while PgColumnarVMClearForRow's own
+	 * contract says it is "called by every write path (insert/delete/update)".
+	 * PgColumnarMarkRowDeleted above covers the OLD row; this covers the new one.
+	 *
+	 * It is a no-op today, and that is the reason to write it rather than a
+	 * reason to leave it out. PgColumnarVMSetVisibleForRelation marks only blocks
+	 * lying ENTIRELY inside an all-visible run -- `bend = hi / K` with a
+	 * `b < bend` loop -- so the partly-filled block at the append frontier is
+	 * never marked, and an appended row can only land there or beyond. That
+	 * safety is a `<` in another file with nothing pointing at it: marking the
+	 * boundary block looks like a tightening, and whoever makes it would turn
+	 * this no-op into a stale all-visible bit on a block that just changed, which
+	 * an index-only scan reads as permission to skip the fetch.
+	 *
+	 * Cheap when no bit is set (a short-circuit read), and the insert path
+	 * already pays it per row.
+	 */
+	PgColumnarVMClearForRow(rel, rowNumber);
 
 	PgColumnarRowNumberToItemPointer(rowNumber, &slot->tts_tid);
 	slot->tts_tableOid = RelationGetRelid(rel);

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -1058,7 +1058,51 @@ pgcolumnar_relation_vacuum(Relation rel, COLUMNAR_VACUUM_PARAMS params,
 	 * concurrent with readers and writers. The space-reclaiming rewrite stays in
 	 * columnar.vacuum (AccessExclusiveLock, the VACUUM-FULL analog).
 	 */
-	PgColumnarVMSetVisibleForRelation(rel);
+	uint64		visibleRows = PgColumnarVMSetVisibleForRelation(rel);
+
+	/*
+	 * Record the result where the planner can see it (#507).
+	 *
+	 * Setting the VM bits is only half the job. rel->allvisfrac is derived from
+	 * pg_class.relallvisible, and core's cost_index prices an index-only scan by
+	 * it, so a relation whose VM is populated and whose relallvisible is 0 is
+	 * priced as though every row still needs a fetch. Measured on 20,000,000
+	 * rows: relallvisible stayed 0 where a heap on identical rows reached 186,914
+	 * of 186,916 pages, and the planner refused an index-only scan running
+	 * 187.8 ms in favour of one running 361.4 ms.
+	 *
+	 * Converted through the row count rather than counted in blocks, because the
+	 * VM is keyed by SYNTHETIC blocks (rowNumber / K) while relpages counts
+	 * stored pages -- 68,730 against 45,994 on that table. Core computes the
+	 * fraction as relallvisible / relpages, so the numerator has to be in
+	 * relpages units or the fraction exceeds 1 by arithmetic alone.
+	 *
+	 * relpages and reltuples are passed back unchanged: ANALYZE owns them, and a
+	 * VACUUM that also rewrote them would make the two commands fight over the
+	 * same fields. InvalidTransactionId and InvalidMultiXactId are core's own
+	 * idiom for "leave the horizons alone".
+	 */
+	if (visibleRows > 0 && rel->rd_rel->reltuples > 0 && rel->rd_rel->relpages > 0)
+	{
+		double		frac = (double) visibleRows / (double) rel->rd_rel->reltuples;
+		BlockNumber allvis;
+
+		if (frac > 1.0)
+			frac = 1.0;
+		/* truncating cast, not floor(): both are non-negative here, and this
+		 * needs no <math.h> in a file that otherwise wants none */
+		allvis = (BlockNumber) ((double) rel->rd_rel->relpages * frac);
+
+		COLUMNAR_VAC_UPDATE_RELSTATS(rel,
+									 rel->rd_rel->relpages,
+									 rel->rd_rel->reltuples,
+									 allvis,
+									 rel->rd_rel->relhasindex,
+									 InvalidTransactionId,
+									 InvalidMultiXactId,
+									 NULL, NULL,
+									 false);
+	}
 
 	/*
 	 * Online compaction (Phase F3a): retire row groups that are fully deleted

--- a/src/columnar_visibilitymap.c
+++ b/src/columnar_visibilitymap.c
@@ -209,10 +209,18 @@ rowrange_cmp(const void *a, const void *b)
  *		lock the caller holds; the table-AM relation_vacuum path holds only
  *		ShareUpdateExclusiveLock, so this is concurrent with readers and writers,
  *		and clear-on-write removes any bit for a row changed after this runs.
+ *
+ *		Returns how many ROWS the bits it set cover, which is what the caller
+ *		needs to record the result in pg_class (#507). Rows and not blocks on
+ *		purpose: these are *synthetic* blocks, rowNumber / K, and relpages counts
+ *		stored pages -- on a 20,000,000-row table that is 68,730 against 45,994.
+ *		Handing a synthetic block count to a field core divides by relpages
+ *		produces an all-visible fraction above 1 from arithmetic alone.
  */
-void
+uint64
 PgColumnarVMSetVisibleForRelation(Relation rel)
 {
+	uint64		visibleRows = 0;
 	uint64		storageId = PgColumnarStorageId(rel);
 	TransactionId oldestXmin = PgColumnarOldestXmin(rel);
 	List	   *groups = PgColumnarComputeAllVisibleGroups(storageId, oldestXmin);
@@ -223,7 +231,7 @@ PgColumnarVMSetVisibleForRelation(Relation rel)
 	int			i;
 
 	if (n == 0)
-		return;
+		return 0;
 
 	arr = palloc(sizeof(PgColumnarRowRange) * n);
 	i = 0;
@@ -253,6 +261,8 @@ PgColumnarVMSetVisibleForRelation(Relation rel)
 		/* blocks entirely within [lo, hi): ceil(lo/K) .. floor(hi/K) - 1 */
 		b = (BlockNumber) ((lo + K - 1) / K);
 		bend = (BlockNumber) (hi / K);
+		if (bend > b)
+			visibleRows += (uint64) (bend - b) * K;
 		for (; b < bend; b++)
 			PgColumnarVMSetVisible(rel, b);
 
@@ -260,6 +270,7 @@ PgColumnarVMSetVisibleForRelation(Relation rel)
 	}
 
 	pfree(arr);
+	return visibleRows;
 }
 
 /*

--- a/test/analyze_stats.sh
+++ b/test/analyze_stats.sh
@@ -512,4 +512,63 @@ check "the bound does not disable the penalty for a full ordered read (#376)" \
 		&& echo yes || echo "no ($(printf '%s' "$plan_nolim" | head -1))")" \
 	"yes"
 
+# --- 10. a vacuumed table is priced with its all-visible pages (#507) ----------
+#
+# cost_index scales an index-only scan's heap-fetch estimate by
+# (1 - allvisfrac), and for a columnar relation allvisfrac arrives from this
+# extension's own relation_estimate_size callback -- core delegates, so that
+# callback is the only place the planner can learn it. It returned a hardcoded
+# zero, which prices every index-only scan as though it fetched every row.
+#
+# The checks are here rather than in native_ios.sh because this is a costing
+# question: native_ios.sh forces the plan with enable_custom_scan=off and
+# therefore cannot see a choice being made at all.
+#
+# Deliberately paired. "Takes the index-only scan" alone is satisfied by a
+# callback that reports everything all-visible unconditionally, which would be
+# the same defect with the sign flipped, so the second check holds a query where
+# the scan is genuinely cheaper and requires it to still win.
+IOSC_ROWS=${PGC_IOSC_ROWS:-300000}
+
+# k is deterministic -- the same (g * 48271) scatter o355 uses above -- because a
+# premise that moves with a random draw fails eventually and blames innocent
+# code (#487). The pad must not compress away: the effect turns on the relation
+# having pages for the fetch estimate to be a fraction of, and a constant string
+# costs almost none.
+psql_run "DROP TABLE IF EXISTS iosc;
+	CREATE TABLE iosc (id int, k int, pad text) USING pgcolumnar;
+	INSERT INTO iosc SELECT g, ((g::bigint * 48271) % 1000000)::int,
+		repeat(md5(g::text), 4) FROM generate_series(1, $IOSC_ROWS) g;
+	CREATE INDEX iosc_k ON iosc (k);
+	ANALYZE iosc;" >/dev/null
+psql_run "VACUUM iosc;" >/dev/null
+
+# Premise: the pricing question below is meaningless unless VACUUM actually
+# recorded all-visible pages, and that is a different mechanism from the one
+# under test -- it is asserted in native_ios.sh, and asserted again here because
+# this suite must not report a costing result that rests on it silently.
+check "premise: VACUUM recorded all-visible pages to price with (#507)" \
+	"$(q "SELECT relallvisible > 0 FROM pg_class WHERE relname = 'iosc';")" "t"
+check "premise: the selective range has its rows (#507)" \
+	"$(q 'SELECT count(*) FROM iosc WHERE k BETWEEN 0 AND 200000;')" "60003"
+
+# 60,003 of 300,000 rows: the index-only scan reads a fifth of the index and no
+# data at all, and beats the columnar scan 1,847 to 4,524 once its fetch estimate
+# is not inflated. Hardcoding allvisfrac to zero prices it at 5,143 and the
+# columnar scan wins instead.
+plan_ios="$(plan_of "EXPLAIN (COSTS off) SELECT k FROM iosc WHERE k BETWEEN 0 AND 200000;")"
+check "a vacuumed columnar table can reach an index-only scan (#507)" \
+	"$(grep -q 'Index Only Scan using iosc_k' <<<"$plan_ios" && echo yes \
+		|| echo "no ($(printf '%s' "$plan_ios" | head -1))")" \
+	"yes"
+
+# ...and the other direction, so a callback that simply claims everything is
+# all-visible does not pass. Reading every row, the columnar scan is genuinely
+# the cheaper plan (4,524 against 9,312) and must still be chosen.
+plan_all="$(plan_of "EXPLAIN (COSTS off) SELECT k FROM iosc WHERE k BETWEEN 0 AND 1000000;")"
+check "the all-visible fraction does not hand every query to the index (#507)" \
+	"$(grep -q 'Custom Scan (PgColumnarScan)' <<<"$plan_all" && echo yes \
+		|| echo "no ($(printf '%s' "$plan_all" | head -1))")" \
+	"yes"
+
 pgc_summary

--- a/test/analyze_stats.sh
+++ b/test/analyze_stats.sh
@@ -571,4 +571,73 @@ check "the all-visible fraction does not hand every query to the index (#507)" \
 		|| echo "no ($(printf '%s' "$plan_all" | head -1))")" \
 	"yes"
 
+# --- 11. the fraction is a fraction of the LIVE relation (#507) ----------------
+#
+# allvisfrac is relallvisible over the block count, and which block count decides
+# whether a relation that has grown since its last vacuum is priced honestly.
+# Divide by the live count and the fraction decays as pages are added, exactly
+# where the new pages are the ones not yet all-visible. Divide by
+# pg_class.relpages -- which is right there in the same struct, looks equivalent,
+# and is stale between vacuums -- and the fraction stays at its old value, so an
+# index-only scan is priced cheap on precisely the pages most likely to fetch.
+#
+# This pins the divisor, and nothing above it does: on a freshly loaded, vacuumed
+# and analyzed table relpages and the live count are equal by construction, so
+# both implementations agree and all of section 10 passes either way. The removal
+# proof for this section is that swap, not deleting a check.
+#
+# The added rows are deliberately OUTSIDE the predicate. Rows inside it would
+# make the index-only scan read more entries and cost more for a reason that has
+# nothing to do with allvisfrac, and the check would then pass under both
+# divisors while appearing to prove something.
+# Measured as the GAP between a plain index scan and an index-only scan on the
+# same index and predicate. In cost_index that gap is the whole of what
+# allvisfrac buys -- the two plans are otherwise identical -- so it isolates the
+# fraction from everything else that moves when a table grows. The first version
+# of this check compared index-only-scan costs directly and was VACUOUS: the
+# estimator reports live *tuples from row-group metadata, so adding rows raises
+# the row estimate and the cost rises under both divisors. It passed either way.
+#
+# The fetch penalty is off for the same reason: it mutates T_IndexScan and not
+# T_IndexOnlyScan, so it would put a term in the gap that is not the fraction.
+ios_gap() {  # (index scan) - (index only scan), the saving allvisfrac buys
+	local off idx ios
+	off="SET pgcolumnar.enable_custom_scan = off; SET enable_seqscan = off;
+	     SET enable_bitmapscan = off; SET pgcolumnar.enable_index_fetch_penalty = off;"
+	ios="$(plan_of "$off EXPLAIN SELECT k FROM iosc WHERE k BETWEEN 0 AND 200000;" \
+		| grep -m1 'Index Only Scan' | sed -E 's/.*\.\.([0-9]+)\.[0-9]+.*/\1/')"
+	idx="$(plan_of "$off SET enable_indexonlyscan = off;
+		EXPLAIN SELECT k FROM iosc WHERE k BETWEEN 0 AND 200000;" \
+		| grep -m1 'Index Scan' | sed -E 's/.*\.\.([0-9]+)\.[0-9]+.*/\1/')"
+	[ -n "$idx" ] && [ -n "$ios" ] && echo $((idx - ios))
+}
+
+iosc_gap_a="$(ios_gap)"
+
+# Grown, and NOT analyzed or vacuumed: the only window in which the two divisors
+# differ, since ANALYZE brings relpages back level with the live count. The added
+# rows sit OUTSIDE the predicate so the index-only scan reads the same entries.
+psql_run "INSERT INTO iosc SELECT g, 200001 + ((g::bigint * 48271) % 799999)::int,
+		repeat(md5(g::text), 4) FROM generate_series(300001, 340000) g;" >/dev/null
+iosc_gap_b="$(ios_gap)"
+
+check "premise: both estimates were taken (#507)" \
+	"$([ -n "$iosc_gap_a" ] && [ -n "$iosc_gap_b" ] && echo yes \
+		|| echo "no (a=$iosc_gap_a b=$iosc_gap_b)")" \
+	"yes"
+
+# The saving is worth a fixed number of all-visible PAGES, and growth adds none
+# of them -- so it must not grow. Against the live count the fraction decays as
+# the fetch estimate rises and the two cancel; against a stale relpages the
+# fraction is frozen and the saving inflates with the table. Measured on this
+# fixture: 3296 -> 3296 correct, 3296 -> 3752 with the stale divisor.
+#
+# One-sided deliberately. Equal-or-lower is what a live divisor gives and the
+# cancellation is only exact while the fetch estimate saturates the relation;
+# higher is what the stale one gives, and that is the direction that misprices.
+check "growth without vacuum does not inflate the all-visible saving (#507)" \
+	"$([ "${iosc_gap_b:-1}" -le "${iosc_gap_a:-0}" ] && echo yes \
+		|| echo "no (grown $iosc_gap_b above vacuumed $iosc_gap_a)")" \
+	"yes"
+
 pgc_summary

--- a/test/analyze_stats.sh
+++ b/test/analyze_stats.sh
@@ -608,12 +608,16 @@ ios_gap() {  # (index scan) - (index only scan), the saving allvisfrac buys
 	# The other three merely stop a cheaper plan being chosen instead.
 	off="SET pgcolumnar.enable_custom_scan = off; SET enable_seqscan = off;
 	     SET enable_bitmapscan = off; SET pgcolumnar.enable_index_fetch_penalty = off;"
+	# The FULL cost, decimals included. Truncating to an integer here is what made
+	# the first version of this check fail in CI on PG17 at "grown 3296 above
+	# vacuumed 3295" -- a one-unit difference manufactured by rounding two
+	# independent subtractions, not by anything the code did.
 	ios="$(plan_of "$off EXPLAIN SELECT k FROM iosc WHERE k BETWEEN 0 AND 200000;" \
-		| grep -m1 'Index Only Scan' | sed -E 's/.*\.\.([0-9]+)\.[0-9]+.*/\1/')"
+		| grep -m1 'Index Only Scan' | sed -E 's/.*\.\.([0-9.]+).*/\1/')"
 	idx="$(plan_of "$off SET enable_indexonlyscan = off;
 		EXPLAIN SELECT k FROM iosc WHERE k BETWEEN 0 AND 200000;" \
-		| grep -m1 'Index Scan' | sed -E 's/.*\.\.([0-9]+)\.[0-9]+.*/\1/')"
-	[ -n "$idx" ] && [ -n "$ios" ] && echo $((idx - ios))
+		| grep -m1 'Index Scan' | sed -E 's/.*\.\.([0-9.]+).*/\1/')"
+	[ -n "$idx" ] && [ -n "$ios" ] && awk -v a="$idx" -v b="$ios" 'BEGIN{printf "%.2f", a - b}'
 }
 
 iosc_gap_a="$(ios_gap)"
@@ -636,12 +640,21 @@ check "premise: both estimates were taken (#507)" \
 # fraction is frozen and the saving inflates with the table. Measured on this
 # fixture: 3296 -> 3296 correct, 3296 -> 3752 with the stale divisor.
 #
-# One-sided deliberately. Equal-or-lower is what a live divisor gives and the
-# cancellation is only exact while the fetch estimate saturates the relation;
-# higher is what the stale one gives, and that is the direction that misprices.
+# One-sided deliberately: equal-or-lower is what a live divisor gives, higher is
+# what the stale one gives, and that is the direction that misprices.
+#
+# The tolerance is arithmetic rather than taste, and it exists because the first
+# version had none and failed in CI on PG17 at 3296 against 3295. The cancellation
+# is only EXACT while the fetch estimate saturates the relation; where it does not
+# quite, the two sides differ in their last fraction of a cost unit. So the noise
+# floor is order 1 unit in 3300, about 0.03%, while the defect this detects is
+# 3296 -> 3752, or 13.8%. Five percent sits two orders of magnitude above the
+# noise and nearly three below the signal -- it cannot be reached by rounding and
+# cannot hide the stale divisor.
+iosc_tol="$(awk -v a="${iosc_gap_a:-0}" 'BEGIN{printf "%.2f", a * 1.05}')"
 check "growth without vacuum does not inflate the all-visible saving (#507)" \
-	"$([ "${iosc_gap_b:-1}" -le "${iosc_gap_a:-0}" ] && echo yes \
-		|| echo "no (grown $iosc_gap_b above vacuumed $iosc_gap_a)")" \
+	"$(awk -v b="${iosc_gap_b:-1}" -v t="$iosc_tol" 'BEGIN{exit !(b <= t)}' && echo yes \
+		|| echo "no (grown $iosc_gap_b above vacuumed $iosc_gap_a, tolerance $iosc_tol)")" \
 	"yes"
 
 pgc_summary

--- a/test/analyze_stats.sh
+++ b/test/analyze_stats.sh
@@ -602,6 +602,10 @@ check "the all-visible fraction does not hand every query to the index (#507)" \
 # T_IndexOnlyScan, so it would put a term in the gap that is not the fraction.
 ios_gap() {  # (index scan) - (index only scan), the saving allvisfrac buys
 	local off idx ios
+	# enable_index_fetch_penalty = off is NOT redundant setup and must not be
+	# tidied away: the penalty adds to T_IndexScan and not to T_IndexOnlyScan, so
+	# it lands inside the very gap this function measures and swamps the fraction.
+	# The other three merely stop a cheaper plan being chosen instead.
 	off="SET pgcolumnar.enable_custom_scan = off; SET enable_seqscan = off;
 	     SET enable_bitmapscan = off; SET pgcolumnar.enable_index_fetch_penalty = off;"
 	ios="$(plan_of "$off EXPLAIN SELECT k FROM iosc WHERE k BETWEEN 0 AND 200000;" \

--- a/test/native_ios.sh
+++ b/test/native_ios.sh
@@ -62,6 +62,35 @@ check "premise: core records all-visible pages for the heap mirror (#507 oracle)
 check "VACUUM records the all-visible pages in pg_class (#507)" \
 	"$(q "SELECT relallvisible > 0 FROM pg_class WHERE relname = 'ios';")" "t"
 
+# Non-zero is not the same as right, and the way this goes wrong is a unit error
+# rather than a logic one. The VM is keyed by SYNTHETIC blocks (rowNumber / K)
+# while relpages counts stored pages; on a 20,000,000-row table that is 68,730
+# against 45,994. Storing a block count would satisfy the check above and give
+# core an all-visible fraction of 1.49 to divide with.
+#
+# Premise first: relallvisible is meaningless if relpages is zero, and the
+# conversion is skipped entirely in that case, so a silent no-op would otherwise
+# reach the checks below as a division by zero rather than as a failure.
+check "premise: the relation has pages and rows to be a fraction of (#507)" \
+	"$(q "SELECT relpages > 0 AND reltuples > 0 FROM pg_class WHERE relname = 'ios';")" "t"
+
+# An upper bound that owes nothing to this implementation: a relation cannot
+# have more all-visible pages than pages. A synthetic block count is free to
+# exceed it, and on a large relation it does.
+check "the all-visible page count cannot exceed the relation (#507)" \
+	"$(q "SELECT relallvisible <= relpages FROM pg_class WHERE relname = 'ios';")" "t"
+
+# ...and a lower bound, because a fraction can be arithmetically sane and still
+# wrong. The heap mirror on identical rows is the oracle rather than a number
+# written here. Deliberately loose: our bits are set only for blocks lying
+# ENTIRELY within an all-visible run, so the partial block at each end stays
+# clear and the columnar fraction is legitimately a little under the heap's.
+# Half is far below that boundary loss and far above either failure mode -- a
+# wrong unit lands above the heap's fraction, a stray small value well under it.
+check "the all-visible fraction is most of the relation, as the heap's is (#507)" \
+	"$(q "SELECT (SELECT relallvisible::float8 / relpages FROM pg_class WHERE relname = 'ios')
+	          >= 0.5 * (SELECT relallvisible::float8 / relpages FROM pg_class WHERE relname = 'ioh');")" "t"
+
 # A delete clears the VM bit for the affected blocks; the scan falls back to the
 # fetch there and must never return a deleted row.
 psql_run "DELETE FROM ios WHERE id BETWEEN 2000 AND 2200;"

--- a/test/native_ios.sh
+++ b/test/native_ios.sh
@@ -43,6 +43,25 @@ check "index-only results match heap (all-visible)" \
 	"$(pgc_set_hash 'SELECT id FROM ios WHERE id BETWEEN 1000 AND 5000')" \
 	"$(pgc_set_hash 'SELECT id FROM ioh WHERE id BETWEEN 1000 AND 5000')"
 
+# --- the VM has to be recorded in the catalog, not only written (#507) --------
+#
+# The zero-fetch check above proves the VM fork is populated. That is not the
+# whole job: rel->allvisfrac is derived from pg_class.relallvisible, and core's
+# cost_index prices an index-only scan by it. A relation whose VM is full and
+# whose relallvisible is 0 is therefore priced as though every row needs a fetch,
+# and the planner declines the scan it should choose. Measured on 20,000,000
+# rows: the index-only scan ran 187.8 ms against the 361.4 ms plan preferred over
+# it, priced 48,117 against 24,628.
+#
+# The heap mirror is the oracle rather than a number written here, so this
+# asserts "the same thing core does for a heap on the same rows" rather than a
+# constant that would have to be maintained alongside the code it checks.
+psql_run "VACUUM ioh;"
+check "premise: core records all-visible pages for the heap mirror (#507 oracle)" \
+	"$(q "SELECT relallvisible > 0 FROM pg_class WHERE relname = 'ioh';")" "t"
+check "VACUUM records the all-visible pages in pg_class (#507)" \
+	"$(q "SELECT relallvisible > 0 FROM pg_class WHERE relname = 'ios';")" "t"
+
 # A delete clears the VM bit for the affected blocks; the scan falls back to the
 # fetch there and must never return a deleted row.
 psql_run "DELETE FROM ios WHERE id BETWEEN 2000 AND 2200;"


### PR DESCRIPTION
Fixes #507.

`VACUUM` marks all-visible row groups in the visibility map, and until now nothing
downstream could act on it. Two links in the chain were missing, and the second is
the one that decides plans.

## The defect

1. **`VACUUM` never recorded what it marked.** `pg_class.relallvisible` stayed 0
   on a relation whose VM fork was 99.985% populated — where a heap on identical
   rows reached 186,914 of 186,916 pages.
2. **The planner never read it anyway.** core's `estimate_rel_size` *delegates* to
   the table AM, so `pgcolumnar_relation_estimate_size` is the only place a
   columnar relation's `allvisfrac` can come from — and it returned a hardcoded
   `0.0`, overriding the catalog entirely.

`cost_index` scales an index-only scan's heap-fetch estimate by
`(1 - allvisfrac)`, so zero prices every index-only scan as though it fetched
every row, however thoroughly the table has been vacuumed.

## What it costs

On a 300,000-row fixture, with the catalog already correct in both arms so that
only the callback differs:

| `SELECT k FROM iosc WHERE k BETWEEN 0 AND 200000` | index-only scan | columnar scan | chosen |
| --- | ---: | ---: | --- |
| `allvisfrac` hardcoded 0 | 5,142.91 | 4,523.63 | Custom Scan |
| derived | **1,846.92** | 4,523.63 | **Index Only Scan** |

On the 20,000,000-row table where I first hit it, the refused index-only scan ran
**187.8 ms** against the **361.4 ms** plan preferred over it.

## The fix

`PgColumnarVMSetVisibleForRelation` returns the rows its bits cover; the vacuum
path converts that to pages and records it; the estimator derives the fraction
from the catalog the way `heapam_estimate_rel_size` does.

Converted through the **row count**, not counted in blocks. The VM is keyed by
*synthetic* blocks (`rowNumber / K`) while `relpages` counts stored pages — 68,730
against 45,994 on the 20M table — and core divides `relallvisible` by a page
count, so a block count in that numerator yields an all-visible fraction above 1
from arithmetic alone.

`relpages` and `reltuples` are passed back unchanged: ANALYZE owns them, and a
VACUUM that rewrote them too would make the two commands fight over the same
fields.

## Tests, and how each was proved

Four checks in `native_ios.sh` and five in `analyze_stats.sh`. Every guard was
proved by removal, each against **its own** failure mode, with the installed `.so`
fingerprinted on both sides — a shared install prefix will otherwise happily let
the "before" run be the fixed binary.

| removal | what reddens | `.so` |
| --- | --- | --- |
| naive synthetic-block count | the upper bound (cannot exceed `relpages`) | `1299773508a0` |
| `allvis` pinned to 1 page | the lower bound (must be most of the relation) | `f95887da2588` |
| `allvisfrac` hardcoded 0 | the plan choice | `18a073980925` |
| divisor swapped to `rd_rel->relpages` | the growth check | `ce752df1c1e8` |

The costing checks are in `analyze_stats.sh` rather than `native_ios.sh` because
`native_ios.sh` forces the plan with `enable_custom_scan = off` and therefore
cannot see a choice being made at all.

Each is paired against the opposite error. "Takes the index-only scan" alone is
satisfied by a callback claiming everything is all-visible unconditionally — the
same defect with the sign flipped — so a second check reads every row, where the
columnar scan is genuinely cheaper (4,523.63 against 9,312.42), and requires it to
still win.

## Three things I got wrong, recorded because the corrections are the useful part

**The issue as filed was wrong.** I claimed the VM is never populated, citing the
phase-1 header in `columnar_visibilitymap.c`. That header is stale and
`native_ios.sh` had been testing the opposite all along. `VACUUM` takes Heap
Fetches from 1,999,999 to 290 and the query from 42,168 ms to 188 ms. The fix I
originally suggested there (`1 - allvisfrac`) was **backwards**, since
`allvisfrac` is 0 even when the VM is full. Corrected in the issue and retitled.

**The first two commits here were inert.** They record `relallvisible` and prove
it correct, and on their own they change nothing, because of the hardcoded
callback above. Both slices asserted properties of the **catalog**, and the
catalog was genuinely correct — nothing about a catalog value can detect a
callback downstream discarding it. "Assert the premise" is what I did, twice, by
removal, and it was not sufficient: **the premise chain has to reach the thing
you claim to fix.** Only an assertion about the plan could see this.

**The first version of the growth check was vacuous.** It compared index-only-scan
costs before and after growth; the estimator reports live `*tuples` from row-group
metadata, so adding rows raises the row estimate whatever the fraction does, and
34 of 34 passed under *both* divisors. What isolates `allvisfrac` is the **gap**
between a plain index scan and an index-only scan on the same index and predicate,
which in `cost_index` is exactly what the fraction buys, so the row-count term
cancels from both sides:

| | vacuumed | grown, not vacuumed |
| --- | ---: | ---: |
| live block count | 3296 | **3296** |
| stale `relpages` | 3296 | **3752** |

The saving is worth a fixed number of all-visible *pages* and growth adds none of
them, so it must not grow. That the assertion is one-sided falls out of the
mechanism rather than being chosen.

## Gate — one complete, one in flight as I open this

**Complete**, full matrix on 18 and 19 in the audit container, at `25f34b8`:

- **PG18 PASS** — 131 ran, 2 skipped. `analyze_stats=PASS`, `native_ios=PASS`.
- **PG19** — every suite passes except `temporal`, which needs `btree_gist`. That
  container has it on **pg18a only**, so the failure is environmental: unmodified
  `main` at `588961d` fails it identically there. Measured across both rigs and
  written up on #505, since "the bench cannot be reproduced from the repo" is
  already that issue.

**In flight**: the same matrix on the bench host, at `852d7b8` (this branch head,
which adds only a comment). That box has `btree_gist` on every assert major, so it
closes the one gap above. I will post the result as a comment rather than edit it
into this description — **do not merge on my say-so until that lands.**

The delta between the two commits is a comment in a test, so I do not expect a
different answer; that is a reason to state the expectation, not to skip the run.

## Related

- **#415** — this makes VACUUM materially more valuable, and un-vacuumed is the
  normal state for a columnar table precisely because autovacuum cannot reach it.
  The two are now linked rather than waiting to be rediscovered.
- **#503** — anything I measured there about index-only shapes rested on
  `allvisfrac = 0` and needs re-measuring from scratch before it is quoted. That
  includes both of my readings of the shape that flipped.
- **#445** — the ClickBench arms were all `VACUUM ANALYZE`d after load, so that
  table sits in exactly the state where these prices change. Not a reason to
  re-run it; a reason not to quote it as a post-merge baseline.
