### PR TITLE
feat: decode honours the skip vector it already builds (#452 phase 1b-i)

### DIFF
--- a/src/columnar.h
+++ b/src/columnar.h
@@ -669,6 +669,7 @@ extern void PgColumnarReadStats(PgColumnarReadState *readState,
 							  uint64 *groupsRead, uint64 *groupsSkipped,
 							  uint64 *groupsTotal);
 extern uint64 PgColumnarVectorsSkipped(PgColumnarReadState *readState);
+extern uint64 PgColumnarVectorsDecoded(PgColumnarReadState *readState);
 
 /*
  * How many of the scan keys the reader was handed became skip predicates it can
@@ -925,6 +926,15 @@ typedef struct PgColumnarGroupStats
 	uint64		groupsRead;
 	uint64		groupsRemoved;
 	uint64		vectorsSkipped;
+
+	/*
+	 * Vectors actually decoded (#452 phase 1b-i). Separate from vectorsSkipped
+	 * because the two answered the same question only by accident: decode ran
+	 * before the skip vector existed, so a skipped vector was decoded in full
+	 * and merely not turned into Datums. "Skipped" therefore never implied "not
+	 * decoded", and no counter could tell those apart until this one.
+	 */
+	uint64		vectorsDecoded;
 } PgColumnarGroupStats;
 
 extern void PgColumnarExplainPushedDown(int64 nfilters, ExplainState *es);

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -2179,6 +2179,15 @@ PgColumnarExplainGroupStats(const PgColumnarGroupStats *stats, ExplainState *es)
 	 */
 	ExplainPropertyInteger("Columnar Vectors Skipped", NULL,
 						   (int64) stats->vectorsSkipped, es);
+	/*
+	 * Printed beside Skipped because neither number means anything alone. Before
+	 * #452 phase 1b-i a skipped vector was still decoded, so "Skipped: 30" beside
+	 * "Decoded: 32" is the honest reading of that state and "Skipped: 30" alone
+	 * invited the reader to assume the work had been avoided. Same failure as
+	 * #477: one number cannot say both.
+	 */
+	ExplainPropertyInteger("Columnar Vectors Decoded", NULL,
+						   (int64) stats->vectorsDecoded, es);
 }
 
 /* -------------------------------------------------------------------------
@@ -2308,6 +2317,7 @@ PgColumnarExplainCustomScan(CustomScanState *node, List *ancestors,
 		gs.groupsRead = groupsRead;
 		gs.groupsRemoved = groupsSkipped;
 		gs.vectorsSkipped = PgColumnarVectorsSkipped(cstate->readState);
+		gs.vectorsDecoded = PgColumnarVectorsDecoded(cstate->readState);
 		PgColumnarExplainGroupStats(&gs, es);
 
 		/*

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -148,6 +148,7 @@ struct PgColumnarReadState
 	uint32	   *nativeVecStart;		/* [nativeVectorCount+1] cumulative row spans */
 	int			nativeCurVec;		/* vector containing rowInGroup */
 	uint64		vectorsSkipped;		/* for EXPLAIN */
+	uint64		vectorsDecoded;		/* for EXPLAIN; see PgColumnarGroupStats */
 
 	/*
 	 * Late materialization (#452 Phase 1a). Rows whose qual columns were decoded,
@@ -768,8 +769,10 @@ static char *
 pgcolumnar_native_decode_chunk(MemoryContext cx, Form_pg_attribute att,
 							 char *values, uint32 valuesLen,
 							 const char *desc, uint32 descLen, int blockCodec,
-							 uint32 **outVecRawLen, int *outVecCount)
+							 uint32 **outVecRawLen, int *outVecCount,
+							 const bool *skipVec, int *outVecDecoded)
 {
+	int			decodedCount = 0;
 	uint32		vectorCount;
 	uint32		v;
 	const char *dp;
@@ -877,13 +880,47 @@ pgcolumnar_native_decode_chunk(MemoryContext cx, Form_pg_attribute att,
 		vecRawLen[v] = rawLen;
 		if (rawLen > 0)
 		{
-			char	   *rawVec = PgColumnarDecodeChunk(encCursor, encLen, encType,
-													 att, valueCount, rawLen,
-													 sharedTable, sharedTableLen,
-													 decodeScratch);
+			/*
+			 * #452 phase 1b-i. A vector the caller's zone maps ruled out is not
+			 * decoded: no PgColumnarDecodeChunk, no memcpy. Both cursors still
+			 * advance by the descriptor's lengths, so every later vector lands
+			 * at the same offset it would have without the skip, and vecRawLen
+			 * still reports the full raw length so the row producer steps over
+			 * the gap exactly as before.
+			 *
+			 * This LEAVES A HOLE in rawBuf: those rawLen bytes are whatever
+			 * palloc handed back. That is safe only because nothing reads them.
+			 * The row producer steps past skipped vectors, and the vectorized
+			 * fold refuses a group whose decode skipped anything (#512, #523) --
+			 * it reads this buffer directly and re-checks every value, so it
+			 * would otherwise re-check uninitialized memory and return a wrong
+			 * aggregate silently. Do not relax that guard without giving the
+			 * fold the mask.
+			 */
+			if (skipVec != NULL && skipVec[v])
+				rawCursor += rawLen;
+			else
+			{
+				char	   *rawVec = PgColumnarDecodeChunk(encCursor, encLen, encType,
+														 att, valueCount, rawLen,
+														 sharedTable, sharedTableLen,
+														 decodeScratch);
 
-			memcpy(rawCursor, rawVec, rawLen);
-			rawCursor += rawLen;
+				memcpy(rawCursor, rawVec, rawLen);
+				rawCursor += rawLen;
+				decodedCount++;
+			}
+		}
+		else if (!(skipVec != NULL && skipVec[v]))
+		{
+			/*
+			 * An empty vector costs no decode, but it is not a saving either,
+			 * and the group's vectors have to add up: the suite asserts decoded
+			 * plus skipped is the vector count, and a rawLen == 0 vector that
+			 * counted as neither would break that arithmetic on any column with
+			 * an all-NULL vector.
+			 */
+			decodedCount++;
 		}
 		encCursor += encLen;
 	}
