### PR TITLE
fix: refuse pgcolumnar.vacuum's stripe_count instead of ignoring it (#560)

### DIFF
--- a/docs/sql-reference.md
+++ b/docs/sql-reference.md
@@ -54,8 +54,8 @@ after many small load transactions have produced many small row groups.
 
 `stripe_count` is not supported and a non-zero value raises an error. The
 argument is retained so existing calls that pass the default keep working. It was
-documented as bounding how many row groups are combined in one call, and it was
-never read: every call rewrote the whole relation regardless of the value.
+documented as bounding how many row groups are combined in one call. It was never
+read, and every call rewrote the whole relation regardless of the value.
 
 To bound the work, use
 [`pgcolumnar.compact_rewrite`](#pgcolumnarcompact_rewriterel-regclass-min_deleted_fraction-float8-max_groups-int),

--- a/docs/sql-reference.md
+++ b/docs/sql-reference.md
@@ -52,8 +52,14 @@ Compacts a columnar table by combining small row groups and reclaiming space hel
 by rows that were deleted or updated. Use it after bulk deletes or updates, or
 after many small load transactions have produced many small row groups.
 
-`stripe_count` bounds how many row groups are combined in one call; `0` places no
-bound.
+`stripe_count` is not supported and a non-zero value raises an error. The
+argument is retained so existing calls that pass the default keep working. It was
+documented as bounding how many row groups are combined in one call, and it was
+never read: every call rewrote the whole relation regardless of the value.
+
+To bound the work, use
+[`pgcolumnar.compact_rewrite`](#pgcolumnarcompact_rewriterel-regclass-min_deleted_fraction-float8-max_groups-int),
+whose `max_groups` does limit how many row groups are rewritten.
 
 ```sql
 SELECT pgcolumnar.vacuum('events');
@@ -160,7 +166,10 @@ SELECT pgcolumnar.truncate('events');
 ### pgcolumnar.vacuum_full(schema name DEFAULT 'public', sleep_time real DEFAULT 0.0, stripe_count int DEFAULT 0)
 
 Runs `pgcolumnar.vacuum` on every columnar table in a schema. `sleep_time` is a
-pause in seconds between tables. Each call receives the same `stripe_count`.
+pause in seconds between tables.
+
+`stripe_count` is passed through to `pgcolumnar.vacuum` and is subject to the same
+restriction: a non-zero value raises an error.
 
 ```sql
 SELECT pgcolumnar.vacuum_full('public');

--- a/src/columnar_vacuum.c
+++ b/src/columnar_vacuum.c
@@ -82,6 +82,21 @@ PgColumnarRequireTableOwner(Relation rel)
 					   RelationGetRelationName(rel));
 }
 
+/*
+ * Same check on an Oid, for callers that must refuse BEFORE table_open (#568).
+ * vacuum, vacuum_sorted and cluster open with AccessExclusiveLock, which queues
+ * in the lock FIFO ahead of readers. An unprivileged caller that reached
+ * table_open would sit in that queue and block every reader of a table it does
+ * not own until its own lock request was resolved, so it has to be turned away
+ * before the lock is requested rather than after it is held.
+ */
+static void
+PgColumnarRequireTableOwnerByOid(Oid relid)
+{
+	if (!COLUMNAR_TABLE_OWNERCHECK(relid))
+		aclcheck_error(ACLCHECK_NOT_OWNER, OBJECT_TABLE, get_rel_name(relid));
+}
+
 /* Z-order helpers (defined later, used by the online recluster below) */
 static bool cluster_type_supported(Oid typid);
 static bytea *cluster_zorder_key(Datum *values, bool *isnull, AttrNumber *atts,
@@ -1289,6 +1304,10 @@ pgcolumnar_vacuum(PG_FUNCTION_ARGS)
 	Oid			relid = PG_GETARG_OID(0);
 	Relation	rel;
 
+	/* Ownership before the AccessExclusiveLock, so a non-owner cannot queue in
+	 * the lock FIFO and block readers of a table it does not own (#568). */
+	PgColumnarRequireTableOwnerByOid(relid);
+
 	rel = table_open(relid, AccessExclusiveLock);
 
 	if (!PgColumnarIsColumnarRelation(relid))
@@ -1299,8 +1318,6 @@ pgcolumnar_vacuum(PG_FUNCTION_ARGS)
 				 errmsg("relation \"%s\" is not a columnar table",
 						RelationGetRelationName(rel))));
 	}
