### PR TITLE
fix: a functional dependency estimate is not collapsed by a truncated MCV (#438)

### DIFF
--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -60,6 +60,8 @@
 #include "optimizer/pathnode.h"
 #include "optimizer/paths.h"
 #include "optimizer/restrictinfo.h"
+#include "statistics/statistics.h"
+#include "catalog/pg_statistic_ext.h"
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
 #include "utils/pg_locale.h"
@@ -1371,6 +1373,107 @@ PgColumnarSetRelPathlist(PlannerInfo *root, RelOptInfo *rel, Index rti,
 		return;
 	if (!OidIsValid(rte->relid) || !PgColumnarIsColumnarRelation(rte->relid))
 		return;
+
+	/*
+	 * #438: a capacity-truncated extended MCV can displace a functional
+	 * dependency and collapse the joint row estimate far below what the columns'
+	 * own marginals allow (measured: 1 against an actual 300). Core's precedence
+	 * cannot be changed from here, but the estimate can. When a dependency
+	 * statistic covers the restriction columns, recompute a dependency-consistent
+	 * estimate and, only if core's is lower, raise rel->rows to it.
+	 *
+	 * The joint selectivity of a FULL dependency is the most selective single-
+	 * column marginal (the determining column decides the rest); of NO dependency
+	 * it is the independence product. Interpolate by the strongest applicable
+	 * dependency degree:  degree*min_marginal + (1-degree)*independence.  That is
+	 * exact for the two-clause case and reduces to no correction at degree 0, so
+	 * a weak dependency is not over-raised and a correct estimate is never lowered.
+	 */
+	if (rel->baserestrictinfo != NIL && rel->tuples > 0 && rel->statlist != NIL)
+	{
+		Bitmapset  *clauseCols = NULL;
+		Selectivity minMarg = 1.0;
+		Selectivity indep = 1.0;
+		int			nclause = 0;
+		double		degree = 0.0;
+		bool		haveDep = false;
+		ListCell   *rc;
+		ListCell   *sc;
+
+		foreach(rc, rel->baserestrictinfo)
+		{
+			RestrictInfo *ri = lfirst_node(RestrictInfo, rc);
+			Selectivity slc = clause_selectivity(root, (Node *) ri, 0,
+												 JOIN_INNER, NULL);
+
+			pull_varattnos((Node *) ri->clause, rel->relid, &clauseCols);
+			if (slc < minMarg)
+				minMarg = slc;
+			indep *= slc;
+			nclause++;
+		}
+
+		if (nclause >= 2 && bms_num_members(clauseCols) >= 2)
+		{
+			foreach(sc, rel->statlist)
+			{
+				StatisticExtInfo *stat = (StatisticExtInfo *) lfirst(sc);
+				Bitmapset  *statCols = NULL;
+				int			x = -1;
+
+				if (stat->kind != STATS_EXT_DEPENDENCIES)
+					continue;
+				while ((x = bms_next_member(stat->keys, x)) >= 0)
+					statCols = bms_add_member(statCols,
+											  x - FirstLowInvalidHeapAttributeNumber);
+				if (bms_is_subset(clauseCols, statCols))
+				{
+					MVDependencies *deps =
+						statext_dependencies_load(stat->statOid, stat->inherit);
+
+					if (deps != NULL)
+					{
+						uint32		d;
+
+						for (d = 0; d < deps->ndeps; d++)
+						{
+							MVDependency *dep = deps->deps[d];
+							bool		covered = true;
+							int			a;
+
+							for (a = 0; a < dep->nattributes; a++)
+							{
+								int			off = dep->attributes[a] -
+									FirstLowInvalidHeapAttributeNumber;
+
+								if (!bms_is_member(off, clauseCols))
+								{
+									covered = false;
+									break;
+								}
+							}
+							if (covered && dep->degree > degree)
+								degree = dep->degree;
+						}
+						haveDep = true;
+					}
+					bms_free(statCols);
+					break;
+				}
+				bms_free(statCols);
+			}
+		}
+
+		if (haveDep && degree > 0.0)
+		{
+			Selectivity depSel = degree * minMarg + (1.0 - degree) * indep;
+			double		depRows = clamp_row_est(rel->tuples * depSel);
+
+			if (depRows > rel->rows)
+				rel->rows = depRows;
+		}
+		bms_free(clauseCols);
+	}
 
 	/*
 	 * The custom scan is the scalar per-row path (PgColumnarReadNextRow), so

--- a/test/dependency_estimate.sh
+++ b/test/dependency_estimate.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# pgColumnar: a functional-dependency row estimate is not collapsed by a
+# capacity-truncated extended MCV (#438).
+#
+# A columnar scan inherits the row estimate core computes, and core applies a
+# partial extended MCV BEFORE the functional dependency, which -- when the MCV
+# cannot hold every group -- displaces the (perfect) dependency and clamps the
+# joint estimate to 1 (measured: 1 against an actual 300, a 300x under-estimate).
+# PgColumnarSetRelPathlist recomputes a dependency-consistent estimate and raises
+# rel->rows to it when core's is lower. This suite pins that, proves it does not
+# distort a case core already gets right, and that a table without a dependency
+# statistic is untouched.
+#
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+est() {  # est <sql> -> the top node's estimated row count
+	q "EXPLAIN (COSTS ON) $1" | grep -m1 -oE 'rows=[0-9]+' | head -1 | cut -d= -f2
+}
+
+# ---- the #438 case: 1000 near-uniform values, b = a*2, full extended stats ----
+psql_run "CREATE TABLE dep_full (a int, b int) USING pgcolumnar;"
+psql_run "INSERT INTO dep_full SELECT g%1000, (g%1000)*2 FROM generate_series(1,300000) g;"
+psql_run "CREATE STATISTICS dep_full_s (dependencies, ndistinct, mcv) ON a, b FROM dep_full;"
+psql_run "ANALYZE dep_full;"
+FULL_ACTUAL="$(q "SELECT count(*) FROM dep_full WHERE a=5 AND b=10;")"
+
+# a table core already estimates correctly (10 values, each an MCV) -- must NOT move
+psql_run "CREATE TABLE dep_ok (a int, b int) USING pgcolumnar;"
+psql_run "INSERT INTO dep_ok SELECT g%10, (g%10)*2 FROM generate_series(1,300000) g;"
+psql_run "CREATE STATISTICS dep_ok_s (dependencies, ndistinct, mcv) ON a, b FROM dep_ok;"
+psql_run "ANALYZE dep_ok;"
+OK_ACTUAL="$(q "SELECT count(*) FROM dep_ok WHERE a=5 AND b=10;")"
+
+# a table with NO extended statistic -- the correction must not fire
+psql_run "CREATE TABLE dep_none (a int, b int) USING pgcolumnar;"
+psql_run "INSERT INTO dep_none SELECT g%1000, (g%1000)*2 FROM generate_series(1,300000) g;"
+psql_run "ANALYZE dep_none;"
+
+# ---- premises: the fixtures express the question ---------------------------
+check_num "premise: the #438 case really matches ~300 rows" "$FULL_ACTUAL" "300"
+
+# ---- the correction: the clamped estimate is raised to the dependency floor -
+# On unfixed main this is 1 (the MCV displaces the dependency). The fix makes it
+# track the dependency-informed estimate, which is within a small factor of actual.
+FULL_EST="$(est "SELECT * FROM dep_full WHERE a=5 AND b=10")"
+check "the functional-dependency estimate is not collapsed to the clamp floor" \
+	"$([ "${FULL_EST:-0}" -ge 100 ] && echo raised || echo "clamped($FULL_EST)")" "raised"
+check "and it is not an over-correction (bounded by the most selective marginal)" \
+	"$([ "${FULL_EST:-0}" -le "$((FULL_ACTUAL * 2))" ] && echo bounded || echo "over($FULL_EST)")" "bounded"
+
+# ---- no distortion where core is already right -----------------------------
+OK_EST="$(est "SELECT * FROM dep_ok WHERE a=5 AND b=10")"
+check "a case core already estimates well is unchanged (within 20%)" \
+	"$(awk -v e="$OK_EST" -v a="$OK_ACTUAL" 'BEGIN{print (e>=a*0.8 && e<=a*1.2)?"same":"moved("e")"}')" "same"
+
+# ---- no dependency statistic -> no correction ------------------------------
+NONE_EST="$(est "SELECT * FROM dep_none WHERE a=5 AND b=10")"
+check "a table with no dependency statistic is left to core's estimate (not raised)" \
+	"$([ "${NONE_EST:-0}" -le 10 ] && echo untouched || echo "raised($NONE_EST)")" "untouched"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -60,6 +60,7 @@ SUITES=(
 	concurrent_diff
 	corruption
 	decode_interrupts
+	dependency_estimate
 	differential
 	docs_style
 	drop_cleanup


### PR DESCRIPTION
Closes the estimation half of #438. Its earlier disposition (mine) concluded there was no pgColumnar-side fix, resting on the structural claim that a custom scan cannot affect a row estimate. That claim does not survive testing — `set_rel_pathlist_hook` *copies* `rel->rows` into the path, but nothing stops it overwriting `rel->rows` first, and EXPLAIN then prints the new value verbatim (proven with a sentinel). So the estimate is ours to correct, and this does.

## The defect

Core applies a partial extended MCV **before** the functional dependency (`statext_clauselist_selectivity` → dependencies gets the MCV-consumed clauses subtracted). When the MCV cannot hold every group it estimates them all and leaves the dependency nothing to anchor to, collapsing `WHERE a=5 AND b=10` to the clamp floor of **1** on data with a degree-1.0 dependency and an actual of **300** — a 300x under-estimate. `dependencies` alone gets it right; adding a truncated `mcv` breaks it. This is upstream (Vondra flagged it in 2020), not fixable in core from here.

## The fix

`PgColumnarSetRelPathlist` recomputes a dependency-consistent estimate when a dependency statistic covers the restriction columns, and raises `rel->rows` only if core's is lower. The joint selectivity of a **full** dependency is the most selective single-column marginal (the determining column decides the rest); of **no** dependency it is the independence product; interpolate by the strongest applicable dependency degree (`statext_dependencies_load`):

```
depSel = degree * min_marginal + (1 - degree) * independence_product
```

Exact for the two-clause case, reduces to no correction at degree 0 (so a weak dependency is not over-raised), and only ever raises a clamped estimate — a correct one is never lowered.

## Proven, TDD (assert build)

| case | main | with fix | reverted |
| --- | ---: | ---: | ---: |
| **full dependency** (actual 300) | 1 | **299** | 1 |
| **partial dependency** (~90%) | 1 | **268** | 1 |
| a case core already gets right (10 values) | 30310 | 30310 | 30310 |
| a table with no dependency statistic | 1 | 1 | 1 |

The partial case is the proof it is *exact*, not merely "raises": 268 is `sel(b=10)` applied through the degree-1.0 `b→a` dependency — precisely what core's `(dependencies, ndistinct)` alone computes, which the displacing MCV was collapsing. So it reproduces core's correct dependency-informed estimate across degrees.

`test/dependency_estimate.sh` pins it: 5 checks, GREEN with the fix, and it goes RED (`got [clamped(1)] want [raised]`) when only `columnar_customscan.c` is reverted — the removal proof. It also asserts the no-distortion and no-statistic arms.

## Gate

PG15-19 matrix running on the bench; I'll post the record. Not merging this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017N82wDmsawqSWoWkmxtHmW
