### PR TITLE
fix: the projection read helpers are a privilege boundary (#562)

### DIFF
--- a/pgcolumnar--1.0-alpha.sql
+++ b/pgcolumnar--1.0-alpha.sql
@@ -585,6 +585,13 @@ CREATE FUNCTION pgcolumnar.reconstruct_via_projection(rel regclass, name text)
 COMMENT ON FUNCTION pgcolumnar.reconstruct_via_projection(regclass, text)
 	IS 'read all live rows via a projection, reconstructing non-covered columns from the base by row number (gap 26)';
 
+-- #562: EXECUTE is granted to PUBLIC by CREATE FUNCTION, so without these the
+-- C check below is the only boundary. Two layers on purpose: the C check is
+-- what makes the functions safe, and this is what keeps an unprivileged role
+-- from reaching them at all.
+REVOKE ALL ON FUNCTION pgcolumnar.read_projection(regclass, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION pgcolumnar.reconstruct_via_projection(regclass, text) FROM PUBLIC;
+
 CREATE FUNCTION pgcolumnar.stats(
 	rel regclass,
 	OUT stripeid bigint,

--- a/src/columnar_projection.c
+++ b/src/columnar_projection.c
@@ -28,6 +28,7 @@
 #include "catalog/pg_type.h"
 #include "funcapi.h"
 #include "miscadmin.h"
+#include "utils/acl.h"
 #include "utils/array.h"
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
@@ -394,6 +395,31 @@ pgcolumnar_read_projection(PG_FUNCTION_ARGS)
 				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
 				 errmsg("\"%s\" is not a columnar table", get_rel_name(relid))));
 
+	/*
+	 * SELECT on the BASE relation, checked before a single row is read (#562).
+	 *
+	 * These two returned any caller-supplied relation's contents with no
+	 * privilege check at all, and CREATE FUNCTION grants EXECUTE to PUBLIC, so
+	 * USAGE on the schema was the whole boundary. reconstruct_via_projection is
+	 * the worse of the pair: it rebuilds NON-COVERED columns from the base by row
+	 * number, so the projection was never the bound on what leaked -- one
+	 * projection on any column exposed the whole row.
+	 *
+	 * ACL_SELECT rather than PgColumnarRequireTableOwner, and that is a
+	 * correctness argument rather than a lenient one. Both functions read base
+	 * columns, so SELECT on the base is exactly the privilege that governs
+	 * reading them by any other route. Ownership would be a stricter bar that
+	 * happens to exclude the attacker, which is a different and worse property:
+	 * it would also refuse a reader who has been granted SELECT deliberately.
+	 * Same pattern as columnar_parallel_export.c:471.
+	 */
+	{
+		AclResult	ac = pg_class_aclcheck(relid, GetUserId(), ACL_SELECT);
+
+		if (ac != ACLCHECK_OK)
+			aclcheck_error(ac, OBJECT_TABLE, get_rel_name(relid));
+	}
+
 	rel = table_open(relid, AccessShareLock);
 	/* persist pending base + projection writes so this read sees them */
 	PgColumnarFlushWriteStateForRelation(relid);
@@ -550,6 +576,31 @@ pgcolumnar_reconstruct_via_projection(PG_FUNCTION_ARGS)
 		ereport(ERROR,
 				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
 				 errmsg("\"%s\" is not a columnar table", get_rel_name(relid))));
