### PR TITLE
feat: SigV4-signed s3:// reads, verified against independent implementations (#393 M2)

### DIFF
--- a/design/ISSUE_393_M2_SIGV4.md
+++ b/design/ISSUE_393_M2_SIGV4.md
@@ -1,0 +1,103 @@
+# Issue #393 M2: SigV4 signing and the s3:// scheme
+
+Design before code. M1 (merged, #605) established the transport: HTTP/1.1
+ranged GET/HEAD on a nonblocking socket, request count asserted. M2 adds AWS
+Signature Version 4 on the same transport and turns the `s3://` scheme on. TLS
+is M3; the validator split and catalog options are M4. This milestone stores
+nothing in any catalog.
+
+## Scope
+
+- `s3://bucket/key` reads, exact keys only (standing v1 scope), path-style
+  addressing, signed GET and HEAD.
+- **Endpoint from the environment**: `AWS_ENDPOINT_URL`, the SDK-standard
+  variable. M2 requires it to be an `http://` endpoint; an `https://` endpoint
+  errors "TLS arrives in M3" rather than silently downgrading, and an absent
+  endpoint errors with the variable named. Virtual-host addressing against
+  AWS's default endpoints is deferred with TLS, which it requires anyway.
+- **Ambient credentials only** (the decided default): `AWS_ACCESS_KEY_ID`,
+  `AWS_SECRET_ACCESS_KEY`, optional `AWS_SESSION_TOKEN`, region from
+  `AWS_REGION` else `AWS_DEFAULT_REGION`. All read from the backend's
+  (postmaster-inherited) environment at open time. Missing credentials or
+  region error before any connection is attempted, SQLSTATE 28000, naming the
+  variable. No `credential_process`, no `~/.aws` parsing, no IMDS: those are
+  the sharp edges the memo scoped out of ambient v1.
+
+## Signing (no new dependency)
+
+The primitives are `pg_hmac_*` and `pg_cryptohash_*`, exported on all five
+majors and proven working without OpenSSL on the issue (compiled, loaded, and
+checked against RFC 4231 and the AWS empty-payload constant). pgBackRest's
+complete implementation is 96 lines; ours is the same shape:
+
+- Canonical request: method; the canonical URI (our own `UriEncode` per AWS's
+  explicit recommendation, two encoders, path preserves `/`; the query string
+  is empty in M2 because exact-key GET/HEAD carries none); canonical headers
+  `host`, `range` (GET only), `x-amz-content-sha256`, `x-amz-date`, and
+  `x-amz-security-token` when a session token is present (alphabetical
+  already); the signed-headers list; the empty-payload hash constant
+  (`e3b0c442...`, reads send no body).
+- String-to-sign over the SHA-256 of the canonical request with scope
+  `date/region/s3/aws4_request`; `x-amz-date` from `pg_gmtime` +
+  `pg_strftime("%Y%m%dT%H%M%SZ")`.
+- Signing key derived by the four chained HMACs, cached per (day, region) for
+  the handle's lifetime so per-request cost is one HMAC, the pgBackRest shape.
+- The `Range` header is signed. Signing it costs nothing here (we sign per
+  request, not per cached signature, so the remote-signing cache concern from
+  #388 does not apply) and leaves no unsigned header a proxy could rewrite.
+
+## The oracle strategy: two independent implementations must agree
+
+A signer tested only against itself proves consistency, not correctness. Two
+independent oracles, both asserted:
+
+1. **The fixture verifies.** The M1 fixture server grows a SigV4-verifying
+   mode: python stdlib `hmac`/`hashlib` recomputes the signature for every
+   request from the same credentials and refuses 403 on mismatch. Every green
+   data check in the suite then proves the C signer and an independent
+   implementation agree on every byte of the canonical request. A tamper arm
+   flips the fixture's secret and asserts 403 surfaces as SQLSTATE 28000 and
+   zero rows: a wrong signature must never yield data.
+2. **Garage, opt-in.** When `PGC_S3_INTEGRATION_ENDPOINT` (plus key/secret
+   variables) is set, the same differential arm runs against a real S3
+   implementation (the `garage-26-04` container on this bench). Where the
+   variables are absent the arm prints a note and the fixture arm carries the
+   proof alone; it is not a skip, because the self-contained arms still ran.
+
+## Failure taxonomy (SQLSTATE-asserted, as M1)
+
+- Missing endpoint, credentials, or region: 28000 before any connection,
+  message naming the variable.
+- Server 403 (bad credentials, clock skew, tamper): 28000, message carrying
+  the server's error code element when present, never the credential itself.
+- Bucket or key absent (404): 58P01, as M1.
+- `https://` endpoint: 0A000 naming M3.
+- Transport failures: 08006, unchanged from M1.
+
+Secrets never appear in any error, log line, or EXPLAIN output: messages name
+the environment variable, not its value.
+
+## What M2 does not do
+
+No catalog options (M4), no TLS (M3), no ListObjectsV2 or globs (standing),
+no virtual-host addressing, no multi-region redirect handling (the 301
+wrong-region answer errors with the region named; redirect-following is not a
+read-path requirement against an explicit endpoint), no SigV4A, no chunked
+upload signing (write-side, #394), no credential refresh (ambient env is
+static per backend).
+
+## Order of work (TDD)
+
+1. Fixture server: SigV4 verification mode (stdlib only), tamper switch,
+   session-token check. Suite `objstore_s3_read.sh`: premises + arms written
+   against the fixture, RED on main (s3:// reports unsupported scheme today).
+2. Module: URL parse for s3://, endpoint/credential resolution, UriEncode,
+   the signer, wire into the M1 request path (one added Authorization header
+   plus the three x-amz headers). handles_url accepts s3://.
+3. Suite green; tamper, taxonomy, and token arms green; removal proofs: break
+   the canonical request (drop Range from the signed set) and the fixture arm
+   must go red with 403; unset the endpoint variable and the 28000 arm must
+   still pass while the data arms are skipped by their premise.
+4. Garage integration arm run on this bench against `pgcolumnar-test`.
+5. Gates as M1: PG17 lane + PG18/19, ASAN+UBSAN on the objstore suites,
+   -Wshadow -Werror.

--- a/objstore/columnar_objstore_module.c
+++ b/objstore/columnar_objstore_module.c
@@ -40,12 +40,17 @@
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <sys/socket.h>
+#include <time.h>
 #include <unistd.h>
 
+#include "common/cryptohash.h"
+#include "common/hmac.h"
+#include "common/sha2.h"
 #include "fmgr.h"
 #include "lib/ilist.h"
 #include "lib/stringinfo.h"
 #include "miscadmin.h"
+#include "pgtime.h"
 #include "storage/fd.h"
 #include "storage/latch.h"
 #include "utils/memutils.h"
@@ -78,6 +83,20 @@ struct PgColumnarObjHandle
 	int64		len;			/* object length from open's HEAD */
 	uint64		served;			/* requests completed on this connection */
 
+	/*
+	 * SigV4 (#393 M2). sign=false is the plain-http M1 path, byte-identical to
+	 * before. The credential strings come from the ambient environment at open
+	 * and live with the handle; the signing key is the four-HMAC derivation,
+	 * cached per UTC day the way pgBackRest caches it.
+	 */
+	bool		sign;
+	char	   *akid;
+	char	   *secret;
+	char	   *token;			/* session token, or NULL */
+	char	   *region;
+	char		sigDate[9];		/* YYYYMMDD the cached key was derived for */
+	uint8		sigKey[PG_SHA256_DIGEST_LENGTH];
+
 	/* receive staging */
 	uint8	   *rb;
 	int			rb_off;			/* consumed up to here */
@@ -85,6 +104,10 @@ struct PgColumnarObjHandle
 
 	dlist_node	node;			/* open-handle list, for abort cleanup */
 };
+
+/* SHA-256 of an empty payload; every request we sign sends no body. */
+#define OS_EMPTY_SHA256 \
+	"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
 /* One parsed response head. */
 typedef struct OsResponse
@@ -130,6 +153,14 @@ os_free_handle(PgColumnarObjHandle *h)
 		pfree(h->host);
 	if (h->abspath)
 		pfree(h->abspath);
+	if (h->akid)
+		pfree(h->akid);
+	if (h->secret)
+		pfree(h->secret);
+	if (h->token)
+		pfree(h->token);
+	if (h->region)
+		pfree(h->region);
 	pfree(h);
 }
 
@@ -566,6 +597,162 @@ os_read_body(PgColumnarObjHandle *h, const OsResponse *resp,
 	}
 }
 
