### PR TITLE
refactor: columnar_reader gets its own header, the second of six (#496)

### DIFF
--- a/src/columnar.h
+++ b/src/columnar.h
@@ -374,7 +374,6 @@ extern uint64 PgColumnarItemPointerToRowNumber(ItemPointer tid);
  * ------------------------------------------------------------------------- */
 extern void PgColumnarVMClearForRow(Relation rel, uint64 rowNumber);
 extern uint64 PgColumnarVMSetVisibleForRelation(Relation rel);
-extern void PgColumnarDiscardFetchCache(void);
 
 /* index maintenance for callers that insert rows without an executor (#153) */
 typedef struct PgColumnarIndexInsertState
@@ -565,13 +564,6 @@ extern bool PgColumnarReadNextRow(PgColumnarReadState *readState,
  */
 typedef bool (*PgColumnarRowFilter) (void *arg);
 
-extern bool PgColumnarReadNextRowFiltered(PgColumnarReadState *readState,
-										Datum *values, bool *nulls,
-										uint64 *rowNumber,
-										const bool *qualCols,
-										PgColumnarRowFilter filter,
-										void *filterArg);
-extern uint64 PgColumnarRowsFilteredEarly(PgColumnarReadState *readState);
 extern void PgColumnarRescanRead(PgColumnarReadState *readState);
 extern void PgColumnarEndRead(PgColumnarReadState *readState);
 
@@ -580,15 +572,6 @@ extern void PgColumnarEndRead(PgColumnarReadState *readState);
  * so an ungrouped aggregate can fold it column-at-a-time instead of one Datum
  * tuple per row. See the block comment in pgcolumnar_reader.c for the contract.
  */
-extern bool PgColumnarReadFoldNextGroup(PgColumnarReadState *readState);
-extern void PgColumnarReadFoldGroupInfo(PgColumnarReadState *readState, uint64 *nrows,
-									  const char **deleteMask, uint32 *deleteMaskLen,
-									  const bool **skipVec, bool *decodeSkipped,
-									  const uint32 **vecStart,
-									  int *vectorCount);
-extern bool PgColumnarReadFoldColumn(PgColumnarReadState *readState, int attidx,
-								   const char **validity, const char **packed,
-								   int16 *attlen, const uint32 **vecRawLen);
 
 /*
  * Restrict a scan to a set of row groups (issue #149). Groups outside the set
@@ -615,9 +598,6 @@ extern void PgColumnarParquetCheckExportable(Relation rel);
  * read off colWanted, so a caller reporting a projection cannot report one it
  * failed to apply.
  */
-extern void PgColumnarReadSetProjection(PgColumnarReadState *readState,
-										Bitmapset *projectedColumns);
-extern int	PgColumnarReadProjectedCount(PgColumnarReadState *readState);
 
 /*
  * Parallel scan (gap 23): point the read state at a shared atomic that hands out
@@ -654,11 +634,6 @@ extern int	PgColumnarReadUsablePredicates(PgColumnarReadState *readState);
 /* cached base-liveness for a projection scan (gap 26): build once per scan,
  * probe per row with a binary search instead of a per-row catalog scan */
 typedef struct PgColumnarLivenessCache PgColumnarLivenessCache;
-extern PgColumnarLivenessCache *PgColumnarBuildLivenessCache(Relation rel,
-														 Snapshot snapshot);
-extern bool PgColumnarLivenessCacheIsLive(PgColumnarLivenessCache *cache,
-										uint64 rowNumber);
-extern void PgColumnarFreeLivenessCache(PgColumnarLivenessCache *cache);
 /*
  * Fetch a single row by its 1-based row number (spec 6), for the table AM's
  * fetch-by-tid callback used by UPDATE. Fills values/nulls (by-reference values
@@ -943,9 +918,6 @@ extern ScanKey PgColumnarBuildScanKeys(List *qual, Index scanrelid,
  */
 #define PGCOLUMNAR_PRUNE_SAMPLE_GROUPS 32
 
-extern double PgColumnarEstimatePruneSurvival(uint64 storageId, TupleDesc tupdesc,
-											List *qual, Index scanrelid,
-											uint64 ngroups, int sampleTarget);
 
 /* -------------------------------------------------------------------------
  * vectorized aggregation and filtering (pgcolumnar_vector.c, spec 9)

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -26,6 +26,7 @@
  */
 #include "columnar.h"
 
+#include "columnar_reader.h"
 #include <math.h>
 
 #include "access/htup_details.h"

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -15,6 +15,7 @@
 #include "columnar.h"
 
 #include "columnar_metadata.h"
+#include "columnar_reader.h"
 #include "fmgr.h"
 #include "access/detoast.h"
 #include "access/htup_details.h"

--- a/src/columnar_reader.h
+++ b/src/columnar_reader.h
@@ -1,0 +1,62 @@
+/*-------------------------------------------------------------------------
+ *
+ * columnar_reader.h
+ *		The read side of pgColumnar: what columnar_reader.c offers the scan and fold paths.
+ *
+ * Split out of columnar.h (#496). Every declaration here had exactly ONE
+ * consumer outside its defining file, so it was a private arrangement between
+ * two files that the other twenty were forced to recompile for.
+ *
+ * The shared vocabulary these signatures take stays in columnar.h, which this
+ * includes.
+ *
+ * Written fresh for pgColumnar.
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef PGCOLUMNAR_READER_H
+#define PGCOLUMNAR_READER_H
+
+#include "columnar.h"
+
+extern void PgColumnarDiscardFetchCache(void);
+
+extern bool PgColumnarReadNextRowFiltered(PgColumnarReadState *readState,
+										Datum *values, bool *nulls,
+										uint64 *rowNumber,
+										const bool *qualCols,
+										PgColumnarRowFilter filter,
+										void *filterArg);
+
+extern uint64 PgColumnarRowsFilteredEarly(PgColumnarReadState *readState);
+
+extern bool PgColumnarReadFoldNextGroup(PgColumnarReadState *readState);
+
+extern void PgColumnarReadFoldGroupInfo(PgColumnarReadState *readState, uint64 *nrows,
+									  const char **deleteMask, uint32 *deleteMaskLen,
+									  const bool **skipVec, bool *decodeSkipped,
+									  const uint32 **vecStart,
+									  int *vectorCount);
+
+extern bool PgColumnarReadFoldColumn(PgColumnarReadState *readState, int attidx,
+								   const char **validity, const char **packed,
+								   int16 *attlen, const uint32 **vecRawLen);
+
+extern void PgColumnarReadSetProjection(PgColumnarReadState *readState,
+										Bitmapset *projectedColumns);
+
+extern int	PgColumnarReadProjectedCount(PgColumnarReadState *readState);
+
+extern PgColumnarLivenessCache *PgColumnarBuildLivenessCache(Relation rel,
+														 Snapshot snapshot);
+
+extern bool PgColumnarLivenessCacheIsLive(PgColumnarLivenessCache *cache,
+										uint64 rowNumber);
+
+extern void PgColumnarFreeLivenessCache(PgColumnarLivenessCache *cache);
+
+extern double PgColumnarEstimatePruneSurvival(uint64 storageId, TupleDesc tupdesc,
+											List *qual, Index scanrelid,
+											uint64 ngroups, int sampleTarget);
+
+#endif							/* PGCOLUMNAR_READER_H */

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -14,6 +14,7 @@
 #include "columnar.h"
 
 #include "columnar_metadata.h"
+#include "columnar_reader.h"
 #include "access/multixact.h"
 #include "access/genam.h"
 #include "access/table.h"

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -37,6 +37,7 @@
 #include "columnar.h"
 
 #include "columnar_metadata.h"
+#include "columnar_reader.h"
 #include <math.h>
 
 #include "miscadmin.h"


### PR DESCRIPTION
Second of six for #496. The 12 declarations defined in `columnar_reader.c` with exactly one consumer outside it — the fold entry points, the liveness cache, the projection and filtered-read calls — consumed only by `customscan`, `tableam` and `vector`.

## Gate

| major | warnings + errors |
| --- | ---: |
| pg15a | 0 |
| pg16a | 0 |
| pg17a | 0 |
| pg18a | 0 |
| pg19a | 0 |

`make clean` between each (#536). `native_vecdecode` 24/24, `native_fold_skipguard` 4/4, `harness_selftest` 54/54 on pg18a.

## This is NOT independent of #546, and I said it was

I set out to make the six module PRs independent so none of them auto-closes when a sibling merges — the failure that closed #534 this morning. I measured the closest pair of declaration removals in `columnar.h` between this patch and #546's: **49 lines apart**, comfortably outside git's 3-line context, and concluded they could both sit on `main`.

The gate applied both to one tree and refused:

```
error: patch failed: src/columnar_reader.c:14
error: patch failed: src/columnar_tableam.c:13
error: patch failed: src/columnar_vector.c:36
```

**The collision is not in the header.** Three files consume *both* modules — `reader`, `tableam`, `vector` — and both patches insert their `#include` immediately after `#include "columnar.h"`, so they edit the same anchor line in the same three files. My arithmetic was right about the thing it measured and blind to the surface that actually collides, which is the second time today I have proved something adjacent to the question.

## So: still based on main, deliberately

The two options were stack or rebase, and rebase is cheaper here.

Stacking is what auto-closed #534: its base branch was deleted when the parent merged, and a closed PR whose base is gone can be neither reopened nor retargeted. The conflict in this case is **three adjacent include lines** — whichever of #546 and this one lands second wants a rebase that is mechanical and takes a minute.

A minute of rebase beats a PR that closes itself. Merge them in either order; I will rebase whichever is second.

The same collision will recur for every remaining module that shares a consumer, so this is the standing arrangement for the series rather than a one-off.

I have not merged this and will not.