+
+	/*
+	 * SELECT on the BASE relation, checked before a single row is read (#562).
+	 *
+	 * These two returned any caller-supplied relation's contents with no
+	 * privilege check at all, and CREATE FUNCTION grants EXECUTE to PUBLIC, so
+	 * USAGE on the schema was the whole boundary. reconstruct_via_projection is
+	 * the worse of the pair: it rebuilds NON-COVERED columns from the base by row
+	 * number, so the projection was never the bound on what leaked -- one
+	 * projection on any column exposed the whole row.
+	 *
+	 * ACL_SELECT rather than PgColumnarRequireTableOwner, and that is a
+	 * correctness argument rather than a lenient one. Both functions read base
+	 * columns, so SELECT on the base is exactly the privilege that governs
+	 * reading them by any other route. Ownership would be a stricter bar that
+	 * happens to exclude the attacker, which is a different and worse property:
+	 * it would also refuse a reader who has been granted SELECT deliberately.
+	 * Same pattern as columnar_parallel_export.c:471.
+	 */
+	{
+		AclResult	ac = pg_class_aclcheck(relid, GetUserId(), ACL_SELECT);
+
+		if (ac != ACLCHECK_OK)
+			aclcheck_error(ac, OBJECT_TABLE, get_rel_name(relid));
+	}
 
 	rel = table_open(relid, AccessShareLock);
 	PgColumnarFlushWriteStateForRelation(relid);

--- a/test/projection_privilege.sh
+++ b/test/projection_privilege.sh
@@ -44,6 +44,18 @@ psql_run "REVOKE ALL ON secret FROM PUBLIC;"
 #   t_prjsel   USAGE + EXECUTE + SELECT. Must SUCCEED. This is the arm that
 #              distinguishes ACL_SELECT from ownership: an owner-only bar refuses
 #              it, and refusing it would be a regression, not a fix.
+#
+# A RULE FOR ANYONE EDITING THE PREMISES BELOW. A premise about a role is
+# connectivity-safe only if THAT ROLE is the one running it. count_as() maps any
+# non-numeric output to "refused", so a FATAL at login satisfies a deny arm just
+# as well as a privilege error does, and a premise the OWNER runs -- a catalog
+# lookup like has_function_privilege -- cannot see that. t_prjexec was exposed
+# exactly that way until the premise below was added; t_prjnone and t_prjsel are
+# covered only because their premises happen to be statements those roles
+# execute themselves (a literal 'permission denied' match, and a row count).
+# Tidying either of those into the count_as idiom reopens the hole silently, and
+# only the error-text checks would still catch it. Keep the role in the driving
+# seat of its own premise.
 for r in t_prjnone t_prjexec t_prjsel; do
 	psql_run "DROP ROLE IF EXISTS $r;"
 	psql_run "CREATE ROLE $r NOSUPERUSER LOGIN;"