+/* ---------------------------------------------------------------- signing */
+
+static void
+os_sha256(const uint8 *data, size_t len, uint8 out[PG_SHA256_DIGEST_LENGTH])
+{
+	pg_cryptohash_ctx *ctx = pg_cryptohash_create(PG_SHA256);
+
+	if (ctx == NULL ||
+		pg_cryptohash_init(ctx) < 0 ||
+		pg_cryptohash_update(ctx, data, len) < 0 ||
+		pg_cryptohash_final(ctx, out, PG_SHA256_DIGEST_LENGTH) < 0)
+		elog(ERROR, "columnar: SHA-256 computation failed");
+	pg_cryptohash_free(ctx);
+}
+
+static void
+os_hmac256(const uint8 *key, size_t klen,
+		   const uint8 *data, size_t dlen,
+		   uint8 out[PG_SHA256_DIGEST_LENGTH])
+{
+	pg_hmac_ctx *ctx = pg_hmac_create(PG_SHA256);
+
+	if (ctx == NULL ||
+		pg_hmac_init(ctx, key, klen) < 0 ||
+		pg_hmac_update(ctx, data, dlen) < 0 ||
+		pg_hmac_final(ctx, out, PG_SHA256_DIGEST_LENGTH) < 0)
+		elog(ERROR, "columnar: HMAC-SHA-256 computation failed");
+	pg_hmac_free(ctx);
+}
+
+static void
+os_hex(const uint8 *in, size_t n, char *out)	/* out: 2n+1 bytes */
+{
+	static const char digits[] = "0123456789abcdef";
+	size_t		i;
+
+	for (i = 0; i < n; i++)
+	{
+		out[2 * i] = digits[in[i] >> 4];
+		out[2 * i + 1] = digits[in[i] & 0xf];
+	}
+	out[2 * n] = '\0';
+}
+
+/*
+ * AWS UriEncode for the path: unreserved bytes and '/' pass, everything else
+ * is %XX with UPPERCASE hex. Hand-written per AWS's own recommendation:
+ * platform encoders disagree on exactly the bytes that break signatures
+ * (space, '+', '=', '~'). The query-string variant (encode '/') is not needed
+ * until a listing operation exists.
+ */
+static void
+os_uriencode_path(StringInfo out, const char *s)
+{
+	for (; *s != '\0'; s++)
+	{
+		unsigned char c = (unsigned char) *s;
+
+		if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+			(c >= '0' && c <= '9') ||
+			c == '-' || c == '.' || c == '_' || c == '~' || c == '/')
+			appendStringInfoChar(out, (char) c);
+		else
+			appendStringInfo(out, "%%%02X", c);
+	}
+}
+
+/*
+ * Derive (or reuse) the day's signing key and return the SigV4 headers for one
+ * request: x-amz-content-sha256, x-amz-date, optional x-amz-security-token,
+ * and Authorization. `rangeVal` is the exact Range header value the request
+ * will carry, or NULL for HEAD; the Range header is signed, which leaves no
+ * unsigned header a middlebox could rewrite.
+ */
+static void
+os_sign_request(PgColumnarObjHandle *h, const char *method,
+				const char *rangeVal, StringInfo headers)
+{
+	char		amzdate[20];	/* YYYYMMDDTHHMMSSZ */
+	char		datestamp[9];	/* YYYYMMDD */
+	pg_time_t	now = (pg_time_t) time(NULL);
+	StringInfoData creq;
+	StringInfoData signedlist;
+	StringInfoData sts;
+	uint8		digest[PG_SHA256_DIGEST_LENGTH];
+	char		hexdigest[PG_SHA256_DIGEST_LENGTH * 2 + 1];
+	char		signature[PG_SHA256_DIGEST_LENGTH * 2 + 1];
+
+	pg_strftime(amzdate, sizeof(amzdate), "%Y%m%dT%H%M%SZ", pg_gmtime(&now));
+	memcpy(datestamp, amzdate, 8);
+	datestamp[8] = '\0';
+
+	/* the four chained HMACs, cached per UTC day */
+	if (strcmp(h->sigDate, datestamp) != 0)
+	{
+		StringInfoData seed;
+		uint8		k[PG_SHA256_DIGEST_LENGTH];
+
+		initStringInfo(&seed);
+		appendStringInfo(&seed, "AWS4%s", h->secret);
+		os_hmac256((uint8 *) seed.data, seed.len,
+				   (uint8 *) datestamp, 8, k);
+		os_hmac256(k, sizeof(k), (uint8 *) h->region, strlen(h->region), k);
+		os_hmac256(k, sizeof(k), (uint8 *) "s3", 2, k);
+		os_hmac256(k, sizeof(k), (uint8 *) "aws4_request", 12, k);
+		memcpy(h->sigKey, k, sizeof(k));
+		strlcpy(h->sigDate, datestamp, sizeof(h->sigDate));
+		pfree(seed.data);
+	}
+
+	/* signed-headers list, alphabetical by construction */
+	initStringInfo(&signedlist);
+	appendStringInfoString(&signedlist, "host");
+	if (rangeVal != NULL)
+		appendStringInfoString(&signedlist, ";range");
+	appendStringInfoString(&signedlist, ";x-amz-content-sha256;x-amz-date");
+	if (h->token != NULL)
+		appendStringInfoString(&signedlist, ";x-amz-security-token");
+
+	/* canonical request */
+	initStringInfo(&creq);
+	appendStringInfo(&creq, "%s\n%s\n\n", method, h->abspath);
+	appendStringInfo(&creq, "host:%s:%d\n", h->host, h->port);
+	if (rangeVal != NULL)
+		appendStringInfo(&creq, "range:%s\n", rangeVal);
+	appendStringInfo(&creq, "x-amz-content-sha256:%s\n", OS_EMPTY_SHA256);
+	appendStringInfo(&creq, "x-amz-date:%s\n", amzdate);
+	if (h->token != NULL)
+		appendStringInfo(&creq, "x-amz-security-token:%s\n", h->token);
+	appendStringInfo(&creq, "\n%s\n%s", signedlist.data, OS_EMPTY_SHA256);
+
+	os_sha256((uint8 *) creq.data, creq.len, digest);
+	os_hex(digest, sizeof(digest), hexdigest);
+
+	/* string to sign, then the signature */
+	initStringInfo(&sts);
+	appendStringInfo(&sts, "AWS4-HMAC-SHA256\n%s\n%s/%s/s3/aws4_request\n%s",
+					 amzdate, datestamp, h->region, hexdigest);
+	os_hmac256(h->sigKey, sizeof(h->sigKey),
+			   (uint8 *) sts.data, sts.len, digest);
+	os_hex(digest, sizeof(digest), signature);
+
+	appendStringInfo(headers, "x-amz-content-sha256: %s\r\n", OS_EMPTY_SHA256);
+	appendStringInfo(headers, "x-amz-date: %s\r\n", amzdate);
+	if (h->token != NULL)
+		appendStringInfo(headers, "x-amz-security-token: %s\r\n", h->token);
+	appendStringInfo(headers,
+					 "Authorization: AWS4-HMAC-SHA256 Credential=%s/%s/%s/s3/aws4_request, "
+					 "SignedHeaders=%s, Signature=%s\r\n",
+					 h->akid, datestamp, h->region, signedlist.data, signature);
+
+	pfree(creq.data);
+	pfree(signedlist.data);
+	pfree(sts.data);
+}
+
 /* ---------------------------------------------------------------- request */
 
 /*
@@ -586,6 +773,15 @@ os_request(PgColumnarObjHandle *h, const char *method,
 	if (isGet)
 		appendStringInfo(&req, "Range: bytes=%lld-%lld\r\n",
 						 (long long) off, (long long) (off + n - 1));
+	if (h->sign)
+	{
+		char		rangeVal[64];
+
+		if (isGet)
+			snprintf(rangeVal, sizeof(rangeVal), "bytes=%lld-%lld",
+					 (long long) off, (long long) (off + n - 1));
+		os_sign_request(h, method, isGet ? rangeVal : NULL, &req);
+	}
 	appendStringInfoString(&req, "User-Agent: pgcolumnar-objstore/1\r\n\r\n");
 
 	for (attempt = 0;; attempt++)
@@ -615,17 +811,164 @@ os_request(PgColumnarObjHandle *h, const char *method,
 	pfree(req.data);
 }
 
+/*
+ * A 403 means the server rejected our authentication or signature. Read out
+ * the XML <Code> element when the body is small and simply framed, so the
+ * error names the server's reason; the credential itself never appears
+ * anywhere. Raises; does not return.
+ */
+static void
+os_reject_403(PgColumnarObjHandle *h, const OsResponse *resp, bool hasBody)
+{
+	char		code[64] = "";
+
+	/*
+	 * hasBody is false for HEAD: its response advertises a Content-Length but
+	 * carries no body bytes, and reading them would wait on a transfer that
+	 * never comes.
+	 */
+	if (hasBody && !resp->chunked && resp->content_length > 0 &&
+		resp->content_length < 8192)
+	{
+		char	   *body = palloc((Size) resp->content_length + 1);
+		char	   *codeStart;
+
+		os_read_exact(h, (uint8 *) body, resp->content_length);
+		body[resp->content_length] = '\0';
+		codeStart = strstr(body, "<Code>");
+		if (codeStart != NULL)
+		{
+			char	   *codeEnd = strstr(codeStart, "</Code>");
+
+			if (codeEnd != NULL &&
+				codeEnd - (codeStart + 6) < (ptrdiff_t) sizeof(code))
+			{
+				memcpy(code, codeStart + 6, codeEnd - (codeStart + 6));
+				code[codeEnd - (codeStart + 6)] = '\0';
+			}
+		}
+		pfree(body);
+	}
+
+	ereport(ERROR,
+			(errcode(ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION),
+			 errmsg("columnar: access to \"%s\" was denied (HTTP 403%s%s)",
+					h->url, code[0] ? ": " : "", code),
+			 errhint("Check the AWS_* credential environment of the server "
+					 "process.")));
+}
+
 /* -------------------------------------------------------------------- ABI */
 
 static bool
 objstore_handles_url(const char *url)
 {
 	/*
-	 * Plain http:// only in M1. https:// and s3:// stay unhandled so they
-	 * report "no such URL scheme" rather than silently downgrading to
-	 * cleartext; they arrive with M3 and M2 respectively.
+	 * Plain http:// (M1) and s3:// (M2). https:// stays unhandled so it
+	 * reports "no such URL scheme" rather than silently downgrading to
+	 * cleartext; it arrives with M3.
 	 */
-	return pg_strncasecmp(url, "http://", 7) == 0;
+	return pg_strncasecmp(url, "http://", 7) == 0 ||
+		pg_strncasecmp(url, "s3://", 5) == 0;
+}
+
+/* A required credential-environment variable, or the 28000 the design owes. */
+static const char *
+os_require_env(const char *name, const char *url)
+{
+	const char *v = getenv(name);
+
+	if (v == NULL || v[0] == '\0')
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION),
+				 errmsg("columnar: reading \"%s\" requires %s in the server "
+						"environment", url, name),
+				 errhint("Ambient credentials are read from the postmaster's "
+						 "environment. Set %s and restart, or use a local "
+						 "path.", name)));
+	return v;
+}
+
+/*
+ * Resolve an s3://bucket/key URL against the ambient environment: endpoint
+ * host and port from AWS_ENDPOINT_URL (http only until M3), credentials and
+ * region from the AWS_* variables, path-style request target with the key
+ * percent-encoded exactly as it is signed.
+ */
+static void
+os_resolve_s3(PgColumnarObjHandle *h, const char *url)
+{
+	const char *bucket = url + 5;
+	const char *slash = strchr(bucket, '/');
+	const char *ep;
+	const char *ephost;
+	const char *epslash;
+	const char *epcolon;
+	const char *region;
+	const char *token;
+	StringInfoData path;
+	MemoryContext oldcxt;
+
+	if (slash == NULL || slash == bucket || slash[1] == '\0')
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("columnar: \"%s\" is not s3://bucket/key", url)));
+
+	ep = os_require_env("AWS_ENDPOINT_URL", url);
+	if (pg_strncasecmp(ep, "https://", 8) == 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("columnar: AWS_ENDPOINT_URL is https, which this "
+						"build does not support yet"),
+				 errdetail("TLS support is milestone M3 of #393; until then "
+						   "only an explicitly configured http endpoint is "
+						   "accepted.")));
+	if (pg_strncasecmp(ep, "http://", 7) != 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("columnar: AWS_ENDPOINT_URL must be an http:// URL")));
+
+	region = getenv("AWS_REGION");
+	if (region == NULL || region[0] == '\0')
+		region = getenv("AWS_DEFAULT_REGION");
+	if (region == NULL || region[0] == '\0')
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION),
+				 errmsg("columnar: reading \"%s\" requires AWS_REGION or "
+						"AWS_DEFAULT_REGION in the server environment", url)));
+
+	oldcxt = MemoryContextSwitchTo(TopMemoryContext);
+	h->akid = pstrdup(os_require_env("AWS_ACCESS_KEY_ID", url));
+	h->secret = pstrdup(os_require_env("AWS_SECRET_ACCESS_KEY", url));
+	token = getenv("AWS_SESSION_TOKEN");
+	h->token = (token != NULL && token[0] != '\0') ? pstrdup(token) : NULL;
+	h->region = pstrdup(region);
+
+	/* endpoint authority */
+	ephost = ep + 7;
+	epslash = strchr(ephost, '/');
+	if (epslash == NULL)
+		epslash = ephost + strlen(ephost);
+	epcolon = memchr(ephost, ':', epslash - ephost);
+	if (epcolon != NULL)
+	{
+		h->host = pnstrdup(ephost, epcolon - ephost);
+		h->port = atoi(epcolon + 1);
+	}
+	else
+	{
+		h->host = pnstrdup(ephost, epslash - ephost);
+		h->port = 80;
+	}
+
+	/* path-style, encoded exactly as signed */
+	initStringInfo(&path);
+	appendStringInfoChar(&path, '/');
+	os_uriencode_path(&path, bucket);	/* bucket/key together; '/' passes */
+	h->abspath = path.data;
+	MemoryContextSwitchTo(oldcxt);
+
+	h->sign = true;
 }
 
 static PgColumnarObjHandle *
