### PR TITLE
fix: the vm self-test helpers are an ownership boundary (#558)

### DIFF
--- a/pgcolumnar--1.0-alpha.sql
+++ b/pgcolumnar--1.0-alpha.sql
@@ -885,6 +885,14 @@ CREATE FUNCTION pgcolumnar.vm_is_visible(rel regclass, blk int)
 COMMENT ON FUNCTION pgcolumnar.vm_is_visible(regclass, int)
 	IS 'gap 28: is the synthetic block marked all-visible in the VM fork?';
 
+-- These two are phase-1 self-test helpers, not user API. CREATE FUNCTION grants
+-- EXECUTE to PUBLIC, which put a visibility-map write behind nothing but USAGE on
+-- this schema -- and the documented maintenance API lives in the same schema, so
+-- any deployment exposing that also exposed these (#558). The C code checks
+-- ownership as well; this REVOKE is the second layer, not the only one.
+REVOKE ALL ON FUNCTION pgcolumnar.vm_selftest(regclass, int) FROM PUBLIC;
+REVOKE ALL ON FUNCTION pgcolumnar.vm_is_visible(regclass, int) FROM PUBLIC;
+
 CREATE FUNCTION pgcolumnar.vacuum_full(
 	schema name DEFAULT 'public',
 	sleep_time real DEFAULT 0.0,

--- a/src/columnar_visibilitymap.c
+++ b/src/columnar_visibilitymap.c
@@ -275,6 +275,30 @@ PgColumnarVMSetVisibleForRelation(Relation rel)
 }
 
 /*
+ * Both entry points below write to, or read, the visibility-map fork of a
+ * caller-supplied relation. They are self-test helpers for the phase-1 VM work,
+ * not user API, and they took an arbitrary regclass and checked nothing --
+ * neither ownership, nor any ACL, nor that the relation was even columnar.
+ *
+ * CREATE FUNCTION grants EXECUTE to PUBLIC and the install script carried no
+ * REVOKE, so any role with USAGE on the pgcolumnar schema could mark pages of
+ * ANY relation all-visible, including a heap table it neither owned nor could
+ * read. An index-only scan over that relation then skips the heap visibility
+ * check and returns deleted rows: measured at 20,000 rows returned from a table
+ * with 10,000 live ones (#558).
+ *
+ * PgColumnarRequireTableOwner is the check the rest of the tree already uses for
+ * "you may act on this relation" -- columnar_vacuum.c and columnar_projection.c
+ * call it at eleven sites. Ownership is the right bar here rather than a
+ * server-file role, because these touch one named relation's storage.
+ *
+ * The install script also revokes EXECUTE from PUBLIC, but this check is the
+ * load-bearing one: a REVOKE is undone by a later GRANT ... ON ALL FUNCTIONS IN
+ * SCHEMA, and it does not protect an already installed extension until it is
+ * upgraded.
+ */
+
+/*
  * pgcolumnar_vm_selftest(rel regclass, blk int) -> bool
  *		Phase-1 proof: set the all-visible bit for a synthetic block on a
  *		columnar relation, then read it back through the backend's own
@@ -292,6 +316,7 @@ pgcolumnar_vm_selftest(PG_FUNCTION_ARGS)
 				after;
 
 	rel = table_open(relid, RowExclusiveLock);
+	PgColumnarRequireTableOwner(rel);
 
 	before = PgColumnarVMIsVisible(rel, blk);
 	PgColumnarVMSetVisible(rel, blk);
@@ -314,8 +339,12 @@ pgcolumnar_vm_is_visible(PG_FUNCTION_ARGS)
 {
 	Oid			relid = PG_GETARG_OID(0);
 	BlockNumber blk = (BlockNumber) PG_GETARG_INT32(1);
-	Relation	rel = table_open(relid, AccessShareLock);
-	bool		vis = PgColumnarVMIsVisible(rel, blk);
+	Relation	rel;
+	bool		vis;
+
+	rel = table_open(relid, AccessShareLock);
+	PgColumnarRequireTableOwner(rel);
+	vis = PgColumnarVMIsVisible(rel, blk);
 
 	table_close(rel, AccessShareLock);
 	PG_RETURN_BOOL(vis);

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -172,6 +172,7 @@ SUITES=(
 	temporal
 	ungrouped_vector_agg
 	unique_conc
+	vm_privilege
 	wal_envelope
 	write_fsst_compressed
 	write_minmax_fastpath

--- a/test/vm_privilege.sh
+++ b/test/vm_privilege.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+#
+# pgColumnar visibility-map privilege boundary (#558).
+#
+# pgcolumnar.vm_selftest() writes an ALL_VISIBLE bit into a relation's
+# visibility-map fork. It took an arbitrary regclass and checked nothing: not
+# ownership, not any ACL, not even that the relation was columnar. CREATE FUNCTION
+# grants EXECUTE to PUBLIC and the install script contains no REVOKE, so any role
+# holding USAGE on the pgcolumnar schema could mark pages of ANY relation
+# all-visible -- including a plain heap table it neither owned nor could read.
+#
+# The consequence is not an error message, it is wrong answers: an index-only scan
+# over the victim skips the heap visibility check and returns deleted rows.
+# Measured before the fix, on a table with 10,000 live rows and 10,000 dead ones:
+#
+#     index-only scan  20000        sequential scan  10000
+#
+# So this suite asserts the CONSEQUENCE and not merely that the call now errors.
+# A suite that only checked for "must be owner" would stay green if a later change
+# made the function succeed for some relation while still skipping the heap check,
+# which is the shape of the original defect.
+#
+# Both directions are pinned, per CONTEXT.md:
+#   - the unprivileged role is refused AND the scan stays correct;
+#   - the OWNER is still allowed, so the gate is permission and not breakage.
+#
+# The schema does not grant USAGE to PUBLIC, and that is what accidentally
+# contained this before it was found. It is granted here on purpose so the call
+# reaches the C gate instead of stopping at the schema -- otherwise this suite
+# would pass against the unfixed code and prove nothing. Sibling of
+# test/server_file_privilege.sh, which makes the same argument for the
+# server-file roles.
+#
+# Usage:  test/vm_privilege.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+_root="$(dirname "${BASH_SOURCE[0]}")/.."
+_ver=$(grep -oE "default_version = '[^']+'" "$_root/pgcolumnar.control" | sed "s/.*'\(.*\)'/\1/")
+SQLFILE="$_root/pgcolumnar--$_ver.sql"
+[ -f "$SQLFILE" ] || { echo "FAIL  install script $SQLFILE not found"; exit 1; }
+
+run_as() {	# role sql -> combined output
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -X -v ON_ERROR_STOP=0 -c "SET ROLE $1;" -c "$2" 2>&1
+}
+
+# ---- fixture: a HEAP table with dead tuples, owned by nobody in particular ----
+# Heap on purpose. The function never checked that its argument was columnar, so
+# the reachable blast radius was every table in the database, and a columnar-only
+# fixture would understate it.
+psql_run "CREATE TABLE vmvictim (id int primary key, secret text);"
+psql_run "INSERT INTO vmvictim SELECT g, 'secret-'||g FROM generate_series(1,20000) g;"
+psql_run "DELETE FROM vmvictim WHERE id % 2 = 0;"
+psql_run "ANALYZE vmvictim;"
+
+# TWO roles, because the fix has two layers and a single role would let one of
+# them be deleted with this suite still green -- the question CONTEXT.md asks of
+# every change ("can I delete this and still be green?").
+#
+#   t_vmnone  schema USAGE only.  Must be stopped by the SQL REVOKE.
+#   t_vmexec  schema USAGE plus an explicit EXECUTE grant, which defeats the
+#             REVOKE on purpose, so the call reaches the C ownership check and
+#             THAT is what refuses it.
+#
+# Without t_vmexec, removing the C gate leaves this suite green, because the
+# REVOKE alone would still refuse t_vmnone.
+psql_run "DROP ROLE IF EXISTS t_vmnone;"
+psql_run "CREATE ROLE t_vmnone NOSUPERUSER;"
+psql_run "GRANT USAGE ON SCHEMA pgcolumnar TO t_vmnone;"
+
+psql_run "DROP ROLE IF EXISTS t_vmexec;"
+psql_run "CREATE ROLE t_vmexec NOSUPERUSER;"
+psql_run "GRANT USAGE ON SCHEMA pgcolumnar TO t_vmexec;"
+psql_run "GRANT EXECUTE ON FUNCTION pgcolumnar.vm_selftest(regclass,int) TO t_vmexec;"
+psql_run "GRANT EXECUTE ON FUNCTION pgcolumnar.vm_is_visible(regclass,int) TO t_vmexec;"
+
+nblocks="$(q "SELECT pg_relation_size('vmvictim')/8192;")"
+
+# ---- premises -----------------------------------------------------------------
+# Each of these makes a later assertion mean something. If any fails, the run is
+# void rather than green.
+check_num "premise: the fixture has 10000 live rows" \
+	"$(q "SELECT count(*) FROM vmvictim;")" 10000
+check "premise: the test role is not a superuser" \
+	"$(q "SELECT rolsuper FROM pg_roles WHERE rolname='t_vmnone';")" "f"
+check "premise: the test role cannot read the victim" \
+	"$(q "SELECT has_table_privilege('t_vmnone','vmvictim','SELECT');")" "f"
+check "premise: the test role does reach the schema (so it meets the C gate)" \
+	"$(q "SELECT has_schema_privilege('t_vmnone','pgcolumnar','USAGE');")" "t"
+check "premise: the victim is a heap relation, not columnar" \
+	"$(q "SELECT a.amname FROM pg_class c JOIN pg_am a ON a.oid=c.relam WHERE c.relname='vmvictim';")" "heap"
+check "premise: no all-visible bit is set yet" \
+	"$(q "SELECT pgcolumnar.vm_is_visible('vmvictim'::regclass,0);")" "f"
+check "premise: the fixture spans more than one block" \
+	"$([ "${nblocks:-0}" -gt 1 ] && echo yes || echo no)" "yes"
+
+# tail -1 is not cosmetic. psql -At -c with several statements echoes a command
+# tag per statement, so these helpers returned "SET\nSET\n20000". check_num then
+# refused the value as "not a measurement" (correct), and worse, the equality
+# check between the two comparing whole multi-line strings PASSED against unfixed
+# code -- a check that could not fail, found by running the red step and reading
+# it rather than by trusting the exit status.
+ios_count() {	# the count as an index-only scan sees it
+	q "SET enable_seqscan=off; SET enable_bitmapscan=off;
+	          SELECT count(*) FROM vmvictim WHERE id > 0;" | tail -1
+}
+seq_count() {	# the same count with the index taken away
+	q "SET enable_indexonlyscan=off; SET enable_indexscan=off;
+	          SELECT count(*) FROM vmvictim WHERE id > 0;" | tail -1
+}
+
+plan="$(psql_run "SET enable_seqscan=off; SET enable_bitmapscan=off;
+                  EXPLAIN (COSTS OFF) SELECT count(*) FROM vmvictim WHERE id > 0;")"
+check "premise: the query under test really is an Index Only Scan" \
+	"$(grep -qi 'Index Only Scan' <<<"$plan" && echo yes || echo no)" "yes"
+check_num "premise: the index-only scan is correct BEFORE anything is attempted" \
+	"$(ios_count)" 10000
+
+# ---- the boundary --------------------------------------------------------------
+# LAYER 1 -- the C ownership check. t_vmexec holds EXECUTE, so a refusal here
+# cannot be the REVOKE and cannot be the schema.
+attack_out=""
+for ((b = 0; b < nblocks; b++)); do
+	attack_out+="$(run_as t_vmexec "SELECT pgcolumnar.vm_selftest('vmvictim'::regclass, $b);")"$'\n'
+done
+check "the granted-but-not-owner role reaches the C gate, not the SQL grant" \
+	"$(grep -qi 'permission denied for function' <<<"$attack_out" && echo yes || echo no)" "no"
+check "the C ownership check names ownership" \
+	"$(grep -qi 'must be owner' <<<"$attack_out" && echo yes || echo no)" "yes"
+
+# LAYER 2 -- the SQL REVOKE, tested on a role that was never granted EXECUTE.
+revoke_out="$(run_as t_vmnone "SELECT pgcolumnar.vm_selftest('vmvictim'::regclass, 0);")"
+check "a role with only schema USAGE is stopped by the REVOKE" \
+	"$(grep -qi 'permission denied for function' <<<"$revoke_out" && echo yes || echo no)" "yes"
+
+# Refused, and refused by the OWNERSHIP gate specifically. Matching on the error
+# text rather than on "it failed" keeps a schema-usage or parse error from being
+# read as a successful defence.
+check "an unprivileged role is refused by vm_selftest" \
+	"$(grep -qiE 'must be owner|permission denied' <<<"$attack_out" && echo yes || echo no)" "yes"
+check "vm_selftest did not report success to the unprivileged role" \
+	"$(grep -qE '^\s*t\s*$' <<<"$attack_out" && echo yes || echo no)" "no"
+
+# The consequence. This is the assertion the issue is actually about.
+check "no all-visible bit was set on block 0 by the unprivileged role" \
+	"$(q "SELECT pgcolumnar.vm_is_visible('vmvictim'::regclass,0);")" "f"
+check_num "the index-only scan still returns only live rows" "$(ios_count)" 10000
+check "index-only and sequential scans agree after the attempt" \
+	"$([ "$(ios_count)" = "$(seq_count)" ] && echo yes || echo no)" "yes"
+
+# vm_is_visible is the read-only sibling and had the same absence of checks.
+isvis_out="$(run_as t_vmexec "SELECT pgcolumnar.vm_is_visible('vmvictim'::regclass, 0);")"
+check "an unprivileged role is refused by vm_is_visible" \
+	"$(grep -qiE 'must be owner|permission denied' <<<"$isvis_out" && echo yes || echo no)" "yes"
+
+# ---- the other direction: the owner must still be able to use them -------------
+# Without this the suite would pass if the fix simply broke both functions.
+check "the owner can still call vm_selftest" \
+	"$(q "SELECT pgcolumnar.vm_selftest('vmvictim'::regclass, 0);")" "t"
+check "the owner can still call vm_is_visible" \
+	"$(q "SELECT pgcolumnar.vm_is_visible('vmvictim'::regclass, 0);")" "t"
+
+# ---- coverage ------------------------------------------------------------------
+# A future vm_* entry point that forgets the gate should turn this red rather than
+# slip past, the same argument test/server_file_privilege.sh makes.
+discovered="$(grep -oE 'CREATE FUNCTION pgcolumnar\.(vm_[a-z_]+)' "$SQLFILE" \
+	| sed 's/.*pgcolumnar\.//' | sort -u)"
+covered=" vm_selftest vm_is_visible "
+for fn in $discovered; do
+	case "$covered" in
+		*" $fn "*) r=yes ;;
+		*)         r=no  ;;
+	esac
+	check "vm entry point is covered by this boundary test: $fn" "$r" "yes"
+done
+check_num "coverage scan found the vm functions (not an empty scan)" \
+	"$(printf '%s\n' "$discovered" | grep -c .)" 2
+
+pgc_summary


### PR DESCRIPTION
Closes #558.

`pgcolumnar.vm_selftest()` opened any caller-supplied `regclass` and called
`PgColumnarVMSetVisible` on it with no ownership check, no ACL check, and no
check that the relation was even columnar. `CREATE FUNCTION` grants `EXECUTE` to
`PUBLIC` and the install script carried no `REVOKE`, so any role with `USAGE` on
the `pgcolumnar` schema could mark pages of **any** relation in the database
all-visible — including a plain heap table it neither owned nor could read.

Measured before the fix, on a heap table with 10,000 live rows and 10,000 dead
ones, attacked by a `NOSUPERUSER` role that cannot read it:

```
index-only scan  20000
sequential scan  10000
```

The index-only scan returns every deleted row. `pgcolumnar.vm_is_visible()` had
the same absence of checks; it is read-only, so it leaked rather than corrupted,
and it is fixed here too.

## The change

Two layers.

**`PgColumnarRequireTableOwner(rel)`** after `table_open` in both functions. That
is the helper the rest of the tree already uses for "may this caller act on this
relation" — `columnar_vacuum.c` and `columnar_projection.c` call it at eleven
sites. Ownership is the right bar rather than a server-file role, because these
touch one named relation's storage.

**`REVOKE ALL ... FROM PUBLIC`** on both functions in the install script. This is
the second layer, not the only one: a `REVOKE` is undone by a later
`GRANT ... ON ALL FUNCTIONS IN SCHEMA`, and it does nothing for an already
installed extension until it is upgraded. The C check is the load-bearing one.

## The test asserts the consequence, not the error message

`test/vm_privilege.sh` (new, registered in sorted position; the runner reports
138 suites). It pins the index-only scan count, because a suite that only checked
for `must be owner` would stay green if a later change made the function succeed
for some relation while still skipping the heap visibility check — which is the
shape of the original defect. It also asserts the reverse direction: **the owner
must still be able to call both functions**, so the fix cannot pass by simply
breaking them.

Premises are asserted before anything is concluded: that the fixture has 10,000
live rows, that the victim is a *heap* relation, that the plan really is an Index
Only Scan, that the scan is correct beforehand, and that the test role reaches
the schema at all — without that last one the suite would pass against the
unfixed code and prove nothing.

Two roles, because the fix has two layers:

| role | holds | stopped by |
| --- | --- | --- |
| `t_vmnone` | schema `USAGE` only | the SQL `REVOKE` |
| `t_vmexec` | schema `USAGE` + explicit `EXECUTE` | the C ownership check |

With a single role, deleting the C gate left the suite green.

## Removal proofs

Each layer deleted on its own, `.so` fingerprinted per arm:

| arm | change | `.so` md5 | suite |
| --- | --- | --- | --- |
| A | full fix | `f23a716a…` | **green**, 23 checks |
| B | ownership check deleted | `8ba40928…` | **red** — on the ownership checks |
| C | `REVOKE` deleted | `f23a716a…` | **red** — on exactly the `REVOKE` check |

Arm C's `.so` is byte-identical to arm A, which is the point: only the SQL
changed, so the C gate is provably still present and the red is attributable to
the `REVOKE` alone.

The fingerprints are not decoration. My first attempt at arm C produced a `.so`
byte-identical to *unfixed main* — `git checkout -- .` left the new test file
behind, the follow-up `git apply` failed atomically, and the arm removed the
whole fix rather than one layer. It went red, which looked like a successful
proof. Only the md5 showed it was measuring nothing.

## Gate

Full matrix, all 138 suites on **pg18a** and **pg19a**: `ALL VERSIONS PASSED`.
The same matrix on unfixed `main` was green beforehand, so the result is
attributable to this change rather than to pre-existing state.

Sanitizer gate (`test/run_san.sh`, ASAN+UBSAN, 800 fuzz mutants) was run on
`main` separately today and is clean — 24 suites, 0 failed, 0 ran no checks, and
38 `__asan` symbols in the installed `.so`, so the green is not vacuous. This
change does not touch a decode path, so that gate is context rather than
evidence for it.

## Not addressed here

#559 is the same *class* — the four serial import/export entry points check the
server-file role and then no privilege on the relation — but a different set of
call sites and a different correct bar (`ACL_SELECT`/`ACL_INSERT` rather than
ownership, for the export side at least). Deliberately left for its own change.
