### PR TITLE
docs: design for #393 M1 (HTTP source) and #394 (object storage sink)

### DIFF
--- a/design/ISSUE_393_M1_HTTP_SOURCE.md
+++ b/design/ISSUE_393_M1_HTTP_SOURCE.md
@@ -1,0 +1,155 @@
+# Issue #393 M1: the HTTP ranged byte source and the asserted request count
+
+Design before code, per the house rule. This implements milestone M1 of the plan
+of record decided on #393 (2026-08-06): plain-HTTP range GET in the separate
+non-preloaded module, no TLS, no signing, exact object keys only. The M1/M2 test
+spec posted on the issue (request count asserted, not reported) is the
+verification contract; this doc turns it into arithmetic against the current
+tree.
+
+## What already exists on main (verified, 99c6a58)
+
+The seam and the module scaffolding landed ahead of this work:
+
+- `PqSourceOps` vtable, never NULL, every byte read through the dispatcher
+  (`src/columnar_parquet_reader.c:1488-1560`). Byte reads outside
+  `pq_source_read`: none.
+- Scheme detection in `pq_source_open` (`:1597`) via `PgColumnarPathIsRemote`
+  (`src/columnar_objstore.c:46-58`), glob refusal for remote paths in
+  `pq_resolve_paths` (`:2655-2673`).
+- The loader: `PgColumnarObjStoreGet()` dlopens `$libdir/pgcolumnar_objstore`
+  via `load_external_function`, distinguishes missing from broken module,
+  checks `abi_version` (`src/columnar_objstore.c:60-169`,
+  `PGCOLUMNAR_OBJSTORE_ABI = 1`).
+- The module skeleton: `objstore/columnar_objstore_module.c`, built as a second
+  `MODULE_big` through the recursive-make hooks (`Makefile:122-145`), with
+  `test/objstore_module.sh` pinning the separation.
+- The remote branch of `pq_source_open` errors "object storage is not
+  implemented yet" (`:1618-1620`). M1 replaces that error with a working
+  source.
+
+The ABI already carries what M1 needs: `PgColumnarObjStoreApi.open` returns the
+object length through `int64 *len` (`src/columnar_objstore.h:57`), which fills
+the one hole in `PqSource` (its `len` is established by `ftello` today, local
+only, `:1629`).
+
+## The request-count problem, measured against the tree
+
+Today's read granularity is per page, two `pq_source_read` calls each: a 4 KB
+header window (`pq_read_page_header`, `:1726`) and the page body (`:1827`),
+plus 3 open-time reads (head magic, tail 8, footer). Mapped 1:1 onto HTTP this
+is the 521-request shape the issue predicts. Two changes bound it:
+
+1. **A prefetch window above the ABI.** `pq_source_prefetch(src, off, n)`:
+   issues ONE `ops->read` for the range, stores it in `src->winbuf`;
+   `pq_source_read` serves any request inside the window from memory and falls
+   through to `ops->read` otherwise. Transport-agnostic, no ABI change, a no-op
+   in effect for local files (the window is served by one fread instead of
+   many, same bytes).
+2. **Prefetch call sites.** `decode_leaf_entries` prefetches the whole column
+   chunk extent (known from the footer: chunk offset and
+   `total_compressed_size`) before walking its pages. `pq_source_open`
+   prefetches nothing in M1: the three open reads stay individual requests, so
+   the arithmetic below stays exact and simple. Coalescing the open (a
+   speculative tail read) is a later, measured refinement.
+
+### The arithmetic the suite asserts
+
+For a fixture with G row groups and C needed leaf columns per group, all chunks
+resident (no group skipping):
+
+- **Buffered (default):** `K = 1 (HEAD for length) + 3 (magic, tail, footer) +
+  G x C (one ranged GET per needed chunk)`.
+- **Unbuffered (dev GUC off):** `>= 1 + 3 + G x C x 2 x P` where P is pages
+  per chunk. The fixture sets a small pyarrow `data_page_size` so P makes the
+  unbuffered arm at least 10x K.
+
+The dev GUC is `pgcolumnar.objstore_buffered` (bool, default on), defined with
+the other GUCs in `src/columnar_tableam.c`. It exists so the suite measures
+both arms in one run, which is what makes K falsifiable rather than
+implementation-defined. Removal proof: with buffering forced off, the buffered
+arm's `check_num <= K` must go red.
+
+## The module's HTTP client
+
+Hand-written HTTP/1.1, GET and HEAD only, over a nonblocking TCP socket driven
+from a `WaitEventSet`, per the plan of record. Rules that are constraints, not
+preferences:
+
+- **No blocking syscall on the socket, ever.** `SA_RESTART` makes the EINTR
+  idiom unreachable (the tree already documents this failure shape at
+  `src/columnar_parquet_reader.c:2368-2372` for FIFOs). Every wait is
+  `WaitLatchOrSocket(MyLatch, WL_LATCH_SET | WL_SOCKET_READABLE | ...,
+  timeout)` followed by `CHECK_FOR_INTERRUPTS()`. This is what makes assertion
+  (c) below passable at all.
+- **Both framings.** Content-Length and chunked transfer coding are both
+  implemented from the start; S3-compatible servers answer XML errors chunked.
+- **Range contract.** Requests send `Range: bytes=off-(off+n-1)` and require
+  status 206 with the exact byte count. A 200 answer (server ignored Range) is
+  an error naming the URL, never a silent whole-object read: arm C of the test
+  spec, wrong answers are worse than failures.
+- **Bounded header parse.** Response head capped (16 KB), parsed with explicit
+  bounds; the fuzz-harness obligation for this parser is M1 scope creep and is
+  deferred to the pre-release gate recorded on the issue (the parser fuzz
+  harness ships before any release, in the `fuzz_parquet.sh` idiom).
+- **One reconnect.** A cleanly closed idle connection is retried once;
+  anything else is an error. Retries with backoff are M2+ scope per the issue.
+- **Errors carry the URL and the HTTP status**, and never any header a future
+  signed request would carry.
+
+Connection state lives in `src->priv` (one struct per open source: fd, parsed
+endpoint, keep-alive state). One connection per source, reused across ranged
+GETs; `close` op shuts it down. `PG_TRY` is not needed inside the module; the
+fd is registered with the resource owner (`ReserveExternalFD` shape) so an
+`ereport` unwinding the scan cannot leak it.
+
+## The suite: `test/objstore_http_read.sh`
+
+Follows the current suite idiom (`lib.sh`, registered in the sorted `SUITES`
+array, chained teardown trap per the objstore_module.sh precedent). Fixture
+server: a python3 stdlib HTTP server (no new dependency; pyarrow is already
+the oracle toolchain) that serves byte ranges and appends one line per request
+(`method path range-header`) to a log file; a flagged URL prefix stalls
+mid-body without closing, for the cancel arm.
+
+Arms, per the test spec on the issue:
+
+- **A, differential oracle:** a table over
+  `http://127.0.0.1:PORT/x.parquet` returns the same rows as the byte-identical
+  local file (`pgc_set_hash` comparison), for `count(*)`, a full projection,
+  and a two-of-N projection.
+- **B, request count:** premise: remote arm rows match local (A); premise: the
+  server logged at least one request. `check_num` buffered requests `<= K`
+  with K stated as the arithmetic above; `check_num` unbuffered `>= 10 * K`;
+  `check_ratio` unbuffered/buffered `>= 10` (the #418 zero-refusal makes an
+  empty log fail loudly).
+- **C, failure taxonomy:** unreachable port, 404, and a Range-ignoring server
+  each produce an error that names the URL; none produces rows. Asserted on
+  SQLSTATE class, not message grep, where a distinct code exists.
+- **D, cancel:** `statement_timeout` fires within bound while the server
+  stalls mid-body (idiom of `test/cancel_decode.sh`). Removal proof: with the
+  `WaitLatchOrSocket` timeout arm deleted, this check must hang or go red.
+
+## Deliberately out of M1
+
+TLS (M3), SigV4 (M2), credentials and the validator split (M4), redirects,
+retries beyond one reconnect, ListObjectsV2 and globs (deferred by the plan of
+record), FDW streaming (a follow-on the tree already documents at `:3348`),
+and any change to the eager tuplestore shape. The Garage container
+(`garage-26-04`, see #393 comment of 2026-08-13) becomes the integration
+target at M2 when signing exists; M1's fixture is the local logging server
+precisely so the request log is assertable.
+
+## Order of work (TDD)
+
+1. Suite skeleton with the fixture server, arms A and C against the LOCAL file
+   path only, green, to prove the fixture and oracle.
+2. RED: point arm A at `http://127.0.0.1` and watch it fail with today's
+   "not implemented yet" error.
+3. Module HTTP client + wire the remote branch of `pq_source_open` (len from
+   `api->open`, reads through the ABI). Arm A and C green, B red (no
+   buffering: the count blows K).
+4. The prefetch window + GUC. B green. D green with the stall fixture.
+5. `-Wshadow -Werror` clean, ASAN+UBSAN run of the suite (network parser =
+   memory-lifecycle change, the #asan-gate rule applies), PG17 lane first,
+   then PG18/19 per the cadence.

--- a/design/ISSUE_394_OBJECT_STORAGE_SINK.md
+++ b/design/ISSUE_394_OBJECT_STORAGE_SINK.md
@@ -1,0 +1,118 @@
+# Issue #394: object storage writes for the export functions
+
+Design before code. Sequenced behind #393's module (the transport, signing and
+credential decisions are built once, there), but the sink seam and the failure
+semantics are decidable now, and two defects found while mapping the write path
+should be fixed ahead of any remote sink.
+
+## What the write path is today (verified, main 99c6a58)
+
+- **Parquet has a single choke point**: `PgColumnarWriteParquetFile`
+  (`src/columnar_parquet.c:944-1126`) writes all data bytes for both the serial
+  and the parallel exporter, through five raw `fwrite` sites (magic `:1007`,
+  page header + body `:1065-1066`, footer `:1113`, footer length `:1115`,
+  tail magic `:1116`).
+- **Arrow is separate**: `src/columnar_arrow.c:948-1158` with its own eight
+  `fwrite` sites. No shared writer abstraction exists; a byte SINK seam is
+  absent on both paths.
+- **Both writers are strictly append-only.** Offsets are tracked by summing
+  written lengths; there is no fseek on the write path. A pure append sink
+  suffices; nothing needs random access.
+- **Write granularity** ranges from 4 bytes (magics, footer length) to a few
+  hundred KB (a 64K-row PLAIN page). Multipart parts have a 5 MiB minimum, so
+  a remote sink must staging-buffer regardless of the writer's call pattern.
+- **Parallel export** (`src/columnar_parallel_export.c`): dispatcher formats
+  per-worker paths `part-%04d.parquet` into DSM slots (`:594-596`), workers
+  write independent files, dispatcher waits for all, and on any failure
+  removes every output (`pexport_remove_outputs`, `:237-259`) and re-raises;
+  a dispatcher FATAL is covered by `PG_ENSURE_ERROR_CLEANUP` (`:624`).
+
+## Two defects to fix first, locally, before any remote sink
+
+Both were found mapping the path and both are wrong today without any object
+storage involved:
+
+1. **`fwrite` return values are unchecked at all 13 sites.** The only error
+   detection is `FreeFile(f) != 0` at close (`columnar_parquet.c:1120`,
+   `columnar_arrow.c:1148`). A disk-full mid-export is detected only if the
+   final flush happens to fail. The sink seam fixes this structurally: the
+   sink's `write` reports short writes as errors at the call, the way the read
+   seam's `pq_source_read` already treats short reads as `DATA_CORRUPTED`.
+2. **Serial exports leave a partial file at the final path on error.** There
+   is no temp-and-rename and no unlink-on-error (the parallel path cleans up;
+   the serial paths do not). The local sink gains: write to
+   `<path>.tmp.<pid>`, durable rename on success, unlink in the error path.
+   This also gives the local path the same appears-whole-or-not-at-all
+   property the remote path gets from multipart completion, which makes the
+   documented semantics uniform.
+
+Removal proofs: a suite that fills a small filesystem quota (or injects a
+failing write via the sink's test hook) must see an error AND no file at the
+final path; deleting the unlink turns the second check red; deleting the
+short-write check turns the first red.
+
+## The sink seam
+
+`PqSink`, mirroring `PqSource` (`columnar_parquet_reader.c:1488-1553`):
+
+    typedef struct PqSinkOps {
+        const char *name;                      /* "file", "s3" */
+        void (*write)(PqSink *snk, const void *buf, size_t n);  /* append */
+        void (*finish)(PqSink *snk);           /* commit: rename / complete */
+        void (*abort)(PqSink *snk);            /* best-effort cleanup */
+    } PqSinkOps;
+
+- Behind the existing `path` argument of `export_parquet`, `export_arrow`,
+  `parallel_export_parquet`; no signature changes (the property #394 already
+  identified).
+- `finish` is the commit point: local rename, remote CompleteMultipartUpload.
+  `abort` runs from `PG_CATCH`/resource-owner callback: local unlink, remote
+  AbortMultipartUpload. The invariant both implementations share: **nothing is
+  ever visible at the final name before `finish` returns.**
+- The remote implementation lives in the #393 module behind a write-side ABI
+  extension (`create`, `write_part`, `complete`, `abort`), staging 8 MiB parts
+  (comfortably above the 5 MiB minimum). The ABI version bumps; the module has
+  never shipped, so no compatibility shim is owed.
+
+## Failure semantics, decided
+
+- **Single-object exports**: complete-or-abort. The only path that can orphan
+  a multipart upload is a backend crash between part uploads and abort; the
+  documentation tells operators to set a bucket lifecycle rule for incomplete
+  multipart uploads (the standard mitigation), and the abort also runs from
+  the resource-owner callback so ERROR-level unwinds always clean up.
+- **`parallel_export_parquet`: one object per worker**, exactly the local
+  shape (`part-%04d.parquet` keys under the destination prefix). This removes
+  the shared-upload-id problem entirely, as the issue thread anticipated: no
+  cross-backend upload state, each worker completes or aborts its own object.
+  On any worker failure the dispatcher deletes the completed objects **by
+  their known keys** (the remote analogue of `pexport_remove_outputs`); no
+  LIST operation is needed, so the ListObjectsV2 deferral holds.
+- **Not transactional, stated in docs on day one**: an export inside a
+  transaction that rolls back has already written to the bucket. The remote
+  case makes visible what is already true locally.
+
+## Privilege
+
+The existing gate stays necessary: `pg_write_server_files` at the three entry
+points (`columnar_parquet.c:1146`, `columnar_arrow.c:980`,
+`columnar_parallel_export.c:466`). Remote destinations additionally require
+the endpoint allow-list GUC decided in the #393 memo (empty by default,
+link-local ranges refused unconditionally), because a remote write is off-box
+exfiltration in a way a local write is not. The allow-list is enforced in the
+module, shared by source and sink.
+
+## Order of work
+
+1. **Local sink seam + the two defect fixes** (short-write errors,
+   temp-and-rename with unlink-on-error), serial paths first, parallel
+   dispatcher unchanged. Suites: byte-identical output via the existing
+   parquet/arrow export oracles, plus the two removal-proof arms. This PR is
+   useful standalone and blocks on nothing.
+2. Arrow and parallel writers onto the seam (parallel workers open their own
+   sinks; dispatcher cleanup unchanged).
+3. Remote sink in the module, single-object first, behind #393 M2 (signing);
+   integration-tested against the Garage container with an injected failure
+   mid-upload asserting abort ran (the arm that "leaks money and never gets
+   exercised by accident").
+4. Parallel-to-remote, per-worker objects, dispatcher key-wise cleanup.

--- a/design/ISSUE_394_OBJECT_STORAGE_SINK.md
+++ b/design/ISSUE_394_OBJECT_STORAGE_SINK.md
@@ -9,12 +9,22 @@ should be fixed ahead of any remote sink.
 
 - **Parquet has a single choke point**: `PgColumnarWriteParquetFile`
   (`src/columnar_parquet.c:944-1126`) writes all data bytes for both the serial
-  and the parallel exporter, through five raw `fwrite` sites (magic `:1007`,
+  and the parallel exporter, through six raw `fwrite` sites (magic `:1007`,
   page header + body `:1065-1066`, footer `:1113`, footer length `:1115`,
   tail magic `:1116`).
-- **Arrow is separate**: `src/columnar_arrow.c:948-1158` with its own eight
-  `fwrite` sites. No shared writer abstraction exists; a byte SINK seam is
-  absent on both paths.
+- **Arrow is separate**, and its writes are NOT all inside the entry function:
+  `pgcolumnar_export_arrow` (`src/columnar_arrow.c:948-1158`) holds six
+  `fwrite` sites, and the helper `write_record_batch` (`:844`, called twice,
+  `:1122` and `:1135`) holds five more (`:929-935`), including the record-batch
+  body write at `:935`, the largest single write on the arrow path. Eleven
+  sites total. No shared writer abstraction exists; a byte SINK seam is absent
+  on both paths.
+- **Census: 17 `fwrite` sites** (6 parquet + 11 arrow), counted by grep against
+  main at review time. The implementation must re-derive the site list by grep
+  when it lands, never work from this number: an earlier revision of this doc
+  said 13 by exactly the lossy enumeration this repo's rules warn about, and
+  the four missed sites included the arrow body write (caught in review, PR
+  #604).
 - **Both writers are strictly append-only.** Offsets are tracked by summing
   written lengths; there is no fseek on the write path. A pure append sink
   suffices; nothing needs random access.
@@ -32,12 +42,16 @@ should be fixed ahead of any remote sink.
 Both were found mapping the path and both are wrong today without any object
 storage involved:
 
-1. **`fwrite` return values are unchecked at all 13 sites.** The only error
+1. **`fwrite` return values are unchecked at all 17 sites.** The only error
    detection is `FreeFile(f) != 0` at close (`columnar_parquet.c:1120`,
    `columnar_arrow.c:1148`). A disk-full mid-export is detected only if the
    final flush happens to fail. The sink seam fixes this structurally: the
    sink's `write` reports short writes as errors at the call, the way the read
    seam's `pq_source_read` already treats short reads as `DATA_CORRUPTED`.
+   The seam is also why the census stops mattering: once every write routes
+   through the one checked `write`, the claim becomes "no `fwrite` remains in
+   either export file", which a grep in the Step-1 suite pins as a check
+   instead of a number maintained by hand.
 2. **Serial exports leave a partial file at the final path on error.** There
    is no temp-and-rename and no unlink-on-error (the parallel path cleans up;
    the serial paths do not). The local sink gains: write to
@@ -107,8 +121,14 @@ module, shared by source and sink.
 1. **Local sink seam + the two defect fixes** (short-write errors,
    temp-and-rename with unlink-on-error), serial paths first, parallel
    dispatcher unchanged. Suites: byte-identical output via the existing
-   parquet/arrow export oracles, plus the two removal-proof arms. This PR is
-   useful standalone and blocks on nothing.
+   parquet/arrow export oracles, plus the two removal-proof arms, plus a
+   zero-`fwrite`-remaining grep check over both export files. The
+   short-write removal proof must inject its failure into a write **inside
+   `write_record_batch`** (the body write at `:935`), not only into the
+   top-level export functions: the helper is where the earlier census missed,
+   and a proof that never reaches it would green a Step 1 that leaves the
+   largest arrow write unchecked. This PR is useful standalone and blocks on
+   nothing.
 2. Arrow and parallel writers onto the seam (parallel workers open their own
    sinks; dispatcher cleanup unchanged).
 3. Remote sink in the module, single-object first, behind #393 M2 (signing);


### PR DESCRIPTION
Two plan-before-code documents for the object storage work, produced from a six-agent recon of main @ 99c6a58 with every file:line citation verified against the tree (not carried from the issue threads, several of which have drifted).

**`design/ISSUE_393_M1_HTTP_SOURCE.md`** — turns the #393 plan of record into implementation arithmetic:

- Inventory of what already landed ahead of M1: the never-NULL `PqSourceOps` seam, scheme dispatch, the `dlopen` loader with ABI versioning, the `objstore/` module skeleton. M1 replaces exactly one error ("object storage is not implemented yet") with a working source.
- The request-count model the suite asserts: open = 1 HEAD + 3 ranged GETs; data = one GET per needed chunk via a prefetch window layered **above** the ABI (no ABI change), with dev GUC `pgcolumnar.objstore_buffered` so the suite measures both arms in one run — K is falsifiable, not implementation-defined.
- HTTP client rules stated as constraints: no blocking syscall on the socket ever (`SA_RESTART` makes EINTR unreachable — the tree already documents this failure shape), both framings from day one, 206-or-error on Range (a Range-ignoring server is an error, never a silent whole-object read), one reconnect only.
- The four suite arms from the already-agreed test spec: differential oracle, asserted request counts with the #418 zero-refusal, failure taxonomy on SQLSTATE, and a cancel arm against a stalling server with its removal proof.

**`design/ISSUE_394_OBJECT_STORAGE_SINK.md`** — the write-path map and the failure semantics:

- `PgColumnarWriteParquetFile` is the single parquet choke point; arrow is separate; both writers are strictly append-only, so a pure append sink with 8 MiB part staging suffices.
- `PqSink` seam with `finish`/`abort`, invariant: nothing visible at the final name before `finish` returns (local temp+rename, remote multipart completion — the same property from both implementations).
- `parallel_export_parquet` writes **one object per worker**: no shared upload id, cleanup by known keys, no LIST — the ListObjectsV2 deferral holds.
- Two local defects found during mapping, to fix ahead of any remote sink: all 13 `fwrite` sites ignore their return value (disk-full is detected only if the final flush fails), and serial exports leave a partial file at the final path on error. Step 1 of the order of work fixes both with removal proofs and blocks on nothing.

Lane note: I am implementing on **PG17**; the peer holds PG18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)