### PR TITLE
refactor: the last four module headers, in one change (#496)

### DIFF
--- a/src/columnar.h
+++ b/src/columnar.h
@@ -344,26 +344,8 @@ typedef struct PgColumnarProjection
  * ------------------------------------------------------------------------- */
 struct SMgrRelationData;
 
-extern void PgColumnarWriteNewMetapage(const RelFileLocator *newrlocator,
-									 struct SMgrRelationData *srel,
-									 char persistence, uint64 storageId);
 extern void PgColumnarReadMetapage(Relation rel, PgColumnarMetapage *meta);
 extern uint64 PgColumnarStorageId(Relation rel);
-extern void PgColumnarEnsureStorageRow(Relation rel);	/* pre-create storage row (#300 parallel_copy) */
-extern void PgColumnarReserveRowNumbers(Relation rel, uint64 rowCount,
-									  uint64 *stripeId, uint64 *firstRowNumber);
-extern void PgColumnarReserveOffset(Relation rel, uint64 dataLength,
-								  uint64 *fileOffset);
-extern void PgColumnarAdvanceReservedOffset(Relation rel, uint64 addBytes);
-extern void PgColumnarDebugSetMetapageVersion(Relation rel, uint32 versionMajor,
-											uint32 versionMinor);
-extern void PgColumnarSetReservedOffset(Relation rel, uint64 newOffset);
-extern void PgColumnarTruncateMainFork(Relation rel, BlockNumber newnblocks);
-extern void PgColumnarWriteLogicalData(Relation rel, uint64 logicalOffset,
-									 char *data, uint64 length);
-extern void PgColumnarReadLogicalData(Relation rel, uint64 logicalOffset,
-									char *dest, uint64 length);
-extern void PgColumnarResetMetapage(Relation rel);
 
 /* row number <-> item pointer (spec 6) */
 extern void PgColumnarRowNumberToItemPointer(uint64 rowNumber, ItemPointer tid);
@@ -453,8 +435,7 @@ extern void PgColumnarCheckFreeSpaceNoOverlap(uint64 storageId);
 extern uint64 PgColumnarNextStorageId(void);
 
 /* projection: needed attnos (pull_varattnos form) -> the reader's 0-based set */
-extern Bitmapset *PgColumnarProjectionFromAttnos(Bitmapset *needed, int natts,
-											   int *nProjected);
+
 extern void PgColumnarCheckNativeFormatVersion(uint64 storageId, const char *relName);
 extern List *PgColumnarReadRowGroupList(uint64 storageId, Snapshot snapshot);
 extern List *PgColumnarReadZoneMapList(uint64 storageId, uint64 groupNumber,
@@ -503,37 +484,17 @@ extern void PgColumnarUpsertDeleteVector(uint64 storageId, DeleteVectorMetadata 
 typedef struct PgColumnarWriteState PgColumnarWriteState;
 
 extern PgColumnarWriteState *PgColumnarGetWriteState(Relation rel);
-extern int PgColumnarWriteStateStripeCount(PgColumnarWriteState *ws);
-extern uint64 *PgColumnarWriteStateStripeIds(PgColumnarWriteState *ws, int *n);
-extern uint64 *PgColumnarWriteStateProjStripeIds(PgColumnarWriteState *ws, int *n);
 extern uint64 PgColumnarWriteRow(PgColumnarWriteState *writeState, Relation rel,
 							   Datum *values, bool *nulls);
 extern void PgColumnarProjectionFanoutRow(Relation rel, PgColumnarWriteState *baseWs,
 										uint64 rowNumber, Datum *values,
 										bool *nulls);
-extern void PgColumnarBackfillProjection(Relation rel,
-									   const PgColumnarProjection *proj);
-extern bool PgColumnarBufferedRowByNumber(Relation rel, uint64 rowNumber,
-										Datum *values, bool *nulls);
 extern void PgColumnarFlushWriteStateForRelation(Oid relid);
-extern void PgColumnarForgetWriteStateForRelation(Oid relid);
-extern void PgColumnarFlushAllPendingWrites(void);
-extern void PgColumnarDiscardAllPendingWrites(void);
-extern void PgColumnarWriteStateDiscardSubXact(SubTransactionId subid);
-extern void PgColumnarWriteStatePromoteSubXact(SubTransactionId subid,
-											 SubTransactionId parent);
 
 /* -------------------------------------------------------------------------
  * delete vector / delete tracking (pgcolumnar_delete_vector.c, spec 7.5, 9)
  * ------------------------------------------------------------------------- */
-extern void PgColumnarMarkRowDeleted(Relation rel, uint64 rowNumber);
-extern bool PgColumnarDeleteVectorBufferedDeleted(Relation rel, uint64 rowNumber);
 extern void PgColumnarFlushDeleteVectorForRelation(Relation rel);
-extern void PgColumnarFlushAllDeleteVectors(void);
-extern void PgColumnarDiscardAllDeleteVectors(void);
-extern void PgColumnarDeleteVectorDiscardSubXact(SubTransactionId subid);
-extern void PgColumnarDeleteVectorPromoteSubXact(SubTransactionId subid,
-										  SubTransactionId parent);
 
 /* -------------------------------------------------------------------------
  * reader (pgcolumnar_reader.c)
@@ -831,7 +792,6 @@ extern void PgColumnarUniqueInit(void);
 /* -------------------------------------------------------------------------
  * planner integration (pgcolumnar_customscan.c, spec 8.3, 9)
  * ------------------------------------------------------------------------- */
-extern void PgColumnarCustomScanInit(void);
 
 /*
  * The single registered CustomScanMethods, shared by the base custom scan and
@@ -899,12 +859,6 @@ typedef struct PgColumnarGroupStats
 	uint64		vectorsRuledOutByValue;
 } PgColumnarGroupStats;
 
-extern void PgColumnarExplainPushedDown(int64 nfilters, ExplainState *es);
-extern void PgColumnarExplainVectorPredicates(int64 npreds, ExplainState *es);
-extern int	PgColumnarCountScanKeys(List *qual, Index scanrelid,
-								  TupleDesc tupdesc);
-extern void PgColumnarExplainGroupStats(const PgColumnarGroupStats *stats,
-									  ExplainState *es);
 
 extern ScanKey PgColumnarBuildScanKeys(List *qual, Index scanrelid,
 									 TupleDesc tupdesc, int *nkeys);

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -26,6 +26,7 @@
  */
 #include "columnar.h"
 
+#include "columnar_customscan.h"
 #include "columnar_reader.h"
 #include <math.h>
 

--- a/src/columnar_customscan.h
+++ b/src/columnar_customscan.h
@@ -1,0 +1,37 @@
+/*-------------------------------------------------------------------------
+ *
+ * columnar_customscan.h
+ *		The planner side: what columnar_customscan.c offers the table AM and the vectorized path.
+ *
+ * Split out of columnar.h (#496). Every declaration here had exactly ONE
+ * consumer outside its defining file, so it was a private arrangement between
+ * two files that the other twenty were forced to recompile for.
+ *
+ * The shared vocabulary these signatures take stays in columnar.h, which this
+ * includes.
+ *
+ * Written fresh for pgColumnar.
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef PGCOLUMNAR_CUSTOMSCAN_H
+#define PGCOLUMNAR_CUSTOMSCAN_H
+
+#include "columnar.h"
+
+extern Bitmapset *PgColumnarProjectionFromAttnos(Bitmapset *needed, int natts,
+											   int *nProjected);
+
+extern void PgColumnarCustomScanInit(void);
+
+extern void PgColumnarExplainPushedDown(int64 nfilters, ExplainState *es);
+
+extern void PgColumnarExplainVectorPredicates(int64 npreds, ExplainState *es);
+
+extern int	PgColumnarCountScanKeys(List *qual, Index scanrelid,
+								  TupleDesc tupdesc);
+
+extern void PgColumnarExplainGroupStats(const PgColumnarGroupStats *stats,
+									  ExplainState *es);
+
+#endif							/* PGCOLUMNAR_CUSTOMSCAN_H */

--- a/src/columnar_delete_vector.c
+++ b/src/columnar_delete_vector.c
@@ -21,6 +21,7 @@
  */
 #include "columnar.h"
 
+#include "columnar_delete_vector.h"
 #include "access/xact.h"
 #include "utils/memutils.h"
 #include "utils/rel.h"

--- a/src/columnar_delete_vector.h
+++ b/src/columnar_delete_vector.h
@@ -1,0 +1,35 @@
+/*-------------------------------------------------------------------------
+ *
+ * columnar_delete_vector.h
+ *		Row deletion: what columnar_delete_vector.c offers the reader and the table AM.
+ *
+ * Split out of columnar.h (#496). Every declaration here had exactly ONE
+ * consumer outside its defining file, so it was a private arrangement between
+ * two files that the other twenty were forced to recompile for.
+ *
+ * The shared vocabulary these signatures take stays in columnar.h, which this
+ * includes.
+ *
+ * Written fresh for pgColumnar.
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef PGCOLUMNAR_DELETE_VECTOR_H
+#define PGCOLUMNAR_DELETE_VECTOR_H
+
+#include "columnar.h"
+
+extern void PgColumnarMarkRowDeleted(Relation rel, uint64 rowNumber);
+
+extern bool PgColumnarDeleteVectorBufferedDeleted(Relation rel, uint64 rowNumber);
+
+extern void PgColumnarFlushAllDeleteVectors(void);
+
+extern void PgColumnarDiscardAllDeleteVectors(void);
+
+extern void PgColumnarDeleteVectorDiscardSubXact(SubTransactionId subid);
+
+extern void PgColumnarDeleteVectorPromoteSubXact(SubTransactionId subid,
+										  SubTransactionId parent);
+
+#endif							/* PGCOLUMNAR_DELETE_VECTOR_H */

--- a/src/columnar_parallel_copy.c
+++ b/src/columnar_parallel_copy.c
@@ -43,6 +43,7 @@
 
 #include "columnar.h"
 
+#include "columnar_write_state.h"
 #include "access/relation.h"
 #include "access/table.h"
 #include "access/twophase.h"

--- a/src/columnar_projection.c
+++ b/src/columnar_projection.c
@@ -23,6 +23,7 @@
 #include "columnar.h"
 
 #include "columnar_metadata.h"
+#include "columnar_write_state.h"
 #include "access/table.h"
 #include "catalog/pg_type.h"
 #include "funcapi.h"

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -14,8 +14,10 @@
  */
 #include "columnar.h"
 
+#include "columnar_delete_vector.h"
 #include "columnar_metadata.h"
 #include "columnar_reader.h"
+#include "columnar_storage.h"
 #include "fmgr.h"
 #include "access/detoast.h"
 #include "access/htup_details.h"

--- a/src/columnar_storage.c
+++ b/src/columnar_storage.c
@@ -12,6 +12,7 @@
  */
 #include "columnar.h"
 
+#include "columnar_storage.h"
 #include "fmgr.h"
 #include "columnar_compat.h"
 #include "access/rmgr.h"

--- a/src/columnar_storage.h
+++ b/src/columnar_storage.h
@@ -1,0 +1,49 @@
+/*-------------------------------------------------------------------------
+ *
+ * columnar_storage.h
+ *		The physical layer: what columnar_storage.c offers for metapages, offsets and logical data.
+ *
+ * Split out of columnar.h (#496). Every declaration here had exactly ONE
+ * consumer outside its defining file, so it was a private arrangement between
+ * two files that the other twenty were forced to recompile for.
+ *
+ * The shared vocabulary these signatures take stays in columnar.h, which this
+ * includes.
+ *
+ * Written fresh for pgColumnar.
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef PGCOLUMNAR_STORAGE_H
+#define PGCOLUMNAR_STORAGE_H
+
+#include "columnar.h"
+
+extern void PgColumnarWriteNewMetapage(const RelFileLocator *newrlocator,
+									 struct SMgrRelationData *srel,
+									 char persistence, uint64 storageId);
+
+extern void PgColumnarReserveRowNumbers(Relation rel, uint64 rowCount,
+									  uint64 *stripeId, uint64 *firstRowNumber);
+
+extern void PgColumnarReserveOffset(Relation rel, uint64 dataLength,
+								  uint64 *fileOffset);
+
+extern void PgColumnarAdvanceReservedOffset(Relation rel, uint64 addBytes);
+
+extern void PgColumnarDebugSetMetapageVersion(Relation rel, uint32 versionMajor,
+											uint32 versionMinor);
+
+extern void PgColumnarSetReservedOffset(Relation rel, uint64 newOffset);
+
+extern void PgColumnarTruncateMainFork(Relation rel, BlockNumber newnblocks);
+
+extern void PgColumnarWriteLogicalData(Relation rel, uint64 logicalOffset,
+									 char *data, uint64 length);
+
+extern void PgColumnarReadLogicalData(Relation rel, uint64 logicalOffset,
+									char *dest, uint64 length);
+
+extern void PgColumnarResetMetapage(Relation rel);
+
+#endif							/* PGCOLUMNAR_STORAGE_H */

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -13,8 +13,12 @@
  */
 #include "columnar.h"
 
+#include "columnar_customscan.h"
+#include "columnar_delete_vector.h"
 #include "columnar_metadata.h"
 #include "columnar_reader.h"
+#include "columnar_storage.h"
+#include "columnar_write_state.h"
 #include "access/multixact.h"
 #include "access/genam.h"
 #include "access/table.h"

--- a/src/columnar_vacuum.c
+++ b/src/columnar_vacuum.c
@@ -21,6 +21,8 @@
  */
 #include "columnar.h"
 #include "columnar_metadata.h"
+#include "columnar_storage.h"
+#include "columnar_write_state.h"
 #include "columnar_compat.h"
 
 #include "fmgr.h"

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -36,6 +36,7 @@
  */
 #include "columnar.h"
 
+#include "columnar_customscan.h"
 #include "columnar_metadata.h"
 #include "columnar_reader.h"
 #include <math.h>

--- a/src/columnar_write_state.c
+++ b/src/columnar_write_state.c
@@ -14,6 +14,8 @@
 #include "columnar.h"
 
 #include "columnar_metadata.h"
+#include "columnar_storage.h"
+#include "columnar_write_state.h"
 #include "columnar_compat.h"
 #include "access/htup_details.h"
 #include "access/table.h"

--- a/src/columnar_write_state.h
+++ b/src/columnar_write_state.h
@@ -1,0 +1,47 @@
+/*-------------------------------------------------------------------------
+ *
+ * columnar_write_state.h
+ *		The write side: what columnar_write_state.c offers the modules that stage and flush rows.
+ *
+ * Split out of columnar.h (#496). Every declaration here had exactly ONE
+ * consumer outside its defining file, so it was a private arrangement between
+ * two files that the other twenty were forced to recompile for.
+ *
+ * The shared vocabulary these signatures take stays in columnar.h, which this
+ * includes.
+ *
+ * Written fresh for pgColumnar.
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef PGCOLUMNAR_WRITE_STATE_H
+#define PGCOLUMNAR_WRITE_STATE_H
+
+#include "columnar.h"
+
+extern void PgColumnarEnsureStorageRow(Relation rel);	/* pre-create storage row (#300 parallel_copy) */
+
+extern int PgColumnarWriteStateStripeCount(PgColumnarWriteState *ws);
+
+extern uint64 *PgColumnarWriteStateStripeIds(PgColumnarWriteState *ws, int *n);
+
+extern uint64 *PgColumnarWriteStateProjStripeIds(PgColumnarWriteState *ws, int *n);
+
+extern void PgColumnarBackfillProjection(Relation rel,
+									   const PgColumnarProjection *proj);
+
+extern bool PgColumnarBufferedRowByNumber(Relation rel, uint64 rowNumber,
+										Datum *values, bool *nulls);
+
+extern void PgColumnarForgetWriteStateForRelation(Oid relid);
+
+extern void PgColumnarFlushAllPendingWrites(void);
+
+extern void PgColumnarDiscardAllPendingWrites(void);
+
+extern void PgColumnarWriteStateDiscardSubXact(SubTransactionId subid);
+
+extern void PgColumnarWriteStatePromoteSubXact(SubTransactionId subid,
+											 SubTransactionId parent);
+
+#endif							/* PGCOLUMNAR_WRITE_STATE_H */


### PR DESCRIPTION
The last four modules for #496: `write_state` (11), `storage` (10), `customscan` (6), `delete_vector` (6) — the 33 remaining declarations with exactly one consumer outside their defining file.

## One PR rather than four, and why

Because of how you reviewed #546 and #547: by **running checks** — every new include used, no moved symbol having more than one consumer — rather than by reading declarations. When correctness is established by script, four diffs are no easier to review than one.

And it collapses the collision problem. Every pair of module PRs sharing a consumer conflicts on the `#include` line, so a six-PR series is up to fifteen rebases as they land one at a time. Three PRs is one.

**Not stacked**, for the reason you laid out rather than recommended: a stacked PR auto-closes when its base is deleted on merge, which is what happened to #534. Merge #546, #547 and this in any order; whichever lands after another wants a one-minute rebase of include lines. I will do them.

## A defect in my splitting tool, found by an assert

Worth recording because it produced a **wrong module assignment rather than an error**. `columnar.h:353` is

```c
extern void PgColumnarEnsureStorageRow(Relation rel);	/* pre-create storage row (#300 parallel_copy) */
```

That line ends in `*/`, not `;`. My block scanner ran to the next line ending in `;` and swallowed the declaration beneath it, filing `PgColumnarReserveRowNumbers` — a **storage** symbol — into `write_state.h`.

It compiles either way, because a declaration is visible from whichever header its consumer includes. Nothing about the build would have told anyone. The `matched 9 of 10` count assert on the *next* module is what caught it, one module after the damage.

**Your "15 of 15 symbols in reader.h" against my stated 12 is what sent me to check the open PRs**, and they are clean: #546 and #547 carry exactly their intended sets — 22 and 12, no extra symbol, none missing, none stranded in `columnar.h`. That is luck rather than care. Neither module's declarations happened to sit beside one carrying a trailing comment.

Terminator detection now strips comments before testing for `;`.

## Verification

| module | moved | extra | missing | left in columnar.h |
| --- | ---: | --- | --- | --- |
| `write_state` | 11/11 | none | none | none |
| `storage` | 10/10 | none | none | none |
| `customscan` | 6/6 | none | none | none |
| `delete_vector` | 6/6 | none | none | none |

`columnar.h`: **1045 → 997 lines, 164 → 131 externs.**

## Gate

| major | warnings + errors |
| --- | ---: |
| pg15a | 0 |
| pg16a | 0 |
| pg17a | 0 |
| pg18a | 0 |
| pg19a | 0 |

`make clean` between each (#536). `native_vecdecode` 24/24, `harness_selftest` 54/54, and `replication` 41/41 — the last included deliberately, since #548/#549 are live in that file and `columnar_storage.h` now sits under it.

## Note for #549

`columnar_customscan.c` uses 8 of `reader.h`'s symbols, which you flagged as the largest cross-file dependency. It survives this split unchanged: `customscan`'s own declarations move to `customscan.h`, and its use of reader symbols is unaffected, so the pair you were worried about does not need taking early.

After this, 84 of 84 single-consumer declarations are placed. What remains for #496 is a judgement call rather than a move: 47 shared declarations stay in `columnar.h` as the actual interface, and I would leave that alone unless someone wants it argued.

I have not merged this and will not.