@@ -633,9 +976,7 @@ objstore_open(const char *url, int64 *len)
 {
 	PgColumnarObjHandle *h;
 	OsResponse	resp;
-	const char *authority = url + 7;
-	const char *slash = strchr(authority, '/');
-	const char *colon;
+	bool		isS3 = (pg_strncasecmp(url, "s3://", 5) == 0);
 	MemoryContext oldcxt;
 
 	if (!os_callback_registered)
@@ -643,15 +984,6 @@ objstore_open(const char *url, int64 *len)
 		RegisterResourceReleaseCallback(os_resource_release, NULL);
 		os_callback_registered = true;
 	}
-
-	if (slash == NULL || slash == authority)
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("columnar: \"%s\" has no object path", url)));
-	if (memchr(authority, '@', slash - authority) != NULL)
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("columnar: userinfo in \"%s\" is not supported", url)));
 
 	/*
 	 * The handle and its buffers live in TopMemoryContext and are freed
@@ -664,33 +996,52 @@ objstore_open(const char *url, int64 *len)
 	h = (PgColumnarObjHandle *) palloc0(sizeof(PgColumnarObjHandle));
 	h->fd = -1;
 	h->url = pstrdup(url);
-	h->abspath = pstrdup(slash);
-	colon = memchr(authority, ':', slash - authority);
-	if (colon != NULL)
-	{
-		h->host = pnstrdup(authority, colon - authority);
-		h->port = atoi(colon + 1);
-	}
-	else
-	{
-		h->host = pnstrdup(authority, slash - authority);
-		h->port = 80;
-	}
 	h->rb = (uint8 *) palloc(OS_RBUF);
 	MemoryContextSwitchTo(oldcxt);
+	dlist_push_head(&os_open_handles, &h->node);
 
-	if (h->port <= 0 || h->port > 65535 || h->host[0] == '\0')
+	if (isS3)
+		os_resolve_s3(h, url);
+	else
 	{
-		dlist_push_head(&os_open_handles, &h->node);	/* so free can delete */
-		os_free_handle(h);
+		const char *authority = url + 7;
+		const char *slash = strchr(authority, '/');
+		const char *colon;
+
+		if (slash == NULL || slash == authority)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("columnar: \"%s\" has no object path", url)));
+		if (memchr(authority, '@', slash - authority) != NULL)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("columnar: userinfo in \"%s\" is not supported", url)));
+
+		oldcxt = MemoryContextSwitchTo(TopMemoryContext);
+		h->abspath = pstrdup(slash);
+		colon = memchr(authority, ':', slash - authority);
+		if (colon != NULL)
+		{
+			h->host = pnstrdup(authority, colon - authority);
+			h->port = atoi(colon + 1);
+		}
+		else
+		{
+			h->host = pnstrdup(authority, slash - authority);
+			h->port = 80;
+		}
+		MemoryContextSwitchTo(oldcxt);
+	}
+
+	if (h->port <= 0 || h->port > 65535 ||
+		h->host == NULL || h->host[0] == '\0')
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("columnar: \"%s\" has an invalid host or port", url)));
-	}
-
-	dlist_push_head(&os_open_handles, &h->node);
 
 	os_request(h, "HEAD", 0, 0, &resp);
