### PR TITLE
fix: one label, one quantity — all three nodes report scan keys (#493)

### DIFF
--- a/src/columnar.h
+++ b/src/columnar.h
@@ -935,6 +935,9 @@ typedef struct PgColumnarGroupStats
 } PgColumnarGroupStats;
 
 extern void PgColumnarExplainPushedDown(int64 nfilters, ExplainState *es);
+extern void PgColumnarExplainVectorPredicates(int64 npreds, ExplainState *es);
+extern int	PgColumnarCountScanKeys(List *qual, Index scanrelid,
+								  TupleDesc tupdesc);
 extern void PgColumnarExplainGroupStats(const PgColumnarGroupStats *stats,
 									  ExplainState *es);
 

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -2076,6 +2076,44 @@ PgColumnarReScanCustomScan(CustomScanState *node)
 }
 
 /*
+ * PgColumnarCountScanKeys
+ *		How many of these quals become scan keys.
+ *
+ * The quantity "Columnar Pushed-Down Filters" names, for callers that need the
+ * number without the keys. The vectorized aggregates report it so that one label
+ * means one thing on every node (#493): they push down through their own
+ * convertibility test, which accepts a different set, and reporting that under
+ * the scalar node's label made the same line mean two quantities depending on a
+ * plan choice the reader did not make.
+ */
+int
+PgColumnarCountScanKeys(List *qual, Index scanrelid, TupleDesc tupdesc)
+{
+	ScanKey		keys;
+	int			nkeys = 0;
+
+	keys = PgColumnarBuildScanKeys(qual, scanrelid, tupdesc, &nkeys);
+	if (keys != NULL)
+		pfree(keys);
+	return nkeys;
+}
+
+/*
+ * PgColumnarExplainVectorPredicates
+ *		What the vectorized filter can evaluate, which is a different question
+ *		from what a zone map can exclude with (#493).
+ *
+ * Its own line rather than sharing one: #479 settled that adding the second
+ * number beats redefining the first, and anything parsing the old line -- which
+ * is #191's whole signal -- keeps working.
+ */
+void
+PgColumnarExplainVectorPredicates(int64 npreds, ExplainState *es)
+{
+	ExplainPropertyInteger("Columnar Vector Predicates", NULL, npreds, es);
+}
+
+/*
  * PgColumnarExplainPushedDown
  *		How many quals the scan was GIVEN as scan keys.
  *

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -553,7 +553,8 @@ typedef struct PgColumnarAggScanState
 	PgColumnarAggSpec *specs;
 	int			naggs;
 
-	int			npreds;			/* pushed-down predicate count, for EXPLAIN */
+	int			npreds;			/* vector predicates, for EXPLAIN (#493) */
+	int			nscankeys;		/* scan keys, the shared label's quantity (#493) */
 
 	MemoryContext resultContext;	/* holds min/max running values */
 	bool		done;			/* the single result row was emitted */
@@ -691,6 +692,7 @@ typedef struct PgColumnarGroupAggScanState
 
 	/* EXPLAIN */
 	int			npreds;
+	int			nscankeys;
 	bool		haveStats;
 	uint64		groupsRead;
 	uint64		groupsSkipped;
@@ -2128,6 +2130,8 @@ PgColumnarBeginAggScan(CustomScanState *node, EState *estate, int eflags)
 	 */
 	PgColumnarCountConvertibleQuals(state->quals, state->scanrelid, tupdesc,
 								  &state->npreds, &allConvertible);
+	state->nscankeys = PgColumnarCountScanKeys(state->quals, state->scanrelid,
+											 tupdesc);
 
 	/*
 	 * Scan-fold mode reads and rechecks every surviving row (#289): a virtual
@@ -3534,7 +3538,8 @@ PgColumnarExplainAggScan(CustomScanState *node, List *ancestors, ExplainState *e
 
 	ExplainPropertyInteger("Columnar Vectorized Aggregates", NULL,
 						   state->naggs, es);
-	PgColumnarExplainPushedDown(state->npreds, es);
+	PgColumnarExplainPushedDown(state->nscankeys, es);
+	PgColumnarExplainVectorPredicates(state->npreds, es);
 	if (state->scanFold)
 		ExplainPropertyText("Columnar Batch Fold",
 							state->batchEligible ? "yes" : "no", es);
@@ -3770,6 +3775,8 @@ PgColumnarBeginGroupAggScan(CustomScanState *node, EState *estate, int eflags)
 	 */
 	PgColumnarCountConvertibleQuals(state->quals, state->scanrelid, basedesc,
 								  &state->npreds, &allConvertible);
