### PR TITLE
fix: vacuum, vacuum_sorted and cluster check ownership before the lock (#568)

### DIFF
--- a/src/columnar_vacuum.c
+++ b/src/columnar_vacuum.c
@@ -82,6 +82,21 @@ PgColumnarRequireTableOwner(Relation rel)
 					   RelationGetRelationName(rel));
 }
 
+/*
+ * Same check on an Oid, for callers that must refuse BEFORE table_open (#568).
+ * vacuum, vacuum_sorted and cluster open with AccessExclusiveLock, which queues
+ * in the lock FIFO ahead of readers. An unprivileged caller that reached
+ * table_open would sit in that queue and block every reader of a table it does
+ * not own until its own lock request was resolved, so it has to be turned away
+ * before the lock is requested rather than after it is held.
+ */
+static void
+PgColumnarRequireTableOwnerByOid(Oid relid)
+{
+	if (!COLUMNAR_TABLE_OWNERCHECK(relid))
+		aclcheck_error(ACLCHECK_NOT_OWNER, OBJECT_TABLE, get_rel_name(relid));
+}
+
 /* Z-order helpers (defined later, used by the online recluster below) */
 static bool cluster_type_supported(Oid typid);
 static bytea *cluster_zorder_key(Datum *values, bool *isnull, AttrNumber *atts,
@@ -1289,6 +1304,10 @@ pgcolumnar_vacuum(PG_FUNCTION_ARGS)
 	Oid			relid = PG_GETARG_OID(0);
 	Relation	rel;
 
+	/* Ownership before the AccessExclusiveLock, so a non-owner cannot queue in
+	 * the lock FIFO and block readers of a table it does not own (#568). */
+	PgColumnarRequireTableOwnerByOid(relid);
+
 	rel = table_open(relid, AccessExclusiveLock);
 
 	if (!PgColumnarIsColumnarRelation(relid))
@@ -1299,8 +1318,6 @@ pgcolumnar_vacuum(PG_FUNCTION_ARGS)
 				 errmsg("relation \"%s\" is not a columnar table",
 						RelationGetRelationName(rel))));
 	}
-
-	PgColumnarRequireTableOwner(rel);
 
 	pgcolumnar_compact_relation(rel, 0, NULL);
 
@@ -1345,6 +1362,9 @@ pgcolumnar_vacuum_sorted(PG_FUNCTION_ARGS)
 				 errmsg("table name cannot be null")));
 	relid = PG_GETARG_OID(0);
 
+	/* Ownership before the AccessExclusiveLock (#568), as in pgcolumnar_vacuum. */
+	PgColumnarRequireTableOwnerByOid(relid);
+
 	rel = table_open(relid, AccessExclusiveLock);
 
 	if (!PgColumnarIsColumnarRelation(relid))
@@ -1355,8 +1375,6 @@ pgcolumnar_vacuum_sorted(PG_FUNCTION_ARGS)
 				 errmsg("relation \"%s\" is not a columnar table",
 						RelationGetRelationName(rel))));
 	}
-
-	PgColumnarRequireTableOwner(rel);
 
 	/*
 	 * Collect the sort-column names. Explicit columns win; when none are given
@@ -1515,6 +1533,9 @@ pgcolumnar_cluster(PG_FUNCTION_ARGS)
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("Z-order clustering supports at most 8 columns")));
 
+	/* Ownership before the AccessExclusiveLock (#568), as in pgcolumnar_vacuum. */
+	PgColumnarRequireTableOwnerByOid(relid);
+
 	rel = table_open(relid, AccessExclusiveLock);
 
 	if (!PgColumnarIsColumnarRelation(relid))
@@ -1525,8 +1546,6 @@ pgcolumnar_cluster(PG_FUNCTION_ARGS)
 				 errmsg("relation \"%s\" is not a columnar table",
 						RelationGetRelationName(rel))));
 	}