@@ -892,6 +929,16 @@ pgcolumnar_native_decode_chunk(MemoryContext cx, Form_pg_attribute att,
 		*outVecRawLen = vecRawLen;
 	if (outVecCount != NULL)
 		*outVecCount = (int) vectorCount;
+	/*
+	 * Reported from the loop that did the work, never derived from the mask the
+	 * caller passed in. Deriving it is the first thing anyone writes here and it
+	 * makes the counter unfalsifiable: it would report the saving whether or not
+	 * decode honoured the mask, and a removal proof would pass. That is not a
+	 * hypothetical -- this counter was written that way first, and the suite
+	 * passed with the skip removed.
+	 */
+	if (outVecDecoded != NULL)
+		*outVecDecoded = decodedCount;
 
 	/* rawBuf and vecRawLen live in cx; the scratch above does not */
 	MemoryContextDelete(decodeScratch);
@@ -1481,6 +1528,7 @@ pgcolumnar_native_load_group(PgColumnarReadState *rs)
 	ListCell   *lc;
 	int			validityBytes;
 	int			maxVecCount;
+	int			groupVecDecoded;	/* measured in the decode loop, never derived */
 	bool		allDescriptor;
 
 	/*
@@ -1554,7 +1602,71 @@ pgcolumnar_native_load_group(PgColumnarReadState *rs)
 	rs->nativeVecRawLen = (uint32 **) palloc0(sizeof(uint32 *) * rs->natts);
 	validityBytes = (int) ((rg->rowCount + 7) / 8);
 	maxVecCount = 0;
+	groupVecDecoded = 0;
 	allDescriptor = (chunks != NIL);
+
+	/*
+	 * #452 phase 1b-i: the skip vector has to exist BEFORE the decode loop, or
+	 * decode cannot honour it. It used to be built afterwards, from the vector
+	 * count the decode returned, which is why every ruled-out vector was decoded
+	 * in full and then merely not turned into Datums.
+	 *
+	 * Nothing about that ordering was necessary. The vector count lives in the
+	 * encoding descriptor header, which is chunk METADATA already in hand, and
+	 * build_skipvec's only other inputs are the predicates and the zone map
+	 * catalog. So this pre-pass reads the count and decides allDescriptor without
+	 * touching a single value byte.
+	 */
+	{
+		ListCell   *pc;
+
+		foreach(pc, chunks)
+		{
+			NativeColumnChunkMetadata *cc = (NativeColumnChunkMetadata *) lfirst(pc);
+			uint32		vc;
+
+			if (cc->columnIndex < 0 || cc->columnIndex >= rs->natts)
+				continue;
+			if (!rs->colWanted[cc->columnIndex])
+				continue;
+
+			if (cc->encodingDescriptorLen == 1 &&
+				(uint8) cc->encodingDescriptor[0] == COLUMNAR_NATIVE_ENCDESC_BASELINE)
+			{
+				/* D2b baseline: no per-vector structure at all */
+				allDescriptor = false;
+				continue;
+			}
+
+			/*
+			 * A descriptor too short to hold its own header is corrupt. Say
+			 * nothing about it here and decode no fewer vectors for it: the
+			 * decode below raises the proper error with the proper message, and
+			 * a skip decided from a malformed header would be a silent wrong
+			 * answer instead of a loud one.
+			 */
+			if (cc->encodingDescriptorLen < COLUMNAR_NATIVE_ENCDESC_HEADER_LEN ||
+				(uint8) cc->encodingDescriptor[0] != COLUMNAR_NATIVE_ENCDESC_VERSION)
+			{
+				allDescriptor = false;
+				continue;
+			}
+
+			memcpy(&vc, cc->encodingDescriptor + 2, sizeof(uint32));
+			if ((int) vc > maxVecCount)
+				maxVecCount = (int) vc;
+		}
+	}
+
+	if (allDescriptor)
+		pgcolumnar_native_build_skipvec(rs, rg->groupNumber, maxVecCount);
+	else
+	{
+		rs->nativeSkipVec = NULL;
+		rs->nativeVecStart = NULL;
+		rs->nativeVectorCount = maxVecCount;
+		rs->nativeCurVec = 0;
+	}
 
 	foreach(lc, chunks)
 	{
@@ -1592,6 +1704,7 @@ pgcolumnar_native_load_group(PgColumnarReadState *rs)
 			Form_pg_attribute att = TupleDescAttr(rs->tupdesc, cc->columnIndex);
 			uint32	   *vraw = NULL;
 			int			vcount = 0;
+			int			vdecoded = 0;
 
 			/* D4: reconstruct the raw present-value stream from the descriptor */
 			rs->nativeValueCursor[cc->columnIndex] =
@@ -1599,28 +1712,29 @@ pgcolumnar_native_load_group(PgColumnarReadState *rs)
 											 (uint32) (cc->pageLength - validityBytes),
 											 cc->encodingDescriptor,
 											 cc->encodingDescriptorLen,
-											 cc->blockCodec, &vraw, &vcount);
+											 cc->blockCodec, &vraw, &vcount,
+											 rs->nativeSkipVec, &vdecoded);
 			rs->nativeVecRawLen[cc->columnIndex] = vraw;
 			if (vcount > maxVecCount)
 				maxVecCount = vcount;