-
-	PgColumnarRequireTableOwner(rel);
 
 	pgcolumnar_compact_relation(rel, 0, NULL);
 
@@ -1345,6 +1362,9 @@ pgcolumnar_vacuum_sorted(PG_FUNCTION_ARGS)
 				 errmsg("table name cannot be null")));
 	relid = PG_GETARG_OID(0);
 
+	/* Ownership before the AccessExclusiveLock (#568), as in pgcolumnar_vacuum. */
+	PgColumnarRequireTableOwnerByOid(relid);
+
 	rel = table_open(relid, AccessExclusiveLock);
 
 	if (!PgColumnarIsColumnarRelation(relid))
@@ -1355,8 +1375,6 @@ pgcolumnar_vacuum_sorted(PG_FUNCTION_ARGS)
 				 errmsg("relation \"%s\" is not a columnar table",
 						RelationGetRelationName(rel))));
 	}
-
-	PgColumnarRequireTableOwner(rel);
 
 	/*
 	 * Collect the sort-column names. Explicit columns win; when none are given
@@ -1515,6 +1533,9 @@ pgcolumnar_cluster(PG_FUNCTION_ARGS)
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("Z-order clustering supports at most 8 columns")));
 
+	/* Ownership before the AccessExclusiveLock (#568), as in pgcolumnar_vacuum. */
+	PgColumnarRequireTableOwnerByOid(relid);
+
 	rel = table_open(relid, AccessExclusiveLock);
 
 	if (!PgColumnarIsColumnarRelation(relid))
@@ -1525,8 +1546,6 @@ pgcolumnar_cluster(PG_FUNCTION_ARGS)
 				 errmsg("relation \"%s\" is not a columnar table",
 						RelationGetRelationName(rel))));
 	}
-
-	PgColumnarRequireTableOwner(rel);
 
 	tupdesc = RelationGetDescr(rel);
 	atts = palloc(ncols * sizeof(AttrNumber));

--- a/src/columnar_vacuum.c
+++ b/src/columnar_vacuum.c
@@ -1304,6 +1304,38 @@ pgcolumnar_vacuum(PG_FUNCTION_ARGS)
 	Oid			relid = PG_GETARG_OID(0);
 	Relation	rel;
 
