### PR TITLE
refactor: the six columnar.h declarations nothing outside their file uses (#496)

### DIFF
--- a/src/columnar.h
+++ b/src/columnar.h
@@ -373,10 +373,7 @@ extern uint64 PgColumnarItemPointerToRowNumber(ItemPointer tid);
 /* -------------------------------------------------------------------------
  * visibility map for index-only scans (pgcolumnar_visibilitymap.c, gap 28)
  * ------------------------------------------------------------------------- */
-extern void PgColumnarVMSetVisible(Relation rel, BlockNumber blk);
-extern void PgColumnarVMClearVisible(Relation rel, BlockNumber blk);
 extern void PgColumnarVMClearForRow(Relation rel, uint64 rowNumber);
-extern bool PgColumnarVMIsVisible(Relation rel, BlockNumber blk);
 extern uint64 PgColumnarVMSetVisibleForRelation(Relation rel);
 extern void PgColumnarDiscardFetchCache(void);
 
@@ -427,8 +424,6 @@ typedef struct PgColumnarRowRange
 
 /* row groups every one of whose rows is deleted as-of oldestXmin. Returns a
  * List of palloc'd uint64 group numbers. */
-extern List *PgColumnarComputeFullyDeletedGroups(uint64 storageId,
-											   TransactionId oldestXmin);
 extern void PgColumnarRetireGroup(uint64 storageId, uint64 groupNumber);
 extern int64 PgColumnarRetireFullyDeletedGroups(Relation rel);
 extern void PgColumnarLockChunkGroup(uint64 storageId, uint64 groupNumber);
@@ -487,8 +482,6 @@ extern List *PgColumnarReadZoneMapList(uint64 storageId, uint64 groupNumber,
 									 Snapshot snapshot);
 extern List *PgColumnarReadZoneMapVectors(uint64 storageId, uint64 groupNumber,
 										Snapshot snapshot);
-extern List *PgColumnarReadBloomList(uint64 storageId, uint64 groupNumber,
-								   Snapshot snapshot);
 extern NativeBloomMetadata *PgColumnarReadBloomForColumn(uint64 storageId,
 													   uint64 groupNumber,
 													   int columnIndex,
@@ -838,7 +831,6 @@ extern bool PgColumnarBlockNextRun(PgColumnarBlockReader *br,
 /* -------------------------------------------------------------------------
  * compression (pgcolumnar_compression.c, spec 5)
  * ------------------------------------------------------------------------- */
-extern bool PgColumnarCodecAvailable(int compressionType);
 extern void PgColumnarCompressValueStream(const char *raw, uint32 rawLen,
 										int requestedType, int level,
 										char **outData, uint32 *outLen,

--- a/src/columnar_compression.c
+++ b/src/columnar_compression.c
@@ -29,36 +29,6 @@
 #endif
 
 /*
- * PgColumnarCodecAvailable
- *		Whether a compression type can be produced by this binary. none and
- *		pglz are always available; lz4 and zstd depend on the build.
- */
-bool
-PgColumnarCodecAvailable(int compressionType)
-{
-	switch (compressionType)
-	{
-		case COLUMNAR_COMPRESSION_NONE:
-		case COLUMNAR_COMPRESSION_PGLZ:
-			return true;
-		case COLUMNAR_COMPRESSION_LZ4:
-#ifdef HAVE_LIBLZ4
-			return true;
-#else
-			return false;
-#endif
-		case COLUMNAR_COMPRESSION_ZSTD:
-#ifdef HAVE_LIBZSTD
-			return true;
-#else
-			return false;
-#endif
-		default:
-			return false;
-	}
-}
-
-/*
  * try_pglz
  *		Compress with PostgreSQL's builtin pglz. Returns the compressed length
  *		on success (always < rawLen because we use the "always" strategy and

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -322,7 +322,7 @@ PgColumnarComputeAllVisibleGroups(uint64 storageId, TransactionId oldestXmin)
  *		delete or any inserter to target, and old-snapshot readers keep the old
  *		catalog version via heap MVCC. Returns a List of palloc'd uint64.
  */
-List *
+static List *
 PgColumnarComputeFullyDeletedGroups(uint64 storageId, TransactionId oldestXmin)
 {
 	Relation	grel = open_columnar_table("row_group", AccessShareLock);
@@ -1917,57 +1917,6 @@ PgColumnarInsertBloomRow(const NativeBloomMetadata *b)
 	CatalogTupleInsert(rel, tuple);
 	heap_freetuple(tuple);
 	table_close(rel, RowExclusiveLock);
-}
-
-/*
- * PgColumnarReadBloomList
- *		The per-column-chunk bloom filters of one row group (native spec 7.2,
- *		Phase D5b). The caller indexes the result by column_index; the filter
- *		bytes are copied into the current memory context.
- */
-List *
-PgColumnarReadBloomList(uint64 storageId, uint64 groupNumber, Snapshot snapshot)
-{
-	Relation	rel = open_columnar_table("bloom", AccessShareLock);
-	TupleDesc	tupdesc = RelationGetDescr(rel);
-	ScanKeyData key[2];
-	SysScanDesc scan;
-	Oid			idxOid;
-	HeapTuple	tuple;
-	List	   *result = NIL;
-
-	ScanKeyInit(&key[0], Anum_bloom_storage_id, BTEqualStrategyNumber,
-				F_INT8EQ, Int64GetDatum((int64) storageId));
-	ScanKeyInit(&key[1], Anum_bloom_group_number, BTEqualStrategyNumber,
-				F_INT8EQ, Int64GetDatum((int64) groupNumber));
-	idxOid = pgcolumnar_index_oid("bloom_pkey");
-	scan = systable_beginscan(rel, idxOid, OidIsValid(idxOid), snapshot,
-							  2, key);
-	while (HeapTupleIsValid(tuple = systable_getnext(scan)))
-	{
-		NativeBloomMetadata *b = palloc0(sizeof(NativeBloomMetadata));
-		bool		isnull;
-		Datum		d;
-
-		b->storageId = storageId;
-		b->groupNumber = groupNumber;
-		b->columnIndex = DatumGetInt16(
-			heap_getattr(tuple, Anum_bloom_column_index, tupdesc, &isnull));
-		d = heap_getattr(tuple, Anum_bloom_filter, tupdesc, &isnull);
-		if (!isnull)
-		{
-			bytea	   *bf = DatumGetByteaPP(d);
-
-			b->filterLen = VARSIZE_ANY_EXHDR(bf);
-			b->filter = (const char *) memcpy(palloc(b->filterLen + 1),
-											  VARDATA_ANY(bf), b->filterLen);
-		}
-		result = lappend(result, b);
-	}
-	systable_endscan(scan);
-	table_close(rel, AccessShareLock);
-
-	return result;
 }
 
 /*

--- a/src/columnar_visibilitymap.c
+++ b/src/columnar_visibilitymap.c
@@ -73,7 +73,7 @@ PG_FUNCTION_INFO_V1(pgcolumnar_vm_is_visible);
  *		only the VM fork -- there is no heap page to flag -- which is why it does
  *		not go through visibilitymap_set().
  */
-void
+static void
 PgColumnarVMSetVisible(Relation rel, BlockNumber blk)
 {
 	Buffer		vmbuf = InvalidBuffer;
@@ -112,7 +112,7 @@ PgColumnarVMSetVisible(Relation rel, BlockNumber blk)
  *		Clear the all-visible (and all-frozen) bits for `blk`, WAL-logged. Used
  *		by write paths so a modified range is never reported all-visible.
  */
-void
+static void
 PgColumnarVMClearVisible(Relation rel, BlockNumber blk)
 {
 	Buffer		vmbuf = InvalidBuffer;
@@ -173,7 +173,7 @@ PgColumnarVMClearForRow(Relation rel, uint64 rowNumber)
  *		True if `blk` is marked all-visible in the VM fork. Thin wrapper over the
  *		stock reader (the same call the index-only-scan executor makes).
  */
-bool
+static bool
 PgColumnarVMIsVisible(Relation rel, BlockNumber blk)
 {
 	Buffer		vmbuf = InvalidBuffer;


### PR DESCRIPTION
A first, deliberately small bite of #496: the declarations in `columnar.h` that **nothing outside their defining file uses**. The issue counts 10 of these and calls them the cheapest thing available. Six of them are, and this is those six.

No behaviour changes. 93 lines removed, 4 added.

## What changed

| symbol | file | change |
| --- | --- | --- |
| `PgColumnarCodecAvailable` | `columnar_compression.c` | **deleted** — no caller anywhere, including its own file |
| `PgColumnarReadBloomList` | `columnar_metadata.c` | **deleted** — same |
| `PgColumnarComputeFullyDeletedGroups` | `columnar_metadata.c` | `static` |
| `PgColumnarVMSetVisible` | `columnar_visibilitymap.c` | `static` |
| `PgColumnarVMClearVisible` | `columnar_visibilitymap.c` | `static` |
| `PgColumnarVMIsVisible` | `columnar_visibilitymap.c` | `static` |

The three VM helpers are the low-level primitives; `columnar_tableam.c` uses the wrappers `PgColumnarVMClearForRow` and `PgColumnarVMSetVisibleForRelation`, which stay exported. Deleted rather than made `static` where there was no in-file caller either, because an uncalled `static` is an unused-function warning, and this matrix treats warnings as failures.

## Why it is six and not ten

**Four of the ten cannot be touched, and the reason is one the compiler will not give you.** `PgColumnarBlockNextRun`, `PgColumnarBlockReaderInit`, `PgColumnarCheckFreeSpaceNoOverlap` and `PgColumnarEncodingName` are named in `test/` or `sql/` — they are reached through the fmgr by name, from `CREATE FUNCTION ... AS 'pgcolumnar', 'sym'`, not by a C caller.

Making one of those `static` **compiles and links cleanly** and then fails at run time when the SQL binding cannot resolve the symbol. So "no `.c` file references it" is not sufficient evidence that a declaration is private, and the audit that produced this list disqualifies anything with `PG_FUNCTION_INFO_V1` or a mention under `test/` or `sql/` before proposing it.

That distinction is the part of this worth keeping for the rest of #496.

## Verification

A successful build proves less than it looks like here: a shared library links with **undefined symbols permitted**, so a stale reference to a now-`static` function would not fail `make` — it would fail at `dlopen`, i.e. at `CREATE EXTENSION`. So the load-bearing evidence is the suites, not the compile.

- Five majors (15.18, 16.14, 17.6, 18.4, 19beta2): build clean, **0 warnings each**.
- `index_only` 27 checks / 0 fail — the suite that drives the visibility-map path these three helpers implement.
- Full matrix on assert builds of PG18 and PG19: **ALL VERSIONS PASSED** (132 and 134 suites). Every one of those does `CREATE EXTENSION`, which is where a missing symbol would surface.

I also tried to verify linkage directly with `nm` and could not make it say anything trustworthy: the `.so` exports nothing in the dynamic table (194 symbols exist only in the full one), and the still-shared wrappers report the same symbol type as the newly-static ones, so the check could not distinguish the two cases it was supposed to distinguish. Recording that rather than quoting the output it did produce.

The gate ran one commit before #524 merged; that commit adds `bench/provision.sh` only, and no suite executes or reads it (`bench_guards` inspects `cb_guards.sh`), so the matrix outcome cannot turn on it.

Refs #496.
