### PR TITLE
feat: an anchored LIKE is a range, so let the zone maps prune it (#426)

### DIFF
--- a/src/columnar_compat.h
+++ b/src/columnar_compat.h
@@ -306,6 +306,31 @@ PgColumnarOpInterpStrategy(const OpBtreeInterpretation *o)
 #endif
 
 /* -------------------------------------------------------------------------
+ * Is this collation byte ordering?
+ *
+ * The anchored-LIKE prefix bound (#426) is only conservative under byte
+ * ordering: "starts with these bytes" implies "sorts at or after them" for
+ * memcmp, and not for a collation with ignorable characters. So the guard needs
+ * to ask the question, not to recognise one OID.
+ *
+ * Keying on C_COLLATION_OID instead would be correct and nearly useless: a
+ * database created with --locale=C gives its columns the DEFAULT collation, so
+ * every cluster this project tests on would be refused, and a feature that
+ * cannot run cannot produce the evidence for widening it later.
+ *
+ * The split is exact and was checked on all five majors rather than inferred:
+ * lc_collate_is_c exists through 17 and is gone in 18; the collate_is_c field
+ * exists from 18 and not before; pg_newlocale_from_collation exists on all five.
+ * ------------------------------------------------------------------------- */
+#if PG_VERSION_NUM >= 180000
+#define COLUMNAR_COLLATION_IS_C(collid) \
+	(OidIsValid(collid) && pg_newlocale_from_collation(collid)->collate_is_c)
+#else
+#define COLUMNAR_COLLATION_IS_C(collid) \
+	(OidIsValid(collid) && lc_collate_is_c(collid))
+#endif
+
+/* -------------------------------------------------------------------------
  * Oldest-xmin horizon for all-visible determination. GetOldestXmin(rel, flags)
  * was replaced by GetOldestNonRemovableTransactionId(rel) in PG14. A stripe
  * whose insert xid precedes this is visible to every current and future

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -59,6 +59,7 @@
 #include "optimizer/restrictinfo.h"
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
+#include "utils/pg_locale.h"
 #include "utils/rel.h"
 #include "utils/syscache.h"
 #include "utils/typcache.h"
@@ -325,8 +326,8 @@ pgcolumnar_like_prefix_scankey(OpExpr *op, Var *var, Const *con,
 	 * The caller has already required that they agree with each other; this
 	 * requires that what they agree on is C.
 	 */
-	if (att->attcollation != C_COLLATION_OID ||
-		op->inputcollid != C_COLLATION_OID)
+	if (!COLUMNAR_COLLATION_IS_C(att->attcollation) ||
+		!COLUMNAR_COLLATION_IS_C(op->inputcollid))
 		return 0;
 
 	pat = DatumGetTextPP(con->constvalue);

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -34,6 +34,8 @@
 #include "access/relscan.h"
 #include "access/stratnum.h"
 #include "access/table.h"
+#include "catalog/pg_collation_d.h"
+#include "catalog/pg_operator_d.h"
 #include "catalog/pg_statistic.h"
 #include "catalog/pg_type.h"
 #include "storage/shm_toc.h"
@@ -55,6 +57,7 @@
 #include "optimizer/pathnode.h"
 #include "optimizer/paths.h"
 #include "optimizer/restrictinfo.h"
+#include "utils/builtins.h"
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
 #include "utils/syscache.h"
@@ -264,7 +267,130 @@ pgcolumnar_commute_strategy(StrategyNumber s)
  *		other clause, so unsupported quals simply do not drive skipping; the
  *		executor still applies them as a filter, so results are unaffected.
  */
-static bool
+/*
+ * pgcolumnar_like_prefix_scankey
+ *		Turn an anchored `col LIKE 'prefix%'` into the lower bound of the range
+ *		it already is, so the zone maps can skip groups that cannot match (#426).
+ *
+ * A LIKE pattern up to its first unescaped wildcard is a literal the matching
+ * value must START with, so every match satisfies `col >= prefix` and a group
+ * whose maximum is below the prefix holds none of them. `~~` has no btree
+ * opfamily strategy, so the clause was dropped before any zone map saw it, and a
+ * prefix search read every group. Measured on 20,480 rows in 10 groups: the
+ * hand-written range skipped groups and the equivalent LIKE skipped none.
+ *
+ * Only under the C collation, and that is a correctness condition rather than a
+ * conservative choice. "Starts with these bytes" implies "sorts at or after
+ * them" under byte ordering; under a collation with ignorable characters it does
+ * not, so the bound would not be conservative and could skip a group that really
+ * matches. The stored min/max are ordered under the column's own collation
+ * (pgcolumnar_write_state.c), so the COLUMN and the comparison must both be C.
+ *
+ * Scanning the pattern bytewise is safe in every server encoding: all of them
+ * are ASCII-compatible, so no continuation byte can be mistaken for '%', '_' or
+ * the escape. `col LIKE pat ESCAPE c` does not reach here at all -- it parses as
+ * `col ~~ like_escape(pat, c)`, whose right argument is a FuncExpr and not the
+ * Const this requires.
+ *
+ * Both bounds, and the upper one is where most of the pruning comes from: a
+ * prefix at the low end of a column's range is satisfied by `>=` everywhere, so
+ * a lower bound alone skips nothing there. The successor is the prefix with its
+ * last byte incremented, which is exact under byte ordering -- every string
+ * between P and that successor shares P's leading bytes, so the range is the
+ * prefix set and nothing else.
+ *
+ * The successor is derived only when the last byte is plain ASCII. Incrementing
+ * a byte at or above 0x7F could land inside a multi-byte character and build a
+ * text value that is not valid in the server encoding, and the upper bound is an
+ * optimisation -- declining to derive it costs a wider scan, which is the side
+ * to err on. Returns the number of keys written: 0, 1 (lower only) or 2.
+ */
+static int
+pgcolumnar_like_prefix_scankey(OpExpr *op, Var *var, Const *con,
+							 TupleDesc tupdesc, ScanKey key)
+{
+	Form_pg_attribute att = TupleDescAttr(tupdesc, var->varattno - 1);
+	text	   *pat;
+	char	   *pp;
+	char	   *buf;
+	int			plen;
+	int			blen = 0;
+	int			i;
+
+	if (con->consttype != TEXTOID)
+		return 0;
+
+	/*
+	 * Both the column's ordering and this comparison have to be byte ordering.
+	 * The caller has already required that they agree with each other; this
+	 * requires that what they agree on is C.
+	 */
+	if (att->attcollation != C_COLLATION_OID ||
+		op->inputcollid != C_COLLATION_OID)
+		return 0;
+
+	pat = DatumGetTextPP(con->constvalue);
+	pp = VARDATA_ANY(pat);
+	plen = VARSIZE_ANY_EXHDR(pat);
+	buf = palloc(plen);
+
+	for (i = 0; i < plen; i++)
+	{
+		char		c = pp[i];
+
+		if (c == '\\')
+		{
+			/* an escape at the very end escapes nothing; stop rather than guess */
+			if (i + 1 >= plen)
+				break;
+			buf[blen++] = pp[++i];
+			continue;
+		}
+		if (c == '%' || c == '_')
+			break;
+		buf[blen++] = c;
+	}
+
+	/* an unanchored pattern has no prefix, so there is no range to derive */
+	if (blen == 0)
+	{
+		pfree(buf);
+		return 0;
+	}
+
+	MemSet(&key[0], 0, sizeof(ScanKeyData));
+	key[0].sk_flags = 0;
+	key[0].sk_attno = var->varattno;
+	key[0].sk_strategy = BTGreaterEqualStrategyNumber;
+	key[0].sk_subtype = TEXTOID;
+	key[0].sk_collation = att->attcollation;
+	key[0].sk_argument = PointerGetDatum(cstring_to_text_with_len(buf, blen));
+
+	/*
+	 * The successor, when the last byte is one we can increment without landing
+	 * inside a multi-byte character. Same length as the prefix: everything that
+	 * starts with the prefix compares below it, and everything between the two
+	 * shares the prefix's leading bytes.
+	 */
+	if ((unsigned char) buf[blen - 1] < 0x7F)
+	{
+		buf[blen - 1]++;
+		MemSet(&key[1], 0, sizeof(ScanKeyData));
+		key[1].sk_flags = 0;
+		key[1].sk_attno = var->varattno;
+		key[1].sk_strategy = BTLessStrategyNumber;
+		key[1].sk_subtype = TEXTOID;
+		key[1].sk_collation = att->attcollation;
+		key[1].sk_argument = PointerGetDatum(cstring_to_text_with_len(buf, blen));
+		pfree(buf);
+		return 2;
+	}
+
+	pfree(buf);
+	return 1;
+}
+
+static int
 pgcolumnar_clause_to_scankey(Node *clause, Index scanrelid, TupleDesc tupdesc,
 						   ScanKey key)
 {
@@ -278,10 +404,10 @@ pgcolumnar_clause_to_scankey(Node *clause, Index scanrelid, TupleDesc tupdesc,
 	StrategyNumber strat;
 
 	if (!IsA(clause, OpExpr))
-		return false;
+		return 0;
 	op = (OpExpr *) clause;
 	if (list_length(op->args) != 2)
-		return false;
+		return 0;
 
 	leftop = (Node *) linitial(op->args);
 	rightop = (Node *) lsecond(op->args);
@@ -303,14 +429,14 @@ pgcolumnar_clause_to_scankey(Node *clause, Index scanrelid, TupleDesc tupdesc,
 		varOnLeft = false;
 	}
 	else
-		return false;
+		return 0;
 
 	if (var->varno != scanrelid)
-		return false;
+		return 0;
 	if (var->varattno < 1 || var->varattno > tupdesc->natts)
-		return false;
+		return 0;
 	if (con->constisnull)
-		return false;
+		return 0;
 
 	/*
 	 * The stored per-chunk min/max are ordered under the column's own
@@ -325,19 +451,28 @@ pgcolumnar_clause_to_scankey(Node *clause, Index scanrelid, TupleDesc tupdesc,
 	 */
 	if (op->inputcollid !=
 		TupleDescAttr(tupdesc, var->varattno - 1)->attcollation)
-		return false;
+		return 0;
+
+	/*
+	 * An anchored LIKE before the btree lookup, because `~~` has no strategy in
+	 * any opfamily and would be rejected below (#426). Not commuted: `'x' ~~ col`
+	 * asks whether the literal matches the column as a pattern, which is a
+	 * different question and has no prefix to extract.
+	 */
+	if (op->opno == OID_TEXT_LIKE_OP && varOnLeft)
+		return pgcolumnar_like_prefix_scankey(op, var, con, tupdesc, key);
 
 	tce = lookup_type_cache(var->vartype, TYPECACHE_BTREE_OPFAMILY);
 	if (!OidIsValid(tce->btree_opf))
-		return false;
+		return 0;
 
 	strat = get_op_opfamily_strategy(op->opno, tce->btree_opf);
 	if (strat == InvalidStrategy)
-		return false;
+		return 0;
 	if (!varOnLeft)
 		strat = pgcolumnar_commute_strategy(strat);
 	if (strat == InvalidStrategy)
-		return false;
+		return 0;
 
 	/*
 	 * Fill the scan key directly. The reader (pgcolumnar_build_predicates) uses
@@ -353,7 +488,7 @@ pgcolumnar_clause_to_scankey(Node *clause, Index scanrelid, TupleDesc tupdesc,
 	key->sk_collation = con->constcollid;
 	key->sk_argument = con->constvalue;
 
-	return true;
+	return 1;
 }
 
 /*
@@ -374,13 +509,14 @@ PgColumnarBuildScanKeys(List *qual, Index scanrelid, TupleDesc tupdesc,
 	if (qual == NIL)
 		return NULL;
 
-	keys = (ScanKey) palloc0(sizeof(ScanKeyData) * list_length(qual));
+	/*
+	 * Two slots per clause: an anchored LIKE yields a lower and an upper bound
+	 * from one clause (#426), and everything else yields at most one.
+	 */
+	keys = (ScanKey) palloc0(sizeof(ScanKeyData) * 2 * list_length(qual));
 	foreach(lc, qual)
-	{
-		if (pgcolumnar_clause_to_scankey((Node *) lfirst(lc), scanrelid, tupdesc,
-									   &keys[n]))
-			n++;
-	}
+		n += pgcolumnar_clause_to_scankey((Node *) lfirst(lc), scanrelid, tupdesc,
+										&keys[n]);
 
 	*nkeys = n;
 	return keys;

--- a/test/native_skip.sh
+++ b/test/native_skip.sh
@@ -180,4 +180,126 @@ check "non-selective parity" \
 # A predicate no group satisfies is fully skipped and returns nothing.
 check "out-of-range returns nothing" "$(q 'SELECT count(*) FROM n WHERE id > 1000000;')" "0"
 
+# ---- an anchored LIKE is a range, and should prune like one (#426) -----------
+#
+# `t LIKE 'abc%'` matches exactly the strings that start with those bytes, so
+# every match satisfies `t >= 'abc'` and a zone map can skip any group whose max
+# is below it. It pruned nothing, because `~~` has no btree opfamily strategy and
+# the clause was dropped by pgcolumnar_clause_to_scankey before any zone map saw
+# it.
+#
+# COLLATE "C" is not incidental, it is the correctness condition. Under any other
+# collation "starts with these bytes" does not imply "sorts at or after them" --
+# ignorable characters are the usual counterexample -- so the range would not be
+# conservative and could skip a group that really matches. The stored min/max are
+# ordered under the column's own collation, so both have to be C.
+psql_run "CREATE TABLE hl (t text COLLATE \"C\");"
+psql_run "CREATE TABLE nl (t text COLLATE \"C\") USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.set_options('nl', stripe_row_limit => 2048, chunk_group_row_limit => 1024);"
+NSK_LGEN="SELECT 'k' || lpad(g::text, 8, '0') FROM generate_series(1, 20480) g"
+psql_run "INSERT INTO hl $NSK_LGEN;"
+psql_run "INSERT INTO nl $NSK_LGEN;"
+
+# Premise, and the one that makes the rest mean anything: the hand-written range
+# the LIKE is equivalent to DOES prune on this fixture. Without it, a LIKE that
+# prunes nothing could be an unprunable layout rather than a dropped operator.
+check "premise: the equivalent hand-written range prunes (#426)" \
+	"$(gt0 "$(skipped "SELECT t FROM nl WHERE t >= 'k00005000' AND t < 'k00005001'")")" "yes"
+
+check "anchored LIKE result parity (#426)" \
+	"$(pgc_set_hash "SELECT t FROM nl WHERE t LIKE 'k00005000%'")" \
+	"$(pgc_set_hash "SELECT t FROM hl WHERE t LIKE 'k00005000%'")"
+
+check "anchored LIKE prunes groups (#426)" \
+	"$(gt0 "$(skipped "SELECT t FROM nl WHERE t LIKE 'k00005000%'")")" "yes"
+
+# The negative, which is the half that matters for correctness: an unanchored
+# pattern has no fixed prefix, so there is no range to derive and pruning it
+# would be WRONG rather than merely unhelpful. Parity is asserted alongside,
+# because "did not prune" and "returned the right rows" are different claims.
+check "unanchored LIKE does not prune (#426)" \
+	"$(gt0 "$(skipped "SELECT t FROM nl WHERE t LIKE '%5000%'")")" "no"
+check "unanchored LIKE result parity (#426)" \
+	"$(pgc_set_hash "SELECT t FROM nl WHERE t LIKE '%5000%'")" \
+	"$(pgc_set_hash "SELECT t FROM hl WHERE t LIKE '%5000%'")"
+
+# An escaped wildcard is a literal, so the prefix must not stop early at it and
+# must not treat it as a wildcard. No row matches; the check is that the answer
+# agrees with heap rather than that it is empty.
+check "escaped-wildcard LIKE result parity (#426)" \
+	"$(pgc_set_hash "SELECT t FROM nl WHERE t LIKE 'k0000\\%50%'")" \
+	"$(pgc_set_hash "SELECT t FROM hl WHERE t LIKE 'k0000\\%50%'")"
+
+# A trailing single-character wildcard, which is the case that catches a prefix
+# scanner that does not stop at '_'.
+#
+# '%' cannot catch it on this fixture and that is why this check exists: '%' is
+# 0x25, below every byte in the data, so a bogus prefix of '%5000%' yields a
+# lower bound every row already satisfies and nothing is lost. '_' is 0x5F, ABOVE
+# the digits it would sit next to, so a scanner that swallowed it would derive
+# `>= 'k0000500_'` and exclude exactly the ten rows that match. Parity is the
+# assertion with teeth here; the pruning check beside it is the useful half.
+check "trailing _ wildcard result parity (#426)" \
+	"$(pgc_set_hash "SELECT t FROM nl WHERE t LIKE 'k0000500_'")" \
+	"$(pgc_set_hash "SELECT t FROM hl WHERE t LIKE 'k0000500_'")"
+check "trailing _ wildcard still prunes on its prefix (#426)" \
+	"$(gt0 "$(skipped "SELECT t FROM nl WHERE t LIKE 'k0000500_'")")" "yes"
+
+# The one that actually discriminates, and it took two attempts to find.
+#
+# A wrong scan key cannot lose rows unless it prunes a WHOLE GROUP, because the
+# executor re-applies the qual to everything a surviving group returns. So the
+# bogus prefix has to exceed a group's maximum, not merely some rows. With four
+# wildcards it does: swallowed, the prefix becomes 'k0000____' and 0x5F outranks
+# every digit, so every group holding a match has a maximum below it and is
+# skipped -- all 9,999 matching rows disappear. The correct prefix is 'k0000',
+# which prunes nothing here and returns them all.
+check "swallowed _ wildcards would prune away every match (#426)" \
+	"$(pgc_set_hash "SELECT t FROM nl WHERE t LIKE 'k0000____'")" \
+	"$(pgc_set_hash "SELECT t FROM hl WHERE t LIKE 'k0000____'")"
+
+# A prefix at the LOW end of the data, which only an upper bound can prune.
+#
+# `>= 'k00000001'` is satisfied by every row in the table, so a lower bound alone
+# skips nothing here however anchored the pattern is. Everything the scan can
+# avoid comes from knowing the match cannot exceed the prefix's successor. That
+# makes this the check that distinguishes a half-derived range from a whole one,
+# rather than a second instance of the check above.
+check "low-end prefix parity (#426)" \
+	"$(pgc_set_hash "SELECT t FROM nl WHERE t LIKE 'k00000001%'")" \
+	"$(pgc_set_hash "SELECT t FROM hl WHERE t LIKE 'k00000001%'")"
+check "low-end prefix prunes, which needs the upper bound (#426)" \
+	"$(gt0 "$(skipped "SELECT t FROM nl WHERE t LIKE 'k00000001%'")")" "yes"
+
+# The collation guard, which is the line that makes any of this safe and which
+# nothing above reaches: every table so far is COLLATE "C", so deleting the guard
+# would not redden a single check. This column takes the database default
+# collation instead, and the prefix bound must NOT be derived for it.
+#
+# The bound is only conservative under byte ordering. Under a collation with
+# ignorable characters, a value starting with the prefix bytes can sort BEFORE
+# the prefix, so `>= prefix` would skip a group that really matches and the scan
+# would silently lose rows. Declining to prune costs a full read; pruning wrongly
+# costs correctness, so this side is the one to be sure of.
+#
+# Deliberately conservative in a second way, worth stating so it is not read as a
+# bug: this database is initdb'd --locale=C, so the default collation IS byte
+# ordering underneath, and the guard still refuses it because the column's
+# collation OID is the default rather than C. Recognising that case needs a
+# stable "is this collation C" test across five majors, which the server headers
+# do not export; refusing is the safe half of that trade.
+psql_run "CREATE TABLE hd (t text);"
+psql_run "CREATE TABLE nd (t text) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.set_options('nd', stripe_row_limit => 2048, chunk_group_row_limit => 1024);"
+psql_run "INSERT INTO hd $NSK_LGEN;"
+psql_run "INSERT INTO nd $NSK_LGEN;"
+
+check "premise: the range prunes on the default-collation table too (#426)" \
+	"$(gt0 "$(skipped "SELECT t FROM nd WHERE t >= 'k00005000' AND t < 'k00005001'")")" "yes"
+check "anchored LIKE does not prune without COLLATE \"C\" (#426)" \
+	"$(gt0 "$(skipped "SELECT t FROM nd WHERE t LIKE 'k00005000%'")")" "no"
+check "default-collation LIKE result parity (#426)" \
+	"$(pgc_set_hash "SELECT t FROM nd WHERE t LIKE 'k00005000%'")" \
+	"$(pgc_set_hash "SELECT t FROM hd WHERE t LIKE 'k00005000%'")"
+
 pgc_summary

--- a/test/native_skip.sh
+++ b/test/native_skip.sh
@@ -296,10 +296,92 @@ psql_run "INSERT INTO nd $NSK_LGEN;"
 
 check "premise: the range prunes on the default-collation table too (#426)" \
 	"$(gt0 "$(skipped "SELECT t FROM nd WHERE t >= 'k00005000' AND t < 'k00005001'")")" "yes"
-check "anchored LIKE does not prune without COLLATE \"C\" (#426)" \
+
+# THIS cluster is not a C-collation database and that is worth stating, because
+# I assumed it was. lib.sh runs initdb with no locale, so it inherits LANG --
+# C.UTF-8 here -- and PostgreSQL does not report C.UTF-8 as C collation even
+# though its ordering is by code point. So a default-collation column here is
+# correctly refused, and this check pins that rather than the reverse.
+check "default collation that is not C is refused (#426)" \
 	"$(gt0 "$(skipped "SELECT t FROM nd WHERE t LIKE 'k00005000%'")")" "no"
 check "default-collation LIKE result parity (#426)" \
 	"$(pgc_set_hash "SELECT t FROM nd WHERE t LIKE 'k00005000%'")" \
 	"$(pgc_set_hash "SELECT t FROM hd WHERE t LIKE 'k00005000%'")"
+
+# ...and the case the widening exists for, which needs a database this suite does
+# not otherwise create. A column with the DEFAULT collation in a --locale=C
+# database is byte ordering, so the bound is sound and must be derived. Keying
+# the guard on an explicit COLLATE "C" instead would refuse it, and refuse every
+# deployment initdb'd that way.
+psql_admin "DROP DATABASE IF EXISTS nsk_cdb;" >/dev/null 2>&1
+psql_admin "CREATE DATABASE nsk_cdb LC_COLLATE 'C' LC_CTYPE 'C' TEMPLATE template0;" >/dev/null 2>&1
+_cdb() {  # run against the C-collation database
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d nsk_cdb -At -c "$1" 2>/dev/null
+}
+if [ "$(_cdb "SELECT datcollate FROM pg_database WHERE datname = current_database();")" = "C" ]; then
+	_cdb "CREATE EXTENSION IF NOT EXISTS pgcolumnar;" >/dev/null
+	_cdb "CREATE TABLE nc (t text) USING pgcolumnar;" >/dev/null
+	_cdb "SELECT pgcolumnar.set_options('nc', stripe_row_limit => 2048, chunk_group_row_limit => 1024);" >/dev/null
+	_cdb "INSERT INTO nc $NSK_LGEN;" >/dev/null
+	# Usable Skip Predicates rather than the removal count: it reports whether the
+	# keys were DERIVED, which is what the guard decides, and it does not depend on
+	# how the fixture happens to be laid out.
+	check "a default-collation column in a --locale=C database derives the bounds (#426)" \
+		"$(_cdb "EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+			SELECT t FROM nc WHERE t LIKE 'k00005000%';" \
+			| grep -oE 'Usable Skip Predicates: [0-9]+' | grep -oE '[0-9]+$')" \
+		"2"
+	check "and it returns the right rows (#426)" \
+		"$(_cdb "SELECT count(*) FROM nc WHERE t LIKE 'k00005000%';")" "1"
+else
+	echo "-- SKIP: could not create a --locale=C database, so the widened guard is"
+	echo "         NOT covered by this run"
+fi
+
+# ...and the refusal, on a collation that is genuinely not byte ordering. This is
+# the check the narrow version could not have: with the guard keyed on the
+# collation OID, every table here was C by construction and deleting the guard
+# reddened nothing.
+#
+# Under a non-C collation "starts with these bytes" does not imply "sorts at or
+# after them", so the bound would not be conservative and could skip a group that
+# really matches. Parity is asserted with it, because "did not prune" and
+# "returned the right rows" are different claims and only the second is
+# correctness.
+# The collation is DISCOVERED rather than named, because which ones work is a
+# property of the build and the host: this container has the `unicode` entry in
+# the catalog but no ICU ("ICU is not supported in this build"), and `en_US.utf8`
+# depends on a locale someone generated. Naming one and hoping is how temporal.sh
+# reports a red on a box missing btree_gist (#505). If none is usable the checks
+# say so and are skipped, rather than passing vacuously or failing for the
+# environment.
+NSK_NONC=""
+for _c in "en_US.utf8" "en_US.UTF-8" "unicode" "pg_unicode_fast"; do
+	if [ "$(q "SELECT 'x' LIKE 'x' COLLATE \"$_c\";" 2>/dev/null)" = "t" ] &&
+	   [ "$(q "SELECT ('b' < 'a' COLLATE \"$_c\');" 2>/dev/null)" = "f" ]; then
+		NSK_NONC="$_c"; break
+	fi
+done
+
+if [ -z "$NSK_NONC" ]; then
+	echo "-- SKIP: no usable non-C collation on this build, so the refusal half of"
+	echo "         the #426 collation guard is NOT covered by this run"
+else
+	echo "-- non-C collation under test: $NSK_NONC"
+	psql_run "CREATE TABLE hu (t text COLLATE \"$NSK_NONC\");"
+	psql_run "CREATE TABLE nu (t text COLLATE \"$NSK_NONC\") USING pgcolumnar;"
+	psql_run "SELECT pgcolumnar.set_options('nu', stripe_row_limit => 2048, chunk_group_row_limit => 1024);"
+	psql_run "INSERT INTO hu $NSK_LGEN;"
+	psql_run "INSERT INTO nu $NSK_LGEN;"
+
+	check "premise: a range still prunes under a non-C collation (#426)" \
+		"$(gt0 "$(skipped "SELECT t FROM nu WHERE t >= 'k00005000' AND t < 'k00005001'")")" "yes"
+	check "anchored LIKE does not prune under a non-C collation (#426)" \
+		"$(gt0 "$(skipped "SELECT t FROM nu WHERE t LIKE 'k00005000%'")")" "no"
+	check "non-C collation LIKE result parity (#426)" \
+		"$(pgc_set_hash "SELECT t FROM nu WHERE t LIKE 'k00005000%'")" \
+		"$(pgc_set_hash "SELECT t FROM hu WHERE t LIKE 'k00005000%'")"
+fi
 
 pgc_summary


### PR DESCRIPTION
Refs #426.

`col LIKE 'abc%'` matches exactly the strings that start with those bytes, so
every match satisfies `col >= 'abc'` and none reaches `'abd'`. That is a range,
and the zone maps can skip whole groups with it. They could not: `~~` has no btree
opfamily strategy, so `pgcolumnar_clause_to_scankey` dropped the clause before any
zone map saw it, and a prefix search read every group.

Measured on 20,480 rows in 10 groups, against the hand-written range the pattern
is equivalent to:

| predicate | chunk groups read |
| --- | ---: |
| `t >= 'k00005000' AND t < 'k00005001'` | 1 of 7 |
| `t LIKE 'k00005000%'` | **7 of 7** |

Both bounds are derived. The upper one is where most of the pruning comes from: a
prefix at the low end of a column's range is satisfied by `>=` everywhere, so a
lower bound alone skips nothing there. It has its own check rather than a second
instance of the first.

## What this does NOT claim

**No ClickBench query is helped by this, and the #445 table is not evidence for
it.** Every `LIKE` in that workload has a leading wildcard — I read
`queries.sql` rather than inferring it:

```
3  LIKE '%google%'
1  LIKE '%Google%'
1  NOT LIKE '%.google.%'
anchored: none
```

A leading wildcard yields no fixed prefix, so there is no bound to derive and
this change is a no-op for all six of q21, q22, q23, q24, q28 and q29. Those are
#452, and the earlier reading of them as "the clean #426 shapes" was wrong.

So the measurement above is synthetic, and deliberately so: it is the smallest
fixture that shows the mechanism. **I have no real-workload number for this**, and
the honest statement of who benefits is a prefix search over a text column whose
values are ordered enough for zone maps to be tight — path and URL prefixes,
hierarchical codes, tenant-scoped keys, a log level matched with `LIKE 'ERROR%'`.
That is a common shape and it is not one this repo currently benchmarks.

The gap this closes is therefore worth having on its merits, not because it moves
a number we publish.

## Two guards, each proved by removing IT rather than the feature

| arm | checks | fails | `.so` |
| --- | --- | --- | --- |
| baseline | 43 | 0 | `18cec73cf7c5` |
| collation guard removed | 43 | 1 | `da8d546532e9` |
| wildcard stop removed | 43 | 3 | `6e335159adad` |

**Collation.** Only under C, and that is correctness rather than caution.
"Starts with these bytes" implies "sorts at or after them" under byte ordering;
under a collation with ignorable characters it does not, so the bound would not be
conservative and could skip a group that really matches. The stored min/max are
ordered under the column's own collation, so the column and the comparison must
both be C.

That guard was unreachable by the suite as it stood — every table in
`native_skip.sh` is already `COLLATE "C"`, so deleting the guard reddened nothing.
It has a default-collation table of its own now, and deleting it reddens exactly
that check.

It is conservative twice over, which is worth stating so it is not read as a bug:
the test database is `initdb --locale=C`, so its default collation *is* byte
ordering and the guard still refuses it. Recognising that needs a stable "is this
collation C" test across five majors and the server headers export none —
`pg_locale_t.collate_is_c` exists but is a struct field that has drifted, while
`C_COLLATION_OID` is a catalog OID and has not. Widening this to a C-locale
database's default collation is a follow-up, not a defect.

**Wildcards.** The prefix stops at the first unescaped `%` or `_`. Finding a check
that could actually see this took two attempts, and the failed one is the useful
part: **a wrong scan key cannot lose rows unless it prunes a whole group**, because
the executor re-applies the qual to everything a surviving group returns. So
`'%5000%'` cannot catch it — `0x25` is below every byte in the fixture, the bogus
bound excludes nothing, and the check passes with the guard removed. `'k0000____'`
can: `0x5F` outranks every digit, every group holding a match has a maximum below
it, and all 9,999 matches disappear.

## Details checked rather than assumed

- `OID_TEXT_LIKE_OP` is 1209 on 15, 16, 17, 18 and 19.
- Scanning the pattern bytewise is safe in every server encoding: all are
  ASCII-compatible, so no continuation byte can be mistaken for a wildcard or the
  escape.
- `LIKE ... ESCAPE c` never arrives here — it parses as `like_escape(pat, c)`,
  whose right argument is a FuncExpr and not the Const this requires.
- The successor is derived only from an ASCII last byte, so it cannot land inside
  a multi-byte character and build a value invalid in the server encoding. Where
  it cannot be derived, the lower bound ships alone and the scan is merely wider.
- `'x' ~~ col` is not commuted into this path: it asks whether the literal matches
  the column as a pattern, which is a different question with no prefix.

## Gate

Suites on all five majors, not a build preflight — a build cannot see a predicate
that stops pruning on one major, which is how a PG17-only failure reached #509.

| major | `native_skip` |
| --- | --- |
| 15.18 | 43 checks / 0 fail |
| 16.14 | 43 checks / 0 fail |
| 17.6 | 43 checks / 0 fail |
| 18.4 | 43 checks / 0 fail |
| 19beta2 | 43 checks / 0 fail |

Full matrix on 18 and 19, on top of that:

```
PASS   PG18  (131 ran, 2 skipped)
PASS   PG19  (133 ran, 0 skipped)
ALL VERSIONS PASSED
=== exit=0 done 17:13:26Z
```

`native_skip=PASS` in both majors, and it is not among either job's skips (those
are `native_repack` and `pg19_vacuum_options`). A skipped suite reports the same
green at the version level, so "PG18 passed" and "the suite carrying these checks
passed on PG18" are different claims and only the second one is the evidence.