+			/*
+			 * Vector POSITIONS, so the max across columns rather than the sum:
+			 * a group of 32 vectors over 5 projected columns decodes 32
+			 * positions, not 160. That is the unit vectorsSkipped uses, and the
+			 * suite's "decoded plus skipped is the group's vectors" is false in
+			 * any other unit.
+			 */
+			if (vdecoded > groupVecDecoded)
+				groupVecDecoded = vdecoded;
 		}
 	}
+	rs->vectorsDecoded += (uint64) groupVecDecoded;
 
 	/*
 	 * Per-vector skipping (native spec 7.1, D5b): build the skip vector from the
 	 * per-vector zone maps. Only when every column carries a descriptor (so the
 	 * vector boundaries line up); a legacy baseline chunk disables it.
 	 */
-	if (allDescriptor)
-		pgcolumnar_native_build_skipvec(rs, rg->groupNumber, maxVecCount);
-	else
-	{
-		rs->nativeSkipVec = NULL;
-		rs->nativeVecStart = NULL;
-		rs->nativeVectorCount = maxVecCount;
-		rs->nativeCurVec = 0;
-	}
-
 	/*
 	 * Native delete visibility (D6b): combine this group's row-mask rows (keyed
 	 * by group number, one bit per row-in-group) into a single delete mask that
@@ -2945,7 +3059,8 @@ pgcolumnar_fetch_row(Relation rel, Snapshot snapshot, uint64 rowNumber,
 												 vstream, vlen,
 												 cc->encodingDescriptor,
 												 cc->encodingDescriptorLen,
-												 cc->blockCodec, NULL, NULL);
+												 cc->blockCodec, NULL, NULL,
+												 NULL, NULL);
 			MemoryContextSwitchTo(decOld);
 
 			/*
@@ -3201,4 +3316,18 @@ uint64
 PgColumnarVectorsSkipped(PgColumnarReadState *readState)
 {
 	return readState->vectorsSkipped;
+}
+
+/*
+ * PgColumnarVectorsDecoded
+ *		How many 1024-value vectors the native scan actually decoded within read
+ *		row groups (#452 phase 1b-i). Counted in vector positions, the same unit
+ *		as PgColumnarVectorsSkipped, so that the two are comparable: on a group
+ *		where decode honours the skip vector, decoded plus skipped is the group's
+ *		vector count. Used by EXPLAIN.
+ */
+uint64
+PgColumnarVectorsDecoded(PgColumnarReadState *readState)
+{
+	return readState->vectorsDecoded;
 }

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -908,7 +908,26 @@ pgcolumnar_native_decode_chunk(MemoryContext cx, Form_pg_attribute att,
 			 * fold the mask.
 			 */
 			if (skipVec != NULL && skipVec[v])
+			{
+				/*
+				 * Poisoned in assert builds, and this is not decoration. Reading
+				 * a hole is undefined behaviour whose SYMPTOM is data-dependent:
+				 * whatever palloc last left here is usually rejected by the
+				 * reader's own scan-key recheck, so a consumer that wrongly reads
+				 * holes returns the right answer on most data and a wrong one on
+				 * some. That is unfalsifiable by a test.
+				 *
+				 * A fixed poison makes the bug deterministic instead: the value
+				 * is the same on every run, so a consumer that reads it can be
+				 * caught by a predicate the poison satisfies. test/native_vecdecode.sh
+				 * does exactly that, and without this the check passes against a
+				 * fold that reads every hole.
+				 */
+#ifdef USE_ASSERT_CHECKING
+				memset(rawCursor, 0xA5, rawLen);
+#endif
 				rawCursor += rawLen;
+			}
 			else
 			{
 				char	   *rawVec = PgColumnarDecodeChunk(encCursor, encLen, encType,
@@ -1739,6 +1758,14 @@ pgcolumnar_native_load_group(PgColumnarReadState *rs)
 		}
 	}
 	rs->vectorsDecoded += (uint64) groupVecDecoded;
+
+	/*
+	 * The #512 tripwire's input, and it is measured rather than inferred from
+	 * the mask: a mask with nothing set in it skips nothing, and a decode that
+	 * ignored the mask skipped nothing either. Both must read as false here, and
+	 * only the decoded count can say so.
+	 */
+	rs->decodeSkippedVectors = (groupVecDecoded < maxVecCount);
 
 	/*
 	 * Per-vector skipping (native spec 7.1, D5b): build the skip vector from the

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -596,6 +596,7 @@ typedef struct PgColumnarAggScanState
 	uint64		groupsRead;
 	uint64		groupsSkipped;
 	uint64		vectorsSkipped;
+	uint64		vectorsDecoded;
 	uint64		groupsTotal;
 
 	/*
@@ -698,6 +699,7 @@ typedef struct PgColumnarGroupAggScanState
 	uint64		groupsRead;
 	uint64		groupsSkipped;
 	uint64		vectorsSkipped;
+	uint64		vectorsDecoded;
 	uint64		groupsTotal;
 	int			usablePreds;	/* of npreds, how many can exclude (#479) */
 } PgColumnarGroupAggScanState;