-
-	PgColumnarRequireTableOwner(rel);
 
 	tupdesc = RelationGetDescr(rel);
 	atts = palloc(ncols * sizeof(AttrNumber));

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -173,6 +173,7 @@ SUITES=(
 	temporal
 	ungrouped_vector_agg
 	unique_conc
+	vacuum_lock_privilege
 	vm_privilege
 	wal_envelope
 	write_fsst_compressed

--- a/test/vacuum_lock_privilege.sh
+++ b/test/vacuum_lock_privilege.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# pgColumnar: vacuum, vacuum_sorted and cluster check ownership BEFORE taking the
+# AccessExclusiveLock (#568), so an unprivileged caller cannot queue in the lock
+# FIFO and block readers of a table it does not own.
+#
+# A plain "a non-owner is refused" test is NOT a removal proof here: on unfixed
+# main the non-owner IS refused, just after table_open has already taken (or
+# queued for) the exclusive lock. The observable that separates the two orderings
+# is contention. This suite holds an AccessExclusiveLock on the table in another
+# session and then calls the function as a non-owner with a short lock_timeout:
+#
+#   fix (privilege first): refused with "must be owner" immediately, no lock wait.
+#   main (lock first):     the caller queues behind the held lock and hits the
+#                          lock_timeout -- proof it requested the exclusive lock
+#                          before its ownership was ever checked.
+#
+# So the deny arms assert the refusal is an OWNERSHIP error and not a lock
+# timeout. On main they see a lock timeout and go red; that red is the proof.
+#
+# Usage:  test/vacuum_lock_privilege.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+psql_run "CREATE TABLE victim (id int, v int) USING pgcolumnar;"
+psql_run "INSERT INTO victim SELECT g, g FROM generate_series(1,2000) g;"
+psql_run "REVOKE ALL ON victim FROM PUBLIC;"
+psql_run "DROP ROLE IF EXISTS t_unpriv;"
+psql_run "CREATE ROLE t_unpriv NOSUPERUSER LOGIN;"
+psql_run "GRANT USAGE ON SCHEMA pgcolumnar TO t_unpriv;"
+
+as_super() { env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" -Atq -v ON_ERROR_STOP=0 "$@" 2>&1; }
+
+# Classify an unprivileged call made WHILE an exclusive lock is held on victim.
+# Returns: owner (refused by ownership, before the lock) | locktimeout (queued
+# for the lock, so ownership was checked too late) | other | success.
+outcome_under_contention() {	# sql -> owner|locktimeout|other|success
+	local out
+	out="$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U t_unpriv \
+		-d "$PGC_DB" -Atq -v ON_ERROR_STOP=0 \
+		-c "SET lock_timeout='4s';" -c "$1" 2>&1)"
+	case "$out" in
+		*"must be owner"*|*"permission denied for"*) echo owner ;;
+		*"lock timeout"*|*"canceling statement due to lock"*) echo locktimeout ;;
+		*ERROR*) echo "other:${out:0:50}" ;;
+		*) echo success ;;
+	esac
+}
+
+# ---- premises ---------------------------------------------------------------
+check_num "premise: the caller can open a session" \
+	"$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U t_unpriv -d "$PGC_DB" -Atq -c 'SELECT 1;' 2>&1)" 1
+check "premise: the caller is not the owner of victim" \
+	"$(q "SELECT pg_get_userbyid(relowner)='t_unpriv' FROM pg_class WHERE oid='victim'::regclass;")" "f"
+check "premise: victim is a columnar table" \
+	"$(q "SELECT a.amname FROM pg_class c JOIN pg_am a ON a.oid=c.relam WHERE c.oid='victim'::regclass;")" "pgcolumnar"
+
+# ---- hold an AccessExclusiveLock on victim in a background session ----------
+# The holder keeps a transaction open with the lock for the window below, then
+# rolls back. Its own lock conflicts with the exclusive lock vacuum/cluster take,
+# so an unfixed caller queues behind it.
+holder_log="$PGC_WORKDIR/holder.log"
+as_super -c "BEGIN;" -c "LOCK TABLE victim IN ACCESS EXCLUSIVE MODE;" -c "SELECT pg_sleep(30);" -c "ROLLBACK;" > "$holder_log" 2>&1 &
+holder_pid=$!
+# Wait until the lock is actually granted before probing, so the test is not racing
+for _ in $(seq 1 40); do
+	held="$(q "SELECT count(*) FROM pg_locks l JOIN pg_class c ON c.oid=l.relation WHERE c.relname='victim' AND l.mode='AccessExclusiveLock' AND l.granted;")"
+	[ "${held:-0}" -ge 1 ] && break
+	sleep 0.25
+done
+check "premise: an AccessExclusiveLock on victim is held before the probes" "${held:-0}" "1"
+
+# ---- the deny arms: refused by ownership, not by a lock wait ----------------
+check "vacuum refuses a non-owner before taking the exclusive lock" \
+	"$(outcome_under_contention "SELECT pgcolumnar.vacuum('victim'::regclass);")" "owner"
+check "vacuum_sorted refuses a non-owner before taking the exclusive lock" \
+	"$(outcome_under_contention "SELECT pgcolumnar.vacuum_sorted('victim'::regclass, 'id');")" "owner"
+check "cluster refuses a non-owner before taking the exclusive lock" \
+	"$(outcome_under_contention "SELECT pgcolumnar.cluster('victim'::regclass, 'id');")" "owner"
+
+# The caller must never have entered the lock queue: no ungranted request from it.
+check "the refused caller left no lock request queued on victim" \
+	"$(q "SELECT count(*) FROM pg_locks l JOIN pg_class c ON c.oid=l.relation JOIN pg_stat_activity a ON a.pid=l.pid WHERE c.relname='victim' AND a.usename='t_unpriv' AND NOT l.granted;")" "0"
+
+# release the holder
+as_super -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query LIKE '%pg_sleep(30)%' AND pid <> pg_backend_pid();" >/dev/null 2>&1
+wait "$holder_pid" 2>/dev/null || true
+
+# ---- allow arm: the owner is not broken (uncontended) -----------------------
+check "the owner can still vacuum the table" \
+	"$(as_super -c "SELECT pgcolumnar.vacuum('victim'::regclass);" | grep -c 'ERROR')" "0"
+
+pgc_summary


