### PR TITLE
docs: the tuned-arm regression is the measured mechanism, not variation (#565)

### DIFF
--- a/bench/cb_guards.sh
+++ b/bench/cb_guards.sh
@@ -202,3 +202,31 @@ cb_verdict() {  # cb_verdict <col_hot> <heap_hot> <band> -> win|tie|loss|-
 		if (d <= b) { print "tie" } else if (c < h) { print "win" } else { print "loss" }
 	}'
 }
+
+# ---- doc guards for the accelerator claim (#565) ---------------------------
+#
+# docs/benchmarks.md published a "run to run variation" verdict on q18 and q31
+# with no measured band, against separations of 115 and 54 percent, and claimed
+# the plan was identical when EXPLAIN on the four-setting tuned arm shows it is
+# not. These turn that prose into the same numbers cb_verdict already decides.
+
+# The query ids named in any "run to run variation" claim. The claim can wrap
+# across lines, so each blank-line paragraph is folded to one line before the
+# match: a line-wise grep for the phrase returns nothing on the real page.
+cb_doc_variation_qids() {  # cb_doc_variation_qids <file> -> qids, one per line
+	awk 'BEGIN { RS = "" } {
+		p = $0; gsub(/\n/, " ", p); gsub(/  +/, " ", p)
+		if (p ~ /run to run variation/) print p
+	}' "$1" | grep -oE 'q[0-9]+' | sort -u
+}
+
+# The default and accelerated figures for a query, read ONLY from the accelerator
+# table (scoped to its own header). A query id can appear in several tables, so
+# an unscoped scan would feed the wrong pair to the verdict.
+cb_doc_accel_figures() {  # cb_doc_accel_figures <file> <qid> -> "<default> <accelerated>" or ""
+	awk -v q="$2" '
+		/^\| query \| default \| accelerated \|/ { f = 1; next }
+		f && NF == 0 { f = 0 }
+		f && $2 == q { d = $4; a = $6; gsub(/[*x]/, "", d); gsub(/[*x]/, "", a); print d, a }
+	' "$1"
+}

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -943,12 +943,10 @@ the same effect in more detail.
 queries are `GROUP BY`. So a default run measures this engine with its main
 analytical accelerator disabled.
 
-The harness therefore runs a third arm with them turned on. Read that arm as "these
-GUCs are set" and not as "the grouped node ran". On this dataset the planner
-declines the grouped node on most shapes. Measured on the same table, it is
-declined at 5,727, 18,344 and 49,511 groups, and chosen only at 4,906,030, where
-it then ties. So the differences below cannot be attributed to it. See issue
-#369.
+The harness runs a third arm with the analytical accelerators on. That arm sets
+four settings, not only the two above. It also sets
+`pgcolumnar.enable_parallel_vector_agg` on and raises
+`pgcolumnar.groupagg_max_groups` to 200000000.
 
 The result does not support turning these settings on by default:
 
@@ -961,12 +959,15 @@ The result does not support turning these settings on by default:
 | q31 | 0.96x | **1.48x** |
 | q15 | 0.84x | **0.92x** |
 
-Three queries improve and three get worse. This is a reason to investigate rather
-than a conclusion, and one caution belongs with it. For `q18` and `q31` the plan
-is **identical** with these settings on and off. Their rows are therefore run to
-run variation, and not an effect of the settings. They are left in the table
-because removing the rows that embarrass a reading is how a benchmark page stops
-being trustworthy.
+Three queries improve and three get worse, and the losses are an effect of the
+settings rather than noise. For `q18` and `q31` the plan is not identical with
+the settings on and off. Measured by `EXPLAIN` on this four-setting arm, each
+query runs a seven-worker parallel plan by default. With the settings on, each
+runs a serial `Custom Scan` with `Columnar Vectorized Group Keys` instead. The
+grouped node is chosen and forecloses the `Gather`, so the query loses its
+parallelism. Both queries have a `GROUP BY`, so that node is responsible. The
+group counts of 5,727, 18,344, 49,511 and 4,906,030 were measured on other query
+shapes, so they do not license excluding the node here. See issue #369.
 
 One query, `q21`, fails outright with the accelerations on. It is
 `COUNT(*) WHERE URL LIKE '%google%'`, and it raises

