### PR TITLE
refactor: columnar_metadata gets its own header, the first of six (#496)

### DIFF
--- a/src/columnar.h
+++ b/src/columnar.h
@@ -228,7 +228,6 @@ typedef struct PgColumnarMetapage
 } PgColumnarMetapage;
 
 
-
 /* -------------------------------------------------------------------------
  * Native format catalog row shapes (re-origination line, PGCN v1). These map
  * to pgcolumnar.storage / row_group / column_chunk (native spec section 11).
@@ -424,19 +423,9 @@ typedef struct PgColumnarRowRange
 
 /* row groups every one of whose rows is deleted as-of oldestXmin. Returns a
  * List of palloc'd uint64 group numbers. */
-extern void PgColumnarRetireGroup(uint64 storageId, uint64 groupNumber);
 extern int64 PgColumnarRetireFullyDeletedGroups(Relation rel);
-extern void PgColumnarLockChunkGroup(uint64 storageId, uint64 groupNumber);
-extern bool PgColumnarAllocateFreeSpace(uint64 storageId, uint64 dataLength,
-									  TransactionId oldestXmin, uint64 *fileOffset);
-extern bool PgColumnarTrailingFreeSpaceSafe(uint64 storageId, uint64 liveEnd,
-										  TransactionId oldestXmin);
-extern void PgColumnarDeleteFreeSpaceAtOrAbove(uint64 storageId, uint64 liveEnd);
-extern void PgColumnarReconcileFreeList(Relation dataRel);
 /* all-visible chunk-group row ranges: stripe committed past the horizon and no
  * deletes (committed or in-progress). Returns a List of PgColumnarRowRange *. */
-extern List *PgColumnarComputeAllVisibleGroups(uint64 storageId,
-											 TransactionId oldestXmin);
 
 /* physical reclaim: split freed ranges on allocate and coalesce on free (GUC) */
 extern bool pgcolumnar_reclaim_coalesce;
@@ -463,38 +452,21 @@ extern void PgColumnarCheckFreeSpaceNoOverlap(uint64 storageId);
  * metadata layer (pgcolumnar_metadata.c)
  * ------------------------------------------------------------------------- */
 extern uint64 PgColumnarNextStorageId(void);
-extern void PgColumnarInsertNativeStorageRow(const NativeStorageMetadata *s);
 
 /* projection: needed attnos (pull_varattnos form) -> the reader's 0-based set */
 extern Bitmapset *PgColumnarProjectionFromAttnos(Bitmapset *needed, int natts,
 											   int *nProjected);
-extern void PgColumnarSetSortedExtent(uint64 storageId, int64 firstGroup,
-									int64 lastGroup);
 extern void PgColumnarCheckNativeFormatVersion(uint64 storageId, const char *relName);
-extern void PgColumnarInsertRowGroupRow(const NativeRowGroupMetadata *rg);
-extern void PgColumnarInsertColumnChunkRow(const NativeColumnChunkMetadata *cc);
-extern void PgColumnarInsertZoneMapRow(const NativeZoneMapMetadata *z);
-extern void PgColumnarInsertBloomRow(const NativeBloomMetadata *b);
 extern List *PgColumnarReadRowGroupList(uint64 storageId, Snapshot snapshot);
-extern List *PgColumnarReadColumnChunkList(uint64 storageId, uint64 groupNumber,
-										 Snapshot snapshot);
 extern List *PgColumnarReadZoneMapList(uint64 storageId, uint64 groupNumber,
 									 Snapshot snapshot);
-extern List *PgColumnarReadZoneMapVectors(uint64 storageId, uint64 groupNumber,
-										Snapshot snapshot);
-extern NativeBloomMetadata *PgColumnarReadBloomForColumn(uint64 storageId,
-													   uint64 groupNumber,
-													   int columnIndex,
-													   Snapshot snapshot);
 extern void PgColumnarDeleteMetadata(uint64 storageId);
 
 /* per-table options catalog (spec 7.4) */
 extern bool PgColumnarReadOptions(Oid relid, PgColumnarOptions *opts);
-extern void PgColumnarDeleteOptions(Oid relid);
 
 /* declared physical sort key (#288); List of pstrdup'd column names, NIL if
  * none is declared. Names (not attnums) so the value survives dump/restore. */
-extern List *PgColumnarReadSortBy(Oid relid);
 
 /* projection catalog (gap 26, format 2.2). List entries are PgColumnarProjection*
  * palloc'd in the current context, ordered by projection_id. */
@@ -502,13 +474,8 @@ extern List *PgColumnarListProjections(uint64 storageId);
 extern void PgColumnarInsertProjectionRow(const PgColumnarProjection *proj);
 /* The dumpable declaration behind a projection, keyed by regclass and stored as
  * column names so a dump and restore can carry it (#266). */
