### PR TITLE
docs: reconcile the #426 prune ceiling to the measured ~91% (was inconsistently ~93%/~91%)

### DIFF
--- a/design/ISSUE_426_SUBSTRING_FILTER.md
+++ b/design/ISSUE_426_SUBSTRING_FILTER.md
@@ -7,8 +7,11 @@ merged in #584) and `design/ISSUE_452_PHASE2_DECODE_GATING.md`.
 ## DISPOSITION (2026-08-11): feasible, measured, NOT built
 
 The design below is sound and the step-1 measurement was taken on real ClickBench
-`hits` URLs (1,000,000 rows via duckdb). Result: reaching the ~93% prune plateau
-costs **~8 bytes/row** on the filtered string column (65536 bits per 1024-row
+`hits` URLs (1,000,000 rows via duckdb; re-checked on the full 11.1M sample).
+Result: reaching the ~91% prune ceiling (the initial 1M-row probe read ~93%, but
+that is a prefix, and the `%google%` matches cluster, so the full sample is the
+truer ~91% -- a prefix over-counts skippable vectors) costs **~8 bytes/row** on
+the filtered string column (65536 bits per 1024-row
 vector; real URLs carry ~7,251 distinct trigrams/vector, so a smaller filter
 saturates and prunes nothing). On URL that is ~40% overhead on the column, ~6% of
 the whole hits table, and it buys only q21/q22 (2.2x/1.8x) because q24 -- the big


### PR DESCRIPTION
## Reconcile the #426 prune ceiling: it's the measured ~91%, not ~93%

The merged `ISSUE_426_SUBSTRING_FILTER.md` cited both a **~93% prune plateau** (disposition, line 10) and a **~91% prune ceiling** (line 101) — internally inconsistent, since a plateau can't exceed the ceiling.

Verified rather than guessed. Re-measured the `%google%` zero-match 1024-row-block fraction on the ClickBench `hits` data via duckdb:

| sample | zero-match block fraction |
| --- | ---: |
| full 11.1M (the columnar table's size) | **91.01%** (10,851 blocks) |
| first 1M (the doc's stated probe) | 93.45% (977 blocks) |
| `%google%` row match rate | 0.0156% |

Both are correct for their scale — but the 1M figure is a **prefix**, and the matches cluster, so it over-counts skippable vectors. The full sample is the truer **~91%**. (Same prefix-unrepresentativeness that broke the first-K decode probe on #595 — a nice consistency between the two.)

The fix uses ~91% in both places and notes why the 1M probe over-read. One-line doc change; no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017N82wDmsawqSWoWkmxtHmW
