### PR TITLE
feat: exact selection feeds back into the skip vector (#452 phase 1b-ii)

### DIFF
--- a/design/ISSUE_452_LATE_MATERIALIZATION.md
+++ b/design/ISSUE_452_LATE_MATERIALIZATION.md
@@ -194,17 +194,74 @@ worse than a specification. Its shape, to rebuild:
 - checks: decoded(narrow) < decoded(wide), and the difference equals the skipped
   count exactly — "fewer" alone would pass on decoding one vector less
 
-### 1b-ii: exact selection, which does need batching
+### 1b-ii: exact selection, which turned out NOT to need batching
 
-To skip decode for vectors holding no *surviving* row, the qual must be evaluated
-before the payload columns are decoded — and the qual can only be evaluated on
-decoded qual columns. So the producer has to work a vector at a time: decode the
-qual columns, evaluate 1024 rows, decode the payload for that vector only if any
-survived, emit.
+**Implemented. The paragraph below this one is what was predicted; the correction
+after it is what the code needed, and it is smaller.**
 
-This is the batching 1a turned out not to need, and it is the larger piece. It is
-also the only one of the two that reaches q24, where the measured budget is the
-~3200 ms 1a leaves behind.
+Predicted: to skip decode for vectors holding no *surviving* row, the qual must
+be evaluated before the payload columns are decoded, and the qual can only be
+evaluated on decoded qual columns. So the producer has to work a vector at a
+time: decode the qual columns, evaluate 1024 rows, decode the payload for that
+vector only if any survived, emit. "This is the batching 1a turned out not to
+need, and it is the larger piece."
+
+**Corrected after 1b-i landed.** No producer restructure was needed, and the
+reason is that 1b-i had already moved the expensive part. Once the skip vector is
+built before the decode loop and decode takes a mask, exact selection is just a
+second pass over the same loop:
+
+1. **Pass 0** decodes only the columns a pushed-down predicate reads.
+2. **Refine** the mask by evaluating those predicates against the decoded values,
+   turning "the zone maps could not rule this vector out" into "no row in it
+   matches".
+3. **Pass 1** decodes everything else against the sharpened mask.
+
+The producer is untouched. It already steps over a set bit, and it does not care
+which mechanism set it.
+
+Three things that were not obvious and cost time:
+
+- **The mask must be allocated even when the zone maps rule nothing out.**
+  `build_skipvec` ended in `rs->nativeSkipVec = any ? skip : NULL`, a fair
+  optimisation while zone maps were the only writer. The case exact selection
+  exists for is exactly the one where `any` is false, so it had nowhere to write
+  and the suite measured no saving at all, silently.
+- **Predicates must be evaluated conjunctively per column.** Evaluating each one
+  independently is sound and useless: `BETWEEN 51 AND 59` is two predicates, and
+  on a column of multiples of ten some row satisfies `>= 51` and another
+  satisfies `<= 59`, so neither is ever unsatisfied and nothing is ever ruled
+  out. Measured that way first.
+- **The counter had to be split.** Exact selection writes into the same mask as
+  the zone maps, so `Columnar Vectors Skipped` stopped being one quantity.
+  `Columnar Vectors Ruled Out by Value` is the subset (#493).
+
+Measured on the suite's fixture, `SELECT *` over six columns, 32 vectors, a
+zero-matching range: **192 vector decodes to 32**, with all 32 vectors ruled out
+by value and none by zone map.
+
+#### The issue's own acceptance case is already solved, by bloom filters
+
+`clienttimezone = 3600` matching zero rows is an **equality**, and the per-chunk
+bloom filter (I7, gap 25) prunes the whole row group for it. Measured: the
+equality form reports `Chunk Groups Removed by Filter: 1` and decodes nothing at
+all. A suite built on it proves nothing about decode, because decode never runs.
+
+So the gap 1b-ii actually closes is **range** predicates that fall in a gap
+between stored values, which bloom cannot answer and min/max cannot bound.
+`test/native_exact_selection.sh` uses `BETWEEN 51 AND 59` on a column of
+multiples of ten for that reason, and asserts the equality form's group pruning
+as a check so that a later "simplification" back to `z = 51` cannot silently stop
+testing anything.
+
+#### What this does NOT do for q24
+
+Nothing. q24's qual is a leading-wildcard `LIKE`, which is not admitted as a
+`SkipPredicate` at all, so `numPredicates` is 0, there is no mask, and exact
+selection has nothing to evaluate. **The ~3200 ms budget on q24 remains
+unclaimed**, and reaching it needs text predicates admitted to the reader (#426)
+or the per-row qual-first materialisation of 1a extended to skip whole vectors.
+Neither is this change.
 
 **Order matters:** 1b-i first, because it is small, independently valuable, and
 its mask plumbing is what 1b-ii extends from zone-map-derived to

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -671,6 +671,8 @@ extern void PgColumnarReadStats(PgColumnarReadState *readState,
 							  uint64 *groupsTotal);
 extern uint64 PgColumnarVectorsSkipped(PgColumnarReadState *readState);
 extern uint64 PgColumnarVectorsDecoded(PgColumnarReadState *readState);
+extern uint64 PgColumnarVectorDecodes(PgColumnarReadState *readState);
+extern uint64 PgColumnarVectorsRuledOutByValue(PgColumnarReadState *readState);
 
 /*
  * How many of the scan keys the reader was handed became skip predicates it can
@@ -936,6 +938,24 @@ typedef struct PgColumnarGroupStats
 	 * decoded", and no counter could tell those apart until this one.
 	 */
 	uint64		vectorsDecoded;
+
+	/*
+	 * Vector decodes as (vector, column) PAIRS, where vectorsDecoded above counts
+	 * vector POSITIONS. Two quantities, two labels (#493). Positions cannot see
+	 * #452 phase 1b-ii at all: exact selection leaves the qual column decoded at
+	 * every position and saves the payload columns, so the max across columns
+	 * does not move while the work done falls by a factor of the column count.
+	 */
+	uint64		vectorDecodes;
+
+	/*
+	 * The subset of vectorsSkipped that exact selection ruled out (#452 phase
+	 * 1b-ii), as opposed to the zone maps. Separate because "Vectors Skipped"
+	 * alone stopped being one quantity the moment a second mechanism could set
+	 * a bit in the same mask, and a reader cannot tell a zone map win from an
+	 * exact-selection win without it (#493).
+	 */
+	uint64		vectorsRuledOutByValue;
 } PgColumnarGroupStats;
 
 extern void PgColumnarExplainPushedDown(int64 nfilters, ExplainState *es);

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -2188,6 +2188,10 @@ PgColumnarExplainGroupStats(const PgColumnarGroupStats *stats, ExplainState *es)
 	 */
 	ExplainPropertyInteger("Columnar Vectors Decoded", NULL,
 						   (int64) stats->vectorsDecoded, es);
+	ExplainPropertyInteger("Columnar Vector Decodes", NULL,
+						   (int64) stats->vectorDecodes, es);
+	ExplainPropertyInteger("Columnar Vectors Ruled Out by Value", NULL,
+						   (int64) stats->vectorsRuledOutByValue, es);
 }
 
 /* -------------------------------------------------------------------------
@@ -2318,6 +2322,8 @@ PgColumnarExplainCustomScan(CustomScanState *node, List *ancestors,
 		gs.groupsRemoved = groupsSkipped;
 		gs.vectorsSkipped = PgColumnarVectorsSkipped(cstate->readState);
 		gs.vectorsDecoded = PgColumnarVectorsDecoded(cstate->readState);
+		gs.vectorDecodes = PgColumnarVectorDecodes(cstate->readState);
+		gs.vectorsRuledOutByValue = PgColumnarVectorsRuledOutByValue(cstate->readState);
 		PgColumnarExplainGroupStats(&gs, es);
 
 		/*

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -149,6 +149,8 @@ struct PgColumnarReadState
 	int			nativeCurVec;		/* vector containing rowInGroup */
 	uint64		vectorsSkipped;		/* for EXPLAIN */
 	uint64		vectorsDecoded;		/* for EXPLAIN; see PgColumnarGroupStats */
+	uint64		vectorDecodes;		/* (vector, column) pairs; see PgColumnarGroupStats */
+	uint64		vectorsRuledOutByValue;	/* subset of vectorsSkipped; #452 1b-ii */
 
 	/*
 	 * Late materialization (#452 Phase 1a). Rows whose qual columns were decoded,
@@ -975,6 +977,192 @@ pgcolumnar_native_decode_chunk(MemoryContext cx, Form_pg_attribute att,
 }
 
 /*
+ * native_is_qual_column
+ *		Does any pushed-down predicate read this column? Decode order depends on
+ *		it: qual columns must be decoded before exact selection can run, payload
+ *		columns after, or there is nothing left to save.
+ */
+static bool
+native_is_qual_column(PgColumnarReadState *rs, int col)
+{
+	int			p;
+
+	for (p = 0; p < rs->numPredicates; p++)
+		if (rs->predicates[p].attidx == col)
+			return true;
+	return false;
+}
+
+/*
+ * native_value_satisfies
+ *		Does one decoded value satisfy one pushed-down predicate? The mirror of
+ *		native_zone_excludes below, which asks the same question of a min/max pair
+ *		rather than of a value.
+ *
+ *		Column first and constant second, like every other comparison here. The
+ *		argument order is part of a cross-type proc's signature and getting it
+ *		backwards is #477.
+ *
+ *		An unrecognised strategy returns true: "cannot rule this out" is the only
+ *		safe answer, because the caller turns a false into a skipped vector.
+ */
+static bool
+native_value_satisfies(SkipPredicate *pred, Datum val)
+{
+	int32		c = DatumGetInt32(FunctionCall2Coll(&pred->cmpFn, pred->collation,
+													val, pred->compareValue));
+
+	switch (pred->strategy)
+	{
+		case BTLessStrategyNumber:
+			return (c < 0);
+		case BTLessEqualStrategyNumber:
+			return (c <= 0);
+		case BTEqualStrategyNumber:
+			return (c == 0);
+		case BTGreaterEqualStrategyNumber:
+			return (c >= 0);
+		case BTGreaterStrategyNumber:
+			return (c > 0);
+		default:
+			return true;
+	}
+}
+
+/*
+ * pgcolumnar_native_refine_skipvec
+ *		Extend the skip vector from "the zone maps could not rule this vector out"
+ *		to "no row in it actually matches" (#452 phase 1b-ii).
+ *
+ *		Called between the two decode passes: the qual columns are decoded, the
+ *		payload columns are not yet, so a vector ruled out here costs the payload
+ *		columns nothing. That ordering IS the optimisation. Run it after both
+ *		passes and it saves nothing at all.
+ *
+ *		Predicates are grouped BY COLUMN and evaluated conjunctively within a
+ *		column: a row keeps the vector alive only if it satisfies EVERY predicate
+ *		on that column. Evaluating them one at a time instead is sound but
+ *		useless, and uselessly in exactly the shape this is for -- `BETWEEN 51 AND
+ *		59` is two predicates, and on a column holding multiples of ten some row
+ *		satisfies `>= 51` and some other row satisfies `<= 59`, so neither alone
+ *		is ever unsatisfied and no vector is ever ruled out. Measured that way
+ *		first; it saved nothing.
+ *
+ *		Across columns it stays conservative: a vector is ruled out when SOME
+ *		column's predicates are satisfied by no row in it. It can miss a vector
+ *		where every row fails some predicate but no single column rules it out.
+ *		Missing a skip costs time; taking a wrong one would cost rows, so the
+ *		asymmetry runs the safe way.
+ *
+ *		A NULL never satisfies a btree comparison, so a NULL row cannot keep a
+ *		vector alive. That matches what the executor does with it.
+ */
+static void
+pgcolumnar_native_refine_skipvec(PgColumnarReadState *rs, int vecCount)
+{
+	MemoryContext scratch;
+	MemoryContext old;
+	int			p;
+
+	if (rs->nativeSkipVec == NULL || rs->nativeVecStart == NULL ||
+		rs->numPredicates == 0 || vecCount <= 0)
+		return;
+
+	scratch = AllocSetContextCreate(CurrentMemoryContext,
+									"columnar exact selection",
+									ALLOCSET_SMALL_SIZES);
+	old = MemoryContextSwitchTo(scratch);
+
+	for (p = 0; p < rs->numPredicates; p++)
+	{
+		int			col = rs->predicates[p].attidx;
+		Form_pg_attribute att;
+		const uint32 *vrl;
+		char	   *cursor;
+		int			v;
+		int			q;
+		bool		seen = false;
+
+		if (col < 0 || col >= rs->natts)
+			continue;
+
+		/* one pass per COLUMN, not per predicate: take the first mention */
+		for (q = 0; q < p; q++)
+			if (rs->predicates[q].attidx == col)
+				seen = true;
+		if (seen)
+			continue;
+		/* not projected, or a baseline chunk with no per-vector structure */
+		if (rs->nativeValueCursor[col] == NULL || rs->nativeVecRawLen[col] == NULL ||
+			rs->nativeValidity[col] == NULL)
+			continue;
+
+		att = TupleDescAttr(rs->tupdesc, col);
+		vrl = rs->nativeVecRawLen[col];
+		cursor = rs->nativeValueCursor[col];
+
+		for (v = 0; v < vecCount; v++)
+		{
+			char	   *vecCur = cursor;
+			uint32		r0 = rs->nativeVecStart[v];
+			uint32		r1 = rs->nativeVecStart[v + 1];
+			uint32		r;
+			bool		any = false;
+
+			/*
+			 * Advance to the next vector BEFORE the skip test. A skipped vector
+			 * still occupies its full raw length; its bytes are simply a hole
+			 * that 1b-i left undecoded, and in an assert build they are poison.
+			 * Reading them is exactly the bug that change was careful about.
+			 */
+			cursor += vrl[v];
+			if (rs->nativeSkipVec[v])
+				continue;
+
+			CHECK_FOR_INTERRUPTS();
+
+			for (r = r0; r < r1; r++)
+			{
+				Datum		val;
+				bool		ok;
+
+				if (!((rs->nativeValidity[col][r >> 3] >> (r & 7)) & 1))
+					continue;	/* NULL: satisfies no btree comparison */
+
+				val = PgColumnarDecodeValue(att, &vecCur, scratch);
+
+				/* every predicate on THIS column, conjunctively */
+				ok = true;
+				for (q = 0; q < rs->numPredicates; q++)
+				{
+					if (rs->predicates[q].attidx != col)
+						continue;
+					if (!native_value_satisfies(&rs->predicates[q], val))
+					{
+						ok = false;
+						break;
+					}
+				}
+				if (ok)
+				{
+					any = true;
+					break;
+				}
+			}
+
+			if (!any)
+			{
+				rs->nativeSkipVec[v] = true;
+				rs->vectorsRuledOutByValue++;
+			}
+		}
+	}
+
+	MemoryContextSwitchTo(old);
+	MemoryContextDelete(scratch);
+}
+
+/*
  * native_zone_excludes
  *		Return true when a zone map's min/max prove that no value in its range can
  *		satisfy the predicate (so the vector or chunk can be skipped). A missing or
@@ -1377,7 +1565,19 @@ pgcolumnar_native_build_skipvec(PgColumnarReadState *rs, uint64 groupNumber, int
 	for (v = 0; v < vecCount; v++)
 		rs->nativeVecStart[v + 1] = rs->nativeVecStart[v] + span[v];
 
-	rs->nativeSkipVec = any ? skip : NULL;
+	/*
+	 * Kept even when the zone maps ruled nothing out, which they usually do not.
+	 *
+	 * This was `any ? skip : NULL`, and returning NULL there was a fair
+	 * optimisation while zone maps were the only thing that could set a bit: an
+	 * all-false mask is pure overhead to consult. Exact selection (#452 phase
+	 * 1b-ii) writes into this same mask AFTER this function returns, and the
+	 * case it exists for is precisely the one where the zone maps found nothing.
+	 * Returning NULL there left it nowhere to write, silently, and the suite
+	 * measured no saving at all.
+	 */
+	rs->nativeSkipVec = skip;
+	(void) any;
 }
 
 /* a half-open span of the row group's bytes, used to build coalesced reads */
