### PR TITLE
fix: the batch fold must refuse a group whose decode skipped vectors (#512)

### DIFF
--- a/src/columnar.h
+++ b/src/columnar.h
@@ -624,7 +624,8 @@ extern void PgColumnarEndRead(PgColumnarReadState *readState);
 extern bool PgColumnarReadFoldNextGroup(PgColumnarReadState *readState);
 extern void PgColumnarReadFoldGroupInfo(PgColumnarReadState *readState, uint64 *nrows,
 									  const char **deleteMask, uint32 *deleteMaskLen,
-									  const bool **skipVec, const uint32 **vecStart,
+									  const bool **skipVec, bool *decodeSkipped,
+									  const uint32 **vecStart,
 									  int *vectorCount);
 extern bool PgColumnarReadFoldColumn(PgColumnarReadState *readState, int attidx,
 								   const char **validity, const char **packed,

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -158,6 +158,16 @@ struct PgColumnarReadState
 	uint64		rowsFilteredEarly;
 
 	/*
+	 * Did loading this group skip the DECODE of any vector (#512)?
+	 *
+	 * False always, today: pgcolumnar_native_decode_chunk takes no skip mask and
+	 * produces every vector. It exists so the batch fold can refuse a group it
+	 * cannot read safely the day that changes -- see PgColumnarReadFoldGroupInfo
+	 * and the check in columnar_vector.c.
+	 */
+	bool		decodeSkippedVectors;
+
+	/*
 	 * Native delete visibility (Phase D6b): the current row group's combined
 	 * delete mask (one bit per row-in-group, set = deleted), from
 	 * pgcolumnar.delete_vector keyed by group number. NULL when the group has no
@@ -1931,13 +1941,14 @@ PgColumnarReadFoldNextGroup(PgColumnarReadState *readState)
 void
 PgColumnarReadFoldGroupInfo(PgColumnarReadState *readState, uint64 *nrows,
 						  const char **deleteMask, uint32 *deleteMaskLen,
-						  const bool **skipVec, const uint32 **vecStart,
+						  const bool **skipVec, bool *decodeSkipped, const uint32 **vecStart,
 						  int *vectorCount)
 {
 	*nrows = readState->groupRowCount;
 	*deleteMask = readState->nativeDeleteMask;
 	*deleteMaskLen = readState->nativeDeleteMaskLen;
 	*skipVec = readState->nativeSkipVec;
+	*decodeSkipped = readState->decodeSkippedVectors;
 	*vecStart = readState->nativeVecStart;
 	*vectorCount = readState->nativeVectorCount;
 }

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -3163,12 +3163,43 @@ pgcolumnar_native_batch_fold(PgColumnarAggScanState *state, Relation rel,
 		const char *dmask;
 		uint32		dlen;
 		const bool *skipVec;
+		bool		decodeSkipped;
 		const uint32 *vecStart;
 		int			vcount;
 		uint64		r;
 
 		PgColumnarReadFoldGroupInfo(rs, &nrows, &dmask, &dlen,
-								  &skipVec, &vecStart, &vcount);
+								  &skipVec, &decodeSkipped, &vecStart, &vcount);
+
+		/*
+		 * This loop does not honour skipVec. It reads every vector and reaches
+		 * the right answer by re-checking every value against the scan keys
+		 * below, which is correct only while decode has produced every vector.
+		 *
+		 * The moment decode is taught to skip the vectors the zone maps ruled
+		 * out (#452 phase 1b, the obvious next optimisation), the buffer gains
+		 * holes and this loop would re-check UNINITIALISED memory: a wrong
+		 * aggregate, silently, and only on data whose zone maps rule something
+		 * out. The row producer is safe there because it steps its cursors past
+		 * skipped vectors; this path is not, and pgcolumnar_batch_shape_eligible
+		 * requires every qual to be convertible to a scan key -- so the fold runs
+		 * precisely when predicates exist, which is exactly when vectors get
+		 * skipped. Common case, not an edge.
+		 *
+		 * So the ordering constraint is enforced rather than written down: the
+		 * fold must learn to skip before decode is allowed to. Whoever makes that
+		 * change gets this error instead of arithmetic, and they are the person
+		 * least likely to look in this file.
+		 *
+		 * Measured, so the ordering is not merely asserted: teaching this loop to
+		 * honour skipVec costs about 2% and saves nothing until decode changes,
+		 * so it belongs IN that change and not before it (#512).
+		 */
+		if (decodeSkipped)
+			elog(ERROR,
+				 "pgcolumnar: the vectorized aggregate cannot fold a row group "
+				 "whose decode skipped vectors (#512); teach this loop to honour "
+				 "the skip vector in the same change that makes decode honour it");
 
 		for (col = 0; col < natts; col++)
 		{

--- a/test/native_fold_skipguard.sh
+++ b/test/native_fold_skipguard.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# pgColumnar: the batch fold must refuse a group whose decode skipped vectors
+# (#512).
+#
+# The fold at columnar_vector.c does NOT honour the skip vector. It reads every
+# vector and reaches the right answer by re-checking every value against the scan
+# keys, which is correct only while decode produces every vector -- and today it
+# does, because pgcolumnar_native_decode_chunk takes no skip mask at all.
+#
+# The day decode is taught to skip ruled-out vectors (#452 phase 1b) the decoded
+# buffer gains holes, and this loop would re-check UNINITIALISED memory: a wrong
+# aggregate, silently, and only on data whose zone maps rule something out. The
+# row producer is safe there; the fold is not. So the ordering constraint is
+# enforced by a guard rather than written in a comment.
+#
+# This suite proves the guard is REACHABLE, which is the part that is easy to get
+# wrong: the fold only runs for a shape that qualifies for it, and the hazard only
+# exists where vectors are skipped. Both have to be true at once, and a check that
+# never reaches the fold would pass forever while guarding nothing.
+#
+# Usage:  test/native_fold_skipguard.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+ROWS=60000
+psql_run "CREATE TABLE t (k int, v int) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.set_options('t'::regclass, stripe_row_limit => 60000, chunk_group_row_limit => 1024);"
+psql_run "INSERT INTO t SELECT g, g FROM generate_series(1, $ROWS) g;"
+psql_run "ANALYZE t;"
+
+# Monotonic k, so each 1024-row vector has a tight non-overlapping zone map and a
+# narrow range rules almost all of them out.
+Q="SELECT count(*), sum(v) FROM t WHERE k BETWEEN 30000 AND 30100"
+
+# The fold needs its GUC and no parallelism; the scalar arm is the same query
+# with the GUC off, which is what reports the per-vector counter.
+SET_ON="SET max_parallel_workers_per_gather=0; SET pgcolumnar.enable_ungrouped_vector_agg=on;"
+SET_OFF="SET max_parallel_workers_per_gather=0; SET pgcolumnar.enable_ungrouped_vector_agg=off;"
+
+run() {  # run <setup> <sql>
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -At -c "$1" -c "$2" 2>&1
+}
+
+# ---- premise one: the reader really does skip vectors for this predicate ----
+#
+# Read off the SCALAR arm, because the vectorized aggregate node does not print
+# "Columnar Vectors Skipped" at all -- a reporting gap of its own. Same table,
+# same predicate, same reader, so what it skips there it skips here.
+vskip=$(run "$SET_OFF" "EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) $Q" \
+	| grep "Columnar Vectors Skipped" | grep -oE '[0-9]+' | head -1)
+check "premise: the predicate rules vectors out at all" \
+	"$([ "${vskip:-0}" -gt 0 ] && echo yes || echo no)" "yes"
+
+# ---- premise two: the query actually reaches the fold -----------------------
+#
+# Without this the guard below is unreachable and the suite would pass forever
+# while protecting nothing. This is the premise a first version of this test
+# lacked, and it is why that version could not be trusted.
+fold=$(run "$SET_ON" "EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) $Q" \
+	| grep -oE "Columnar Batch Fold: [a-z]+" | head -1)
+check "premise: the query reaches the batch fold" "$fold" "Columnar Batch Fold: yes"
+
+# ---- the guard is silent while decode produces every vector ----------------
+#
+# Today decode never skips, so the fold must run normally and answer correctly.
+# The heap arithmetic is the oracle: 101 rows, sum of 30000..30100.
+want_n=101
+want_s=$(( (30000 + 30100) * 101 / 2 ))
+got=$(run "$SET_ON" "$Q" | tail -1)
+check "the fold answers correctly while decode skips nothing" "$got" "$want_n|$want_s"
+
+# And the same answer without the fold, so the fold is not quietly wrong in a way
+# that matches a wrong expectation.
+got_off=$(run "$SET_OFF" "$Q" | tail -1)
+check "and the scalar arm agrees" "$got_off" "$got"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -96,6 +96,7 @@ SUITES=(
 	native_fetch_interrupt
 	native_fetch_position
 	native_fetch_projection
+	native_fold_skipguard
 	native_format
 	native_gap
 	native_groupagg


### PR DESCRIPTION
The batch fold does not honour the skip vector. It reads every vector and reaches the right answer by re-checking every value against the scan keys — correct only while decode produces every vector, which today it does, because `pgcolumnar_native_decode_chunk` takes no skip mask at all. `skipVec` is fetched into a local that is **never indexed**.

## The hazard, now stated as a number rather than a code reading

@ChronicallyJD measured it on `native_vecskip`'s fixture — 8192 rows, one row group, eight 1024-row vectors, monotonic id so each zone map is tight. Same table, same predicate, only the node differing:

| node | `Columnar Vectors Skipped` |
| --- | ---: |
| scalar custom scan | **7** |
| vectorized aggregate (`Batch Fold: yes`) | **0** |

The scalar node steps past seven of eight vectors. The fold traverses all eight. **That is why holes in the decoded buffer would be read**: the fold genuinely walks vectors the zone maps ruled out.

The day decode is taught to skip them (#452 phase 1b, the obvious next optimisation), that loop would re-check **uninitialised memory** — a wrong aggregate, silently, and only on data whose zone maps rule something out. The row producer is safe there because it steps its cursors past skipped vectors. And `pgcolumnar_batch_shape_eligible` requires every qual to be convertible to a scan key, so the fold runs **precisely when predicates exist**, which is exactly when vectors get skipped. Common case, not an edge.

**What that 7-against-0 does not say.** It is a hazard argument, not a cost one. The work the fold does on those rows is a scan-key re-check, not materialisation. Measured on a 2M-row single-group fixture with 1,952 vectors skipped, teaching the fold to honour `skipVec` runs **76.8 ms → 78.4 ms — slower** — with identical answers, because the gather must still run to keep each column's present-index aligned. So the saving is only the key test and the aggregate apply, which is less than the per-row vector tracking costs. Both numbers belong here, or someone reads 7-against-0 as a performance defect and optimises a 2% regression into place.

That measurement is also the argument for **where** the fix belongs: honouring `skipVec` costs today and pays only once decode skips, so it goes *in* that change, not before it.

## The guard

The loader reports whether it skipped any vector's decode — `false` always, today — and the fold refuses a group it cannot read safely:

```
ERROR:  pgcolumnar: the vectorized aggregate cannot fold a row group whose decode
skipped vectors (#512); teach this loop to honour the skip vector in the same
change that makes decode honour it
```

**Not the form first proposed.** "Assert no vector is skipped" would trip on ordinary aggregate queries, since the fold runs precisely when predicates exist and predicates are what cause skipping. This asserts the condition that makes the hazard **real**, not the one that makes it possible.

## Proof

`test/native_fold_skipguard.sh` proves the guard is **reachable**, which is the part that is easy to get wrong, and carries the two premises that make it worth anything:

1. the reader must skip vectors for this predicate, and
2. the query must reach the fold.

Either alone lets the suite pass forever while guarding nothing.

Fired by simulating the hazard exactly as a decode-skipping change would — the loader reporting skipped wherever a skip vector exists — with the `.so` fingerprinted across both arms. Guard present and hazard simulated: the error above. Guard present, no simulation: 4/4 green.

**An earlier attempt at this guard could not be proven and was correctly not shipped.** The cause was a wrong GUC name — `enable_vectorization` rather than `enable_ungrouped_vector_agg` — so the fixture ran the scalar path and the guard was unreachable. The guard was fine; the probe was not.

## Gate

```
PASS PG15 (130 ran, 5 skipped) · PASS PG16 (130) · PASS PG17 (130)
PASS PG18 (133 ran, 2 skipped) · PASS PG19 (135 ran, 0 skipped)
ALL VERSIONS PASSED · exit=0
```

`native_fold_skipguard=PASS` on all five and absent from every skip list.

Refs #512, #452