### PR TITLE
fix: a columnar partition gets the custom scan (#436)

### DIFF
--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -1316,7 +1316,22 @@ PgColumnarSetRelPathlist(PlannerInfo *root, RelOptInfo *rel, Index rti,
 		return;
 	if (rte->rtekind != RTE_RELATION || rte->relkind != RELKIND_RELATION)
 		return;
-	if (rel->reloptkind != RELOPT_BASEREL)
+	/*
+	 * A partition is RELOPT_OTHER_MEMBER_REL, not RELOPT_BASEREL, and excluding
+	 * it cost the custom scan entirely: no column projection, no zone-map
+	 * pruning, no index-fetch penalty, and a fall back to a sequential scan
+	 * through the table AM with nothing in the plan saying why (#436).
+	 *
+	 * Measured on 400,000 rows, same data and same predicate, partitioning the
+	 * only difference: 1.4 ms unpartitioned against 74.1 ms partitioned, 53x.
+	 *
+	 * Only these two kinds. The rest are joins, upper rels and dead rels, none of
+	 * which is a base relation this scan could read, and PgColumnarIsColumnarRelation
+	 * below still decides per relation -- so a heap partition beside a columnar
+	 * one is unaffected.
+	 */
+	if (rel->reloptkind != RELOPT_BASEREL &&
+		rel->reloptkind != RELOPT_OTHER_MEMBER_REL)
 		return;
 	if (!OidIsValid(rte->relid) || !PgColumnarIsColumnarRelation(rte->relid))
 		return;

--- a/test/native_skip.sh
+++ b/test/native_skip.sh
@@ -384,4 +384,48 @@ else
 		"$(pgc_set_hash "SELECT t FROM hu WHERE t LIKE 'k00005000%'")"
 fi
 
+# ---- a columnar PARTITION must get the custom scan too (#436) ----------------
+#
+# set_rel_pathlist_hook returned early unless reloptkind was RELOPT_BASEREL, and a
+# partition is RELOPT_OTHER_MEMBER_REL -- so a partitioned columnar table lost the
+# custom scan entirely, and with it column projection, zone-map pruning and the
+# index-fetch penalty. It fell back to a sequential scan through the table AM and
+# nothing in the plan said why.
+#
+# Measured on 400,000 rows, same data and same predicate, partitioning the only
+# difference: 1.4 ms unpartitioned against 74.1 ms partitioned, 53x, with the
+# partitioned plan reading every row group and projecting every column.
+#
+# Parity first and not as decoration: the risk in a scan that never ran on this
+# relation shape is a WRONG answer, not a slow one.
+psql_run "CREATE TABLE nskp_h (id int, k int, label text);"
+psql_run "CREATE TABLE nskp (id int, k int, label text) PARTITION BY RANGE (id);"
+psql_run "CREATE TABLE nskp_1 PARTITION OF nskp FOR VALUES FROM (1) TO (10241)
+	USING pgcolumnar;"
+psql_run "CREATE TABLE nskp_2 PARTITION OF nskp FOR VALUES FROM (10241) TO (20481)
+	USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.set_options('nskp_1', stripe_row_limit => 2048, chunk_group_row_limit => 1024);"
+psql_run "SELECT pgcolumnar.set_options('nskp_2', stripe_row_limit => 2048, chunk_group_row_limit => 1024);"
+NSKP_GEN="SELECT g, g * 10, 'lbl-' || (g % 100) FROM generate_series(1, 20480) g"
+psql_run "INSERT INTO nskp_h $NSKP_GEN;"
+psql_run "INSERT INTO nskp $NSKP_GEN;"
+
+check "premise: both partitions are columnar (#436)" \
+	"$(q "SELECT count(*) FROM pg_class c JOIN pg_am a ON a.oid = c.relam
+		  WHERE c.relname IN ('nskp_1','nskp_2') AND a.amname = 'pgcolumnar';")" "2"
+
+check "a partitioned columnar table returns the same rows as heap (#436)" \
+	"$(pgc_set_hash 'SELECT id, k, label FROM nskp WHERE id BETWEEN 5000 AND 5100')" \
+	"$(pgc_set_hash 'SELECT id, k, label FROM nskp_h WHERE id BETWEEN 5000 AND 5100')"
+
+check "a partition takes the columnar custom scan (#436)" \
+	"$(q "EXPLAIN (COSTS off) SELECT id FROM nskp WHERE id BETWEEN 5000 AND 5100;" \
+		| grep -c 'Custom Scan (PgColumnarScan)')" "1"
+
+# and the consequence the custom scan exists for: it prunes. A partition that got
+# the node but not the pruning would pass the check above and still read
+# everything.
+check "and it prunes row groups (#436)" \
+	"$(gt0 "$(skipped 'SELECT id FROM nskp WHERE id BETWEEN 5000 AND 5100')")" "yes"
+
 pgc_summary


### PR DESCRIPTION
Fixes #436.

`set_rel_pathlist_hook` returned early unless `reloptkind == RELOPT_BASEREL`. **A
partition is `RELOPT_OTHER_MEMBER_REL`**, so a partitioned columnar table lost the
custom scan entirely and fell back to a sequential scan through the table AM.

Same 400,000 rows, same predicate, partitioning the only difference:

| | plan | time |
| --- | --- | ---: |
| unpartitioned | `Custom Scan` — projects 1 of 3 columns, reads 1 of 3 row groups, 14 vectors skipped | **1.4 ms** |
| partitioned | `Seq Scan` on each partition — every column, every group | **74.1 ms** |

**53x, and nothing in the plan said why.** No column projection, no zone-map
pruning, no index-fetch penalty. With this change the partitioned query is 1.9 ms,
which is the unpartitioned figure.

Only `RELOPT_OTHER_MEMBER_REL` is admitted. The rest are joins, upper rels and
dead rels, none of which is a base relation this scan could read, and
`PgColumnarIsColumnarRelation` still decides per relation — so a heap partition
beside a columnar one is untouched.

## Why this was invisible

**The answers were always right.** Both parity checks pass on unmodified `main`;
the partitioned table returned exactly what heap returned, just by reading
everything. There is no wrong result to notice, no error, and no plan line saying
a node is missing — the absence of `Custom Scan (PgColumnarScan)` is only visible
if you know to look for it.

That is why the tests assert parity **before** plan shape. The risk in a scan that
has never run on this relation shape is a wrong answer rather than a slow one, so
rows come first in the order of assertion even though rows were never the defect.

Red on `main`:

```
PASS  premise: both partitions are columnar (#436)
PASS  a partitioned columnar table returns the same rows as heap (#436)
FAIL  a partition takes the columnar custom scan (#436): got [0] want [1]
FAIL  and it prunes row groups (#436): got [no] want [yes]
```

The pruning check is separate from the node check deliberately: a partition that
got the node but not the pruning would satisfy the plan-shape assertion and still
read everything, which is the failure this issue is actually about.

## Bearing on #434, which is worth settling before either issue is scheduled

My comment on #436 says the first move is to **ask the external reporter whether
their ledger table was partitioned**. That question is sharper now: a silent 53x
on partitioned tables is a plausible cause of a 33-minute query, and if their
table was partitioned then **#436 explains it and #434 does not** — which changes
which issue gets the work and which gets closed.

I have not contacted them and have no way to; flagging it because the answer
decides more than it looks like it does.

## Gate

| major | `native_skip` |
| --- | --- |
| 15.18 | 49 checks / 0 fail |
| 16.14 | 49 checks / 0 fail |
| 17.6 | 49 checks / 0 fail |
| 18.4 | 49 checks / 0 fail |
| 19beta2 | 49 checks / 0 fail |

Full matrix: **PG18 PASS** (132 ran, 2 skipped), zero warnings. PG19's only failure
is `temporal`, the audit container's missing `btree_gist`, which unmodified `main`
fails identically there (#505). Happy to re-run on the bench host if you would
rather see it without that caveat — this one touches path generation, so I would
not object to being asked.