+	if (resp.status == 403)
+		os_reject_403(h, &resp, false);
 	if (resp.status == 404)
 		ereport(ERROR,
 				(errcode(ERRCODE_UNDEFINED_FILE),
@@ -738,6 +1089,8 @@ objstore_read(PgColumnarObjHandle *h, int64 off, void *buf, size_t n)
 				 errdetail("The server answered 200 with the whole object "
 						   "instead of 206 with the requested bytes.")));
 	}
+	if (resp.status == 403)
+		os_reject_403(h, &resp, true);
 	if (resp.status == 404)
 		ereport(ERROR,
 				(errcode(ERRCODE_UNDEFINED_FILE),

--- a/test/objstore_http_server.py
+++ b/test/objstore_http_server.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-# Range-capable logging HTTP fixture for test/objstore_http_read.sh (#393 M1).
+# Range-capable logging HTTP fixture for test/objstore_http_read.sh (#393 M1)
+# and test/objstore_s3_read.sh (#393 M2).
 #
 # Serves files from --dir and appends one line per request to --log:
 #     METHOD <path> <value of the Range header, or "-">
@@ -13,16 +14,48 @@
 #                    then sleep: the cancel arm proves statement_timeout gets the
 #                    backend back while the transfer is wedged.
 #
+# SigV4 verification mode (#393 M2): with --sigv4-key/--sigv4-secret/
+# --sigv4-region, every request must carry a valid AWS Signature Version 4
+# Authorization header. The signature is recomputed here with python's stdlib
+# hmac/hashlib, so a green data check proves the C signer and an INDEPENDENT
+# implementation agree on every byte of the canonical request; any mismatch is
+# a 403 with SignatureDoesNotMatch. --sigv4-token additionally requires the
+# x-amz-security-token header, with the right value, inside the signed set.
+# --tamper-bucket names a top-level path component whose requests are verified
+# against a deliberately different secret, so a correctly signing client is
+# always refused there: the suite's 403-surface arm.
+#
 # Written fresh for pgColumnar.
 
 import argparse
+import hashlib
+import hmac
 import os
 import re
 import sys
 import time
+import urllib.parse
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 RANGE_RE = re.compile(r"^bytes=(\d*)-(\d*)$")
+AUTH_RE = re.compile(
+    r"^AWS4-HMAC-SHA256 Credential=([^/]+)/(\d{8})/([^/]+)/s3/aws4_request,\s*"
+    r"SignedHeaders=([^,]+),\s*Signature=([0-9a-f]{64})$")
+
+
+def sigv4_expected(secret, method, path, headers, signed_headers, amzdate,
+                   datestamp, region, payload_hash):
+    canon_headers = "".join(
+        "%s:%s\n" % (h, headers.get(h, "").strip()) for h in signed_headers)
+    creq = "\n".join([method, path, "", canon_headers,
+                      ";".join(signed_headers), payload_hash])
+    scope = "%s/%s/s3/aws4_request" % (datestamp, region)
+    sts = "\n".join(["AWS4-HMAC-SHA256", amzdate, scope,
+                     hashlib.sha256(creq.encode()).hexdigest()])
+    k = ("AWS4" + secret).encode()
+    for part in (datestamp, region, "s3", "aws4_request"):
+        k = hmac.new(k, part.encode(), hashlib.sha256).digest()
+    return hmac.new(k, sts.encode(), hashlib.sha256).hexdigest()
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -37,7 +70,9 @@ class Handler(BaseHTTPRequestHandler):
             f.write("%s %s %s\n" % (self.command, self.path, rng))
 
     def _resolve(self):
-        path = self.path
+        # SigV4 verification runs over the RAW request target (that is what
+        # the client signed); only the filesystem lookup decodes it.
+        path = urllib.parse.unquote(self.path)
         mode = "normal"
         for prefix in ("/norange/", "/stall/"):
             if path.startswith(prefix):
@@ -46,6 +81,60 @@ class Handler(BaseHTTPRequestHandler):
                 break
         local = os.path.join(self.server.rootdir, path.lstrip("/"))
         return mode, local
+
+    def _deny(self, status, code):
+        body = ("<?xml version=\"1.0\"?><Error><Code>%s</Code></Error>"
+                % code).encode()
+        self.send_response(status)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(body)
+
+    def _sigv4_check(self):
+        """True when the request may proceed. Answers 403 itself otherwise."""
+        srv = self.server
+        if srv.sigv4_secret is None:
+            return True
+        auth = self.headers.get("Authorization", "")
+        m = AUTH_RE.match(auth)
+        if m is None:
+            self._deny(403, "AccessDenied")
+            return False
+        keyid, datestamp, region, signed, got_sig = m.groups()
+        signed_headers = signed.split(";")
+        secret = srv.sigv4_secret
+        # The tamper bucket verifies against a different secret, so a client
+        # signing correctly with the real one is always refused there.
+        top = self.path.lstrip("/").split("/", 1)[0]
+        if srv.tamper_bucket is not None and top == srv.tamper_bucket:
+            secret = srv.sigv4_secret + "-tampered"
+        if keyid != srv.sigv4_key or region != srv.sigv4_region:
+            self._deny(403, "InvalidAccessKeyId")
+            return False
+        if srv.sigv4_token is not None:
+            if ("x-amz-security-token" not in signed_headers or
+                    self.headers.get("x-amz-security-token") != srv.sigv4_token):
+                self._deny(403, "InvalidToken")
+                return False
+        # Stricter than AWS on purpose: our client PROMISES to sign the Range
+        # header (design/ISSUE_393_M2_SIGV4.md), and a compliant verifier
+        # cannot falsify that promise because it follows the client's own
+        # SignedHeaders list. This pin can: a ranged request whose signature
+        # excludes Range is refused, so the removal proof (drop range from the
+        # signed set) goes red here instead of passing as protocol-legal.
+        if self.headers.get("Range") and "range" not in signed_headers:
+            self._deny(403, "UnsignedRange")
+            return False
+        amzdate = self.headers.get("x-amz-date", "")
+        payload_hash = self.headers.get("x-amz-content-sha256", "")
+        want = sigv4_expected(secret, self.command, self.path, self.headers,
+                              signed_headers, amzdate, datestamp, region,
+                              payload_hash)
+        if not hmac.compare_digest(want, got_sig):
+            self._deny(403, "SignatureDoesNotMatch")
+            return False
+        return True
 
     def _head_common(self, local):
         if not os.path.isfile(local):
@@ -57,6 +146,8 @@ class Handler(BaseHTTPRequestHandler):
 
     def do_HEAD(self):
         self._log_line()
+        if not self._sigv4_check():
+            return
         size = self._head_common(self._resolve()[1])
         if size < 0:
             return
@@ -67,6 +158,8 @@ class Handler(BaseHTTPRequestHandler):
 
     def do_GET(self):
         self._log_line()
+        if not self._sigv4_check():
+            return
         mode, local = self._resolve()
         size = self._head_common(local)
         if size < 0:
@@ -117,11 +210,21 @@ def main():
     ap.add_argument("--dir", required=True)
     ap.add_argument("--port", type=int, required=True)
     ap.add_argument("--log", required=True)
+    ap.add_argument("--sigv4-key")
+    ap.add_argument("--sigv4-secret")
+    ap.add_argument("--sigv4-region")
+    ap.add_argument("--sigv4-token")
+    ap.add_argument("--tamper-bucket")
     args = ap.parse_args()
 
     srv = ThreadingHTTPServer(("127.0.0.1", args.port), Handler)
     srv.rootdir = args.dir
     srv.reqlog = args.log
+    srv.sigv4_key = args.sigv4_key
+    srv.sigv4_secret = args.sigv4_secret
+    srv.sigv4_region = args.sigv4_region
+    srv.sigv4_token = args.sigv4_token
+    srv.tamper_bucket = args.tamper_bucket
     open(args.log, "a").close()
     # Readiness marker for the suite: print once the socket is bound.
     print("READY", flush=True)

--- a/test/objstore_module.sh
+++ b/test/objstore_module.sh
@@ -106,7 +106,7 @@ check_num "positive control: it IS defined in the module, so nm really looked" \
 for url in "s3://bucket/key.parquet" "gs://bucket/key.parquet" "https://host/key.parquet"; do
 	out=$(psql_run "SELECT * FROM pgcolumnar.read_parquet('$url') AS (a int)" 2>&1)
 	check "a $(cut -d: -f1 <<<"$url") URL reports an object-storage error, not a missing file" \
-		"$([ "$(grep -c 'object storage is not implemented\|is not supported\|requires the object-store module' <<<"$out")" -ge 1 ] && echo yes || echo no)" "yes"
+		"$([ "$(grep -c 'object storage is not implemented\|is not supported\|requires the object-store module\|requires AWS_' <<<"$out")" -ge 1 ] && echo yes || echo no)" "yes"
 	check_num "and does NOT report it as a missing file" \
 		"$(grep -c 'No such file or directory' <<<"$out")" "0"
 done
@@ -206,7 +206,12 @@ mv "$MOD.probe" "$MOD" 2>/dev/null
 #    queries, one session, two different errors, the second one plausible.
 #
 # Both reads run in ONE psql session on purpose. Separate sessions cannot see it.
-Q="SELECT * FROM pgcolumnar.read_parquet('s3://bucket/key.parquet') AS (a int)"
+# gs:// deliberately: the scheme must be one the module recognizes as remote
+# but does NOT handle. s3:// stopped qualifying when #393 M2 implemented it
+# (its no-environment error is pinned in the loop above and in
+# objstore_s3_read.sh); gs:// stays unhandled until a GCS milestone exists,
+# at which point this becomes az:// or a reserved test scheme.
+Q="SELECT * FROM pgcolumnar.read_parquet('gs://bucket/key.parquet') AS (a int)"
 two_reads() {
 	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" \
 		-At -q -c "$Q" -c "$Q" 2>&1

--- a/test/objstore_s3_read.sh
+++ b/test/objstore_s3_read.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+#
+# pgColumnar #393 M2: SigV4-signed s3:// reads, verified against an INDEPENDENT
+# implementation of the signature.
+#
+# The fixture server (test/objstore_http_server.py, sigv4 mode) recomputes
+# every request's AWS Signature Version 4 with python's stdlib hmac/hashlib and
+# refuses 403 on any mismatch, so every green data check below proves the C
+# signer and a second implementation agree on every byte of the canonical
+# request. Arms, per design/ISSUE_393_M2_SIGV4.md:
+#
+#   config   an s3:// read with no AWS_* in the postmaster environment errors
+#            28000 naming AWS_ENDPOINT_URL, before any connection exists to
+#            fail differently.
+#   A        differential oracle vs the byte-identical local file, including a
+#            key that needs percent-encoding (space in both directory and
+#            file name): an encoding disagreement cannot pass the verifier.
+#   B        the M1 request arithmetic holds unchanged under signing
+#            (open = HEAD + 3 GETs, data = one GET per needed chunk).
+#   token    the postmaster env carries AWS_SESSION_TOKEN and the server
+#            REQUIRES x-amz-security-token inside the signed set, so the data
+#            arms prove token signing rather than merely tolerating it.
+#   403      a tamper bucket the server verifies against a different secret:
+#            correct client signature, always refused; must surface 28000 and
+#            never rows. 404 on the real bucket stays 58P01, and its
+#            reachability doubles as proof requests pass verification first.
+#   https    an https:// endpoint is refused 0A000 (TLS is M3), never
+#            silently downgraded.
+#
+# The postmaster environment is the ambient credential source (the decided
+# default), so the suite restarts its own cluster between phases instead of
+# pretending env can change per-session.
+#
+# Usage:  test/objstore_s3_read.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+python3 -c 'import pyarrow' 2>/dev/null || pgc_skip pyarrow "pyarrow is required to write the fixture"
+
+S3_PORT="$(pgc_pick_free_port "$PGC_AUX_PORT_LO" "$PGC_AUX_PORT_HI")"
+S3_LOG="$PGC_WORKDIR/s3.log"
+SRV_PID=""
+
+AKID="PGCTESTKEYID"
+SECRET="pgctest-secret-shhh"
+REGION="pgc-test-1"
+TOKEN="pgctest-session-token"
+BUCKET="pgc-bucket"
+
+objstore_s3_teardown() {
+	[ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null
+	pgc_teardown
+}
+trap objstore_s3_teardown EXIT INT TERM
+
+# Restart OUR cluster with the given environment strings in the postmaster.
+pg_restart_env() {
+	pgc_pg "pg_ctl -D '$PGC_PGDATA' stop -m fast -w" >/dev/null 2>&1
+	pgc_pg "$* pg_ctl -D '$PGC_PGDATA' -l '$PGC_LOGFILE' start -w" >/dev/null 2>&1
+	for _ in $(seq 1 30); do
+		[ -n "$(q 'SELECT 1')" ] && return 0
+		sleep 0.5
+	done
+	echo "FATAL: cluster did not come back after env restart"
+	exit 1
+}
+
+sqlstate_of() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -qtA 2>&1 <<SQLEOF | sed -n 's/^ERROR:  \([0-9A-Z]\{5\}\).*/\1/p' | head -1
+\\set VERBOSITY sqlstate
+$1;
+SQLEOF
+}
+
+reqs() { wc -l < "$S3_LOG" | tr -d ' '; }
+
+# ---- fixture ----------------------------------------------------------------
+G=3
+NCOLS=8
+ROWS_PER_GROUP=8000
+mkdir -p "$PGC_WORKDIR/$BUCKET/dir with space"
+
+python3 - "$PGC_WORKDIR/$BUCKET/fixture.parquet" <<PYEOF
+import sys, shutil
+import pyarrow as pa, pyarrow.parquet as pq
+G, NCOLS, RPG = $G, $NCOLS, $ROWS_PER_GROUP
+n = G * RPG
+cols = {("c%d" % i): pa.array([(i + 1) * v for v in range(n)], pa.int64())
+        for i in range(NCOLS)}
+pq.write_table(pa.table(cols), sys.argv[1], row_group_size=RPG,
+               data_page_size=1024, compression="NONE", use_dictionary=False)
+shutil.copyfile(sys.argv[1],
+                sys.argv[1].rsplit("/", 1)[0] + "/dir with space/f 1.parquet")
+PYEOF
+check "premise: fixture written" \
+	"$([ -s "$PGC_WORKDIR/$BUCKET/fixture.parquet" ] && echo yes)" "yes"
+
+python3 "$(dirname "${BASH_SOURCE[0]}")/objstore_http_server.py" \
+	--dir "$PGC_WORKDIR" --port "$S3_PORT" --log "$S3_LOG" \
+	--sigv4-key "$AKID" --sigv4-secret "$SECRET" --sigv4-region "$REGION" \
+	--sigv4-token "$TOKEN" --tamper-bucket "tamperbkt" \
+	> "$PGC_WORKDIR/s3_server.out" 2>&1 &
+SRV_PID=$!
+for _ in $(seq 1 50); do
+	grep -q READY "$PGC_WORKDIR/s3_server.out" 2>/dev/null && break
+	sleep 0.1
+done
+check "premise: sigv4 fixture server is up" \
+	"$(grep -c READY "$PGC_WORKDIR/s3_server.out" 2>/dev/null)" "1"
+
+COLDEFS="$(python3 -c "print(', '.join('c%d int8' % i for i in range($NCOLS)))")"
+SUM_ALL="$(python3 -c "print(' + '.join('sum(c%d)' % i for i in range($NCOLS)))")"
+
+psql_run "CREATE SERVER s3srv FOREIGN DATA WRAPPER pgcolumnar_parquet;"
+psql_run "CREATE FOREIGN TABLE flocal ($COLDEFS) SERVER s3srv OPTIONS (path '$PGC_WORKDIR/$BUCKET/fixture.parquet');"
+psql_run "CREATE FOREIGN TABLE fs3 ($COLDEFS) SERVER s3srv OPTIONS (path 's3://$BUCKET/fixture.parquet');"
+psql_run "CREATE FOREIGN TABLE fs3enc ($COLDEFS) SERVER s3srv OPTIONS (path 's3://$BUCKET/dir with space/f 1.parquet');"
+psql_run "CREATE FOREIGN TABLE fs3tamper ($COLDEFS) SERVER s3srv OPTIONS (path 's3://tamperbkt/fixture.parquet');"
+psql_run "CREATE FOREIGN TABLE fs3miss ($COLDEFS) SERVER s3srv OPTIONS (path 's3://$BUCKET/no_such.parquet');"
+
+# ---- phase 1: no AWS environment at all ------------------------------------
+check "config: s3 read with no environment is 28000" \
+	"$(sqlstate_of "SELECT count(*) FROM fs3")" "28000"
+
+# ---- phase 2: full ambient environment, fixture endpoint --------------------
+pg_restart_env "AWS_ENDPOINT_URL='http://127.0.0.1:$S3_PORT'" \
+	"AWS_ACCESS_KEY_ID='$AKID'" "AWS_SECRET_ACCESS_KEY='$SECRET'" \
+	"AWS_REGION='$REGION'" "AWS_SESSION_TOKEN='$TOKEN'"
+
+check "A: full scan s3 == local" \
+	"$(pgc_set_hash "SELECT * FROM fs3")" "$(pgc_set_hash "SELECT * FROM flocal")"
+check "A: projection s3 == local" \
+	"$(pgc_set_hash "SELECT c1, c6 FROM fs3")" "$(pgc_set_hash "SELECT c1, c6 FROM flocal")"
+check "A: percent-encoded key s3 == local" \
+	"$(pgc_set_hash "SELECT * FROM fs3enc")" "$(pgc_set_hash "SELECT * FROM flocal")"
+check_num "A: count(*) over s3" "$(q "SELECT count(*) FROM fs3")" "$((G * ROWS_PER_GROUP))"
+
+K_FULL=$((4 + G * NCOLS))
+: > "$S3_LOG"
+q "SELECT $SUM_ALL FROM fs3" >/dev/null
+FULL_SIGNED="$(reqs)"
+check "premise: signed run logged requests" \
+	"$([ "${FULL_SIGNED:-0}" -gt 0 ] 2>/dev/null && echo yes)" "yes"
+check_num "B: signing left the request arithmetic unchanged" "$FULL_SIGNED" "$K_FULL"
+
+check "403: tamper bucket surfaces 28000" \
+	"$(sqlstate_of "SELECT count(*) FROM fs3tamper")" "28000"
+check "403 ordering premise: verified requests still reach 404 = 58P01" \
+	"$(sqlstate_of "SELECT count(*) FROM fs3miss")" "58P01"
+
+# ---- phase 3: https endpoint refused until M3 -------------------------------
+pg_restart_env "AWS_ENDPOINT_URL='https://127.0.0.1:$S3_PORT'" \
+	"AWS_ACCESS_KEY_ID='$AKID'" "AWS_SECRET_ACCESS_KEY='$SECRET'" \
+	"AWS_REGION='$REGION'"
+check "https endpoint is refused 0A000, not downgraded" \
+	"$(sqlstate_of "SELECT count(*) FROM fs3")" "0A000"
+
+# ---- phase 4: optional integration against a real S3 implementation --------
+if [ -n "${PGC_S3_INTEGRATION_ENDPOINT:-}" ]; then
+	pg_restart_env "AWS_ENDPOINT_URL='$PGC_S3_INTEGRATION_ENDPOINT'" \
+		"AWS_ACCESS_KEY_ID='$PGC_S3_INTEGRATION_KEY'" \
+		"AWS_SECRET_ACCESS_KEY='$PGC_S3_INTEGRATION_SECRET'" \
+		"AWS_REGION='${PGC_S3_INTEGRATION_REGION:-garage}'"
+	IB="${PGC_S3_INTEGRATION_BUCKET:-pgcolumnar-test}"
+	IKEY="m2/integration-$$.parquet"
+	if env AWS_ACCESS_KEY_ID="$PGC_S3_INTEGRATION_KEY" \
+		AWS_SECRET_ACCESS_KEY="$PGC_S3_INTEGRATION_SECRET" \
+		AWS_DEFAULT_REGION="${PGC_S3_INTEGRATION_REGION:-garage}" \
+		aws --endpoint-url "$PGC_S3_INTEGRATION_ENDPOINT" \
+		s3 cp "$PGC_WORKDIR/$BUCKET/fixture.parquet" "s3://$IB/$IKEY" \
+		>/dev/null 2>&1
+	then
+		psql_run "CREATE FOREIGN TABLE fs3real ($COLDEFS) SERVER s3srv OPTIONS (path 's3://$IB/$IKEY');"
+		check "integration: real S3 implementation == local" \
+			"$(pgc_set_hash "SELECT * FROM fs3real")" \
+			"$(pgc_set_hash "SELECT * FROM flocal")"
+	else
+		echo "note: integration endpoint set but the upload helper failed;" \
+			"the stdlib-verifier arms above carry the proof alone"
+	fi
+else
+	echo "note: PGC_S3_INTEGRATION_ENDPOINT unset; the stdlib-verifier arms" \
+		"above carry the proof alone"
+fi
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -148,6 +148,7 @@ SUITES=(
 	native_zonemap
 	objstore_http_read
 	objstore_module
+	objstore_s3_read
 	objstore_stash_recovery
 	parallel
 	parallel_copy


### PR DESCRIPTION
Milestone M2 of the #393 plan of record, on the merged M1 transport (#605). Design: `design/ISSUE_393_M2_SIGV4.md` (in this PR).

## What lands

- **SigV4 with zero new dependencies**: `pg_hmac`/`pg_cryptohash` (the primitives ChronicallyJD proved exported and correct on all five majors, without OpenSSL), four-HMAC key derivation cached per UTC day, hand-written UriEncode per AWS's own recommendation, Range signed on every GET.
- **`s3://bucket/key` becomes a handled scheme**, path-style against `AWS_ENDPOINT_URL` (http only until M3 — an https endpoint errors 0A000 naming M3, never a silent downgrade). Ambient credentials from the postmaster environment per the decided default; missing variables error **28000 naming the variable before any connection exists to fail differently**. 403 surfaces as 28000 with the server's XML `Code`; no error path ever carries a credential.

## The oracle: independent implementations must agree

- The fixture server **recomputes every signature with python stdlib `hmac`/`hashlib`** and refuses on mismatch — every green data check is a byte-for-byte cross-implementation agreement on the canonical request.
- The **Garage integration arm ran live** on the bench (`garage-26-04`, Garage v2.3.0): a real S3 implementation accepted our signatures and the differential oracle matched. 13/13.

## The removal proof that taught something

The first mutation (drop Range from the signed set) **stayed green** — correctly: a compliant verifier follows the client's own SignedHeaders list, so "we sign Range" is a promise no compliant server can falsify. The fixture is now deliberately stricter than AWS on exactly that point (403 `UnsignedRange` when a ranged request leaves Range unsigned), which turns the mutation red; a second mutation (misspell `aws4_request` in the key derivation) reds everything while the tamper arm stays green, which is correct since it expects refusal either way. Both proofs recorded in the commit.

## Suite mechanics worth a reviewer's eye

- Ambient credentials are postmaster state, so `objstore_s3_read.sh` **restarts its own cluster between environment phases** (none → full → https) rather than pretending env can change per-session.
- The percent-encoding arm reads a key with spaces in two path segments; an encoding disagreement cannot pass the verifier.
- `objstore_module.sh` updated where M2 changes pinned behavior by design: the unhandled-scheme probe graduates from `s3://` to `gs://` (with the next graduation documented in place), and the remote-error grep accepts the no-environment message. Caught by the sanitizer-gate run, which is the process working.

## Verification

- 12/12 on PG17 (my lane), PG18, PG19; 13/13 with the Garage arm.
- ASAN+UBSAN gate passes all three objstore suites.
- `-Wshadow -Werror` clean; M1 suite 18/18 unregressed.
- RED-first recorded: every arm failed 0A000 on main before implementation (the https arm passes vacuously pre-implementation — it asserts the same SQLSTATE for a different reason until s3 exists; the other eleven arms de-vacuate it).

Remaining on #393 after this: M3 (TLS), M4 (validator split + catalog options).

🤖 Generated with [Claude Code](https://claude.com/claude-code)