+	/*
+	 * stripe_count is refused rather than honoured (#560).
+	 *
+	 * It was documented as bounding how many row groups are combined in one
+	 * call, and it has never been read: this function fetched argument 0 and
+	 * passed a literal 0 as the bound. A caller asking for a bound of 4 got an
+	 * unbounded whole-relation rewrite and no indication of it.
+	 *
+	 * Honouring it is not a small change and must not be attempted here.
+	 * pgcolumnar_compact_relation's second parameter is nsortkeys, not a bound,
+	 * and its body dereferences sortAtts[i]. More seriously it swaps the whole
+	 * relation to a NEW relfilenode, so rewriting only some row groups would
+	 * leave the rest behind in storage that is then discarded. Bounded
+	 * compaction is a different algorithm, and one already exists:
+	 * pgcolumnar.compact_rewrite passes its max_groups through to
+	 * pgcolumnar_rewrite_partial_groups.
+	 *
+	 * So refuse, and name the thing that works. An accepted-and-ignored
+	 * argument is a documented promise the code does not keep; an error is the
+	 * only answer that is both truthful and non-breaking for the default form.
+	 */
+	if (!PG_ARGISNULL(1) && PG_GETARG_INT32(1) != 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("pgcolumnar.vacuum does not support a stripe_count bound"),
+				 errdetail("The argument was accepted and ignored in earlier "
+						   "releases: every call rewrote the whole relation."),
+				 errhint("Use pgcolumnar.compact_rewrite(rel, min_deleted_fraction, "
+						 "max_groups), which bounds the number of row groups it "
+						 "rewrites, or omit stripe_count to rewrite the whole "
+						 "relation.")));
+
 	/* Ownership before the AccessExclusiveLock, so a non-owner cannot queue in
 	 * the lock FIFO and block readers of a table it does not own (#568). */
 	PgColumnarRequireTableOwnerByOid(relid);

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -174,12 +174,12 @@ SUITES=(
 	ungrouped_vector_agg
 	unique_conc
 	vacuum_lock_privilege
+	vacuum_stripe_count
 	vm_privilege
 	wal_envelope
 	write_fsst_compressed
 	write_minmax_fastpath
-	zonemap_cost
-)
+	zonemap_cost)
 
 
 # ---------------------------------------------------------------------------

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -173,6 +173,7 @@ SUITES=(
 	temporal
 	ungrouped_vector_agg
 	unique_conc
+	vacuum_lock_privilege
 	vm_privilege
 	wal_envelope
 	write_fsst_compressed

--- a/test/vacuum_lock_privilege.sh
+++ b/test/vacuum_lock_privilege.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# pgColumnar: vacuum, vacuum_sorted and cluster check ownership BEFORE taking the
+# AccessExclusiveLock (#568), so an unprivileged caller cannot queue in the lock
+# FIFO and block readers of a table it does not own.
+#
+# A plain "a non-owner is refused" test is NOT a removal proof here: on unfixed
+# main the non-owner IS refused, just after table_open has already taken (or
+# queued for) the exclusive lock. The observable that separates the two orderings
+# is contention. This suite holds an AccessExclusiveLock on the table in another
+# session and then calls the function as a non-owner with a short lock_timeout:
+#
+#   fix (privilege first): refused with "must be owner" immediately, no lock wait.
+#   main (lock first):     the caller queues behind the held lock and hits the
+#                          lock_timeout -- proof it requested the exclusive lock
+#                          before its ownership was ever checked.
+#
+# So the deny arms assert the refusal is an OWNERSHIP error and not a lock
+# timeout. On main they see a lock timeout and go red; that red is the proof.
+#
+# Usage:  test/vacuum_lock_privilege.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+psql_run "CREATE TABLE victim (id int, v int) USING pgcolumnar;"
+psql_run "INSERT INTO victim SELECT g, g FROM generate_series(1,2000) g;"
+psql_run "REVOKE ALL ON victim FROM PUBLIC;"
+psql_run "DROP ROLE IF EXISTS t_unpriv;"
+psql_run "CREATE ROLE t_unpriv NOSUPERUSER LOGIN;"
+psql_run "GRANT USAGE ON SCHEMA pgcolumnar TO t_unpriv;"
+
+as_super() { env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" -Atq -v ON_ERROR_STOP=0 "$@" 2>&1; }
+
+# Classify an unprivileged call made WHILE an exclusive lock is held on victim.
+# Returns: owner (refused by ownership, before the lock) | locktimeout (queued
+# for the lock, so ownership was checked too late) | other | success.
+outcome_under_contention() {	# sql -> owner|locktimeout|other|success
+	local out
+	out="$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U t_unpriv \
+		-d "$PGC_DB" -Atq -v ON_ERROR_STOP=0 \
+		-c "SET lock_timeout='4s';" -c "$1" 2>&1)"
+	case "$out" in
+		*"must be owner"*|*"permission denied for"*) echo owner ;;
+		*"lock timeout"*|*"canceling statement due to lock"*) echo locktimeout ;;
+		*ERROR*) echo "other:${out:0:50}" ;;
+		*) echo success ;;
+	esac
+}
+
+# ---- premises ---------------------------------------------------------------
+check_num "premise: the caller can open a session" \
+	"$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U t_unpriv -d "$PGC_DB" -Atq -c 'SELECT 1;' 2>&1)" 1
+check "premise: the caller is not the owner of victim" \
+	"$(q "SELECT pg_get_userbyid(relowner)='t_unpriv' FROM pg_class WHERE oid='victim'::regclass;")" "f"
+check "premise: victim is a columnar table" \
+	"$(q "SELECT a.amname FROM pg_class c JOIN pg_am a ON a.oid=c.relam WHERE c.oid='victim'::regclass;")" "pgcolumnar"
+
+# ---- hold an AccessExclusiveLock on victim in a background session ----------
+# The holder keeps a transaction open with the lock for the window below, then
+# rolls back. Its own lock conflicts with the exclusive lock vacuum/cluster take,
+# so an unfixed caller queues behind it.
+holder_log="$PGC_WORKDIR/holder.log"
+as_super -c "BEGIN;" -c "LOCK TABLE victim IN ACCESS EXCLUSIVE MODE;" -c "SELECT pg_sleep(30);" -c "ROLLBACK;" > "$holder_log" 2>&1 &
+holder_pid=$!
+# Wait until the lock is actually granted before probing, so the test is not racing
+for _ in $(seq 1 40); do
+	held="$(q "SELECT count(*) FROM pg_locks l JOIN pg_class c ON c.oid=l.relation WHERE c.relname='victim' AND l.mode='AccessExclusiveLock' AND l.granted;")"
+	[ "${held:-0}" -ge 1 ] && break
+	sleep 0.25
+done
+check "premise: an AccessExclusiveLock on victim is held before the probes" "${held:-0}" "1"
+
+# ---- the deny arms: refused by ownership, not by a lock wait ----------------
+check "vacuum refuses a non-owner before taking the exclusive lock" \
+	"$(outcome_under_contention "SELECT pgcolumnar.vacuum('victim'::regclass);")" "owner"
+check "vacuum_sorted refuses a non-owner before taking the exclusive lock" \
+	"$(outcome_under_contention "SELECT pgcolumnar.vacuum_sorted('victim'::regclass, 'id');")" "owner"
+check "cluster refuses a non-owner before taking the exclusive lock" \
+	"$(outcome_under_contention "SELECT pgcolumnar.cluster('victim'::regclass, 'id');")" "owner"
+
+# The caller must never have entered the lock queue: no ungranted request from it.
+check "the refused caller left no lock request queued on victim" \
+	"$(q "SELECT count(*) FROM pg_locks l JOIN pg_class c ON c.oid=l.relation JOIN pg_stat_activity a ON a.pid=l.pid WHERE c.relname='victim' AND a.usename='t_unpriv' AND NOT l.granted;")" "0"
+
+# release the holder
+as_super -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query LIKE '%pg_sleep(30)%' AND pid <> pg_backend_pid();" >/dev/null 2>&1
+wait "$holder_pid" 2>/dev/null || true
+
+# ---- allow arm: the owner is not broken (uncontended) -----------------------
+check "the owner can still vacuum the table" \
+	"$(as_super -c "SELECT pgcolumnar.vacuum('victim'::regclass);" | grep -c 'ERROR')" "0"
+
+pgc_summary