@@ -1558,6 +1758,7 @@ pgcolumnar_native_load_group(PgColumnarReadState *rs)
 	int			validityBytes;
 	int			maxVecCount;
 	int			groupVecDecoded;	/* measured in the decode loop, never derived */
+	int			pass;
 	bool		allDescriptor;
 
 	/*
@@ -1697,6 +1898,23 @@ pgcolumnar_native_load_group(PgColumnarReadState *rs)
 		rs->nativeCurVec = 0;
 	}
 
+	/*
+	 * Two passes, and the order is the whole of #452 phase 1b-ii.
+	 *
+	 * Pass 0 decodes only the columns a pushed-down predicate reads. Exact
+	 * selection then evaluates those predicates against the decoded values and
+	 * turns "the zone maps could not rule this vector out" into "no row in it
+	 * matches". Pass 1 decodes everything else against that sharpened mask, so a
+	 * vector holding no matching row costs the payload columns nothing.
+	 *
+	 * Run as one pass, the refinement still produces a correct mask and saves
+	 * exactly nothing, because the payload columns are already decoded by then.
+	 */
+	for (pass = 0; pass < 2; pass++)
+	{
+	if (pass == 1 && allDescriptor)
+		pgcolumnar_native_refine_skipvec(rs, maxVecCount);
+
 	foreach(lc, chunks)
 	{
 		NativeColumnChunkMetadata *cc = (NativeColumnChunkMetadata *) lfirst(lc);
@@ -1706,6 +1924,10 @@ pgcolumnar_native_load_group(PgColumnarReadState *rs)
 		CHECK_FOR_INTERRUPTS();
 
 		if (cc->columnIndex < 0 || cc->columnIndex >= rs->natts)
+			continue;
+
+		/* pass 0 is the qual columns, pass 1 is the rest */
+		if (native_is_qual_column(rs, cc->columnIndex) != (pass == 0))
 			continue;
 
 		/*
@@ -1755,7 +1977,10 @@ pgcolumnar_native_load_group(PgColumnarReadState *rs)
 			 */
 			if (vdecoded > groupVecDecoded)
 				groupVecDecoded = vdecoded;
+			/* pairs, so summed across columns rather than maxed */
+			rs->vectorDecodes += (uint64) vdecoded;
 		}
+	}
 	}
 	rs->vectorsDecoded += (uint64) groupVecDecoded;
 
