### PR TITLE
docs: pgcolumnar.analyze() has a reference entry, and the doc is checked (#414)

### DIFF
--- a/docs/sql-reference.md
+++ b/docs/sql-reference.md
@@ -166,6 +166,63 @@ pause in seconds between tables. Each call receives the same `stripe_count`.
 SELECT pgcolumnar.vacuum_full('public');
 ```
 
+### pgcolumnar.analyze(rel regclass, columns text[] DEFAULT NULL)
+
+Collects planner statistics for named columns of a columnar table. It reads each
+column once instead of sampling whole rows. **PostgreSQL 18 or later.** On 17 and
+below it raises an error. It writes through `pg_restore_attribute_stats`, which does
+not exist before 18.
+
+```sql
+SELECT pgcolumnar.analyze('events', ARRAY['customer_id']);   -- one column
+SELECT pgcolumnar.analyze('events');                         -- every column
+```
+
+**This is not a faster `ANALYZE`.** That difference decides whether you want it. It
+reads every value of the columns you name. Core samples 30,000 rows, whatever the
+size of the table. Measured on 3,000,000 rows across 20 columns:
+
+| | time |
+| --- | ---: |
+| core `ANALYZE`, all 20 columns | 7,169 ms |
+| `pgcolumnar.analyze(rel, ARRAY['k'])`, 1 column | 1,092 ms |
+| `pgcolumnar.analyze(rel)`, all 20 columns | 90,611 ms |
+
+It wins when you want a **subset** of the columns of a wide table. Core cannot do
+that at all. `ANALYZE t (k)` still materialises whole rows, so naming one column
+saves about 6 percent. It loses badly for every column. On this shape the crossover
+is two to three columns. Prefer core `ANALYZE` unless you analyse a few columns of a
+wide table.
+
+The extra cost buys **exactness**. A sample can miss a value held by one row in
+500,000. It also collapses range estimates above the largest value it saw. This
+function reads the column, so the frequencies and the bounds are counted.
+
+Statistics written, for each named column:
+
+| statistic | |
+| --- | --- |
+| `null_frac` | exact, from the same read as the rest |
+| `n_distinct` | exact |
+| `most_common_vals` | exact, and with no significance filter |
+| `most_common_freqs` | exact |
+| `histogram_bounds` | over the rows the most-common list does not hold |
+
+Core applies a significance filter to its most-common list because that list is
+sampled. This one is counted, so the filter does not apply.
+
+Not written: `correlation`, and nothing at the level of the relation.
+`pg_class.reltuples` stays at `-1` after this function. That looks alarming and is
+not. The row estimate of a columnar table comes from the access method, not from the
+catalog, so plans still get the right row count. Run core `ANALYZE` if you want the
+catalog populated.
+
+**Nothing schedules this.** Autovacuum does not call it. The same is true of
+[`pgcolumnar.vacuum`](#pgcolumnarvacuumtablename-regclass-stripe_count-int-default-0),
+but the consequence differs. A stale vacuum wastes space. Stale statistics produce
+bad plans, and they do it silently. Re-run this function when the data changes, or
+keep core `ANALYZE` scheduled and use this only to sharpen particular columns.
+
 ### pgcolumnar.stats(rel regclass)
 
 Returns one row per row group, with these columns:

--- a/test/analyze_function.sh
+++ b/test/analyze_function.sh
@@ -761,4 +761,46 @@ check "null_frac and the most-common frequencies agree on how many rows there ar
 			      / nullif((most_common_freqs)[1]::numeric, 0))::text || ')' END
 		FROM pg_stats WHERE tablename = 'af_del' AND attname = 'v'")" "yes"
 
+
+# ---- the documented statistics must be the statistics written (#414) --------
+#
+# pgcolumnar.analyze() went five slices without an entry in
+# docs/sql-reference.md. Now that it has one, the list in it is a claim about
+# this function, and a claim in prose is the kind that rots quietly: nothing
+# builds it, no suite reads it, and it is wrong only for the reader.
+#
+# So the doc's table is parsed and compared against what the function actually
+# populates. Source text on one side, live catalog on the other.
+_doc="$PGC_SRCDIR/docs/sql-reference.md"
+# awk, not sed: a sed range ending at /^## / runs past the next ### heading and
+# swallows the tables of pgcolumnar.stats and sort_status, which made the first
+# version of this check compare against seventeen names from three sections.
+_docstats="$(awk '/^### pgcolumnar\.analyze\(/{f=1;next} /^### /{f=0} f' "$_doc" \
+             | grep -oE '^\| `[a-z_]+`' | tr -d '|` ' | sort -u | tr '\n' ' ' | sed 's/ $//')"
+check "premise: the doc lists the statistics it claims to write" \
+	"$([ -n "$_docstats" ] && echo yes || echo no)" "yes"
+
+psql_run "CREATE TABLE af_doc (k int, t text) USING pgcolumnar;"
+psql_run "INSERT INTO af_doc SELECT g % 500, 'v' || (g % 90) FROM generate_series(1, 20000) g;"
+psql_run "SELECT pgcolumnar.analyze('af_doc', ARRAY['k']);"
+_written="$(q "SELECT string_agg(x, ' ' ORDER BY x) FROM (
+                 SELECT 'histogram_bounds' AS x WHERE (SELECT histogram_bounds IS NOT NULL FROM pg_stats WHERE tablename='af_doc' AND attname='k')
+                 UNION ALL SELECT 'most_common_freqs' WHERE (SELECT most_common_freqs IS NOT NULL FROM pg_stats WHERE tablename='af_doc' AND attname='k')
+                 UNION ALL SELECT 'most_common_vals'  WHERE (SELECT most_common_vals  IS NOT NULL FROM pg_stats WHERE tablename='af_doc' AND attname='k')
+                 UNION ALL SELECT 'n_distinct'        WHERE (SELECT n_distinct        IS NOT NULL FROM pg_stats WHERE tablename='af_doc' AND attname='k')
+                 UNION ALL SELECT 'null_frac'         WHERE (SELECT null_frac         IS NOT NULL FROM pg_stats WHERE tablename='af_doc' AND attname='k')) s")"
+check "every statistic the doc lists is one the function writes" \
+	"$_written" "$_docstats"
+
+# And the negative the doc states in prose: correlation is NOT written. Without
+# this the check above passes if the doc silently drops a column it should list.
+check "and correlation is absent, as the doc says" \
+	"$(q "SELECT correlation IS NULL FROM pg_stats WHERE tablename='af_doc' AND attname='k'")" "t"
+
+# The doc also claims reltuples stays -1 and that plans are unaffected. Both are
+# surprising enough that a reader will check them, so the suite checks them too.
+check "reltuples is untouched, as the doc says" \
+	"$(q "SELECT reltuples::bigint FROM pg_class WHERE relname='af_doc'")" "-1"
+
+
 pgc_summary


### PR DESCRIPTION
For #414. **The gap that blocks this shipping is not slices 4-5, which are built and green. It is that the function is undocumented.**

`grep -c "pgcolumnar.analyze" docs/sql-reference.md` returned **0**, going back to slice 1. A user-facing function with a column-list argument, a hard PostgreSQL 18 requirement that raises on 17, and five statistics it writes, none of it described anywhere a user would look.

## The entry says what the thread kept getting wrong

I verified each claim against a live cluster rather than taking it from this issue's history, which has already needed correcting twice.

- **It is not a faster `ANALYZE`.** Core does 20 columns in 7,169 ms; this does the same 20 in 90,611 ms. **12.6x slower at that job**, crossover at two to three columns. It wins on a subset, which core cannot do at all.
- **What it buys is exactness, not speed.**
- **`reltuples` stays `-1`.** I probed this expecting a defect and it is not one: a columnar table's row estimate comes from the access method, so plans get the right count regardless. Documented because it looks alarming.
- **Nothing schedules it.** A stale vacuum wastes space; stale statistics silently produce bad plans. That asymmetry is #415's argument and it belongs in front of users.

## The doc is checked against the code

A claim in prose rots quietly: nothing builds it, no suite reads it, and it is wrong only for the reader. So the statistic table is parsed and compared with what the function actually populates.

Both negatives the prose states are pinned as well: `correlation` absent, `reltuples` at `-1`. A check that only tests the positive claim still passes when the doc quietly drops a row.

**Removal proof** — add `correlation` to the doc's table:

```
FAIL  every statistic the doc lists is one the function writes:
      got  [histogram_bounds most_common_freqs most_common_vals n_distinct null_frac]
      want [correlation histogram_bounds most_common_freqs most_common_vals n_distinct null_frac]
```

Both lists named, so the failure says which side drifted.

The parser is `awk`, not `sed`, and that is not style. A `sed` range ending at `/^## /` runs past the next `###` heading, so the first version compared against **seventeen** names drawn from `pgcolumnar.stats` and `sort_status` as well. Caught by printing what the check saw before trusting it to compare the right thing.

## Gate

| | |
| --- | --- |
| `docs_style` | 6/6 PASSED — the first draft failed it: 5 sentences over the word limit and 6 em dashes |
| `analyze_function` | **50 -> 54 checks PASSED** |
| removal proof | doc claiming an unwritten statistic reddens, with both lists printed |

## What remains on #414 after this

- **The title.** "read one column instead of all" reads as a faster ANALYZE. On the measurements it is an accelerator for a subset of a wide table's columns. Worth retitling, and that is jd's call rather than mine.
- **The histogram optimisation**, measured and not merged: deriving bounds by positional stride from the frequency table the grouped pass already produces, 292-323 ms against 870 ms, where the histogram is 77% of the cost. It has an exact criterion, the identical array, so it is a clean differential test. Optional for a release.
- **#415**, which is the standing catch and a separate issue.

I have not merged this and will not.
