### PR TITLE
docs: what today taught about how a check can mislead, in CONTEXT.md

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -167,9 +167,12 @@ and ends with `pgc_summary`.
   **one name per line and sorted**; insert in sorted position, never at the end.
   `harness_selftest` fails if the order decays.
 - Count suites by asking the runner, never by parsing the source:
-  `bash test/run_all_versions.sh --list-suites | wc -l`. It is 132 today. A text
-  parser over the array disagrees with bash on exactly the mistake this invites,
-  and the disagreement is silent.
+  `bash test/run_all_versions.sh --list-suites | wc -l`. A text parser over the
+  array disagrees with bash on exactly the mistake this invites, and the
+  disagreement is silent. No number is quoted here on purpose: this bullet used
+  to end "it is 132 today", which was 137 by the time anyone noticed. A count
+  that changes weekly, written beside the command that computes it, is a
+  liability and not a convenience.
 - Assertions: `check` (string equality), `check_num`, `check_text` (for hashes
   and other things `check_num` must refuse), `check_ratio`, `check_timing`.
   `check "" ""` passes, which is why the helpers refuse empty sides.
@@ -190,12 +193,47 @@ than a wrong algorithm.
   asserts a derived relation without asserting the physical fact underneath it
   can stay green for its whole life while measuring nothing. `zonemap_cost`
   priced pruning correctly for a year while pruning zero groups.
