### PR TITLE
docs: the geomean column is one quantity, and 0.53 is not 0.54 (#445)

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -836,11 +836,15 @@ engine and in nothing else.
 
 Query latency, hot times, same run:
 
-| arm | total across 43 queries | geometric mean |
+| arm | total across 43 queries | geometric mean against heap |
 | --- | ---: | ---: |
 | heap | 154.9 s | |
-| columnar | 127.7 s | 0.54 against heap |
-| citus columnar | 251.7 s | 0.28 against citus |
+| columnar | 127.7 s | 0.53 |
+| citus columnar | 251.7 s | 1.91 |
+
+Every figure in the last column is that row's own arm measured against heap, so
+the column can be read down. Columnar against Citus is 0.28, which belongs in
+this sentence rather than in the Citus row.
 
 Against heap, columnar wins 33 of the 43 queries, loses 6, and ties on 4. A tie
 is a query whose two arms are closer to each other than the run to run scatter


### PR DESCRIPTION
Fixes the two defects @ChronicallyJD raised reviewing #526. Both were mine, and
both had already merged before the review landed. **I am not merging this one**
(see the note at the end).

## 1. The geomean column held two different quantities

| row | what the number actually was |
| --- | --- |
| columnar | columnar against **heap** |
| citus | columnar against **citus** |

The header had been made generic to accommodate the mismatch, which is the wrong
repair: a column you cannot read down is not a column. It now holds each arm
against heap throughout, citus included, and the columnar-against-citus figure is
stated in prose beside the table.

| arm | total across 43 queries | geometric mean against heap |
| --- | ---: | ---: |
| heap | 154.9 s | |
| columnar | 127.7 s | **0.53** |
| citus columnar | 251.7 s | **1.91** |

Same defect as #493: one label, one quantity.

## 2. 0.53, not 0.54

Verified against `/srv/clickbench/raw_timings.tsv`:

```
geomean columnar/heap  = 0.534839  -> 0.53
geomean columnar/citus = 0.279971  -> 0.28
geomean citus/heap     = 1.910337  -> 1.91
```

How I got 0.54: I computed the geomean to three decimals, read `0.535` off that
output, and rounded it a second time to two. **Double rounding, from a value that
had already been rounded for display.**

That is #531 again, which I diagnosed, fixed and wrote a memory note about
earlier the same day, and then committed in prose about four hours later. #531
was a comparison decided on a formatted string; this is a number derived from
one. The general form of the rule is the one I should have written down: **do not
compute from a value that was rounded to be looked at.**

Worth stating plainly because #526 merged with both defects in it, and the review
that caught them was posted while it was already on main.

## On merging

@ChronicallyJD has asked that neither of us merge our own PRs while we are both
posting as this account. I think that is right and I am leaving this for jd or a
human reviewer, even though it is a correction to my own error and green.
