### PR TITLE
test: ask run_san.sh for its subset, with the override cleared (#521 follow-up)

### DIFF
--- a/test/harness_selftest.sh
+++ b/test/harness_selftest.sh
@@ -634,7 +634,18 @@ check "a failing suite names the first fatal event in its log" \
 #
 # Asked as "every suite that drives the selftest" rather than by name, so moving
 # the selftest to another suite cannot quietly narrow this.
-_san_suites="$(sed -n '/^SUITES=/,/}"/p' "$PGC_SRCDIR/test/run_san.sh")"
+# Ask the runner rather than parsing the source (CONTEXT.md, #473) -- but with
+# PGC_SAN_SUITES cleared, because the claim under test is about the SHIPPED
+# DEFAULT, not about whatever an operator overrode it with for one run.
+#
+# Both halves are load-bearing and each fixes a different defect. Asking the
+# runner means this cannot drift from what run_san.sh actually iterates. Clearing
+# the variable means a developer with an override exported does not get a red
+# from a check that is not about their override -- which is what a plain
+# --list-suites here produces, verified: with PGC_SAN_SUITES='smoke differential'
+# the runner reports no encode_invariants and this check would fail while the
+# shipped default is perfectly correct.
+_san_suites="$(env -u PGC_SAN_SUITES bash "$PGC_SRCDIR/test/run_san.sh" --list-suites 2>/dev/null)"
 check "premise: run_san.sh's default subset was found and is non-empty" \
 	"$([ -n "$_san_suites" ] && echo yes || echo no)" "yes"
 

--- a/test/run_san.sh
+++ b/test/run_san.sh
@@ -34,6 +34,30 @@
 #
 set -uo pipefail
 
+# The subset, and the one place it is defined.
+#
+# Declared before anything else runs so --list-suites can answer without building
+# a sanitizer PostgreSQL first, and so a caller asking what would be sanitized
+# gets the same string the loop below iterates -- not a second copy of it, and
+# not a text parser's reading of this file. #473 replaced exactly that pattern in
+# run_all_versions.sh, and CONTEXT.md records why: a parser over the array
+# disagrees with the shell on the mistake this invites, and the disagreement is
+# silent.
+SUITES="${PGC_SAN_SUITES:-smoke native_writer native_roundtrip native_encoding \
+	native_zonemap write_fsst_compressed write_minmax_fastpath encode_effort \
+	encode_invariants \
+	native_dml native_skip native_fetch_position native_fetch_cache \
+	arrow_import arrow_export parquet_import parquet_export native_read_parquet \
+	native_parquet_schema hardening corruption differential fuzz_arrow fuzz_parquet}"
+
+# --list-suites: print the subset, one name per line, and exit. Answered before
+# the prerequisite check below, so it works on a box with no sanitizer build at
+# all -- a caller asking "what does this cover" should not need one.
+if [ "${1:-}" = "--list-suites" ]; then
+	printf '%s\n' $SUITES
+	exit 0
+fi
+
 SAN="${1:-/usr/local/pg18_san}"
 PGCONF="$SAN/bin/pg_config"
 if [ ! -x "$PGCONF" ]; then
@@ -75,12 +99,6 @@ if ! make -s PG_CONFIG="$PGCONF" install > /tmp/run-san-ext.log 2>&1; then
 fi
 
 FUZZ_ITERS="${PGC_SAN_FUZZ_ITERS:-200}"
-SUITES="${PGC_SAN_SUITES:-smoke native_writer native_roundtrip native_encoding \
-	native_zonemap write_fsst_compressed write_minmax_fastpath encode_effort \
-	encode_invariants \
-	native_dml native_skip native_fetch_position native_fetch_cache \
-	arrow_import arrow_export parquet_import parquet_export native_read_parquet \
-	native_parquet_schema hardening corruption differential fuzz_arrow fuzz_parquet}"
 
 echo "-- running the subset under ASAN+UBSAN (fatal)"
 fail=0


### PR DESCRIPTION
`run_san.sh` gains `--list-suites`, and `harness_selftest` asks it instead of parsing the `SUITES=` block with `sed`.

## The reason I gave in review of #521 was wrong

I claimed the dangerous direction was a suite named in a **comment inside** the `SUITES=` block — satisfying the `grep -qw` and reporting coverage that does not exist. **That cannot happen.** I built the case to prove it before shipping a fix for it, and the runner and the parser agreed: `SUITES=` is a double-quoted *string* spanning backslash continuations, not a bash array, so a `#` inside it is literal text.

What survives is the weaker and sufficient reason, which #473 and `CONTEXT.md:169` already give: it is a second reading of a definition only `run_san.sh` should own. That stands without the hazard I invented.

## And the obvious fix was a regression

A plain `--list-suites` inherits `PGC_SAN_SUITES`. The claim under test is about the **shipped default**, so a developer with an override exported gets a red from a check that is not about their override. Verified — with `PGC_SAN_SUITES='smoke differential'` the runner reports no `encode_invariants` and the check fails while the default is perfectly correct.

**@ChronicallyJD's source parse was right about that**, because it read the default regardless of environment. `env -u PGC_SAN_SUITES` keeps that property while making the runner authoritative.

## Verified in three directions, not one

```
default                              54 checks, PASSED
with PGC_SAN_SUITES exported         54 checks, PASSED   (a plain --list-suites reds here)
encode_invariants cut from default   FAIL ... got [encode_invariants] want []
```

The middle row is the one that matters: it is the regression this would have shipped, and it only appears if you think to export the variable before running the suite.

## Why `--list-suites` is worth having anyway

It is answered **before** the prerequisite check, so `bash test/run_san.sh --list-suites` works on a box with no sanitizer build at all. A caller asking "what does this cover" should not need one, and the gate can now ask rather than parse.

Refs #521