### PR TITLE
test: print the .so under test, and name what PGC_SKIP_BUILD actually skips (#508 follow-up)

### DIFF
--- a/test/harness_selftest.sh
+++ b/test/harness_selftest.sh
@@ -534,4 +534,30 @@ check "pgc_require_tools passes on tools that exist" \
 check "pgc_require_tools fails on one that does not" \
 	"$(_probe pgc_require_tools pgc_no_such_tool_exists)" "1"
 
+# ---- the harness must say which binary it is testing (#508 follow-up) -------
+#
+# Three separate defects this session were a suite reporting checks against a
+# binary nobody had just built: a compile failure the harness did not check
+# (#508), a PGC_SKIP_BUILD run that skipped the INSTALL and exercised a
+# guard-removed leftover, and objects from another major linked into a third.
+# Every one produced a plausible PASS/FAIL list, and every one is one line of
+# md5sum away from being obvious.
+#
+# The first check is the line existing; the second is the one with teeth. It
+# compares what is INSTALLED against what was just BUILT, using the build tree as
+# an independent source rather than recomputing the installed hash the same way
+# twice. Equal means the install actually happened.
+_so_line="$(pgc_so_line)"
+echo "$_so_line"
+
+check "pgc_setup reports the installed .so" \
+	"$(grep -cE '^-- \.so: [0-9a-f]{12} ' <<<"$_so_line")" "1"
+
+_so_installed="$(awk '{print $3}' <<<"$_so_line")"
+_so_built="$(md5sum "$PGC_SRCDIR/pgcolumnar.so" 2>/dev/null | cut -c1-12)"
+check "the installed .so is the one this run built" \
+	"$([ -n "$_so_built" ] && [ "$_so_installed" = "$_so_built" ] && echo yes \
+		|| echo "no (installed $_so_installed, built ${_so_built:-<none>})")" \
+	"yes"
+
 pgc_summary

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -87,6 +87,29 @@ pgc_cluster_is_ours() {
 
 # ---- setup / teardown ------------------------------------------------------
 
+# pgc_so_line
+#		One line naming the shared library the suites are about to exercise.
+#
+# Printed on every run, not only when something looks wrong, because the failure
+# it catches is invisible in a PASS/FAIL list: a suite reporting checks against a
+# binary nobody just built. Three separate instances in one session -- a compile
+# error the harness did not check (#508), a PGC_SKIP_BUILD run that skipped the
+# INSTALL and exercised a guard-removed leftover, and objects from another major
+# linked into a third -- all produced plausible results and all were one md5sum
+# from being obvious.
+#
+# It also makes a red-on-change proof self-evidencing: two arms that report the
+# same hash have proved nothing, whatever their check counts say.
+pgc_so_line() {
+	local so
+	so="$("$PGC_PG_CONFIG" --pkglibdir)/pgcolumnar.so"
+	if [ -r "$so" ]; then
+		echo "-- .so: $(md5sum "$so" | cut -c1-12) $so"
+	else
+		echo "-- .so: NOT PRESENT at $so"
+	fi
+}
+
 pgc_setup() {
 	PGC_PG_CONFIG="${1:-/usr/local/pg17/bin/pg_config}"
 	PGC_BINDIR="$("$PGC_PG_CONFIG" --bindir)"
@@ -162,7 +185,17 @@ pgc_setup() {
 			echo "       (refusing to report checks against the previously installed .so)" >&2
 			exit 1
 		fi
+	else
+		# Named because the variable is not what it says. It reads as "skip the
+		# build" and means "skip the build AND the install, and test whatever is
+		# already installed" -- correct for the matrix, which installs once per
+		# major before setting it, and a trap for a person who has just edited
+		# source and run make by hand.
+		echo "-- PGC_SKIP_BUILD=1: not building AND NOT INSTALLING;"
+		echo "   whatever is already installed is what these checks measure"
 	fi
+
+	pgc_so_line
 
 	echo "-- initdb"
 	pgc_pg "initdb -D '$PGC_PGDATA' -A trust" >/dev/null 2>&1


### PR DESCRIPTION
Follow-up to #508, which fixed the harness reporting checks after a build that
failed. This makes the same class visible rather than fixing one instance of it.

`pgc_setup` now prints one line on every run:

```
-- .so: 8b58d7fdcb0d /usr/local/pg18a/lib/postgresql/pgcolumnar.so
```

## Why a line nobody asked for

Three separate defects in a single session were a suite reporting checks against
a binary nobody had just built:

- a compile error the harness did not check, which reported **19 green checks**
  against a source file containing invalid C (#508);
- a `PGC_SKIP_BUILD=1` run that skipped the **install**, not just the build, and
  exercised a guard-removed leftover from an earlier removal proof — three suites
  failing for a reason unrelated to the change;
- objects from one major linked into another's `.so`, which surfaces as a cluster
  that will not start behind a message naming nothing.

Every one produced a plausible PASS/FAIL list. Every one is one line of `md5sum`
away from being obvious. The point is that it prints when nothing looks wrong,
because that is the state all three of those were in.

It also makes a red-on-change proof self-evidencing. Two arms reporting the same
hash have proved nothing whatever their check counts say, and today that is
something each of us has to remember to verify by hand.

## PGC_SKIP_BUILD is named in the same change

The variable is not what it says. It reads as "skip the build" and means "skip
the build **and the install**, and test whatever is already installed" — correct
for the matrix, which installs once per major before setting it, and a trap for a
person who has just edited source and run `make` by hand. That is exactly how the
second defect above happened, so the harness now says it out loud.

## Which removals were tried, and which one proved nothing

`harness_selftest` gains two checks: that the line exists, and — the one with
teeth — that what is **installed** matches what was just **built**, using the
build tree as an independent source rather than recomputing the installed hash
the same way twice. Recomputing it two ways proves only that `md5sum` is
deterministic.

Proved by reproducing the original incident rather than by deleting the check:

```
build a different binary, do not install it, run with PGC_SKIP_BUILD=1
  -> FAIL  the installed .so is the one this run built:
           got [no (installed 8b58d7fdcb0d, built 7564d4f138ed)] want [yes]
```

**And the removal that proved nothing, which belongs here rather than buried in a
commit message.** My first attempt appended a C *comment* to a source file and
rebuilt, expecting a different binary. The hashes were identical — comments do not
survive to the object — the check passed, and it would have shipped labelled
"proved by removal". The line being justified is what revealed it.

The general form, which is worth more than this patch: **a removal proof must
remove something the compiler, the planner or the runtime can observe.** A
comment; a fixture where two cases coincide; a guard nothing reaches. In each the
"before" arm equals the "after" by construction, and the check passes in both
while carrying the authority of a real proof.

## Gate

Full matrix on 18 and 19. `harness_selftest=PASS` on both majors and not among
either job's skips.

PG19 reports `temporal=FAIL` in the container this ran in, which is its missing
`btree_gist` and which unmodified `main` fails identically there — measured, and
written up on #505. Happy to re-run on the bench host before merge if you would
rather see it without that caveat.