@@ -3368,4 +3593,28 @@ uint64
 PgColumnarVectorsDecoded(PgColumnarReadState *readState)
 {
 	return readState->vectorsDecoded;
+}
+
+/*
+ * PgColumnarVectorDecodes
+ *		How many individual (vector, column) decodes the native scan performed.
+ *		This is the quantity that measures decode WORK; PgColumnarVectorsDecoded
+ *		measures how many row positions were covered. Used by EXPLAIN.
+ */
+uint64
+PgColumnarVectorDecodes(PgColumnarReadState *readState)
+{
+	return readState->vectorDecodes;
+}
+
+/*
+ * PgColumnarVectorsRuledOutByValue
+ *		How many vectors exact selection ruled out by evaluating the pushed-down
+ *		predicates against decoded values, rather than against min/max (#452
+ *		phase 1b-ii). A subset of PgColumnarVectorsSkipped. Used by EXPLAIN.
+ */
+uint64
+PgColumnarVectorsRuledOutByValue(PgColumnarReadState *readState)
+{
+	return readState->vectorsRuledOutByValue;
 }

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -597,6 +597,8 @@ typedef struct PgColumnarAggScanState
 	uint64		groupsSkipped;
 	uint64		vectorsSkipped;
 	uint64		vectorsDecoded;