### PR DESCRIPTION
Closes #568. **Not merging it.**

`pgcolumnar.vacuum`, `pgcolumnar.vacuum_sorted` and `pgcolumnar.cluster` opened the
target with `table_open(relid, AccessExclusiveLock)` and only then checked
ownership (`PgColumnarRequireTableOwner`). `AccessExclusiveLock` queues in the lock
FIFO ahead of readers, so an unprivileged caller reached the queue before being
refused — and a pending `AccessExclusiveLock` request blocks every subsequent
reader. So any role with `USAGE` on the schema could stall reads of a table it
does not own, on a table under any concurrent read, until its own doomed request
resolved. #568 (found and measured by @jdatcmd).

## The change

A relid-based owner check, `PgColumnarRequireTableOwnerByOid`, called **before**
`table_open` in all three functions. `COLUMNAR_TABLE_OWNERCHECK` reads `pg_class`
and needs no lock on the target, so an unprivileged caller is turned away before
it ever requests the exclusive lock. The now-redundant post-lock
`PgColumnarRequireTableOwner(rel)` is removed from these three (the eight other
call sites are unchanged).

## The test proves the ordering, not just the refusal

`test/vacuum_lock_privilege.sh` (new, registered sorted; 140 suites). A plain
"a non-owner is refused" check is **not** a removal proof here — on unfixed main
the non-owner is still refused, only after the lock has been taken. The observable
that separates the two orderings is contention:

The suite holds an `ACCESS EXCLUSIVE` lock on the table in a background session,
then calls each function as a non-owner with `lock_timeout='4s'`:

- **fix (privilege first):** refused with "must be owner" immediately.
- **main (lock first):** the caller queues behind the held lock and hits the
  `lock_timeout` — which is the proof it requested the exclusive lock before its
  ownership was ever checked.

So the deny arms assert the outcome is an **ownership** error and not a lock
timeout, plus a `pg_locks` check that the refused caller left no queued request.

## TDD, `.so` fingerprinted per arm

```
RED   (unfixed main, test present)   .so ba39cc55   RequireTableOwnerByOid: 0
      FAIL vacuum        ... got [locktimeout] want [owner]
      FAIL vacuum_sorted ... got [locktimeout] want [owner]
      FAIL cluster       ... got [locktimeout] want [owner]

GREEN (fix)                          .so 3831f3c6   RequireTableOwnerByOid: 4
      vacuum_lock_privilege.sh: PASSED (9 checks)
```

`got [locktimeout]` on main is the DoS itself: the unprivileged caller sat in the
lock queue behind the held lock. The `.so` md5 differs between arms.

## Scope

`#560`'s two defects (the ignored `stripe_count` argument and `stats()` being
refused for a table's own owner) touch the same file but are separate decisions —
`stripe_count` is a remove-vs-warn API question and `stats()` is a wider
catalog-ACL class — so they are left for their own change rather than bundled with
this proven lock-ordering fix.

## Gate

Full matrix: **ALL VERSIONS PASSED** — PG18 (138 ran, 2 skipped), PG19 (140 ran,
0 skipped), `vacuum_lock_privilege=PASS` on both.
