### PR TITLE
docs: what the sanitizer gate cannot see (#520)

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -313,6 +313,41 @@ x86_64 cannot see. x86_64 puts stores in a more strict order than aarch64. Thus 
 missing barrier in concurrent code can be invisible on one architecture and a
 defect on the other. The suites that would show it must run.
 
+### What the sanitizer gate cannot see
+
+A green sanitizer run does not mean there is no over-read. AddressSanitizer
+reports a read past an **allocation**. `palloc` sub-allocates chunks out of an
+8 KB block. The sanitizer sees that block as one live object. So a read past a
+chunk's logical end usually lands inside the block. That memory is allocated and
+addressable, and the read is not reported. Detection depends on where in its
+block the chunk happened to sit.
+
+Measured on the instrumented build. The injected read is one byte past a
+`palloc(8)`:
+
+| the chunk sat | ASAN | Valgrind, `USE_VALGRIND` build |
+| --- | --- | --- |
+| at the end of its 8 KB block | reports | reports |
+| interior to its block | **silent** | reports |
+
+This is structural, not a configuration mistake. PostgreSQL has no ASAN poisoning
+hooks. `aset.c` marks chunk padding for Valgrind with
+`VALGRIND_MAKE_MEM_NOACCESS`, and AddressSanitizer has no equivalent. A
+`USE_VALGRIND` build under memcheck does see these reads. It is the right
+instrument for a decode-path audit. It is not in CI, because it is far too slow
+for one.
+
+One class no memory tool can report is a read that stays **inside** an allocated
+buffer. `bitunpack` receives a pointer into a larger `palloc`'d blob. A modest
+over-read of the packed body lands in that same chunk. It produces wrong values
+rather than a fault. That is not a memory error, so nothing flags it.
+
+The consequence for review is narrow but important. A clean sanitizer run is not
+evidence that a bounds calculation is correct. What protects those is the
+arithmetic itself, and the reference oracles described under the differential
+oracle above. Read "ASAN clean" as its true meaning: no use-after-free, no escape
+from the allocation, and no alignment fault.
+
 **On documentation changes** (`.github/workflows/docs.yml`): builds and publishes
 the site at
 [commandprompt.github.io/pgcolumnar](https://commandprompt.github.io/pgcolumnar/).


### PR DESCRIPTION
#520 established what AddressSanitizer does and does not report in this codebase. That belongs in `docs/testing.md`, beside the gate it qualifies, rather than in an open issue nobody reads before trusting a green run.

The value of this text is pre-emptive. Someone reads "the nightly run includes the ASAN and UBSAN sanitizer gate", concludes that a green run means there is no over-read, and stops. The correction has to sit next to the claim it qualifies.

## What the section records

Measured on the instrumented build, injecting a read one byte past a `palloc(8)`:

| the chunk sat | ASAN | Valgrind, `USE_VALGRIND` build |
| --- | --- | --- |
| at the end of its 8 KB block | reports | reports |
| interior to its block | **silent** | reports |

- ASAN reports a read past an **allocation**. `palloc` sub-allocates chunks out of an 8 KB block that the sanitizer sees as one live object, so detection of a chunk over-read depends on where in its block the chunk happened to sit.
- It is **structural, not misconfiguration**: PostgreSQL has no ASAN poisoning hooks, and `aset.c` marks chunk padding for Valgrind only (`VALGRIND_MAKE_MEM_NOACCESS`).
- One class **no** memory tool reports: a read that stays *inside* an allocated buffer. `bitunpack` receives a pointer into a larger `palloc`'d blob, so a modest over-read lands in the same chunk and yields wrong values rather than a fault.

And the conclusion that makes it worth writing: **a clean sanitizer run is not evidence that a bounds calculation is correct.** The arithmetic and the reference oracles are what protect those. "ASAN clean" means no use-after-free, no escape from the allocation, no alignment fault, and nothing wider.

It also names the `USE_VALGRIND` build as the right instrument for a decode-path audit, and says why it is not in CI.

## On the provenance

I reached this after **three** public positions on #520: filed on evidence that did not support it, retracted it on evidence I had not read, then restored it on a control that distinguished the cases. @jdatcmd refusing the retraction and asking for the discriminator is what settled it. The text here is the settled version, and none of that history is in the document, which is as it should be.

## Gate

- `docs_style` 6 checks / 0 fail.
- Full matrix on assert builds of PG18 and PG19: **ALL VERSIONS PASSED**.

`docs_style` rejected the first draft: four sentences over the 25-word STE limit and three em dashes. Recording that because it is the check doing its job on prose I would otherwise have shipped, and because the rewrite is shorter and better for it.

Closes #520.