+	uint64		vectorDecodes;
+	uint64		vectorsRuledOutByValue;
 	uint64		groupsTotal;
 
 	/*
@@ -700,6 +702,8 @@ typedef struct PgColumnarGroupAggScanState
 	uint64		groupsSkipped;
 	uint64		vectorsSkipped;
 	uint64		vectorsDecoded;
+	uint64		vectorDecodes;
+	uint64		vectorsRuledOutByValue;
 	uint64		groupsTotal;
 	int			usablePreds;	/* of npreds, how many can exclude (#479) */
 } PgColumnarGroupAggScanState;
@@ -3332,6 +3336,8 @@ pgcolumnar_native_batch_fold(PgColumnarAggScanState *state, Relation rel,
 	state->usablePreds = PgColumnarReadUsablePredicates(rs);
 	state->vectorsSkipped = PgColumnarVectorsSkipped(rs);
 	state->vectorsDecoded = PgColumnarVectorsDecoded(rs);
+	state->vectorDecodes = PgColumnarVectorDecodes(rs);
+	state->vectorsRuledOutByValue = PgColumnarVectorsRuledOutByValue(rs);
 	state->haveStats = true;
 	state->batchFolded = true;
 	PgColumnarEndRead(rs);
@@ -3468,6 +3474,8 @@ pgcolumnar_native_scan_agg(PgColumnarAggScanState *state,
 		state->usablePreds = PgColumnarReadUsablePredicates(rs);
 	state->vectorsSkipped = PgColumnarVectorsSkipped(rs);
 	state->vectorsDecoded = PgColumnarVectorsDecoded(rs);
+	state->vectorDecodes = PgColumnarVectorDecodes(rs);
+	state->vectorsRuledOutByValue = PgColumnarVectorsRuledOutByValue(rs);
 		state->haveStats = true;
 	}
 
@@ -3626,6 +3634,8 @@ PgColumnarExplainAggScan(CustomScanState *node, List *ancestors, ExplainState *e
 		gs.groupsRemoved = state->groupsSkipped;
 		gs.vectorsSkipped = state->vectorsSkipped;
 		gs.vectorsDecoded = state->vectorsDecoded;
+		gs.vectorDecodes = state->vectorDecodes;
+		gs.vectorsRuledOutByValue = state->vectorsRuledOutByValue;
 		PgColumnarExplainGroupStats(&gs, es);
 	}
 }
