### PR TITLE
fix: import/export and get_storage_id check table privilege (#559, #566)

### DIFF
--- a/src/columnar_arrow.c
+++ b/src/columnar_arrow.c
@@ -986,6 +986,20 @@ pgcolumnar_export_arrow(PG_FUNCTION_ARGS)
 	pathText = PG_GETARG_TEXT_PP(1);
 	path = text_to_cstring(pathText);
 
+	/*
+	 * SELECT on the source, before the file is opened (#559). The server-file
+	 * role above governs writing a file; it says nothing about reading this
+	 * relation, so without this a pg_write_server_files member could dump any
+	 * columnar table it cannot SELECT. The parallel twin already checks this
+	 * (columnar_parallel_export.c:471).
+	 */
+	{
+		AclResult	ac = pg_class_aclcheck(relid, GetUserId(), ACL_SELECT);
+
+		if (ac != ACLCHECK_OK)
+			aclcheck_error(ac, OBJECT_TABLE, get_rel_name(relid));
+	}
+
 	rel = table_open(relid, AccessShareLock);
 	if (!PgColumnarIsColumnarRelation(relid))
 	{
@@ -1761,6 +1775,19 @@ pgcolumnar_import_arrow(PG_FUNCTION_ARGS)
 
 	relid = PG_GETARG_OID(0);
 	path = text_to_cstring(PG_GETARG_TEXT_PP(1));
+
+	/*
+	 * INSERT on the target, before the file is opened (#559). The server-file
+	 * role above governs reading a file; it says nothing about writing this
+	 * relation, so without this a pg_read_server_files member could insert into
+	 * any columnar table it cannot INSERT into.
+	 */
+	{
+		AclResult	ac = pg_class_aclcheck(relid, GetUserId(), ACL_INSERT);
+
+		if (ac != ACLCHECK_OK)
+			aclcheck_error(ac, OBJECT_TABLE, get_rel_name(relid));
+	}
 
 	rel = table_open(relid, RowExclusiveLock);
 	if (!PgColumnarIsColumnarRelation(relid))

--- a/src/columnar_parquet.c
+++ b/src/columnar_parquet.c
@@ -1151,6 +1151,19 @@ pgcolumnar_export_parquet(PG_FUNCTION_ARGS)
 	relid = PG_GETARG_OID(0);
 	path = text_to_cstring(PG_GETARG_TEXT_PP(1));
 
+	/*
+	 * SELECT on the source, before the file is opened (#559). The server-file
+	 * role above governs writing a file; it does not govern reading this
+	 * relation. The parallel twin already checks this
+	 * (columnar_parallel_export.c:471).
+	 */
+	{
+		AclResult	ac = pg_class_aclcheck(relid, GetUserId(), ACL_SELECT);
+
+		if (ac != ACLCHECK_OK)
+			aclcheck_error(ac, OBJECT_TABLE, get_rel_name(relid));
+	}
+
 	rel = table_open(relid, AccessShareLock);
 	if (!PgColumnarIsColumnarRelation(relid))
 	{

--- a/src/columnar_parquet_reader.c
+++ b/src/columnar_parquet_reader.c
@@ -3030,6 +3030,20 @@ pgcolumnar_import_parquet(PG_FUNCTION_ARGS)
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 				 errmsg("must be superuser or a member of the pg_read_server_files role to read a server file")));
 
+	/*
+	 * INSERT on the target, before any file is opened (#559). The server-file
+	 * role above governs reading a file; it says nothing about writing this
+	 * relation, so without this a pg_read_server_files member could insert into
+	 * any columnar table it cannot INSERT into. The parallel twin already checks
+	 * this (columnar_parallel_copy.c:1294).
+	 */
+	{
+		AclResult	ac = pg_class_aclcheck(relid, GetUserId(), ACL_INSERT);
+
+		if (ac != ACLCHECK_OK)
+			aclcheck_error(ac, OBJECT_TABLE, get_rel_name(relid));
+	}
+
 	/* resolve the path (file, directory, or glob) before taking the lock */
 	files = pq_resolve_paths(path);
 

--- a/src/columnar_vacuum.c
+++ b/src/columnar_vacuum.c
@@ -843,6 +843,20 @@ pgcolumnar_relation_storageid(PG_FUNCTION_ARGS)
 	Relation	rel;
 	uint64		storageId;
 
+	/*
+	 * SELECT on the relation (#566). This returns an internal storage identifier
+	 * of a caller-supplied relation and checked nothing, so USAGE on the schema
+	 * was the whole boundary. The value is not otherwise reachable: a role with
+	 * schema USAGE is refused pgcolumnar.storage directly. A reader who may
+	 * SELECT the table may know its storage id; anyone else may not.
+	 */
+	{
+		AclResult	ac = pg_class_aclcheck(relid, GetUserId(), ACL_SELECT);
+
+		if (ac != ACLCHECK_OK)
+			aclcheck_error(ac, OBJECT_TABLE, get_rel_name(relid));
+	}
+
 	rel = try_relation_open(relid, AccessShareLock);
 	if (rel == NULL)
 		PG_RETURN_NULL();

--- a/test/import_export_privilege.sh
+++ b/test/import_export_privilege.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+#
+# pgColumnar: import/export functions check table privilege, not only the
+# server-file role (#559), and get_storage_id checks it too (#566).
+#
+# The four serial import/export functions gated on pg_read_server_files /
+# pg_write_server_files and then checked NO privilege on the relation they read
+# or wrote. So pg_read_server_files conferred INSERT on every columnar table and
+# pg_write_server_files conferred SELECT on every one, exfiltrated to a file. The
+# parallel twins (parallel_copy, parallel_export_parquet) already checked it; the
+# serial four did not. get_storage_id returned an internal storage id of any
+# relation to a role with only schema USAGE.
+#
+# LAYER ISOLATION is the whole point of the role setup. These functions have
+# three refusers BEFORE the new table check: the pgcolumnar schema USAGE, the
+# EXECUTE grant on the function, and the server-file role. A test role missing
+# any of those is refused for a reason that is not the table ACL, and a total
+# removal of the new check would still read as "refused". So the attacker role
+# here holds ALL THREE outer layers and NO privilege on the target table -- the
+# only configuration in which the new pg_class_aclcheck is the sole thing that
+# can refuse. Verified by removal: deleting the five aclcheck blocks makes every
+# makes every deny arm below report "allowed" (the leak), not a different error.
+#
+# The refusal is matched on "permission denied for table", which only
+# aclcheck_error emits, and allow arms prove the owner is not broken by the fix.
+#
+# Usage:  test/import_export_privilege.sh [PG_CONFIG]
+# Written fresh for pgColumnar. Sibling of test/server_file_privilege.sh.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+export PGC_EXTRA_CONF=$'max_prepared_transactions=4\nmax_worker_processes=8'
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+nope="/tmp/pgc_iep_does_not_exist.parquet"
+arrow_out="$PGC_WORKDIR/iep_out.arrow"
+parq_out="$PGC_WORKDIR/iep_out.parquet"
+
+# A columnar table owned by the superuser. The attacker never gets a grant on it.
+psql_run "CREATE TABLE victim (id int, secret text) USING pgcolumnar;"
+psql_run "INSERT INTO victim SELECT g, 'ssn-'||g FROM generate_series(1,200) g;"
+psql_run "REVOKE ALL ON victim FROM PUBLIC;"
+
+# A source file the attacker legitimately produced from her OWN table, so the
+# import arms fail on the target ACL and not on a missing or unreadable file.
+psql_run "CREATE TABLE mine (id int, secret text) USING pgcolumnar;"
+psql_run "DROP ROLE IF EXISTS t_files;"
+psql_run "CREATE ROLE t_files NOSUPERUSER LOGIN;"
+psql_run "GRANT USAGE ON SCHEMA pgcolumnar TO t_files;"
+psql_run "GRANT pg_read_server_files, pg_write_server_files TO t_files;"
+psql_run "ALTER TABLE mine OWNER TO t_files;"
+mine_arrow="$PGC_WORKDIR/mine.arrow"
+mine_parq="$PGC_WORKDIR/mine.parquet"
+psql_run "INSERT INTO mine SELECT g, 'x'||g FROM generate_series(1,50) g;"
+psql_run "SELECT pgcolumnar.export_arrow('mine'::regclass, '$mine_arrow');"
+psql_run "SELECT pgcolumnar.export_parquet('mine'::regclass, '$mine_parq');"
+
+# A DIRECT connection as the role, matching test/native_ownership.sh:22 and the
+# trust auth pgc_setup uses (test/lib.sh:214, initdb -A trust). SET ROLE over a
+# superuser connection was the wrong tool: a failed SET ROLE silently leaves the
+# session as the superuser, so a deny arm reads as noerror for the wrong reason.
+run_as() {	# role sql -> output as that role
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U "$1" \
+		-d "$PGC_DB" -Atq -v ON_ERROR_STOP=0 -c "$2" 2>&1
+}
+# Whether a statement was refused by a table-privilege check, matching the repo
+# idiom (test/native_ownership.sh, test/server_file_privilege.sh grep error text).
+# "permission denied for table/relation" is emitted only by aclcheck_error, so it
+# names the table ACL specifically and not the schema, the grant, or a file error.
+# The role setup isolates this to a single refuser, so text is unambiguous here.
+denied_as() {	# role sql -> denied | allowed
+	local out
+	out="$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U "$1" \
+		-d "$PGC_DB" -Atq -v ON_ERROR_STOP=0 -c "$2" 2>&1)"
+	grep -qiE 'permission denied for (table|relation)' <<<"$out" && echo denied || echo allowed
+}
+
+# ---- premises, each run BY the attacker so a login failure cannot pass a deny -
+check_num "premise: the attacker can open a session" \
+	"$(run_as t_files 'SELECT 1;')" 1
+check "premise: the attacker holds pg_read_server_files" \
+	"$(q "SELECT pg_has_role('t_files','pg_read_server_files','USAGE');")" "t"
+check "premise: the attacker holds pg_write_server_files" \
+	"$(q "SELECT pg_has_role('t_files','pg_write_server_files','USAGE');")" "t"
+check "premise: the attacker reaches the schema (so a refusal is not schema USAGE)" \
+	"$(q "SELECT has_schema_privilege('t_files','pgcolumnar','USAGE');")" "t"
+check "premise: the attacker has NO privilege on victim" \
+	"$(q "SELECT has_table_privilege('t_files','victim','SELECT') OR has_table_privilege('t_files','victim','INSERT');")" "f"
+check "premise: the attacker can execute the functions (so a refusal is the table ACL)" \
+	"$(q "SELECT has_function_privilege('t_files','pgcolumnar.import_parquet(regclass,text)','EXECUTE');")" "t"
+check_num "premise: victim has its rows before any import is attempted" \
+	"$(q "SELECT count(*) FROM victim;")" 200
+check "premise: the attacker's own source files exist" \
+	"$([ -s "$mine_arrow" ] && [ -s "$mine_parq" ] && echo yes || echo no)" "yes"
+
+# ---- the deny arms: the new table ACL is the only thing that can refuse -------
+# Each is "allowed" (leak) on main and "denied" after the ACL fix lands.
+check "import_parquet refuses INSERT into a table the caller cannot write" \
+	"$(denied_as t_files "SELECT pgcolumnar.import_parquet('victim'::regclass, '$mine_parq');")" "denied"
+check "import_arrow refuses INSERT into a table the caller cannot write" \
+	"$(denied_as t_files "SELECT pgcolumnar.import_arrow('victim'::regclass, '$mine_arrow');")" "denied"
+check "export_parquet refuses SELECT of a table the caller cannot read" \
+	"$(denied_as t_files "SELECT pgcolumnar.export_parquet('victim'::regclass, '$parq_out');")" "denied"
+check "export_arrow refuses SELECT of a table the caller cannot read" \
+	"$(denied_as t_files "SELECT pgcolumnar.export_arrow('victim'::regclass, '$arrow_out');")" "denied"
+check "get_storage_id refuses a caller who cannot SELECT the relation" \
+	"$(denied_as t_files "SELECT pgcolumnar.get_storage_id('victim'::regclass);")" "denied"
+
+# ---- the consequence: no rows leaked in or out -------------------------------
+check_num "victim still holds exactly its own rows (no import landed)" \
+	"$(q "SELECT count(*) FROM victim;")" 200
+check "no victim file was written by the export attempts" \
+	"$([ -e "$parq_out" ] || [ -e "$arrow_out" ] && echo written || echo none)" "none"
+
+# ---- allow arms: the owner is not broken by the fix --------------------------
+# t_files owns 'mine' and may read and write it, so the same calls must succeed.
+check "the owner can still export_arrow its own table" \
+	"$(denied_as t_files "SELECT pgcolumnar.export_arrow('mine'::regclass, '$PGC_WORKDIR/mine2.arrow');")" "allowed"
+check "the owner can still export_parquet its own table" \
+	"$(denied_as t_files "SELECT pgcolumnar.export_parquet('mine'::regclass, '$PGC_WORKDIR/mine2.parquet');")" "allowed"
+check "the owner can still read its own storage id" \
+	"$(denied_as t_files "SELECT pgcolumnar.get_storage_id('mine'::regclass);")" "allowed"
+check "the owner can still import into its own table" \
+	"$(denied_as t_files "SELECT pgcolumnar.import_arrow('mine'::regclass, '$mine_arrow');")" "allowed"
+
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -76,6 +76,7 @@ SUITES=(
 	harness_selftest
 	import_deferred
 	import_exclusion
+	import_export_privilege
 	index_only
 	isolation
 	logical_subscriber


### PR DESCRIPTION
Closes #559 and #566. **Not merging it.**

## What was wrong

The four serial import/export functions gated on the server-file role and then
checked **no** privilege on the relation they read or wrote. So
`pg_read_server_files` conferred `INSERT` on every columnar table and
`pg_write_server_files` conferred `SELECT` on every one, exfiltrated to a file.
`get_storage_id` returned an internal storage identifier of any relation to a role
with only schema `USAGE`. The parallel twins (`parallel_copy`,
`parallel_export_parquet`) already made the check; these five did not.

Reproduced on main before the fix (a `NOSUPERUSER` role holding both server-file
roles and no grant on `bobsecret`): all four import/export calls succeeded, the
row count moved, and `strings` recovered the plaintext. After the fix the same
calls return `permission denied for table bobsecret` and the row count is
untouched.

## The change

Five `pg_class_aclcheck` blocks, matching the in-tree idiom at
`columnar_parallel_export.c:471`, placed **before** `table_open` so the privilege
check runs before the lock and before the is-columnar check (privilege first):

| function | check | file |
| --- | --- | --- |
| `import_arrow` | `ACL_INSERT` | `columnar_arrow.c` |
| `import_parquet` | `ACL_INSERT` | `columnar_parquet_reader.c` |
| `export_arrow` | `ACL_SELECT` | `columnar_arrow.c` |
| `export_parquet` | `ACL_SELECT` | `columnar_parquet.c` |
| `get_storage_id` | `ACL_SELECT` | `columnar_vacuum.c` |

`ACL_SELECT` for `get_storage_id` rather than ownership: the value is not
otherwise reachable (a role with schema `USAGE` is refused `pgcolumnar.storage`
directly), and a role that may `SELECT` the table may know its storage id.

## The test asserts layer isolation, not just a refusal

`test/import_export_privilege.sh` (new, registered sorted; 140 suites). These
functions have **three** refusers before the new table check: schema `USAGE`, the
`EXECUTE` grant, and the server-file role. A role missing any of them is refused
for the wrong reason, and a total removal of the new check would still read as
"refused". So the attacker role holds **all three outer layers and no privilege
on the target** — the only configuration in which the new `pg_class_aclcheck` is
the sole thing that can refuse. (This is the correction @jdatcmd made to the
SQLSTATE advice: a two/three-layer fix needs the outer layers granted, or they
mask the inner one.)

Refusal is matched on `permission denied for table`, which only `aclcheck_error`
emits, so it names the table ACL specifically and not the schema, the grant, or a
file error. The role connects directly (trust auth, per `native_ownership.sh`),
not via `SET ROLE` over a superuser session — a failed `SET ROLE` leaves the
session as the superuser and a deny arm then reads as allowed for the wrong
reason. Allow arms prove the owner is not broken by the fix.

## TDD, `.so` fingerprinted per arm

```
RED   (unfixed main, test present)   .so ba39cc55   0 aclcheck blocks
      FAIL import_parquet ... got [allowed] want [denied]
      FAIL import_arrow / export_parquet / export_arrow / get_storage_id  (all leak)
      -> the fix is load-bearing: without it, all five leak

GREEN (full fix)                     .so d86c99e3   5 aclcheck blocks
      import_export_privilege.sh: PASSED (19 checks)
```

The RED arm is the removal proof: on unfixed main every deny arm reports the call
**succeeding**, which is the leak itself, not an absent refusal. The `.so` md5
differs between arms, so neither measured a stale binary.

## Not in this PR

The class assertion that every relation-taking entry point is bucketed and none
is forgotten belongs in #572 (@jdatcmd's enumerated privilege suite), not here —
per the split agreed on #569. This PR carries the per-function behavioural arms
for the five it fixes; #572 carries the enumeration that proves the set is
complete.

## Gate

Full matrix, both majors the per-PR cadence names: **ALL VERSIONS PASSED** —
PG18 (138 ran, 2 skipped), PG19 (140 ran, 0 skipped), `import_export_privilege=PASS`
on both.