--- a/test/projection_privilege.sh
+++ b/test/projection_privilege.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+#
+# pgColumnar: the projection READ helpers are a privilege boundary (#562).
+#
+# pgcolumnar.read_projection() and pgcolumnar.reconstruct_via_projection() opened
+# a caller-supplied regclass and returned its contents with no privilege check of
+# any kind, and CREATE FUNCTION grants EXECUTE to PUBLIC with no REVOKE in the
+# install script. Any role with USAGE on the pgcolumnar schema could read any
+# columnar table that had a projection.
+#
+# reconstruct_via_projection is the worse of the two and the reason the title
+# says EVERY column: it reconstructs NON-COVERED columns from the base relation
+# by row number, so the projection is not the bound on what leaks, it is only the
+# entry ticket. One projection on any column exposed the whole row.
+#
+# The bar is ACL_SELECT on the BASE relation rather than ownership, and that is a
+# correctness argument rather than a leniency one: reconstruct returns columns
+# the projection does not store, so SELECT on the base is precisely the privilege
+# that governs reading those columns by any other route. Ownership is a stricter
+# bar that happens to work, which is a different and worse property.
+#
+# Usage:  test/projection_privilege.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+ROWS=2000
+
+psql_run "CREATE TABLE secret (id int, ssn text, note text) USING pgcolumnar;"
+psql_run "INSERT INTO secret SELECT g, 'ssn-'||g, 'note-'||g FROM generate_series(1,$ROWS) g;"
+# The projection covers id and ssn. It does NOT cover note, which is the whole
+# point: reconstruct returns note anyway.
+psql_run "SELECT pgcolumnar.add_projection('secret','p1',ARRAY['id','ssn'],ARRAY['id']);"
+psql_run "SELECT pgcolumnar.rebuild_projections('secret');"
+psql_run "REVOKE ALL ON secret FROM PUBLIC;"
+
+# Three roles, one per layer, so a refusal can be attributed rather than guessed.
+#
+#   t_prjnone  schema USAGE only.        Must be stopped by the SQL REVOKE.
+#   t_prjexec  USAGE + EXECUTE granted.  Passes the SQL layer on purpose, so the
+#              call reaches the C privilege check and can only be stopped there.
+#   t_prjsel   USAGE + EXECUTE + SELECT. Must SUCCEED. This is the arm that
+#              distinguishes ACL_SELECT from ownership: an owner-only bar refuses
+#              it, and refusing it would be a regression, not a fix.
+for r in t_prjnone t_prjexec t_prjsel; do
+	psql_run "DROP ROLE IF EXISTS $r;"
+	psql_run "CREATE ROLE $r NOSUPERUSER LOGIN;"
+	psql_run "GRANT USAGE ON SCHEMA pgcolumnar TO $r;"
+done
+for r in t_prjexec t_prjsel; do
+	psql_run "GRANT EXECUTE ON FUNCTION pgcolumnar.read_projection(regclass,text) TO $r;"
+	psql_run "GRANT EXECUTE ON FUNCTION pgcolumnar.reconstruct_via_projection(regclass,text) TO $r;"
+done
+psql_run "GRANT SELECT ON secret TO t_prjsel;"
+
+as() {  # as <role> <sql>
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U "$1" \
+		-d "$PGC_DB" -At -c "$2" 2>&1
+}
+# Rows, or the string "refused". A count is the answer and an error is not a
+# count, which is what keeps a broken call from reading as a denial.
+count_as() {  # count_as <role> <function>
+	local out
+	out="$(as "$1" "SELECT count(*) FROM pgcolumnar.$2('secret','p1');" | head -1)"
+	case "$out" in
+		''|*[!0-9]*) echo refused ;;
+		*) echo "$out" ;;
+	esac
+}
+
+# ---- premises: the fixture, and that the functions WORK ----------------------
+#
+# The owner arms are not decoration. A DENIED result and a BROKEN result are
+# indistinguishable from outside, so a suite that concludes anything from a
+# refusal needs an arm on the SAME call that is expected to succeed. Measured,
+# not hypothetical: an earlier probe of these functions passed a column
+# definition list, every arm died with "a column definition list is only allowed
+# for functions returning record", and all five read as refusals.
+#
+# And the owner arm asserts a ROW COUNT rather than absence of error. If a later
+# change made these return zero rows for everyone, a no-error owner arm would
+# stay green while the deny arms stayed green and the suite would pass over a
+# function that does nothing.
+check_num "premise: the owner reads the projection, and gets rows" \
+	"$(q "SELECT count(*) FROM pgcolumnar.read_projection('secret','p1');")" "$ROWS"
+check_num "premise: the owner reconstructs, and gets rows" \
+	"$(q "SELECT count(*) FROM pgcolumnar.reconstruct_via_projection('secret','p1');")" "$ROWS"
+# Both functions RETURN SETOF text: one row is a single pipe-joined string, not
+# a record. A column definition list is rejected outright, which is how an
+# earlier probe of these functions produced five arms that all looked like
+# refusals and were actually call errors. Match the text.
+check "premise: reconstruct really does return the NON-COVERED column" \
+	"$(q "SELECT pgcolumnar.reconstruct_via_projection('secret','p1') LIKE '%note-%' LIMIT 1;")" \
+	"t"
+check "premise: and read_projection does NOT, so the two differ as the issue says" \
+	"$(q "SELECT pgcolumnar.read_projection('secret','p1') LIKE '%note-%' LIMIT 1;")" \
+	"f"
+check "premise: the test roles are not superusers" \
+	"$(q "SELECT bool_and(NOT rolsuper) FROM pg_roles WHERE rolname LIKE 't_prj%';")" "t"
+check "premise: the unprivileged role cannot read the table by any ordinary route" \
+	"$(as t_prjnone 'SELECT count(*) FROM secret;' | grep -c 'permission denied')" "1"
+check "premise: t_prjsel CAN read the table, so its arm below tests the bar" \
+	"$(as t_prjsel 'SELECT count(*) FROM secret;' | head -1)" "$ROWS"
+
+# ---- layer one: the SQL grant ------------------------------------------------
+check "a role with only schema USAGE is refused read_projection" \
+	"$(count_as t_prjnone read_projection)" "refused"
+check "and is refused reconstruct_via_projection" \
+	"$(count_as t_prjnone reconstruct_via_projection)" "refused"
+
+# WHICH layer refused, not merely that one did. Both layers reject this role, so
+# a bare "refused" stays true if the REVOKE is deleted and the C check catches it
+# instead -- measured: with the REVOKE removed this suite still passed 14 of 14.
+# The error text is the only thing that attributes the refusal, so it is asserted
+# here to tell the layers apart rather than in place of behaviour.
+check "and the refusal comes from the SQL grant, naming the function" \
+	"$(as t_prjnone "SELECT count(*) FROM pgcolumnar.read_projection('secret','p1');" | grep -c 'permission denied for function')" \
+	"1"
+
+# ---- layer two: the C check, reached only because EXECUTE was granted --------
+#
+# This role clears the SQL layer deliberately. If it is refused, the refusal
+# cannot be the REVOKE and cannot be the schema.
+check "premise: t_prjexec really does hold EXECUTE, so it reaches the C gate" \
+	"$(q "SELECT has_function_privilege('t_prjexec','pgcolumnar.read_projection(regclass,text)','EXECUTE');")" "t"
+check "a role with EXECUTE but no SELECT is refused read_projection" \
+	"$(count_as t_prjexec read_projection)" "refused"
+check "and is refused reconstruct_via_projection, which leaks non-covered columns" \
+	"$(count_as t_prjexec reconstruct_via_projection)" "refused"
+check "and THAT refusal names the table, so it is the C check and not the grant" \
+	"$(as t_prjexec "SELECT count(*) FROM pgcolumnar.read_projection('secret','p1');" | grep -c 'permission denied for table')" \
+	"1"
+
+# ---- the bar is SELECT, not ownership ---------------------------------------
+#
+# Without these two the fix could pass by refusing everyone, which is not a fix,
+# it is a broken function with a good error message.
+check "a role WITH SELECT still reads the projection" \
+	"$(count_as t_prjsel read_projection)" "$ROWS"
+check "and still reconstructs" \
+	"$(count_as t_prjsel reconstruct_via_projection)" "$ROWS"
+
+pgc_summary

