### PR TITLE
test: the port walk wraps instead of walking off the ceiling (#548)

### DIFF
--- a/test/harness_selftest.sh
+++ b/test/harness_selftest.sh
@@ -710,6 +710,21 @@ pgc_port_free() { return 1; }
 _none="$(pgc_pick_free_port "$PGC_AUX_PORT_LO" "$PGC_AUX_PORT_HI" 5 || echo NONE)"
 check "an entirely busy band reports itself full and terminates" "$_none" "NONE"
 
+# The caller says "no free port for the restore cluster in [lo,hi)". That names
+# the WHOLE band, so the picker has to have swept the whole band before it may
+# say nothing is free. It used to stop after 300 probes, which meant a free port
+# 500 away from the base was reported as a full band -- #548's own defect
+# surviving inside #548's fix, and #537's defect in the message.
+#
+# One free port, deliberately further from the base than the old 300 bound.
+pgc_port_free() { [ "$1" = "$(( PGC_AUX_PORT_LO + 500 ))" ]; }
+check "premise: the stub frees exactly one port, 500 past the floor" \
+	"$(pgc_port_free $(( PGC_AUX_PORT_LO + 500 )) && echo free || echo busy)/$(pgc_port_free $(( PGC_AUX_PORT_LO + 200 )) && echo free || echo busy)" \
+	"free/busy"
+_far="$(pgc_pick_free_port "$PGC_AUX_PORT_LO" "$PGC_AUX_PORT_HI" 0 || echo NONE)"
+check "a free port beyond the old 300-probe bound is still found" \
+	"$_far" "$(( PGC_AUX_PORT_LO + 500 ))"
+
 eval "$_realfree"
 check "premise: the real prober was restored, or every check after this lies" \
 	"$(pgc_port_free 1 && echo probing || echo stubbed)" "probing"

--- a/test/harness_selftest.sh
+++ b/test/harness_selftest.sh
@@ -667,4 +667,51 @@ check "premise: at least one suite drives the C-level encoding selftest" \
 check "the sanitizer subset runs every suite that drives the encoding selftest" \
 	"$(printf '%s' "$_san_missing" | sed 's/^ //')" ""
 
+# ---- the port walk must WRAP, not walk off the ceiling (#548) ---------------
+#
+# pgc_pick_free_port seeds a base from the PID and scans forward. It used to
+# `break` at hi, so a seed near the ceiling got a truncated scan: the failure
+# needs the ports at the top of the band to be BUSY, and then the walk gives up
+# with the whole band free beneath it. About 1 replication run in 2000, which
+# across five majors is roughly 1 CI run in 400, presenting as an unattributable
+# red that moved between majors.
+#
+# The band must be made busy to test this. A first version of these checks asked
+# the picker for a port with the band EMPTY, where the old code also succeeds --
+# they passed with the no-wrap walk restored, which is to say they tested
+# nothing. The stub is the whole point.
+
+_w=$(( PGC_AUX_PORT_HI - PGC_AUX_PORT_LO ))
+check "premise: the auxiliary band has a width to wrap within" \
+	"$([ "$_w" -gt 400 ] && echo yes || echo no)" "yes"
+
+_realfree=$(declare -f pgc_port_free)
+
+# Every port in the TOP 400 is busy; everything below is free. A walk that stops
+# at hi finds nothing from a base inside that region. A walk that wraps lands in
+# the free part below.
+pgc_port_free() { [ "$1" -lt $(( PGC_AUX_PORT_HI - 400 )) ]; }
+check "premise: the stub really does refuse the top of the band" \
+	"$(pgc_port_free $(( PGC_AUX_PORT_HI - 1 )) && echo free || echo busy)" "busy"
+check "premise: and really does allow the bottom" \
+	"$(pgc_port_free "$PGC_AUX_PORT_LO" && echo free || echo busy)" "free"
+
+_top="$(pgc_pick_free_port "$PGC_AUX_PORT_LO" "$PGC_AUX_PORT_HI" $(( _w - 1 )) || echo NONE)"
+check "a seed at the ceiling wraps past a busy top and still finds a port" \
+	"$([ "$_top" != "NONE" ] && [ -n "$_top" ] && echo yes || echo no)" "yes"
+check "and the port it found is below the busy region, which is where wrapping lands" \
+	"$([ "$_top" != "NONE" ] && [ "$_top" -lt $(( PGC_AUX_PORT_HI - 400 )) ] && [ "$_top" -ge "$PGC_AUX_PORT_LO" ] && echo yes || echo no)" \
+	"yes"
+
+# A band with every port busy must report itself full rather than spin. The
+# bound is half the fix; without it the wrap turns a hard failure into a hang,
+# which is worse than the failure it replaces.
+pgc_port_free() { return 1; }
+_none="$(pgc_pick_free_port "$PGC_AUX_PORT_LO" "$PGC_AUX_PORT_HI" 5 || echo NONE)"
+check "an entirely busy band reports itself full and terminates" "$_none" "NONE"
+
+eval "$_realfree"
+check "premise: the real prober was restored, or every check after this lies" \
+	"$(pgc_port_free 1 && echo probing || echo stubbed)" "probing"
+
 pgc_summary

--- a/test/portlib.sh
+++ b/test/portlib.sh
@@ -161,8 +161,18 @@ pgc_pick_free_port() {
 	#
 	# The bound matters as much as the wrap. Without it a genuinely full band
 	# spins forever rather than reporting itself full.
-	span=300
-	[ "$width" -lt "$span" ] && span=$width
+	#
+	# The bound is the WHOLE BAND, not a 300-probe budget. A budget reintroduces
+	# the defect it was meant to fix one layer up: the caller reports "no free
+	# port in [lo,hi)", naming 2000 ports, on the strength of 300 probes, so a
+	# free port 500 away from the base reads as a full band. Sweeping the band is
+	# what makes that message true, which is #537's rule applied here.
+	#
+	# It costs nothing that matters. The picker returns on the first free port, so
+	# a full sweep happens only when the band really is full, which is the failure
+	# path. Measured on the bench container: 2000 probes take 856 ms, against
+	# 191 ms for 300, and neither is paid on the success path.
+	span=$width
 	for i in $(seq 0 $(( span - 1 ))); do
 		p=$(( lo + ((base - lo + i) % width) ))
 		if pgc_port_free "$p"; then

--- a/test/portlib.sh
+++ b/test/portlib.sh
@@ -144,10 +144,27 @@ pgc_port_free() {
 # A free port from a band, verified rather than assumed. Callers pass the band so
 # a suite standing up extra clusters can draw from AUX while the matrix walks MAIN.
 pgc_pick_free_port() {
-	local lo="$1" hi="$2" seed="${3:-$$}" base p
-	base=$(( lo + (seed % (hi - lo)) ))
-	for p in $(seq "$base" $(( base + 300 ))); do
-		[ "$p" -ge "$hi" ] && break
+	local lo="$1" hi="$2" seed="${3:-$$}" width base span i p
+
+	width=$(( hi - lo ))
+	[ "$width" -le 0 ] && return 1
+	base=$(( lo + (seed % width) ))
+
+	# The walk WRAPS to lo, and is bounded by the band width (#548).
+	#
+	# It used to run `seq base base+300` and `break` at hi, so a seed landing
+	# near the ceiling got a truncated scan and a seed landing on hi-1 got a scan
+	# of one port. The caller then reported the band full while the whole band
+	# beneath it was free. Resizing the band does not fix that: the failure needs
+	# a base within one port of the ceiling, which stays a fixed fraction of the
+	# width whatever the width is.
+	#
+	# The bound matters as much as the wrap. Without it a genuinely full band
+	# spins forever rather than reporting itself full.
+	span=300
+	[ "$width" -lt "$span" ] && span=$width
+	for i in $(seq 0 $(( span - 1 ))); do
+		p=$(( lo + ((base - lo + i) % width) ))
 		if pgc_port_free "$p"; then
 			printf '%s\n' "$p"
 			return 0

--- a/test/replication.sh
+++ b/test/replication.sh
@@ -73,7 +73,7 @@ pick_sb_port() {
 }
 SB_PORT="$(pick_sb_port)"
 if [ -z "$SB_PORT" ]; then
-	echo "FAIL  no free port for the standby"
+	echo "FAIL  no free port for the standby in [$PGC_AUX_PORT_LO,$PGC_AUX_PORT_HI): the picker swept the whole band"
 	PGC_FAIL=1
 	pgc_summary
 fi
@@ -83,7 +83,7 @@ RS_PORT="$(pick_sb_port)"
 # but an unreachable branch that silently probes the empty string is the kind of
 # thing that stops being unreachable when the band is resized.
 if [ -z "$RS_PORT" ]; then
-	echo "FAIL  no free port for the restore cluster in [$PGC_AUX_PORT_LO,$PGC_AUX_PORT_HI)"
+	echo "FAIL  no free port for the restore cluster in [$PGC_AUX_PORT_LO,$PGC_AUX_PORT_HI): the picker swept the whole band"
 	PGC_FAIL=1
 	pgc_summary
 fi

--- a/test/replication.sh
+++ b/test/replication.sh
@@ -62,17 +62,14 @@ RS_LOG="$PGC_WORKDIR/restore.log"
 # Probing for free is kept, but it is now meaningful: below the floor, a port that
 # probes free is still free when the standby binds it, because the kernel does not
 # allocate from here.
+#
+# Delegates to portlib's picker rather than keeping a second copy of the same
+# walk. This function WAS that second copy, and it carried the #548 defect the
+# original had: no wrap at the ceiling, so a seed landing on hi-1 scanned one
+# port and reported the band full with the band empty. Two copies of a walk is
+# how one of them gets fixed.
 pick_sb_port() {
-	local base p
-	base=$(( PGC_AUX_PORT_LO + ($$ % (PGC_AUX_PORT_HI - PGC_AUX_PORT_LO)) ))
-	for p in $(seq "$base" $((base + 300))); do
-		[ "$p" -ge "$PGC_AUX_PORT_HI" ] && break
-		if pgc_port_free "$p"; then
-			echo "$p"
-			return 0
-		fi
-	done
-	return 1
+	pgc_pick_free_port "$PGC_AUX_PORT_LO" "$PGC_AUX_PORT_HI"
 }
 SB_PORT="$(pick_sb_port)"
 if [ -z "$SB_PORT" ]; then
@@ -90,9 +87,32 @@ if [ -z "$RS_PORT" ]; then
 	PGC_FAIL=1
 	pgc_summary
 fi
+#
+# Both draws return the SAME port by construction: $$ inside $( ) is the
+# invoking shell's PID, not the subshell's, so pick_sb_port is deterministic
+# within a run. This loop exists to step off that collision, and it is expected
+# to run at least once.
+#
+# It WRAPS to the band floor and is bounded by the band width (#548). It used to
+# increment and hard-fail at PGC_AUX_PORT_HI, so a seed landing on hi-1 failed
+# immediately with all 2000 ports free beneath it: about 1 run in 2000 per
+# replication run, which across five majors is roughly 1 CI run in 400 and
+# matches the observed "rare, unattributable, moves between majors".
+#
+# The bound is what makes the failure message honest. Sweeping the whole band
+# and finding it full is a different fact from walking off the end of it, and
+# they want different responses from whoever reads the log; the old message
+# asserted the first when only the second had been established.
+_rs_width=$(( PGC_AUX_PORT_HI - PGC_AUX_PORT_LO ))
+_rs_tries=0
 while [ "$RS_PORT" = "$SB_PORT" ] || ! pgc_port_free "$RS_PORT"; do
-	RS_PORT=$((RS_PORT + 1))
-	[ "$RS_PORT" -ge "$PGC_AUX_PORT_HI" ] && { echo "FAIL  no free port for the restore"; PGC_FAIL=1; pgc_summary; }
+	RS_PORT=$(( PGC_AUX_PORT_LO + ((RS_PORT - PGC_AUX_PORT_LO + 1) % _rs_width) ))
+	_rs_tries=$(( _rs_tries + 1 ))
+	if [ "$_rs_tries" -ge "$_rs_width" ]; then
+		echo "FAIL  no free port for the restore: swept all $_rs_width ports in [$PGC_AUX_PORT_LO,$PGC_AUX_PORT_HI) and every one was busy or the standby's"
+		PGC_FAIL=1
+		pgc_summary
+	fi
 done
 echo "-- primary port $PGC_PORT, standby port $SB_PORT"
 


### PR DESCRIPTION
Closes #548. Analysis and issue by @ChronicallyJD. **Reproduced here with a
forced PID before anything was changed**, because this is shared harness code and
arithmetic alone is not a demonstration. **I am not merging it.**

## Reproduced

Band `[29768,31768)`, width 2000, **nothing listening**:

```
base at HI-1 (31767):  SB=31767, RS increments to 31768, hits the bound
                       -> FAIL no free port for the restore, 1,999 ports free
base at HI-2:          ok
mid band:              ok
```

`pick_sb_port` seeds `base` from `$$`. Both draws return the same port by
construction — `$$` inside `$( )` is the invoking shell's PID, not the
subshell's — which is why the loop opens by testing for that collision. It then
incremented and hard-failed at `PGC_AUX_PORT_HI` instead of wrapping to `LO`.

About 1 replication run in 2000; across five majors roughly **1 CI run in 400**,
which matches the observed rare, unattributable red that moved between majors.
It took down #545's PG17 leg on a diff containing nothing but `CONTEXT.md`.

## Not a sizing problem, so the band is untouched

The failure needs a base within one port of the ceiling, and that stays a fixed
fraction of the width whatever the width is. A 20,000-port band fails
identically, just less often, and still with the whole band free beneath it.

## Both halves

The walk **wraps**, and it is **bounded** by the band width so a genuinely full
band reports itself full rather than spinning forever. The message now
distinguishes sweeping the whole band from walking off the end of it — those want
different responses from whoever reads the log, and the old one asserted the
first when only the second had been established. That is #537's defect in a
different file.

`pick_sb_port` was a second copy of `pgc_pick_free_port` carrying the same bug.
It now delegates. **Two copies of a walk is how one of them gets fixed.**

## The tests were vacuous first, and my own removal proof caught it

`harness_selftest` **54 → 61**.

The first version PASSED with the no-wrap walk restored — 60 of 60 against the
defect. Both reasons were mine:

- I asked the picker for a port with the band **empty**, where the old code also
  succeeds. A truncated scan only fails when the top of the band is **busy**.
- The "wraps to the floor" check computed the wrap from `PGC_AUX_PORT_LO` and
  `HI` directly **without calling the picker at all** — a tautology over my own
  expression.

Rewritten to stub `pgc_port_free` so the top 400 are busy and the rest free. A
walk that stops at `hi` finds nothing from a base in that region; a walk that
wraps lands below it.

Proved by removal — restoring the old walk fails by name:

```
FAIL  a seed at the ceiling wraps past a busy top and still finds a port
FAIL  and the port it found is below the busy region, which is where wrapping lands
```

A full-band stub proves termination rather than a hang, and a premise asserts the
real prober was restored, since a stub left installed would make every later
check lie.

## One that nearly shipped

I wrote the `portlib` comment in C style out of habit and **`bash -n` passed
it**. The `*` lines are globs and `*/` is a word, so it parses cleanly and would
have executed as commands inside the function at runtime, breaking port selection
outright. A syntax check cannot see that a comment is not a comment. Caught by
reading the rendered function rather than trusting the parse.

## Gate

PG17 assert 132 ran, PASS. PG19 assert 137 ran, one failure — `temporal`,
`btree_gist` absent from this container, identical on unmodified main. Gated on
the full set rather than on units because `portlib` is in the path of every suite.