@@ -4189,6 +4199,8 @@ pgcolumnar_groupagg_build(PgColumnarGroupAggScanState *state)
 	state->usablePreds = PgColumnarReadUsablePredicates(rs);
 	state->vectorsSkipped = PgColumnarVectorsSkipped(rs);
 	state->vectorsDecoded = PgColumnarVectorsDecoded(rs);
+	state->vectorDecodes = PgColumnarVectorDecodes(rs);
+	state->vectorsRuledOutByValue = PgColumnarVectorsRuledOutByValue(rs);
 	state->haveStats = true;
 
 	PgColumnarEndRead(rs);
@@ -4310,6 +4322,8 @@ PgColumnarExplainGroupAggScan(CustomScanState *node, List *ancestors,
 		gs.groupsRemoved = state->groupsSkipped;
 		gs.vectorsSkipped = state->vectorsSkipped;
 		gs.vectorsDecoded = state->vectorsDecoded;
+		gs.vectorDecodes = state->vectorDecodes;
+		gs.vectorsRuledOutByValue = state->vectorsRuledOutByValue;
 		PgColumnarExplainGroupStats(&gs, es);
 	}
 }

--- a/test/native_exact_selection.sh
+++ b/test/native_exact_selection.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+#
+# pgColumnar: exact selection feeds back into the skip vector (#452 phase 1b-ii).
+#
+# Phase 1b-i taught decode to honour the skip vector, but that vector is built
+# from zone maps alone: it says "min/max could not rule this vector out", never
+# "no row in it actually matches". So the case #452 opens with is untouched by
+# it. A predicate that matches ZERO rows while lying inside every vector's
+# min/max rules out nothing, and all 105 columns of ClickBench are decoded to
+# produce no rows at all.
+#
+# This suite builds that shape deliberately: z holds only EVEN values, and the
+# predicate asks for an odd one. Every vector's min/max brackets it, so zone maps
+# are useless by construction, and the premises below assert that rather than
+# hope for it -- if the zone maps ever did prune this, the suite would be
+# measuring 1b-i again and would pass without 1b-ii existing.
+#
+# The observable is "Columnar Vector Decodes", which counts (vector, column)
+# decodes. That unit is the point. "Columnar Vectors Decoded" counts vector
+# POSITIONS, so it cannot see this fix at all: the qual column is still decoded
+# for every position, and the saving is entirely in the payload columns.
+#
+# Usage:  test/native_exact_selection.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+ROWS=32768
+VECTORS=32				# ROWS / 1024
+NCOLS=6					# z plus five payload columns
+
+psql_run "CREATE TABLE h (z int, p1 int, p2 int, p3 int, p4 int, p5 int);"
+psql_run "CREATE TABLE n (z int, p1 int, p2 int, p3 int, p4 int, p5 int) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.set_options('n', stripe_row_limit => 65536, chunk_group_row_limit => 1024);"
+
+# z is EVEN throughout and spans 0..198 inside every single vector, because it
+# cycles every 100 rows and a vector is 1024 rows. So no vector's zone map can
+# exclude an odd value in that range: min <= 51 <= max holds everywhere.
+GEN="SELECT (g % 100) * 2, g, g + 1, g + 2, g + 3, g + 4 FROM generate_series(1, $ROWS) g"
+psql_run "INSERT INTO h $GEN;"
+psql_run "INSERT INTO n $GEN;"
+
+explain_of() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -At -c "EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) $1" 2>/dev/null
+}
+counter_in() { grep -F "$2" <<<"$1" | grep -oE '[0-9]+' | head -1; }
+has_line() { grep -qF "$2" <<<"$1" && echo yes || echo no; }
+
+# The zero-matching query, and an all-matching one as the control. Both project
+# every column and both are pushed down, so they differ only in how many rows
+# actually satisfy the predicate.
+ZEROQ="SELECT * FROM n WHERE z = 51"
+ALLQ="SELECT * FROM n WHERE z >= 0"
+
+PLAN_ZERO="$(explain_of "$ZEROQ")"
+PLAN_ALL="$(explain_of "$ALLQ")"
+
+# ---- premises --------------------------------------------------------------
+
+check "premise: the zero-match plan is a columnar custom scan" \
+	"$(has_line "$PLAN_ZERO" 'Columnar Projected Columns')" "yes"
+check "premise: one row group, so every count below is one group's" \
+	"$(q "SELECT count(*) FROM pgcolumnar.row_group WHERE storage_id = pgcolumnar.get_storage_id('n');")" \
+	"1"
+check "premise: the predicate really matches no row" \
+	"$(q 'SELECT count(*) FROM n WHERE z = 51;')" "0"
+check "premise: and the control matches every row" \
+	"$(q 'SELECT count(*) FROM n WHERE z >= 0;')" "$ROWS"
+
+# The whole point of the fixture. If zone maps prune here, this is the 1b-i case
+# and the checks below would pass without exact selection existing at all.
+check "premise: ZONE MAPS RULE OUT NOTHING, which is what makes this 1b-ii" \
+	"$(counter_in "$PLAN_ZERO" 'Columnar Vectors Skipped')" "0"
+check "premise: no whole row group is pruned either" \
+	"$(counter_in "$PLAN_ZERO" 'Columnar Chunk Groups Removed by Filter')" "0"
+
+# ---- the observable --------------------------------------------------------
+
+check "EXPLAIN reports Columnar Vector Decodes" \
+	"$(has_line "$PLAN_ALL" 'Columnar Vector Decodes')" "yes"
+
+# The control decodes every column of every vector: nothing can be ruled out
+# when every row matches. This pins the unit as (vector, column) pairs rather
+# than positions, so a counter that quietly counted positions would fail here
+# rather than silently make the next check unfalsifiable.
+check "the control decodes every column of every vector" \
+	"$(counter_in "$PLAN_ALL" 'Columnar Vector Decodes')" "$(( VECTORS * NCOLS ))"
+
+# ---- the fix ---------------------------------------------------------------
+#
+# Exactly the qual column, and nothing else. Not "fewer": a payload column that
+# was decoded for even one vector would be a mask that leaks, and the arithmetic
+# is what catches that. The qual column must still be decoded in full, because
+# the values are what the selection is evaluated against.
+check "a zero-matching predicate decodes the qual column and no payload column" \
+	"$(counter_in "$PLAN_ZERO" 'Columnar Vector Decodes')" "$VECTORS"
+
+# ---- correctness -----------------------------------------------------------
+
+check "the zero-matching query returns nothing" \
+	"$(q 'SELECT count(*) FROM n WHERE z = 51;')" "0"
+check "a selective matching predicate still returns the right rows" \
+	"$(pgc_set_hash 'SELECT * FROM n WHERE z = 50')" \
+	"$(pgc_set_hash 'SELECT * FROM h WHERE z = 50')"
+check "and a partially matching one does too" \
+	"$(pgc_set_hash 'SELECT * FROM n WHERE z BETWEEN 100 AND 120')" \
+	"$(pgc_set_hash 'SELECT * FROM h WHERE z BETWEEN 100 AND 120')"
+check "the control returns every row" \
+	"$(q 'SELECT count(*), sum(p1) FROM n WHERE z >= 0;')" \
+	"$(q 'SELECT count(*), sum(p1) FROM h WHERE z >= 0;')"
+
+pgc_summary