-extern void PgColumnarRecordProjectionDeclaration(Oid relid, const char *name,
-												ArrayType *columns,
-												ArrayType *sortKey);
-extern void PgColumnarDeleteProjectionDeclaration(Oid relid, const char *name);
 /* Every declaration for a relation, for the drop hook: a dropped table must not
  * leave rows behind whose regclass no longer resolves (#304). */
-extern void PgColumnarDeleteProjectionDeclarationsForRel(Oid relid);
 extern void PgColumnarDeleteProjectionRow(uint64 storageId, int projectionId);
 
 /* whether a relation uses the columnar table access method */
@@ -529,7 +496,6 @@ extern Snapshot PgColumnarCatalogSnapshot(Snapshot base);
 /* delete_vector catalog access (spec 7.5) */
 extern List *PgColumnarReadDeleteVectorList(uint64 storageId, uint64 stripeId,
 									 Snapshot snapshot);
-extern bool PgColumnarStorageHasDeleteVector(uint64 storageId, Snapshot snapshot);
 extern void PgColumnarUpsertDeleteVector(uint64 storageId, DeleteVectorMetadata *rm);
 
 /* -------------------------------------------------------------------------

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -11,6 +11,7 @@
  */
 #include "columnar.h"
 
+#include "columnar_metadata.h"
 #include "fmgr.h"
 #include "columnar_compat.h"
 #include "access/genam.h"

--- a/src/columnar_metadata.h
+++ b/src/columnar_metadata.h
@@ -1,0 +1,80 @@
+/*-------------------------------------------------------------------------
+ *
+ * columnar_metadata.h
+ *		The catalog side of pgColumnar: what columnar_metadata.c offers the
+ *		modules that read and write our own catalog tables.
+ *
+ * Split out of columnar.h (#496). Every declaration here had exactly ONE
+ * consumer outside its defining file, so it was a private arrangement between
+ * two files that the other twenty were forced to recompile for, and that anyone
+ * reading columnar.h had to scan past to reach the interface that is genuinely
+ * shared.
+ *
+ * The shared vocabulary -- the Native*Metadata structs these signatures take,
+ * the GUCs, the format constants -- stays in columnar.h, which this includes.
+ *
+ * Written fresh for pgColumnar.
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef PGCOLUMNAR_METADATA_H
+#define PGCOLUMNAR_METADATA_H
+
+#include "columnar.h"
+
+extern void PgColumnarRetireGroup(uint64 storageId, uint64 groupNumber);
+
+extern void PgColumnarLockChunkGroup(uint64 storageId, uint64 groupNumber);
+
+extern bool PgColumnarAllocateFreeSpace(uint64 storageId, uint64 dataLength,
+									  TransactionId oldestXmin, uint64 *fileOffset);
+
+extern bool PgColumnarTrailingFreeSpaceSafe(uint64 storageId, uint64 liveEnd,
+										  TransactionId oldestXmin);
+
+extern void PgColumnarDeleteFreeSpaceAtOrAbove(uint64 storageId, uint64 liveEnd);
+
+extern void PgColumnarReconcileFreeList(Relation dataRel);
+
+extern List *PgColumnarComputeAllVisibleGroups(uint64 storageId,
+											 TransactionId oldestXmin);
+
+extern void PgColumnarInsertNativeStorageRow(const NativeStorageMetadata *s);
+
+extern void PgColumnarSetSortedExtent(uint64 storageId, int64 firstGroup,
+									int64 lastGroup);
+
+extern void PgColumnarInsertRowGroupRow(const NativeRowGroupMetadata *rg);
+
+extern void PgColumnarInsertColumnChunkRow(const NativeColumnChunkMetadata *cc);
+
+extern void PgColumnarInsertZoneMapRow(const NativeZoneMapMetadata *z);
+
+extern void PgColumnarInsertBloomRow(const NativeBloomMetadata *b);
+
+extern List *PgColumnarReadColumnChunkList(uint64 storageId, uint64 groupNumber,
+										 Snapshot snapshot);
+
+extern List *PgColumnarReadZoneMapVectors(uint64 storageId, uint64 groupNumber,
+										Snapshot snapshot);
+
+extern NativeBloomMetadata *PgColumnarReadBloomForColumn(uint64 storageId,
+													   uint64 groupNumber,
+													   int columnIndex,
+													   Snapshot snapshot);
+
+extern void PgColumnarDeleteOptions(Oid relid);
+
+extern List *PgColumnarReadSortBy(Oid relid);
+
+extern void PgColumnarRecordProjectionDeclaration(Oid relid, const char *name,
+												ArrayType *columns,
+												ArrayType *sortKey);
+
+extern void PgColumnarDeleteProjectionDeclaration(Oid relid, const char *name);
+
+extern void PgColumnarDeleteProjectionDeclarationsForRel(Oid relid);
+
+extern bool PgColumnarStorageHasDeleteVector(uint64 storageId, Snapshot snapshot);
+
+#endif							/* PGCOLUMNAR_METADATA_H */

