### PR TITLE
fix: EXPLAIN ANALYZE reports the batch fold that ran, not the prediction (#602)

### DIFF
--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -3618,8 +3618,23 @@ PgColumnarExplainAggScan(CustomScanState *node, List *ancestors, ExplainState *e
 	PgColumnarExplainPushedDown(state->nscankeys, es);
 	PgColumnarExplainVectorPredicates(state->npreds, es);
 	if (state->scanFold)
+	{
+		/*
+		 * Plain EXPLAIN has no execution to report, so it shows the shape
+		 * prediction. Once the node has run, report what actually happened:
+		 * a predicted-eligible fold can still fall back to the row path (a
+		 * column added after some row groups), and printing the prediction
+		 * under ANALYZE reported "yes" for a row-path run (#602).
+		 *
+		 * A node ANALYZE marks "(never executed)" has no stats either, so
+		 * the prediction prints there too; beside that marker it means
+		 * "would have been attempted", not "ran".
+		 */
 		ExplainPropertyText("Columnar Batch Fold",
-							state->batchEligible ? "yes" : "no", es);
+							(state->haveStats ? state->batchFolded
+											  : state->batchEligible)
+							? "yes" : "no", es);
+	}
 
 	if (state->haveStats)
 	{

--- a/test/batch_fold_explain.sh
+++ b/test/batch_fold_explain.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# pgColumnar #602: EXPLAIN ANALYZE must not report "Columnar Batch Fold: yes"
+# for an execution that fell back to the row path.
+#
+# The ungrouped vectorized aggregate decides fold eligibility from the query
+# shape at Begin (so plain EXPLAIN can report what will be attempted), and
+# records during execution whether the fold actually ran. The two can disagree:
+# a column added after some row groups exist is predicted-eligible, but the
+# first old group is missing the column, pgcolumnar_native_batch_fold returns
+# false before claiming any group, and the whole scan runs the row path.
+# Printing the prediction under ANALYZE reported "yes" for that row-path run,
+# which is exactly the line a fold-path measurement pins its premise on.
+#
+# Plain EXPLAIN keeps the prediction: with no execution there is nothing else
+# to report, and "will this shape fold" is the useful answer there.
+#
+# Usage:  test/batch_fold_explain.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+GUC="SET pgcolumnar.enable_ungrouped_vector_agg = on;"
+
+# Scalar under this suite's GUCs. tail -1 drops the SET tags psql prints
+# ahead of the result row.
+sq() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -At -c "$GUC $1" 2>/dev/null | tail -1
+}
+
+# The "Columnar Batch Fold" value out of an EXPLAIN, or empty if the plan has
+# no such line (wrong node planned): check_text refuses empty, so a fixture
+# that misses the custom aggregate node fails by name instead of passing.
+fold_line() {	# fold_line <explain-prefix> <query>
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -At -c "$GUC $1 $2" 2>/dev/null \
+		| grep "Columnar Batch Fold" | grep -oE "yes|no" | head -1
+}
+
+# ---- fixtures ---------------------------------------------------------------
+# bfe_old: 50k rows written BEFORE v exists, 10k after. The old groups have no
+# chunk for v, so the fold must refuse the relation at execution.
+# bfe_ctrl: the same 10k post-ADD rows, columns present from the start, so the
+# same query shape genuinely folds. v is NULL on every pre-ADD row, so both
+# tables aggregate the same 10k generate_series values.
+psql_run "CREATE TABLE bfe_old(q int) USING pgcolumnar;"
+psql_run "INSERT INTO bfe_old SELECT 1 + g % 100 FROM generate_series(1,50000) g;"
+psql_run "ALTER TABLE bfe_old ADD COLUMN v int;"
+psql_run "INSERT INTO bfe_old SELECT 1 + g % 100, g FROM generate_series(1,10000) g;"
+psql_run "CREATE TABLE bfe_ctrl(q int, v int) USING pgcolumnar;"
+psql_run "INSERT INTO bfe_ctrl SELECT 1 + g % 100, g FROM generate_series(1,10000) g;"
+
+Q_OLD="SELECT sum(v) FROM bfe_old WHERE q <= 50"
+Q_CTRL="SELECT sum(v) FROM bfe_ctrl WHERE q <= 50"
+ANALYZE_PFX="EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF, SUMMARY OFF)"
+PLAIN_PFX="EXPLAIN (COSTS OFF)"
+
+# ---- premises ---------------------------------------------------------------
+check_num "premise: fixture loaded every row" \
+	"$(sq "SELECT count(*) FROM bfe_old;")" "60000"
+
+# The answers, against an oracle that touches neither table.
+want_sum="$(sq "SELECT sum(g) FROM generate_series(1,10000) g WHERE 1 + g % 100 <= 50;")"
+check_num "premise: fallback table returns the right sum" "$(sq "$Q_OLD;")" "$want_sum"
+check_num "premise: control table returns the right sum" "$(sq "$Q_CTRL;")" "$want_sum"
+
+# The control genuinely folds, and ANALYZE says so. Guards the fix against
+# breaking the true positive.
+check_text "control: ANALYZE reports the fold that ran" \
+	"$(fold_line "$ANALYZE_PFX" "$Q_CTRL")" "yes"
+
+# Plain EXPLAIN keeps reporting the prediction: the shape IS eligible.
+check_text "fallback table: plain EXPLAIN still reports the prediction" \
+	"$(fold_line "$PLAIN_PFX" "$Q_OLD")" "yes"
+
+# ---- the check (#602) -------------------------------------------------------
+# Execution on bfe_old cannot fold (old groups lack v), so ANALYZE must say no.
+# On the pre-fix code this read "yes": the prediction, printed as if it ran.
+check_text "fallback table: ANALYZE reports the row path that actually ran" \
+	"$(fold_line "$ANALYZE_PFX" "$Q_OLD")" "no"
+
+# ---- fallback-exists pin ----------------------------------------------------
+# The parallel partial fold cannot take this fallback (its group counter has
+# already advanced) and refuses the relation with a hard error. When the
+# planner gives us the partial fold, that error is independent proof the
+# fixture still forces the fallback. If the fold ever learns to read a column
+# added after some row groups, this and the "no" check above go red together,
+# which is the loud revisit this suite wants.
+PGUC="$GUC SET pgcolumnar.enable_parallel_vector_agg = on;
+SET max_parallel_workers_per_gather = 2; SET parallel_setup_cost = 0;
+SET parallel_tuple_cost = 0; SET min_parallel_table_scan_size = 0;"
+pplan="$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+	-d "$PGC_DB" -At -c "$PGUC $PLAIN_PFX $Q_OLD;" 2>/dev/null)"
+# case patterns, not a pipe into an early-exit grep: piping a captured string
+# into a quiet-mode reader loses the match to EPIPE under pipefail (selftest
+# rule #486 — whose scanner reads these comment lines too).
+par_planned=no
+case "$pplan" in
+	*Gather*)
+		case "$pplan" in
+			*"Columnar Batch Fold"*) par_planned=yes ;;
+		esac ;;
+esac
+if [ "$par_planned" = yes ]; then
+	perr_out="$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -At -c "$PGUC $Q_OLD;" 2>&1)"
+	perr_hits="$(printf '%s\n' "$perr_out" | grep -c "cannot fold a relation with a column added")"
+	check_num "parallel partial fold refuses the fallback relation" "$perr_hits" "1"
+else
+	echo "note: no parallel partial fold planned on major $PGC_MAJOR;" \
+		"the ANALYZE 'no' check above carries the fallback proof alone"
+fi
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -50,6 +50,7 @@ SUITES=(
 	arrow_nested
 	arrow_nested_import
 	audit
+	batch_fold_explain
 	bench_guards
 	bloom_lazy
 	bloom_setting


### PR DESCRIPTION
Fixes #602.

## What

`EXPLAIN (ANALYZE)` on the ungrouped vectorized aggregate printed
`state->batchEligible` — the Begin-time shape prediction — so an execution that
fell back to the row path still read `Columnar Batch Fold: yes`. One line in
`PgColumnarExplainAggScan`: once execution stats exist, print
`state->batchFolded`, the field whose struct comment already says it "records
that the fold actually ran". Plain `EXPLAIN` keeps the prediction, which is all
it has to report before execution.

## Why it matters

The line is the natural premise pin for any fold-path measurement, and until
now it could not serve that role: prediction and record read identically. Both
recent fold-path measurement efforts on #405 leaned on it (details on #602).

## Test — `test/batch_fold_explain.sh` (RED before the fix, on exactly the new check)

Fixture: a column added after 50k rows already sit in row groups, then 10k rows
with the column present. Predicted-eligible, but `pgcolumnar_native_batch_fold`
finds the column absent from the first old group and abandons the fold: the read
state is discarded and the accumulators reset, and the scan runs the row path.
(Per jdatcmd's review note on #602: the serial path does claim that group via
`PgColumnarReadFoldNextGroup` before discarding everything — "no group claimed"
is true only in the shared-counter sense of the parallel arm, which is why the
serial fallback is safe and the parallel partial node must error instead.)

| check | pre-fix | post-fix |
|---|---|---|
| ANALYZE on the ADD-COLUMN table | **yes (the lie)** | **no** |
| plain EXPLAIN on the same table (prediction preserved) | yes | yes |
| ANALYZE on a genuinely folding control | yes | yes |
| sums vs a table-free `generate_series` oracle | pass | pass |
| parallel partial fold refuses the relation (pins that the fixture forces the fallback) | pass | pass |

The parallel-arm check means that if the fold ever learns to read a column
added after some row groups, this suite reddens loudly instead of passing
vacuously.

## Gate

- RED on unfixed tree (pg18a): failed on exactly the new check, all premises green.
- GREEN pg18a and pg19a.
- Preflight (build + new suite) on pg15a/pg16a/pg17a: see below.
- Full assert matrix on pg18a + pg19a: see below.

Reviewed on #602 by jdatcmd before this PR (independent PG17 non-assert lane):
code-read of the three state fields, full repro rerun, and three adversarial
probes of the fix (parallel node explain callback, loops>1, never-executed
node) — all survive. The never-executed case is now covered by a comment at
the print site, per that review.

Final gate, commit 49120c8:

- **Preflight** (build + this suite, per-major): pg15a, pg16a, pg17a — PASSED.
- **Full assert matrix**: **ALL VERSIONS PASSED** — PG18 (152 ran, 2
  version-appropriate skips), PG19 (154 ran, 0 skipped), `batch_fold_explain`
  and `harness_selftest` green on both.

Two earlier gate rounds went red on `harness_selftest`'s #486 lint against this
suite itself, not the fix: first the suite piped a captured string into
`grep -q` (rewritten as `case` patterns), then the comment explaining that
rewrite contained the banned pattern literally (the lint scans comment text
too; reworded). The functional suites were green on both majors in every
round.
