### PR TITLE
bench: a win is decided on the times, not on the printed string (#531)

### DIFF
--- a/bench/cb_guards.sh
+++ b/bench/cb_guards.sh
@@ -134,3 +134,71 @@ cb_cold_tag() {
 			;;
 	esac
 }
+
+# ---------------------------------------------------------------------------
+# Deciding a win from two timings (#531)
+# ---------------------------------------------------------------------------
+#
+# The report used to count wins by comparing the "%.2f" string it had already
+# printed for the table:
+#
+#     r1=$(ratio "$c" "$h")
+#     if [ "$(awk -v r="$r1" 'BEGIN { print (r < 1) ? 1 : 0 }')" = 1 ] ...
+#
+# so a query where columnar was faster by less than half a percent printed 1.00
+# and was counted a LOSS -- contradicting the legend printed directly above the
+# same table, which says "above 1.00 means we lose". On the 2026-08-09 run this
+# reported 33 wins and 10 losses where the times give 36 and 7.
+#
+# Comparing the unrounded times fixes the contradiction, but a bare two-way
+# comparison then over-claims in the other direction: q35 that day was 0.01
+# percent apart while the arms' OWN warm tries were 2.9 percent apart. A
+# difference smaller than the instrument's scatter is not a result in either
+# direction, so the verdict is three-way and the band is that scatter, measured
+# per query from the arms in play rather than picked here as a constant.
+
+# Fractional spread of a set of timings: (worst - best) / best, or "-" when
+# there is nothing usable. With CB_TRIES=2 there is ONE warm try per arm, so
+# this is 0 and cb_verdict degenerates to a strict comparison. That is the
+# honest degeneration: no repeat means no evidence about repeatability, which is
+# not licence to call a 0.01 percent difference a result.
+cb_warm_spread() {  # cb_warm_spread <t> [t...] -> "n.nnnn" or "-"
+	local t best="" worst=""
+	for t in "$@"; do
+		case "$t" in '' | *ERR*) continue ;; esac
+		if [ -z "$best" ]; then best="$t"; worst="$t"; continue; fi
+		[ "$(awk -v a="$t" -v b="$best"  'BEGIN { print (a < b) ? 1 : 0 }')" = 1 ] && best="$t"
+		[ "$(awk -v a="$t" -v b="$worst" 'BEGIN { print (a > b) ? 1 : 0 }')" = 1 ] && worst="$t"
+	done
+	[ -z "$best" ] && { echo '-'; return; }
+	if [ "$(awk -v x="$best" 'BEGIN { print (x + 0 == 0) ? 1 : 0 }')" = 1 ]; then
+		echo '-'; return
+	fi
+	awk -v w="$worst" -v b="$best" 'BEGIN { printf "%.4f", (w - b) / b }'
+}
+
+# The wider of two arms' spreads, which is the band a difference has to clear.
+# "-" from either side is not treated as zero: an arm whose scatter is unknown
+# must not silently license a strict comparison.
+cb_band() {  # cb_band <spread_a> <spread_b> -> "n.nnnn" or "-"
+	awk -v a="${1:--}" -v b="${2:--}" 'BEGIN {
+		if (a == "-" || a == "" || b == "-" || b == "") { print "-" }
+		else { printf "%.4f", (a > b) ? a : b }
+	}'
+}
+
+# win / tie / loss for one query, decided on the UNROUNDED times.
+cb_verdict() {  # cb_verdict <col_hot> <heap_hot> <band> -> win|tie|loss|-
+	local c="$1" h="$2" band="$3"
+	case "$c" in '' | *ERR*) echo '-'; return ;; esac
+	case "$h" in '' | *ERR*) echo '-'; return ;; esac
+	case "$band" in '' | '-' | *ERR*) echo '-'; return ;; esac
+	if [ "$(awk -v x="$h" 'BEGIN { print (x + 0 == 0) ? 1 : 0 }')" = 1 ]; then
+		echo '-'; return
+	fi
+	awk -v c="$c" -v h="$h" -v b="$band" 'BEGIN {
+		d = c / h - 1
+		if (d < 0) d = -d
+		if (d <= b) { print "tie" } else if (c < h) { print "win" } else { print "loss" }
+	}'
+}

--- a/bench/run_clickbench.sh
+++ b/bench/run_clickbench.sh
@@ -773,7 +773,7 @@ grouped_engaged() {  # grouped_engaged <arm> <sql>
 		grep -qi 'Vectorized Group Keys' && echo yes || echo no
 }
 
-declare -A COLD HOT ERRS
+declare -A COLD HOT ERRS WARMSPREAD
 : > "$CB_DATA/query_errors.log"
 : > "$CB_DATA/raw_timings.tsv"
 