--- a/test/bench_guards.sh
+++ b/test/bench_guards.sh
@@ -264,6 +264,56 @@ check "ratio()'s output reaches printf and nothing else" \
 check "and the verdict is asked of cb_verdict rather than recomputed inline" \
 	"$([ "$(grep -c 'cb_verdict "' "$CB")" -ge 1 ] && echo yes || echo no)" "yes"
 
+# ---- the accelerator claim must not call a separation "variation" (#565) ----
+#
+# docs/benchmarks.md called q18 and q31 "run to run variation" while publishing
+# them at 2.17x and 1.48x against a shared baseline, and claimed the plan was
+# identical when EXPLAIN on the four-setting tuned arm shows a seven-worker
+# parallel plan replaced by a serial vectorized node. Three checks, because the
+# headline one goes vacuous once the sentence is removed.
+DOC="$SRCDIR/docs/benchmarks.md"
+check "premise: the benchmark page is present to be judged" \
+	"$([ -f "$DOC" ] && echo yes || echo no)" "yes"
+
+# 1. Frozen fixture. The extractor must find both ids in a claim wrapped across
+# lines, so it stays proven after the real page no longer carries the sentence.
+# Without this the headline check below is satisfiable by an extractor that
+# matches nothing, which is exactly how the first draft of this guard passed.
+_fx="$(mktemp)"
+printf 'A lead sentence naming q18 and q31 here.\ntheir rows are therefore run to\nrun variation, not an effect.\n' > "$_fx"
+check "the variation-claim extractor reads ids wrapped across two lines" \
+	"$(cb_doc_variation_qids "$_fx" | tr '\n' ' ' | sed 's/ *$//')" "q18 q31"
+rm -f "$_fx"
+
+# 2. Headline. A query may be called "run to run variation" only if its own
+# accelerator figures are a tie within the page's band. The page publishes no
+# per-query scatter, so the band is '-' and cb_verdict returns '-', not "tie" --
+# any such claim is unbanded and refused. Fires on the unfixed page (q18, q31),
+# passes once the sentence is gone.
+_bad=""
+for _q in $(cb_doc_variation_qids "$DOC"); do
+	set -- $(cb_doc_accel_figures "$DOC" "$_q")
+	_v="$(cb_verdict "${2:-}" "${1:-}" "$(cb_band - -)")"
+	[ "$_v" = tie ] || _bad="$_bad $_q(${1:-?}/${2:-?}:$_v)"
+done
+_nclaim="$(cb_doc_variation_qids "$DOC" | grep -c .)"
+echo "  variation claims examined: $_nclaim"
+check "no query is called run-to-run variation unless its figures are a measured tie" \
+	"claims=$_nclaim$_bad" "claims=0"
+
+# 3. Census, which never goes vacuous. The tuned arm sets FOUR settings; the page
+# must name all four and the group-cap value it sets, so it cannot be described
+# as the two enable_* GUCs alone (the pre-fix text) or misstate the arm.
+_sec="$(awk '/^### The accelerations are off by default/{f=1; next} f&&/^#/{f=0} f' "$DOC")"
+_miss=""
+for _t in pgcolumnar.enable_group_vectorization pgcolumnar.enable_ungrouped_vector_agg \
+	pgcolumnar.enable_parallel_vector_agg pgcolumnar.groupagg_max_groups 200000000; do
+	grep -qF "$_t" <<<"$_sec" || _miss="$_miss $_t"
+done
+echo "  tuned-arm settings named on the page:$([ -z "$_miss" ] && echo ' all four + value' || echo "$_miss MISSING")"
+check "the tuned-arm section names all four settings and the group-cap value" \
+	"missing:$_miss" "missing:"
+
 echo
 echo "checks run: $PGC_CHECKS"
 if [ "$PGC_FAIL" != 0 ]; then