@@ -3271,6 +3273,7 @@ pgcolumnar_native_batch_fold(PgColumnarAggScanState *state, Relation rel,
 					  &state->groupsTotal);
 	state->usablePreds = PgColumnarReadUsablePredicates(rs);
 	state->vectorsSkipped = PgColumnarVectorsSkipped(rs);
+	state->vectorsDecoded = PgColumnarVectorsDecoded(rs);
 	state->haveStats = true;
 	state->batchFolded = true;
 	PgColumnarEndRead(rs);
@@ -3406,6 +3409,7 @@ pgcolumnar_native_scan_agg(PgColumnarAggScanState *state,
 						  &state->groupsTotal);
 		state->usablePreds = PgColumnarReadUsablePredicates(rs);
 	state->vectorsSkipped = PgColumnarVectorsSkipped(rs);
+	state->vectorsDecoded = PgColumnarVectorsDecoded(rs);
 		state->haveStats = true;
 	}
 
@@ -3563,6 +3567,7 @@ PgColumnarExplainAggScan(CustomScanState *node, List *ancestors, ExplainState *e
 		gs.groupsRead = state->groupsRead;
 		gs.groupsRemoved = state->groupsSkipped;
 		gs.vectorsSkipped = state->vectorsSkipped;
+		gs.vectorsDecoded = state->vectorsDecoded;
 		PgColumnarExplainGroupStats(&gs, es);
 	}
 }
@@ -4125,6 +4130,7 @@ pgcolumnar_groupagg_build(PgColumnarGroupAggScanState *state)
 					  &state->groupsTotal);
 	state->usablePreds = PgColumnarReadUsablePredicates(rs);
 	state->vectorsSkipped = PgColumnarVectorsSkipped(rs);
+	state->vectorsDecoded = PgColumnarVectorsDecoded(rs);
 	state->haveStats = true;
 
 	PgColumnarEndRead(rs);
