### PR TITLE
test: a document quoting the version must quote the current one

### DIFF
--- a/test/docs_style.sh
+++ b/test/docs_style.sh
@@ -92,6 +92,37 @@ check "no document carries a merge conflict marker" \
 # CHANGELOG.md: dash characters only. See the scope note above.
 dashes=$(grep -c '—\|–' "$SRCDIR/CHANGELOG.md" || true)
 check "CHANGELOG.md carries no em or en dash" "$dashes" "0"
+# ---- a document that quotes the version must quote the current one ----------
+#
+# Nothing reads the VERSION file mechanically: no Makefile rule, no CI step. Two
+# documents cite it AND hardcode the string beside the citation:
+#
+#     CHANGELOG.md         the version marker is `1.0-alpha`, recorded in `VERSION`
+#     docs/limitations.md  The version marker is `1.0-alpha`, recorded in `VERSION`,
+#
+# So a release that bumps VERSION and pgcolumnar.control, and forgets these, ships
+# documentation asserting the previous version. Nothing else would notice: the
+# upgrade path is gated by extension_upgrade.sh, which compares control against
+# the installed extension and never reads prose.
+#
+# The pairing is what makes it checkable. A document that says "recorded in
+# `VERSION`" is pointing at a file whose content is knowable, so the two can be
+# compared instead of trusted to be edited together.
+_ver="$(cat "$SRCDIR/VERSION" 2>/dev/null | tr -d '[:space:]')"
+check "premise: the VERSION file has a version to compare against" \
+	"$([ -n "$_ver" ] && echo yes || echo no)" "yes"
+
+_verdocs="$(grep -rln 'recorded in `VERSION`' "$SRCDIR/CHANGELOG.md" "$SRCDIR/docs" 2>/dev/null | sort)"
+check "premise: at least one document cites the VERSION file" \
+	"$([ -n "$_verdocs" ] && echo yes || echo no)" "yes"
+
+_stale=""
+for _d in $_verdocs; do
+	grep -q "\`$_ver\`, recorded in \`VERSION\`" "$_d" || _stale="$_stale $(basename "$_d")"
+done
+check "every document citing VERSION quotes the version VERSION holds" \
+	"$(printf '%s' "$_stale" | sed 's/^ //')" ""
+
 
 echo "checks run: $checks"
 if [ "$fail" = 0 ]; then


### PR DESCRIPTION
A release-consistency gate, found while answering "what is left to release alpha2".

## The gap

Nothing reads the `VERSION` file mechanically — no Makefile rule, no CI step. But two documents cite it **and hardcode the string beside the citation**:

```
CHANGELOG.md:5         the version marker is `1.0-alpha`, recorded in `VERSION`
docs/limitations.md:5  The version marker is `1.0-alpha`, recorded in `VERSION`,
```

A cut that bumps `VERSION` and `pgcolumnar.control` and forgets these ships documentation asserting the previous version. `docs_style` passed, because nothing compared them.

The pairing is what makes it checkable rather than a matter of discipline. A document that says *"recorded in `VERSION`"* is pointing at a file whose content is knowable, so the two can be compared instead of trusted to be edited together.

## I first believed this gap was larger, and it is not

I reported that the **upgrade script** was the ungated risk, on the evidence that `pgcolumnar--1.0-dev--1.0-alpha.sql` was added in a commit *after* `release: cut 1.0-alpha` rather than with it.

That part is already gated. `extension_upgrade.sh:172`, registered in `SUITES`:

```
FAIL  default_version moved $old_ver -> $new_default with no
      pgcolumnar--$old_ver--$new_default.sql, so an existing install cannot upgrade
```

The guard looks like the lesson learned from exactly that omission. So the user-breaking failure is covered, and what was left uncovered is the prose, which no build and no upgrade test reads. Correcting that here rather than letting my earlier claim stand.

## Proved in both directions

A check that only catches one direction passes when the drift runs the other way:

```
VERSION bumped, docs stale      FAIL ... got [CHANGELOG.md limitations.md] want []
CHANGELOG bumped, VERSION not   FAIL ... got [CHANGELOG.md] want []
```

Both name the drifted file, so the failure says which side moved.

Two premises in front: the `VERSION` file must hold something, and at least one document must cite it. Without the second, the loop iterates nothing and the check passes by finding no documents to disagree with — which is the shape this repo keeps filing against.

`docs_style` goes **6 to 9 checks**, PASSED on a clean tree.

## Not in scope here

`VERSION` against `pgcolumnar.control` is still uncompared. I left it out deliberately: nothing consumes `VERSION`, so the divergence has no mechanical consequence, and the documents above are the only place it is asserted to a reader. Worth a follow-up only if `VERSION` acquires a consumer.

I have not merged this and will not.