### PR DESCRIPTION
Closes #565. **Not merging it.**

`docs/benchmarks.md` called q18 and q31 "run to run variation" and claimed the
plan was "identical with these settings on and off". Both are false, and I filed
#565 on the strength of a **two-setting** probe that the plan's adversary correctly
flagged as the wrong arm. So I re-measured on the page's actual **four-setting**
tuned arm before writing anything.

## The measurement (four-setting arm, on the loaded ClickBench table)

`arm_settings columnar_tuned` sets four GUCs, not two: `enable_group_vectorization`,
`enable_ungrouped_vector_agg`, `enable_parallel_vector_agg`, and
`groupagg_max_groups=200000000`. `EXPLAIN` under all four vs none:

```
q18 default:  Finalize GroupAggregate -> Gather Merge (Workers Planned: 7) -> Parallel Custom Scan   [19 rows]
q18 four-on:  Custom Scan (PgColumnarScan)  Columnar Vectorized Group Keys: 2                          [ 8 rows, serial]

q31 default:  GroupAggregate -> Gather Merge (Workers Planned: 7) -> Parallel Custom Scan             [20 rows]
q31 four-on:  Custom Scan (PgColumnarScan)  Columnar Vectorized Group Keys: 2                          [11 rows, serial]
```

Even with `enable_parallel_vector_agg=on`, the grouped vectorized node is chosen
serial and forecloses the 7-worker Gather. So the regression **is** the settings,
the plan is **not** identical, and the mechanism is now proven on the page's own
arm rather than a proxy for it. Query text pulled from `queries.sql`: both q18 and
q31 have a `GROUP BY` (the issue's later claim that q31 is ungrouped was wrong).

## The docs edit

- Removes the "identical plan / run to run variation" paragraph.
- Corrects the contradicting claim five lines up that the node "cannot be
  responsible" — q18 is in the chosen regime and the node is responsible.
- Describes the arm by all four settings it sets, not two.
- States the measured mechanism. Passes `test/ste_check.py` (25-word limit, no dashes).

## The check (test/bench_guards.sh, no cluster)

Three checks, because the headline one goes vacuous once the sentence is gone:

1. **Frozen fixture** — the extractor must find `q18 q31` in a claim wrapped
   across two lines. This keeps the extractor proven after the real page no longer
   carries the sentence. (An earlier draft of this guard passed because its
   extractor matched nothing; this is the guard against that.)
2. **Headline** — a query may be called "run to run variation" only if its
   accelerator figures are a tie within the page's band. The page publishes no
   per-query scatter, so `cb_band - -` is `-`, `cb_verdict` returns `-`, and the
   claim is refused.
3. **Census** — the section must name all four settings and `200000000`, so it
   cannot revert to describing a two-setting arm.

## TDD

```
RED (unfixed docs, test present):
  PASS  extractor reads ids wrapped across two lines
  variation claims examined: 2
  FAIL  no query is called run-to-run variation unless its figures are a measured tie
        got [claims=2 q18(1.01/2.17:-) q31(0.96/1.48:-)]
  FAIL  the tuned-arm section names all four settings and the group-cap value
        got [missing: enable_parallel_vector_agg groupagg_max_groups 200000000]

GREEN (with the docs fix):
  variation claims examined: 0
  tuned-arm settings named on the page: all four + value
  bench_guards.sh: PASSED   (53 checks; the 49 pre-existing intact)

docs_style.sh: PASSED
```

The red step is the removal proof: reverting the docs fix reddens the suite for
the stated reason (`claims=2` with the two query ids, three named-missing tokens),
never with `claims=0`, which would be the extractor breaking rather than the guard
working.

## Not done here

The page still retracts into "the mechanism was measured on a two-setting arm" for
nobody — this PR replaces the false explanation with the measured one, so no
follow-up issue is needed for the mechanism. What remains unmeasured is a published
per-query band for the tuned arm; the harness records the scatter
(`run_clickbench.sh:808`) but computes a verdict only for the default arm, so the
page carries no tuned-arm band to cite. That is a harness change, not a docs one.
