### PR TITLE
feat: HTTP ranged byte source with the request count asserted (#393 M1)

### DIFF
--- a/objstore/columnar_objstore_module.c
+++ b/objstore/columnar_objstore_module.c
@@ -5,57 +5,762 @@
  * Loaded on demand by PgColumnarObjStoreGet, never preloaded. See
  * src/columnar_objstore.h for why it is a separate library and for the ABI.
  *
- * This commit establishes the module, its build, and the ABI. The protocol
- * itself arrives next: a range GET over HTTP/1.1 driven from a WaitEventSet, then
- * SigV4 signing, then TLS. Until then every scheme reports unsupported, which is
- * a better failure than the reader silently treating an s3:// URL as a filename.
+ * M1 scope (design/ISSUE_393_M1_HTTP_SOURCE.md): plain-HTTP/1.1 ranged reads,
+ * exact object keys only. GET and HEAD are the whole request set. SigV4 (M2)
+ * and TLS (M3) layer on top of the same transport; https:// and s3:// report
+ * unsupported until then, which is a better failure than a cleartext fallback.
+ *
+ * Transport rules, which are constraints rather than style:
+ *
+ * - No blocking syscall ever touches the socket. The backend's signal handlers
+ *   are installed with SA_RESTART, so a blocking recv would resume around a
+ *   query cancel instead of failing with EINTR; the tree documents the same
+ *   failure shape for FIFOs (columnar_parquet_reader.c, pq_path_is_candidate).
+ *   Every wait is WaitLatchOrSocket + CHECK_FOR_INTERRUPTS, which is what makes
+ *   statement_timeout able to get the backend back mid-transfer.
+ *
+ * - A server that answers a Range request with 200 is an error, never a silent
+ *   whole-object read: the caller sized its buffer for `n` bytes, and "the
+ *   wrong bytes quietly" is the failure mode this tree keeps deciding not to
+ *   ship.
+ *
+ * - Sockets are cleaned up on abort through a resource-release callback over
+ *   the open-handle list. The invariant that makes close-all-on-abort correct:
+ *   no handle survives its statement (every reader materializes and closes
+ *   before returning), so a live handle during an abort belongs to the
+ *   statement being aborted.
  *-------------------------------------------------------------------------
  */
 #include "postgres.h"
 
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
 #include "fmgr.h"
+#include "lib/ilist.h"
+#include "lib/stringinfo.h"
+#include "miscadmin.h"
+#include "storage/fd.h"
+#include "storage/latch.h"
+#include "utils/memutils.h"
+#include "utils/resowner.h"
+#include "utils/wait_event.h"
+
 #include "columnar_objstore.h"
 
 PG_MODULE_MAGIC;
 
 PGDLLEXPORT const PgColumnarObjStoreApi *pgcolumnar_objstore_init(void);
 
+/* Response head is bounded before it is parsed; a server cannot size us. */
+#define OS_MAX_HEAD		16384
+/* Receive staging buffer; body bytes stream through it into the caller's. */
+#define OS_RBUF			65536
+/* One wait slice; consecutive silent slices add up to the inactivity limit. */
+#define OS_WAIT_SLICE_MS	5000
+#define OS_MAX_QUIET_SLICES	12	/* 60 s of silence is a dead peer */
+
+struct PgColumnarObjHandle
+{
+	char	   *url;			/* full URL, for error messages */
+	char	   *host;			/* authority, split for connect */
+	int			port;
+	char	   *abspath;		/* request-target, always starts with '/' */
+
+	int			fd;				/* -1 when disconnected */
+	bool		fd_reserved;	/* ReserveExternalFD accounting */
+	int64		len;			/* object length from open's HEAD */
+	uint64		served;			/* requests completed on this connection */
+
+	/* receive staging */
+	uint8	   *rb;
+	int			rb_off;			/* consumed up to here */
+	int			rb_len;			/* valid bytes */
+
+	dlist_node	node;			/* open-handle list, for abort cleanup */
+};
+
+/* One parsed response head. */
+typedef struct OsResponse
+{
+	int			status;
+	int64		content_length; /* -1 when absent */
+	bool		chunked;
+	bool		conn_close;
+} OsResponse;
+
+static dlist_head os_open_handles = DLIST_STATIC_INIT(os_open_handles);
+static bool os_callback_registered = false;
+
+/* ---------------------------------------------------------------- lifecycle */
+
+static void
+os_disconnect(PgColumnarObjHandle *h)
+{
+	if (h->fd >= 0)
+	{
+		close(h->fd);
+		h->fd = -1;
+	}
+	if (h->fd_reserved)
+	{
+		ReleaseExternalFD();
+		h->fd_reserved = false;
+	}
+	h->served = 0;
+	h->rb_off = h->rb_len = 0;
+}
+
+static void
+os_free_handle(PgColumnarObjHandle *h)
+{
+	os_disconnect(h);
+	dlist_delete(&h->node);
+	if (h->rb)
+		pfree(h->rb);
+	if (h->url)
+		pfree(h->url);
+	if (h->host)
+		pfree(h->host);
+	if (h->abspath)
+		pfree(h->abspath);
+	pfree(h);
+}
+
+/*
+ * Abort cleanup. ereport out of a read unwinds the scan without reaching
+ * close(); this returns the socket and the ExternalFD reservation. See the
+ * header comment for why closing every handle is correct.
+ */
+static void
+os_resource_release(ResourceReleasePhase phase, bool isCommit,
+					bool isTopLevel, void *arg)
+{
+	if (phase != RESOURCE_RELEASE_AFTER_LOCKS || !isTopLevel)
+		return;
+
+	while (!dlist_is_empty(&os_open_handles))
+	{
+		PgColumnarObjHandle *h =
+			dlist_container(PgColumnarObjHandle, node,
+							dlist_head_node(&os_open_handles));
+
+		if (isCommit)
+			elog(WARNING,
+				 "columnar: object-store handle for \"%s\" leaked to commit",
+				 h->url);
+		os_free_handle(h);
+	}
+}
+
+/* ------------------------------------------------------------------ waiting */
+
+static void
+os_wait(PgColumnarObjHandle *h, uint32 sockEvents, int *quiet)
+{
+	int			rc;
+
+	rc = WaitLatchOrSocket(MyLatch,
+						   WL_LATCH_SET | WL_EXIT_ON_PM_DEATH | sockEvents,
+						   h->fd, OS_WAIT_SLICE_MS, PG_WAIT_EXTENSION);
+	if (rc & WL_LATCH_SET)
+		ResetLatch(MyLatch);
+	CHECK_FOR_INTERRUPTS();
+
+	if (rc & (WL_SOCKET_READABLE | WL_SOCKET_WRITEABLE))
+		*quiet = 0;
+	else if (++(*quiet) >= OS_MAX_QUIET_SLICES)
+		ereport(ERROR,
+				(errcode(ERRCODE_CONNECTION_FAILURE),
+				 errmsg("columnar: timeout reading \"%s\"", h->url),
+				 errdetail("The server sent nothing for %d seconds.",
+						   OS_MAX_QUIET_SLICES * OS_WAIT_SLICE_MS / 1000)));
+}
+
+/* ---------------------------------------------------------------- connect */
+
+static void
+os_connect(PgColumnarObjHandle *h)
+{
+	struct addrinfo hints;
+	struct addrinfo *addrs = NULL;
+	struct addrinfo *ai;
+	char		portstr[16];
+	int			rc;
+	int			quiet = 0;
+
+	Assert(h->fd < 0);
+
+	if (!h->fd_reserved)
+	{
+		if (!AcquireExternalFD())
+			ereport(ERROR,
+					(errcode(ERRCODE_INSUFFICIENT_RESOURCES),
+					 errmsg("columnar: no file descriptor available to read \"%s\"",
+							h->url)));
+		h->fd_reserved = true;
+	}
+
+	/*
+	 * Name resolution is synchronous in M1. The fixture and the ordinary
+	 * endpoint form are IP literals, which never block; a DNS name against a
+	 * slow resolver blocks here and is a known, documented M1 limitation
+	 * rather than a socket-wait violation.
+	 */
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_family = AF_UNSPEC;
+	hints.ai_socktype = SOCK_STREAM;
+	snprintf(portstr, sizeof(portstr), "%d", h->port);
+	rc = getaddrinfo(h->host, portstr, &hints, &addrs);
+	if (rc != 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_CONNECTION_FAILURE),
+				 errmsg("columnar: could not resolve \"%s\": %s",
+						h->host, gai_strerror(rc))));
+
+	for (ai = addrs; ai != NULL; ai = ai->ai_next)
+	{
+		h->fd = socket(ai->ai_family, SOCK_STREAM, 0);
+		if (h->fd < 0)
+			continue;
+		if (fcntl(h->fd, F_SETFL, O_NONBLOCK) < 0)
+		{
+			close(h->fd);
+			h->fd = -1;
+			continue;
+		}
+
+		if (connect(h->fd, ai->ai_addr, ai->ai_addrlen) == 0)
+			break;
+		if (errno == EINPROGRESS)
+		{
+			socklen_t	errlen = sizeof(rc);
+
+			do
+			{
+				os_wait(h, WL_SOCKET_WRITEABLE, &quiet);
+				rc = -1;
+				if (getsockopt(h->fd, SOL_SOCKET, SO_ERROR, &rc, &errlen) < 0)
+					rc = errno;
+			} while (rc == EINPROGRESS || rc == EALREADY);
+			if (rc == 0)
+				break;
+			errno = rc;
+		}
+		close(h->fd);
+		h->fd = -1;
+	}
+	freeaddrinfo(addrs);
+
+	if (h->fd < 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_CONNECTION_FAILURE),
+				 errmsg("columnar: could not connect to \"%s\": %m", h->url)));
+
+	rc = 1;
+	(void) setsockopt(h->fd, IPPROTO_TCP, TCP_NODELAY, &rc, sizeof(rc));
+	h->served = 0;
+	h->rb_off = h->rb_len = 0;
+}
+
+/* ------------------------------------------------------------------- send */
+
+/*
+ * Send the whole request. Returns false on a connection-level failure so the
+ * caller can retry once on a stale keep-alive connection; raises for anything
+ * that a fresh connection cannot fix.
+ */
+static bool
+os_send_all(PgColumnarObjHandle *h, const char *buf, size_t len)
+{
+	int			quiet = 0;
+
+	while (len > 0)
+	{
+		ssize_t		sent = send(h->fd, buf, len, MSG_NOSIGNAL);
+
+		if (sent > 0)
+		{
+			buf += sent;
+			len -= (size_t) sent;
+			continue;
+		}
+		if (sent < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
+		{
+			os_wait(h, WL_SOCKET_WRITEABLE, &quiet);
+			continue;
+		}
+		if (sent < 0 && errno == EINTR)
+			continue;
+		return false;			/* EPIPE, ECONNRESET, ... : maybe stale */
+	}
+	return true;
+}
+
+/* ------------------------------------------------------------------- recv */
+
+/* Pull more bytes into the staging buffer. Returns false on orderly EOF. */
+static bool
+os_fill(PgColumnarObjHandle *h)
+{
+	int			quiet = 0;
+
+	if (h->rb_off == h->rb_len)
+		h->rb_off = h->rb_len = 0;
+	else if (h->rb_len == OS_RBUF)
+	{
+		memmove(h->rb, h->rb + h->rb_off, h->rb_len - h->rb_off);
+		h->rb_len -= h->rb_off;
+		h->rb_off = 0;
+	}
+
+	for (;;)
+	{
+		ssize_t		got = recv(h->fd, h->rb + h->rb_len,
+							   OS_RBUF - h->rb_len, 0);
+
+		if (got > 0)
+		{
+			h->rb_len += (int) got;
+			return true;
+		}
+		if (got == 0)
+			return false;
+		if (errno == EAGAIN || errno == EWOULDBLOCK)
+		{
+			os_wait(h, WL_SOCKET_READABLE, &quiet);
+			continue;
+		}
+		if (errno == EINTR)
+			continue;
+		ereport(ERROR,
+				(errcode(ERRCODE_CONNECTION_FAILURE),
+				 errmsg("columnar: could not read from \"%s\": %m", h->url)));
+	}
+}
+
+/* --------------------------------------------------------------- response */
+
+/*
+ * Read and parse one response head. Returns false when the connection died
+ * before a single status byte arrived (the stale keep-alive case); raises on
+ * everything else.
+ */
+static bool
+os_read_head(PgColumnarObjHandle *h, OsResponse *resp)
+{
+	int			headEnd = -1;
+
+	memset(resp, 0, sizeof(*resp));
+	resp->content_length = -1;
+
+	for (;;)
+	{
+		int			avail = h->rb_len - h->rb_off;
+		const char *p = (const char *) h->rb + h->rb_off;
+		int			i;
+
+		for (i = 0; i + 3 < avail; i++)
+			if (memcmp(p + i, "\r\n\r\n", 4) == 0)
+			{
+				headEnd = i + 4;
+				break;
+			}
+		if (headEnd >= 0)
+			break;
+		if (avail >= OS_MAX_HEAD)
+			ereport(ERROR,
+					(errcode(ERRCODE_PROTOCOL_VIOLATION),
+					 errmsg("columnar: oversized HTTP response header from \"%s\"",
+							h->url)));
+		if (!os_fill(h))
+		{
+			if (h->rb_len - h->rb_off == 0)
+				return false;	/* clean EOF before any byte: stale */
+			ereport(ERROR,
+					(errcode(ERRCODE_CONNECTION_FAILURE),
+					 errmsg("columnar: connection to \"%s\" closed mid-response",
+							h->url)));
+		}
+	}
+
+	{
+		const char *head;
+		const char *line;
+		const char *end;
+
+		/*
+		 * NUL-terminate the head (over its final LF) so the strstr calls
+		 * below cannot run past the staging buffer: rb is not a C string, and
+		 * an unbounded strstr reads whatever follows the allocation until it
+		 * happens upon a zero byte.
+		 */
+		h->rb[h->rb_off + headEnd - 1] = '\0';
+		head = (const char *) h->rb + h->rb_off;
+		line = head;
+		end = head + headEnd;
+
+		if (headEnd < 12 || strncmp(head, "HTTP/1.", 7) != 0)
+			ereport(ERROR,
+					(errcode(ERRCODE_PROTOCOL_VIOLATION),
+					 errmsg("columnar: \"%s\" did not answer HTTP", h->url)));
+		resp->status = atoi(head + 9);
+
+		while (line < end)
+		{
+			const char *eol = memchr(line, '\n', end - line);
+
+			if (eol == NULL)
+				break;
+			if (pg_strncasecmp(line, "Content-Length:", 15) == 0)
+				resp->content_length = strtoll(line + 15, NULL, 10);
+			else if (pg_strncasecmp(line, "Transfer-Encoding:", 18) == 0 &&
+					 strstr(line, "chunked") != NULL && strstr(line, "chunked") < eol)
+				resp->chunked = true;
+			else if (pg_strncasecmp(line, "Connection:", 11) == 0 &&
+					 strstr(line, "close") != NULL && strstr(line, "close") < eol)
+				resp->conn_close = true;
+			line = eol + 1;
+		}
+	}
+
+	h->rb_off += headEnd;
+	return true;
+}
+
+/* Take min(n, buffered) bytes from staging into dst (or discard). */
+static int64
+os_take(PgColumnarObjHandle *h, uint8 *dst, int64 n)
+{
+	int64		avail = h->rb_len - h->rb_off;
+	int64		take = Min(n, avail);
+
+	if (take > 0 && dst != NULL)
+		memcpy(dst, h->rb + h->rb_off, take);
+	h->rb_off += (int) take;
+	return take;
+}
+
+/* Read exactly n body bytes into dst (NULL discards). */
+static void
+os_read_exact(PgColumnarObjHandle *h, uint8 *dst, int64 n)
+{
+	while (n > 0)
+	{
+		int64		got = os_take(h, dst, n);
+
+		if (dst != NULL)
+			dst += got;
+		n -= got;
+		if (n > 0 && !os_fill(h))
+			ereport(ERROR,
+					(errcode(ERRCODE_CONNECTION_FAILURE),
+					 errmsg("columnar: connection to \"%s\" closed mid-body",
+							h->url)));
+	}
+}
+
+/* Read one CRLF-terminated line (chunk framing) into buf; bounded. */
+static void
+os_read_line(PgColumnarObjHandle *h, char *buf, size_t cap)
+{
+	size_t		used = 0;
+
+	for (;;)
+	{
+		while (h->rb_off < h->rb_len)
+		{
+			char		c = (char) h->rb[h->rb_off++];
+
+			if (c == '\n')
+			{
+				buf[used] = '\0';
+				return;
+			}
+			if (c != '\r')
+			{
+				if (used + 1 >= cap)
+					ereport(ERROR,
+							(errcode(ERRCODE_PROTOCOL_VIOLATION),
+							 errmsg("columnar: oversized chunk header from \"%s\"",
+									h->url)));
+				buf[used++] = c;
+			}
+		}
+		if (!os_fill(h))
+			ereport(ERROR,
+					(errcode(ERRCODE_CONNECTION_FAILURE),
+					 errmsg("columnar: connection to \"%s\" closed mid-body",
+							h->url)));
+	}
+}
+
+/*
+ * Consume a response body. dst != NULL requires the body to be exactly `want`
+ * bytes; dst == NULL discards a body of any length (error pages, HEAD has
+ * none and must not call this).
+ */
+static void
+os_read_body(PgColumnarObjHandle *h, const OsResponse *resp,
+			 uint8 *dst, int64 want)
+{
+	if (resp->chunked)
+	{
+		char		line[64];
+		int64		total = 0;
+
+		for (;;)
+		{
+			int64		sz;
+
+			os_read_line(h, line, sizeof(line));
+			sz = strtoll(line, NULL, 16);
+			if (sz < 0)
+				ereport(ERROR,
+						(errcode(ERRCODE_PROTOCOL_VIOLATION),
+						 errmsg("columnar: bad chunk size from \"%s\"", h->url)));
+			if (sz == 0)
+			{
+				/* trailers until the empty line */
+				do
+				{
+					os_read_line(h, line, sizeof(line));
+				} while (line[0] != '\0');
+				break;
+			}
+			if (dst != NULL && total + sz > want)
+				ereport(ERROR,
+						(errcode(ERRCODE_PROTOCOL_VIOLATION),
+						 errmsg("columnar: \"%s\" sent more bytes than requested",
+								h->url)));
+			os_read_exact(h, dst ? dst + total : NULL, sz);
+			total += sz;
+			os_read_line(h, line, sizeof(line));	/* chunk-terminating CRLF */
+		}
+		if (dst != NULL && total != want)
+			ereport(ERROR,
+					(errcode(ERRCODE_PROTOCOL_VIOLATION),
+					 errmsg("columnar: \"%s\" sent %lld of %lld requested bytes",
+							h->url, (long long) total, (long long) want)));
+	}
+	else
+	{
+		int64		cl = resp->content_length;
+
+		if (cl < 0)
+			ereport(ERROR,
+					(errcode(ERRCODE_PROTOCOL_VIOLATION),
+					 errmsg("columnar: \"%s\" sent a body with no length", h->url)));
+		if (dst != NULL && cl != want)
+			ereport(ERROR,
+					(errcode(ERRCODE_PROTOCOL_VIOLATION),
+					 errmsg("columnar: \"%s\" sent %lld of %lld requested bytes",
+							h->url, (long long) cl, (long long) want)));
+		os_read_exact(h, dst, cl);
+	}
+}
+
+/* ---------------------------------------------------------------- request */
+
+/*
+ * One request/response cycle with a single reconnect on a stale keep-alive
+ * connection. `off`/`n` describe the Range for GET; HEAD sends no Range.
+ */
+static void
+os_request(PgColumnarObjHandle *h, const char *method,
+		   int64 off, int64 n, OsResponse *resp)
+{
+	StringInfoData req;
+	bool		isGet = (strcmp(method, "GET") == 0);
+	int			attempt;
+
+	initStringInfo(&req);
+	appendStringInfo(&req, "%s %s HTTP/1.1\r\nHost: %s:%d\r\n",
+					 method, h->abspath, h->host, h->port);
+	if (isGet)
+		appendStringInfo(&req, "Range: bytes=%lld-%lld\r\n",
+						 (long long) off, (long long) (off + n - 1));
+	appendStringInfoString(&req, "User-Agent: pgcolumnar-objstore/1\r\n\r\n");
+
+	for (attempt = 0;; attempt++)
+	{
+		bool		fresh = (h->fd < 0);
+
+		if (h->fd < 0)
+			os_connect(h);
+
+		if (os_send_all(h, req.data, req.len) && os_read_head(h, resp))
+			break;
+
+		/*
+		 * The connection failed before a status byte. On a connection that
+		 * already served a request this is the ordinary keep-alive race and is
+		 * retried once on a fresh connection; on a fresh connection it is the
+		 * server's answer and is an error.
+		 */
+		os_disconnect(h);
+		if (fresh || attempt > 0)
+			ereport(ERROR,
+					(errcode(ERRCODE_CONNECTION_FAILURE),
+					 errmsg("columnar: connection to \"%s\" failed before a response",
+							h->url)));
+	}
+
+	pfree(req.data);
+}
+
+/* -------------------------------------------------------------------- ABI */
+
 static bool
 objstore_handles_url(const char *url)
 {
 	/*
-	 * Nothing is handled yet. Deliberately not returning true for s3:// before
-	 * the protocol exists: the reader asks this question so it can report an
-	 * unsupported scheme without attempting a connection, and answering yes here
-	 * would turn a clear error into a failure inside open().
+	 * Plain http:// only in M1. https:// and s3:// stay unhandled so they
+	 * report "no such URL scheme" rather than silently downgrading to
+	 * cleartext; they arrive with M3 and M2 respectively.
 	 */
-	(void) url;
-	return false;
+	return pg_strncasecmp(url, "http://", 7) == 0;
 }
 
 static PgColumnarObjHandle *
 objstore_open(const char *url, int64 *len)
 {
-	(void) len;
-	ereport(ERROR,
-			(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-			 errmsg("columnar: object storage is not implemented yet"),
-			 errdetail("The object-store module is installed but carries no "
-					   "protocol implementation for \"%s\".", url)));
-	return NULL;				/* unreachable */
+	PgColumnarObjHandle *h;
+	OsResponse	resp;
+	const char *authority = url + 7;
+	const char *slash = strchr(authority, '/');
+	const char *colon;
+	MemoryContext oldcxt;
+
+	if (!os_callback_registered)
+	{
+		RegisterResourceReleaseCallback(os_resource_release, NULL);
+		os_callback_registered = true;
+	}
+
+	if (slash == NULL || slash == authority)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("columnar: \"%s\" has no object path", url)));
+	if (memchr(authority, '@', slash - authority) != NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("columnar: userinfo in \"%s\" is not supported", url)));
+
+	/*
+	 * The handle and its buffers live in TopMemoryContext and are freed
+	 * explicitly (close, or the release callback on abort): the per-scan
+	 * context this open runs in dies during an abort BEFORE the callback
+	 * walks the list, and a handle in that context would be freed memory by
+	 * the time the callback closes its socket.
+	 */
+	oldcxt = MemoryContextSwitchTo(TopMemoryContext);
+	h = (PgColumnarObjHandle *) palloc0(sizeof(PgColumnarObjHandle));
+	h->fd = -1;
+	h->url = pstrdup(url);
+	h->abspath = pstrdup(slash);
+	colon = memchr(authority, ':', slash - authority);
+	if (colon != NULL)
+	{
+		h->host = pnstrdup(authority, colon - authority);
+		h->port = atoi(colon + 1);
+	}
+	else
+	{
+		h->host = pnstrdup(authority, slash - authority);
+		h->port = 80;
+	}
+	h->rb = (uint8 *) palloc(OS_RBUF);
+	MemoryContextSwitchTo(oldcxt);
+
+	if (h->port <= 0 || h->port > 65535 || h->host[0] == '\0')
+	{
+		dlist_push_head(&os_open_handles, &h->node);	/* so free can delete */
+		os_free_handle(h);
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("columnar: \"%s\" has an invalid host or port", url)));
+	}
+
+	dlist_push_head(&os_open_handles, &h->node);
+
+	os_request(h, "HEAD", 0, 0, &resp);
+	if (resp.status == 404)
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_FILE),
+				 errmsg("columnar: \"%s\" does not exist (HTTP 404)", url)));
+	if (resp.status != 200)
+		ereport(ERROR,
+				(errcode(ERRCODE_PROTOCOL_VIOLATION),
+				 errmsg("columnar: unexpected HTTP status %d for \"%s\"",
+						resp.status, url)));
+	if (resp.content_length < 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_PROTOCOL_VIOLATION),
+				 errmsg("columnar: \"%s\" reported no length", url)));
+	/* HEAD carries no body, whatever its headers say about one. */
+	if (resp.conn_close)
+		os_disconnect(h);
+	else
+		h->served++;
+
+	h->len = resp.content_length;
+	*len = h->len;
+	return h;
 }
 
 static void
 objstore_read(PgColumnarObjHandle *h, int64 off, void *buf, size_t n)
 {
-	(void) h; (void) off; (void) buf; (void) n;
-	elog(ERROR, "columnar: object-store read reached an unopened handle");
+	OsResponse	resp;
+
+	Assert(h != NULL && n > 0);
+
+	os_request(h, "GET", off, (int64) n, &resp);
+
+	if (resp.status == 200)
+	{
+		/*
+		 * The server ignored the Range header. Refuse rather than read: the
+		 * caller asked for n bytes and a whole-object body silently desyncs
+		 * every later read on this connection.
+		 */
+		os_disconnect(h);
+		ereport(ERROR,
+				(errcode(ERRCODE_PROTOCOL_VIOLATION),
+				 errmsg("columnar: \"%s\" ignored a Range request", h->url),
+				 errdetail("The server answered 200 with the whole object "
+						   "instead of 206 with the requested bytes.")));
+	}
+	if (resp.status == 404)
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_FILE),
+				 errmsg("columnar: \"%s\" does not exist (HTTP 404)", h->url)));
+	if (resp.status != 206)
+		ereport(ERROR,
+				(errcode(ERRCODE_PROTOCOL_VIOLATION),
+				 errmsg("columnar: unexpected HTTP status %d for \"%s\"",
+						resp.status, h->url)));
+
+	os_read_body(h, &resp, (uint8 *) buf, (int64) n);
+
+	if (resp.conn_close)
+		os_disconnect(h);
+	else
+		h->served++;
 }
 
 static void
 objstore_close(PgColumnarObjHandle *h)
 {
-	(void) h;
+	if (h != NULL)
+		os_free_handle(h);
 }
 
 static const PgColumnarObjStoreApi objstore_api = {

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -190,6 +190,7 @@ extern bool pgcolumnar_enable_late_materialization;
 extern bool pgcolumnar_enable_column_projection;
 extern bool pgcolumnar_enable_custom_scan;
 extern bool pgcolumnar_enable_bloom_filter;	/* bloom equality skipping (I7) */
+extern bool pgcolumnar_objstore_buffered;	/* chunk-granular remote reads (#393) */
 
 /* Phase 6 GUCs (spec 8.3) */
 extern bool pgcolumnar_enable_vectorization;	/* vectorized aggregate path */

--- a/src/columnar_parquet_reader.c
+++ b/src/columnar_parquet_reader.c
@@ -1484,6 +1484,7 @@ decode_plain_bools(const uint8 *buf, size_t buflen, int n, Datum *out)
  * client links is mapped into the postmaster. See PgColumnarObjStoreApi.
  */
 typedef struct PqSource PqSource;
+static void pq_source_close(PqSource *src);
 
 typedef struct PqSourceOps
 {
@@ -1497,10 +1498,25 @@ struct PqSource
 	const PqSourceOps *ops;		/* the implementation; never NULL once opened */
 	FILE	   *f;				/* AllocateFile handle (buffered), local only */
 	void	   *priv;			/* remote implementation's own state */
+	const PgColumnarObjStoreApi *api;	/* remote only; NULL for local */
 	const char *path;			/* for error messages; palloc'd by the caller */
 	int64		len;			/* file length in bytes */
 	uint8	   *meta;			/* serialized footer metadata */
 	uint32		metalen;
+
+	/*
+	 * Prefetch window (#393 M1). pq_source_prefetch fills it with ONE
+	 * underlying read covering a whole column chunk, and pq_source_read serves
+	 * any request that falls inside it from memory. Local sources skip it: the
+	 * local path's read behaviour must not change, and stdio already buffers.
+	 * The pgcolumnar.objstore_buffered GUC (dev) turns it off so the
+	 * request-count suite measures the unbuffered arm in the same run.
+	 */
+	uint8	   *win;
+	int64		winOff;
+	int64		winLen;
+	MemoryContext winCtx;		/* win lives here, not in a per-group context
+								 * that resets under the window's feet */
 };
 
 /*
@@ -1552,11 +1568,76 @@ static const PqSourceOps pq_local_ops = {
 	.close = pq_source_close_local,
 };
 
+/*
+ * The remote implementation (#393): every call forwards to the object-store
+ * module through the ABI. The module has already been resolved and the handle
+ * opened by the time these can run, so src->api and src->priv are never NULL
+ * here.
+ */
+static void
+pq_source_read_remote(PqSource *src, int64 off, void *buf, size_t n)
+{
+	Assert(off >= 0 && n <= (size_t) (src->len - off));
+	src->api->read((PgColumnarObjHandle *) src->priv, off, buf, n);
+}
+
+static void
+pq_source_close_remote(PqSource *src)
+{
+	if (src->priv != NULL)
+	{
+		src->api->close((PgColumnarObjHandle *) src->priv);
+		src->priv = NULL;
+	}
+}
+
+static const PqSourceOps pq_remote_ops = {
+	.name = "remote",
+	.read = pq_source_read_remote,
+	.close = pq_source_close_remote,
+};
+
 /* The dispatchers every caller uses. */
 static void
 pq_source_read(PqSource *src, int64 off, void *buf, size_t n)
 {
+	if (src->win != NULL &&
+		off >= src->winOff &&
+		(int64) (off + n) <= src->winOff + src->winLen)
+	{
+		memcpy(buf, src->win + (off - src->winOff), n);
+		return;
+	}
 	src->ops->read(src, off, buf, n);
+}
+
+/*
+ * Pull [off, off+n) into the window with one underlying read, so the per-page
+ * reads that follow are served from memory. A remote-only, best-effort hint:
+ * requests outside the window still work, they just cost a request each. The
+ * clamp against src->len matters because callers pass the chunk extent plus a
+ * page-header pad, which can run past the end of the last chunk.
+ */
+static void
+pq_source_prefetch(PqSource *src, int64 off, int64 n)
+{
+	if (src->ops != &pq_remote_ops || !pgcolumnar_objstore_buffered)
+		return;
+	if (off < 0 || off >= src->len)
+		return;
+	n = Min(n, src->len - off);
+	if (n <= 0 || n > (int64) MaxAllocSize)
+		return;
+
+	if (src->win != NULL)
+	{
+		pfree(src->win);
+		src->win = NULL;
+	}
+	src->win = (uint8 *) MemoryContextAlloc(src->winCtx, (Size) n);
+	src->ops->read(src, off, src->win, (size_t) n);
+	src->winOff = off;
+	src->winLen = n;
 }
 
 
@@ -1614,27 +1695,37 @@ pq_source_open(const char *path, PqSource *src, PqFile *pf)
 					 errdetail("The installed object-store module handles no "
 							   "such URL scheme."),
 					 errhint("Use a local filesystem path.")));
