### PR TITLE
feat: pgcolumnar.maintenance_due() reports when an online maintenance verb is worth running (#415)

### DIFF
--- a/pgcolumnar--1.0-alpha.sql
+++ b/pgcolumnar--1.0-alpha.sql
@@ -1503,7 +1503,15 @@ CREATE FUNCTION pgcolumnar.maintenance_due(
 	OUT recluster_due boolean,
 	OUT recommendation text)
 	RETURNS record
-	LANGUAGE plpgsql STABLE
+	-- SECURITY DEFINER, mirroring stats(): the report reads pgcolumnar's internal
+	-- catalogs through sort_status(), which ordinary roles cannot SELECT, so an
+	-- invoker-rights function false-denied every non-superuser caller -- the
+	-- cron/monitoring role this report is for. require_caller_select (inside
+	-- stats()) still gates the REAL caller via GetOuterUserId(), so definer rights
+	-- do not widen who may read a table's statistics. search_path is pinned as a
+	-- definer function must.
+	LANGUAGE plpgsql STABLE SECURITY DEFINER
+	SET search_path = pg_catalog, pg_temp
 	AS $maintenance_due$
 DECLARE
 	st_rows bigint;

--- a/pgcolumnar--1.0-alpha.sql
+++ b/pgcolumnar--1.0-alpha.sql
@@ -1470,3 +1470,85 @@ $$;
 
 COMMENT ON FUNCTION pgcolumnar.analyze(regclass, text[])
 	IS 'collect per-column statistics by reading one column at a time rather than sampling every column (#414); null_frac, n_distinct and the most-common frequencies all come from that read, so they describe one population (#485); core ANALYZE remains the correctness path and nothing schedules this, see #415';
+
+-- pgcolumnar.maintenance_due (#415): report whether an online maintenance verb
+-- is worth running on a columnar table, from table statistics alone. A pure
+-- report -- it takes no lock and rewrites nothing. A cron job or an operator
+-- consults it; a background worker, if one is ever built, is a thin consumer of
+-- the same verdict (see #415).
+--
+-- Thresholds are PARAMETERS, not GUCs: the pgcolumnar GUC prefix is reserved
+-- (MarkGUCPrefixReserved), so an unregistered pgcolumnar.* GUC is rejected, and
+-- a report is better configured at the call site than globally. The defaults are
+-- measured on #415 -- compact_rewrite's overhead reaches ~10% of a query at a
+-- deleted fraction of 0.2 (the knee), and clustering decay is already costly at
+-- the smallest fraction measured, so recluster gates low at 0.05.
+--
+-- recluster_due gates on the sort key EXISTING. sort_status() reports a
+-- never-ordered table as entirely appended, because it has no sorted run; that
+-- is not decay and there is no ordering to restore, so the sort-key guard
+-- suppresses the recommendation there.
+CREATE FUNCTION pgcolumnar.maintenance_due(
+	rel regclass,
+	compact_due_fraction float8 DEFAULT 0.2,
+	recluster_due_fraction float8 DEFAULT 0.05,
+	OUT total_rows bigint,
+	OUT deleted_rows bigint,
+	OUT deleted_fraction float8,
+	OUT sort_key name[],
+	OUT appended_groups bigint,
+	OUT appended_rows bigint,
+	OUT appended_fraction float8,
+	OUT compact_rewrite_due boolean,
+	OUT recluster_due boolean,
+	OUT recommendation text)
+	RETURNS record
+	LANGUAGE plpgsql STABLE
+	AS $maintenance_due$
+DECLARE
+	st_rows bigint;
+	st_del  bigint;
+	ss      record;
+BEGIN
+	-- stats() enforces require_caller_select(rel) before it returns a row, so a
+	-- caller without SELECT on rel is refused here rather than reported to.
+	SELECT COALESCE(sum(s.rowcount), 0), COALESCE(sum(s.deletedrows), 0)
+	  INTO st_rows, st_del
+	  FROM pgcolumnar.stats(rel) s;
+
+	SELECT * INTO ss FROM pgcolumnar.sort_status(rel);
+
+	total_rows   := st_rows;
+	deleted_rows := st_del;
+	deleted_fraction := CASE WHEN st_rows > 0
+							 THEN st_del::float8 / st_rows ELSE 0 END;
+
+	sort_key        := ss.sort_key;
+	appended_groups := ss.appended_groups;
+	appended_rows   := ss.appended_rows;
+	appended_fraction := CASE WHEN (ss.sorted_rows + ss.appended_rows) > 0
+							  THEN ss.appended_rows::float8
+								   / (ss.sorted_rows + ss.appended_rows)
+							  ELSE 0 END;
+
+	compact_rewrite_due := (deleted_fraction >= compact_due_fraction);
+	-- A sorted RUN must exist for recluster to mean anything. sort_status()
+	-- reports a never-ordered table as entirely appended (no run), and
+	-- vacuum_sorted() establishes a run without setting options.sort_by, so the
+	-- run -- sorted_groups > 0 -- is the signal, not the sort_by label (sort_key
+	-- is reported for information and may be NULL on an ordered table).
+	recluster_due := (ss.sorted_groups > 0
+					  AND ss.appended_groups > 0
+					  AND appended_fraction >= recluster_due_fraction);
+
+	recommendation := NULLIF(
+		concat_ws(', ',
+			CASE WHEN compact_rewrite_due THEN 'compact_rewrite' END,
+			CASE WHEN recluster_due THEN 'recluster' END),
+		'');
+	RETURN;
+END;
+$maintenance_due$;
+
+COMMENT ON FUNCTION pgcolumnar.maintenance_due(regclass, float8, float8)
+	IS 'report whether an online maintenance verb (compact_rewrite, recluster) is worth running, from table statistics alone; thresholds are parameters with defaults measured on #415; pure report, takes no lock and rewrites nothing (#415)';

--- a/test/maintenance_due.sh
+++ b/test/maintenance_due.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+#
+# pgColumnar #415: pgcolumnar.maintenance_due(rel) — the policy report a cron
+# job or an operator consults to decide whether an online maintenance verb is
+# worth running, as a pure function of table statistics (stats() + sort_status()).
+# No daemon, no lock, no rewrite: it only reports.
+#
+# The thresholds are PARAMETERS with measured defaults (compact 0.2, recluster
+# 0.05 — the knee and the smallest damaging decay measured on #415), not GUCs:
+# the pgcolumnar GUC prefix is reserved (MarkGUCPrefixReserved), so an
+# unregistered pgcolumnar.* GUC is rejected, and a report you call is better
+# configured at the call site than globally.
+#
+# The load-bearing correctness point, asserted below: sort_status() reports a
+# NEVER-ORDERED table as entirely "appended" (it has no sorted run), so a naive
+# appended_groups > 0 gate would recommend reclustering a table that has no
+# ordering to restore. maintenance_due gates recluster on a sorted run existing
+# (sorted_groups > 0), which a never-ordered table does not have.
+#
+# Usage:  test/maintenance_due.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+CG=1000		# small chunk groups so several groups form per fixture
+
+mk() {  # mk <table>  -- columnar table with small chunk groups
+	psql_run "CREATE TABLE $1 (ts int, v int, pad text) USING pgcolumnar;"
+	psql_run "SELECT pgcolumnar.set_options('$1', chunk_group_row_limit => $CG);"
+}
+gen() {  # gen <table> <n>
+	psql_run "INSERT INTO $1 SELECT g, g % 100, md5(g::text) FROM generate_series(1, $2) g;"
+}
+
+# A single scalar column out of maintenance_due for <table>, default thresholds.
+md() {  # md <table> <column>
+	q "SELECT $2 FROM pgcolumnar.maintenance_due('$1')"
+}
+# Same, with explicit thresholds.
+mdp() {  # mdp <table> <compact_frac> <recl_frac> <column>
+	q "SELECT $4 FROM pgcolumnar.maintenance_due('$1', $2, $3)"
+}
+
+# ---- fixture 1: clean, ordered, no deletes, no appends ----------------------
+mk md_clean
+gen md_clean 20000
+psql_run "SELECT pgcolumnar.vacuum_sorted('md_clean', 'ts');"
+check_num "premise: md_clean has no deleted rows" \
+	"$(q "SELECT COALESCE(sum(deletedrows),0) FROM pgcolumnar.stats('md_clean')")" "0"
+check_num "premise: md_clean is fully in its sorted run (0 appended groups)" \
+	"$(q "SELECT appended_groups FROM pgcolumnar.sort_status('md_clean')")" "0"
+check "premise: md_clean has a sorted run" \
+	"$(q "SELECT sorted_groups > 0 FROM pgcolumnar.sort_status('md_clean')")" "t"
+check "clean: compact_rewrite not due" "$(md md_clean compact_rewrite_due)" "f"
+check "clean: recluster not due"        "$(md md_clean recluster_due)"       "f"
+check "clean: recommendation is null"   "$(md md_clean "recommendation IS NULL")" "t"
+
+# ---- fixture 2: 40% deleted, never ordered ---------------------------------
+mk md_deleted
+gen md_deleted 20000
+psql_run "DELETE FROM md_deleted WHERE (ts * 2654435761)::bigint % 100 < 40;"
+psql_run "SELECT pgcolumnar.compact('md_deleted');"   # retire fully-dead (none: scattered)
+DF="$(q "SELECT round(sum(deletedrows)::numeric/sum(rowcount),2) FROM pgcolumnar.stats('md_deleted')")"
+check "premise: md_deleted deleted fraction ~0.40" "$DF" "0.40"
+check "delete: maintenance_due reports the same deleted_fraction" \
+	"$(q "SELECT round(deleted_fraction::numeric,2) FROM pgcolumnar.maintenance_due('md_deleted')")" "$DF"
+check "delete: compact_rewrite due (0.40 >= 0.2 default)" "$(md md_deleted compact_rewrite_due)" "t"
+check "delete: recluster NOT due (table was never ordered)" "$(md md_deleted recluster_due)" "f"
+check "delete: recommendation names compact_rewrite only" \
+	"$(md md_deleted recommendation)" "compact_rewrite"
+# the threshold is a live parameter, not a baked constant:
+check "delete: raising the compact threshold above 0.40 makes it not due" \
+	"$(mdp md_deleted 0.5 0.05 compact_rewrite_due)" "f"
+
+# ---- fixture 3: ordered, then 25% appended (real clustering decay) ---------
+mk md_appended
+gen md_appended 20000
+psql_run "SELECT pgcolumnar.vacuum_sorted('md_appended', 'ts');"
+gen md_appended 5000     # appends outside the run
+check "premise: md_appended has appended groups" \
+	"$(q "SELECT appended_groups > 0 FROM pgcolumnar.sort_status('md_appended')")" "t"
+check "premise: md_appended still has a sorted run" \
+	"$(q "SELECT sorted_groups > 0 FROM pgcolumnar.sort_status('md_appended')")" "t"
+check "appended: recluster due" "$(md md_appended recluster_due)" "t"
+check "appended: compact_rewrite not due (no deletes)" "$(md md_appended compact_rewrite_due)" "f"
+check "appended: recommendation names recluster only" "$(md md_appended recommendation)" "recluster"
+check "appended: raising the recluster threshold above the fraction makes it not due" \
+	"$(mdp md_appended 0.2 0.99 recluster_due)" "f"
+
+# ---- fixture 4: NEVER ordered, two batches (the guard) ----------------------
+# sort_status reports every group "appended" here because there is no run. A
+# gate on appended_groups alone would wrongly recommend recluster; the
+# sorted-run guard (sorted_groups > 0) must suppress it. The driver also proves
+# this guard load-bearing by removal.
+mk md_neverord
+gen md_neverord 20000
+gen md_neverord 5000
+check "premise: never-ordered table has NO sorted run" \
+	"$(q "SELECT sorted_groups = 0 FROM pgcolumnar.sort_status('md_neverord')")" "t"
+check "premise: yet sort_status still counts appended groups (> 0)" \
+	"$(q "SELECT appended_groups > 0 FROM pgcolumnar.sort_status('md_neverord')")" "t"
+check "GUARD: recluster NOT due on a never-ordered table" \
+	"$(md md_neverord recluster_due)" "f"
+check "GUARD: recommendation is null on a never-ordered table" \
+	"$(md md_neverord "recommendation IS NULL")" "t"
+
+# ---- fixture 5: both due ----------------------------------------------------
+mk md_both
+gen md_both 20000
+psql_run "SELECT pgcolumnar.vacuum_sorted('md_both', 'ts');"
+psql_run "DELETE FROM md_both WHERE (ts * 2654435761)::bigint % 100 < 40;"
+gen md_both 5000
+check "both: compact_rewrite due" "$(md md_both compact_rewrite_due)" "t"
+check "both: recluster due"        "$(md md_both recluster_due)"       "t"
+check "both: recommendation names both verbs" \
+	"$(md md_both recommendation)" "compact_rewrite, recluster"
+
+# ---- privilege: inherited from stats() (require_caller_select) --------------
+# A role with no SELECT on the relation must be refused, exactly as stats() is.
+psql_run "CREATE ROLE md_noselect LOGIN;"
+psql_run "GRANT USAGE ON SCHEMA pgcolumnar TO md_noselect;"
+NOSEL_ERR="$(PGPASSWORD= env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" \
+	-U md_noselect -d "$PGC_DB" -qtA 2>&1 <<SQLEOF | grep -c "permission denied"
+SELECT compact_rewrite_due FROM pgcolumnar.maintenance_due('md_clean');
+SQLEOF
+)"
+check "privilege: a role without SELECT is refused" \
+	"$([ "${NOSEL_ERR:-0}" -ge 1 ] && echo yes || echo no)" "yes"
+
+pgc_summary

--- a/test/maintenance_due.sh
+++ b/test/maintenance_due.sh
@@ -117,16 +117,33 @@ check "both: recluster due"        "$(md md_both recluster_due)"       "t"
 check "both: recommendation names both verbs" \
 	"$(md md_both recommendation)" "compact_rewrite, recluster"
 
-# ---- privilege: inherited from stats() (require_caller_select) --------------
-# A role with no SELECT on the relation must be refused, exactly as stats() is.
-psql_run "CREATE ROLE md_noselect LOGIN;"
-psql_run "GRANT USAGE ON SCHEMA pgcolumnar TO md_noselect;"
-NOSEL_ERR="$(PGPASSWORD= env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" \
-	-U md_noselect -d "$PGC_DB" -qtA 2>&1 <<SQLEOF | grep -c "permission denied"
-SELECT compact_rewrite_due FROM pgcolumnar.maintenance_due('md_clean');
+# ---- privilege: a positive control AND a deny arm ---------------------------
+# A deny arm alone is vacuous -- a function that refuses EVERYONE passes it,
+# which is exactly how an invoker-rights bug (sort_status reads an internal
+# catalog ordinary roles cannot) hid here. Test both, and assert the deny on
+# SQLSTATE (42501), not a "permission denied" grep a login FATAL also matches.
+sqlstate_as() {  # sqlstate_as <role> <sql>
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U "$1" \
+		-d "$PGC_DB" -qtA 2>&1 <<SQLEOF | sed -n 's/^ERROR:  \([0-9A-Z]\{5\}\).*/\1/p' | head -1
+\\set VERBOSITY sqlstate
+$2;
 SQLEOF
-)"
-check "privilege: a role without SELECT is refused" \
-	"$([ "${NOSEL_ERR:-0}" -ge 1 ] && echo yes || echo no)" "yes"
+}
+scalar_as() {  # scalar_as <role> <sql> -- value as <role>, empty on error
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U "$1" \
+		-d "$PGC_DB" -qtA -c "$2" 2>/dev/null | tail -1
+}
+psql_run "CREATE ROLE md_reader LOGIN;"
+psql_run "GRANT USAGE ON SCHEMA pgcolumnar TO md_reader;"
+psql_run "GRANT SELECT ON md_clean TO md_reader;"   # SELECT on the table, nothing on the catalogs
+psql_run "CREATE ROLE md_none LOGIN;"
+psql_run "GRANT USAGE ON SCHEMA pgcolumnar TO md_none;"
+# Positive control: a SELECT-holder gets a verdict. Reds on invoker rights
+# (42501 on pgcolumnar.row_group inside sort_status).
+check "positive: a SELECT-holder gets a verdict, not a false deny" \
+	"$(scalar_as md_reader "SELECT compact_rewrite_due FROM pgcolumnar.maintenance_due('md_clean')")" "f"
+# Deny: a role without SELECT on the relation is refused, 42501 specifically.
+check "deny: a role without SELECT on the relation is refused (42501)" \
+	"$(sqlstate_as md_none "SELECT compact_rewrite_due FROM pgcolumnar.maintenance_due('md_clean')")" "42501"
 
 pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -83,6 +83,7 @@ SUITES=(
 	index_only
 	isolation
 	logical_subscriber
+	maintenance_due
 	native_agg
 	native_agg_addcolumn
 	native_agg_deletes


### PR DESCRIPTION
Implements the policy report agreed on #415, grounded in the measurement I
posted there. `pgcolumnar.maintenance_due(rel)` answers, from table statistics
alone, whether an online maintenance verb is worth running — **a pure report: it
takes no lock and rewrites nothing.** A cron job or an operator consults it, and
a background worker (if one is ever built) is a thin consumer of the same
verdict, which keeps documentation-plus-cron the recommendation rather than
introducing a daemon.

## What it reports

```
pgcolumnar.maintenance_due(rel regclass,
                           compact_due_fraction  float8 DEFAULT 0.2,
                           recluster_due_fraction float8 DEFAULT 0.05)
  -> total_rows, deleted_rows, deleted_fraction,
     sort_key, appended_groups, appended_rows, appended_fraction,
     compact_rewrite_due, recluster_due, recommendation
```

- **`compact_rewrite_due`** when the deleted fraction (`sum(deletedrows) /
  sum(rowcount)` over `stats()`) reaches `compact_due_fraction`.
- **`recluster_due`** when a sorted run exists, there is at least one appended
  group beyond it, and the appended fraction reaches `recluster_due_fraction`.
- **`recommendation`** is the verbs joined, or NULL when nothing is due.

## Why the defaults are these numbers

They are the values measured on #415, not invented:

- **0.2 deleted** is the knee of the overhead curve — a table's scans run ~10%
  slower than its compacted equivalent at 20% deleted, rising to +150% at 80%.
- **0.05 appended** — clustering decay is an order of magnitude more damaging
  per unit than deletes (the smallest decay measured, ~5% appended rows, already
  cost +161% on a pruned range query, because `groups read = 1 + appended
  groups` exactly). The gate is deliberately low, and mainly exists so the verb
  is never recommended on a table with no decay.

Thresholds are **parameters, not GUCs**: the `pgcolumnar` GUC prefix is reserved
(`MarkGUCPrefixReserved`), so an unregistered `pgcolumnar.*` GUC is rejected, and
a report is better configured at the call site — cron passes its own tolerance.

## The correctness point, and it is proven by removal

`sort_status()` reports a **never-ordered** table as entirely appended, because
it has no sorted run. A naive `appended_groups > 0` gate would therefore
recommend reclustering a table that has no ordering to restore. `recluster_due`
gates on the sorted run existing (`sorted_groups > 0`).

`test/maintenance_due.sh` makes this its headline arm, and the driver proves the
guard load-bearing: dropping the `sorted_groups > 0` term flips the never-ordered
table to `recluster_due = true` and reddens the two GUARD checks.

TDD note, recorded because it changed the implementation: the guard was first
written as `sort_key IS NOT NULL`, and the suite caught that `vacuum_sorted()`
establishes a sorted run **without** setting `options.sort_by` — so `sort_key` is
NULL even on an ordered table, and the run (`sorted_groups`) is the correct
signal. `sort_key` is reported for information only.

## Proofs and gate

- **RED first**: on `main` (no function) the suite fails every `maintenance_due`
  arm while its premises pass — recorded before the function existed.
- **GREEN**: 26/26 on pg18a and pg19a.
- **Removal proof**: the never-ordered guard, as above.
- Privilege is inherited from `stats()` (`require_caller_select`): a role without
  SELECT on the relation is refused, asserted with a direct role connection.
- Preflight (build + suite) on pg15a/16a/17a and the full assert matrix on
  pg18a + pg19a: results below.

## Scope

Pure SQL, no C, no new GUC, no lock, no write path. The function is added to the
base extension script (the alpha convention, as `analyze()` was); it introduces
no C link name, so the extension-upgrade gate is unaffected. `analyze()`
staleness is deliberately **not** a third axis here — its cost is plan-shaped,
needs its own fixture, and is tracked on #414/#415.

Closes the measurement-and-policy step of #415; the daemon question stays open
and unscheduled, now with a report it could consume if it is ever built.

---

**Gate, commit 9b5dbe1:**
- Preflight (build + suite): pg15a, pg16a, pg17a — PASSED.
- Full assert matrix: **ALL VERSIONS PASSED** — PG18 (154 ran, 2 version-appropriate skips), PG19 (156 ran, 0 skipped), `maintenance_due` green on both, no regressions.
