### PR TITLE
test: the sanitizer subset must cover the C-level encoding selftest

### DIFF
--- a/test/harness_selftest.sh
+++ b/test/harness_selftest.sh
@@ -613,4 +613,47 @@ check "a failing suite names the first fatal event in its log" \
 		| grep -c "$_fatal_marker")" -ge 1 ] && echo yes || echo no)" \
 	"yes"
 
+# ---- the sanitizer subset must cover the C-level encoding selftest -----------
+#
+# test/run_san.sh runs a SUBSET of the suites, and a suite that is not in it is
+# not sanitized -- silently, since nothing reports the omission.
+#
+# encode_invariants is the only suite that drives pgcolumnar_debug_encoding_selftest,
+# which exercises bitunpack at every width 1..64 across counts 1,2,3,7,8,9,17,64,129
+# plus a derived count per width. That matters because it is the only fixture that
+# crosses bitunpack's fast/tail boundary in both directions: nFast is 0 until the
+# encoded body reaches nine bytes, so small counts are all tail. Measured with a
+# probe build, counting backends that reached the tail loop:
+#
+#     encode_invariants  21
+#     differential        0
+#
+# differential's chunks are large enough that nFast == n throughout, so a
+# sanitizer pass that includes differential and not encode_invariants covers one
+# of bitunpack's two paths -- over exactly the code #514 rewrote.
+#
+# Asked as "every suite that drives the selftest" rather than by name, so moving
+# the selftest to another suite cannot quietly narrow this.
+_san_suites="$(sed -n '/^SUITES=/,/}"/p' "$PGC_SRCDIR/test/run_san.sh")"
+check "premise: run_san.sh's default subset was found and is non-empty" \
+	"$([ -n "$_san_suites" ] && echo yes || echo no)" "yes"
+
+_san_missing=""
+_san_drivers=0
+for _f in "$PGC_SRCDIR"/test/*.sh; do
+	# Skip this file. It names the function in the pattern just below, so a
+	# blind sweep matches the searcher as well as the searched -- the same
+	# self-match that makes `pgrep -f <pattern>` find its own command line.
+	[ "$(basename "$_f")" = "$(basename "${BASH_SOURCE[0]}")" ] && continue
+	grep -q 'debug_encoding_selftest' "$_f" || continue
+	_san_drivers=$((_san_drivers + 1))
+	_b="$(basename "$_f" .sh)"
+	grep -qw "$_b" <<<"$_san_suites" || _san_missing="$_san_missing $_b"
+done
+check "premise: at least one suite drives the C-level encoding selftest" \
+	"$([ "$_san_drivers" -ge 1 ] && echo yes || echo no)" "yes"
+
+check "the sanitizer subset runs every suite that drives the encoding selftest" \
+	"$(printf '%s' "$_san_missing" | sed 's/^ //')" ""
+
 pgc_summary

--- a/test/run_san.sh
+++ b/test/run_san.sh
@@ -77,6 +77,7 @@ fi
 FUZZ_ITERS="${PGC_SAN_FUZZ_ITERS:-200}"
 SUITES="${PGC_SAN_SUITES:-smoke native_writer native_roundtrip native_encoding \
 	native_zonemap write_fsst_compressed write_minmax_fastpath encode_effort \
+	encode_invariants \
 	native_dml native_skip native_fetch_position native_fetch_cache \
 	arrow_import arrow_export parquet_import parquet_export native_read_parquet \
 	native_parquet_schema hardening corruption differential fuzz_arrow fuzz_parquet}"


### PR DESCRIPTION
`test/run_san.sh` runs a **subset** of the suites, and a suite outside that subset is not sanitized — silently, because nothing reports the omission.

`encode_invariants` was outside it.

## Why that one matters

It is the only suite that drives `pgcolumnar_debug_encoding_selftest`, which exercises `bitunpack` at every width 1..64 across counts 1, 2, 3, 7, 8, 9, 17, 64, 129 plus a derived count per width.

That makes it the only fixture crossing `bitunpack`'s fast/tail boundary in **both** directions: `nFast` is zero until the encoded body reaches nine bytes (`n * width >= 65`), so small counts run the tail and larger ones the wide load. Measured with a probe build that recorded whether the tail loop executed, counting backends that reached it:

| suite | backends reaching the tail |
| --- | ---: |
| `encode_invariants` | **21** |
| `differential` | **0** |

`differential` is in the subset; its chunks are large enough that `nFast == n` throughout. So the sanitizer pass covered one of `bitunpack`'s two paths — over exactly the code #514 rewrote — and "clean under ASAN" described the half that ran.

## Tests

The check asks whether **every suite driving the selftest** is in the subset, rather than naming `encode_invariants`, so relocating the selftest cannot quietly narrow it. Same construction as the oracle deriving its count instead of listing it.

Two premises first, because the check has two ways to pass vacuously — an empty subset parse, or no drivers found at all:

```
PASS  premise: run_san.sh's default subset was found and is non-empty
PASS  premise: at least one suite drives the C-level encoding selftest
```

Red before the change, and again with `run_san.sh` alone reverted (the removal proof):

```
FAIL  the sanitizer subset runs every suite that drives the encoding selftest: got [encode_invariants] want []
```

The sweep skips `harness_selftest.sh` itself. It names the function in the pattern it searches with, so a blind sweep matches the searcher as well as the searched — the same self-match that makes `pgrep -f <pattern>` find its own command line. The first run of this check reported `[encode_invariants harness_selftest]`.

## Gate

- Five majors (15.18, 16.14, 17.6, 18.4, 19beta2): `harness_selftest` **54 checks / 0 fail**, 0 warnings each.
- **Through `run_san.sh` itself**, with its own fatal-on-violation options rather than options I chose: `PASS encode_invariants`, 1 suite under sanitizers, 0 failed, 0 ran no checks. Adding a suite to the subset would be worthless if it failed there.
- Full matrix, assert builds of PG18 and PG19: **ALL VERSIONS PASSED**.

Refs #520, #514.