--- a/src/columnar_projection.c
+++ b/src/columnar_projection.c
@@ -22,6 +22,7 @@
  */
 #include "columnar.h"
 
+#include "columnar_metadata.h"
 #include "access/table.h"
 #include "catalog/pg_type.h"
 #include "funcapi.h"

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -14,6 +14,7 @@
  */
 #include "columnar.h"
 
+#include "columnar_metadata.h"
 #include "fmgr.h"
 #include "access/detoast.h"
 #include "access/htup_details.h"

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -13,6 +13,7 @@
  */
 #include "columnar.h"
 
+#include "columnar_metadata.h"
 #include "access/multixact.h"
 #include "access/genam.h"
 #include "access/table.h"

--- a/src/columnar_vacuum.c
+++ b/src/columnar_vacuum.c
@@ -20,6 +20,7 @@
  *-------------------------------------------------------------------------
  */
 #include "columnar.h"
+#include "columnar_metadata.h"
 #include "columnar_compat.h"
 
 #include "fmgr.h"

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -36,6 +36,7 @@
  */
 #include "columnar.h"
 
+#include "columnar_metadata.h"
 #include <math.h>
 
 #include "miscadmin.h"

--- a/src/columnar_visibilitymap.c
+++ b/src/columnar_visibilitymap.c
@@ -33,6 +33,7 @@
  */
 #include "columnar.h"
 
+#include "columnar_metadata.h"
 #include "fmgr.h"
 #include "columnar_compat.h"
 

--- a/src/columnar_write_state.c
+++ b/src/columnar_write_state.c
@@ -13,6 +13,7 @@
  */
 #include "columnar.h"
 
+#include "columnar_metadata.h"
 #include "columnar_compat.h"
 #include "access/htup_details.h"
 #include "access/table.h"


### PR DESCRIPTION
First of six, for #496. **`columnar_metadata.c`'s 22 single-consumer declarations move to `src/columnar_metadata.h` beside it.**

## The census, re-measured, because the issue's numbers were stale

| | when filed | today (`3e86a7e`) |
| --- | ---: | ---: |
| `columnar.h` lines | 957 | **1045** |
| `extern` declarations | 159 | **164** |
| single-consumer functions | 79 | **84** |

The header gained interface faster than #527 removed it. Of 137 function declarations, 84 have exactly one consumer outside the defining file and 49 are genuinely shared.

## What moved, and what did not

The 22 functions defined in `columnar_metadata.c` and used by exactly one other file. The shared vocabulary they take — the `Native*Metadata` structs, the GUCs, the format constants — stays in `columnar.h`, which the new header includes. Nothing is made `static`, so #527's disqualification does not apply here: this relocates declarations, it does not narrow linkage.

Verified mechanically: each of the 22 appears exactly once in the new header and zero times in `columnar.h`.

## A defect in my own measurement, since it decided which module went first

The first version of my census attributed `PgColumnarBloomBuild` and `PgColumnarEncodeChunk` to `columnar_write_state.c`, which defines neither. It picked whichever file matched first in directory order. Requiring a definition at column 0 — the style this tree uses, return type on its own line — changed the ranking:

| module | corrected | broken tool said |
| --- | ---: | ---: |
| `columnar_metadata.c` | **22** | outside the top three |
| `columnar_reader.c` | 12 | 20 |
| `columnar_write_state.c` | 11 | **25, ranked first** |

**The wrong module would have been extracted first.** It was caught only because `PgColumnarBloomBuild` living in `columnar_write_state.c` is absurd on sight; two plausible filenames and I would have believed it.

## Gate

| major | build | warnings + errors |
| --- | --- | ---: |
| pg15a | rc=0 | 0 |
| pg16a | rc=0 | 0 |
| pg17a | rc=0 | 0 |
| pg18a | rc=0 | 0 |
| pg19a | rc=0 | 0 |

`make clean` between each, per #536. Plus `native_vecdecode` 24/24 and `harness_selftest` 54/54 on pg18a.

**The five-major build is the gate that matters here** and I want to be explicit about why rather than pad the list: nothing in this diff alters a line of executable code. The failure mode of a declaration move is a consumer left without a declaration it needs, and that fails to compile — loudly, on whichever major first sees it — rather than misbehaving at run time. Zero occurrences of `error:` or `warning:` across five full builds is the direct evidence for that, and a suite run is corroboration rather than the proof.

## Remaining

`reader` (12), `write_state` (11), `storage` (10), `customscan` (6), `delete_vector` (6) — one PR each. 84 declarations in a single diff is not a reviewable change, and each module's consumers are a different set of files.

I have not merged this and will not.
