### PR TITLE
test: the report must ask cb_verdict, not merely have it (#531 follow-up)

### DIFF
--- a/test/bench_guards.sh
+++ b/test/bench_guards.sh
@@ -217,6 +217,53 @@ check "an unknown band suppresses the verdict, it does not strict-compare" \
 check "an errored arm has no verdict" "$(cb_verdict ERR 1000 0.02)" "-"
 check "and neither does a zero baseline" "$(cb_verdict 500 0 0.02)" "-"
 
+# ---- and the report must ASK the guard, not merely have one (#531) ---------
+#
+# The checks above prove cb_verdict's arithmetic. None of them proves that
+# bench/run_clickbench.sh asks it anything. This suite sources bench/cb_guards.sh
+# and never reads the benchmark, so the call site is invisible to it: restoring
+# the #531 defect verbatim,
+#
+#     r1=$(ratio "$c" "$h")
+#     if [ "$(awk -v r="$r1" 'BEGIN { print (r < 1) ? 1 : 0 }')" = 1 ] ...
+#
+# leaves every check above PASSING. That is measured and not reasoned about --
+# the revert was applied to a clean tree and the suite ran 45/45 green before
+# these four checks existed.
+#
+# These are checks over source text, which is the weaker kind, and they are here
+# because the behaviour they guard needs the 15 GB download and the tuned cluster
+# this suite exists to do without. The alternative is not a better test; it is no
+# test, which is what the 45 above amounted to at this seam.
+CB="$SRCDIR/bench/run_clickbench.sh"
+check "premise: the benchmark script is present to be judged" \
+	"$([ -f "$CB" ] && echo yes || echo no)" "yes"
+
+# Without this premise the next check is vacuous. Rename r1 and "no ratio value
+# decides anything" passes against a report that has gone back to deciding on one
+# under another name -- the grep finds nothing and nothing is what it approves.
+check "premise: the report still captures ratio() into a display variable" \
+	"$([ "$(grep -c 'r[12]=\$(ratio' "$CB")" -ge 1 ] && echo yes || echo no)" "yes"
+
+check "ratio()'s output reaches printf and nothing else" \
+	"$(grep '\$r[12]' "$CB" | grep -vc 'printf')" "0"
+
+# Matched as a CALL and not as a mention. `grep -c 'cb_verdict'` counts any
+# occurrence, including one in a comment, and that is enough to approve a report
+# that has gone back to deciding inline: measured, the verdict was recomputed on
+# $c and $h directly with only a "might reinstate cb_verdict here" comment left
+# behind, and this suite reported 49 checks PASSED. Deciding on $c and $h rather
+# than on $r1 satisfies the check above at the same time, so both fall together.
+#
+# The realistic path is not somebody being clever. It is somebody refactoring the
+# loop and leaving a TODO that names the function.
+#
+# `cb_verdict "` is the shape a call takes here and a mention almost never does.
+# Measured on the bypassed tree: loose 1 (approves), tight 0 (rejects); on the
+# good tree tight is 1 and still approves.
+check "and the verdict is asked of cb_verdict rather than recomputed inline" \
+	"$([ "$(grep -c 'cb_verdict "' "$CB")" -ge 1 ] && echo yes || echo no)" "yes"
+
 echo
 echo "checks run: $PGC_CHECKS"
 if [ "$PGC_FAIL" != 0 ]; then


### PR DESCRIPTION
#532 fixed the win count and added `cb_verdict`, `cb_warm_spread` and `cb_band`
with fifteen checks over their arithmetic. This adds the check nobody has: that
the report **asks** them.

## The gap, proved by removal

`test/bench_guards.sh` sources `bench/cb_guards.sh` and never reads
`bench/run_clickbench.sh`, so the call site is invisible to it. Restoring the
#531 defect verbatim:

```sh
r1=$(ratio "$c" "$h")
if [ "$(awk -v r="$r1" 'BEGIN { print (r < 1) ? 1 : 0 }')" = 1 ]; then
        wins=$((wins + 1)); else losses=$((losses + 1)); fi
```

| tree | suite |
| --- | --- |
| main | 45 checks PASSED |
| **#531 defect restored, main's suite** | **45 checks PASSED** |
| #531 defect restored, this branch | 49 checks, **2 FAIL** |
| main, this branch | 49 checks PASSED |

The second row is the point. The fix was merged and the harness could have been
reverted to the exact defect it fixed without a single check reddening.

## What the four checks are

Two premises and two assertions. `ratio()`'s output must reach `printf` and
nothing else, and the verdict must come from `cb_verdict`.

The premises are load-bearing rather than decoration. Rename `r1` and a bare
"no ratio value decides anything" passes against a report that has gone back to
deciding on one under another name — the grep finds nothing, and nothing is what
it approves. So the suite first asserts that the report still captures `ratio()`
into a display variable at all.

These check source text, which is the weaker kind of check. They are here
because the behaviour they guard needs the 15 GB download and the tuned cluster
that `bench_guards` exists to do without. The alternative is not a better test;
it is no test, which is what the 45 amounted to at this seam.

They live in the suite rather than in `bench/cb_guards.sh` on purpose: that
file's contract is "Nothing here touches a database or the filesystem", and a
guard that reads a source file would break it.

## Gate

| | |
| --- | --- |
| `bench_guards` on main | 45 PASSED |
| `bench_guards` on this branch | **49 PASSED** |
| removal proof (defect restored) | **FAILED**, rc=1 — non-vacuous |
| `harness_selftest` pg18a | 54 PASSED |
| `harness_selftest` pg19a | 54 PASSED |

The pg19a number needed #536 dealt with first: the run initially failed every
cluster start because the build had reused pg18a's objects. `make clean` and a
rebuild for pg19a alone, and it passes. Nothing in that is caused by this branch
— the control on unpatched main fails identically — but it is why the gate took
two passes, and it is filed as #536.

Closes nothing on its own; it is the follow-up #532 wanted. See also #537 for
why diagnosing that gate failure took six probes.
