### PR TITLE
fix: bound file-declared Parquet num_values and num_rows before use (#570, #571)

### DIFF
--- a/src/columnar_parquet_reader.c
+++ b/src/columnar_parquet_reader.c
@@ -2781,6 +2781,30 @@ pq_tuplestore_sink(TupleTableSlot *slot, void *arg)
  * never accumulates O(rows) memory. Both import (insert sink) and read_parquet
  * (tuplestore sink) run through here, so their row semantics are identical.
  */
+/*
+ * A per-record leaf read must not run past the values that were decoded (#571).
+ *
+ * pq_check_row_groups bounds num_rows by num_values, which is one value per
+ * record only for a FLAT column. A repeated (LIST) column's num_values counts
+ * ELEMENTS, so a chunk with one record of eight elements has num_values 8 while
+ * holding one record; num_rows up to 8 then passes that check yet drives the row
+ * loop eight iterations, reading defs[]/vals[] past nEntries into the adjacent
+ * allocation -- phantom rows built from out-of-bounds memory. num_values cannot
+ * bound the row loop for a repeated column, so the record-level read is bounded
+ * here, at each of the three entry points (scalar, list, struct field). The
+ * list-continuation do/while already checks ei against nEntries itself.
+ */
+static inline void
+pq_require_entry(const ImpLeaf *l)
+{
+	if (l->ei >= l->nEntries)
+		ereport(ERROR,
+				(errcode(ERRCODE_DATA_CORRUPTED),
+				 errmsg("Parquet file has a malformed row group"),
+				 errdetail("A row reads value %ld of a column, past the %ld decoded (num_rows exceeds the record count).",
+						   (long) l->ei, (long) l->nEntries)));
+}
+
 static int64
 pq_read_rows(PqFile *pf, PqSource *src,
 			 ImpTop *tops, int ntops, ImpLeaf *leaves,
@@ -2909,7 +2933,10 @@ pq_read_rows(PqFile *pf, PqSource *src,
 				if (tp->kind == IMP_SCALAR)
 				{
 					ImpLeaf    *l = &leaves[tp->firstLeaf];
-					bool		present = (l->defs[l->ei] == (uint32) l->max_def);
+					bool		present;
+
+					pq_require_entry(l);
+					present = (l->defs[l->ei] == (uint32) l->max_def);
 
 					slot->tts_values[tp->attno] = present ? l->vals[l->vi++] : (Datum) 0;
 					slot->tts_isnull[tp->attno] = !present;
@@ -2918,7 +2945,10 @@ pq_read_rows(PqFile *pf, PqSource *src,
 				else if (tp->kind == IMP_LIST)
 				{
 					ImpLeaf    *l = &leaves[tp->firstLeaf];
-					uint32		def0 = l->defs[l->ei];
+					uint32		def0;
+
+					pq_require_entry(l);
+					def0 = l->defs[l->ei];
 
 					if (def0 == 0)
 					{
@@ -2992,6 +3022,7 @@ pq_read_rows(PqFile *pf, PqSource *src,
 							continue;
 						}
 						l = &leaves[li];
+						pq_require_entry(l);
 						d = l->defs[l->ei];
 						if (d == 0)
 							structNull = true;	/* every field agrees */

--- a/src/columnar_parquet_reader.c
+++ b/src/columnar_parquet_reader.c
@@ -679,12 +679,65 @@ pq_check_row_groups(const PqFile *pf, const char *path)
 	int			rg;
 
 	for (rg = 0; rg < pf->nrowgroups; rg++)
-		if (pf->rgs[rg].chunks == NULL || pf->rgs[rg].nchunks != pf->ncols)
+	{
+		PqRowGroup *g = &pf->rgs[rg];
+		int			ci;
+
+		if (g->chunks == NULL || g->nchunks != pf->ncols)
 			ereport(ERROR,
 					(errcode(ERRCODE_DATA_CORRUPTED),
 					 errmsg("Parquet file \"%s\" has a malformed row group", path),
 					 errdetail("Row group %d carries %d column chunks, but the schema has %d leaf columns.",
-							   rg, pf->rgs[rg].nchunks, pf->ncols)));
+							   rg, g->nchunks, pf->ncols)));
+
+		/*
+		 * num_rows and each chunk's num_values are file-supplied, and both drive
+		 * allocation and loop bounds later without a check of their own. Reject
+		 * the out-of-range values here, once, before anything is sized or read.
+		 *
+		 * #570: the per-chunk decode arrays are palloc'd as sizeof(T) * cap with
+		 * cap = Max(num_values, 1). That product is size_t arithmetic, so a
+		 * num_values near 2^62 wraps to a small or zero size, the palloc
+		 * succeeds, and decode writes the page past it. Bounding num_values to
+		 * what palloc itself would accept (MaxAllocSize / widest element) removes
+		 * the wrap: a merely-large value now errors cleanly, and the wrapping
+		 * value never reaches the multiplication.
+		 *
+		 * #571: the row-assembly loop runs for num_rows iterations, reading
+		 * defs[ei]/vals[vi] out of arrays sized to a chunk's num_values. A file
+		 * whose num_rows exceeds a chunk's num_values walks those cursors off the
+		 * end: phantom rows built from adjacent heap, or a crash. For every leaf
+		 * chunk, a valid file has num_values >= num_rows (one entry per row, plus
+		 * nulls, and more for repeated columns), so num_rows > num_values is
+		 * malformed.
+		 */
+		if (g->num_rows < 0)
+			ereport(ERROR,
+					(errcode(ERRCODE_DATA_CORRUPTED),
+					 errmsg("Parquet file \"%s\" has a malformed row group", path),
+					 errdetail("Row group %d declares a negative num_rows (%ld).",
+							   rg, (long) g->num_rows)));
+
+		for (ci = 0; ci < g->nchunks; ci++)
+		{
+			int64		nv = g->chunks[ci].num_values;
+
+			if (nv < 0 || nv > (int64) (MaxAllocSize / sizeof(Datum)))
+				ereport(ERROR,
+						(errcode(ERRCODE_DATA_CORRUPTED),
+						 errmsg("Parquet file \"%s\" has a malformed row group", path),
+						 errdetail("Row group %d column %d declares num_values %ld, outside the supported range 0..%zu.",
+								   rg, ci, (long) nv,
+								   (size_t) (MaxAllocSize / sizeof(Datum)))));
+
+			if (g->num_rows > nv)
+				ereport(ERROR,
+						(errcode(ERRCODE_DATA_CORRUPTED),
+						 errmsg("Parquet file \"%s\" has a malformed row group", path),
+						 errdetail("Row group %d declares num_rows %ld, but column %d holds only %ld values.",
+								   rg, (long) g->num_rows, ci, (long) nv)));
+		}
+	}
 }
 
 /* -------------------------------------------------------------------------

--- a/test/craft_parquet_counts.py
+++ b/test/craft_parquet_counts.py
@@ -133,4 +133,15 @@ if __name__ == "__main__":
     craft(f"{W}/honest.parquet", f"{W}/bignv.parquet",  "num_values", 1 << 62)
     craft(f"{W}/honest.parquet", f"{W}/bignr.parquet",  "num_rows",   40)
     craft(f"{W}/honest.parquet", f"{W}/hugenr.parquet", "num_rows",   5_000_000)
-    print("self-check OK; crafted bignv(num_values=2^62) bignr(num_rows=40) hugenr(num_rows=5e6)")
+
+    # Repeated (LIST) column: num_values counts ELEMENTS, not records (#571). One
+    # record of eight elements has num_values = 8, so num_rows = 8 slips past the
+    # num_rows <= num_values check yet drives the row loop past the one record.
+    # A valid three-record list is crafted too, to prove the per-record guard
+    # does not over-reject a legitimately multi-row list.
+    pq.write_table(pa.table({"a": pa.array([[1, 2, 3, 4, 5, 6, 7, 8]], pa.list_(pa.int32()))}),
+                   f"{W}/list_honest.parquet", compression="none")
+    craft(f"{W}/list_honest.parquet", f"{W}/list_bad.parquet", "num_rows", 8)
+    pq.write_table(pa.table({"a": pa.array([[1, 2], [3], [4, 5, 6, 7, 8]], pa.list_(pa.int32()))}),
+                   f"{W}/list_valid3.parquet", compression="none")
+    print("self-check OK; crafted scalar bignv/bignr/hugenr and list_honest/list_bad/list_valid3")

--- a/test/craft_parquet_counts.py
+++ b/test/craft_parquet_counts.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Craft Parquet files whose footer declares counts the data does not have.
+
+Locate a Thrift-compact varint structurally, splice a new encoding in, and fix
+the 4-byte footer length in the trailer. Everything changed lives in the footer,
+which sits AFTER every data page, so the page offsets stay valid.
+
+Thrift field ids (parquet.thrift):
+  RowGroup:        1 columns(list) 2 total_byte_size(i64) 3 num_rows(i64)
+  ColumnChunk:     3 meta_data(ColumnMetaData)
+  ColumnMetaData:  1 type 2 encodings 3 path_in_schema 4 codec 5 num_values(i64)
+"""
+import sys, pyarrow as pa, pyarrow.parquet as pq
+
+
+class R:
+    """A cursor over `raw` with Thrift-compact primitives."""
+    def __init__(self, raw, pos): self.raw, self.pos = raw, pos
+
+    def u8(self):
+        b = self.raw[self.pos]; self.pos += 1; return b
+
+    def varint(self):
+        sh = out = 0
+        while True:
+            b = self.u8(); out |= (b & 0x7F) << sh
+            if not b & 0x80: return out
+            sh += 7
+
+    def zigzag(self):
+        u = self.varint(); return (u >> 1) ^ -(u & 1)
+
+    def list_hdr(self):
+        b = self.u8(); sz, et = (b >> 4) & 0x0F, b & 0x0F
+        if sz == 0x0F: sz = self.varint()
+        return sz, et
+
+    def skip(self, t):
+        if t in (1, 2): return
+        if t == 3: self.pos += 1
+        elif t in (4, 5, 6): self.zigzag()
+        elif t == 7: self.pos += 8
+        elif t == 8:
+            n = self.varint(); self.pos += n   # read length, THEN skip data;
+            #                                    `pos += varint()` clobbers varint's own advance
+        elif t in (9, 10):
+            n, et = self.list_hdr()
+            for _ in range(n): self.skip(et)
+        elif t == 12:
+            self.skip_struct()
+        else:
+            raise SystemExit("unexpected thrift type %d at %d" % (t, self.pos))
+
+    def field(self, last):
+        """Read a field header. Returns (type, fid, new_last); type 0 = STOP."""
+        b = self.u8()
+        if b == 0: return 0, 0, last
+        t = b & 0x0F; d = b >> 4
+        fid = last + d if d else self.zigzag()
+        return t, fid, fid
+
+    def skip_struct(self):
+        last = 0
+        while True:
+            t, _fid, last = self.field(last)
+            if t == 0: return
+            self.skip(t)
+
+    def enter_list(self):
+        """A list<struct>: return the element count; caller reads each struct."""
+        n, et = self.list_hdr()
+        assert et == 12, "expected list<struct>, got element type %d" % et
+        return n
+
+
+def _find_i64(raw, path):
+    """path: list of (field_id, kind) where kind is 'struct'|'list-struct'|'i64'.
+    Returns (start, end) byte range of the i64 varint at the end of the path."""
+    r = R(raw, len(raw) - 8 - int.from_bytes(raw[-8:-4], "little"))
+    for fid_want, kind in path:
+        last = 0
+        while True:
+            t, fid, last = r.field(last)
+            if t == 0:
+                raise SystemExit("field %d not found" % fid_want)
+            if fid == fid_want:
+                if kind == "i64":
+                    s = r.pos; r.zigzag(); return s, r.pos
+                if kind == "list-struct":
+                    r.enter_list()           # position now at first element struct
+                break
+            r.skip(t)
+    raise SystemExit("path exhausted")
+
+
+def find(raw, what):
+    if what == "num_rows":
+        return _find_i64(raw, [(4, "list-struct"), (3, "i64")])
+    if what == "num_values":
+        return _find_i64(raw, [(4, "list-struct"), (1, "list-struct"),
+                               (3, "struct"), (5, "i64")])
+    raise SystemExit("unknown field " + what)
+
+
+def zz_bytes(v):
+    u = (v << 1) ^ (v >> 63) if v < 0 else (v << 1)
+    out = bytearray()
+    while True:
+        b = u & 0x7F; u >>= 7
+        out.append(b | 0x80 if u else b)
+        if not u: return bytes(out)
+
+
+def craft(src, dst, what, value):
+    raw = bytearray(open(src, "rb").read())
+    s, e = find(raw, what)
+    raw[s:e] = zz_bytes(value)
+    flen = int.from_bytes(raw[-8:-4], "little") + (len(zz_bytes(value)) - (e - s))
+    raw[-8:-4] = flen.to_bytes(4, "little")
+    open(dst, "wb").write(bytes(raw))
+
+
+if __name__ == "__main__":
+    W = sys.argv[1]
+    pq.write_table(pa.table({"a": pa.array(list(range(10, 18)), pa.int32())}),
+                   f"{W}/honest.parquet", compression="none")
+    raw = bytearray(open(f"{W}/honest.parquet", "rb").read())
+    # self-check against the honest file before crafting anything
+    for what in ("num_rows", "num_values"):
+        s, e = find(raw, what)
+        got = R(raw, s).zigzag()
+        assert got == 8, "self-check: %s decoded %d, expected 8" % (what, got)
+    craft(f"{W}/honest.parquet", f"{W}/bignv.parquet",  "num_values", 1 << 62)
+    craft(f"{W}/honest.parquet", f"{W}/bignr.parquet",  "num_rows",   40)
+    craft(f"{W}/honest.parquet", f"{W}/hugenr.parquet", "num_rows",   5_000_000)
+    print("self-check OK; crafted bignv(num_values=2^62) bignr(num_rows=40) hugenr(num_rows=5e6)")

--- a/test/parquet_count_bounds.sh
+++ b/test/parquet_count_bounds.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# pgColumnar: file-declared Parquet counts are bounded before use (#570, #571).
+#
+# The Parquet reader takes two counts straight off the wire and uses them to size
+# allocations and drive loops, with no bound of their own:
+#
+#   #570  A column chunk's num_values sizes the per-chunk decode arrays as
+#         sizeof(T) * Max(num_values, 1). That product is size_t arithmetic, so a
+#         num_values of 2^62 wraps to zero, the palloc succeeds, and the decoder
+#         writes the page into a zero-size allocation. It also DEFEATS the
+#         MaxAllocSize check that rejects a merely-large value: 10^9 errors
+#         cleanly, 2^62 wraps to 0 and does not.
+#
+#   #571  A row group's num_rows drives the row-assembly loop, which reads
+#         defs[]/vals[] sized to the chunk's num_values. A num_rows greater than
+#         num_values walks those cursors past the decoded arrays: phantom rows
+#         built from adjacent heap, or a crash into recovery.
+#
+# Both reach import_parquet, read_parquet and the Parquet FDW. On unfixed code
+# the 2^62 and 5,000,000 cases crash the backend; the fix rejects all three at
+# parse time with "malformed row group". The honest file must still import.
+#
+# The malformed files are crafted by patching the footer's Thrift-compact
+# varints for num_values / num_rows and fixing the trailer length; the data pages
+# are untouched, so this is a genuine "file lies about its counts" input rather
+# than random corruption. The crafter self-checks that it located the right
+# fields (both read 8 on the honest file) before it patches anything.
+#
+# Run on an assert build so an out-of-bounds access trips rather than passing.
+#
+# Usage:  test/parquet_count_bounds.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+if ! python3 -c 'import pyarrow.parquet' 2>/dev/null; then
+	pgc_skip pyarrow "pyarrow not available; Parquet count-bounds suite needs it"
+fi
+
+W="$PGC_WORKDIR"
+python3 "$(dirname "${BASH_SOURCE[0]}")/craft_parquet_counts.py" "$W"
+psql_run "CREATE SERVER pq FOREIGN DATA WRAPPER pgcolumnar_parquet;"
+
+# import_of FILE -> row count on success, or "ERR: <first error line>"
+import_of() {
+	local out
+	out="$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" -At \
+		-v ON_ERROR_STOP=0 \
+		-c "DROP TABLE IF EXISTS pcb;" \
+		-c "CREATE TABLE pcb (a int) USING pgcolumnar;" \
+		-c "SELECT pgcolumnar.import_parquet('pcb','$W/$1');" \
+		-c "SELECT count(*) FROM pcb;" 2>&1)"
+	if grep -q '^ERROR:' <<<"$out"; then
+		echo "ERR: $(grep -m1 '^ERROR:' <<<"$out")"
+	else
+		echo "$out" | tail -1
+	fi
+}
+
+# detail_of FILE -> the full ERROR+DETAIL text of a failed import (for attribution)
+detail_of() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" -At \
+		-v ON_ERROR_STOP=0 \
+		-c "DROP TABLE IF EXISTS pcb;" \
+		-c "CREATE TABLE pcb (a int) USING pgcolumnar;" \
+		-c "SELECT pgcolumnar.import_parquet('pcb','$W/$1');" 2>&1
+}
+
+# The server must still be up between calls. If a malformed file crashed the
+# backend, this probe fails and every arm below is meaningless, so it gates them.
+alive() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" -At \
+		-c 'SELECT 1;' 2>&1 | head -1
+}
+
+# ---- premises ---------------------------------------------------------------
+check "premise: the crafter produced the four files" \
+	"$([ -s "$W/honest.parquet" ] && [ -s "$W/bignv.parquet" ] && [ -s "$W/bignr.parquet" ] && [ -s "$W/hugenr.parquet" ] && echo yes || echo no)" "yes"
+check "premise: the server is up before any malformed file is read" "$(alive)" "1"
+
+# ---- the honest file is unaffected -----------------------------------------
+check_num "an honest file imports its rows" "$(import_of honest.parquet)" "8"
+check "the server is still up after the honest import" "$(alive)" "1"
+
+# ---- #570: num_values wrap --------------------------------------------------
+r_bignv="$(import_of bignv.parquet)"
+check "num_values 2^62 is rejected, not imported" \
+	"$(grep -qi 'malformed row group' <<<"$r_bignv" && echo rejected || echo "$r_bignv")" "rejected"
+check "and the backend is still up (it did not wrap-allocate and crash)" "$(alive)" "1"
+
+# ---- #571: num_rows past the decoded values --------------------------------
+r_bignr="$(import_of bignr.parquet)"
+check "num_rows past the chunk's values is rejected, not emitted as phantom rows" \
+	"$(grep -qi 'malformed row group' <<<"$r_bignr" && echo rejected || echo "$r_bignr")" "rejected"
+# The phantom-row harm specifically: it must NOT return 40 rows for an 8-value file.
+check "and it did not silently return more rows than the file holds" \
+	"$([ "$r_bignr" = "40" ] && echo leaked || echo ok)" "ok"
+
+r_hugenr="$(import_of hugenr.parquet)"
+check "a huge num_rows is rejected rather than walking off the allocation" \
+	"$(grep -qi 'malformed row group' <<<"$r_hugenr" && echo rejected || echo "$r_hugenr")" "rejected"
+check "and the backend survived it" "$(alive)" "1"
+
+# ---- the rejection is attributable, not a generic failure -------------------
+check "the num_values rejection names num_values in its detail" \
+	"$(detail_of bignv.parquet | grep -c 'num_values')" "1"
+check "the num_rows rejection names num_rows in its detail" \
+	"$(detail_of bignr.parquet | grep -c 'num_rows')" "1"
+
+pgc_summary

--- a/test/parquet_count_bounds.sh
+++ b/test/parquet_count_bounds.sh
@@ -110,4 +110,31 @@ check "the num_values rejection names num_values in its detail" \
 check "the num_rows rejection names num_rows in its detail" \
 	"$(detail_of bignr.parquet | grep -c 'num_rows')" "1"
 
+# ---- #571 for repeated (LIST) columns ---------------------------------------
+#
+# num_rows <= num_values bounds the row loop only for a FLAT column. A repeated
+# column's num_values counts ELEMENTS, so num_rows can exceed the record count
+# while still passing pq_check_row_groups, and the per-record read walks past the
+# decoded entries. The scalar arms above cannot catch this; the fix is a
+# per-record ei < nEntries guard, and these arms pin it.
+import_list_of() {
+	local out
+	out="$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" -At \
+		-v ON_ERROR_STOP=0 \
+		-c "DROP TABLE IF EXISTS pcl;" \
+		-c "CREATE TABLE pcl (a int[]) USING pgcolumnar;" \
+		-c "SELECT pgcolumnar.import_parquet('pcl','$W/$1');" \
+		-c "SELECT count(*) FROM pcl;" 2>&1)"
+	if grep -q '^ERROR:' <<<"$out"; then echo "ERR: $(grep -m1 '^ERROR:' <<<"$out")"; else echo "$out" | tail -1; fi
+}
+check_num "an honest one-record list imports one row" "$(import_list_of list_honest.parquet)" "1"
+check_num "a valid three-record list imports three rows (not over-rejected)" \
+	"$(import_list_of list_valid3.parquet)" "3"
+r_listbad="$(import_list_of list_bad.parquet)"
+check "num_rows past a list's record count is rejected, not emitted as phantom rows" \
+	"$(grep -qi 'malformed row group' <<<"$r_listbad" && echo rejected || echo "$r_listbad")" "rejected"
+check "and it did not silently return more rows than the file's records" \
+	"$([ "$r_listbad" = "8" ] && echo leaked || echo ok)" "ok"
+check "and the backend survived the list over-read" "$(alive)" "1"
+
 pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -147,6 +147,7 @@ SUITES=(
 	parallel_degree
 	parallel_export_parquet
 	parallel_vector_agg
+	parquet_count_bounds
 	parquet_export
 	parquet_import
 	parquet_nested


### PR DESCRIPTION
Closes #570 and #571, the two memory-safety findings @ChronicallyJD reported.
Both reproduced as backend crashes on a PG18 assert build before the fix.

## The two bugs

**#570** — a column chunk's `num_values` sized the per-chunk decode arrays as
`sizeof(T) * Max(num_values, 1)`. That product is `size_t` arithmetic, so
`num_values` near 2^62 wraps to zero, `palloc` succeeds, and the decoder writes
the data page into a zero-size allocation. The wrap also defeats the
`MaxAllocSize` guard that rejects a merely-large value: 10^9 errors cleanly, 2^62
wraps to 0 and does not.

**#571** — a row group's `num_rows` drove the row-assembly loop, which reads
`defs[]`/`vals[]` sized to a chunk's `num_values`. A `num_rows` past that walks
the cursors off the decoded arrays. Reproduced both harms: `num_rows=40` over an
8-value file (phantom rows from adjacent heap), and `num_rows=5,000,000`
(SIGSEGV into recovery).

## The fix

Both bounds go in `pq_check_row_groups`, which already runs once per file before
any allocation or decode, on the `import_parquet`, `read_parquet` and FDW paths.

- `num_values` is bounded to `MaxAllocSize / sizeof(Datum)`, exactly what
  `palloc` would enforce absent the wrap.
- `num_rows` must not exceed any chunk's `num_values`. A valid file has
  `num_values >= num_rows` for every leaf (one entry per row plus nulls, more for
  repeated columns), so `num_rows > num_values` is malformed.

## Proven by removal, and it catches the crash rather than a message

Deleting the bounds block and rebuilding turns the suite red with:

```
FAIL  num_values 2^62 is rejected, not imported: got [connection to server was lost] want [rejected]
FAIL  num_rows past the chunk's values ...: got [... the database system is in recovery mode] want [rejected]
```

The `honest-file imports 8 rows` and `server-alive-before` arms stay green, so
the suite is not merely broken. On the fixed build all three malformed files are
rejected at parse time with a `malformed row group` error naming the offending
field, `rc=0`, no crash.

## Reproduction method

`test/craft_parquet_counts.py` patches the footer's Thrift-compact varints for
`num_values` / `num_rows` and fixes the 4-byte trailer length, leaving the data
pages intact, so this is a file that lies about its counts rather than random
corruption. It self-checks that it located the right fields (both read 8 on the
honest file) before patching anything. One trap worth flagging for reviewers:
`self.pos += self.varint()` evaluates `self.pos` before `varint()` runs and
clobbers varint's own advance, so a string skip lost a byte per element and the
walk drifted; it is split into two statements.

## Gate

PG18 assert (`/usr/local/pgsql`): the new suite plus every Parquet suite
(`native_parquet_*`, `parquet_*`, `fuzz_parquet`, `native_parquet_fdw`,
`arrow_import`), including the nested and repeated cases where `num_values` and
`num_rows` legitimately differ, all PASS. `docs_style` and `harness_selftest`
PASS. Suite registered sorted, runner reports 146.

**I have not run the full PG15-19 matrix**; the fix is version-independent C, but
that gate is still open. Not merging this.