### PR TITLE
perf: detoast each varlena once per row on the write path (#445)

### DIFF
--- a/src/columnar_write_state.c
+++ b/src/columnar_write_state.c
@@ -727,8 +727,27 @@ PgColumnarWriteRow(PgColumnarWriteState *writeState, Relation rel,
 		}
 		else
 		{
+			Datum		v = values[c];
+			struct varlena *flat = NULL;
+
+			/*
+			 * Detoast a varlena ONCE per row and reuse the flattened Datum for
+			 * everything below. It is otherwise flattened up to four times -- by
+			 * the encoder, the bloom hash, and each of the two min/max
+			 * comparisons -- and for a toasted (compressed) value each of those
+			 * is a full decompression, which #445's profile saw as detoast_attr
+			 * on the write path. pg_detoast_datum returns the same pointer for an
+			 * already-flat value, so the uncompressed common case copies and
+			 * frees nothing; non-varlena types skip it entirely.
+			 */
+			if (att->attlen == -1)
+			{
+				flat = pg_detoast_datum((struct varlena *) DatumGetPointer(v));
+				v = PointerGetDatum(flat);
+			}
+
 			appendStringInfoChar(&col->existsStream, 1);
-			PgColumnarEncodeValue(&col->valueStream, att, values[c]);
+			PgColumnarEncodeValue(&col->valueStream, att, v);
 			col->valueCount++;
 
 			/* accumulate the value's hash for the per-chunk bloom filter (I7) */
@@ -737,7 +756,7 @@ PgColumnarWriteRow(PgColumnarWriteState *writeState, Relation rel,
 				uint32		h = DatumGetUInt32(
 					FunctionCall1Coll(&writeState->colDefs[c].hashFn,
 									  writeState->colDefs[c].hashCollation,
-									  values[c]));
+									  v));
 
 				appendBinaryStringInfo(&col->hashBuf, (char *) &h, sizeof(uint32));
 			}
@@ -745,8 +764,8 @@ PgColumnarWriteRow(PgColumnarWriteState *writeState, Relation rel,
 			/* maintain the per-chunk exact int sum for the zone map (D5) */
 			if (writeState->colDefs[c].summableInt)
 				col->sum += (att->atttypid == INT2OID)
-					? (int64) DatumGetInt16(values[c])
-					: (int64) DatumGetInt32(values[c]);
+					? (int64) DatumGetInt16(v)
+					: (int64) DatumGetInt32(v);
 
 			/* maintain the per-chunk min/max for orderable types */
 			if (writeState->colDefs[c].orderable)
@@ -757,10 +776,8 @@ PgColumnarWriteRow(PgColumnarWriteState *writeState, Relation rel,
 
 				if (!col->hasMinMax)
 				{
-					col->minValue = datumCopy(values[c], att->attbyval,
-											  att->attlen);
-					col->maxValue = datumCopy(values[c], att->attbyval,
-											  att->attlen);
+					col->minValue = datumCopy(v, att->attbyval, att->attlen);
+					col->maxValue = datumCopy(v, att->attbyval, att->attlen);
 					col->hasMinMax = true;
 				}
 				else
@@ -773,28 +790,34 @@ PgColumnarWriteRow(PgColumnarWriteState *writeState, Relation rel,
 					 * of a serial or timestamp column produces -- cost one
 					 * comparison per value instead of two.
 					 */
-					int32		cmpMax = pgcolumnar_cmp_value(def, values[c],
+					int32		cmpMax = pgcolumnar_cmp_value(def, v,
 														   col->maxValue);
 
 					if (cmpMax > 0)
 					{
 						if (!att->attbyval)
 							pfree(DatumGetPointer(col->maxValue));
-						col->maxValue = datumCopy(values[c], att->attbyval,
-												  att->attlen);
+						col->maxValue = datumCopy(v, att->attbyval, att->attlen);
 					}
-					else if (pgcolumnar_cmp_value(def, values[c],
-												col->minValue) < 0)
+					else if (pgcolumnar_cmp_value(def, v, col->minValue) < 0)
 					{
 						if (!att->attbyval)
 							pfree(DatumGetPointer(col->minValue));
-						col->minValue = datumCopy(values[c], att->attbyval,
-												  att->attlen);
+						col->minValue = datumCopy(v, att->attbyval, att->attlen);
 					}
 				}
 
 				MemoryContextSwitchTo(oldContext);
 			}
+
+			/*
+			 * Free the flattened copy if detoasting made one. Everything above
+			 * has consumed it: the encoder and bloom copied the bytes out, and
+			 * min/max datumCopy'd into the stripe context. Nothing was allocated
+			 * when the value was already flat (flat == the original pointer).
+			 */
+			if (flat != NULL && (char *) flat != DatumGetPointer(values[c]))
+				pfree(flat);
 		}
 	}
 