-		/* the remote source is wired in the next commit */
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("columnar: object storage is not implemented yet")));
+
+		/*
+		 * The module raises on failure (connection refused, 404, a server
+		 * ignoring Range), so a non-NULL handle with a length is the only way
+		 * out of open. The window context is captured here: the source struct
+		 * outlives the per-group decode contexts the prefetch runs under.
+		 */
+		src->winCtx = CurrentMemoryContext;
+		src->api = api;
+		src->priv = (void *) api->open(path, &src->len);
+		src->ops = &pq_remote_ops;
+	}
+	else
+	{
+		src->f = AllocateFile(path, PG_BINARY_R);
+		if (src->f == NULL)
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not open file \"%s\" for reading: %m", path)));
+		/* off_t, not long: a 32-bit long would cap a readable file at 2GB */
+		if (fseeko(src->f, 0, SEEK_END) != 0 || (src->len = ftello(src->f)) < 0)
+		{
+			FreeFile(src->f);
+			ereport(ERROR, (errcode_for_file_access(),
+							errmsg("could not size \"%s\": %m", path)));
+		}
 	}
 
-	src->f = AllocateFile(path, PG_BINARY_R);
-	if (src->f == NULL)
-		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not open file \"%s\" for reading: %m", path)));
-	/* off_t, not long: a 32-bit long would cap a readable file at 2GB */
-	if (fseeko(src->f, 0, SEEK_END) != 0 || (src->len = ftello(src->f)) < 0)
-	{
-		FreeFile(src->f);
-		ereport(ERROR, (errcode_for_file_access(),
-						errmsg("could not size \"%s\": %m", path)));
-	}
 	if (src->len < 12)
 	{
-		FreeFile(src->f);
+		pq_source_close(src);
 		ereport(ERROR, (errcode(ERRCODE_DATA_CORRUPTED),
 						errmsg("\"%s\" is not a Parquet file", path)));
 	}
