### PR TITLE
fix: price per-column decode CPU so the planner sees the parallel win (#503)

### DIFF
--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -954,6 +954,40 @@ pgcolumnar_full_scan_cost(RelOptInfo *rel, Path *seqpath)
  *		Both the target list and the restriction clauses count: a qual on a
  *		column that is not selected still has to be decoded to be evaluated.
  */
+/*
+ * pgcolumnar_projected_ncols
+ *		How many distinct columns a scan decodes: the projected columns plus the
+ *		columns any restriction reads. This is the multiplier for the per-value
+ *		decode cost (#503); the inherited heap seqscan cost has no such term, so a
+ *		wide projection is priced the same as a narrow one and the planner cannot
+ *		see that decoding nine columns costs nine times the CPU of decoding one.
+ *		Counted from the same "needed" set as the width fraction below, but as a
+ *		count rather than a width, because decode cost is per value not per byte.
+ */
+static int
+pgcolumnar_projected_ncols(RelOptInfo *rel)
+{
+	Bitmapset  *needed = NULL;
+	ListCell   *lc;
+	int			n = 0;
+	int			m = -1;
+
+	pull_varattnos((Node *) rel->reltarget->exprs, rel->relid, &needed);
+	foreach(lc, rel->baserestrictinfo)
+	{
+		RestrictInfo *rinfo = lfirst_node(RestrictInfo, lc);
+
+		pull_varattnos((Node *) rinfo->clause, rel->relid, &needed);
+	}
+
+	while ((m = bms_next_member(needed, m)) >= 0)
+		if (m + FirstLowInvalidHeapAttributeNumber >= 1)		/* a real column, not a system attr */
+			n++;
+
+	bms_free(needed);
+	return n;
+}
+
 static double
 pgcolumnar_projected_width_fraction(RelOptInfo *rel, Oid heapRelid)
 {
@@ -1420,6 +1454,7 @@ PgColumnarSetRelPathlist(PlannerInfo *root, RelOptInfo *rel, Index rti,
 		double		widthFrac = pgcolumnar_projected_width_fraction(rel, rte->relid);
 		Cost		pageCost = seq_page_cost * (double) rel->pages;
 		Cost		run = full - cpath->path.startup_cost;
+		double		ntuples = (rel->tuples >= 0) ? rel->tuples : rel->rows;
 
 		/*
 		 * Only the page-read part scales with the projected width: the CPU terms
@@ -1440,6 +1475,22 @@ PgColumnarSetRelPathlist(PlannerInfo *root, RelOptInfo *rel, Index rti,
 				saved = run;
 			run -= saved;
 		}
+
+		/*
+		 * Per-column decode CPU (#503). The inherited heap seqscan cost has no
+		 * term for decoding column values -- cpu_tuple_cost is per row, paid once
+		 * whatever the projection width. So a scan that decodes many columns is
+		 * priced the same as one that decodes one, and the planner cannot see the
+		 * CPU that a parallel plan would divide across workers: it declines the
+		 * partial path even where the parallel scan is measured 2.56x faster.
+		 *
+		 * Price one cpu_operator_cost per decoded value, ncols per row, added to
+		 * the run and scaled by survival like the rest (only surviving vectors
+		 * decode). This raises the full-scan cost, which is the safe direction for
+		 * #171 -- a pricier full scan makes the planner MORE likely to keep an
+		 * index scan, never less -- and analyze_stats/zonemap_cost pin that.
+		 */
+		run += cpu_operator_cost * ntuples * (double) pgcolumnar_projected_ncols(rel);
 
 		cpath->path.total_cost = cpath->path.startup_cost + run * survival;
 	}

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -169,6 +169,7 @@ SUITES=(
 	rewrite_group_scan
 	rls_direct_storage
 	row_triggers
+	scan_decode_cost
 	server_file_privilege
 	smoke
 	sort_status

--- a/test/scan_decode_cost.sh
+++ b/test/scan_decode_cost.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# pgColumnar: a columnar scan's cost scales with the number of decoded columns (#503).
+#
+# The custom scan inherits the heap seqscan cost, whose CPU term (cpu_tuple_cost)
+# is per row and paid once whatever the projection width. So decoding nine columns
+# was priced the same as decoding one, the planner could not see the decode CPU a
+# parallel plan would divide, and it declined the partial path even where the
+# parallel scan is measured 2.56x faster (the row-scan case in #503, distinct from
+# the aggregate parallel_safe=false of #565).
+#
+# The fix prices one cpu_operator_cost per decoded value, ncols per row. This suite
+# pins the plan-side of it -- a wide projection now costs measurably more than a
+# narrow one -- without a timing measurement, which lives on the bench. It also
+# pins #171: raising the full-scan cost must keep the point-lookup on its index.
+#
+# Usage:  test/scan_decode_cost.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+N=2000000
+psql_run "CREATE TABLE cw (k int, v1 bigint, v2 bigint, v3 bigint, v4 bigint, v5 bigint, v6 bigint, v7 bigint, v8 bigint) USING pgcolumnar;"
+psql_run "INSERT INTO cw SELECT (g % 1000000), g,g,g,g,g,g,g,g FROM generate_series(1,$N) g;"
+psql_run "ANALYZE cw;"
+
+# total_cost of a query's top node
+topcost() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" -Atq \
+		-c "EXPLAIN (COSTS ON) $1" 2>&1 | grep -oiE 'cost=[0-9.]+\.\.[0-9.]+' | head -1 \
+		| sed -E 's/.*\.\.([0-9.]+)/\1/'
+}
+
+NARROW="$(topcost 'SELECT k FROM cw')"
+WIDE="$(topcost 'SELECT k,v1,v2,v3,v4,v5,v6,v7,v8 FROM cw')"
+
+# premise: both are the columnar scan, and non-empty measurements
+check "premise: the narrow scan has a cost" "$([ -n "$NARROW" ] && echo yes || echo no)" "yes"
+check "premise: the wide scan has a cost"   "$([ -n "$WIDE" ] && echo yes || echo no)" "yes"
+
+# The load-bearing assertion: decoding 9 columns must cost meaningfully more than
+# decoding 1. Before the fix these are ~equal (flat in column count). The fix adds
+# cpu_operator_cost per value per column, so 8 extra columns over 2M rows is a
+# large, deterministic gap. Assert the wide scan is at least 1.5x the narrow one,
+# which the flat pricing (a ~1.4% width difference) cannot reach.
+RATIO="$(awk -v w="$WIDE" -v n="$NARROW" 'BEGIN{ printf "%.3f", (n>0)?w/n:0 }')"
+check "a wide projection costs materially more than a narrow one (decode is priced)" \
+	"$(awk -v r="$RATIO" 'BEGIN{ print (r >= 1.5) ? "scaled" : "flat" }')" "scaled"
+
+# #171 guard: a point lookup on an indexed column must still choose the index,
+# not a full columnar scan. Raising the scan cost is the safe direction, but pin
+# it so a too-large term cannot push the planner off the index either.
+psql_run "CREATE TABLE pt (id int, v bigint) USING pgcolumnar;"
+psql_run "INSERT INTO pt SELECT g, g FROM generate_series(1,$N) g;"
+psql_run "CREATE INDEX pt_id ON pt (id);"
+psql_run "ANALYZE pt;"
+PLAN="$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" -Atq \
+	-c 'EXPLAIN (COSTS OFF) SELECT v FROM pt WHERE id = 12345' 2>&1)"
+check "#171: a point lookup still uses the index, not a full scan" \
+	"$(grep -qi 'Index' <<<"$PLAN" && echo index || echo "$PLAN")" "index"
+
+pgc_summary


### PR DESCRIPTION
Closes the plan-side of #503. The measured half was @ChronicallyJD's; this is the
fix built on that measurement.

## The defect

A columnar scan inherited the heap seqscan cost, whose CPU term
(`cpu_tuple_cost`) is per row, paid once whatever the projection width. So
decoding nine columns was priced the same as decoding one, and the planner could
not see the decode CPU that a parallel plan divides across workers. It declined
the partial path (which `add_path` builds, `columnar_customscan.c:1649`) even
where the parallel scan is faster.

## Isolated cleanly, not conflated with cardinality

@ChronicallyJD measured the issue's 4M shape and controlled the confound I
flagged: **after `ANALYZE` the row estimate is accurate (156,596 vs 159,604
actual) and the plan is STILL serial** — so it is the cost model, not the
estimate. Interleaved A/B on an idle bench: **serial 64.4 ms vs forced-parallel
25.1 ms = 2.56x**, `Workers Launched: 4`.

Distinct from #565: that is the aggregate `parallel_safe = false` foreclosing the
plan structurally; here the plan exists and is only mispriced.

## The fix

`pgcolumnar_projected_ncols` counts decoded columns, and the cost site prices one
`cpu_operator_cost` per decoded value, `ncols` per row, scaled by survival — the
same per-value shape the index-fetch penalty already uses.

## #171 safety, proven not asserted

Raising the full-scan cost is the safe direction for #171 (a pricier full scan
keeps the index scan more often, never less). The new suite pins a point-lookup
arm directly, and `analyze_stats` (the #171 regression pin), `zonemap_cost` and
`planner_choice_quality` all stay green — so a too-large term cannot push the
planner off the index either.

## Effect confirmed in-container

On the 4M shape the planner now chooses `Gather -> Parallel Custom Scan` where it
previously chose serial. The magnitude — does the flipped plan match the measured
2.56x on real ClickBench data — is a bench follow-up @ChronicallyJD can take; the
plan flip, the #171 safety, and the cost scaling are proven here.

## TDD

`test/scan_decode_cost.sh`: a wide projection must cost >= 1.5x a narrow one.
RED on unfixed main (`got [flat]`, the two are ~1.4% apart), GREEN after. Point-
lookup arm pins #171. Broad plan-dependent sweep green:
native_agg/index/index_projection, differential, parallel/parallel_degree,
pushdown_report, column_projection, native_projection.

## Gate

PG18 non-assert for the plan/timing reasoning; the suite is version-independent
plan logic. **I have not run the full PG15-19 matrix.** Suite registered sorted,
runner reports 146, harness_selftest 107. Not merging this.