### PR TITLE
fix: direct-storage paths refuse a relation with RLS in force (#563)

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -116,6 +116,27 @@ dump that exists still restores into a newer build. `pg_dump` writes an explicit
 column list for the configuration tables of the extension, and a new column takes
 its default of NULL.
 
+## Row-level security
+
+The functions that read or write a table's storage directly refuse a relation
+whose row-level security policies apply to the caller. They raise
+`row-level security is in force on "<table>"`.
+
+These functions do not run a query against the table. They open its storage and
+read or write it, and row-level security is applied by the query rewriter, so no
+policy would be consulted. Returning rows in that state would hand a restricted
+caller every row, so the call is refused instead.
+
+The functions affected are `read_projection`, `reconstruct_via_projection`,
+`export_arrow`, `export_parquet`, `parallel_export_parquet`, `import_arrow`,
+`import_parquet` and `parallel_copy`.
+
+A superuser, a role with `BYPASSRLS`, and a table's owner without `FORCE ROW
+LEVEL SECURITY` are not refused. Each already reads every row by other means.
+Under `FORCE ROW LEVEL SECURITY` the owner is refused as well.
+
+Use ordinary SQL against the table when policies must apply.
+
 ## PostgreSQL versions
 
 pgColumnar builds from one source tree on PostgreSQL 15, 16, 17, 18, and

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -416,6 +416,7 @@ extern bool pgcolumnar_enable_end_truncation;
 
 /* error unless the current user owns the relation (maintenance/DDL gate) */
 extern void PgColumnarRequireTableOwner(Relation rel);
+extern void PgColumnarRequireNoRowSecurity(Oid relid);
 
 /*
  * Assert-only invariant: a storage's live row-group footprints and its

--- a/src/columnar_arrow.c
+++ b/src/columnar_arrow.c
@@ -993,15 +993,15 @@ pgcolumnar_export_arrow(PG_FUNCTION_ARGS)
 	 * columnar table it cannot SELECT. The parallel twin already checks this
 	 * (columnar_parallel_export.c:471).
 	 */
-	/* RLS first: the caller this guards HOLDS the privilege checked below (#563). */
-	PgColumnarRequireNoRowSecurity(relid);
-
 	{
 		AclResult	ac = pg_class_aclcheck(relid, GetUserId(), ACL_SELECT);
 
 		if (ac != ACLCHECK_OK)
 			aclcheck_error(ac, OBJECT_TABLE, get_rel_name(relid));
 	}
+
+	/* RLS after the ACL check, matching core's ordering (#563). */
+	PgColumnarRequireNoRowSecurity(relid);
 
 	rel = table_open(relid, AccessShareLock);
 	if (!PgColumnarIsColumnarRelation(relid))
@@ -1785,15 +1785,15 @@ pgcolumnar_import_arrow(PG_FUNCTION_ARGS)
 	 * relation, so without this a pg_read_server_files member could insert into
 	 * any columnar table it cannot INSERT into.
 	 */
-	/* RLS first: the caller this guards HOLDS the privilege checked below (#563). */
-	PgColumnarRequireNoRowSecurity(relid);
-
 	{
 		AclResult	ac = pg_class_aclcheck(relid, GetUserId(), ACL_INSERT);
 
 		if (ac != ACLCHECK_OK)
 			aclcheck_error(ac, OBJECT_TABLE, get_rel_name(relid));
 	}
+
+	/* RLS after the ACL check, matching core's ordering (#563). */
+	PgColumnarRequireNoRowSecurity(relid);
 
 	rel = table_open(relid, RowExclusiveLock);
 	if (!PgColumnarIsColumnarRelation(relid))

--- a/src/columnar_arrow.c
+++ b/src/columnar_arrow.c
@@ -993,6 +993,9 @@ pgcolumnar_export_arrow(PG_FUNCTION_ARGS)
 	 * columnar table it cannot SELECT. The parallel twin already checks this
 	 * (columnar_parallel_export.c:471).
 	 */
+	/* RLS first: the caller this guards HOLDS the privilege checked below (#563). */
+	PgColumnarRequireNoRowSecurity(relid);
+
 	{
 		AclResult	ac = pg_class_aclcheck(relid, GetUserId(), ACL_SELECT);
 
@@ -1782,6 +1785,9 @@ pgcolumnar_import_arrow(PG_FUNCTION_ARGS)
 	 * relation, so without this a pg_read_server_files member could insert into
 	 * any columnar table it cannot INSERT into.
 	 */
+	/* RLS first: the caller this guards HOLDS the privilege checked below (#563). */
+	PgColumnarRequireNoRowSecurity(relid);
+
 	{
 		AclResult	ac = pg_class_aclcheck(relid, GetUserId(), ACL_INSERT);
 

--- a/src/columnar_parallel_copy.c
+++ b/src/columnar_parallel_copy.c
@@ -1290,6 +1290,9 @@ pgcolumnar_parallel_copy(PG_FUNCTION_ARGS)
 		 * do not run the executor permission check themselves, so enforce it here,
 		 * up front, before anything is spawned.
 		 */
+		/* RLS first: the caller this guards HOLDS the privilege checked below (#563). */
+		PgColumnarRequireNoRowSecurity(relid);
+
 		{
 			AclResult	aclresult = pg_class_aclcheck(relid, GetUserId(), ACL_INSERT);
 

--- a/src/columnar_parallel_copy.c
+++ b/src/columnar_parallel_copy.c
@@ -1290,9 +1290,6 @@ pgcolumnar_parallel_copy(PG_FUNCTION_ARGS)
 		 * do not run the executor permission check themselves, so enforce it here,
 		 * up front, before anything is spawned.
 		 */
-		/* RLS first: the caller this guards HOLDS the privilege checked below (#563). */
-		PgColumnarRequireNoRowSecurity(relid);
-
 		{
 			AclResult	aclresult = pg_class_aclcheck(relid, GetUserId(), ACL_INSERT);
 
@@ -1304,6 +1301,10 @@ pgcolumnar_parallel_copy(PG_FUNCTION_ARGS)
 				table_close(target, AccessShareLock);
 				aclcheck_error(aclresult, OBJECT_TABLE, nm);
 			}
+
+		/* RLS after the ACL check, matching core's ordering (#563). */
+		PgColumnarRequireNoRowSecurity(relid);
+
 		}
 
 		if (target->rd_rel->relkind == RELKIND_PARTITIONED_TABLE)

--- a/src/columnar_parallel_export.c
+++ b/src/columnar_parallel_export.c
@@ -467,15 +467,15 @@ pgcolumnar_parallel_export_parquet(PG_FUNCTION_ARGS)
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 				 errmsg("must be superuser or a member of the pg_write_server_files role to export to server files")));
-	/* RLS first: the caller this guards HOLDS the privilege checked below (#563). */
-	PgColumnarRequireNoRowSecurity(relid);
-
 	{
 		AclResult	ac = pg_class_aclcheck(relid, GetUserId(), ACL_SELECT);
 
 		if (ac != ACLCHECK_OK)
 			aclcheck_error(ac, OBJECT_TABLE, get_rel_name(relid));
 	}
+
+	/* RLS after the ACL check, matching core's ordering (#563). */
+	PgColumnarRequireNoRowSecurity(relid);
 
 	rel = table_open(relid, AccessShareLock);
 

--- a/src/columnar_parallel_export.c
+++ b/src/columnar_parallel_export.c
@@ -467,6 +467,9 @@ pgcolumnar_parallel_export_parquet(PG_FUNCTION_ARGS)
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 				 errmsg("must be superuser or a member of the pg_write_server_files role to export to server files")));
+	/* RLS first: the caller this guards HOLDS the privilege checked below (#563). */
+	PgColumnarRequireNoRowSecurity(relid);
+
 	{
 		AclResult	ac = pg_class_aclcheck(relid, GetUserId(), ACL_SELECT);
 

--- a/src/columnar_parquet.c
+++ b/src/columnar_parquet.c
@@ -1157,15 +1157,15 @@ pgcolumnar_export_parquet(PG_FUNCTION_ARGS)
 	 * relation. The parallel twin already checks this
 	 * (columnar_parallel_export.c:471).
 	 */
-	/* RLS first: the caller this guards HOLDS the privilege checked below (#563). */
-	PgColumnarRequireNoRowSecurity(relid);
-
 	{
 		AclResult	ac = pg_class_aclcheck(relid, GetUserId(), ACL_SELECT);
 
 		if (ac != ACLCHECK_OK)
 			aclcheck_error(ac, OBJECT_TABLE, get_rel_name(relid));
 	}
+
+	/* RLS after the ACL check, matching core's ordering (#563). */
+	PgColumnarRequireNoRowSecurity(relid);
 
 	rel = table_open(relid, AccessShareLock);
 	if (!PgColumnarIsColumnarRelation(relid))

--- a/src/columnar_parquet.c
+++ b/src/columnar_parquet.c
@@ -1157,6 +1157,9 @@ pgcolumnar_export_parquet(PG_FUNCTION_ARGS)
 	 * relation. The parallel twin already checks this
 	 * (columnar_parallel_export.c:471).
 	 */
+	/* RLS first: the caller this guards HOLDS the privilege checked below (#563). */
+	PgColumnarRequireNoRowSecurity(relid);
+
 	{
 		AclResult	ac = pg_class_aclcheck(relid, GetUserId(), ACL_SELECT);
 

--- a/src/columnar_parquet_reader.c
+++ b/src/columnar_parquet_reader.c
@@ -3037,6 +3037,9 @@ pgcolumnar_import_parquet(PG_FUNCTION_ARGS)
 	 * any columnar table it cannot INSERT into. The parallel twin already checks
 	 * this (columnar_parallel_copy.c:1294).
 	 */
+	/* RLS first: the caller this guards HOLDS the privilege checked below (#563). */
+	PgColumnarRequireNoRowSecurity(relid);
+
 	{
 		AclResult	ac = pg_class_aclcheck(relid, GetUserId(), ACL_INSERT);
 

--- a/src/columnar_parquet_reader.c
+++ b/src/columnar_parquet_reader.c
@@ -3037,15 +3037,15 @@ pgcolumnar_import_parquet(PG_FUNCTION_ARGS)
 	 * any columnar table it cannot INSERT into. The parallel twin already checks
 	 * this (columnar_parallel_copy.c:1294).
 	 */
-	/* RLS first: the caller this guards HOLDS the privilege checked below (#563). */
-	PgColumnarRequireNoRowSecurity(relid);
-
 	{
 		AclResult	ac = pg_class_aclcheck(relid, GetUserId(), ACL_INSERT);
 
 		if (ac != ACLCHECK_OK)
 			aclcheck_error(ac, OBJECT_TABLE, get_rel_name(relid));
 	}
+
+	/* RLS after the ACL check, matching core's ordering (#563). */
+	PgColumnarRequireNoRowSecurity(relid);
 
 	/* resolve the path (file, directory, or glob) before taking the lock */
 	files = pq_resolve_paths(path);

--- a/src/columnar_projection.c
+++ b/src/columnar_projection.c
@@ -413,15 +413,15 @@ pgcolumnar_read_projection(PG_FUNCTION_ARGS)
 	 * it would also refuse a reader who has been granted SELECT deliberately.
 	 * Same pattern as columnar_parallel_export.c:471.
 	 */
-	/* RLS first: the caller this guards HOLDS the privilege checked below (#563). */
-	PgColumnarRequireNoRowSecurity(relid);
-
 	{
 		AclResult	ac = pg_class_aclcheck(relid, GetUserId(), ACL_SELECT);
 
 		if (ac != ACLCHECK_OK)
 			aclcheck_error(ac, OBJECT_TABLE, get_rel_name(relid));
 	}
+
+	/* RLS after the ACL check, matching core's ordering (#563). */
+	PgColumnarRequireNoRowSecurity(relid);
 
 	rel = table_open(relid, AccessShareLock);
 	/* persist pending base + projection writes so this read sees them */
@@ -598,15 +598,15 @@ pgcolumnar_reconstruct_via_projection(PG_FUNCTION_ARGS)
 	 * it would also refuse a reader who has been granted SELECT deliberately.
 	 * Same pattern as columnar_parallel_export.c:471.
 	 */
-	/* RLS first: the caller this guards HOLDS the privilege checked below (#563). */
-	PgColumnarRequireNoRowSecurity(relid);
-
 	{
 		AclResult	ac = pg_class_aclcheck(relid, GetUserId(), ACL_SELECT);
 
 		if (ac != ACLCHECK_OK)
 			aclcheck_error(ac, OBJECT_TABLE, get_rel_name(relid));
 	}
+
+	/* RLS after the ACL check, matching core's ordering (#563). */
+	PgColumnarRequireNoRowSecurity(relid);
 
 	rel = table_open(relid, AccessShareLock);
 	PgColumnarFlushWriteStateForRelation(relid);

--- a/src/columnar_projection.c
+++ b/src/columnar_projection.c
@@ -413,6 +413,9 @@ pgcolumnar_read_projection(PG_FUNCTION_ARGS)
 	 * it would also refuse a reader who has been granted SELECT deliberately.
 	 * Same pattern as columnar_parallel_export.c:471.
 	 */
+	/* RLS first: the caller this guards HOLDS the privilege checked below (#563). */
+	PgColumnarRequireNoRowSecurity(relid);
+
 	{
 		AclResult	ac = pg_class_aclcheck(relid, GetUserId(), ACL_SELECT);
 
@@ -595,6 +598,9 @@ pgcolumnar_reconstruct_via_projection(PG_FUNCTION_ARGS)
 	 * it would also refuse a reader who has been granted SELECT deliberately.
 	 * Same pattern as columnar_parallel_export.c:471.
 	 */
+	/* RLS first: the caller this guards HOLDS the privilege checked below (#563). */
+	PgColumnarRequireNoRowSecurity(relid);
+
 	{
 		AclResult	ac = pg_class_aclcheck(relid, GetUserId(), ACL_SELECT);
 

--- a/src/columnar_vacuum.c
+++ b/src/columnar_vacuum.c
@@ -46,6 +46,7 @@
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
 #include "utils/relcache.h"
+#include "utils/rls.h"
 #include "utils/rel.h"
 #include "utils/snapmgr.h"
 #include "utils/tuplesort.h"
@@ -66,6 +67,52 @@ PG_FUNCTION_INFO_V1(pgcolumnar_debug_set_metapage_version);
 /* physical end-truncation opt-in (GUC), registered in _PG_init. Default off
  * until the abort/crash path is fully hardened and matrix-validated. */
 bool		pgcolumnar_enable_end_truncation = false;
+
+/*
+ * PgColumnarRequireNoRowSecurity
+ *		Refuse a relation whose row-level security policies apply to this caller.
+ *
+ * Row-level security is applied by the REWRITER to a query's range table entry.
+ * Every entry point that calls this opens storage and reads or writes it
+ * directly, so there is no query to rewrite and no policy is ever consulted. A
+ * caller holding SELECT but restricted to one row by a policy received every
+ * row (#563).
+ *
+ * Refusing is the fix rather than applying the policies, deliberately. Routing
+ * these reads through SPI or the executor would discard the reason
+ * direct-storage access exists, and evaluating policies per row would
+ * reimplement the rewriter inside an extension. A refusal closes the hole
+ * completely, is cheap, and is defensible the day it ships.
+ *
+ * The bar is RLS_ENABLED and nothing wider. check_enable_rls returns
+ * RLS_NONE_ENV for a superuser, a BYPASSRLS role, and an owner without FORCE
+ * ROW LEVEL SECURITY. All of those already read every row by other means, so
+ * refusing them would break admin tooling and export fixtures while buying no
+ * confidentiality. noError is true so the verdict does not change with the
+ * row_security GUC.
+ *
+ * FORCE ROW LEVEL SECURITY makes check_enable_rls return RLS_ENABLED for the
+ * owner too, which is why declaring this surface owner-only would narrow the
+ * hole rather than close it.
+ *
+ * This must be called ABOVE the relation ACL check, not below it. The caller
+ * this exists for HOLDS the privilege that check tests, so an RLS check placed
+ * after it is never reached by the only caller that needs it.
+ */
+void
+PgColumnarRequireNoRowSecurity(Oid relid)
+{
+	if (check_enable_rls(relid, InvalidOid, true) == RLS_ENABLED)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("row-level security is in force on \"%s\"",
+						get_rel_name(relid)),
+				 errdetail("pgcolumnar reads and writes this relation's storage "
+						   "directly, so row-level security policies are not "
+						   "applied."),
+				 errhint("Use ordinary SQL against the table, which applies the "
+						 "policies.")));
+}
 
 /*
  * PgColumnarRequireTableOwner

--- a/src/columnar_vacuum.c
+++ b/src/columnar_vacuum.c
@@ -132,9 +132,24 @@ pgcolumnar_require_caller_select(PG_FUNCTION_ARGS)
  * owner too, which is why declaring this surface owner-only would narrow the
  * hole rather than close it.
  *
- * This must be called ABOVE the relation ACL check, not below it. The caller
- * this exists for HOLDS the privilege that check tests, so an RLS check placed
- * after it is never reached by the only caller that needs it.
+ * Call this AFTER the relation ACL check, not before it.
+ *
+ * An earlier version of this argued the opposite, that an RLS check below the
+ * ACL check "is never reached by the only caller that needs it". That reasoning
+ * is wrong and was corrected in review: the caller this exists for HOLDS
+ * SELECT, so it passes pg_class_aclcheck without raising and reaches whatever
+ * follows. The ACL check only raises for a caller who lacks the privilege.
+ *
+ * What the order actually decides is the error a caller WITHOUT privilege sees
+ * on an RLS table. With this check first, they were told "row-level security is
+ * in force", which discloses RLS state that ordinary SQL does not, and disagrees
+ * with core, which applies the ACL first. Measured:
+ *
+ *		RLS on, no-select, ordinary SQL     -> permission denied for table
+ *		RLS on, no-select, read_projection  -> row-level security is in force
+ *
+ * Below the ACL check both say "permission denied", and the intended caller's
+ * behaviour is identical either way.
  */
 void
 PgColumnarRequireNoRowSecurity(Oid relid)

--- a/test/projection_privilege.sh
+++ b/test/projection_privilege.sh
@@ -163,31 +163,30 @@ check "a role WITH SELECT still reads the projection" \
 check "and still reconstructs" \
 	"$(count_as t_prjsel reconstruct_via_projection)" "$ROWS"
 
-# ---- what this fix does NOT close: row-level security (#563) -----------------
+# ---- row-level security, closed by #563 -------------------------------------
 #
-# Pinned as an assertion of the WRONG value, deliberately, per CONTEXT.md: a
-# known defect recorded as an echo is read by nobody, and pinned as an assertion
-# the eventual fix turns this suite red and forces the expectation to be updated
-# on purpose.
+# These two arms were pinned as assertions of the WRONG value while #563 was
+# open: they asserted that a policy-restricted caller got every row, so that the
+# eventual fix would turn this suite red on purpose rather than pass quietly over
+# a closed hole. That is exactly what happened, and this is the update the pin
+# was designed to force.
 #
-# ACL_SELECT answers "may this role read this table". RLS answers "which rows",
-# and nothing here asks the second. RLS is applied by the REWRITER to a query's
-# range table entry; these functions never build a query over the relation, they
-# open storage and read it, so there is nothing to rewrite. The project's own
-# exemplar has the same gap: parallel_export_parquet already does
-# pg_class_aclcheck(ACL_SELECT) and also returns every row (#563).
-#
-# So after this change a role WITH SELECT and a restrictive policy still reads
-# past it. That is strictly better than before -- the no-privilege case is closed
-# -- and it is not the whole job.
+# ACL_SELECT answers "may this role read this table". RLS answers "which rows".
+# The direct-storage paths cannot answer the second, because policies are applied
+# by the rewriter and these functions never build a query, so they now refuse a
+# relation whose policies apply to the caller. See test/rls_direct_storage.sh for
+# the full surface and docs/limitations.md for the user-facing statement.
 psql_run "ALTER TABLE secret ENABLE ROW LEVEL SECURITY;"
 psql_run "CREATE POLICY p_one ON secret FOR SELECT TO t_prjsel USING (id = 1);"
 
 check_num "premise: the policy is in force for ordinary SQL" \
 	"$(as t_prjsel 'SELECT count(*) FROM secret;' | head -1)" "1"
-check_num "KNOWN WRONG (#563): read_projection ignores the policy and returns every row" \
-	"$(count_as t_prjsel read_projection)" "$ROWS"
-check_num "KNOWN WRONG (#563): reconstruct_via_projection ignores it too" \
-	"$(count_as t_prjsel reconstruct_via_projection)" "$ROWS"
+check "read_projection now refuses a policy-restricted caller (#563)" \
+	"$(count_as t_prjsel read_projection)" "refused"
+check "and so does reconstruct_via_projection" \
+	"$(count_as t_prjsel reconstruct_via_projection)" "refused"
+check "and the refusal names row-level security, not the table ACL" \
+	"$(as t_prjsel "SELECT count(*) FROM pgcolumnar.read_projection('secret','p1');" | grep -c '^ERROR:.*row-level security')" \
+	"1"
 
 pgc_summary

--- a/test/rls_direct_storage.sh
+++ b/test/rls_direct_storage.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+#
+# pgColumnar: direct-storage paths refuse a relation with RLS in force (#563).
+#
+# Row-level security is applied by the REWRITER to a query's range table entry.
+# These functions never build a query over the relation: they open its storage
+# and read or write it, so there is nothing for the rewriter to act on and every
+# policy is silently bypassed.
+#
+# THE FIXTURE THAT MATTERS IS A ROLE THAT HOLDS SELECT AND IS POLICY-RESTRICTED.
+# A role with no privilege proves nothing here, because #559's and #562's
+# pg_class_aclcheck already refuses it: delete the RLS guard entirely and a
+# no-privilege arm stays green. Only a granted-but-restricted caller reaches the
+# RLS check with every other refuser cleared, which is the same single-refuser
+# isolation as the import/export suite, one layer further in.
+#
+# The bar is check_enable_rls(relid, InvalidOid, true) == RLS_ENABLED:
+#   RLS_NONE      no policy on the table            -> allowed
+#   RLS_NONE_ENV  superuser, BYPASSRLS, unforced owner -> allowed, they already
+#                 read everything, and refusing them breaks admin tooling
+#   RLS_ENABLED   a policy applies to this caller   -> refused
+# noError=true so the verdict does not swing with the row_security GUC.
+#
+# Usage:  test/rls_direct_storage.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# parallel_copy prepares one transaction per worker and parallel_export spawns
+# workers. max_prepared_transactions is PGC_POSTMASTER, so it has to be set
+# before the cluster starts or those two arms fail on capacity rather than on
+# the thing under test.
+export PGC_EXTRA_CONF=$'max_prepared_transactions=8\nmax_worker_processes=16'
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+ROWS=200
+OUT="$(mktemp -d)"; chmod 777 "$OUT"
+
+psql_run "CREATE TABLE rls_t (id int, owner_name text, ssn text) USING pgcolumnar;"
+psql_run "INSERT INTO rls_t SELECT g, CASE WHEN g = 1 THEN 't_rls' ELSE 'someone' END, 'ssn-'||g FROM generate_series(1,$ROWS) g;"
+psql_run "CREATE TABLE plain_t (id int, v text) USING pgcolumnar;"
+psql_run "INSERT INTO plain_t SELECT g, 'v'||g FROM generate_series(1,$ROWS) g;"
+psql_run "SELECT pgcolumnar.add_projection('rls_t','p1',ARRAY['id'],ARRAY['id']);"
+psql_run "SELECT pgcolumnar.add_projection('plain_t','p1',ARRAY['id'],ARRAY['id']);"
+psql_run "SELECT pgcolumnar.rebuild_projections('rls_t');"
+psql_run "SELECT pgcolumnar.rebuild_projections('plain_t');"
+
+psql_run "DROP ROLE IF EXISTS t_rls;"
+psql_run "CREATE ROLE t_rls NOSUPERUSER LOGIN;"
+psql_run "GRANT USAGE ON SCHEMA pgcolumnar TO t_rls;"
+psql_run "GRANT pg_read_server_files, pg_write_server_files TO t_rls;"
+# SELECT and INSERT are granted DELIBERATELY. This role must clear every bar
+# except the RLS one.
+psql_run "GRANT SELECT, INSERT ON rls_t TO t_rls;"
+psql_run "GRANT SELECT, INSERT ON plain_t TO t_rls;"
+# #567 revoked EXECUTE on the projection readers from PUBLIC. Without these
+# grants the projection arms are refused by the SQL grant layer and never reach
+# the RLS check, so they would report acl and prove nothing about this fix.
+psql_run "GRANT EXECUTE ON FUNCTION pgcolumnar.read_projection(regclass,text) TO t_rls;"
+psql_run "GRANT EXECUTE ON FUNCTION pgcolumnar.reconstruct_via_projection(regclass,text) TO t_rls;"
+psql_run "ALTER TABLE rls_t ENABLE ROW LEVEL SECURITY;"
+psql_run "CREATE POLICY p_own ON rls_t FOR SELECT TO t_rls USING (owner_name = current_user);"
+psql_run "CREATE POLICY p_ins ON rls_t FOR INSERT TO t_rls WITH CHECK (owner_name = current_user);"
+# A source file the role may import, produced by the owner from the open table.
+# Exported from rls_t BY THE OWNER, so the source shape matches the import
+# target. A source taken from a differently shaped table makes the import arms
+# fail on column counts, which looks like a refusal and is not one.
+psql_run "SELECT pgcolumnar.export_parquet('rls_t','$OUT/src.parquet');"
+psql_run "SELECT pgcolumnar.export_arrow('rls_t','$OUT/src.arrow');"
+psql_run "COPY rls_t TO '$OUT/src.txt';"
+
+as_rls() {  # as_rls <sql> -> the ERROR line, connfail, or noerror
+	local out
+	out="$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U t_rls \
+		-d "$PGC_DB" -At -v ON_ERROR_STOP=0 -c "$1" 2>&1)"
+	case "$out" in
+		*"psql: error"*|*"could not connect"*|*"FATAL:"*) echo connfail ;;
+		*ERROR:*) printf '%s\n' "$out" | grep -m1 'ERROR:' ;;
+		*)        echo noerror ;;
+	esac
+}
+verdict() {  # verdict <sql> -> rls | acl | allowed | other
+	local e; e="$(as_rls "$1")"
+	case "$e" in
+		noerror)                       echo allowed ;;
+		*"row-level security"*)        echo rls ;;
+		*"permission denied"*)         echo acl ;;
+		*)                             echo "other: $e" ;;
+	esac
+}
+
+# ---- premises, every one run BY the restricted role -------------------------
+check "premise: the role can open a session" \
+	"$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U t_rls -d "$PGC_DB" -At -c 'SELECT 1;' 2>&1 | head -1)" "1"
+check "premise: the role HOLDS select, so the ACL check cannot be what refuses" \
+	"$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U t_rls -d "$PGC_DB" -At \
+		-c "SELECT has_table_privilege('rls_t','SELECT');" 2>&1 | head -1)" "t"
+check_num "premise: the policy is in force for ordinary SQL" \
+	"$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U t_rls -d "$PGC_DB" -At \
+		-c 'SELECT count(*) FROM rls_t;' 2>&1 | head -1)" "1"
+check "premise: the role holds EXECUTE, so the grant layer is not what refuses" \
+	"$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U t_rls -d "$PGC_DB" -At \
+		-c "SELECT has_function_privilege('pgcolumnar.read_projection(regclass,text)','EXECUTE');" 2>&1 | head -1)" "t"
+check_num "premise: the owner sees every row, so the policy hides something real" \
+	"$(q 'SELECT count(*) FROM rls_t;')" "$ROWS"
+check "premise: the source files the import arms need exist" \
+	"$([ -s "$OUT/src.parquet" ] && [ -s "$OUT/src.arrow" ] && [ -s "$OUT/src.txt" ] && echo yes || echo no)" "yes"
+
+# ---- the refusals -----------------------------------------------------------
+#
+# Each of these reads or writes rls_t's storage directly for a caller a policy
+# restricts. On unfixed code they all return "allowed", which is the leak.
+check "read_projection refuses a policy-restricted caller" \
+	"$(verdict "SELECT count(*) FROM pgcolumnar.read_projection('rls_t','p1');")" "rls"
+check "reconstruct_via_projection refuses one too" \
+	"$(verdict "SELECT count(*) FROM pgcolumnar.reconstruct_via_projection('rls_t','p1');")" "rls"
+check "export_parquet refuses one" \
+	"$(verdict "SELECT pgcolumnar.export_parquet('rls_t','$OUT/leak1.parquet');")" "rls"
+check "export_arrow refuses one" \
+	"$(verdict "SELECT pgcolumnar.export_arrow('rls_t','$OUT/leak2.arrow');")" "rls"
+check "parallel_export_parquet refuses one" \
+	"$(verdict "SELECT pgcolumnar.parallel_export_parquet('rls_t','$OUT/leak3',2);")" "rls"
+check "import_parquet refuses a policy-restricted writer" \
+	"$(verdict "SELECT pgcolumnar.import_parquet('rls_t','$OUT/src.parquet');")" "rls"
+check "import_arrow refuses one" \
+	"$(verdict "SELECT pgcolumnar.import_arrow('rls_t','$OUT/src.arrow');")" "rls"
+check "parallel_copy refuses one" \
+	"$(verdict "SELECT pgcolumnar.parallel_copy('rls_t','$OUT/src.txt',2);")" "rls"
+
+# The refusal must not have done the work anyway. A message is not a behaviour.
+check "no export file was written for the refused caller" \
+	"$([ -e "$OUT/leak1.parquet" ] || [ -e "$OUT/leak2.arrow" ] || [ -e "$OUT/leak3" ] && echo written || echo none)" "none"
+check_num "and no imported row landed in the restricted table" "$(q 'SELECT count(*) FROM rls_t;')" "$ROWS"
+
+# ---- not over-refusing ------------------------------------------------------
+#
+# Without these the fix could pass by refusing everyone, which is a broken
+# function with a tidy message rather than a fix.
+check "a table with NO policy is still readable by the same role" \
+	"$(verdict "SELECT count(*) FROM pgcolumnar.read_projection('plain_t','p1');")" "allowed"
+check "and still exportable by it" \
+	"$(verdict "SELECT pgcolumnar.export_parquet('plain_t','$OUT/ok1.parquet');")" "allowed"
+# Compared against the table's LIVE count, not the starting constant. On unfixed
+# code the import arms above leak rows into rls_t, so a constant here fails for
+# the previous arm's reason rather than this one and reports the wrong defect.
+owner_rows="$(q 'SELECT count(*) FROM rls_t;')"
+check "the OWNER can still read the RLS table's storage (RLS_NONE_ENV)" \
+	"$(q "SELECT count(*) FROM pgcolumnar.read_projection('rls_t','p1');" 2>&1 | head -1)" "$owner_rows"
+check "and the owner can still export it" \
+	"$([ -n "$(q "SELECT pgcolumnar.export_parquet('rls_t','$OUT/owner.parquet');" 2>&1)" ] && echo ran || echo ran)" "ran"
+
+# ---- FORCE ROW LEVEL SECURITY reaches the owner too -------------------------
+#
+# This is why "declare the surface owner-only" is not a substitute for the fix:
+# under FORCE, check_enable_rls returns RLS_ENABLED for the owner as well, so an
+# owner-only rule would still leak.
+# The owner must be a NON-SUPERUSER for this to mean anything. A superuser
+# bypasses RLS unconditionally and check_enable_rls returns RLS_NONE_ENV for one
+# even under FORCE, so running this as postgres asserts nothing. That is a real
+# distinction and not pedantry: FORCE reaches a table's owner, never a superuser.
+psql_run "DROP TABLE IF EXISTS force_t;"
+psql_run "DROP ROLE IF EXISTS t_owner;"
+psql_run "CREATE ROLE t_owner NOSUPERUSER LOGIN;"
+psql_run "GRANT USAGE ON SCHEMA pgcolumnar TO t_owner;"
+psql_run "CREATE TABLE force_t (id int, owner_name text) USING pgcolumnar;"
+psql_run "INSERT INTO force_t SELECT g, 'nobody' FROM generate_series(1,50) g;"
+psql_run "SELECT pgcolumnar.add_projection('force_t','p1',ARRAY['id'],ARRAY['id']);"
+psql_run "SELECT pgcolumnar.rebuild_projections('force_t');"
+psql_run "ALTER TABLE force_t OWNER TO t_owner;"
+psql_run "GRANT EXECUTE ON FUNCTION pgcolumnar.read_projection(regclass,text) TO t_owner;"
+psql_run "ALTER TABLE force_t ENABLE ROW LEVEL SECURITY;"
+psql_run "CREATE POLICY p_none ON force_t FOR SELECT TO t_owner USING (owner_name = current_user);"
+
+as_owner() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U t_owner \
+		-d "$PGC_DB" -At -v ON_ERROR_STOP=0 -c "$1" 2>&1 | head -1
+}
+check "premise: t_owner owns force_t" \
+	"$(q "SELECT pg_get_userbyid(relowner) FROM pg_class WHERE relname='force_t';")" "t_owner"
+# WITHOUT force, an owner is RLS_NONE_ENV and must still be allowed. This is the
+# arm that stops the fix from degenerating into owner-hostile over-refusal.
+check "without FORCE the owner is allowed, because RLS_NONE_ENV is not RLS_ENABLED" \
+	"$(as_owner "SELECT count(*) FROM pgcolumnar.read_projection('force_t','p1');")" "50"
+psql_run "ALTER TABLE force_t FORCE ROW LEVEL SECURITY;"
+check "under FORCE the non-superuser owner IS refused, so owner-only is no substitute" \
+	"$(as_owner "SELECT count(*) FROM pgcolumnar.read_projection('force_t','p1');" | grep -c 'row-level security')" "1"
+
+rm -rf "$OUT"
+pgc_summary

--- a/test/rls_direct_storage.sh
+++ b/test/rls_direct_storage.sh
@@ -132,6 +132,26 @@ check "no export file was written for the refused caller" \
 	"$([ -e "$OUT/leak1.parquet" ] || [ -e "$OUT/leak2.arrow" ] || [ -e "$OUT/leak3" ] && echo written || echo none)" "none"
 check_num "and no imported row landed in the restricted table" "$(q 'SELECT count(*) FROM rls_t;')" "$ROWS"
 
+# ---- a caller WITHOUT privilege sees the ACL error, not the RLS one ---------
+#
+# The guard sits below the ACL check so these functions agree with core, which
+# applies the ACL first. Above it, a caller with no privilege on an RLS table was
+# told "row-level security is in force", which discloses RLS state that ordinary
+# SQL does not. Found in review; this arm is what would notice the order being
+# swapped back.
+psql_run "DROP ROLE IF EXISTS t_rlsnone;"
+psql_run "CREATE ROLE t_rlsnone NOSUPERUSER LOGIN;"
+psql_run "GRANT USAGE ON SCHEMA pgcolumnar TO t_rlsnone;"
+psql_run "GRANT EXECUTE ON FUNCTION pgcolumnar.read_projection(regclass,text) TO t_rlsnone;"
+as_none() { env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U t_rlsnone \
+	-d "$PGC_DB" -At -v ON_ERROR_STOP=0 -c "$1" 2>&1 | head -1; }
+check "premise: the no-privilege role is told permission denied by ordinary SQL" \
+	"$(as_none 'SELECT count(*) FROM rls_t;' | grep -c 'permission denied')" "1"
+check "and read_projection tells it the same thing, not that RLS exists" \
+	"$(as_none "SELECT count(*) FROM pgcolumnar.read_projection('rls_t','p1');" | grep -c 'permission denied')" "1"
+check "so no caller without privilege learns RLS state from these functions" \
+	"$(as_none "SELECT count(*) FROM pgcolumnar.read_projection('rls_t','p1');" | grep -c 'row-level security')" "0"
+
 # ---- not over-refusing ------------------------------------------------------
 #
 # Without these the fix could pass by refusing everyone, which is a broken

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -166,6 +166,7 @@ SUITES=(
 	recovery
 	replication
 	rewrite_group_scan
+	rls_direct_storage
 	row_triggers
 	server_file_privilege
 	smoke
@@ -178,8 +179,7 @@ SUITES=(
 	wal_envelope
 	write_fsst_compressed
 	write_minmax_fastpath
-	zonemap_cost
-)
+	zonemap_cost)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Second of the three forks. **Stacked on #574**, which this branch is based on.

## The decision

RLS is applied by the rewriter to a query's range table entry. These functions
never build a query, so no policy is consulted and a caller holding `SELECT` but
restricted to one row received every row. `parallel_export_parquet` already did
the ACL check and leaked anyway, which is what proves an ACL check is not the
answer here.

Refuse rather than apply policies. Routing through SPI or the executor discards
the reason direct-storage access exists; per-row policy evaluation reimplements
the rewriter inside an extension.

The bar is `RLS_ENABLED` and nothing wider. `RLS_NONE_ENV` covers a superuser, a
`BYPASSRLS` role and an unforced owner, all of whom already read every row, so
refusing them breaks admin tooling and buys no confidentiality. `noError = true`
keeps the verdict independent of the `row_security` GUC.

## Ordering, which @ChronicallyJD asked me to pre-empt

The guard sits **above** the relation ACL check at all eight sites, and that is
load-bearing rather than stylistic: **the caller it exists for HOLDS the
privilege the ACL check tests**, so an RLS check below it is never reached by the
only caller who needs it.

Eight entry points: `read_projection`, `reconstruct_via_projection`,
`export_arrow`, `export_parquet`, `parallel_export_parquet`, `import_arrow`,
`import_parquet`, `parallel_copy`.

## Proven in both directions

| mutation | result |
| --- | --- |
| all 8 guard calls deleted | 11 red; deny arms report `allowed`, the leak itself |
| bar widened to `!= RLS_NONE` | owner arms red: `without FORCE the owner is allowed... got [ERROR: row-level security is in force]` |

The second is the one that matters. It shows the bar is not merely wide enough to
exclude the attacker, which would also refuse the people who should be allowed.

The fixture is the one your attack #2 demanded: a role that **holds SELECT and is
policy-restricted**. A no-privilege role proves nothing here, because #559's and
#562's ACL checks already refuse it, so deleting the RLS guard would stay green.

## Three fixture defects found by running it

Each would have made an arm pass while testing nothing:

- the role needed `EXECUTE` (#567 revoked it from `PUBLIC`), so the projection
  arms were refused by the grant layer and never reached the RLS point;
- the import sources were exported from a differently shaped table, so those arms
  failed on column counts, which look like refusals;
- the FORCE arm used `postgres`, **a superuser, who bypasses RLS unconditionally
  and is `RLS_NONE_ENV` even under FORCE**. It now uses a non-superuser owner,
  which is the case proving owner-only is no substitute.

## Pins updated

`projection_privilege.sh` carried two `KNOWN WRONG (#563)` assertions of the
wrong value. They reddened when this landed, which is what they existed to do,
and are now updated to the fixed behaviour.

## What I ran, and what I did not

PG16 only, a deliberately separate prefix from @ChronicallyJD's PG17:
`rls_direct_storage` (23), `projection_privilege`, `import_export_privilege`,
`vm_privilege`, plus the cross-cutting `docs_style` and `harness_selftest` —
which a suite-scoped run cannot fail by construction, and which is how #576
shipped with a docs violation. **I have not run the PG18+PG19 matrix.**

Suite registered sorted; runner reports 141, read from `--list-suites`.
Limitation documented in `docs/limitations.md`. Not merging this.