@@ -802,6 +802,10 @@ while IFS= read -r sql; do
 			fi
 		done
 		HOT["$qn:$arm"]="${best:-ERR}"
+		# The scatter of the warm tries, kept because it is the only estimate of
+		# this run's own resolution that the run produces. "$@" is already the
+		# warm set: the shift above dropped the cold try.
+		WARMSPREAD["$qn:$arm"]=$(cb_warm_spread "$@")
 		case "${COLD["$qn:$arm"]}${HOT["$qn:$arm"]}" in
 			*ERR*) ERRS["$arm"]=$(( ${ERRS["$arm"]:-0} + 1 )) ;;
 		esac
@@ -847,7 +851,7 @@ echo "-- hot times, milliseconds. 'x' is columnar over heap; above 1.00 means we
 printf '%-6s' query
 for arm in "${ARMS[@]}"; do printf ' %14s' "$arm"; done
 printf ' %10s %10s\n' 'col/heap' 'tuned/heap'
-wins=0; losses=0
+wins=0; losses=0; ties=0; tielist=""
 for q in $(seq 1 "$qn"); do
 	printf 'q%-5s' "$q"
 	for arm in "${ARMS[@]}"; do printf ' %14s' "${HOT["$q:$arm"]}"; done
@@ -856,15 +860,23 @@ for q in $(seq 1 "$qn"); do
 	c="${HOT["$q:columnar"]:-}"
 	tu="${HOT["$q:columnar_tuned"]:-}"
 	r1=$(ratio "$c" "$h")
-	if [ "$r1" != "-" ]; then
-		if [ "$(awk -v r="$r1" 'BEGIN { print (r < 1) ? 1 : 0 }')" = 1 ]; then
-			wins=$((wins + 1)); else losses=$((losses + 1)); fi
-	fi
+	# Counted from the times, NOT from r1. r1 is rounded for the table, and
+	# rounding a comparison decides sub-percent differences by typography.
+	band=$(cb_band "${WARMSPREAD["$q:heap"]:--}" "${WARMSPREAD["$q:columnar"]:--}")
+	case "$(cb_verdict "$c" "$h" "$band")" in
+		win)  wins=$((wins + 1)) ;;
+		loss) losses=$((losses + 1)) ;;
+		tie)  ties=$((ties + 1)); tielist="$tielist q$q" ;;
+	esac
 	r2=$(ratio "$tu" "$h")
 	printf ' %10s %10s\n' "$r1" "$r2"
 done
 echo
-echo "columnar beats heap on $wins queries and loses on $losses, at defaults."
+echo "columnar beats heap on $wins queries, ties on $ties, and loses on $losses, at defaults."
+if [ "$ties" -gt 0 ]; then
+	echo "   tie:$tielist -- the two arms are closer than the run-to-run scatter of"
+	echo "   their own warm tries, so this run cannot separate them in either direction."
+fi
 if [ -s "$CB_DATA/query_errors.log" ]; then
 	echo
 	echo "-- queries that errored, which are reported and NOT dropped:"

--- a/test/bench_guards.sh
+++ b/test/bench_guards.sh
@@ -174,6 +174,49 @@ check "a host that could not drop the page cache is not called a cold run" \
 check "and the tag says plainly that the run was warm" \
 	"$(grep -q 'WARM-RUN' <<<"$tag_none" && echo yes || echo no)" "yes"
 
