### PR TITLE
test: a failing suite must name the first fatal event, not just the tail (#518)

### DIFF
--- a/test/harness_selftest.sh
+++ b/test/harness_selftest.sh
@@ -560,4 +560,57 @@ check "the installed .so is the one this run built" \
 		|| echo "no (installed $_so_installed, built ${_so_built:-<none>})")" \
 	"yes"
 
+# ---- a failing suite must surface the FIRST fatal event, not just the tail ---
+#
+# On failure pgc_summary tails 40 lines of the server log. That is the right
+# thing to show when one statement failed, and the wrong thing after a crash:
+# the first fatal event is at the TOP of the log and everything below it is
+# aftermath, so the tail shows recovery messages and not the cause.
+#
+# Measured, on a deliberate heap overrun run through this harness under the
+# pg18_san build: 67 AddressSanitizer reports in an 8,777-line log, the first at
+# line 12. The tail showed lines 8738-8777 -- 8,765 lines of crash recovery below
+# the answer -- and then pgc_teardown removed the file, so there was nowhere left
+# to look. The suite reported 123 failures and not one word about why.
+#
+# This stands that up without needing a sanitizer build: a fatal-looking line,
+# then enough filler to push it past the tail window, then a real failure.
+_fatal_marker="AddressSanitizer: heap-buffer-overflow PGCSELFTEST"
+_sub="$(mktemp /tmp/pgcolumnar-subsuite.XXXXXX.sh)"
+cat > "$_sub" <<SUBEOF
+#!/bin/bash
+set -uo pipefail
+. "$PGC_SRCDIR/test/lib.sh"
+pgc_setup "\$1"
+# RAISE LOG writes to the server log at a level the default log_min_messages
+# keeps, which is how this gets a line into the log without a crash.
+psql_run "DO \\\$\\\$ BEGIN RAISE LOG '$_fatal_marker'; END \\\$\\\$;"
+psql_run "DO \\\$\\\$ BEGIN FOR i IN 1..60 LOOP RAISE LOG 'selftest filler %', i; END LOOP; END \\\$\\\$;"
+check "deliberate failure so the summary runs" "got" "want"
+pgc_summary
+SUBEOF
+chmod +x "$_sub"
+# PGC_SKIP_BUILD: this sub-suite is testing the summary, not the build, and the
+# .so was already verified above.
+_subout="$(PGC_SKIP_BUILD=1 bash "$_sub" "$PGC_PG_CONFIG" 2>&1)"
+rm -f "$_sub"
+
+# The premise: the sub-suite must actually have failed, and its filler must
+# actually have pushed the marker out of the tail window. Without both, the
+# check below passes for the wrong reason.
+check "premise: the sub-suite failed, so its summary ran" \
+	"$(grep -cE ': FAILED$' <<<"$_subout")" "1"
+check "premise: the 40-line tail is filler, not the marker" \
+	"$(sed -n '/---- server log tail ----/,$p' <<<"$_subout" | grep -c "$_fatal_marker")" "0"
+
+# Scoped to the new section rather than to the whole output, and asked as
+# "is it there" rather than "how many times". PostgreSQL emits a STATEMENT: line
+# beside the message, so the marker legitimately appears twice; an exact count
+# would be asserting a detail of PostgreSQL's logging and would go red the day
+# that changed, without anything being wrong.
+check "a failing suite names the first fatal event in its log" \
+	"$([ "$(sed -n '/---- first fatal events/,/---- server log tail ----/p' <<<"$_subout" \
+		| grep -c "$_fatal_marker")" -ge 1 ] && echo yes || echo no)" \
+	"yes"
+
 pgc_summary

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -726,6 +726,27 @@ pgc_summary() {
 		# summary dies on an unset PGC_LOGFILE under `set -u` and the suite
 		# reports "unbound variable" instead of which check failed.
 		if [ -n "${PGC_LOGFILE:-}" ]; then
+			# The tail is the right thing to show when one statement failed and
+			# the wrong thing after a crash. A crashing backend takes the
+			# postmaster through "terminating any other active server processes"
+			# and recovery for every subsequent check, so the cause sits at the
+			# TOP of the log and the last 40 lines are its aftermath.
+			#
+			# Measured under the pg18_san build, with a deliberate heap overrun:
+			# 67 AddressSanitizer reports in an 8,777-line log, the first at line
+			# 12. The tail showed lines 8738-8777 and pgc_teardown then removed
+			# the file, so a suite reported 123 failures with no way to find out
+			# why -- the diagnosis existed, for a quarter of a second, 8,765 lines
+			# above the only window anyone was shown.
+			#
+			# grep the whole file for the events that mean "this was not a failed
+			# assertion", and print the first few with line numbers.
+			_pgc_fatal="$(pgc_pg "grep -nE 'AddressSanitizer|UndefinedBehaviorSanitizer|runtime error:|terminated by signal|PANIC:' '$PGC_LOGFILE' | head -5" 2>/dev/null || true)"
+			if [ -n "$_pgc_fatal" ]; then
+				echo "---- first fatal events in the server log ----"
+				printf '%s\n' "$_pgc_fatal"
+				echo "(the tail below is what followed; the cause is above)"
+			fi
 			echo "---- server log tail ----"
 			pgc_pg "tail -40 '$PGC_LOGFILE'" 2>/dev/null || true
 		fi


### PR DESCRIPTION
Closes #518.

A suite that fails because a backend **crashed** printed 40 lines of crash
recovery and then deleted the evidence.

`pgc_summary` tails 40 lines of the server log on failure. That is the right view
when one statement failed, and the wrong one after a crash: the postmaster goes
through "terminating any other active server processes" and recovery for *every
subsequent check*, so the cause sits at the top and the tail is aftermath.
`pgc_teardown` then `rm -rf`s the workdir holding the log.

Measured, running a deliberate heap overrun through this harness under `pg18_san`:

| | |
| --- | ---: |
| server log | 8,777 lines |
| `AddressSanitizer` reports | 67 |
| first report at line | **12** |
| what the tail showed | lines 8738-8777 |

123 failures, no cause, evidence deleted.

## The change

Additive. The failure path greps the whole log for the events that mean "this was
not a failed assertion" — `AddressSanitizer`, `UndefinedBehaviorSanitizer`,
`runtime error:`, `terminated by signal`, `PANIC:` — and prints the first five
with line numbers, above the existing tail.

The tail stays. For the ordinary single-statement failure it is still the useful
view, and replacing it would trade one blind spot for another.

## Tests

`harness_selftest.sh` builds the scenario without needing a sanitizer build: a
fatal-looking line via `RAISE LOG`, 60 filler lines to push it past the tail
window, then a real failure.

Two premise checks first, because this check has two ways to pass for the wrong
reason — if the sub-suite never failed, the summary never runs; if the filler
never buried the marker, the existing tail would have shown it and the new code
would be untested:

```
PASS  premise: the sub-suite failed, so its summary ran
PASS  premise: the 40-line tail is filler, not the marker
```

Red before the change, and again with `lib.sh` reverted under the new test
(the removal proof):

```
FAIL  a failing suite names the first fatal event in its log: got [no] want [yes]
```

The assertion is scoped to the new section and asks whether the marker is
present rather than how many times. PostgreSQL emits a `STATEMENT:` line beside
the message so it legitimately appears twice, and pinning the count would assert
a detail of PostgreSQL's logging rather than of this fix.

## Gate

- Five majors (15.18, 16.14, 17.6, 18.4, 19beta2): `harness_selftest` **51 checks / 0 fail**, 0 warnings.
- Full matrix, assert builds of PG18 and PG19: **ALL VERSIONS PASSED** (132 and 134 suites). `lib.sh` is shared by every suite, so the matrix is the check that matters here.

## Provenance

Found while running the sanitizer build over today's decode-path merges (#511,
#514) — ASAN is in neither CI nor the assert matrix, so neither had been run
under one. **No defect was found in either.** Getting to a trustworthy answer
took six controls, because a clean sanitizer run and a broken instrument look
identical; this issue is one of the two things that made them look identical.

The other is environmental and is written up in #518: `ASAN_OPTIONS=log_path=`
pointing somewhere the `postgres` user cannot write discards every report with no
error and no stderr fallback.