--- a/test/projection_privilege.sh
+++ b/test/projection_privilege.sh
@@ -125,6 +125,15 @@ check "and the refusal comes from the SQL grant, naming the function" \
 # cannot be the REVOKE and cannot be the schema.
 check "premise: t_prjexec really does hold EXECUTE, so it reaches the C gate" \
 	"$(q "SELECT has_function_privilege('t_prjexec','pgcolumnar.read_projection(regclass,text)','EXECUTE');")" "t"
+# And that it can CONNECT. The line above is a catalog lookup run as the owner,
+# so it is blind to whether this role can open a session at all -- and count_as
+# turns any non-numeric output into "refused", which a FATAL at login satisfies
+# just as well as a privilege error does. Measured, not hypothetical: with
+# `ALTER ROLE t_prjexec NOLOGIN` injected, the EXECUTE premise above and both
+# "is refused" checks below still PASSED, and only the error-text check caught
+# it. A deny arm is evidence only if the call reached the code that denies it.
+check "premise: t_prjexec can open a session, so a refusal below is a refusal" \
+	"$(as t_prjexec 'SELECT 1;' | head -1)" "1"
 check "a role with EXECUTE but no SELECT is refused read_projection" \
 	"$(count_as t_prjexec read_projection)" "refused"
 check "and is refused reconstruct_via_projection, which leaks non-covered columns" \

