### PR TITLE
feat: late materialization, phase 1a — build the qual's columns first (#452)

### DIFF
--- a/design/ISSUE_452_LATE_MATERIALIZATION.md
+++ b/design/ISSUE_452_LATE_MATERIALIZATION.md
@@ -1,0 +1,182 @@
+# Issue #452: late materialization
+
+Decode cost scales with rows scanned rather than rows emitted. This is the plan,
+written before any code, per the house rule.
+
+Status: **plan only, nothing implemented.** Read `CONTEXT.md` first for the
+vocabulary; note especially that a stripe is a row group and that EXPLAIN's
+"Chunk Groups" counters count ROW groups.
+
+## What is actually there today, verified in the source
+
+Established by reading, not assumed. Line numbers are `main` at `ed28c32`.
+
+- **A chunk is one (row group, column).** `NativeColumnChunkMetadata`
+  (`columnar.h:254`) carries `groupNumber` and `columnIndex` and **no chunk-group
+  index**. There is no smaller addressable unit on disk than a column's whole
+  row group.
+- **Columns are independently addressable.** The group loader builds per-chunk
+  byte ranges and skips unwanted columns before reading
+  (`columnar_reader.c:1271`), so column projection already avoids I/O.
+- **A chunk's payload is per-1024-value vector streams concatenated, then
+  block-compressed as a whole** (`pgcolumnar_native_decode_chunk`, `:647`).
+  Decode reverses the codec once, then decodes each vector separately. So
+  **vectors are individually decodable after decompression**, and the FSST
+  shared symbol table is a chunk-level trailing region that is available to every
+  vector once the descriptor is parsed.
+- **Per-vector skipping already exists** (Phase D5b, `:1115`) and already avoids
+  *decode*: `nativeSkipVec[v]` marks a vector ruled out, and `nativeVecRawLen`
+  steps the value cursor past it, so its rows are "neither decoded nor emitted"
+  (`:137-144`).
+- **But it is driven only by per-vector zone maps.** `build_skipvec` rules a
+  vector out when a predicate's min/max proves no row can match. Nothing
+  evaluates the predicate against decoded values.
+- **Reader predicates are btree-only.** `SkipPredicate` (`columnar_reader.c`)
+  holds a strategy, a constant and a comparison function. `URL LIKE '%google%'`
+  is never a `SkipPredicate`, so for q24 `numPredicates` is **0** and no
+  reader-level mechanism can help it at all.
+
+## Three separable costs, and only one needs a format change
+
+The issue treats decode as one cost. It is three, with different fixes:
+
+| cost | granularity available today | needs format change |
+| --- | --- | --- |
+| 1. block-codec decompression | whole chunk (row group x column) | **yes** |
+| 2. per-vector decode | 1024 rows, already skippable | no |
+| 3. per-row materialization (deform, palloc+memcpy per varlena) | per row | no |
+
+The scoping comment on the issue costed only a fix for **cost 1** (Route A,
++169% storage; Route B, +29-58%) and correctly called that an owner decision.
+**Costs 2 and 3 are the larger share for wide text and need no format change**,
+so the owner decision is not on the critical path and should not block this.
+
+## Phase 1a: qual-column-first materialization (the heap analogue)
+
+This is the one that fixes q24 and it does not live in the reader.
+
+Heap's advantage, stated exactly in the issue: `slot_deform_heap_tuple` stops at
+the qual's attribute for rejected rows and pays the full 105-attribute deform
+only for survivors. The analogue here:
+
+1. Split the projected columns into **qual columns** (those referenced by the
+   node's qual) and **payload columns** (the rest of the targetlist).
+2. Materialize qual columns only, per row.
+3. Run `ExecQual`.
+4. Materialize payload columns **only for rows that survive**.
+
+Properties worth stating because they decide the design:
+
+- **It works for any qual, including ones that cannot be pushed down.** The
+  custom scan holds the qual as an `ExprState` regardless of whether the reader
+  would admit it as a `SkipPredicate`. This is why it, and not the reader route,
+  is what reaches q24.
+- It is orthogonal to #426. #426 makes text predicates *prunable*; this makes
+  them *cheap to evaluate*. Either helps; together they compound.
+- For fixed-width by-value columns, positional access into the decoded raw
+  buffer is `row * attlen`. For varlena the cursor must still be walked to
+  advance, but walking a length prefix is not the cost — the cost is the
+  `MemoryContextAlloc` plus memcpy per value, and that is what gets skipped.
+
+### Corrected after reading the producer: no batching, and no random access
+
+The paragraph below was written before tracing the code and is **wrong in a way
+that made 1a look harder than it is.** Recorded rather than deleted, because the
+correction is the useful part.
+
+Each column carries its **own** cursor — `nativeValueCursor[natts]`
+(`columnar_reader.c:135`), advanced per column inside the per-row loop. The order
+in which columns are visited *within a row* is therefore free. So 1a needs
+neither a batch restructure nor random access:
+
+1. Visit the **qual columns** for this row, decoding their values.
+2. `ExecQual`.
+3. On false: **advance the payload cursors without decoding** and move to the
+   next row. For a by-value column that is `+= attlen`; for a varlena it is
+   reading a length prefix and adding it — no `MemoryContextAlloc`, no memcpy,
+   which is the cost being removed.
+4. On true: decode the payload columns normally and return the row.
+
+`rs->rowInGroup` is shared and must not advance until both phases are done, which
+is the only sequencing constraint.
+
+This is exactly heap's `slot_deform_heap_tuple` behaviour: stop at the qual's
+attribute for rejected rows, pay the full deform only for survivors.
+
+**Where the qual is evaluated today, and what has to change.**
+`PgColumnarExecCustomScan` delegates to core's `ExecScan`
+(`columnar_customscan.c:1763`), which calls `PgColumnarScanNext` for a **fully
+materialized** tuple and only then applies the qual. So 1a moves qual evaluation
+inside `PgColumnarScanNext`, which loops until a row passes.
+
+**Consequence that needs a guard:** core's `ExecScan` will then evaluate the same
+qual a second time on the returned tuple. Harmless for an immutable qual, wrong
+for a volatile one, which would be evaluated twice per surviving row. So 1a is
+enabled only when `contain_volatile_functions()` is false for the qual, and that
+guard needs its own test.
+
+**Superseded, kept for the record:** the reason this looked harder — the reader
+currently exposes a per-row sequential producer that fills `values[]`/`nulls[]`
+for all wanted columns in one pass (`:1640-1690`). Phase 1a needs that split into
+two passes over the same decoded group. The cursors are per column
+(`nativeValueCursor[]`), so a second pass is feasible, but a varlena payload
+column cannot be re-walked from an arbitrary row without either retaining
+per-row offsets or walking from the vector boundary. Retaining per-vector start
+offsets already exists (`nativeVecStart`); per-row offsets within a vector do
+not. **Walking from the vector start (at most 1023 length-prefix steps, no
+copies) is the cheap answer and should be measured before anything more clever.**
+
+## Phase 1b: exact selection feedback into the existing skip vector
+
+Cheap, additive, and it fixes the issue's own headline test case.
+
+Where a predicate *is* admitted as a `SkipPredicate`, evaluate it against the
+decoded qual column and extend `nativeSkipVec` from "zone maps could not rule
+this vector out" to "no row in this vector actually matched". Payload columns
+then skip decode for those vectors through the machinery that already exists.
+
+This is what makes the issue's stated acceptance check pass:
+
+- `clienttimezone = 3600` matches zero rows of 11,110,833 but lies inside every
+  min/max, so today every vector is admitted and all 105 columns are decoded.
+  With exact feedback, zero vectors survive and the payload columns are never
+  decoded.
+- It does nothing for q24, whose qual is not a `SkipPredicate`. That is Phase 1a.
+
+## Phase 2: per-vector compression blocks (deferred, owner decision)
+
+Only needed to avoid cost 1. Route B (+29-58% storage) keeps the codec and makes
+vectors independently decompressible. **Not required for Phases 1a/1b**, and it
+should be re-costed after them, because if 1a and 1b remove most of the decode
+and materialization cost, the remaining decompression may not be worth 29-58% of
+the storage headline. Do not decide this until 1a is measured.
+
+## Acceptance checks
+
+From the issue, restated as assertions a suite can make. Each needs a removal
+proof, and per the house rule the proof must fail for the stated reason.
+
+1. **The complements must diverge.** `clienttimezone = 3600` (pushed down, zero
+   matches) and `clienttimezone <> 3600` (not pushed down, all rows) currently
+   read 1351 blocks each. After 1b the first must read materially fewer.
+2. **`SELECT *` with a zero-matching pushed-down qual must approach the
+   `count(*)` figure**, not 134x it (181,103 blocks against 1351).
+3. **A qual that cannot be pushed down must still get 1a's benefit**, which is
+   the q24 case and the one no reader-level check can see. Assert on rows
+   materialized rather than blocks read, since 1a does not change I/O.
+
+Check 3 is the one most likely to be written vacuously: blocks read will NOT
+move for 1a, so a check written against `BUFFERS` will pass unchanged with the
+feature removed. It must assert something 1a actually changes.
+
+## Risks
+
+- **A second pass over a decoded group must not change results.** The existing
+  per-vector skip already proves rows in skipped vectors are never emitted;
+  splitting materialization must preserve that, including for `nulls[]` on
+  non-projected columns, which are deliberately set to an explicit NULL rather
+  than a missing-value default (`:1652`).
+- **`EXEC_FLAG_SKIP_TRIGGERS` / qual side effects.** A qual containing a volatile
+  function must not be evaluated a different number of times than today.
+- Vectorized aggregate paths (`columnar_vector.c`) build their own selection and
+  must not double-apply a selection built here.

--- a/design/ISSUE_452_LATE_MATERIALIZATION.md
+++ b/design/ISSUE_452_LATE_MATERIALIZATION.md
@@ -126,7 +126,91 @@ offsets already exists (`nativeVecStart`); per-row offsets within a vector do
 not. **Walking from the vector start (at most 1023 length-prefix steps, no
 copies) is the cheap answer and should be measured before anything more clever.**
 
-## Phase 1b: exact selection feedback into the existing skip vector
+## Phase 1b splits in two, and only one half needs batching
+
+Established by reading `pgcolumnar_native_load_group`, not assumed:
+
+```
+:1598   pgcolumnar_native_decode_chunk(...)      per wanted column
+:1615   pgcolumnar_native_build_skipvec(...)     from zone maps
+```
+
+**Decode runs before the skip vector exists.** So today even a vector the zone
+maps have ruled out is fully decoded; `nativeSkipVec` only makes the row producer
+step its cursors past it (`:1686`). "Vectors Skipped" means "not turned into
+Datums", never "not decoded". That is a stronger statement than #452's text,
+which says only that decompression is not skipped.
+
+### 1b-i: let decode honour the skip vector it already builds
+
+Self-contained, and a prerequisite for 1b-ii. Move `build_skipvec` above the
+decode loop (it reads zone maps and needs no decoded data) and give
+`pgcolumnar_native_decode_chunk` the mask, so ruled-out vectors are never
+decoded. **No batching, no restructure, no new observable** — `Columnar Vectors
+Skipped` already reports the count and the suites already assert on it.
+
+Worth being explicit that **this does nothing for ClickBench q24**, whose qual is
+a leading-wildcard LIKE and therefore yields `numPredicates == 0` and a NULL skip
+vector. It pays on queries with a usable predicate, which is most analytic
+filters and none of the six #445 losses.
+
+#### 1b-i is larger than it looks: the vectorized fold reads the raw buffer
+
+Found before writing the code, and it is the reason 1b-i was not attempted in the
+same session as 1a.
+
+Skipping a vector's decode leaves a **hole** in the chunk's raw buffer. The row
+producer never reads it, because it steps its cursors past skipped vectors. But
+the batch-fold path does:
+
+- `PgColumnarReadFoldColumn` (`columnar_reader.c:1953`) hands out the raw buffer
+  pointer and the per-vector lengths, with no skip information.
+- `columnar_vector.c:3161` fetches `skipVec` into a local and **never indexes
+  it** — `skipVec[` does not appear in that file.
+- The fold stays correct anyway because it **evaluates the scan keys itself**,
+  per value (`columnar_vector.c:3236-3242`). That is exact filtering, so a
+  ruled-out vector's rows are excluded by evaluation rather than by the skip.
+
+So today the fold reads vectors the zone maps ruled out, and gets the right
+answer because it re-checks every value. **Leave a hole and it re-checks
+uninitialized memory**, which can only produce a wrong aggregate — silently, and
+only on data whose zone maps rule something out.
+
+**1b-i therefore requires the fold to honour the skip as well**, and that is a
+change to the vectorized aggregate path, not just the loader. It is still worth
+doing, and it is no longer a small self-contained slice. The eligibility rule
+(`pgcolumnar_batch_shape_eligible` requires every qual to be convertible to a
+scan key) means the fold runs precisely when predicates exist — which is exactly
+when vectors get skipped, so this is the common case, not an edge.
+
+A suite was written for 1b-i and is red against `main` for the right reasons: 30
+of 32 vectors skipped, no `Columnar Vectors Decoded` counter. It is not in the
+tree, because a registered red suite or an unregistered stray `.sh` are both
+worse than a specification. Its shape, to rebuild:
+
+- one row group of 32 vectors, monotonic `id` so zone maps are tight
+- narrow predicate (`id BETWEEN 2000 AND 2050`) against wide (`BETWEEN 1 AND n`)
+- premises: narrow skips vectors, wide skips none, the counter exists and moves
+- checks: decoded(narrow) < decoded(wide), and the difference equals the skipped
+  count exactly — "fewer" alone would pass on decoding one vector less
+
+### 1b-ii: exact selection, which does need batching
+
+To skip decode for vectors holding no *surviving* row, the qual must be evaluated
+before the payload columns are decoded — and the qual can only be evaluated on
+decoded qual columns. So the producer has to work a vector at a time: decode the
+qual columns, evaluate 1024 rows, decode the payload for that vector only if any
+survived, emit.
+
+This is the batching 1a turned out not to need, and it is the larger piece. It is
+also the only one of the two that reaches q24, where the measured budget is the
+~3200 ms 1a leaves behind.
+
+**Order matters:** 1b-i first, because it is small, independently valuable, and
+its mask plumbing is what 1b-ii extends from zone-map-derived to
+evaluation-derived.
+
+## Phase 1b (original sketch): exact selection feedback into the existing skip vector
 
 Cheap, additive, and it fixes the issue's own headline test case.
 

--- a/design/ISSUE_452_ROUTE_B_VS_PHASE_1.md
+++ b/design/ISSUE_452_ROUTE_B_VS_PHASE_1.md
@@ -195,6 +195,39 @@ Note the codec buys **2.25x** on this table (3.33 GB to 1.48 GB) for 3.36% of
 this query's time. That is a good trade and an argument for keeping it, not
 against it.
 
+### Measured after 1a shipped: the 71% was 1a and 1b together, not 1a
+
+1a is implemented and measured on the same table, same box, interleaved, medians
+of 3, **with the postmaster restarted so the new `.so` was actually loaded** (the
+first attempt measured the old binary and reported plausible numbers; the premise
+check caught it):
+
+| query | 1a off | 1a on | saved |
+| --- | ---: | ---: | ---: |
+| q24 `SELECT *`, 105 columns | 6253 ms | **5184 ms** | **1069 ms, 17.1% (1.21x)** |
+| q21 `count(*)`, 1 column | 1378 ms | 1392 ms | none, as designed |
+
+q21 is unchanged because its qual column *is* its only projected column, so the
+`deferrable == 0` guard refuses the path. That the number does not move is the
+guard working, not the feature failing.
+
+**Why 1069 ms and not the 4265 ms this document predicted.** The prediction
+conflated two costs that turn out to be separable in the code:
+
+- `pgcolumnar_native_decode_chunk` decodes a **whole chunk** into a raw buffer at
+  group-load time, before any row is produced.
+- The per-row work 1a removes is only the copy **out of that raw buffer** into
+  the row context -- the `MemoryContextAlloc` plus memcpy per value.
+
+So **1a captures M and leaves E untouched.** The decode already happened. Getting
+E requires not decoding the vectors that hold no surviving row, which is exactly
+1b, and 1b now has a measured budget rather than an assumed one: roughly the
+3200 ms of q24 that 1a does not reach.
+
+This does not change the Route B decision -- D is still 202 ms and Route B still
+cannot exceed it -- but it does mean **1b is worth more than 1a was**, and the
+71% figure should be read as the pair, not as either one.
+
 ### Decision
 
 **Do Phase 1a then 1b. Defer Route B and do not spend the storage.** Re-measure D

--- a/design/ISSUE_452_ROUTE_B_VS_PHASE_1.md
+++ b/design/ISSUE_452_ROUTE_B_VS_PHASE_1.md
@@ -1,0 +1,212 @@
+# #452: Route B against Phase 1, decided by measurement
+
+Owner asked for the two courses to be tested against each other rather than
+argued. This is the experiment design, written **before** any measurement so the
+attribution is pre-committed and cannot be chosen after seeing the numbers.
+
+Companion to `ISSUE_452_LATE_MATERIALIZATION.md`, which holds the architecture.
+
+## The two courses
+
+- **Phase 1** (1a + 1b): qual columns materialized first, `ExecQual`, then
+  payload columns only for surviving rows; plus exact selection fed into the
+  existing per-vector skip. **No storage-format change.**
+- **Route B**: per-vector compression blocks, so a vector can be decompressed
+  independently. Costs **+29% to +58%** on disk by the reviewer's measurement,
+  which this experiment re-derives rather than trusts.
+
+They are not exclusive. The question is which is worth doing, and whether
+Route B's storage cost buys anything once Phase 1 exists.
+
+## The question that decides it
+
+For the shape that actually loses — the ClickBench wide-text queries, q21-q24 —
+what fraction of scan time is:
+
+| bucket | what removes it | route |
+| --- | --- | --- |
+| **D** block-codec decompression (zstd) | decompressing fewer vectors | **Route B only** |
+| **E** per-vector decode (encoding -> raw buffer) | skipping vectors with no selected row | **1b** (already has the skip machinery) |
+| **M** per-row materialization (deform, `MemoryContextAlloc` + memcpy per varlena) | not materializing rejected rows | **1a** |
+
+**Pre-committed decision rule**, fixed now:
+
+- If **D < 20%** of scan time, Route B cannot repay +29-58% storage on this
+  workload and Phase 1 is the course. Do Phase 1, defer Route B.
+- If **D > 50%**, Phase 1 leaves the dominant cost untouched and Route B is
+  required regardless of storage. Cost it properly and take it to the owner.
+- Between 20% and 50%, do Phase 1 first and **re-measure D afterwards**, because
+  Phase 1 removes E and M from the denominator and D's share necessarily rises;
+  the decision is then made on absolute milliseconds saved per GB spent, not on
+  a share.
+
+Storage is a headline number for this project, so the burden is on Route B to
+justify itself, not on Phase 1 to rule it out.
+
+## Method
+
+**Fixture: the real thing, not a synthetic stand-in.** The whole question is
+about wide text, and `url`/`title` compressibility is the variable. Load
+`hits_col` from the existing 11,110,833-row stride extract on the bench
+(`/srv/clickbench/hits.every9.tsv`), which is the same table the #445 run
+measured. A synthetic fixture would decide this question with invented data.
+
+**Query: q24**, the 8.49x loss and the extreme case:
+
+    SELECT * FROM hits_col WHERE URL LIKE '%google%' ORDER BY EventTime LIMIT 10
+
+with q21 (`SELECT count(*) ... WHERE URL LIKE '%google%'`, one column) as the
+control that isolates M — q21 materializes almost nothing, so the difference
+between them is close to pure M plus E.
+
+### Method change, recorded before any measurement was taken
+
+**`perf` cannot sample on this box, so the symbol-bucket attribution below is not
+available.** Established by performing it, not by reading #505:
+
+    perf stat -e cycles true   ->  "No supported events found. The cycles event is not supported."
+    perf record -e cpu-clock   ->  writes /tmp/p.data, 21,400 bytes, "has no samples!"
+    /proc/sys/kernel/perf_event_paranoid = -1   (already permissive; not a permissions fix)
+
+Note the shape: `perf record` **succeeded**, produced a non-empty file, and
+contained nothing. An instrument reporting success while measuring nothing, which
+is the same failure this session has now met nine times, and which #505 predicted
+for this host.
+
+**Replaced with a differential design, which is better evidence for this
+decision anyway** — it measures the cost each route would *remove*, in
+milliseconds, rather than attributing symbols and inferring what a change would
+save:
+
+- **D, the decompression cost** = `T(zstd table) - T(none table)` for the same
+  query on the same data. `pgcolumnar.compression` takes `none`, and it is a
+  per-table option, so two tables can differ in exactly that one property.
+  **Route B's ceiling is D times the fraction of vectors holding no selected
+  row**, because Route B does not remove decompression, it lets unselected
+  vectors go undecompressed.
+- **M + E, what Phase 1 removes** = `T(SELECT *) - T(count(*))` under the same
+  predicate, which is the cost of the 104 columns that only the wide query
+  touches. Measured on the `none` table it excludes decompression, isolating
+  decode plus materialization — exactly what 1a and 1b remove.
+
+The decision rule above is restated in these terms: compare **D x unselected
+vector fraction** against **M + E**. Both are milliseconds on the same query, so
+they are directly comparable, and the storage cost is then priced per
+millisecond saved.
+
+Ratios are reported with their baselines, per the standing rule, since the two
+tables have different absolute times by construction.
+
+**Superseded plan, kept because it is why the method changed:**
+`perf` symbol buckets, from `bench/run_profile.sh`'s probe
+(non-assert `pg18n`, DWARF unwind, whatever event the box exposes; #505 records
+that this host has no hardware PMU, so the profiler's own report of event and
+unwind method must be read and recorded rather than assumed).
+
+Buckets by symbol, decided now:
+
+- **D**: `ZSTD_*`, and any block-codec entry point.
+- **E**: `pgcolumnar_native_decode_chunk`, `PgColumnarDecodeChunk`, FSST decode
+  (`fsst_*`, `decode_fsst*`), bit-unpacking (`bitunpack*`, per #501).
+- **M**: `PgColumnarDecodeValue`, `MemoryContextAlloc`/`palloc`, `memcpy` under
+  the per-row producer, slot fill.
+
+Anything unattributed is reported as its own bucket rather than distributed,
+because a residual quietly spread across three buckets is how a 70%/16% figure
+went wrong in #472.
+
+## Verification, before any number is quoted
+
+Per the standing rule, the instrument is a claim:
+
+1. **The box must be idle** — `uptime`, stray backends, per the #207/#212
+   history. Recorded with the result.
+2. **Non-assert build** — `pg_config --configure` must not show
+   `--enable-cassert`. #504 exists because an assert build put a function that
+   does not exist in production at 9.28% of a profile.
+3. **The profile must not measure its own fixture.** #504's other artifact:
+   `md5_calc` at 12.31% of an "ingest" profile was the generator inside the
+   timed statement. The query here reads a pre-loaded table, so the load must be
+   outside the sample window.
+4. **Sanity bound**: bucket shares must sum to 100% with the residual named, and
+   D+E+M must not exceed total scan time. A share above 100% means the buckets
+   double-count a symbol.
+5. **The two queries must differ in the predicted direction.** q21 (1 column)
+   must show far less M than q24 (105 columns). If it does not, the attribution
+   is wrong, not the theory.
+
+## Route B's storage cost, re-derived
+
+The +29-58% figure was measured on 122,880 rows of three columns. Before it is
+used in a decision it gets re-derived at the scale that matters, on the same
+`hits_col`, by re-encoding representative columns with per-vector blocking and
+comparing bytes. If it cannot be re-derived without implementing Route B, that
+is stated plainly and the decision uses the reviewer's number **labelled as
+theirs and unverified**, rather than silently adopting it.
+
+## Result: Phase 1, and Route B is not close
+
+Measured 2026-08-08 on the bench (16 cores, 62 GB, load 0.02), PostgreSQL 18.4
+non-assert `pg18n`, on the real 11,110,833-row ClickBench table. Both tables
+carry identical data (same row count, same 1,728 matches) and differ only in the
+codec, **proven from the catalog** rather than inferred from size:
+
+    hits_col        block_codec 3 (zstd)  7,718 chunks  1288 MB
+    hits_col        block_codec 0         157 chunks     119 MB
+    hits_col_none   block_codec 0         7,875 chunks  3166 MB
+
+Medians of 3 interleaved tries, milliseconds, **baselines beside the shares**:
+
+| query | zstd | none | D (codec's whole contribution) |
+| --- | ---: | ---: | ---: |
+| q21 `count(*)`, 1 column | 1237.0 | 1117.7 | 119.3 ms = **9.65%** of q21 |
+| q24 `SELECT *`, 105 columns | 6005.2 | 5803.2 | 202.0 ms = **3.36%** of q24 |
+
+Vector occupancy of the predicate: **974 of 10,851 vectors** hold a matching row,
+so **91.0% hold none**.
+
+| | ms | share of q24 |
+| --- | ---: | ---: |
+| **Route B ceiling** (D x 91.0%) | **184** | **3.06%** |
+| **Phase 1 target** (q24 - q21, codec removed) | **4686** | 80.7% |
+| **Phase 1 ceiling** (target x 91.0%) | **4265** | **71.0%** |
+
+**23.2x more opportunity in Phase 1 than in Route B.** The pre-committed rule
+said D < 20% means Route B cannot repay its storage; D is 3.36%.
+
+**The bound is stronger than the estimate, and does not depend on the estimate
+being precise.** Route B keeps the codec and changes only the granularity at
+which it is applied. Removing the codec **entirely** saves 202 ms on this query.
+So no scheme that merely applies the codec more selectively can save more than
+202 ms, and skipping 91% of vectors puts it at ~184 ms. That holds even if the
+202 ms is wrong.
+
+**Honest about the noise:** D(q24) at 202 ms is the same size as the run-to-run
+spread (197.5 ms zstd, 170.9 ms none), so D is at the edge of what these three
+tries resolve. Min-against-min gives 227.7 ms (3.87%), the same answer. The
+conclusion does not rest on the precision of D, only on it being far below 20%,
+and it is an order of magnitude below.
+
+**Route B's storage cost was therefore not re-derived.** The decision does not
+turn on whether it is +29% or +58%, because the whole prize is 3%. The
+reviewer's figure stays labelled as theirs and unverified, per the plan.
+
+Note the codec buys **2.25x** on this table (3.33 GB to 1.48 GB) for 3.36% of
+this query's time. That is a good trade and an argument for keeping it, not
+against it.
+
+### Decision
+
+**Do Phase 1a then 1b. Defer Route B and do not spend the storage.** Re-measure D
+after Phase 1 lands, because removing 71% of the runtime necessarily raises D's
+*share* — and that rise must not be read as Route B having become worthwhile. It
+will be the same 202 ms against a smaller denominator, which is the presentation
+trap this project has already met once today.
+
+## What this experiment cannot decide
+
+Whether Route B is worth it for a *different* workload. This measures
+ClickBench wide text because that is where #452 was found and ranked. A
+narrow-projection scan over compressible integers may attribute completely
+differently, and the write-up must say so rather than generalising from one
+workload — the failure this session already produced twice.

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -185,6 +185,7 @@ extern int	pgcolumnar_fsst_verdict_reuse;
 #define COLUMNAR_FSST_HELPS		1
 #define COLUMNAR_FSST_HURTS		2
 extern bool pgcolumnar_enable_qual_pushdown;
+extern bool pgcolumnar_enable_late_materialization;
 extern bool pgcolumnar_enable_column_projection;
 extern bool pgcolumnar_enable_custom_scan;
 extern bool pgcolumnar_enable_bloom_filter;	/* bloom equality skipping (I7) */
@@ -597,6 +598,21 @@ extern PgColumnarReadState *PgColumnarBeginReadWithStorage(Relation rel,
 extern bool PgColumnarReadNextRow(PgColumnarReadState *readState,
 								Datum *values, bool *nulls,
 								uint64 *rowNumber);
+
+/*
+ * Late materialization (#452 Phase 1a). The filter is asked whether a row can
+ * survive once the columns it reads are decoded, and returns true to keep it.
+ * It must read only the columns the caller marked in qualCols.
+ */
+typedef bool (*PgColumnarRowFilter) (void *arg);
+
+extern bool PgColumnarReadNextRowFiltered(PgColumnarReadState *readState,
+										Datum *values, bool *nulls,
+										uint64 *rowNumber,
+										const bool *qualCols,
+										PgColumnarRowFilter filter,
+										void *filterArg);
+extern uint64 PgColumnarRowsFilteredEarly(PgColumnarReadState *readState);
 extern void PgColumnarRescanRead(PgColumnarReadState *readState);
 extern void PgColumnarEndRead(PgColumnarReadState *readState);
 

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -38,6 +38,7 @@
 #include "catalog/pg_type.h"
 #include "storage/shm_toc.h"
 #include "commands/explain.h"
+#include "optimizer/optimizer.h"
 #if PG_VERSION_NUM >= 180000
 /* PG18 split the ExplainProperty* helpers out into explain_format.h. */
 #include "commands/explain_format.h"
@@ -94,6 +95,14 @@ typedef struct PgColumnarCustomScanState
 	 */
 	char	   *projName;			/* chosen projection name (EXPLAIN), or NULL */
 	bool		projScan;
+
+	/*
+	 * Late materialization (#452 Phase 1a). qualCols marks the columns the node's
+	 * qual reads; lateMat says the two-pass producer is in use for this scan. Both
+	 * are settled at Begin, because whether it is legal cannot change mid-scan.
+	 */
+	bool	   *qualCols;
+	bool		lateMat;
 	int			projNcols;			/* projection column count (K) */
 	int		   *projColMap;			/* base attno-1 -> index into projValues, or -1 */
 	Datum	   *projValues;			/* scratch, length K+1 (index 0 = rownumber) */
@@ -1625,6 +1634,113 @@ pgcolumnar_setup_projection_scan(PgColumnarCustomScanState *cstate, Relation rel
 	cstate->projScan = true;
 }
 
+/*
+ * pgcolumnar_setup_late_materialization
+ *		Decide whether this scan can build the qual's columns first (#452), and
+ *		if so which columns those are.
+ *
+ * Refused, in order, when: the feature is off; there is no qual to filter with;
+ * the qual reads a system column, whose attnos do not address the value cursors;
+ * the qual is volatile, because ExecScan re-applies the qual to every row this
+ * returns and a volatile expression would then run twice per surviving row; or
+ * the qual reads every projected column, in which case there is nothing left to
+ * defer and the second pass would be pure overhead.
+ */
+static void
+pgcolumnar_setup_late_materialization(PgColumnarCustomScanState *cstate,
+									CustomScan *cscan, TupleDesc tupdesc)
+{
+	Bitmapset  *qualAttrs = NULL;
+	int			natts = tupdesc->natts;
+	int			deferrable = 0;
+	int			x = -1;
+	int			c;
+
+	cstate->qualCols = NULL;
+	cstate->lateMat = false;
+
+	if (!pgcolumnar_enable_late_materialization)
+		return;
+	if (cscan->scan.plan.qual == NIL)
+		return;
+	if (contain_volatile_functions((Node *) cscan->scan.plan.qual))
+		return;
+
+	pull_varattnos((Node *) cscan->scan.plan.qual, cscan->scan.scanrelid,
+				   &qualAttrs);
+
+	cstate->qualCols = (bool *) palloc0(sizeof(bool) * natts);
+
+	while ((x = bms_next_member(qualAttrs, x)) >= 0)
+	{
+		AttrNumber	attno = x + FirstLowInvalidHeapAttributeNumber;
+
+		/* whole-row or system reference: not addressable as a value cursor */
+		if (attno <= 0 || attno > natts)
+		{
+			pfree(cstate->qualCols);
+			cstate->qualCols = NULL;
+			return;
+		}
+		cstate->qualCols[attno - 1] = true;
+	}
+
+	/*
+	 * Something must actually be deferred. A column the scan does not project is
+	 * not built either way, so only projected non-qual columns count.
+	 */
+	for (c = 0; c < natts; c++)
+	{
+		if (cstate->qualCols[c])
+			continue;
+		/*
+		 * projectedColumns holds ZERO-based attribute indexes
+		 * (PgColumnarProjectionFromAttnos adds attno - 1), and NULL means every
+		 * column is projected. Not the FirstLowInvalidHeapAttributeNumber-offset
+		 * convention that pull_varattnos uses just above, which is why the two
+		 * loops in this function index differently.
+		 */
+		if (cstate->projectedColumns == NULL ||
+			bms_is_member(c, cstate->projectedColumns))
+			deferrable++;
+	}
+
+	if (deferrable == 0)
+	{
+		pfree(cstate->qualCols);
+		cstate->qualCols = NULL;
+		return;
+	}
+
+	cstate->lateMat = true;
+}
+
+/*
+ * pgcolumnar_scan_row_filter
+ *		The reader's callback: does the row pass the node's qual, given only the
+ *		columns the qual reads?
+ *
+ * The slot is stored as a virtual tuple so ExecQual can read it. Its Datums point
+ * into the reader's row context, which outlives this call. The per-tuple context
+ * is reset per evaluation exactly as ExecScan resets it per fetched tuple, so a
+ * scan that rejects millions of rows does not accumulate their qual allocations.
+ */
+static bool
+pgcolumnar_scan_row_filter(void *arg)
+{
+	ScanState  *ss = (ScanState *) arg;
+	ExprContext *econtext = ss->ps.ps_ExprContext;
+	TupleTableSlot *slot = ss->ss_ScanTupleSlot;
+
+	ExecClearTuple(slot);
+	ExecStoreVirtualTuple(slot);
+
+	ResetExprContext(econtext);
+	econtext->ecxt_scantuple = slot;
+
+	return ExecQual(ss->ps.qual, econtext);
+}
+
 static void
 PgColumnarBeginCustomScan(CustomScanState *node, EState *estate, int eflags)
 {
@@ -1648,6 +1764,8 @@ PgColumnarBeginCustomScan(CustomScanState *node, EState *estate, int eflags)
 
 	/* the projection the planner chose (gap 26); reported by EXPLAIN */
 	cstate->projName = pgcolumnar_chosen_projection(cscan);
+
+	pgcolumnar_setup_late_materialization(cstate, cscan, tupdesc);
 
 	if (eflags & EXEC_FLAG_EXPLAIN_ONLY)
 		return;
@@ -1742,8 +1860,29 @@ PgColumnarScanNext(ScanState *ss)
 
 	ExecClearTuple(slot);
 
-	if (!PgColumnarReadNextRow(cstate->readState, slot->tts_values,
-							 slot->tts_isnull, &rowNumber))
+	if (cstate->lateMat)
+	{
+		/*
+		 * Late materialization (#452): the reader applies the qual once the
+		 * columns it reads are decoded, and builds the rest only for a row that
+		 * survives. The filter leaves the slot stored with the qual columns; the
+		 * second pass writes the remaining Datums straight into tts_values, so
+		 * the slot is re-stored here to publish the complete row.
+		 *
+		 * ExecScan will apply the same qual again to what this returns. That is
+		 * redundant but correct, and it is why a volatile qual refuses this path
+		 * at Begin -- it would otherwise be evaluated twice per surviving row.
+		 */
+		if (!PgColumnarReadNextRowFiltered(cstate->readState, slot->tts_values,
+										 slot->tts_isnull, &rowNumber,
+										 cstate->qualCols,
+										 pgcolumnar_scan_row_filter, ss))
+			return NULL;
+
+		ExecClearTuple(slot);
+	}
+	else if (!PgColumnarReadNextRow(cstate->readState, slot->tts_values,
+									slot->tts_isnull, &rowNumber))
 		return NULL;
 
 	ExecStoreVirtualTuple(slot);
@@ -1918,6 +2057,15 @@ PgColumnarExplainCustomScan(CustomScanState *node, List *ancestors,
 							   (int64) groupsSkipped, es);
 		ExplainPropertyInteger("Columnar Vectors Skipped", NULL,
 							   (int64) PgColumnarVectorsSkipped(cstate->readState), es);
+
+		/*
+		 * Rows the qual rejected before their remaining projected columns were
+		 * built (#452). Distinct from the counters above: those are rows never
+		 * READ, this is rows read but not materialized.
+		 */
+		ExplainPropertyInteger("Columnar Rows Filtered Before Materialization", NULL,
+							   (int64) PgColumnarRowsFilteredEarly(cstate->readState),
+							   es);
 	}
 }
 

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -1738,7 +1738,22 @@ pgcolumnar_scan_row_filter(void *arg)
 	ResetExprContext(econtext);
 	econtext->ecxt_scantuple = slot;
 
-	return ExecQual(ss->ps.qual, econtext);
+	if (ExecQual(ss->ps.qual, econtext))
+		return true;
+
+	/*
+	 * Count the rejection where the executor would have counted it.
+	 *
+	 * ExecScan increments nfiltered1 for every tuple its own qual rejects, and
+	 * that is what EXPLAIN prints as "Rows Removed by Filter". Filtering here
+	 * instead means ExecScan never sees the rejected rows, so without this the
+	 * line silently reads 0 on every columnar scan with a qual -- an
+	 * instrumentation counter that stops counting while the plan still looks
+	 * right. The five-major gate caught exactly that: pushdown_report and
+	 * analyze_stats both read this line, and both failed on all five majors.
+	 */
+	InstrCountFiltered1(ss, 1);
+	return false;
 }
 
 static void

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -150,6 +150,14 @@ struct PgColumnarReadState
 	uint64		vectorsSkipped;		/* for EXPLAIN */
 
 	/*
+	 * Late materialization (#452 Phase 1a). Rows whose qual columns were decoded,
+	 * the qual then rejected them, and whose remaining projected columns were
+	 * therefore never built -- their cursors advanced without a
+	 * MemoryContextAlloc or a memcpy. For EXPLAIN.
+	 */
+	uint64		rowsFilteredEarly;
+
+	/*
 	 * Native delete visibility (Phase D6b): the current row group's combined
 	 * delete mask (one bit per row-in-group, set = deleted), from
 	 * pgcolumnar.delete_vector keyed by group number. NULL when the group has no
@@ -285,6 +293,108 @@ PgColumnarDecodeValue(Form_pg_attribute att, char **cursor,
 	}
 
 	return result;
+}
+
+/*
+ * pgcolumnar_skip_value
+ *		Advance one column's cursor past a present value WITHOUT building it.
+ *
+ * The whole of late materialization (#452) is the difference between this and
+ * PgColumnarDecodeValue directly above: same cursor arithmetic, no
+ * MemoryContextAlloc and no memcpy. For a rejected row that is the entire cost
+ * avoided, and it is why the feature needs neither batching nor random access --
+ * the cursor still walks every row, it just stops copying the ones nothing will
+ * read.
+ *
+ * Deliberately mirrors PgColumnarDecodeValue's three cases in the same order,
+ * and sits next to it so a change to that cursor arithmetic cannot miss this.
+ */
+static inline void
+pgcolumnar_skip_value(Form_pg_attribute att, char **cursor)
+{
+	char	   *p = *cursor;
+
+	if (att->attbyval || att->attlen > 0)
+		*cursor = p + att->attlen;
+	else
+		*cursor = p + PgColumnarVarSizeAnyUnaligned(p);
+}
+
+/*
+ * pgcolumnar_row_read_column / pgcolumnar_row_skip_column
+ *		One column of the current row: build its value, or step past it.
+ *
+ * Extracted from the producer's loop so late materialization (#452) can visit
+ * the columns in two groups without restating the rules. The order of the tests
+ * is load-bearing and is preserved exactly: not-projected is checked BEFORE
+ * absent-from-this-group, because both leave nativeValidity NULL and they mean
+ * different things -- falling through would hand back an ADD COLUMN default for
+ * a column that was simply never fetched.
+ *
+ * Must be called with the row context current, and only from the producer, which
+ * owns rowInGroup.
+ */
+static inline void
+pgcolumnar_row_read_column(PgColumnarReadState *rs, int c, Datum *values, bool *nulls)
+{
+	Form_pg_attribute att = TupleDescAttr(rs->tupdesc, c);
+	char	   *vbits = rs->nativeValidity[c];
+
+	if (!rs->colWanted[c])
+	{
+		values[c] = (Datum) 0;
+		nulls[c] = true;
+		return;
+	}
+	if (vbits == NULL)
+	{
+		values[c] = rs->missingValues[c];
+		nulls[c] = rs->missingIsnull[c];
+		return;
+	}
+
+	if ((vbits[rs->rowInGroup >> 3] >> (rs->rowInGroup & 7)) & 1)
+	{
+		/* Fast path (#289): inline the attbyval decode, as the loop always has. */
+		if (att->attbyval)
+		{
+			char	   *p = rs->nativeValueCursor[c];
+
+			values[c] = fetch_att(p, true, att->attlen);
+			rs->nativeValueCursor[c] = p + att->attlen;
+		}
+		else
+			values[c] = PgColumnarDecodeValue(att, &rs->nativeValueCursor[c],
+											rs->rowContext);
+		nulls[c] = false;
+	}
+	else
+	{
+		values[c] = (Datum) 0;
+		nulls[c] = true;
+	}
+}
+
+static inline void
+pgcolumnar_row_skip_column(PgColumnarReadState *rs, int c, Datum *values, bool *nulls)
+{
+	Form_pg_attribute att = TupleDescAttr(rs->tupdesc, c);
+	char	   *vbits = rs->nativeValidity[c];
+
+	/*
+	 * Nothing above the scan may read this column for this row: the row is
+	 * either about to be discarded or is deleted. An explicit NULL rather than a
+	 * stale Datum, so a reader that does look finds an obvious value.
+	 */
+	values[c] = (Datum) 0;
+	nulls[c] = true;
+
+	/* No cursor to advance: never fetched, or absent from this group entirely. */
+	if (!rs->colWanted[c] || vbits == NULL)
+		return;
+
+	if ((vbits[rs->rowInGroup >> 3] >> (rs->rowInGroup & 7)) & 1)
+		pgcolumnar_skip_value(att, &rs->nativeValueCursor[c]);
 }
 
 /* -------------------------------------------------------------------------
@@ -1588,13 +1698,27 @@ pgcolumnar_native_skip_current_vector(PgColumnarReadState *rs)
  *		the current row group, reconstructing each column from its validity bit
  *		and, when present, the next value on its cursor. Vectors the zone maps rule
  *		out are stepped over without decoding (Phase D5b).
+ *
+ * Late materialization (#452 Phase 1a): when qualCols is non-NULL the row is
+ * built in two passes. The columns the qual reads are decoded first, `filter` is
+ * asked whether the row can survive, and the remaining projected columns are
+ * decoded only if it can -- otherwise their cursors are advanced past the row
+ * without allocating or copying anything. Each column carries its own cursor, so
+ * visiting them in two groups within one row is free; only rowInGroup is shared,
+ * and it advances once, after both passes.
+ *
+ * With qualCols NULL this is exactly the single-pass producer it has always
+ * been, which is the path every other caller still takes.
  */
 static bool
 pgcolumnar_native_next_row(PgColumnarReadState *rs, Datum *values, bool *nulls,
-						 uint64 *rowNumber)
+						 uint64 *rowNumber,
+						 const bool *qualCols,
+						 PgColumnarRowFilter filter, void *filterArg)
 {
 	MemoryContext oldContext;
 	int			c;
+	bool		keep = true;
 
 	if (rs->exhausted)
 		return false;
@@ -1631,78 +1755,86 @@ pgcolumnar_native_next_row(PgColumnarReadState *rs, Datum *values, bool *nulls,
 		 * even for a deleted row so the cursors stay aligned for the next row; a
 		 * deleted row is simply not emitted (D6b).
 		 */
-		MemoryContextReset(rs->rowContext);
-		oldContext = MemoryContextSwitchTo(rs->rowContext);
-
-		for (c = 0; c < rs->natts; c++)
-		{
-			Form_pg_attribute att = TupleDescAttr(rs->tupdesc, c);
-			char	   *vbits = rs->nativeValidity[c];
-
-			/*
-			 * Not projected (#338): never read, so there is no value to give.
-			 * This is tested before the absent-column case on purpose. Both
-			 * leave nativeValidity NULL, but they mean different things, and
-			 * falling through to missingValues here would hand back an ADD
-			 * COLUMN default for a column that simply was not fetched -- a
-			 * plausible wrong value instead of an obvious one. Nothing above
-			 * the scan can read this column (the projection unions the
-			 * targetlist and the qual), so an explicit NULL is unobservable.
-			 */
-			if (!rs->colWanted[c])
-			{
-				values[c] = (Datum) 0;
-				nulls[c] = true;
-				continue;
-			}
-
-			/* column absent from this group (added by a later ADD COLUMN) */
-			if (vbits == NULL)
-			{
-				values[c] = rs->missingValues[c];
-				nulls[c] = rs->missingIsnull[c];
-				continue;
-			}
-
-			if ((vbits[rs->rowInGroup >> 3] >> (rs->rowInGroup & 7)) & 1)
-			{
-				/*
-				 * Fast path (#289): inline the attbyval decode. This is exactly
-				 * what PgColumnarDecodeValue does for a by-value type -- one
-				 * fetch_att and advance attlen -- but skips the out-of-line call
-				 * and its own attbyval branch, which is the per-row decode
-				 * dispatch #289 profiled as hot. It works for both baseline and
-				 * descriptor chunks, since both leave nativeValueCursor pointing
-				 * at the present-value bytes. By-reference and varlena keep the
-				 * call, which copies into rowContext. No array, no extra memory,
-				 * so a scan that materialises few columns pays nothing extra.
-				 */
-				if (att->attbyval)
-				{
-					char	   *p = rs->nativeValueCursor[c];
-
-					values[c] = fetch_att(p, true, att->attlen);
-					rs->nativeValueCursor[c] = p + att->attlen;
-				}
-				else
-					values[c] = PgColumnarDecodeValue(att,
-													&rs->nativeValueCursor[c],
-													rs->rowContext);
-				nulls[c] = false;
-			}
-			else
-			{
-				values[c] = (Datum) 0;
-				nulls[c] = true;
-			}
-		}
-
-		MemoryContextSwitchTo(oldContext);
-
 		deleted = (rs->nativeDeleteMask != NULL &&
 				   (rs->rowInGroup >> 3) < rs->nativeDeleteMaskLen &&
 				   (rs->nativeDeleteMask[rs->rowInGroup >> 3] &
 					(1 << (rs->rowInGroup & 7))) != 0);
+
+		MemoryContextReset(rs->rowContext);
+		oldContext = MemoryContextSwitchTo(rs->rowContext);
+
+		if (qualCols != NULL)
+		{
+			/*
+			 * A deleted row must never reach the filter. Nothing above the scan
+			 * can see it, and the qual is arbitrary user expression: evaluating
+			 * a cast or a division on an invisible row could raise an error the
+			 * query has no business raising. Its cursors are advanced and it is
+			 * dropped, which is also cheaper than the full build it used to get.
+			 */
+			if (deleted)
+			{
+				for (c = 0; c < rs->natts; c++)
+					pgcolumnar_row_skip_column(rs, c, values, nulls);
+			}
+			else
+			{
+				/* Pass one: only what the qual reads. */
+				for (c = 0; c < rs->natts; c++)
+				{
+					if (qualCols[c])
+						pgcolumnar_row_read_column(rs, c, values, nulls);
+					else
+					{
+						values[c] = (Datum) 0;
+						nulls[c] = true;
+					}
+				}
+
+				/*
+				 * Ask outside the row context: the filter runs executor code that
+				 * allocates in its own context. The pass-one values live in
+				 * rowContext and stay valid -- it is reset per row, not here.
+				 */
+				MemoryContextSwitchTo(oldContext);
+				keep = filter(filterArg);
+				MemoryContextSwitchTo(rs->rowContext);
+
+				/* Pass two: the rest, built only if the row survived. */
+				for (c = 0; c < rs->natts; c++)
+				{
+					if (qualCols[c])
+						continue;
+					if (keep)
+						pgcolumnar_row_read_column(rs, c, values, nulls);
+					else
+						pgcolumnar_row_skip_column(rs, c, values, nulls);
+				}
+			}
+
+			MemoryContextSwitchTo(oldContext);
+
+			*rowNumber = rs->nativeGroup->firstRowNumber + rs->rowInGroup;
+			rs->rowInGroup++;
+
+			if (deleted)
+				continue;
+			if (!keep)
+			{
+				rs->rowsFilteredEarly++;
+				continue;
+			}
+			return true;
+		}
+
+		/*
+		 * The single-pass path every other caller takes: build every projected
+		 * column, including for a deleted row so the cursors stay aligned.
+		 */
+		for (c = 0; c < rs->natts; c++)
+			pgcolumnar_row_read_column(rs, c, values, nulls);
+
+		MemoryContextSwitchTo(oldContext);
 
 		*rowNumber = rs->nativeGroup->firstRowNumber + rs->rowInGroup;
 		rs->rowInGroup++;
@@ -1719,7 +1851,43 @@ PgColumnarReadNextRow(PgColumnarReadState *readState, Datum *values, bool *nulls
 					uint64 *rowNumber)
 {
 	pgcolumnar_read_start(readState);
-	return pgcolumnar_native_next_row(readState, values, nulls, rowNumber);
+	return pgcolumnar_native_next_row(readState, values, nulls, rowNumber,
+									NULL, NULL, NULL);
+}
+
+/*
+ * PgColumnarReadNextRowFiltered
+ *		Late materialization (#452 Phase 1a): produce the next row that survives
+ *		`filter`, building the columns outside qualCols only for a row that does.
+ *
+ * qualCols is [natts] and marks the columns the filter reads. The filter is
+ * called with only those decoded; it must not look at any other column, and it
+ * must not assume anything about a row it rejects. Deleted rows are dropped
+ * without consulting it.
+ *
+ * The caller keeps ownership of the qual and of whatever the filter closes over.
+ */
+bool
+PgColumnarReadNextRowFiltered(PgColumnarReadState *readState,
+							Datum *values, bool *nulls, uint64 *rowNumber,
+							const bool *qualCols,
+							PgColumnarRowFilter filter, void *filterArg)
+{
+	Assert(qualCols != NULL && filter != NULL);
+	pgcolumnar_read_start(readState);
+	return pgcolumnar_native_next_row(readState, values, nulls, rowNumber,
+									qualCols, filter, filterArg);
+}
+
+/*
+ * PgColumnarRowsFilteredEarly
+ *		Rows whose payload columns were never built because the qual rejected
+ *		them first. For EXPLAIN.
+ */
+uint64
+PgColumnarRowsFilteredEarly(PgColumnarReadState *readState)
+{
+	return readState ? readState->rowsFilteredEarly : 0;
 }
 
 /* -------------------------------------------------------------------------

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -67,6 +67,7 @@ int			pgcolumnar_compression = COLUMNAR_COMPRESSION_ZSTD;
 int			pgcolumnar_compression_level = 3;
 int			pgcolumnar_fsst_min_gain_percent = 5;
 bool		pgcolumnar_enable_qual_pushdown = true;
+bool		pgcolumnar_enable_late_materialization = true;
 bool		pgcolumnar_enable_column_projection = true;
 bool		pgcolumnar_enable_bloom_filter = true;
 
@@ -2498,6 +2499,18 @@ _PG_init(void)
 							 "Push scan qualifiers down for chunk-group skipping.",
 							 NULL,
 							 &pgcolumnar_enable_qual_pushdown,
+							 true,
+							 PGC_USERSET,
+							 0,
+							 NULL, NULL, NULL);
+
+	DefineCustomBoolVariable("pgcolumnar.enable_late_materialization",
+							 "Evaluate the scan qualifier before building the columns it does not read.",
+							 "A row the qualifier rejects has its remaining projected columns "
+							 "stepped over rather than built, so decode cost scales with rows "
+							 "emitted rather than rows scanned (#452). Off restores the single "
+							 "pass, and is the A/B oracle the late-materialization test uses.",
+							 &pgcolumnar_enable_late_materialization,
 							 true,
 							 PGC_USERSET,
 							 0,

--- a/test/native_late_materialization.sh
+++ b/test/native_late_materialization.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# pgColumnar late materialization (#452 Phase 1a): a row the qual rejects must
+# not have its payload columns materialized.
+#
+# Today the scan builds a complete tuple -- every projected column, every
+# varlena copied into the row context -- and core's ExecScan applies the qual
+# afterwards, so decode cost scales with rows SCANNED rather than rows EMITTED.
+# Heap does the opposite: slot_deform_heap_tuple stops at the qual's attribute
+# for a rejected row and pays the full deform only for survivors. Measured on
+# ClickBench q24 (#445), that difference is 8.49x.
+#
+# The predicate here is deliberately one that CANNOT be pushed down (a leading
+# wildcard LIKE builds no scan key, and no min/max can prune a substring match),
+# because pruning is a different mechanism with its own suites. The premises
+# below assert that nothing was pruned, so a green run cannot be pruning wearing
+# this feature's name.
+#
+# Usage:  test/native_late_materialization.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+ROWS=20480
+NEEDLE=zqx
+
+# One row group so nothing is pruned wholesale, and wide payload columns so
+# materialization is the cost under test. Only row 7 in every 2048 carries the
+# needle, so the qual rejects the overwhelming majority.
+GEN="SELECT g AS id,
+            CASE WHEN g % 2048 = 7 THEN 'aaa${NEEDLE}bbb' ELSE 'aaaaaabbb' END AS k,
+            repeat(md5(g::text), 4) AS p1,
+            repeat(md5((g+1)::text), 4) AS p2,
+            repeat(md5((g+2)::text), 4) AS p3
+     FROM generate_series(1, $ROWS) g"
+
+psql_run "CREATE TABLE h (id int, k text, p1 text, p2 text, p3 text);"
+psql_run "CREATE TABLE n (id int, k text, p1 text, p2 text, p3 text) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.set_options('n', stripe_row_limit => 65536, chunk_group_row_limit => 1024);"
+psql_run "INSERT INTO h $GEN;"
+psql_run "INSERT INTO n $GEN;"
+psql_run "ANALYZE h; ANALYZE n;"
+
+Q="SELECT * FROM n WHERE k LIKE '%${NEEDLE}%'"
+QH="SELECT * FROM h WHERE k LIKE '%${NEEDLE}%'"
+
+# One EXPLAIN ANALYZE counter for a query.
+counter() {  # counter <label> <query>
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -At -c "EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) $2" 2>/dev/null \
+		| grep "$1" | grep -oE '[0-9]+' | head -1
+}
+scalar() {  # scalar <sql>
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -At -c "$1" 2>/dev/null
+}
+
+# ---- premises, so a green run cannot mean something else --------------------
+
+n_rows=$(scalar "SELECT count(*) FROM n;")
+check_num "premise: the fixture loaded every row" "$n_rows" "$ROWS"
+
+n_match=$(scalar "SELECT count(*) FROM n WHERE k LIKE '%${NEEDLE}%';")
+h_match=$(scalar "SELECT count(*) FROM h WHERE k LIKE '%${NEEDLE}%';")
+check_num "premise: the needle is selective, not most of the table" "$n_match" "10"
+check_num "premise: heap agrees on how many rows match" "$h_match" "$n_match"
+
+# The scalar columnar custom scan reports "Columnar Projected Columns"; no other
+# node reports it. Without this the counters below would be read off a node that
+# is not the one under test.
+proj=$(counter "Columnar Projected Columns" "$Q")
+check "premise: the query runs on the columnar custom scan" \
+	"$([ -n "$proj" ] && echo yes || echo no)" "yes"
+
+# A leading-wildcard LIKE must not prune. If it ever does, this suite is
+# measuring pruning and its headline check means nothing.
+removed=$(counter "Columnar Chunk Groups Removed by Filter" "$Q")
+vskip=$(counter "Columnar Vectors Skipped" "$Q")
+check_num "premise: nothing was pruned at the group level" "${removed:-0}" "0"
+check_num "premise: nothing was pruned at the vector level" "${vskip:-0}" "0"
+
+# ---- the feature -----------------------------------------------------------
+
+early=$(counter "Columnar Rows Filtered Before Materialization" "$Q")
+check_num "a rejected row does not materialize its payload columns" \
+	"${early:-0}" "$((ROWS - n_match))"
+
+# ---- and it may not change a single answer ---------------------------------
+#
+# The heap mirror is the oracle. Late materialization is a pure optimization:
+# every row heap returns, columnar must return, byte for byte.
+nh=$(scalar "SELECT md5(string_agg(t::text, '|' ORDER BY id)) FROM ($QH) t;")
+nn=$(scalar "SELECT md5(string_agg(t::text, '|' ORDER BY id)) FROM ($Q) t;")
+check_text "the rows are identical to the heap mirror" "$nn" "$nh"
+
+# ---- the removal proof, run by the suite itself ----------------------------
+#
+# With the feature off the counter must be 0 AND the answers must be unchanged.
+# Asserting only the first would let a broken implementation that silently
+# emitted nothing pass the off-arm.
+psql_run "SET pgcolumnar.enable_late_materialization = off;"
+off_early=$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+	-d "$PGC_DB" -At \
+	-c "SET pgcolumnar.enable_late_materialization = off;" \
+	-c "EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) $Q" 2>/dev/null \
+	| grep "Columnar Rows Filtered Before Materialization" | grep -oE '[0-9]+' | head -1)
+check_num "with the feature off nothing is filtered early" "${off_early:-0}" "0"
+
+nn_off=$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+	-d "$PGC_DB" -At \
+	-c "SET pgcolumnar.enable_late_materialization = off;" \
+	-c "SELECT md5(string_agg(t::text, '|' ORDER BY id)) FROM ($Q) t;" 2>/dev/null \
+	| tail -1)
+check_text "and the answers are the same with it off" "$nn_off" "$nh"
+
+pgc_summary

--- a/test/native_late_materialization.sh
+++ b/test/native_late_materialization.sh
@@ -87,6 +87,20 @@ early=$(counter "Columnar Rows Filtered Before Materialization" "$Q")
 check_num "a rejected row does not materialize its payload columns" \
 	"${early:-0}" "$((ROWS - n_match))"
 
+# ---- the executor's own counter must keep counting -------------------------
+#
+# ExecScan increments nfiltered1 for every tuple ITS qual rejects, and that is
+# what EXPLAIN prints as "Rows Removed by Filter". Filtering inside the scan
+# means ExecScan never sees a rejected row, so the line silently went to 0 on
+# every columnar scan with a qual -- the plan still looked right and a counter
+# other suites depend on had stopped counting.
+#
+# The five-major gate caught it (pushdown_report and analyze_stats, all five
+# majors); this pins it here, next to the feature that broke it.
+removed=$(counter "Rows Removed by Filter" "$Q")
+check_num "the executor still reports the rows the scan filtered" \
+	"${removed:-0}" "$((ROWS - n_match))"
+
 # ---- and it may not change a single answer ---------------------------------
 #
 # The heap mirror is the oracle. Late materialization is a pure optimization:

--- a/test/native_late_materialization.sh
+++ b/test/native_late_materialization.sh
@@ -115,4 +115,36 @@ nn_off=$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgr
 	| tail -1)
 check_text "and the answers are the same with it off" "$nn_off" "$nh"
 
+# ---- a volatile qual must refuse the path entirely -------------------------
+#
+# ExecScan re-applies the node's qual to every row this returns, so a row that
+# survives has its qual evaluated twice. That is invisible for an immutable
+# expression and wrong for a volatile one, which is why Begin refuses the path.
+#
+# This check exists because nothing else reaches that guard: every other query in
+# this suite is immutable, so deleting contain_volatile_functions() would leave
+# the whole suite green. Same shape as the collation and divisor guards found
+# unreachable elsewhere today.
+#
+# random() < 2 is always true, so the rows are the ones the LIKE selects and the
+# heap mirror is still the oracle. It cannot be constant-folded away: volatile is
+# precisely what stops the planner doing that, which is what makes it a fixture.
+QV="SELECT * FROM n WHERE k LIKE '%${NEEDLE}%' AND random() < 2"
+QVH="SELECT * FROM h WHERE k LIKE '%${NEEDLE}%' AND random() < 2"
+
+vol_early=$(counter "Columnar Rows Filtered Before Materialization" "$QV")
+check_num "a volatile qual is refused the two-pass path" "${vol_early:-0}" "0"
+
+# And refusing it must not change the answer either.
+vh=$(scalar "SELECT md5(string_agg(t::text, '|' ORDER BY id)) FROM ($QVH) t;")
+vn=$(scalar "SELECT md5(string_agg(t::text, '|' ORDER BY id)) FROM ($QV) t;")
+check_text "and the volatile query still matches the heap mirror" "$vn" "$vh"
+
+# The premise that makes the check above mean something: the SAME query without
+# the volatile term does take the path. Without this, "0" would be satisfied by a
+# fixture that never qualified for late materialization at all.
+check_num "premise: the same shape without the volatile term does use it" \
+	"$(counter "Columnar Rows Filtered Before Materialization" "$Q")" \
+	"$((ROWS - n_match))"
+
 pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -102,6 +102,7 @@ SUITES=(
 	native_index
 	native_index_projection
 	native_ios
+	native_late_materialization
 	native_lazy_slot
 	native_ownership
 	native_parquet_codecs


### PR DESCRIPTION
Decode cost scaled with rows **scanned** rather than rows **emitted**. The scan built a complete tuple — every projected column, every varlena copied into the row context — and core's `ExecScan` applied the qual afterwards. Heap does the opposite: `slot_deform_heap_tuple` stops at the qual's attribute for a rejected row and pays the full deform only for survivors. On ClickBench q24 that difference is 8.49x (#445).

## What it does

The reader produces a row in two passes when the caller supplies a qual-column mask and a filter: the columns the qual reads are decoded, the filter is asked, and the remaining projected columns are built **only for a row that survives**. A rejected row has their cursors advanced past it instead — `pgcolumnar_skip_value`, which is `PgColumnarDecodeValue`'s cursor arithmetic without the `MemoryContextAlloc` and the memcpy. That is the entire cost removed.

**No batching and no random access**, contrary to the first plan. Every column carries its own cursor, so visiting them in two groups within one row is free; only `rowInGroup` is shared, and it advances once, after both passes. The plan document records the wrong version and why it was wrong.

## Measured, on the real thing

11,110,833-row ClickBench table, `pg18n` non-assert, bench idle, interleaved, medians of 3, **postmaster restarted so the new `.so` was actually loaded**:

| query | off | on | saved |
| --- | ---: | ---: | ---: |
| q24 `SELECT *`, 105 columns | 6253 ms | **5184 ms** | **1069 ms, 1.21x** |
| q21 `count(*)`, 1 column | 1378 ms | 1392 ms | none, by design |

Results byte-identical both ways, on the `LIMIT 10` **and** the full 1,728-row set. q21 does not move because its qual column is its only projected column, so the `deferrable == 0` guard refuses the path — the guard working, not the feature failing.

**This is below the 71% this work was forecast to deliver, and the reason matters more than the number.** `pgcolumnar_native_decode_chunk` decodes a *whole chunk* into a raw buffer at group-load time, so 1a removes only the copy **out of** that buffer. 1a captures materialization; decode is untouched. Getting decode means not decoding vectors that hold no surviving row — Phase 1b — which now has a **measured** budget of roughly the remaining 3200 ms rather than an assumed one. The forecast was wrong because I read the plan I had written rather than the code it described; the same document already said chunks are decoded whole.

## Refused, at Begin

The feature is off; there is no qual; the qual reads a **system column**, whose attnos do not address value cursors; the qual is **volatile**, because `ExecScan` re-applies the same qual to every row this returns and a volatile expression would then run twice per surviving row; or the qual reads **every** projected column, leaving nothing to defer.

A **deleted row never reaches the filter**. Nothing above the scan can see it, and evaluating an arbitrary user expression on an invisible row could raise an error the query has no business raising.

## The regression the five-major gate caught

Filtering inside the scan means `ExecScan` never sees a rejected row, so it never increments `nfiltered1` — and **`Rows Removed by Filter` silently read 0** on every columnar scan carrying a qual. The plan still looked right. `pushdown_report` and `analyze_stats` both read that line and both failed, on all five majors:

```
FAIL  pushdown off examines every row: got [unset] want [199999]
FAIL  having an index available saves the point lookup real work:
      got [no (0 with the index, 0 without)] want [yes]
```

Fixed by counting the rejection where the executor would have counted it, and pinned in `native_late_materialization.sh` next to the feature that broke it. An instrumentation counter that stops counting while the plan above it stays correct is the `check "" ""` shape one layer down.

## Proof by removal — including which removal was a no-op

Per the rule this repository keeps re-learning: a removal proof must remove something the compiler, the planner or the runtime can observe.

| guard | removal | result |
| --- | --- | --- |
| late materialization itself | `enable_late_materialization = off` | counter 0, rows unchanged — in-suite, both arms |
| volatility guard | delete `contain_volatile_functions()` | `got [20470] want [0]`, `.so` `024c0f74` → `3fc733b3` |

**The volatility check was a no-op until its fixture was changed.** Every other qual in the suite is immutable, so deleting the guard left the suite green; the fixture had to gain `AND random() < 2` to reach it. And its heap-mirror companion does **not** protect it — `random() < 2` is true however many times it runs, so the mirror passes with the guard removed. Only the counter check sees the defect.

## Gate

**Five majors, all green**, at this head on the bench host:

```
PASS PG15 (129 ran, 5 skipped) · PASS PG16 (129) · PASS PG17 (129)
PASS PG18 (132 ran, 2 skipped) · PASS PG19 (134 ran, 0 skipped)
ALL VERSIONS PASSED · exit=0
```

`native_late_materialization=PASS` on all five and **absent from every skip list** — a green major and "the new suite ran" are different claims. `pushdown_report` and `analyze_stats` also PASS on all five.

## Known limitation

The EXPLAIN counter is read from the leader's read state, exactly like `Chunk Groups Read` and `Vectors Skipped` beside it, so under a parallel scan it reports the leader's share. Consistent with its neighbours rather than new behaviour; the suite pins `max_parallel_workers_per_gather = 0`, where it is exact.

Refs #452