+	state->nscankeys = PgColumnarCountScanKeys(state->quals, state->scanrelid,
+											 basedesc);
 
 	if (eflags & EXEC_FLAG_EXPLAIN_ONLY)
 	{
@@ -4220,7 +4227,8 @@ PgColumnarExplainGroupAggScan(CustomScanState *node, List *ancestors,
 						   state->nkeys, es);
 	ExplainPropertyInteger("Columnar Vectorized Aggregates", NULL,
 						   state->naggs, es);
-	PgColumnarExplainPushedDown(state->npreds, es);
+	PgColumnarExplainPushedDown(state->nscankeys, es);
+	PgColumnarExplainVectorPredicates(state->npreds, es);
 
 	if (state->haveStats)
 	{

--- a/test/pushdown_report.sh
+++ b/test/pushdown_report.sh
@@ -290,14 +290,23 @@ check "ungrouped: the usable arm removes chunk groups" \
 check "ungrouped: the unusable arm removes none" \
 	"$(field "$u_unusable" 'Columnar Chunk Groups Removed by Filter')" "0"
 
-# NOTE, and it is a finding rather than a detail: on these two nodes
-# "Columnar Pushed-Down Filters" is NOT the quantity the scalar node prints. It
-# comes from PgColumnarCountConvertibleQuals, which asks
-# pgcolumnar_clause_to_predicate (convertible to a VECTOR predicate), while the
-# scalar node counts pgcolumnar_clause_to_scankey results (scan keys). The two
-# tests do not accept the same clauses, so one label reports two different
-# quantities depending on which node ran. Filed separately; #479's own complaint
-# in a new place.
+# One label, one quantity, on every node (#493).
+#
+# "Columnar Pushed-Down Filters" used to come from PgColumnarCountConvertibleQuals
+# on these two nodes -- quals convertible to a VECTOR predicate -- and from
+# pgcolumnar_clause_to_scankey on the scalar node. The two tests do not accept the
+# same clauses, so the same line reported two different quantities depending on a
+# plan choice the reader did not make: "Pushed-Down Filters went from 1 to 0" read
+# as a pushdown regression and could mean the planner switched to a vectorized
+# aggregate, which is usually a speedup.
+#
+# The remedy is #479's, which this issue is a repeat of: add the second number,
+# do not redefine the first. All three nodes now report scan keys under the old
+# label, and the vector-predicate count has its own line where it applies.
+#
+# The `>>>` operator below is the discriminator: it builds a scan key and is not
+# convertible to a vector predicate, so before the fix the scalar node said 1 and
+# these two said 0. Asserting the three agree is the whole of this issue.
 #
 # The practical consequence here is that the constructed operator is not
 # convertible to a vector predicate either, so this arm reads 0 on BOTH counters
@@ -363,5 +372,34 @@ for _line in "Columnar Pushed-Down Filters" \
 		"$(grep -rho "ExplainPropertyInteger(\"$_line\"" "$PGC_SRC_DIR" | wc -l | tr -d ' ')" \
 		"1"
 done
+
+# The three nodes, same table, same predicate, same label.
+pdr_scalar="$(q "SET pgcolumnar.enable_qual_pushdown = on;
+	SET pgcolumnar.enable_ungrouped_vector_agg = off;
+	SET pgcolumnar.enable_group_vectorization = off;
+	EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+	SELECT count(*), sum(b) FROM pdr_u WHERE b >>> $((ROWS - 10000))::oid;")"
+
+check "premise: the scalar arm really is the scalar scan (#493)" \
+	"$(has "$pdr_scalar" 'Columnar Projected Columns')" "yes"
+
+check "scalar and ungrouped agree on Pushed-Down Filters (#493)" \
+	"$(field "$u_unusable" 'Columnar Pushed-Down Filters')" \
+	"$(field "$pdr_scalar" 'Columnar Pushed-Down Filters')"
+check "scalar and grouped agree on Pushed-Down Filters (#493)" \
+	"$(field "$g_unusable" 'Columnar Pushed-Down Filters')" \
+	"$(field "$pdr_scalar" 'Columnar Pushed-Down Filters')"
+
+# and the quantity that used to be printed under that label still exists, under
+# its own name, on the nodes it applies to -- otherwise this trades one
+# asymmetry for a loss of information.
+check "the ungrouped node reports its vector-predicate count separately (#493)" \
+	"$(has "$u_unusable" 'Columnar Vector Predicates')" "yes"
+check "and it is the count that used to be mislabelled (#493)" \
+	"$(field "$u_unusable" 'Columnar Vector Predicates')" "0"
+
+check "exactly one emitter for \"Columnar Vector Predicates\" (#495)" \
+	"$(grep -rho "ExplainPropertyInteger(\"Columnar Vector Predicates\"" "$PGC_SRC_DIR" | wc -l | tr -d ' ')" \
+	"1"
 
 pgc_summary


### PR DESCRIPTION
Closes #493.

`Columnar Pushed-Down Filters` reported two different quantities depending on
which node ran. On the scalar custom scan it counted clauses that became **scan
keys**; on both vectorized aggregates it counted clauses convertible to a
**vector predicate**. The two tests do not accept the same clauses, so the line
changed meaning based on a plan choice the reader did not make and cannot see in
the number. `1` becoming `0` read as a pushdown regression when it could equally
mean the planner had switched to a vectorized aggregate — usually a speedup.

## The option taken, and why

Option 2 of the three the issue lists, per @jdatcmd, and the reasoning is his:
it is **#479's own remedy**, which this issue is explicitly a repeat of — add the
second number, do not redefine the first.

- Anything parsing the existing line, which is #191's whole signal, keeps working.
- **Option 1** (aggregates stop reporting scan keys) trades one asymmetry for its
  mirror: the scalar node would report a quantity the aggregates never do.
- **Option 3** changes what gets *pushed down* rather than what gets *printed*.
  Folding a behaviour change into a labelling fix would hide it.

So all three nodes report scan keys under the existing label, and the
vector-predicate count gets its own line, `Columnar Vector Predicates`, on the two
nodes where it means anything.

```
 Custom Scan (ColumnarVectorAgg)
   Columnar Pushed-Down Filters: 1      <- scan keys, same as the scalar node
   Columnar Vector Predicates: 0        <- what this line used to be reporting
```

`PgColumnarCountScanKeys` builds the keys and frees them rather than duplicating
`pgcolumnar_clause_to_scankey`'s acceptance rules. A second copy of that test is
how this issue happened; there should not be a third.

## Tests

The `>>>` operator already used in `pushdown_report.sh` is the discriminator: it
builds a scan key and is *not* convertible to a vector predicate, so it is exactly
the clause on which the two counters disagreed.

Red on `main` before the C change (this is also the removal proof — reverting
`src/` and keeping the tests reproduces it):

```
PASS  premise: the scalar arm really is the scalar scan (#493)
FAIL  scalar and ungrouped agree on Pushed-Down Filters (#493): got [0] want [1]
FAIL  scalar and grouped agree on Pushed-Down Filters (#493): got [0] want [1]
FAIL  the ungrouped node reports its vector-predicate count separately (#493): got [no] want [yes]
FAIL  and it is the count that used to be mislabelled (#493): got [] want [0]
FAIL  exactly one emitter for "Columnar Vector Predicates" (#495): got [0] want [1]
```

**The premise check earns its place.** The scalar arm is obtained by turning both
aggregate nodes *off*. A query that one of them quietly declined would fall back
to precisely the plan being compared against, and the comparison would be
trivially true — green whether or not the fix worked. So the test asserts the
scalar arm really is the scalar scan before comparing anything to it.

The new line also gets #495's one-emitter-per-label source check, so it cannot
grow a second copy the way the five labels before it did.

The stale `NOTE` in `pushdown_report.sh` documenting the divergence is deleted, as
the issue asks — the comment described the bug, and describing it is not fixing it.

## Gate

- Five majors (15.18, 16.14, 17.6, 18.4, 19beta2): `pushdown_report` **45 checks / 0 fail**, **0 warnings** each.
- Full matrix on assert builds of PG18 and PG19: green.

Two things the gate itself needed fixing for, both pre-existing and neither caused
by this change:

- **My five-major loop never grepped its own build output for `warning:`** — it
  redirected each build to a file and only checked the exit status. Warnings could
  therefore only ever be caught by the matrix, which runs two majors, which is how
  #495's `-Wdeclaration-after-statement` got through a green five-major report.
  Fixed in my gate script, noted here in case the same hole exists elsewhere.
- **`temporal` FAILed on pg19a in my container** because `btree_gist` had never
  been built for that install. Verified pre-existing by running `temporal.sh` at
  `origin/main` and at this branch on both pg18a and pg19a: 18 passes 5/0 and 19
  fails identically on *both* commits. Since #448 that is a deliberate hard fail
  rather than a skip, and it was right to be: the two `FOR PORTION OF` columnar
  checks are PG19-only, so they had never once executed on that box. After
  `make install` of `contrib/btree_gist` against pg19a, temporal is **8/0** there.

Refs #493, #479, #191, #495.