--- a/test/native_exact_selection.sh
+++ b/test/native_exact_selection.sh
@@ -9,11 +9,20 @@
 # min/max rules out nothing, and all 105 columns of ClickBench are decoded to
 # produce no rows at all.
 #
-# This suite builds that shape deliberately: z holds only EVEN values, and the
-# predicate asks for an odd one. Every vector's min/max brackets it, so zone maps
-# are useless by construction, and the premises below assert that rather than
-# hope for it -- if the zone maps ever did prune this, the suite would be
-# measuring 1b-i again and would pass without 1b-ii existing.
+# The predicate has to be a RANGE, and finding that out is half of what this
+# suite records. The issue's own example is an EQUALITY on an absent value
+# (clienttimezone = 3600), and that case is ALREADY SOLVED: the per-chunk bloom
+# filter prunes the whole row group, measured here as
+# "Chunk Groups Removed by Filter: 1" with nothing decoded at all. A suite built
+# on it would prove nothing about decode, because decode never runs.
+#
+# Bloom filters answer equality and nothing else, so a range that falls in a gap
+# between stored values reaches the case #452 is actually about: z holds only
+# multiples of ten, and the predicate asks for 51..59. Every vector's min/max
+# brackets that range, so zone maps are useless by construction, and the
+# premises below assert that rather than hope for it -- if anything ever did
+# prune this, the suite would be measuring 1b-i again and would pass without
+# 1b-ii existing.
 #
 # The observable is "Columnar Vector Decodes", which counts (vector, column)
 # decodes. That unit is the point. "Columnar Vectors Decoded" counts vector
@@ -35,10 +44,10 @@ psql_run "CREATE TABLE h (z int, p1 int, p2 int, p3 int, p4 int, p5 int);"
 psql_run "CREATE TABLE n (z int, p1 int, p2 int, p3 int, p4 int, p5 int) USING pgcolumnar;"
 psql_run "SELECT pgcolumnar.set_options('n', stripe_row_limit => 65536, chunk_group_row_limit => 1024);"
 
-# z is EVEN throughout and spans 0..198 inside every single vector, because it
-# cycles every 100 rows and a vector is 1024 rows. So no vector's zone map can
-# exclude an odd value in that range: min <= 51 <= max holds everywhere.
-GEN="SELECT (g % 100) * 2, g, g + 1, g + 2, g + 3, g + 4 FROM generate_series(1, $ROWS) g"
+# z holds only multiples of ten and spans 0..990 inside every single vector,
+# because it cycles every 100 rows and a vector is 1024 rows. So no vector's zone
+# map can exclude 51..59: min <= 51 and max >= 59 hold everywhere.
+GEN="SELECT (g % 100) * 10, g, g + 1, g + 2, g + 3, g + 4 FROM generate_series(1, $ROWS) g"
 psql_run "INSERT INTO h $GEN;"
 psql_run "INSERT INTO n $GEN;"
 
@@ -52,7 +61,7 @@ has_line() { grep -qF "$2" <<<"$1" && echo yes || echo no; }
 # The zero-matching query, and an all-matching one as the control. Both project
 # every column and both are pushed down, so they differ only in how many rows
 # actually satisfy the predicate.