--- a/test/vacuum_stripe_count.sh
+++ b/test/vacuum_stripe_count.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+#
+# pgColumnar: pgcolumnar.vacuum's stripe_count is refused, not silently ignored (#560).
+#
+# docs/sql-reference.md documented `stripe_count` as bounding how many row groups
+# are combined in one call. The C function reads PG_GETARG_OID(0) and nothing
+# else, and passes a literal 0 to pgcolumnar_compact_relation, so the argument
+# has never done anything.
+#
+# HONOURING IT IS NOT AN OPTION, and that is the whole reason this fix refuses
+# rather than implements. pgcolumnar_compact_relation's second parameter is
+# nsortkeys, not a bound, and its body dereferences sortAtts[i]. More seriously,
+# it swaps the whole relation to a NEW RELFILENODE, so a partial rewrite of some
+# row groups would leave the rest behind and destroy them. A bounded compaction
+# is a different algorithm, not a parameter.
+#
+# pgcolumnar.compact_rewrite(rel, min_deleted_fraction, max_groups) already does
+# bounded work: its maxGroups reaches pgcolumnar_rewrite_partial_groups. So the
+# refusal can name a function that actually works, which is what makes an ERROR
+# defensible rather than merely honest.
+#
+# vacuum_full carries the same argument and PASSES IT THROUGH to
+# pgcolumnar.vacuum, so it inherits the refusal without its own change. That
+# propagation is asserted here, because it is the only thing making the second
+# instance safe.
+#
+# Usage:  test/vacuum_stripe_count.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+# NGROUPS, not GROUPS. GROUPS is a bash BUILT-IN array holding the invoking
+# user's group ids, so the assignment is silently discarded and the name expands
+# to the first gid (0 for root in the test container). That made `seq 1` empty,
+# so the fixture built NOTHING, and every premise below compared 0 with 0 and
+# PASSED. A suite that measured an empty table and reported success.
+#
+# stripe_row_limit also has a floor of 1000: set_options raises below it, on
+# stderr, which a suite reading only stdout never sees.
+NGROUPS=6
+ROWS_PER=1000
+STRIPE_LIMIT=100000
+
+build_fixture() {
+	psql_run "DROP TABLE IF EXISTS vsc;"
+	psql_run "CREATE TABLE vsc (id int, v text) USING pgcolumnar;"
+	psql_run "SELECT pgcolumnar.set_options('vsc', stripe_row_limit => $STRIPE_LIMIT, chunk_group_row_limit => $ROWS_PER);"
+	for _i in $(seq 1 $NGROUPS); do
+		psql_run "INSERT INTO vsc SELECT g, 'v'||g FROM generate_series(1,$ROWS_PER) g;"
+	done
+}
+groups_now() { q "SELECT count(*) FROM pgcolumnar.stats('vsc');"; }
+rows_now()   { q "SELECT count(*) FROM vsc;"; }
+
+err_of() {  # err_of <sql> -> the ERROR line, connfail, or the literal noerror
+	#
+	# -U postgres is not optional and its absence is why this helper had to be
+	# rewritten. Without it psql connects as the OS user, which is not a role
+	# here, so every call failed at connect. psql reports that as a LOWERCASE
+	# "psql: error:", which the ERROR: case below does not match, so the helper
+	# returned "noerror" and a call that never reached the server read as a
+	# successful one. Every arm using it was green for the wrong reason.
+	#
+	# So connect the way lib.sh does, and give a connection failure its OWN token
+	# rather than letting it fall through to the success branch. An arm can then
+	# never pass because the server was unreachable.
+	local out
+	out="$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -At -v ON_ERROR_STOP=0 -c "$1" 2>&1)"
+	case "$out" in
+		*"psql: error"*|*"could not connect"*|*"FATAL:"*) echo connfail ;;
+		*ERROR:*) printf '%s\n' "$out" | grep -m1 'ERROR:' ;;
+		*)        echo noerror ;;
+	esac
+}
+
+# The helper is itself a claim, so prove it can say all three things before any
+# arm depends on it. Without this, the rewrite above could have been wrong in a
+# new way and every arm would still have looked fine.
+check "premise: err_of reports a clean call"      "$(err_of 'SELECT 1;')" "noerror"
+check "premise: err_of reports a real error"      "$(err_of 'SELECT 1/0;' | grep -c 'ERROR:')" "1"
+check "premise: err_of cannot mistake an unreachable server for success" \
+	"$(PGC_PORT=1 err_of 'SELECT 1;')" "connfail"
+
+# Guard against the failure that produced the comment above: if the fixture
+# constants are zero, every arm compares 0 with 0 and passes on an empty table.
+check "premise: the fixture constants are non-zero, so the arms can fail" \
+	"$([ "${NGROUPS:-0}" -gt 1 ] && [ "${ROWS_PER:-0}" -ge 1000 ] && echo sane || echo "NGROUPS=$NGROUPS ROWS_PER=$ROWS_PER")" \
+	"sane"
+# And that the groups are COMBINABLE. Six groups of exactly stripe_row_limit rows
+# are already full, so a correct vacuum leaves all six and an arm expecting one
+# fails against working code. The fixture must leave headroom, or it measures the
+# limit rather than the compaction.
+check "premise: the whole fixture fits in one stripe, so combining is possible" \
+	"$([ "$(( NGROUPS * ROWS_PER ))" -le "$STRIPE_LIMIT" ] && echo combinable || echo "capped at $STRIPE_LIMIT")" \
+	"combinable"
+
+build_fixture
+
+# ---- premises ---------------------------------------------------------------
+#
+# The fixture must be able to DISTINGUISH bounded from unbounded work, or every
+# arm below is satisfied by a table that was never going to be rewritten anyway.
+check_num "premise: the fixture really has several row groups to combine" \
+	"$(groups_now)" "$NGROUPS"
+check_num "premise: the fixture has the rows it should" \
+	"$(rows_now)" "$(( NGROUPS * ROWS_PER ))"
+
+
+# ---- the default form must keep working -------------------------------------
+#
+# Without these the fix could pass by refusing everything, which is not a fix.
+check "the one-argument form still vacuums" "$(err_of "SELECT pgcolumnar.vacuum('vsc');")" "noerror"
+check_num "and it combined the groups, so it did the work" "$(groups_now)" "1"
+check_num "and it preserved every row" "$(rows_now)" "$(( NGROUPS * ROWS_PER ))"
+
+build_fixture
+check "the explicit default 0 is still accepted" \
+	"$(err_of "SELECT pgcolumnar.vacuum('vsc', 0);")" "noerror"
+check_num "and 0 also did the work" "$(groups_now)" "1"
+
+# ---- the refusal ------------------------------------------------------------
+#
+# A non-default stripe_count must be refused rather than accepted and ignored.
+# On unfixed code these calls SUCCEED, which is the defect.
+build_fixture
+before="$(groups_now)"
+refusal="$(err_of "SELECT pgcolumnar.vacuum('vsc', 4);")"
+check "a non-default stripe_count is refused rather than ignored" \
+	"$([ "$refusal" = noerror ] && echo accepted || echo refused)" "refused"
+# The hint is a separate line of psql output, so it is read from the FULL error
+# block rather than from err_of, which deliberately returns only the ERROR line.
+# A refusal that does not name a working alternative is a dead end for the user.
+full_err="$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+	-d "$PGC_DB" -At -v ON_ERROR_STOP=0 -c "SELECT pgcolumnar.vacuum('vsc', 4);" 2>&1)"
+check "and the refusal names the function that does bound the work" \
+	"$(printf '%s' "$full_err" | grep -c 'compact_rewrite')" "1"
+check "and it is offered as a HINT, where psql shows it to the user" \
+	"$(printf '%s' "$full_err" | grep -c '^HINT:')" "1"
+
+# The refusal must not have done the work anyway. A message is not a behaviour:
+# if the rewrite ran before the argument was inspected, the table would already
+# be compacted and only the error would differ.
+check_num "the refused call did no work: the groups are untouched" "$(groups_now)" "$before"
+check_num "and no rows were lost to it" "$(rows_now)" "$(( NGROUPS * ROWS_PER ))"
+
+# ---- the second instance, inherited rather than fixed separately ------------
+#
+# vacuum_full(schema, sleep_time, stripe_count) passes stripe_count straight to
+# pgcolumnar.vacuum, so it must inherit the refusal. If that propagation ever
+# stops, this arm is the only thing that would notice.
+check "vacuum_full inherits the refusal for a non-default stripe_count" \
+	"$([ "$(err_of "SELECT pgcolumnar.vacuum_full('public', 0.0, 4);")" = noerror ] && echo accepted || echo refused)" \
+	"refused"
+check_num "the refused vacuum_full did no work either" "$(groups_now)" "$before"
+check "vacuum_full's own default form still works" \
+	"$(err_of "SELECT pgcolumnar.vacuum_full('public', 0.0);")" "noerror"
+check_num "and it combined the groups" "$(groups_now)" "1"
+
+# ---- the documented alternative must actually bound work --------------------
+#
+# The errhint points callers at compact_rewrite. If that did not bound anything
+# either, the refusal would be trading one false promise for another.
+build_fixture
+psql_run "DELETE FROM vsc WHERE id % 2 = 0;"
+check "premise: compact_rewrite's bounded form is accepted" \
+	"$(err_of "SELECT pgcolumnar.compact_rewrite('vsc', 0.1, 2);")" "noerror"
+check "the named alternative left more than one group, so the bound did something" \
+	"$([ "$(groups_now)" -gt 1 ] && echo bounded || echo unbounded)" "bounded"
+
+pgc_summary