@@ -1644,7 +1735,7 @@ pq_source_open(const char *path, PqSource *src, PqFile *pf)
 	pq_source_read(src, src->len - 8, tail, 8);
 	if (memcmp(head, "PAR1", 4) != 0 || memcmp(tail + 4, "PAR1", 4) != 0)
 	{
-		FreeFile(src->f);
+		pq_source_close(src);
 		ereport(ERROR, (errcode(ERRCODE_DATA_CORRUPTED),
 						errmsg("\"%s\" is not a Parquet file (bad magic)", path)));
 	}
@@ -1657,7 +1748,7 @@ pq_source_open(const char *path, PqSource *src, PqFile *pf)
 	 */
 	if ((int64) src->metalen + 8 > src->len || src->metalen > MaxAllocSize)
 	{
-		FreeFile(src->f);
+		pq_source_close(src);
 		ereport(ERROR, (errcode(ERRCODE_DATA_CORRUPTED),
 						errmsg("\"%s\" has a corrupt Parquet footer", path)));
 	}
@@ -1667,7 +1758,7 @@ pq_source_open(const char *path, PqSource *src, PqFile *pf)
 
 	if (!parse_file_metadata(src->meta, src->metalen, pf))
 	{
-		FreeFile(src->f);
+		pq_source_close(src);
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						errmsg("could not parse \"%s\" (unsupported or corrupt Parquet metadata)", path)));
 	}