--- a/test/projection_privilege.sh
+++ b/test/projection_privilege.sh
@@ -142,4 +142,31 @@ check "a role WITH SELECT still reads the projection" \
 check "and still reconstructs" \
 	"$(count_as t_prjsel reconstruct_via_projection)" "$ROWS"
 
+# ---- what this fix does NOT close: row-level security (#563) -----------------
+#
+# Pinned as an assertion of the WRONG value, deliberately, per CONTEXT.md: a
+# known defect recorded as an echo is read by nobody, and pinned as an assertion
+# the eventual fix turns this suite red and forces the expectation to be updated
+# on purpose.
+#
+# ACL_SELECT answers "may this role read this table". RLS answers "which rows",
+# and nothing here asks the second. RLS is applied by the REWRITER to a query's
+# range table entry; these functions never build a query over the relation, they
+# open storage and read it, so there is nothing to rewrite. The project's own
+# exemplar has the same gap: parallel_export_parquet already does
+# pg_class_aclcheck(ACL_SELECT) and also returns every row (#563).
+#
+# So after this change a role WITH SELECT and a restrictive policy still reads
+# past it. That is strictly better than before -- the no-privilege case is closed
+# -- and it is not the whole job.
+psql_run "ALTER TABLE secret ENABLE ROW LEVEL SECURITY;"
+psql_run "CREATE POLICY p_one ON secret FOR SELECT TO t_prjsel USING (id = 1);"
+
+check_num "premise: the policy is in force for ordinary SQL" \
+	"$(as t_prjsel 'SELECT count(*) FROM secret;' | head -1)" "1"
+check_num "KNOWN WRONG (#563): read_projection ignores the policy and returns every row" \
+	"$(count_as t_prjsel read_projection)" "$ROWS"
+check_num "KNOWN WRONG (#563): reconstruct_via_projection ignores it too" \
+	"$(count_as t_prjsel reconstruct_via_projection)" "$ROWS"
+
 pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -157,6 +157,7 @@ SUITES=(
 	phase5
 	phase6
 	planner_choice_quality
+	projection_privilege
 	projections
 	pushdown_report
 	read_stream


### PR DESCRIPTION
> Reopened from #564 under the correct account. The branch, commits and base are
> unchanged. #564 was authored under @ChronicallyJD because my `gh` client was
> authenticated as the wrong account; I wrote this change, and the misattribution
> is why @ChronicallyJD could not review it. Their review history is on #564.

Closes #562. **Not merging it** — the standing hold applies.

`read_projection()` and `reconstruct_via_projection()` returned any
caller-supplied relation's contents with no privilege check of any kind, and
`CREATE FUNCTION` grants `EXECUTE` to `PUBLIC` with no `REVOKE` in the install
script. `USAGE` on the schema was the whole boundary.

## Reproduced before the fix

`NOSUPERUSER` role, `REVOKE ALL ON secret FROM PUBLIC`:

```
CONTROL  SELECT count(*) FROM secret            -> permission denied for table secret
ATTACK   read_projection('secret','p1')         -> 1|ssn-1
ATTACK   reconstruct_via_projection('secret','p1') -> 1|ssn-1|note-1
CONTROL  owner read_projection                  -> 2000 rows
```

**`note` is not covered by the projection.** `reconstruct_via_projection`
rebuilds non-covered columns from the base by row number, so the projection was
never the bound on what leaked — it was the entry ticket. One projection on any
column exposed the whole row. Found reviewing #561; the escalation was
@ChronicallyJD's and is reproduced here on a separate fixture.

## `ACL_SELECT`, not ownership

A correctness argument rather than a lenient one: both functions read base
columns, so `SELECT` on the base is exactly the privilege that governs reading
them by any other route. Ownership would be a stricter bar that *happens* to
exclude the attacker — a different and worse property, since it also refuses a
reader granted `SELECT` deliberately. Same pattern as
`columnar_parallel_export.c:471`.

Two layers: the C check, plus `REVOKE ALL ... FROM PUBLIC` so an unprivileged
role does not reach it at all.

## The suite

`test/projection_privilege.sh`, 16 checks, **three roles** so a refusal can be
attributed rather than guessed:

| role | granted | expected |
| --- | --- | --- |
| `t_prjnone` | USAGE | refused by the SQL grant |
| `t_prjexec` | USAGE + EXECUTE | refused by the C check |
| `t_prjsel` | USAGE + EXECUTE + SELECT | **must succeed** |

The third is what stops the fix passing by refusing everyone.

## Two things the suite caught about itself

**A premise was void.** It passed a column definition list to a `SETOF text`
function and returned empty rather than failing loudly — the identical error that
made an earlier probe of these functions produce five arms that all read as
refusals and were call errors. Caught only because the check compared against a
value.

**The first version passed 14/14 with the `REVOKE` deleted.** Both layers reject
the same callers, so the C check subsumes the SQL one and a bare "refused" stays
true. I would have shipped "two layers, both proven" on evidence that proved one.
Two checks now assert *which* layer refused — the only observable that separates
them, and the technique is lifted from #561:

```
USAGE only        'permission denied for function'  -> the SQL grant
USAGE + EXECUTE   'permission denied for table'     -> the C check
```

## Proved by removal, `.so` fingerprinted per arm

```
remove the C check   b84a24cae85e   FAIL  EXECUTE-but-no-SELECT reads 2000 rows
remove the REVOKE    dfd9bebcb033   FAIL  the refusal no longer names the function
both present         dfd9bebcb033   16 checks PASSED
```

The REVOKE arm's fingerprint is **identical** to the good build, correctly — the
REVOKE lives in SQL and the `.so` does not change. That is the same reading which
would mean "the arm did not build" for a C change, so it is recorded rather than
assumed.

## Gate

PG17 assert 133 ran, PASS. PG19 assert 138 ran, one failure — `temporal`,
`btree_gist` absent from this container, identical on unmodified main.

---

## Added since #564 was opened

Two commits, both from adversarial review rather than from CI.

`0f47569` — **a deny arm is evidence only if the call reached the code that
denies it.** The `t_prjexec` premise was a catalog lookup (`has_function_privilege`)
run by the owner, so it was blind to whether that role could open a session, and
`count_as()` maps any non-numeric output to `refused`. Injecting
`ALTER ROLE t_prjexec NOLOGIN` left the premise and both "is refused" checks
PASSING, with only the error-text check catching it, and the failure it reported
named the wrong cause. Added the missing premise, which asserts a live session as
that role. Prompted by @ChronicallyJD.

`567e4bc` — the general rule in the suite header, because `t_prjnone` and
`t_prjsel` are safe only by accident of phrasing and tidying either into the
`count_as` idiom would reopen the hole silently: **a premise about a role is
connectivity-safe only if that role is the one running it.**

## Removal proof

Three arms, PG17 assert build, each rebuilt and reinstalled, each mutation
asserting it landed before its arm ran:

| arm | mutation | suite | failed |
| --- | --- | --- | --- |
| base | none | exit 0 | 0 of 20 |
| noC | both `pg_class_aclcheck(... ACL_SELECT)` blocks deleted | exit 1 | 3 |
| noRevoke | both `REVOKE ALL ON FUNCTION` lines deleted | exit 1 | 1 |

The `noC` arm shows the leak rather than merely losing a refusal:
`got [2000] want [refused]`, twice, to a role holding no privilege on the table.
`noRevoke` fails exactly the one check naming the grant. Both layers are
independently load-bearing.

## Scope

Does not close #563: RLS is still bypassed, and the suite pins that as
`KNOWN WRONG (#563)` rather than hiding it. Does not close #566
(`get_storage_id`), which is the remaining member of the same ungated class
described on #559.