@@ -4245,6 +4251,7 @@ PgColumnarExplainGroupAggScan(CustomScanState *node, List *ancestors,
 		gs.groupsRead = state->groupsRead;
 		gs.groupsRemoved = state->groupsSkipped;
 		gs.vectorsSkipped = state->vectorsSkipped;
+		gs.vectorsDecoded = state->vectorsDecoded;
 		PgColumnarExplainGroupStats(&gs, es);
 	}
 }

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -3170,40 +3170,42 @@ pgcolumnar_native_batch_fold(PgColumnarAggScanState *state, Relation rel,
 		bool		decodeSkipped;
 		const uint32 *vecStart;
 		int			vcount;
+		int			curVec;
 		uint64		r;
 
 		PgColumnarReadFoldGroupInfo(rs, &nrows, &dmask, &dlen,
 								  &skipVec, &decodeSkipped, &vecStart, &vcount);
 
 		/*
-		 * This loop does not honour skipVec. It reads every vector and reaches
-		 * the right answer by re-checking every value against the scan keys
-		 * below, which is correct only while decode has produced every vector.
+		 * This loop now honours skipVec, and it has to (#512, #452 phase 1b-i).
+		 * Decode no longer produces the vectors the zone maps ruled out, so the
+		 * packed stream has HOLES in it. Reading one would re-check uninitialised
+		 * memory: a wrong aggregate, silently, and only on data whose zone maps
+		 * rule something out.
 		 *
-		 * The moment decode is taught to skip the vectors the zone maps ruled
-		 * out (#452 phase 1b, the obvious next optimisation), the buffer gains
-		 * holes and this loop would re-check UNINITIALISED memory: a wrong
-		 * aggregate, silently, and only on data whose zone maps rule something
-		 * out. The row producer is safe there because it steps its cursors past
-		 * skipped vectors; this path is not, and pgcolumnar_batch_shape_eligible
-		 * requires every qual to be convertible to a scan key -- so the fold runs
-		 * precisely when predicates exist, which is exactly when vectors get
-		 * skipped. Common case, not an edge.
+		 * Skipping them is not merely safe, it is exact. The reader built skipVec
+		 * from the same scan keys this loop re-checks -- pgcolumnar_batch_shape_
+		 * eligible requires every qual to be convertible to a scan key, and those
+		 * keys are what PgColumnarBeginRead was given -- so a vector those zone
+		 * maps rule out contains no row this fold would have counted.
 		 *
-		 * So the ordering constraint is enforced rather than written down: the
-		 * fold must learn to skip before decode is allowed to. Whoever makes that
-		 * change gets this error instead of arithmetic, and they are the person
-		 * least likely to look in this file.
+		 * The present index must still advance across a skipped vector, exactly
+		 * as it does across a deleted row: the stream is packed by presence, so
+		 * a skipped row's slot is consumed whether or not its value is read.
+		 * Getting that wrong misaligns every later vector rather than losing one.
 		 *
-		 * Measured, so the ordering is not merely asserted: teaching this loop to
-		 * honour skipVec costs about 2% and saves nothing until decode changes,
-		 * so it belongs IN that change and not before it (#512).
+		 * The tripwire that used to stand here (#523) was an ordering guard: it
+		 * refused a group whose decode had skipped, so that decode could not be
+		 * taught to skip without this loop being taught first. It has done its
+		 * job -- it fired on exactly the change it was written for -- and the
+		 * handling below replaces it. What remains of it is the fallback: if the
+		 * reader reports a skip without the per-vector map this loop needs to
+		 * honour it, refuse rather than guess.
 		 */
-		if (decodeSkipped)
+		if (decodeSkipped && (skipVec == NULL || vecStart == NULL || vcount <= 0))
 			elog(ERROR,
 				 "pgcolumnar: the vectorized aggregate cannot fold a row group "
-				 "whose decode skipped vectors (#512); teach this loop to honour "
-				 "the skip vector in the same change that makes decode honour it");
+				 "whose decode skipped vectors without the per-vector map (#512)");
 
 		for (col = 0; col < natts; col++)
 		{
@@ -3242,12 +3244,27 @@ pgcolumnar_native_batch_fold(PgColumnarAggScanState *state, Relation rel,
 			cattlen[col] = al;
 		}
 
+		curVec = 0;
 		for (r = 0; r < nrows; r++)
 		{
 			bool		del;
 			bool		pass = true;
+			bool		vecSkipped = false;
 
 			CHECK_FOR_INTERRUPTS();
+
+			/*
+			 * Which vector holds this row, and was it ruled out? vecStart is
+			 * cumulative row spans with a [vcount] terminator, and r only ever
+			 * increases, so this walk costs one step per vector boundary across
+			 * the whole group rather than a search per row.
+			 */
+			if (skipVec != NULL && vecStart != NULL && vcount > 0)
+			{
+				while (curVec < vcount && r >= vecStart[curVec + 1])
+					curVec++;
+				vecSkipped = (curVec < vcount && skipVec[curVec]);
+			}
 
 			/* gather needed values at each column's present index; advance it */
 			for (col = 0; col < natts; col++)
@@ -3256,14 +3273,24 @@ pgcolumnar_native_batch_fold(PgColumnarAggScanState *state, Relation rel,
 					continue;
 				if ((cvalidity[col][r >> 3] >> (r & 7)) & 1)
 				{
-					cval[col] = fetch_att(cpacked[col] + cpresent[col] * cattlen[col],
-										  true, cattlen[col]);
-					cisnull[col] = false;
+					/*
+					 * A skipped vector's bytes were never decoded. Consume the
+					 * slot, do not read it.
+					 */
+					if (!vecSkipped)
+					{
+						cval[col] = fetch_att(cpacked[col] + cpresent[col] * cattlen[col],
+											  true, cattlen[col]);
+						cisnull[col] = false;
+					}
 					cpresent[col]++;
 				}
 				else
 					cisnull[col] = true;
 			}
+
+			if (vecSkipped)
+				continue;			/* value slots already consumed above */
 
 			del = (dmask != NULL && (r >> 3) < dlen &&
 				   (dmask[r >> 3] & (1 << (r & 7))) != 0);

--- a/test/native_vecdecode.sh
+++ b/test/native_vecdecode.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#
+# pgColumnar: decode honours the skip vector (#452 phase 1b-i).
+#
+# "Columnar Vectors Skipped" has never meant what its name suggests. Decode runs
+# BEFORE the skip vector exists -- pgcolumnar_native_decode_chunk at
+# columnar_reader.c:1598, pgcolumnar_native_build_skipvec at :1615 -- so a vector
+# the zone maps ruled out is decoded in full and the skip only stops it being
+# turned into Datums. The counter says "not emitted", never "not decoded", and no
+# existing counter can tell those apart.
+#
+# So this suite needs its own observable, "Columnar Vectors Decoded", and the
+# central check is not that it moves but that it moves by EXACTLY the skipped
+# count. "Decodes fewer" would pass on decoding one vector less out of thirty,
+# which is the shape of a fix that does not work.
+#
+# Usage:  test/native_vecdecode.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+# One row group of 32 vectors x 1024 rows. The stripe limit is above the row
+# count so nothing is pruned at the row-group level and every difference below
+# is per-vector. id is monotonic, so each vector's zone map is tight and
+# non-overlapping, which is what lets a narrow range rule most of them out.
+ROWS=32768
+GEN="SELECT g AS id, (g % 97) AS v FROM generate_series(1, $ROWS) g"
+
+psql_run "CREATE TABLE h (id int, v int);"
+psql_run "CREATE TABLE n (id int, v int) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.set_options('n', stripe_row_limit => 65536, chunk_group_row_limit => 1024);"
+psql_run "INSERT INTO h $GEN;"
+psql_run "INSERT INTO n $GEN;"
+
+explain_of() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -At -c "EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) $1" 2>/dev/null
+}
+
+# A counter's value, or empty when the line is absent. Read from the plan text
+# rather than from a second EXPLAIN, so every counter in one check comes from
+# one run of one query.
+counter_in() {  # counter_in <plan text> <label>
+	grep -F "$2" <<<"$1" | grep -oE '[0-9]+' | head -1
+}
+
+has_line() { grep -qF "$2" <<<"$1" && echo yes || echo no; }
+
+# The narrow range lives inside a single vector; the wide one spans them all.
+NARROW="SELECT id, v FROM n WHERE id BETWEEN 2000 AND 2050"
+WIDE="SELECT id, v FROM n WHERE id BETWEEN 1 AND $ROWS"
+
+PLAN_NARROW="$(explain_of "$NARROW")"
+PLAN_WIDE="$(explain_of "$WIDE")"
+
+# ---- premises -------------------------------------------------------------
+#
+# Every number below is read out of these two plans. If the planner stops
+# choosing the columnar custom scan, or the group splits, the comparisons start
+# reporting a decode regression that is really a plan or a layout change. Assert
+# the ground first so a failure names its own cause.
+
+check "premise: the narrow plan is a columnar custom scan" \
+	"$(has_line "$PLAN_NARROW" 'Columnar Projected Columns')" "yes"
+check "premise: the wide plan is a columnar custom scan" \
+	"$(has_line "$PLAN_WIDE" 'Columnar Projected Columns')" "yes"
+check "premise: one row group, so every difference is per-vector" \
+	"$(q "SELECT count(*) FROM pgcolumnar.row_group WHERE storage_id = pgcolumnar.get_storage_id('n');")" \
+	"1"
+check "premise: no whole group is pruned on the narrow query" \
+	"$(counter_in "$PLAN_NARROW" 'Columnar Chunk Groups Removed by Filter')" "0"
+
+# The two arms must differ in what the zone maps rule out, or the central check
+# compares a number with itself and passes against any implementation.
+SKIP_NARROW="$(counter_in "$PLAN_NARROW" 'Columnar Vectors Skipped')"
+SKIP_WIDE="$(counter_in "$PLAN_WIDE" 'Columnar Vectors Skipped')"
+check "premise: the narrow range skips vectors" \
+	"$([ "${SKIP_NARROW:-0}" -gt 0 ] && echo yes || echo no)" "yes"
+check "premise: the wide range skips none, so the arms really differ" \
+	"$SKIP_WIDE" "0"
+
+# ---- the observable -------------------------------------------------------
+
+check "EXPLAIN reports Columnar Vectors Decoded" \
+	"$(has_line "$PLAN_WIDE" 'Columnar Vectors Decoded')" "yes"
+
+DEC_WIDE="$(counter_in "$PLAN_WIDE" 'Columnar Vectors Decoded')"
+check "and it is not stuck at zero when a full scan decodes everything" \
+	"$([ "${DEC_WIDE:-0}" -gt 0 ] && echo yes || echo no)" "yes"
+
+# ---- the fix itself -------------------------------------------------------
+
+DEC_NARROW="$(counter_in "$PLAN_NARROW" 'Columnar Vectors Decoded')"
+
+check "a ruled-out vector is not decoded" \
+	"$([ "${DEC_NARROW:-0}" -lt "${DEC_WIDE:-0}" ] && echo yes || echo no)" "yes"
+
+# The check that has teeth. "Decodes fewer" is satisfied by decoding one vector
+# less out of thirty-two, which is what a half-working mask does. Every vector
+# the zone maps ruled out must go undecoded, so the two counters must account
+# for the whole group between them.
+check "and EVERY ruled-out vector is: decoded plus skipped is the group's vectors" \
+	"$(( ${DEC_NARROW:-0} + ${SKIP_NARROW:-0} ))" "${DEC_WIDE:-0}"
+
+# ---- correctness, which is the risk this change carries -------------------
+#
+# Not decoding a vector leaves a hole in the chunk's raw buffer. The row
+# producer steps its cursors past it, but the vectorized fold reads that buffer
+# directly and re-checks every value, so a hole would be re-checked as
+# uninitialized memory -- a wrong aggregate, silently, and only on data whose
+# zone maps rule something out. #512 and #523 are that hazard; these are the
+# checks that would catch it coming back.
+
+check "narrow range parity with heap" \
+	"$(pgc_set_hash "$NARROW")" \
+	"$(pgc_set_hash 'SELECT id, v FROM h WHERE id BETWEEN 2000 AND 2050')"
+check "cross-vector range parity" \
+	"$(pgc_set_hash 'SELECT id, v FROM n WHERE id BETWEEN 3000 AND 9000')" \
+	"$(pgc_set_hash 'SELECT id, v FROM h WHERE id BETWEEN 3000 AND 9000')"
+check "boundary range parity, a range starting exactly on a vector edge" \
+	"$(pgc_set_hash 'SELECT id, v FROM n WHERE id BETWEEN 1025 AND 2048')" \
+	"$(pgc_set_hash 'SELECT id, v FROM h WHERE id BETWEEN 1025 AND 2048')"
+
+# The aggregate path is the one that reads the raw buffer directly.
+check "aggregate over a skipping range matches heap" \
+	"$(q 'SELECT count(*), sum(v) FROM n WHERE id BETWEEN 2000 AND 2050;')" \
+	"$(q 'SELECT count(*), sum(v) FROM h WHERE id BETWEEN 2000 AND 2050;')"
+check "aggregate over a range spanning many skipped vectors matches heap" \
+	"$(q 'SELECT count(*), sum(v), min(v), max(v) FROM n WHERE id BETWEEN 5000 AND 5200;')" \
+	"$(q 'SELECT count(*), sum(v), min(v), max(v) FROM h WHERE id BETWEEN 5000 AND 5200;')"
+check "a range matching no row at all is still correct" \
+	"$(q 'SELECT count(*) FROM n WHERE id BETWEEN 100000 AND 200000;')" "0"
+
+pgc_summary

--- a/test/native_vecdecode.sh
+++ b/test/native_vecdecode.sh
@@ -133,4 +133,84 @@ check "aggregate over a range spanning many skipped vectors matches heap" \
 check "a range matching no row at all is still correct" \
 	"$(q 'SELECT count(*) FROM n WHERE id BETWEEN 100000 AND 200000;')" "0"
 
+# ---- the fold, which is the path that reads the holes ----------------------
+#
+# The checks above run the SCALAR scan, which is safe by construction: it steps
+# its cursors past a skipped vector and never looks at the bytes. The vectorized
+# fold reads the packed stream directly, so it is the one that would read an
+# undecoded hole, and it is OFF by default -- meaning every aggregate check
+# above passed without ever touching the path at risk. That is the whole reason
+# this section exists.
+
+fold_run() {  # fold_run <sql>
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -At \
+		-c "SET max_parallel_workers_per_gather=0; SET pgcolumnar.enable_ungrouped_vector_agg=on;" \
+		-c "$1" 2>&1 | tail -1
+}
+fold_plan() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -At \
+		-c "SET max_parallel_workers_per_gather=0; SET pgcolumnar.enable_ungrouped_vector_agg=on;" \
+		-c "EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) $1" 2>&1
+}
+
+FQ="SELECT count(*), sum(v) FROM n WHERE id BETWEEN 2000 AND 2050"
+
+# Without this the two checks below are unreachable and would pass forever while
+# guarding nothing: the fold declines most shapes, and a declined fold answers
+# from the scalar path that was never at risk.
+check "premise: the aggregate really reaches the batch fold" \
+	"$(fold_plan "$FQ" | grep -oE 'Columnar Batch Fold: [a-z]+' | head -1)" \
+	"Columnar Batch Fold: yes"
+
+check "the fold answers correctly over a range that skips vectors" \
+	"$(fold_run "$FQ")" \
+	"$(q 'SELECT count(*), sum(v) FROM h WHERE id BETWEEN 2000 AND 2050;')"
+
+# A range deep in the table, so the fold must advance the present index across
+# about nineteen leading skipped vectors before it reaches a row it keeps. That
+# is the alignment risk: the packed stream is indexed by presence, so an index
+# that does not advance over a skipped vector reads later values shifted by
+# nineteen vectors' worth of rows and still returns a plausible number.
+#
+# The first range above starts in vector 1 and cannot show this: one leading
+# skipped vector is too few for a misalignment to be obvious, and its answer
+# could be right by luck.
+FQ2="SELECT count(*), sum(v) FROM n WHERE id BETWEEN 20000 AND 20050"
+check "premise: the deep range reaches the fold too" \
+	"$(fold_plan "$FQ2" | grep -oE 'Columnar Batch Fold: [a-z]+' | head -1)" \
+	"Columnar Batch Fold: yes"
+check "and it agrees with heap after many leading skipped vectors" \
+	"$(fold_run "$FQ2")" \
+	"$(q 'SELECT count(*), sum(v) FROM h WHERE id BETWEEN 20000 AND 20050;')"
+
+# The check that can actually catch a consumer reading an undecoded hole.
+#
+# The two above cannot, and that is worth stating plainly: a fold that reads
+# every hole PASSES them. Whatever palloc last left in the buffer is rejected by
+# the fold's own scan-key recheck, so the wrong code returns the right answer.
+# The hazard is real and the symptom is data-dependent, which is precisely the
+# combination a test cannot pin down.
+#
+# So assert builds poison a skipped vector's bytes with 0xA5, which as an int4 is
+# -1515870811. This predicate is chosen to ACCEPT that value while still letting
+# the zone maps rule most vectors out: every id in the table is between 1 and
+# 32768, so the lower bound excludes nothing and the upper bound rules out every
+# vector past id 3000. A fold that reads the poison counts rows that are not
+# there and the count runs away from heap's 3000.
+#
+# On a non-assert build there is no poison and this check is merely another
+# parity check. The matrix runs assert builds, which is where it has teeth.
+POISONQ="SELECT count(*), sum(v) FROM n WHERE id BETWEEN -2000000000 AND 3000"
+check "premise: the poison-accepting range reaches the fold" \
+	"$(fold_plan "$POISONQ" | grep -oE 'Columnar Batch Fold: [a-z]+' | head -1)" \
+	"Columnar Batch Fold: yes"
+check "premise: and it still skips vectors, or there is no hole to read" \
+	"$([ "$(counter_in "$(explain_of "SELECT id FROM n WHERE id BETWEEN -2000000000 AND 3000")" 'Columnar Vectors Skipped')" -gt 0 ] && echo yes || echo no)" \
+	"yes"
+check "the fold does not count rows from a vector it never decoded" \
+	"$(fold_run "$POISONQ")" \
+	"$(q 'SELECT count(*), sum(v) FROM h WHERE id BETWEEN -2000000000 AND 3000;')"
+
 pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -132,6 +132,7 @@ SUITES=(
 	native_sort_by
 	native_truncate
 	native_vacuum_race
+	native_vecdecode
 	native_vecskip
 	native_writer
 	native_zonemap


### PR DESCRIPTION
#452 phase 1b-i, specified in `design/ISSUE_452_LATE_MATERIALIZATION.md`.

## What was wrong

`Columnar Vectors Skipped` never meant what its name suggests. Decode ran
**before** the skip vector existed:

```
:1598   pgcolumnar_native_decode_chunk(...)      per wanted column
:1615   pgcolumnar_native_build_skipvec(...)     from zone maps
```

So a vector the zone maps had ruled out was decoded in full, and the skip only
stopped it being turned into Datums. The counter said "not emitted", never "not
decoded", and no existing counter could tell those apart.

Nothing about that ordering was necessary. The vector count lives in the
encoding descriptor header, which is chunk **metadata** already in hand, and
`build_skipvec`'s only other inputs are the predicates and the zone map catalog.
A metadata-only pre-pass reads the count and decides `allDescriptor` without
touching a value byte.

## Two things this deliberately does not do

- **It does nothing for ClickBench q24.** A leading-wildcard `LIKE` yields
  `numPredicates == 0` and a NULL skip vector. The ~3200 ms budget there is
  1b-ii, and none of the six #445 losses is helped by this. It pays on queries
  with a usable predicate, which is most analytic filters.
- **It does not avoid decompression.** The block codec still reverses the whole
  chunk; that is cost 1 and needs a format change (Phase 2). This removes cost 2,
  the per-vector decode.

## The fold had to change too, and #523's tripwire is why I knew

Skipping decode leaves **holes** in the packed value stream. The row producer is
safe (it steps its cursors past skipped vectors); the fold is not, because it
reads that buffer directly and re-checks every value. #523 landed a guard for
exactly this ordering, and it fired on the first run:

```
ERROR: pgcolumnar: the vectorized aggregate cannot fold a row group whose
decode skipped vectors (#512); teach this loop to honour the skip vector in the
same change that makes decode honour it
```

That guard did its job. The fold now walks the per-vector map it was already
handed, and skipping there is exact rather than merely safe:
`pgcolumnar_batch_shape_eligible` requires every qual to be convertible to a scan
key, and those keys are what the reader built the skip vector from. The present
index still advances across a skipped vector, as it does across a deleted row,
because the stream is packed by presence.

## The part worth reviewing: two instruments that could not see their subject

**The counter was unfalsifiable.** I first derived "vectors decoded" from the
mask the caller passed in. It reported the saving whether or not decode honoured
the mask, and the removal proof **passed with the fix removed**. It is now
reported from the loop that does the work.

**The correctness checks could not see the hazard.** Reading a hole is undefined
behaviour whose symptom is data-dependent: whatever `palloc` last left there is
normally rejected by the fold's own scan-key recheck, so a fold that reads every
hole returns the *right* answer on ordinary data. Measured, not reasoned about:
with the skip removed from the fold, all 20 checks passed.

So assert builds now poison a skipped vector's bytes with `0xA5`, which as an
`int4` is `-1515870811`, and the suite adds a predicate chosen to accept that
value while still letting the zone maps rule most vectors out. With the fold's
skip removed, that check reports **32,696 rows where heap says 3,000**.

## Proof

`test/native_vecdecode.sh`, 23 checks. Every premise is asserted first, so a
plan change or a split row group cannot masquerade as a decode regression.

Proved by removal, three ways:

| removal | what catches it |
| --- | --- |
| decode ignores the mask | `decoded + skipped == the group's vectors` |
| a HALF-working mask, skipping only the first ruled-out vector | the same check; `decodes fewer` still passes, which is why the check is an equality and not an inequality |
| the fold ignores the mask | **only** the poison check |
| the present index does not advance over a skipped vector | the deep-range fold check returns 0 rows; the shallow one merely returns a wrong count, which is why the deep range is there |

## Gate

- **PG17 assert**: 131 ran, 5 skipped, all pass.
- **PG19 assert**: 136 ran, one failure: `temporal`. That is `btree_gist` missing
  in my container, it fails **identically on unmodified main**, #448 made a
  missing dependency a failure by design, and `PGC_ALLOW_MISSING_BTREE_GIST=1` is
  its documented override. Not this change.

Refs #452, #512