-ZEROQ="SELECT * FROM n WHERE z = 51"
+ZEROQ="SELECT * FROM n WHERE z BETWEEN 51 AND 59"
 ALLQ="SELECT * FROM n WHERE z >= 0"
 
 PLAN_ZERO="$(explain_of "$ZEROQ")"
@@ -66,14 +75,20 @@ check "premise: one row group, so every count below is one group's" \
 	"$(q "SELECT count(*) FROM pgcolumnar.row_group WHERE storage_id = pgcolumnar.get_storage_id('n');")" \
 	"1"
 check "premise: the predicate really matches no row" \
-	"$(q 'SELECT count(*) FROM n WHERE z = 51;')" "0"
+	"$(q 'SELECT count(*) FROM n WHERE z BETWEEN 51 AND 59;')" "0"
 check "premise: and the control matches every row" \
 	"$(q 'SELECT count(*) FROM n WHERE z >= 0;')" "$ROWS"
 
 # The whole point of the fixture. If zone maps prune here, this is the 1b-i case
 # and the checks below would pass without exact selection existing at all.
+# "Columnar Vectors Skipped" is the TOTAL, and since exact selection writes into
+# the same mask it no longer says which mechanism did the ruling out. So the
+# premise is stated as the subtraction: every vector skipped here was ruled out
+# by value, therefore the zone maps ruled out none. Asserting the total is 0
+# would have been the obvious phrasing and it fails the moment the feature works.
 check "premise: ZONE MAPS RULE OUT NOTHING, which is what makes this 1b-ii" \
-	"$(counter_in "$PLAN_ZERO" 'Columnar Vectors Skipped')" "0"
+	"$(( $(counter_in "$PLAN_ZERO" 'Columnar Vectors Skipped') - $(counter_in "$PLAN_ZERO" 'Columnar Vectors Ruled Out by Value') ))" \
+	"0"
 check "premise: no whole row group is pruned either" \
 	"$(counter_in "$PLAN_ZERO" 'Columnar Chunk Groups Removed by Filter')" "0"
 
@@ -95,19 +110,36 @@ check "the control decodes every column of every vector" \
 # was decoded for even one vector would be a mask that leaks, and the arithmetic
 # is what catches that. The qual column must still be decoded in full, because
 # the values are what the selection is evaluated against.
+check "exact selection rules out every vector, none of them by zone map" \
+	"$(counter_in "$PLAN_ZERO" 'Columnar Vectors Ruled Out by Value')" "$VECTORS"
+
 check "a zero-matching predicate decodes the qual column and no payload column" \
 	"$(counter_in "$PLAN_ZERO" 'Columnar Vector Decodes')" "$VECTORS"
+
+# The control must rule out nothing by value: every row matches it. Without this
+# the check above passes against an implementation that marks vectors
+# unconditionally, which would also return no rows for every query.
+check "and the control rules out no vector by value" \
+	"$(counter_in "$PLAN_ALL" 'Columnar Vectors Ruled Out by Value')" "0"
 
 # ---- correctness -----------------------------------------------------------
 
 check "the zero-matching query returns nothing" \
-	"$(q 'SELECT count(*) FROM n WHERE z = 51;')" "0"
+	"$(q 'SELECT count(*) FROM n WHERE z BETWEEN 51 AND 59;')" "0"
+
+# Recorded as a check rather than a comment, because it is the reason this suite
+# uses a range at all: the equality form of the same question never reaches
+# decode, so a future edit that "simplifies" the predicate back to z = 51 would
+# silently stop testing anything.
+check "premise: the EQUALITY form is pruned by bloom and reaches no decode" \
+	"$(counter_in "$(explain_of 'SELECT * FROM n WHERE z = 51')" 'Columnar Chunk Groups Removed by Filter')" \
+	"1"
 check "a selective matching predicate still returns the right rows" \
 	"$(pgc_set_hash 'SELECT * FROM n WHERE z = 50')" \
 	"$(pgc_set_hash 'SELECT * FROM h WHERE z = 50')"
-check "and a partially matching one does too" \
-	"$(pgc_set_hash 'SELECT * FROM n WHERE z BETWEEN 100 AND 120')" \
-	"$(pgc_set_hash 'SELECT * FROM h WHERE z BETWEEN 100 AND 120')"
+check "and a partially matching range does too" \
+	"$(pgc_set_hash 'SELECT * FROM n WHERE z BETWEEN 100 AND 220')" \
+	"$(pgc_set_hash 'SELECT * FROM h WHERE z BETWEEN 100 AND 220')"
 check "the control returns every row" \
 	"$(q 'SELECT count(*), sum(p1) FROM n WHERE z >= 0;')" \
 	"$(q 'SELECT count(*), sum(p1) FROM h WHERE z >= 0;')"

--- a/test/native_vecdecode.sh
+++ b/test/native_vecdecode.sh
@@ -206,9 +206,30 @@ POISONQ="SELECT count(*), sum(v) FROM n WHERE id BETWEEN -2000000000 AND 3000"
 check "premise: the poison-accepting range reaches the fold" \
 	"$(fold_plan "$POISONQ" | grep -oE 'Columnar Batch Fold: [a-z]+' | head -1)" \
 	"Columnar Batch Fold: yes"
