### PR TITLE
docs: columnar parallel scans under-chosen for narrow-selective shapes (#581)

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -352,11 +352,16 @@ scan. A columnar scan ships fewer, already-decoded rows, so that rate overstates
 its Gather cost. On the shape above the Gather cost reached almost the whole cost
 of the serial scan. The serial plan won on cost while losing on the clock.
 
-A columnar table would want about half the default `parallel_tuple_cost` for this
-decision. That rate is a global setting, applied through the core Gather cost. An
-access method cannot set its own value without a core change. Lowering the global
-setting is not the fix, because it changes the rate for every table on the system
-and the evidence is one workload.
+The default rate is conservative for any row-returning parallel scan, not only a
+columnar one. A heap scan on the same shape also flipped and ran faster at the
+lower rate. A columnar scan is affected most, because its own cost is low and the
+Gather cost then dominates. About half the default rate picks the faster plan on
+the shape above.
+
+That rate is a global setting, applied through the core Gather cost. An access
+method cannot set its own value without a core change. Lowering the global setting
+is not the fix, because it changes the rate for every table on the system and the
+evidence is one workload.
 
 The workaround is to force the parallel plan when it helps, with `SET
 max_parallel_workers_per_gather` and a lower `SET parallel_tuple_cost` for the

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -335,6 +335,33 @@ returning no rows.
   therefore skip fewer groups than the natural insertion order permits. Sort by
   the key that your selective queries filter on.
 
+## Parallel scans
+
+A columnar scan can run in parallel, and the planner builds a parallel path for
+it. On a wide projection it now chooses that path, because the per-column decode
+cost is priced and a parallel plan divides it across workers.
+
+On a narrow but selective scan the planner still prefers the serial plan even
+where the parallel one is faster. Measured: a three-column selective scan of a
+four-million-row table ran up to 2.5x faster in parallel, and the planner chose
+serial anyway.
+
+The cause is the cost of the Gather node. The planner prices each row passed from
+a worker to the leader at `parallel_tuple_cost`, the same rate it uses for a heap
+scan. A columnar scan ships fewer, already-decoded rows, so that rate overstates
+its Gather cost. On the shape above the Gather cost reached almost the whole cost
+of the serial scan. The serial plan won on cost while losing on the clock.
+
+A columnar table would want about half the default `parallel_tuple_cost` for this
+decision. That rate is a global setting, applied through the core Gather cost. An
+access method cannot set its own value without a core change. Lowering the global
+setting is not the fix, because it changes the rate for every table on the system
+and the evidence is one workload.
+
+The workaround is to force the parallel plan when it helps, with `SET
+max_parallel_workers_per_gather` and a lower `SET parallel_tuple_cost` for the
+session.
+
 ## Index-only scans
 
 An index-only scan uses the columnar visibility-map fork, which lazy `VACUUM`


### PR DESCRIPTION
The plan-side close for #581 (the gather-overcosting half of #503). Documents a
known limitation that needs a core change the extension does not make.

## What it documents

A narrow but selective columnar scan runs faster in parallel yet the planner
chooses serial. Measured (@ChronicallyJD's bench, confirmed by plan inspection):
a 3-column selective scan of a 4M-row table ran **up to 2.5x faster in parallel**
while the planner chose serial. The cause is the Gather node pricing each row at
`parallel_tuple_cost` (the heap rate), which overstates a columnar scan's Gather
cost -- on that shape the Gather cost reached almost the whole serial scan cost.

## Why it is documented, not fixed

- The columnar-appropriate rate is ~half the default (flip point between 0.1 and
  0.05, confirmed to pick the genuinely faster plan).
- That rate cannot be set per access method without a core change; core's
  `cost_gather` uses the global GUC.
- Lowering the global GUC is the wrong granularity (it changes every table's rate
  on one workload's evidence). An earlier "a global cut regresses heap" framing
  was retracted on #581 -- it did not reproduce; the objection is granularity, not
  demonstrated harm.

So #581 is a documented limitation with the magnitude pinned and a session
workaround (`SET max_parallel_workers_per_gather` + a lower session
`parallel_tuple_cost`).

## Gate

`ste_check` ok, `docs_style` and `harness_selftest` pass (PG18). Doc-only, no code
change. This does not close #581 by itself -- it is the plan-side disposition;
whether to close #581 as documented-wontfix or keep it for an eventual upstream
hook is the maintainer's call. Not merging this.