### PR TITLE
fix: pgcolumnar.stats checks the caller, not the definer (#560)

### DIFF
--- a/docs/sql-reference.md
+++ b/docs/sql-reference.md
@@ -225,6 +225,10 @@ keep core `ANALYZE` scheduled and use this only to sharpen particular columns.
 
 ### pgcolumnar.stats(rel regclass)
 
+Requires `SELECT` on the table. The function runs with the privileges of the
+extension owner, because it reads pgcolumnar's own catalog tables. It checks the
+calling role's privilege on the table before it returns anything.
+
 Returns one row per row group, with these columns:
 
 | Column | Type | Meaning |

--- a/pgcolumnar--1.0-alpha.sql
+++ b/pgcolumnar--1.0-alpha.sql
@@ -592,6 +592,25 @@ COMMENT ON FUNCTION pgcolumnar.reconstruct_via_projection(regclass, text)
 REVOKE ALL ON FUNCTION pgcolumnar.read_projection(regclass, text) FROM PUBLIC;
 REVOKE ALL ON FUNCTION pgcolumnar.reconstruct_via_projection(regclass, text) FROM PUBLIC;
 
+CREATE FUNCTION pgcolumnar.require_caller_select(rel regclass) RETURNS void
+	LANGUAGE C STRICT
+	AS 'MODULE_PATHNAME', 'pgcolumnar_require_caller_select';
+
+REVOKE ALL ON FUNCTION pgcolumnar.require_caller_select(regclass) FROM PUBLIC;
+
+COMMENT ON FUNCTION pgcolumnar.require_caller_select(regclass)
+	IS 'raise unless the calling role may SELECT the relation; for SECURITY DEFINER callers (#560)';
+
+-- SECURITY DEFINER, because this reads pgcolumnar's catalog tables and those
+-- carry no GRANT, so a columnar table's own owner could not read the statistics
+-- of the table they own. Granting SELECT on the catalog instead would publish
+-- pgcolumnar.zone_map, which holds per-column minimum, maximum and sum for every
+-- columnar table. That is actual column data and a far larger disclosure than
+-- the usability defect it would fix.
+--
+-- Definer rights mean nothing else will refuse anyone, so the privilege check is
+-- explicit and is the first statement. search_path is pinned because a definer
+-- function must not resolve names through a caller-controlled path.
 CREATE FUNCTION pgcolumnar.stats(
 	rel regclass,
 	OUT stripeid bigint,
@@ -601,8 +620,12 @@ CREATE FUNCTION pgcolumnar.stats(
 	OUT chunkcount integer,
 	OUT datalength bigint)
 	RETURNS SETOF record
-	LANGUAGE sql STABLE
+	LANGUAGE plpgsql STABLE SECURITY DEFINER
+	SET search_path = pg_catalog, pg_temp
 	AS $stats$
+BEGIN
+	PERFORM pgcolumnar.require_caller_select(rel);
+	RETURN QUERY
 	-- Native (PGCN v1) tables report one row per row group from the native
 	-- catalog.
 	SELECT rg.group_number,
@@ -621,6 +644,7 @@ CREATE FUNCTION pgcolumnar.stats(
 	FROM pgcolumnar.row_group rg
 	WHERE rg.storage_id = pgcolumnar.get_storage_id(rel)
 	ORDER BY 1;
+END;
 $stats$;
 
 COMMENT ON FUNCTION pgcolumnar.stats(regclass)

--- a/src/columnar_vacuum.c
+++ b/src/columnar_vacuum.c
@@ -67,6 +67,43 @@ PG_FUNCTION_INFO_V1(pgcolumnar_debug_set_metapage_version);
  * until the abort/crash path is fully hardened and matrix-validated. */
 bool		pgcolumnar_enable_end_truncation = false;
 
+PG_FUNCTION_INFO_V1(pgcolumnar_require_caller_select);
+
+/*
+ * pgcolumnar_require_caller_select(rel regclass) -> void
+ *		Raise unless the CALLER may SELECT the relation.
+ *
+ * Exists for pgcolumnar.stats, which is SECURITY DEFINER (#560). stats() reads
+ * pgcolumnar's catalog tables, which carry no GRANT, so a columnar table's own
+ * owner could not read the statistics of the table they own. Granting SELECT on
+ * those catalogs instead would publish pgcolumnar.zone_map, which stores per
+ * column minimum, maximum and sum for every columnar table: actual column
+ * values, and a much larger disclosure than the bug being fixed.
+ *
+ * GetOuterUserId, NOT GetUserId. Inside a SECURITY DEFINER function the
+ * effective user is the function's OWNER, so GetUserId returns the superuser who
+ * installed the extension and pg_class_aclcheck against it returns ACLCHECK_OK
+ * for every relation in the database. Such a check refuses nobody while looking
+ * exactly like a correct one. Measured on a build of this tree:
+ *
+ *		plain call   as t_id: cur=t_id      outer=t_id  sess=t_id
+ *		definer call as t_id: cur=postgres  outer=t_id  sess=t_id
+ *
+ * GetOuterUserId is the calling role, and it follows SET ROLE, which is the
+ * behaviour wanted: the privilege tested is the one the caller is acting with.
+ */
+Datum
+pgcolumnar_require_caller_select(PG_FUNCTION_ARGS)
+{
+	Oid			relid = PG_GETARG_OID(0);
+	AclResult	ac = pg_class_aclcheck(relid, GetOuterUserId(), ACL_SELECT);
+
+	if (ac != ACLCHECK_OK)
+		aclcheck_error(ac, OBJECT_TABLE, get_rel_name(relid));
+
+	PG_RETURN_VOID();
+}
+
 /*
  * PgColumnarRequireTableOwner
  *		Error unless the current user owns the relation (superusers pass). Every

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -170,6 +170,7 @@ SUITES=(
 	smoke
 	sort_status
 	sorted_projection
+	stats_privilege
 	temporal
 	ungrouped_vector_agg
 	unique_conc
@@ -177,8 +178,7 @@ SUITES=(
 	wal_envelope
 	write_fsst_compressed
 	write_minmax_fastpath
-	zonemap_cost
-)
+	zonemap_cost)
 
 
 # ---------------------------------------------------------------------------

--- a/test/stats_privilege.sh
+++ b/test/stats_privilege.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# pgColumnar: pgcolumnar.stats is usable by a table's owner, and only by a
+# caller who may read the table (#560).
+#
+# stats() is documented as the function "most users" read, and it failed for the
+# owner of the table being inspected: it is LANGUAGE sql and selects straight
+# from pgcolumnar.row_group, delete_vector and zone_map, and the install script
+# contains no GRANT, so those tables are owner-only and the owner of a COLUMNAR
+# table is not their owner.
+#
+# The obvious fix is worse than the defect. GRANTing SELECT on the catalog to
+# PUBLIC would publish pgcolumnar.zone_map, which stores per-column minimum,
+# maximum and sum for every columnar table: actual column values. That is a
+# larger disclosure than the usability bug it fixes.
+#
+# So the function runs SECURITY DEFINER and does the privilege check itself.
+#
+# THE TRAP THIS SUITE EXISTS TO CATCH. Inside a SECURITY DEFINER function the
+# effective user is the function OWNER, so pg_class_aclcheck(relid, GetUserId(),
+# ...) checks the superuser who installed the extension and returns ACLCHECK_OK
+# for every relation in the database. It looks exactly like a correct check and
+# refuses nobody. Measured on this build:
+#
+#   plain call    as t_id: cur=t_id     outer=t_id  sess=t_id
+#   definer call  as t_id: cur=postgres outer=t_id  sess=t_id
+#
+# GetOuterUserId() is the caller. The "a role with no privilege is refused" arm
+# below is what fails if that is ever changed back to GetUserId().
+#
+# Usage:  test/stats_privilege.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+ROWS=500
+
+psql_run "DROP ROLE IF EXISTS t_stowner;"
+psql_run "DROP ROLE IF EXISTS t_stnone;"
+psql_run "DROP ROLE IF EXISTS t_stsel;"
+psql_run "CREATE ROLE t_stowner NOSUPERUSER LOGIN;"
+psql_run "CREATE ROLE t_stnone NOSUPERUSER LOGIN;"
+psql_run "CREATE ROLE t_stsel NOSUPERUSER LOGIN;"
+for r in t_stowner t_stnone t_stsel; do
+	psql_run "GRANT USAGE ON SCHEMA pgcolumnar TO $r;"
+done
+psql_run "CREATE TABLE st_t (id int, v text) USING pgcolumnar;"
+psql_run "INSERT INTO st_t SELECT g, 'v'||g FROM generate_series(1,$ROWS) g;"
+psql_run "ALTER TABLE st_t OWNER TO t_stowner;"
+psql_run "REVOKE ALL ON st_t FROM PUBLIC;"
+psql_run "GRANT SELECT ON st_t TO t_stsel;"
+
+as() { env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U "$1" \
+	-d "$PGC_DB" -At -v ON_ERROR_STOP=0 -c "$2" 2>&1 | head -1; }
+
+# ---- premises, each run by the role it is about ----------------------------
+check "premise: the owner can open a session" "$(as t_stowner 'SELECT 1;')" "1"
+check "premise: the no-privilege role can open a session" "$(as t_stnone 'SELECT 1;')" "1"
+check "premise: t_stowner really owns the table" \
+	"$(q "SELECT pg_get_userbyid(relowner) FROM pg_class WHERE relname='st_t';")" "t_stowner"
+check "premise: none of these roles is a superuser" \
+	"$(q "SELECT bool_and(NOT rolsuper) FROM pg_roles WHERE rolname LIKE 't_st%';")" "t"
+check "premise: the owner can read its own table by ordinary SQL" \
+	"$(as t_stowner 'SELECT count(*) FROM st_t;')" "$ROWS"
+check "premise: the no-privilege role cannot read it by ordinary SQL" \
+	"$(as t_stnone 'SELECT count(*) FROM st_t;' | grep -c 'permission denied')" "1"
+check "premise: the catalog tables are NOT readable by these roles, so a GRANT is not the fix" \
+	"$(as t_stsel 'SELECT count(*) FROM pgcolumnar.row_group;' | grep -c 'permission denied')" "1"
+
+# ---- the defect ------------------------------------------------------------
+check_num "the OWNER of the table can read its stats" "$(as t_stowner "SELECT count(*) FROM pgcolumnar.stats('st_t');")" "1"
+check_num "a role merely GRANTed select can read them too" "$(as t_stsel "SELECT count(*) FROM pgcolumnar.stats('st_t');")" "1"
+
+# ---- the bar ---------------------------------------------------------------
+#
+# This is the arm that catches a check reading the DEFINER instead of the caller.
+# With GetUserId() the check tests the superuser who owns the function, passes,
+# and this role reads the stats of a table it cannot read.
+check "a role with no privilege on the table is refused" \
+	"$(as t_stnone "SELECT count(*) FROM pgcolumnar.stats('st_t');" | grep -c 'permission denied for table')" "1"
+check "and the refusal names the TABLE, not a catalog table it never asked about" \
+	"$(as t_stnone "SELECT count(*) FROM pgcolumnar.stats('st_t');" | grep -c 'st_t')" "1"
+
+# ---- the superuser path still works ----------------------------------------
+check_num "a superuser still reads stats" "$(q "SELECT count(*) FROM pgcolumnar.stats('st_t');")" "1"
+
+pgc_summary


### PR DESCRIPTION
Third and last of the forks. Based on `main`, not stacked on anything.

## The decision, and why the obvious fix is worse than the bug

`stats()` is documented as the function most users read, and it failed for the
owner of the table being inspected: it is `LANGUAGE sql` and selects straight
from `pgcolumnar.row_group`, `delete_vector` and `zone_map`. The install script
has no `GRANT`, so those tables are owner-only, and a **columnar table's owner is
not their owner**.

Granting `SELECT` on the catalog would publish `pgcolumnar.zone_map`, which
stores per-column `minimum`, `maximum` and `sum` for every columnar table. That
is actual column data, and a larger disclosure than #558, #559, #562 and #566
combined, introduced while fixing a usability defect.

So `stats()` runs `SECURITY DEFINER` and does the privilege check itself. This is
the **first `SECURITY DEFINER` function in the extension**, so `search_path` is
pinned and the check is explicit, because definer rights mean nothing else
refuses anyone.

## The trap, which I walked into first

I recommended `pg_class_aclcheck(relid, GetUserId(), ACL_SELECT)` to @jdatcmd and
to @ChronicallyJD before discovering it does not work. **Inside a `SECURITY
DEFINER` function the effective user is the function's owner**, so `GetUserId()`
returns the superuser who installed the extension and the check returns
`ACLCHECK_OK` for every relation in the database. It refuses nobody while looking
exactly like a correct privilege check.

Measured on a build of this tree rather than argued:

```
plain call   as t_id: cur=t_id      outer=t_id  sess=t_id
definer call as t_id: cur=postgres  outer=t_id  sess=t_id
```

`GetOuterUserId()` is the calling role, and it follows `SET ROLE`, which is the
behaviour wanted: the privilege tested is the one the caller is acting with.

## The suite is built around catching that, not around demonstrating the fix

Two mutations, both reddening the same two arms:

| mutation | result |
| --- | --- |
| `GetOuterUserId` → `GetUserId` (the trap) | a no-privilege role reads the statistics of a table it cannot read |
| the check deleted entirely | same |

The discriminating arm is **"the refusal names the TABLE, not a catalog table it
never asked about."** On unfixed code `a role with no privilege is refused`
already passes, because the catalog refuses everyone, so on its own it proves
nothing. Only the naming arm separates a working check from the pre-existing
accident.

## What I ran, and what I did not

PG16 only, a separate prefix from @ChronicallyJD's PG17: `stats_privilege` (12),
`analyze_stats`, `native_vacuum_race`, plus the cross-cutting `docs_style` and
`harness_selftest`. `docs_style` caught a 30-word sentence in my own new prose,
which is the check working. **I have not run the PG18+PG19 matrix.**

One interaction worth knowing when this and #574 are both in: inside the definer
context, `get_storage_id`'s own ACL check tests the definer and is therefore
vacuous. That is harmless here because the caller is checked first, on the same
relation, with the stricter identity — but it is exactly the trap above, so it
should not be relied on as a second layer.

Suite registered sorted; runner reports 140. Not merging this.