+# ---- a win is decided on the times, not on the printed string (#531) --------
+#
+# The defect: the report counted wins from the "%.2f" ratio it had already
+# formatted for the table, so columnar ahead by less than half a percent printed
+# 1.00, failed `r < 1`, and was counted a LOSS -- against the legend printed
+# directly above it. The 2026-08-09 run reported 33 wins and 10 losses where the
+# times give 36 and 7.
+#
+# The three numbers below are that run's q13, the smallest real case: heap
+# 1588.095 ms, columnar 1582.859 ms, and a warm-try scatter of 0.99 percent.
+check "premise: the verdict helpers are present to be judged" \
+	"$(type -t cb_verdict)/$(type -t cb_warm_spread)/$(type -t cb_band)" \
+	"function/function/function"
+
+check "a clear win is a win" "$(cb_verdict 500 1000 0.02)" "win"
+check "a clear loss is a loss" "$(cb_verdict 2000 1000 0.02)" "loss"
+# The regression case, stated as the defect: rounding to 1.00 must not flip the
+# sign of the verdict. With no band this is a win; it must never be a loss.
+check "columnar ahead by 0.33 percent is not a LOSS, which is the #531 defect" \
+	"$(cb_verdict 1582.859 1588.095 0.0000)" "win"
+check "and under a band wider than the gap it is a tie, not a win either" \
+	"$(cb_verdict 1582.859 1588.095 0.0099)" "tie"
+check "a gap just outside the band is still called" \
+	"$(cb_verdict 900 1000 0.05)" "win"
+check "and a loss just outside it likewise" \
+	"$(cb_verdict 1100 1000 0.05)" "loss"
+
+# Scatter is measured from the tries, and an unknown scatter must not read as
+# zero: "-" through cb_band must suppress the verdict rather than license a
+# strict comparison on an arm nobody measured twice.
+check "spread is the fractional range over the best" "$(cb_warm_spread 100 103)" "0.0300"
+check "order does not matter, and ERR tries are dropped" \
+	"$(cb_warm_spread 103 100 ERR)" "0.0300"
+check "a single warm try has no measurable scatter" "$(cb_warm_spread 100)" "0.0000"
+check "no usable try yields no spread, not zero" "$(cb_warm_spread '' ERR)" "-"
+check "a zero best is refused rather than divided by" "$(cb_warm_spread 0 5)" "-"
+check "the band is the wider of the two arms" "$(cb_band 0.0100 0.0290)" "0.0290"
+check "and is unknown if either arm is unknown" "$(cb_band - 0.0290)" "-"
+check "an unknown band suppresses the verdict, it does not strict-compare" \
+	"$(cb_verdict 1582.859 1588.095 -)" "-"
+check "an errored arm has no verdict" "$(cb_verdict ERR 1000 0.02)" "-"
+check "and neither does a zero baseline" "$(cb_verdict 500 0 0.02)" "-"
+
 echo
 echo "checks run: $PGC_CHECKS"
 if [ "$PGC_FAIL" != 0 ]; then


### PR DESCRIPTION
Closes #531.

The report counted wins from the string it had already printed for the table:

```sh
r1=$(ratio "$c" "$h")                      # "%.2f"
if [ "$(awk -v r="$r1" 'BEGIN { print (r < 1) ? 1 : 0 }')" = 1 ]; then
        wins=$((wins + 1)); else losses=$((losses + 1)); fi
```

So columnar ahead by less than half a percent printed `1.00`, failed `r < 1`,
and was counted a loss, against the legend printed directly above it.

### What it did to the 2026-08-09 run

    columnar beats heap on 33 queries and loses on 10, at defaults.

Three of those ten are queries columnar won:

| query | heap | columnar | printed | counted |
| --- | ---: | ---: | ---: | --- |
| q13 | 1588.095 | 1582.859 | 1.00 | loss |
| q34 | 7247.047 | 7221.889 | 1.00 | loss |
| q35 | 7278.204 | 7277.247 | 1.00 | loss |

### Why this is not just an unrounded comparison

That fixes the sign and over-claims the other way. q35 is 0.01 percent apart
and the two arms' own warm tries that run were 2.9 percent apart. A difference
smaller than the instrument's own scatter is not a result in either direction.

The run already measures its scatter and discards it: it keeps the best of the
warm tries and drops the rest. Keeping the range gives a per-query band with no
constant to argue about, so nothing here is a tuned threshold.

On the 2026-08-09 data:

    columnar beats heap on 33 queries, ties on 4, and loses on 6, at defaults.
       tie: q13 q19 q34 q35 -- the two arms are closer than the run-to-run scatter of
       their own warm tries, so this run cannot separate them in either direction.

q19 is the one a two-way count still gets wrong: 1.03 against a 4.29 percent
scatter on the heap arm. The six real losses are q21, q22, q23, q24, q28, q29.

With `CB_TRIES=2` there is one warm try, the band is 0, and the verdict
degenerates to a strict comparison. No repeat means no evidence about
repeatability, which is not licence to call 0.01 percent a result.

### Where it lives

In `bench/cb_guards.sh`, so `test/bench_guards.sh` covers it in the matrix.
That is what #465 set that file up to do: the benchmark needs a 15 GB download
and a tuned cluster, its arithmetic needs neither.

`ratio` is unchanged and stays where it is. It is a formatter, it is correct,
and it was not the bug. The bug was deciding a comparison from its output.

### Proof

`test/bench_guards.sh` goes from 27 checks to 45, and passes.

Proved by removal, not asserted:

- Restoring the rounded comparison inside `cb_verdict` turns the named check
  red: `FAIL columnar ahead by 0.33 percent is not a LOSS, which is the #531
  defect: got [tie] want [win]`.
- `cb_warm_spread` returning a constant instead of measuring turns its own
  checks red.
- `cb_verdict` never returning `tie` turns the band checks red.

Two independent implementations were run over the run's real
`raw_timings.tsv`, the shipped bash and a separate Python reading of the same
file, and both give 33 / 4 / 6 with the same four ties.

The premise check is there for the reason #465 records: without
`premise: the verdict helpers are present to be judged`, an absent function
yields an empty string and every negative check below it passes against no
implementation at all.