@@ -1676,6 +1767,12 @@ pq_source_open(const char *path, PqSource *src, PqFile *pf)
 static void
 pq_source_close(PqSource *src)
 {
+	if (src->win != NULL)
+	{
+		pfree(src->win);
+		src->win = NULL;
+		src->winLen = 0;
+	}
 	src->ops->close(src);
 }
 
@@ -1762,6 +1859,18 @@ decode_leaf_entries(PqSource *src, PqChunk *ch,
 	Datum	   *dict = NULL;
 	int			dictCount = 0;
 	int			nDictPages = 0;
+
+	/*
+	 * One underlying read for the whole chunk (#393 M1): the page walk below is
+	 * then served from the window instead of costing two ranged requests per
+	 * page. The pad keeps the fixed-size page-header window reads near the
+	 * chunk's tail inside the window; total_compressed_size is file-declared,
+	 * so the prefetch clamps it against the object length rather than trusting
+	 * it to size anything beyond one bounded allocation.
+	 */
+	if (ch->total_compressed_size > 0)
+		pq_source_prefetch(src, pos,
+						   ch->total_compressed_size + PQ_PAGE_HDR_WIN_MIN);
 
 	while (nEntries < ch->num_values && pos < src->len)
 	{
@@ -3609,14 +3718,15 @@ pqfdw_partition_values(const char *root, const char *file, TupleDesc tupdesc,
 			if (strcmp(NameStr(att->attname), key) != 0)
 				continue;
 			{
-				char	   *text = pq_percent_decode(eq + 1, file);
+				/* not "text": -Wshadow, the SQL type of that name */
+				char	   *decoded = pq_percent_decode(eq + 1, file);
 
 				/*
 				 * The null marker is checked after decoding, so a value that
 				 * spells it out through escapes is treated the same way a writer
 				 * that emitted it plainly would be.
 				 */
-				if (strcmp(text, PQ_HIVE_NULL_PARTITION) == 0)
+				if (strcmp(decoded, PQ_HIVE_NULL_PARTITION) == 0)
 				{
 					vals[i] = (Datum) 0;
 					isnull[i] = true;
@@ -3627,7 +3737,7 @@ pqfdw_partition_values(const char *root, const char *file, TupleDesc tupdesc,
 					Oid			ioparam;
 
 					getTypeInputInfo(att->atttypid, &infunc, &ioparam);
-					vals[i] = OidInputFunctionCall(infunc, text, ioparam,
+					vals[i] = OidInputFunctionCall(infunc, decoded, ioparam,
 												   att->atttypmod);
 					isnull[i] = false;
 				}

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -77,6 +77,7 @@ bool		pgcolumnar_enable_qual_pushdown = true;
 bool		pgcolumnar_enable_late_materialization = true;
 bool		pgcolumnar_enable_column_projection = true;
 bool		pgcolumnar_enable_bloom_filter = true;
+bool		pgcolumnar_objstore_buffered = true;	/* #393 */
 
 /* value set for columnar.compression (spec 5, 8.3) */
 static const struct config_enum_entry pgcolumnar_compression_options[] = {
@@ -2525,6 +2526,20 @@ _PG_init(void)
 							 "Push scan qualifiers down for chunk-group skipping.",
 							 NULL,
 							 &pgcolumnar_enable_qual_pushdown,
+							 true,
+							 PGC_USERSET,
+							 0,
+							 NULL, NULL, NULL);
+
+	/*
+	 * Dev control for #393: off maps every page read 1:1 onto a ranged request
+	 * so the request-count suite can measure both arms in one run. Nothing
+	 * else should turn it off; the buffered path is the supported one.
+	 */
+	DefineCustomBoolVariable("pgcolumnar.objstore_buffered",
+							 "Coalesce remote Parquet reads to one request per column chunk.",
+							 NULL,
+							 &pgcolumnar_objstore_buffered,
 							 true,
 							 PGC_USERSET,
 							 0,

--- a/test/objstore_http_read.sh
+++ b/test/objstore_http_read.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+#
+# pgColumnar #393 M1: the HTTP ranged byte source, with the request count
+# ASSERTED rather than reported (the M1 test spec agreed on the issue).
+#
+# Four arms, per design/ISSUE_393_M1_HTTP_SOURCE.md:
+#   A  differential oracle: a foreign table over http://127.0.0.1 returns the
+#      same rows as the byte-identical local file. Premise for everything else.
+#   B  request count, both arms in one run: buffered requests == K where K is
+#      arithmetic from the fixture's structure (open = 1 HEAD + 3 ranged GETs,
+#      data = one GET per needed chunk); unbuffered (dev GUC off) >= 10*K.
+#      Removal proof: force the GUC off and the buffered check must go red.
+#   C  failure taxonomy on SQLSTATE: unreachable port and 404 name the URL and
+#      produce no rows; a Range-ignoring server is an error, never a silent
+#      whole-object read.
+#   D  cancel: statement_timeout fires within bound while the server stalls
+#      mid-body. Removal proof: with the module's WaitLatchOrSocket wait arm
+#      deleted, this check hangs or reds.
+#
+# The fixture server (test/objstore_http_server.py) logs one line per request;
+# that log is seam B. The suite tears the server down through a chained trap
+# (the bare-trap EXIT gotcha is pinned by harness_selftest).
+#
+# Usage:  test/objstore_http_read.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+python3 -c 'import pyarrow' 2>/dev/null || pgc_skip pyarrow "pyarrow is required to write the fixture"
+
+HTTP_PORT="$(pgc_pick_free_port "$PGC_AUX_PORT_LO" "$PGC_AUX_PORT_HI")"
+HTTP_LOG="$PGC_WORKDIR/http.log"
+SRV_PID=""
+
+objstore_http_teardown() {
+	[ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null
+	pgc_teardown
+}
+trap objstore_http_teardown EXIT INT TERM
+
+# ---- fixture ---------------------------------------------------------------
+# G row groups x NCOLS int64 columns, tiny data pages so the unbuffered arm's
+# per-page request count dwarfs the buffered per-chunk count. The arithmetic
+# below depends only on G and the projection width, never on the page count.
+G=3
+NCOLS=8
+ROWS_PER_GROUP=8000
+
+python3 - "$PGC_WORKDIR/fixture.parquet" <<PYEOF
+import sys
+import pyarrow as pa, pyarrow.parquet as pq
+G, NCOLS, RPG = $G, $NCOLS, $ROWS_PER_GROUP
+n = G * RPG
+cols = {("c%d" % i): pa.array([(i + 1) * v for v in range(n)], pa.int64())
+        for i in range(NCOLS)}
+t = pa.table(cols)
+pq.write_table(t, sys.argv[1], row_group_size=RPG, data_page_size=1024,
+               compression="NONE", use_dictionary=False)
+md = pq.ParquetFile(sys.argv[1]).metadata
+assert md.num_row_groups == G, md.num_row_groups
+print("fixture: %d groups, %d cols, %d rows" % (md.num_row_groups, md.num_columns, md.num_rows))
+PYEOF
+check "premise: fixture written" "$([ -s "$PGC_WORKDIR/fixture.parquet" ] && echo yes)" "yes"
+
+# ---- fixture server --------------------------------------------------------
+python3 "$(dirname "${BASH_SOURCE[0]}")/objstore_http_server.py" \
+	--dir "$PGC_WORKDIR" --port "$HTTP_PORT" --log "$HTTP_LOG" \
+	> "$PGC_WORKDIR/http_server.out" 2>&1 &
+SRV_PID=$!
+for _ in $(seq 1 50); do
+	grep -q READY "$PGC_WORKDIR/http_server.out" 2>/dev/null && break
+	sleep 0.1
+done
+check "premise: fixture server is up" \
+	"$(grep -c READY "$PGC_WORKDIR/http_server.out" 2>/dev/null)" "1"
+
+BASE="http://127.0.0.1:$HTTP_PORT"
+COLDEFS="$(python3 -c "print(', '.join('c%d int8' % i for i in range($NCOLS)))")"
+
+psql_run "CREATE SERVER osrv FOREIGN DATA WRAPPER pgcolumnar_parquet;"
+psql_run "CREATE FOREIGN TABLE flocal ($COLDEFS) SERVER osrv OPTIONS (path '$PGC_WORKDIR/fixture.parquet');"
+psql_run "CREATE FOREIGN TABLE fhttp  ($COLDEFS) SERVER osrv OPTIONS (path '$BASE/fixture.parquet');"
+
+# SQLSTATE of a failing statement (psql VERBOSITY sqlstate prints the bare code).
+sqlstate_of() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -qtA 2>&1 <<SQLEOF | sed -n 's/^ERROR:  \([0-9A-Z]\{5\}\).*/\1/p' | head -1
+\\set VERBOSITY sqlstate
+$1;
+SQLEOF
+}
+
+# Requests logged since the last truncation.
+reqs() { wc -l < "$HTTP_LOG" | tr -d ' '; }
+
+# ---- arm A: differential oracle -------------------------------------------
+check "A: full scan http == local" \
+	"$(pgc_set_hash "SELECT * FROM fhttp")" "$(pgc_set_hash "SELECT * FROM flocal")"
+check "A: projection http == local" \
+	"$(pgc_set_hash "SELECT c1, c6 FROM fhttp")" "$(pgc_set_hash "SELECT c1, c6 FROM flocal")"
+check_num "A: count(*) over http" "$(q "SELECT count(*) FROM fhttp")" "$((G * ROWS_PER_GROUP))"
+
+# ---- arm B: the asserted request count -------------------------------------
+# K is arithmetic from the fixture, stated here, not a remembered literal:
+# open = 1 HEAD + 3 ranged GETs (head magic, tail, footer); data = one GET per
+# needed chunk = G row groups x the projection's column width. The projections
+# are sums so every named column is genuinely pulled (count(*) pulls none and
+# would make the width premise silently wrong).
+SUM_ALL="$(python3 -c "print(' + '.join('sum(c%d)' % i for i in range($NCOLS)))")"
+K_FULL=$((4 + G * NCOLS))
+K_PROJ=$((4 + G * 2))
+
+: > "$HTTP_LOG"
+q "SELECT $SUM_ALL FROM fhttp" >/dev/null
+FULL_BUF="$(reqs)"
+: > "$HTTP_LOG"
+q "SELECT sum(c1) + sum(c6) FROM fhttp" >/dev/null
+PROJ_BUF="$(reqs)"
+
+: > "$HTTP_LOG"
+env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" -qtA \
+	-c "SET pgcolumnar.objstore_buffered = off" \
+	-c "SELECT $SUM_ALL FROM fhttp" >/dev/null 2>&1
+FULL_UNBUF="$(reqs)"
+
+check "premise: buffered run logged requests" "$([ "${FULL_BUF:-0}" -gt 0 ] 2>/dev/null && echo yes)" "yes"
+check "premise: unbuffered run logged requests" "$([ "${FULL_UNBUF:-0}" -gt 0 ] 2>/dev/null && echo yes)" "yes"
+# Buffered counts are deterministic (keep-alive, no retries in this phase), so
+# they are asserted as equalities: stricter than the spec's <= bound, and it
+# catches over-coalescing as well as under.
+check_num "B: buffered full-width requests (K = 4 + G*NCOLS)" "$FULL_BUF" "$K_FULL"
+check_num "B: buffered 2-col requests (K = 4 + G*2)" "$PROJ_BUF" "$K_PROJ"
+check_num "B: unbuffered >= 10x K" \
+	"$([ "${FULL_UNBUF:-0}" -ge $((10 * K_FULL)) ] 2>/dev/null && echo 1 || echo 0)" "1"
+check_ratio "B: buffered/unbuffered request ratio" "$FULL_BUF" "$FULL_UNBUF" "0.1"
+
+# Every data-phase request carried a Range header (the HEAD is the one allowed
+# exception per open). The GET-count premise keeps this from passing vacuously
+# on an empty log, which is exactly what the RED run produced.
+: > "$HTTP_LOG"
+q "SELECT sum(c0) FROM fhttp" >/dev/null
+NGETS="$(awk '$1 == "GET"' "$HTTP_LOG" | wc -l | tr -d ' ')"
+NORANGE="$(awk '$1 == "GET" && $3 == "-"' "$HTTP_LOG" | wc -l | tr -d ' ')"
+check "premise: the range-audit phase logged GETs" \
+	"$([ "${NGETS:-0}" -gt 0 ] 2>/dev/null && echo yes)" "yes"
+check_num "B: every GET carried a Range header" "$NORANGE" "0"
+
+# ---- arm C: failure taxonomy ----------------------------------------------
+DEADPORT="$(pgc_pick_free_port "$PGC_AUX_PORT_LO" "$PGC_AUX_PORT_HI" $((HTTP_PORT + 7)))"
+psql_run "CREATE FOREIGN TABLE fdead ($COLDEFS) SERVER osrv OPTIONS (path 'http://127.0.0.1:$DEADPORT/fixture.parquet');"
+psql_run "CREATE FOREIGN TABLE f404  ($COLDEFS) SERVER osrv OPTIONS (path '$BASE/no_such.parquet');"
+psql_run "CREATE FOREIGN TABLE fnorange ($COLDEFS) SERVER osrv OPTIONS (path '$BASE/norange/fixture.parquet');"
+
+check "C: unreachable endpoint SQLSTATE" "$(sqlstate_of "SELECT count(*) FROM fdead")" "08006"
+check "C: http 404 SQLSTATE" "$(sqlstate_of "SELECT count(*) FROM f404")" "58P01"
+check "C: range-ignoring server SQLSTATE" "$(sqlstate_of "SELECT count(*) FROM fnorange")" "08P01"
+
+# ---- arm D: cancel while the server stalls mid-body ------------------------
+psql_run "CREATE FOREIGN TABLE fstall ($COLDEFS) SERVER osrv OPTIONS (path '$BASE/stall/fixture.parquet');"
+D_START=$(date +%s)
+D_STATE="$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+	-d "$PGC_DB" -qtA 2>&1 <<SQLEOF | sed -n 's/^ERROR:  \([0-9A-Z]\{5\}\).*/\1/p' | head -1
+\\set VERBOSITY sqlstate
+SET statement_timeout = '2s';
+SELECT count(*) FROM fstall;
+SQLEOF
+)"
+D_ELAPSED=$(( $(date +%s) - D_START ))
+check "D: stalled transfer cancelled with query_canceled" "$D_STATE" "57014"
+check_num "D: cancel latency bounded (<=10s)" \
+	"$([ "$D_ELAPSED" -le 10 ] 2>/dev/null && echo 1 || echo 0)" "1"
+
+pgc_summary

--- a/test/objstore_http_server.py
+++ b/test/objstore_http_server.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# Range-capable logging HTTP fixture for test/objstore_http_read.sh (#393 M1).
+#
+# Serves files from --dir and appends one line per request to --log:
+#     METHOD <path> <value of the Range header, or "-">
+# The log is the suite's seam B: request counts are asserted against it, so this
+# server must log every request exactly once, before serving it.
+#
+# Special path prefixes, used by the failure and cancel arms:
+#   /norange/<file>  serve <file> but IGNORE any Range header (status 200, whole
+#                    body): the client must treat this as an error, never as data.
+#   /stall/<file>    answer the first ranged GET's headers, send half the body,
+#                    then sleep: the cancel arm proves statement_timeout gets the
+#                    backend back while the transfer is wedged.
+#
+# Written fresh for pgColumnar.
+
+import argparse
+import os
+import re
+import sys
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+RANGE_RE = re.compile(r"^bytes=(\d*)-(\d*)$")
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, fmt, *args):   # silence stderr chatter
+        pass
+
+    def _log_line(self):
+        rng = self.headers.get("Range", "-").replace(" ", "")
+        with open(self.server.reqlog, "a") as f:
+            f.write("%s %s %s\n" % (self.command, self.path, rng))
+
+    def _resolve(self):
+        path = self.path
+        mode = "normal"
+        for prefix in ("/norange/", "/stall/"):
+            if path.startswith(prefix):
+                mode = prefix.strip("/")
+                path = "/" + path[len(prefix):]
+                break
+        local = os.path.join(self.server.rootdir, path.lstrip("/"))
+        return mode, local
+
+    def _head_common(self, local):
+        if not os.path.isfile(local):
+            self.send_response(404)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return -1
+        return os.path.getsize(local)
+
+    def do_HEAD(self):
+        self._log_line()
+        size = self._head_common(self._resolve()[1])
+        if size < 0:
+            return
+        self.send_response(200)
+        self.send_header("Content-Length", str(size))
+        self.send_header("Accept-Ranges", "bytes")
+        self.end_headers()
+
+    def do_GET(self):
+        self._log_line()
+        mode, local = self._resolve()
+        size = self._head_common(local)
+        if size < 0:
+            return
+
+        rng = self.headers.get("Range")
+        m = RANGE_RE.match(rng.replace(" ", "")) if rng else None
+        if m is None or mode == "norange":
+            # No Range, or deliberately ignoring it: whole object, status 200.
+            self.send_response(200)
+            self.send_header("Content-Length", str(size))
+            self.end_headers()
+            with open(local, "rb") as f:
+                self.wfile.write(f.read())
+            return
+
+        if m.group(1) == "":                     # suffix form bytes=-N
+            n = int(m.group(2))
+            lo, hi = max(0, size - n), size - 1
+        else:
+            lo = int(m.group(1))
+            hi = int(m.group(2)) if m.group(2) != "" else size - 1
+        hi = min(hi, size - 1)
+        if lo > hi or lo >= size:
+            self.send_response(416)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+
+        n = hi - lo + 1
+        with open(local, "rb") as f:
+            f.seek(lo)
+            body = f.read(n)
+        self.send_response(206)
+        self.send_header("Content-Range", "bytes %d-%d/%d" % (lo, hi, size))
+        self.send_header("Content-Length", str(n))
+        self.end_headers()
+        if mode == "stall":
+            self.wfile.write(body[: n // 2])
+            self.wfile.flush()
+            time.sleep(300)                      # the suite cancels long before
+            return
+        self.wfile.write(body)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dir", required=True)
+    ap.add_argument("--port", type=int, required=True)
+    ap.add_argument("--log", required=True)
+    args = ap.parse_args()
+
+    srv = ThreadingHTTPServer(("127.0.0.1", args.port), Handler)
+    srv.rootdir = args.dir
+    srv.reqlog = args.log
+    open(args.log, "a").close()
+    # Readiness marker for the suite: print once the socket is bound.
+    print("READY", flush=True)
+    srv.serve_forever()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -145,6 +145,7 @@ SUITES=(
 	native_vecskip
 	native_writer
 	native_zonemap
+	objstore_http_read
 	objstore_module
 	objstore_stash_recovery
 	parallel


### PR DESCRIPTION
Implements milestone M1 of the #393 plan of record: the object-store module's first protocol, plain HTTP/1.1 ranged reads, with the request count **asserted, not reported** per the test spec agreed on the issue. Design: `design/ISSUE_393_M1_HTTP_SOURCE.md` (PR #604).

## What lands

- **Module HTTP client** (`objstore/columnar_objstore_module.c`): GET and HEAD over a nonblocking socket, every wait a `WaitLatchOrSocket` + `CHECK_FOR_INTERRUPTS` (no blocking syscall ever touches the socket — `SA_RESTART` makes a blocking recv un-cancellable), both Content-Length and chunked framing, bounded 16 KB head parse (NUL-bounded before any `strstr`), one reconnect on a stale keep-alive, sockets returned on abort via a resource-release callback.
- **Remote wiring in `pq_source_open`**: the "not implemented yet" error is replaced by `api->open` (HEAD supplies the length `ftello` supplied locally); the common footer path's error cleanup goes through `pq_source_close` so both transports unwind identically.
- **Prefetch window above the ABI** (`pq_source_prefetch`): one ranged GET per column chunk instead of two per page; dev GUC `pgcolumnar.objstore_buffered` so the suite measures both arms in one run.
- **`test/objstore_http_read.sh`** + logging Range fixture server (python stdlib): differential oracle, `K = 4 + G×chunks` asserted as equalities (28 full-width, 10 for 2-of-8, unbuffered 388), SQLSTATE failure taxonomy (08006 / 58P01 / 08P01), and a cancel arm against a mid-body stall (~2 s against a 300 s stall).

## Proofs

- **RED first**: on main the suite fails every remote arm with today's 0A000; recorded before any implementation.
- **Removal proof 1**: delete the prefetch call → buffered arm counts 388 (equal to unbuffered), the three arm-B checks go red.
- **Removal proof 2**: delete `CHECK_FOR_INTERRUPTS` from the wait loop → both arm-D cancel checks go red.
- The RED run also exposed a vacuous pass in my own suite (Range-audit over an empty log); it is premise-guarded now.

## Verification

- 18/18 on **PG17** (my lane), **PG18**, **PG19**.
- **ASAN+UBSAN gate** (`test/run_san.sh`, pg18_san): `objstore_http_read` and `objstore_module` both pass.
- Five neighbouring parquet suites green on PG17 (`objstore_module`, `native_parquet_fdw`, `parquet_import`, `parquet_export`, `native_read_parquet`).
- `-Wshadow -Werror` clean, including a drive-by rename of the pre-existing `text` shadow in the Hive partition decode (only file this PR already touches).

## Scope guard

`https://` and `s3://` still report unsupported by design (M3/M2). No ListObjectsV2, no globs, no retries beyond one reconnect, no FDW streaming change. Known M1 limitation, stated in code: DNS resolution for non-literal hosts is synchronous.

Closes nothing by itself; #393 continues with M2 (SigV4, integration against the `garage-26-04` endpoint), M3 (TLS), M4 (validator split).

🤖 Generated with [Claude Code](https://claude.com/claude-code)