-check "premise: and it still skips vectors, or there is no hole to read" \
-	"$([ "$(counter_in "$(explain_of "SELECT id FROM n WHERE id BETWEEN -2000000000 AND 3000")" 'Columnar Vectors Skipped')" -gt 0 ] && echo yes || echo no)" \
-	"yes"
+# Measured on the FOLD plan, not on a bare projection beside it.
+#
+# This premise used to read "Columnar Vectors Skipped" off
+# "SELECT id FROM n WHERE ...", a scalar-arm plan, and infer that the fold arm
+# skipped too. That inference is true today because both arms share one decode,
+# but it makes the premise for a fold check a measurement of a different plan.
+# It is also unfixable in its own terms: Vectors Skipped reads 0 on the fold arm
+# whatever happens, because it is incremented in the row-production path the fold
+# never enters (#542).
+#
+# "Columnar Vectors Decoded" does report correctly on the fold arm, so the
+# premise is now a direct statement about the plan under test. Ids 1..3000 live
+# in the first three vectors of 1024, so three is the whole of what this query
+# needs and the other 29 are the saving.
+FOLD_DEC="$(counter_in "$(fold_plan "$POISONQ")" 'Columnar Vectors Decoded')"
+check "premise: the FOLD ARM really decodes only the vectors it needs" "$FOLD_DEC" "3"
+
+# The counter must be capable of reading high on this arm, or the check above is
+# satisfied by a number that is simply always small. This is the case that would
+# catch a fold which silently stopped skipping and decoded everything: it would
+# return the right answer, read no poison, and fail nothing else we assert.
+check "control: and the same counter reads every vector when nothing is skipped" \
+	"$(counter_in "$(fold_plan 'SELECT count(*), sum(v) FROM n WHERE id >= 0')" 'Columnar Vectors Decoded')" \
+	"32"
 check "the fold does not count rows from a vector it never decoded" \
 	"$(fold_run "$POISONQ")" \
 	"$(q 'SELECT count(*), sum(v) FROM h WHERE id BETWEEN -2000000000 AND 3000;')"

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -90,6 +90,7 @@ SUITES=(
 	native_ctas
 	native_dml
 	native_encoding
+	native_exact_selection
 	native_fastdecode
 	native_fetch_bigcap
 	native_fetch_cache


### PR DESCRIPTION
#452 phase 1b-ii. **I am not merging this** — see the note at the end.

The skip vector said "the zone maps could not rule this vector out", never "no
row in it matches". A predicate satisfied by no row still decoded every column of
every vector to produce nothing.

Measured on the suite's fixture (`SELECT *` over six columns, 32 vectors, a
zero-matching range): **192 vector decodes down to 32**.

## The spec was wrong about the shape, and smaller is the good news

`design/ISSUE_452_LATE_MATERIALIZATION.md` predicted a vector-at-a-time producer
and called this "the larger piece". It is not, because 1b-i already moved the
expensive part. Once the mask is built before the decode loop and decode takes
it, exact selection is a second pass over the same loop:

1. **Pass 0** decodes only the columns a pushed-down predicate reads.
2. **Refine** evaluates those predicates against the decoded values.
3. **Pass 1** decodes everything else against the sharpened mask.

The producer is untouched. It already steps over a set bit and does not care
which mechanism set it. The design doc is updated with the correction.

## Three things that were not obvious

**The mask must exist even when the zone maps rule nothing out.** `build_skipvec`
ended in `nativeSkipVec = any ? skip : NULL` — a fair optimisation while zone
maps were the only writer. The case this feature exists for is precisely the one
where `any` is false, so it had nowhere to write. No error, no crash: the suite
just measured no saving.

**Predicates must be conjunctive per column.** Evaluating them one at a time is
sound and useless. `BETWEEN 51 AND 59` is two predicates, and on a column of
multiples of ten some row satisfies `>= 51` and another satisfies `<= 59`, so
neither is ever unsatisfied and nothing is ever ruled out. I measured it that way
first and it ruled out zero vectors.

**`Columnar Vectors Skipped` stopped being one quantity** the moment a second
mechanism could set a bit in the same mask, so `Columnar Vectors Ruled Out by
Value` reports the subset (#493). The suite's premise had to become a subtraction
for the same reason: asserting the total is 0 fails as soon as the feature works.

## The issue's own acceptance case is already solved, and not by this

`clienttimezone = 3600` matching zero rows is an **equality**, and the per-chunk
bloom filter prunes the whole row group for it. Measured: the equality form
reports `Chunk Groups Removed by Filter: 1` and decodes nothing at all. A suite
built on it would prove nothing about decode, because decode never runs.

The gap that remains is **range** predicates falling in a gap between stored
values, which bloom cannot answer and min/max cannot bound. The suite uses
`BETWEEN 51 AND 59` for that reason, and asserts the equality form's group
pruning as a check so a later "simplification" back to `z = 51` cannot silently
stop testing anything.

## What this does not do

**Nothing for ClickBench q24.** A leading-wildcard `LIKE` is not admitted as a
`SkipPredicate`, so `numPredicates` is 0 and there is no mask to sharpen. The
~3200 ms budget there is still unclaimed and needs #426 or an extension of 1a.

## Proof

`test/native_exact_selection.sh`, 16 checks, every premise asserted first.

| removal | what happens |
| --- | --- |
| refinement never runs | decodes stay at 192 |
| refinement runs **after** both passes | the mask is still correct and that check still passes, but decodes stay at 192 — the **ordering** earns the saving, not the refinement |
| the mask set unconditionally | parity and control checks lose every row |

## On merging

@ChronicallyJD asked that neither of us merge our own PRs while we are both
posting as this account, and I agreed. Leaving this for jd or a human reviewer.

Refs #452