--- a/test/native_toasted_write.sh
+++ b/test/native_toasted_write.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# pgColumnar: writing a TOASTED varlena is correct (#445 detoast-once).
+#
+# The writer flattens each varlena value once per row and reuses the flat Datum
+# for the encoder, the bloom hash and the min/max comparisons, rather than
+# letting each of those detoast the value independently (for a compressed value,
+# each is a full decompression -- ~11% of a large-text load, #445's write-path
+# detoast_attr). This suite guards the CORRECTNESS of that flatten-once path,
+# which the other write suites do not reach because they use short, non-toasted
+# values. The perf win is a timing, not a check here; the removal proof for the
+# optimisation is the load time, recorded on the PR.
+#
+# The source is a HEAP table, so its wide values are stored pglz-compressed and
+# reading it back hands the columnar writer already-toasted varlenas -- the exact
+# input the flatten-once path exists for. The heap mirror is the oracle.
+#
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+# big is ~3.2 kB and compressible, so heap stores it toasted (pglz). small is a
+# non-toasted varlena, so both branches of the flatten (copy vs no-copy) run.
+psql_run "CREATE TABLE src (k int, big text, small text);"
+psql_run "INSERT INTO src SELECT g, repeat(md5((g % 777)::text), 100) || chr(65 + (g % 26)), (g % 50)::text FROM generate_series(1, 60000) g;"
+psql_run "CREATE TABLE h (k int, big text, small text);"
+psql_run "CREATE TABLE c (k int, big text, small text) USING pgcolumnar;"
+psql_run "INSERT INTO h SELECT * FROM src;"
+psql_run "INSERT INTO c SELECT * FROM src;"
+
+q() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -Atqc "$1" 2>/dev/null
+}
+
+# If this ever reads non-pglz, the fixture stopped toasting and the suite is no
+# longer exercising the path it exists for.
+check_text "premise: the source values are toasted (pglz)" \
+	"$(q "SELECT pg_column_compression(big) FROM src LIMIT 1")" "pglz"
+
+# The value bytes must survive the flatten-once path exactly.
+check_text "toasted values are byte-identical to the heap mirror" \
+	"$(q "SELECT md5(string_agg(big, '|' ORDER BY k)) FROM c")" \
+	"$(q "SELECT md5(string_agg(big, '|' ORDER BY k)) FROM h")"
+
+# min/max is built from the flattened value; a range prune must match heap.
+check_num "the min/max zone map is correct (range count matches heap)" \
+	"$(q "SELECT count(*) FROM c WHERE big > repeat('z', 10)")" \
+	"$(q "SELECT count(*) FROM h WHERE big > repeat('z', 10)")"
+
+# the bloom hash is taken from the flattened value; equality must match heap.
+check_num "equality on a toasted value (bloom + recheck) matches heap" \
+	"$(q "SELECT count(*) FROM c WHERE big = (SELECT big FROM src WHERE k = 12345)")" \
+	"$(q "SELECT count(*) FROM h WHERE big = (SELECT big FROM src WHERE k = 12345)")"
+
+# the short non-toasted column must be unaffected.
+check_text "the non-toasted column is byte-identical too" \
+	"$(q "SELECT md5(string_agg(small, '|' ORDER BY k)) FROM c")" \
+	"$(q "SELECT md5(string_agg(small, '|' ORDER BY k)) FROM h")"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -136,6 +136,7 @@ SUITES=(
 	native_roundtrip
 	native_skip
 	native_sort_by
+	native_toasted_write
 	native_truncate
 	native_vacuum_race
 	native_vecdecode


### PR DESCRIPTION
## What

`PgColumnarWriteRow` flattened every varlena value **up to four times per row** — once in `PgColumnarEncodeValue`, once for the bloom hash, and once per min/max comparison. For a **toasted (pglz-compressed)** value each of those is a full decompression; #445's write-path profile saw it as `detoast_attr`.

This detoasts once at the top of the row's column handling and reuses the flat `Datum` for the encoder, bloom hash, and min/max compares, freeing the copy after the row. `pg_detoast_datum` returns the same pointer for an already-flat value, so the uncompressed common case copies and frees nothing and non-varlena types skip it — **output is byte-identical either way**.

## Measured

300,000-row load of a ~3.8 kB `pglz`-compressed text column, pg18 non-assert, median of 3:

| | load |
|---|---:|
| before | 3193 ms |
| after | **2836 ms** |

**11.2% faster.** The saving scales with how compressed the values are — small for short strings (ClickBench URLs), larger for wide text. This is one item in #445's broad write-path tail, not its headline (that is compression, which parallelises).

## Tests

`test/native_toasted_write.sh` (new): loads a heap table's **toasted** values into columnar and differences against a heap mirror — values byte-identical, min/max range prune correct, equality (bloom + recheck) correct, and the short non-toasted column unaffected. It guards the flatten-once path specifically, which the other write suites don't reach (they use short, non-toasted values). Registered, `harness_selftest` green (107).

Correctness unaffected: `differential`, `native_writer`, `native_zonemap`, `native_bloom` all pass. The removal proof for the optimisation is the load-time number above (deleting it stays green — the output is identical — so the perf win is a timing, not a check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)