### PR DESCRIPTION
First of the three design forks jd decided. **Stacked on #575**, which this
branch is based on, so review that first or read only the last commit here.

## The decision, and why the other two options lose

`stripe_count` was documented as bounding how many row groups are combined and
has never been read: `PG_GETARG_OID(0)` was the only argument fetched and a
literal `0` was passed as the bound.

- **Honouring it is not available.** `pgcolumnar_compact_relation`'s second
  parameter is `nsortkeys`, not a bound, and its body dereferences
  `sortAtts[i]`. More seriously it swaps the whole relation to a **new
  relfilenode**, so rewriting only some row groups would leave the rest behind in
  storage that is then discarded. Bounded compaction is a different algorithm.
- **Removing the argument** breaks every existing caller for no gain.
- **Refusing** is the only option that neither lies nor breaks the default form.

The refusal names a function that actually bounds work.
`pgcolumnar.compact_rewrite` passes its `max_groups` to
`pgcolumnar_rewrite_partial_groups` — checked one level past the trap, because
*fetched* is not *honoured*, and the suite asserts it genuinely leaves more than
one group rather than taking the parameter's existence as proof.

## The second instance, which #560 does not mention

`vacuum_full(schema, sleep_time, stripe_count)` passes `stripe_count` straight to
`pgcolumnar.vacuum`, so it inherits the refusal with no change of its own. The
suite asserts that propagation, because it is the only thing making the second
instance safe.