-- **Prove the guard by removal.** A test proves nothing until it has been seen to
-  fail with that specific guard removed. Fingerprint the installed `.so` when you
-  do it, because a shared install prefix will happily let the "before" run be the
-  fixed binary.
+- **Prove it by removal, and not only guards.** A test proves nothing until it
+  has been seen to fail with the thing under test removed. The one-line form,
+  which needs no interpretation and costs ten seconds:
+
+      Can I delete this change and still be green?
+
+  It applies to any change at all, not just a guard: a bug fix, a feature, an
+  optimisation, a counter, a call site, a comment claiming a behaviour. This
+  bullet used to say "guard", and on 2026-08-09 two changes shipped whose entire
+  contribution could be deleted with the suite still green (#538, and the first
+  version of #537's own fix). Neither was a guard, which is exactly why this line
+  did not fire for either.
+
+  Fingerprint the installed `.so` when you do it, because a shared install prefix
+  will happily let the "before" run be the fixed binary.
 - **A removal proof must fail for the STATED reason.** That a check can fail is
   not evidence that it fails for the reason claimed. Read the failure text.
+- **A suite that sources a helper cannot see whether anything calls it.** Feeding
+  a function fixtures proves its arithmetic and nothing else, so the caller can
+  be deleted with every check still passing. Assert the call site too. A grep
+  over source text is the weaker kind of check and is still worth writing;
+  premise it on the call site existing, or it approves a file that no longer has
+  one.
+- **Before believing a check, make it say the other thing.** There are two ways
+  to be misled and they are mirror images. A check too TIGHT to fail approves
+  anything, and you find out when someone deletes your feature and the suite
+  stays green. A check too LOOSE to be believed condemns anything, and you find
+  out after chasing a defect that does not exist -- a grep for one message
+  matched a different message that merely began the same way, and reported a
+  fault that was not there. So: make a passing check fail, and show a failing
+  check passes on code known to be good. Both directions, every time.
+- **When a rule does not fire, fix its trigger, not your discipline.** Guidance
+  here, in a code comment, or in a local note can be correct, specific, and
+  silent, because the condition that summons it is narrower than the content it
+  guards. The bullet above is the worked example: it said "guard" while its
+  content covered any removal, so it stayed quiet for two people writing fixes.
+  When something you had already written fails to help, ask whether its CONTENT
+  would have covered the case. If yes the trigger is the bug, so widen it and put
+  the wider form in the first line where it is actually read. If no, the content
+  is. Only the second is about knowledge, and the first is the common one.
+  "Consult it more carefully" is not a fix.
 - **Never gate on luck.** A premise that requires a random sample to miss, or
   core to be unlucky, will fail eventually and will blame innocent code (#487).
   Restate it as arithmetic, or print it as an observation.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -222,7 +222,7 @@ than a wrong algorithm.
   stays green. A check too LOOSE to be believed condemns anything, and you find
   out after chasing a defect that does not exist -- in #537 a grep for one
   message matched a different message that merely began the same way, one about
-  the previously installed `.so` (#513), and reported a fault that was not there.
+  the previously installed `.so` (#508), and reported a fault that was not there.
   So: make a passing check fail, and show a failing check passes on code known to
   be good. Both directions, every time.
 - **When a rule does not fire, fix its trigger, not your discipline.** Guidance
@@ -235,6 +235,14 @@ than a wrong algorithm.
   the wider form in the first line where it is actually read. If no, the content
   is. Only the second is about knowledge, and the first is the common one.
   "Consult it more carefully" is not a fix.
+- **When you fix one instance, look for the rest before you believe you are
+  done.** A correction is not complete until you have searched for the same claim
+  elsewhere: grep for the phrasing you just removed. The bullets above were
+  written with a claim about people in them, corrected in one place, and the same
+  claim survived one paragraph below in different words. Then a wrong issue
+  citation was corrected in one place and a second wrong one survived four lines
+  away, and was caught by this rule rather than by rereading. Both times the
+  first correction felt like completion.
 - **Never gate on luck.** A premise that requires a random sample to miss, or
   core to be unlucky, will fail eventually and will blame innocent code (#487).
   Restate it as arithmetic, or print it as an observation.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -202,9 +202,9 @@ than a wrong algorithm.
   It applies to any change at all, not just a guard: a bug fix, a feature, an
   optimisation, a counter, a call site, a comment claiming a behaviour. This
   bullet used to say "guard", and on 2026-08-09 two changes shipped whose entire
-  contribution could be deleted with the suite still green (#538, and the first
-  version of #537's own fix). Neither was a guard, which is exactly why this line
-  did not fire for either.
+  contribution could be deleted with the suite still green (#532, and the first
+  version of #537's own fix; #538 is the change that caught the first of those).
+  Neither was a guard, which is exactly why this line did not fire for either.
 
   Fingerprint the installed `.so` when you do it, because a shared install prefix
   will happily let the "before" run be the fixed binary.
@@ -220,16 +220,17 @@ than a wrong algorithm.
   to be misled and they are mirror images. A check too TIGHT to fail approves
   anything, and you find out when someone deletes your feature and the suite
   stays green. A check too LOOSE to be believed condemns anything, and you find
-  out after chasing a defect that does not exist -- a grep for one message
-  matched a different message that merely began the same way, and reported a
-  fault that was not there. So: make a passing check fail, and show a failing
-  check passes on code known to be good. Both directions, every time.
+  out after chasing a defect that does not exist -- in #537 a grep for one
+  message matched a different message that merely began the same way, one about
+  the previously installed `.so` (#513), and reported a fault that was not there.
+  So: make a passing check fail, and show a failing check passes on code known to
+  be good. Both directions, every time.
 - **When a rule does not fire, fix its trigger, not your discipline.** Guidance
   here, in a code comment, or in a local note can be correct, specific, and
   silent, because the condition that summons it is narrower than the content it
   guards. The bullet above is the worked example: it said "guard" while its
-  content covered any removal, so it stayed quiet for two people writing fixes.
-  When something you had already written fails to help, ask whether its CONTENT
+  content covered any removal, so it stayed quiet for both changes above. When
+  something you had already written fails to help, ask whether its CONTENT
   would have covered the case. If yes the trigger is the bug, so widen it and put
   the wider form in the first line where it is actually read. If no, the content
   is. Only the second is about knowledge, and the first is the common one.


### PR DESCRIPTION
jd asked for this directly. It is the section that tells every future agent in
this repository how to argue, so it was deliberately left unwritten until he did:
@ChronicallyJD declined to write it on my asking, correctly, on the grounds that
a good argument is what a bad request would also look like. They have offered to
review it properly, and I would like them to.

**I am not merging this.** The no-self-merge rule still stands; jd's earlier
authorisation was #540 and #541 by number.

Everything here comes from a defect committed on 2026-08-09, not from principle.

## Widened: "Prove the guard by removal" → prove it by removal, and not only guards

With the one-line form up front, because it needs no interpretation and costs ten
seconds:

> **Can I delete this change and still be green?**

The bullet said *guard*, and fired reliably for guards. Two changes shipped that
day whose entire contribution could be deleted with the suite still green —
**#538**, and the first version of **#537**'s own fix — and neither was a guard,
which is exactly why the line stayed quiet. The rule failed by its own trigger.

## Added: a suite that sources a helper cannot see whether anything calls it

Feeding a function fixtures proves its arithmetic and nothing else, so the caller
can be deleted with every check still passing. Assert the call site too. A grep
over source text is the weaker kind of check and is still worth writing; premise
it on the call site existing, or it approves a file that no longer has one.

## Added: before believing a check, make it say the other thing

Two mirror-image failures, and the second cost as much diagnosis time as the
first that day:

| | behaviour | how you find out |
| --- | --- | --- |
| too **TIGHT** to fail | approves anything | someone deletes your feature and the suite stays green |
| too **LOOSE** to believe | condemns anything | after chasing a defect that does not exist |

One loose instance was a grep matching a message that merely began the same way,
reporting a fault that was not there.

## Added: when a rule does not fire, fix its trigger, not your discipline

Guidance can be correct, specific, and silent, because the condition that summons
it is narrower than the content it guards. The widened bullet above is the worked
example. Ask whether the CONTENT would have covered the case: if yes the trigger
is the bug, if no the content is. "Consult it more carefully" is not a fix.

## Also: a number removed from the suite-count bullet

It read "it is 132 today", which was **137** by the time anyone noticed, sitting
one clause after the command that computes it. Quoting a weekly-changing count
beside its own query is precisely the drift this file warns about, committed in
the file that warns about it.

## Two corrections to my own first draft, both the defects it describes

I wrote **"Both authors had read this line"** — asserting something about other
people's reading that I cannot establish, in the section about not asserting what
has not been established. And it was wrong on the facts: both changes were the
same author's. It now states what happened instead.

## Verification

`CONTEXT.md` is not covered by `docs_style`, which checks `docs/*.md` and
`README.md`, because it is internal engineering guidance like `design/`.
`docs_style` and `harness_selftest` both pass. No em dashes, matching house style.

---

## Update after review

@ChronicallyJD reviewed. Four findings, all taken.

**1. Structural, and it was the real problem.** This branch was cut from
`fix/537-start-failure-reason`, not from `main`, so #545 carried all four of
#544's commits — `test/lib.sh` +124 and `test/harness_selftest.sh` +114 alongside
the CONTEXT.md change. Two PRs against `main` carrying the same 238 lines, and
anyone reviewing "the CONTEXT.md PR" was reviewing a harness change.

Rebased onto `main`. This PR is now **one commit, one file**. #544 stands on its
own with their sign-off at `b7b8f52`, and the two are independent rather than
stacked — deliberately, because a stacked PR auto-closed on me earlier today when
its base branch was deleted on merge (#534 → #535).

**2. I cited the remedy as the defect.** The removal bullet listed #538 as a
change that shipped deletable. #538 is the change that **caught** it; the one that
shipped deletable was **#532**. Corrected, with #538 named as the catcher so the
pair stays findable.

**3. The person-claim survived one paragraph down.** I cut *"Both authors had
read this line"*, said so in the commit message, and left *"it stayed quiet for
two people writing fixes"* in the next bullet — the same unestablished assertion
in different words, and wrong the same way, since both changes were one author's.
It now reads "for both changes above".

This is the finding worth keeping, and it is their diagnosis rather than mine:
**a corrected sentence is not a corrected belief, and the second instance is
where you stop looking**, because the first one felt like the fix. Same shape as
the trigger bullet itself — knowing the rule is not what makes it fire.

**4. The one uncited claim.** The loose-grep example carried no issue number
while #532, #537, #487 and `zonemap_cost` all do, in a section about not making
unverifiable statements. Now cites #537, and #513 for the message it collided
with.

## On attribution, recorded deliberately

**No names in the file, including where the additions are not mine.** Two of the
four additions are substantially @ChronicallyJD's — the call-site bullet
generalised from #538, and the trigger bullet entirely. Both of us independently
reached the same reasoning: a rule that reads as one agent's lesson invites the
next reader to weigh the agent instead of the argument, and every bullet cites a
numbered defect anyone can pull up, so **the citation is the attribution, and a
better one, because it can be checked.**

Noted here rather than left silent so it reads as a decision rather than an
oversight.

They also note they are not a neutral party to this PR, having written two of the
four additions. Neither am I. It wants a human.