## Removal proof

Deleting the refusal reddens six checks. The one that matters is not the missing
error:

```
FAIL  the refused call did no work: the groups are untouched: got [1] want [6]
```

That is the whole relation being rewritten on behalf of a caller who asked for a
bound of 4.

## Two fixture defects found by running the suite, not reading it

Both made it pass while measuring nothing, and both are now guarded:

- **`GROUPS` is a bash built-in** (the caller's group-id array). `GROUPS=6` was
  silently discarded, `$GROUPS` expanded to `0`, `seq 1 0` inserted nothing, and
  every premise compared `0` with `0` and **passed against an empty table**.
  Renamed `NGROUPS`, with a premise asserting the constants are non-zero.
- **`stripe_row_limit` has a floor of 1000**, so every `set_options` call was
  failing on stderr while the suite read only stdout. Separately, six groups of
  exactly `stripe_row_limit` rows are already full, so a correct vacuum leaves
  all six and an arm expecting one fails against working code. The fixture now
  leaves headroom and a premise asserts the groups are combinable.

The suite also proves its own error helper can report success, a real error, and
an unreachable server, before any arm depends on it — an earlier version omitted
`-U postgres`, so psql failed at connect with a lowercase `psql: error:` that the
`ERROR:` case never matched, and every call read as success.

## Gate

23 checks green on PG16, a deliberately separate prefix from @ChronicallyJD's
PG17 work. The vacuum family all pass unchanged: `native_cluster`,
`native_compact`, `native_recluster`, `native_vacuum_race`, `recluster_extent`,
`vacuum_lock_privilege`; `pg19_vacuum_options` skips on 16 as designed. Suite
registered sorted, runner reports 141 and the list is sorted, both read from
`--list-suites`.

Docs corrected in both places. Not merging this.