### PR TITLE
feat: the validator split and catalog credentials (#393 M4)

### DIFF
--- a/design/ISSUE_393_M4_CREDENTIALS.md
+++ b/design/ISSUE_393_M4_CREDENTIALS.md
@@ -1,0 +1,120 @@
+# Issue #393 M4: the validator split and catalog credentials
+
+Design before code. The last #393 milestone: M1-M3 (merged) read over HTTP,
+sign with SigV4, and verify TLS, with every credential ambient in the
+postmaster environment. M4 gives credentials a catalog home with the placement
+policy the decision memo fixed, so a secret can never land world-readable and
+a non-superuser can be granted remote reads without owning the postmaster's
+identity.
+
+## The placement policy (memo 3.4, enforced at DDL time)
+
+| catalog | options | visibility |
+|---|---|---|
+| foreign table | `path`, `partition_columns` (unchanged) | world-readable, no secrets by construction |
+| server | `endpoint`, `region` | world-readable, deliberately non-secret |
+| user mapping | `access_key_id`, `secret_access_key`, `session_token`, `credentials_required` | protected (`pg_user_mapping` is not PUBLIC-readable) |
+
+The validator rejects every option on any other catalog with
+`ERRCODE_FDW_INVALID_OPTION_NAME`, so the world-readable outcome the issue
+opened with is foreclosed at CREATE/ALTER time, not by documentation.
+
+## Resolution order at scan time (FDW path)
+
+1. The scanning user's mapping for the server, else the PUBLIC mapping,
+   probed without erroring (a mapping is optional here, unlike postgres_fdw).
+2. Mapping credentials present: use them. Endpoint and region come from the
+   server options, else the environment (`AWS_ENDPOINT_URL`, `AWS_REGION`),
+   so one server definition serves both styles.
+3. No mapping credentials: **ambient is a privilege, not a default.** The
+   postmaster's environment identity is used only when the caller is a
+   superuser, or the applicable mapping carries `credentials_required
+   'false'`. That option follows `password_required`'s shape exactly: only a
+   superuser may set it to false (enforced in the validator), because it
+   hands the mapped role the instance's ambient identity.
+4. Otherwise: SQLSTATE 28000 naming what is missing ("no credentials in any
+   user mapping for this server"), before any connection exists.
+
+This tightens M2/M3 behaviour for non-superusers on the FDW path, which is
+the point of the milestone; the merged suites all run as superuser and are
+unaffected.
+
+## The function API (`read_parquet`, `import_parquet`, `parquet_schema`)
+
+No server object exists in those signatures, so no mapping can apply. They
+keep the M2 ambient-environment behaviour behind the existing
+`pg_read_server_files` gate, which the memo assessed as granting no new
+capability (that role already reads any file as the postgres user). The
+memo's stricter alternative (functions refuse remote schemes outright) was
+not adopted: M1-M3 shipped function-path remote reads behind that role and
+the suites pin them. Recorded here so the divergence from memo 3.5(a) is a
+decision, not a drift.
+
+## The ABI change
+
+The module currently reads only the environment. Catalog config has to reach
+it, so `PGCOLUMNAR_OBJSTORE_ABI` bumps to 2 and `open` gains a config struct:
+
+    typedef struct PgColumnarObjStoreConfig {
+        const char *endpoint;   /* NULL: environment */
+        const char *region;     /* NULL: environment */
+        const char *akid;       /* credential triple: all-or-nothing */
+        const char *secret;
+        const char *token;      /* optional */
+        bool        allow_ambient;  /* may fall back to the environment */
+    } PgColumnarObjStoreConfig;
+
+The loader already refuses an ABI mismatch, and both sides ship in one PR.
+`cfg == NULL` behaves as `{allow_ambient = true}` (the function paths).
+Credential resolution inside the module stays where the 28000 messages
+already live; the FDW layer only gathers catalog strings and never sees a
+wire operation.
+
+## What never happens
+
+- No secret in any error, log line, or EXPLAIN output: messages name the
+  option or variable, never its value; the suite greps the verbose error and
+  EXPLAIN output for the literal secret and asserts zero.
+- No secret accepted at server or table level, ever, including through
+  ALTER.
+- No endpoint allow-list GUC in this milestone: the memo recommends one,
+  empty by default, which is a default-deny posture change that needs its
+  own owner decision the way FUSE and the module split got one. Recorded on
+  the issue as the follow-on question rather than smuggled in here.
+
+## The suite: `test/objstore_credentials.sh`
+
+Fixture: the M2 SigV4-verifying server (stdlib verifier). Postmaster started
+WITHOUT any AWS_* environment for the catalog arms, so nothing ambient can
+make them pass vacuously.
+
+- **Placement arms**: each secret option on server or table errors
+  `HV00D`; `endpoint` on the mapping errors; the documented placements
+  succeed. `credentials_required 'false'` by a non-superuser errors; by a
+  superuser succeeds.
+- **Catalog-resolved credentials**: server(endpoint,region) + superuser
+  mapping(key,secret,token) reads the differential oracle green with no
+  environment at all - proof the catalog path reaches the wire, not env.
+- **Per-user resolution**: role alice's mapping carries the good secret,
+  role bob's carries a wrong one; alice reads, bob gets 28000 (the fixture
+  refuses his signature), same table, same server. Both roles hold
+  pg_read_server_files and SELECT, so the only variable is the mapping.
+- **Ambient as privilege**: role carol (no mapping) gets 28000; after a
+  superuser creates her mapping with only `credentials_required 'false'`
+  and the postmaster restarts WITH the environment, carol reads. The
+  superuser reads ambient with no mapping throughout.
+- **No leak**: the verbose error from bob's failed read and EXPLAIN VERBOSE
+  output contain zero occurrences of any secret literal.
+
+Removal proofs: drop the superuser check on `credentials_required` in the
+validator and the non-superuser-sets-false arm reds; drop the mapping lookup
+and the alice/bob arms collapse to the same result (the per-user arm reds);
+revert the ABI plumbing and the no-environment catalog arm reds.
+
+## Order of work (TDD)
+
+1. Suite, RED on main: placement arms fail (options rejected today),
+   catalog-credential arms fail (no plumbing).
+2. ABI v2 + module credential resolution; validator; FDW-side gathering.
+3. Green; removal proofs; gates (PG17 lane, PG18/19, ASAN on objstore
+   suites, -Wshadow -Werror); M1-M3 suites unregressed.

--- a/objstore/columnar_objstore_module.c
+++ b/objstore/columnar_objstore_module.c
@@ -1120,13 +1120,16 @@ os_require_env(const char *name, const char *url)
 }
 
 /*
- * Resolve an s3://bucket/key URL against the ambient environment: endpoint
- * host and port from AWS_ENDPOINT_URL (http only until M3), credentials and
- * region from the AWS_* variables, path-style request target with the key
- * percent-encoded exactly as it is signed.
+ * Resolve an s3://bucket/key URL: endpoint and region from the catalog config
+ * when present, else the environment; credentials from the config's mapping
+ * triple when present, else the environment IF ambient use is allowed
+ * (superuser, credentials_required=false, or a function-path caller), else a
+ * 28000 refusal. Path-style request target with the key percent-encoded
+ * exactly as it is signed.
  */
 static void
-os_resolve_s3(PgColumnarObjHandle *h, const char *url)
+os_resolve_s3(PgColumnarObjHandle *h, const char *url,
+			  const PgColumnarObjStoreConfig *cfg)
 {
 	const char *bucket = url + 5;
 	const char *slash = strchr(bucket, '/');
@@ -1136,6 +1139,7 @@ os_resolve_s3(PgColumnarObjHandle *h, const char *url)
 	const char *epcolon;
 	const char *region;
 	const char *token;
+	bool		ambientOk = (cfg == NULL || cfg->allow_ambient);
 	StringInfoData path;
 	MemoryContext oldcxt;
 
@@ -1144,7 +1148,10 @@ os_resolve_s3(PgColumnarObjHandle *h, const char *url)
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("columnar: \"%s\" is not s3://bucket/key", url)));
 
-	ep = os_require_env("AWS_ENDPOINT_URL", url);
+	if (cfg != NULL && cfg->endpoint != NULL)
+		ep = cfg->endpoint;
+	else
+		ep = os_require_env("AWS_ENDPOINT_URL", url);
 	if (pg_strncasecmp(ep, "https://", 8) == 0)
 	{
 #ifdef HAVE_OBJSTORE_OPENSSL
@@ -1164,20 +1171,51 @@ os_resolve_s3(PgColumnarObjHandle *h, const char *url)
 				 errmsg("columnar: AWS_ENDPOINT_URL must be an http:// or "
 						"https:// URL")));
 
-	region = getenv("AWS_REGION");
-	if (region == NULL || region[0] == '\0')
-		region = getenv("AWS_DEFAULT_REGION");
-	if (region == NULL || region[0] == '\0')
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION),
-				 errmsg("columnar: reading \"%s\" requires AWS_REGION or "
-						"AWS_DEFAULT_REGION in the server environment", url)));
+	if (cfg != NULL && cfg->region != NULL)
+		region = cfg->region;
+	else
+	{
+		region = getenv("AWS_REGION");
+		if (region == NULL || region[0] == '\0')
+			region = getenv("AWS_DEFAULT_REGION");
+		if (region == NULL || region[0] == '\0')
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION),
+					 errmsg("columnar: reading \"%s\" requires a region option "
+							"on the server, or AWS_REGION in the server "
+							"environment", url)));
+	}
 
 	oldcxt = MemoryContextSwitchTo(TopMemoryContext);
-	h->akid = pstrdup(os_require_env("AWS_ACCESS_KEY_ID", url));
-	h->secret = pstrdup(os_require_env("AWS_SECRET_ACCESS_KEY", url));
-	token = getenv("AWS_SESSION_TOKEN");
-	h->token = (token != NULL && token[0] != '\0') ? pstrdup(token) : NULL;
+	if (cfg != NULL && cfg->akid != NULL)
+	{
+		/* the mapping's credential triple; the validator required the pair */
+		h->akid = pstrdup(cfg->akid);
+		h->secret = pstrdup(cfg->secret);
+		h->token = (cfg->token != NULL && cfg->token[0] != '\0')
+			? pstrdup(cfg->token) : NULL;
+	}
+	else if (ambientOk)
+	{
+		h->akid = pstrdup(os_require_env("AWS_ACCESS_KEY_ID", url));
+		h->secret = pstrdup(os_require_env("AWS_SECRET_ACCESS_KEY", url));
+		token = getenv("AWS_SESSION_TOKEN");
+		h->token = (token != NULL && token[0] != '\0') ? pstrdup(token) : NULL;
+	}
+	else
+	{
+		MemoryContextSwitchTo(oldcxt);
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION),
+				 errmsg("columnar: no credentials for \"%s\"", url),
+				 errdetail("No user mapping for this server carries "
+						   "access_key_id and secret_access_key for the "
+						   "current role."),
+				 errhint("Create a user mapping with credentials, or have a "
+						 "superuser set credentials_required 'false' on the "
+						 "mapping to permit the server environment's ambient "
+						 "identity.")));
+	}
 	h->region = pstrdup(region);
 
 	/* endpoint authority */
@@ -1208,7 +1246,7 @@ os_resolve_s3(PgColumnarObjHandle *h, const char *url)
 }
 
 static PgColumnarObjHandle *
-objstore_open(const char *url, int64 *len)
+objstore_open(const char *url, const PgColumnarObjStoreConfig *cfg, int64 *len)
 {
 	PgColumnarObjHandle *h;
 	OsResponse	resp;
@@ -1237,7 +1275,7 @@ objstore_open(const char *url, int64 *len)
 	dlist_push_head(&os_open_handles, &h->node);
 
 	if (isS3)
-		os_resolve_s3(h, url);
+		os_resolve_s3(h, url, cfg);
 	else
 	{
 		bool		isHttps = (pg_strncasecmp(url, "https://", 8) == 0);

--- a/src/columnar_objstore.h
+++ b/src/columnar_objstore.h
@@ -33,10 +33,29 @@
 
 #include "postgres.h"
 
-#define PGCOLUMNAR_OBJSTORE_ABI 1
+#define PGCOLUMNAR_OBJSTORE_ABI 2
 
 /* An open remote object. The module owns everything behind this. */
 typedef struct PgColumnarObjHandle PgColumnarObjHandle;
+
+/*
+ * Connection configuration resolved from the FDW catalogs (#393 M4). NULL
+ * means "no catalog config": endpoint/region/credentials come from the
+ * ambient environment, allowed - the function-API paths, which are gated by
+ * pg_read_server_files and have no server object to hang a mapping on. A
+ * non-NULL config with allow_ambient=false and no credential triple makes the
+ * module refuse (SQLSTATE 28000) rather than fall back to the postmaster's
+ * identity: ambient is a privilege, not a default.
+ */
+typedef struct PgColumnarObjStoreConfig
+{
+	const char *endpoint;		/* NULL: AWS_ENDPOINT_URL */
+	const char *region;			/* NULL: AWS_REGION / AWS_DEFAULT_REGION */
+	const char *akid;			/* credential triple; akid+secret together */
+	const char *secret;
+	const char *token;			/* optional session token */
+	bool		allow_ambient;	/* may fall back to the environment */
+} PgColumnarObjStoreConfig;
 
 typedef struct PgColumnarObjStoreApi
 {
@@ -52,9 +71,11 @@ typedef struct PgColumnarObjStoreApi
 	 * Open `url` and report its size. Raises on failure, like every other read
 	 * path in this extension. `len` is required: the Parquet footer is located
 	 * from the end of the object, so a source that cannot report a length cannot
-	 * be read.
+	 * be read. `cfg` may be NULL (see PgColumnarObjStoreConfig).
 	 */
-	PgColumnarObjHandle *(*open) (const char *url, int64 *len);
+	PgColumnarObjHandle *(*open) (const char *url,
+								  const PgColumnarObjStoreConfig *cfg,
+								  int64 *len);
 
 	/*
 	 * Read exactly `n` bytes at `off`. The caller has already bounded the range

--- a/src/columnar_parquet_reader.c
+++ b/src/columnar_parquet_reader.c
@@ -49,7 +49,10 @@
 #endif
 #include "executor/tuptable.h"
 #include "foreign/fdwapi.h"
+#include "catalog/pg_foreign_server.h"
+#include "catalog/pg_user_mapping.h"
 #include "foreign/foreign.h"
+#include "utils/syscache.h"
 #include "lib/stringinfo.h"
 #include "mb/pg_wchar.h"
 #include "catalog/pg_authid_d.h"
@@ -1647,7 +1650,8 @@ pq_source_prefetch(PqSource *src, int64 off, int64 n)
  * crafted file reports the same thing through either path.
  */
 static void
-pq_source_open(const char *path, PqSource *src, PqFile *pf)
+pq_source_open_cfg(const char *path, PqSource *src, PqFile *pf,
+				   const PgColumnarObjStoreConfig *cfg)
 {
 	uint8		tail[8];
 	uint8		head[4];
@@ -1704,7 +1708,7 @@ pq_source_open(const char *path, PqSource *src, PqFile *pf)
 		 */
 		src->winCtx = CurrentMemoryContext;
 		src->api = api;
-		src->priv = (void *) api->open(path, &src->len);
+		src->priv = (void *) api->open(path, cfg, &src->len);
 		src->ops = &pq_remote_ops;
 	}
 	else
@@ -1774,6 +1778,18 @@ pq_source_close(PqSource *src)
 		src->winLen = 0;
 	}
 	src->ops->close(src);
+}
+
+/*
+ * The function-API entry points (read_parquet, import, schema) have no server
+ * object and therefore no user mapping; they open with a NULL config, which
+ * the module treats as ambient-allowed. Their gate is pg_read_server_files,
+ * which already implies the postmaster's identity (#393 M4 design).
+ */
+static void
+pq_source_open(const char *path, PqSource *src, PqFile *pf)
+{
+	pq_source_open_cfg(path, src, pf, NULL);
 }
 
 
@@ -4204,6 +4220,85 @@ pqfdw_compute_needed(ForeignScanState *node, ImpTop *tops, int ntops,
 	return needTop;
 }
 
+/*
+ * Resolve the object-store configuration for a foreign table (#393 M4):
+ * endpoint and region from the SERVER options, the credential triple from the
+ * scanning user's USER MAPPING (else the PUBLIC mapping), probed without
+ * erroring because a mapping is optional here, unlike postgres_fdw. Ambient
+ * (environment) credentials are a privilege: a superuser, or a mapping a
+ * superuser marked credentials_required 'false'.
+ */
+static void
+pqfdw_objstore_config(Oid foreigntableid, PgColumnarObjStoreConfig *cfg)
+{
+	ForeignTable *ft = GetForeignTable(foreigntableid);
+	ForeignServer *server = GetForeignServer(ft->serverid);
+	HeapTuple	tp;
+	List	   *umoptions = NIL;
+	bool		credRequired = true;
+	ListCell   *lc;
+
+	memset(cfg, 0, sizeof(*cfg));
+
+	foreach(lc, server->options)
+	{
+		DefElem    *def = (DefElem *) lfirst(lc);
+
+		if (strcmp(def->defname, "endpoint") == 0)
+			cfg->endpoint = defGetString(def);
+		else if (strcmp(def->defname, "region") == 0)
+			cfg->region = defGetString(def);
+	}
+
+	tp = SearchSysCache2(USERMAPPINGUSERSERVER,
+						 ObjectIdGetDatum(GetUserId()),
+						 ObjectIdGetDatum(server->serverid));
+	if (!HeapTupleIsValid(tp))
+		tp = SearchSysCache2(USERMAPPINGUSERSERVER,
+							 ObjectIdGetDatum(InvalidOid),
+							 ObjectIdGetDatum(server->serverid));
+	if (HeapTupleIsValid(tp))
+	{
+		Datum		datum;
+		bool		isnull;
+
+		datum = SysCacheGetAttr(USERMAPPINGUSERSERVER, tp,
+								Anum_pg_user_mapping_umoptions, &isnull);
+		if (!isnull)
+			umoptions = untransformRelOptions(datum);
+		ReleaseSysCache(tp);
+	}
+
+	foreach(lc, umoptions)
+	{
+		DefElem    *def = (DefElem *) lfirst(lc);
+
+		if (strcmp(def->defname, "access_key_id") == 0)
+			cfg->akid = defGetString(def);
+		else if (strcmp(def->defname, "secret_access_key") == 0)
+			cfg->secret = defGetString(def);
+		else if (strcmp(def->defname, "session_token") == 0)
+			cfg->token = defGetString(def);
+		else if (strcmp(def->defname, "credentials_required") == 0)
+			credRequired = defGetBoolean(def);
+	}
+
+	/*
+	 * The validator cannot see across ALTER statements, so the pairing is
+	 * enforced here: half a credential is a misconfiguration, not a fallback
+	 * to somebody else's identity.
+	 */
+	if ((cfg->akid == NULL) != (cfg->secret == NULL))
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION),
+				 errmsg("columnar: the user mapping for server \"%s\" carries "
+						"only half a credential", server->servername),
+				 errhint("Set both access_key_id and secret_access_key, or "
+						 "neither.")));
+
+	cfg->allow_ambient = superuser() || !credRequired;
+}
+
 static void
 pqfdwBeginForeignScan(ForeignScanState *node, int eflags)
 {
@@ -4224,6 +4319,7 @@ pqfdwBeginForeignScan(ForeignScanState *node, int eflags)
 	bool	   *partNull = NULL;
 	List	   *partQuals = NIL;
 	TupleTableSlot *partSlot = NULL;
+	PgColumnarObjStoreConfig oscfg;
 
 	/* nothing to do for a plan-only (EXPLAIN without ANALYZE) invocation */
 	if (eflags & EXEC_FLAG_EXPLAIN_ONLY)
@@ -4233,6 +4329,8 @@ pqfdwBeginForeignScan(ForeignScanState *node, int eflags)
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 				 errmsg("must be superuser or a member of the pg_read_server_files role to read a server file")));
+
+	pqfdw_objstore_config(RelationGetRelid(rel), &oscfg);
 
 	path = pqfdw_get_path(RelationGetRelid(rel));
 	if (path == NULL)
@@ -4300,7 +4398,7 @@ pqfdwBeginForeignScan(ForeignScanState *node, int eflags)
 		}
 
 		st->filesRead++;
-		pq_source_open((char *) lfirst(lc), &src, &pf);
+		pq_source_open_cfg((char *) lfirst(lc), &src, &pf, &oscfg);
 		pq_check_row_groups(&pf, (char *) lfirst(lc));
 		tops = build_imp_targets(tupdesc, &pf, &leaves, &ntops, partMask);
 
@@ -4467,11 +4565,60 @@ pgcolumnar_parquet_fdw_validator(PG_FUNCTION_ARGS)
 						(errcode(ERRCODE_FDW_INVALID_OPTION_NAME),
 						 errmsg("\"partition_columns\" is not a valid comma-separated column list")));
 		}
+		else if (catalog == ForeignServerRelationId &&
+				 (strcmp(def->defname, "endpoint") == 0 ||
+				  strcmp(def->defname, "region") == 0))
+		{
+			/*
+			 * Non-secret connection config only (#393 M4). srvoptions is
+			 * world-readable, which is exactly why nothing secret is accepted
+			 * here.
+			 */
+			if (defGetString(def)[0] == '\0')
+				ereport(ERROR,
+						(errcode(ERRCODE_FDW_INVALID_OPTION_NAME),
+						 errmsg("\"%s\" option cannot be empty", def->defname)));
+			if (strcmp(def->defname, "endpoint") == 0 &&
+				pg_strncasecmp(defGetString(def), "http://", 7) != 0 &&
+				pg_strncasecmp(defGetString(def), "https://", 8) != 0)
+				ereport(ERROR,
+						(errcode(ERRCODE_FDW_INVALID_OPTION_NAME),
+						 errmsg("\"endpoint\" must be an http:// or https:// URL")));
+		}
+		else if (catalog == UserMappingRelationId &&
+				 (strcmp(def->defname, "access_key_id") == 0 ||
+				  strcmp(def->defname, "secret_access_key") == 0 ||
+				  strcmp(def->defname, "session_token") == 0))
+		{
+			/* secrets live HERE and only here: pg_user_mapping is protected */
+			if (defGetString(def)[0] == '\0')
+				ereport(ERROR,
+						(errcode(ERRCODE_FDW_INVALID_OPTION_NAME),
+						 errmsg("\"%s\" option cannot be empty", def->defname)));
+		}
+		else if (catalog == UserMappingRelationId &&
+				 strcmp(def->defname, "credentials_required") == 0)
+		{
+			/*
+			 * password_required's shape: setting it false hands the mapped
+			 * role the postmaster's ambient identity, so only a superuser may
+			 * do that. defGetBoolean also rejects a non-boolean value.
+			 */
+			if (!defGetBoolean(def) && !superuser())
+				ereport(ERROR,
+						(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+						 errmsg("only a superuser may set \"credentials_required\" to false"),
+						 errdetail("It permits the mapped role to use the "
+								   "server process's ambient credentials.")));
+		}
 		else
 			ereport(ERROR,
 					(errcode(ERRCODE_FDW_INVALID_OPTION_NAME),
 					 errmsg("invalid option \"%s\"", def->defname),
-					 errhint("The pgcolumnar_parquet wrapper accepts the foreign-table options \"path\" and \"partition_columns\".")));
+					 errhint("Foreign tables accept \"path\" and \"partition_columns\"; "
+							 "servers accept \"endpoint\" and \"region\"; user mappings "
+							 "accept \"access_key_id\", \"secret_access_key\", "
+							 "\"session_token\", and \"credentials_required\".")));
 	}
 
 	PG_RETURN_VOID();

--- a/test/objstore_credentials.sh
+++ b/test/objstore_credentials.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+#
+# pgColumnar #393 M4: the validator split and catalog credentials.
+#
+# The placement policy is enforced at DDL time: non-secret config (endpoint,
+# region) lives on the SERVER, secrets (access_key_id, secret_access_key,
+# session_token) live ONLY on a USER MAPPING, and every misplacement is
+# HV00D at CREATE/ALTER -- so a secret can never land in a world-readable
+# catalog. Ambient (postmaster environment) credentials become a privilege:
+# superusers, or a mapping a superuser marked credentials_required 'false'
+# (password_required's shape). See design/ISSUE_393_M4_CREDENTIALS.md.
+#
+# The catalog arms run with NO AWS_* in the postmaster environment at all, so
+# nothing ambient can make them pass vacuously: a green read in phase 1 proves
+# the catalog options reached the wire. Per-user resolution is proven by two
+# roles reading the SAME table over the SAME server where the only variable is
+# their mapping (alice's carries the right secret, bob's a wrong one, and the
+# SigV4-verifying fixture judges).
+#
+# Usage:  test/objstore_credentials.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+python3 -c 'import pyarrow' 2>/dev/null || pgc_skip pyarrow "pyarrow is required to write the fixture"
+
+S3_PORT="$(pgc_pick_free_port "$PGC_AUX_PORT_LO" "$PGC_AUX_PORT_HI")"
+S3_LOG="$PGC_WORKDIR/cred.log"
+SRV_PID=""
+AKID="PGCTESTKEYID"
+SECRET="pgctest-good-secret"
+BADSECRET="pgctest-wrong-secret"
+REGION="pgc-test-1"
+BUCKET="pgc-bucket"
+
+objstore_cred_teardown() {
+	[ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null
+	pgc_teardown
+}
+trap objstore_cred_teardown EXIT INT TERM
+
+pg_restart_env() {
+	pgc_pg "pg_ctl -D '$PGC_PGDATA' stop -m fast -w" >/dev/null 2>&1
+	pgc_pg "$* pg_ctl -D '$PGC_PGDATA' -l '$PGC_LOGFILE' start -w" >/dev/null 2>&1
+	for _ in $(seq 1 30); do
+		[ -n "$(q 'SELECT 1')" ] && return 0
+		sleep 0.5
+	done
+	echo "FATAL: cluster did not come back after env restart"; exit 1
+}
+
+sqlstate_of() {  # sqlstate_of <sql> [role]
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U "${2:-postgres}" \
+		-d "$PGC_DB" -qtA 2>&1 <<SQLEOF | sed -n 's/^ERROR:  \([0-9A-Z]\{5\}\).*/\1/p' | head -1
+\\set VERBOSITY sqlstate
+$1;
+SQLEOF
+}
+q_as() {  # q_as <role> <sql>
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U "$1" \
+		-d "$PGC_DB" -At -c "$2" 2>/dev/null || true
+}
+
+# ---- fixture + verifying server --------------------------------------------
+G=3; NCOLS=4; ROWS_PER_GROUP=6000
+mkdir -p "$PGC_WORKDIR/$BUCKET"
+python3 - "$PGC_WORKDIR/$BUCKET/fixture.parquet" <<PYEOF
+import sys
+import pyarrow as pa, pyarrow.parquet as pq
+G, NCOLS, RPG = $G, $NCOLS, $ROWS_PER_GROUP
+n = G * RPG
+cols = {("c%d" % i): pa.array([(i + 1) * v for v in range(n)], pa.int64())
+        for i in range(NCOLS)}
+pq.write_table(pa.table(cols), sys.argv[1], row_group_size=RPG,
+               data_page_size=4096, compression="NONE", use_dictionary=False)
+PYEOF
+python3 "$(dirname "${BASH_SOURCE[0]}")/objstore_http_server.py" \
+	--dir "$PGC_WORKDIR" --port "$S3_PORT" --log "$S3_LOG" \
+	--sigv4-key "$AKID" --sigv4-secret "$SECRET" --sigv4-region "$REGION" \
+	> "$PGC_WORKDIR/cred_server.out" 2>&1 &
+SRV_PID=$!
+for _ in $(seq 1 50); do
+	grep -q READY "$PGC_WORKDIR/cred_server.out" 2>/dev/null && break
+	sleep 0.1
+done
+check "premise: sigv4 fixture server is up" \
+	"$(grep -c READY "$PGC_WORKDIR/cred_server.out" 2>/dev/null)" "1"
+
+COLDEFS="$(python3 -c "print(', '.join('c%d int8' % i for i in range($NCOLS)))")"
+
+# ---- roles ------------------------------------------------------------------
+for r in cred_alice cred_bob cred_carol; do
+	psql_run "CREATE ROLE $r LOGIN;"
+	psql_run "GRANT pg_read_server_files TO $r;"
+done
+
+# ---- placement arms (the validator split) -----------------------------------
+check "placement: secret on a SERVER is HV00D" \
+	"$(sqlstate_of "CREATE SERVER badsrv FOREIGN DATA WRAPPER pgcolumnar_parquet OPTIONS (secret_access_key 'x')")" "HV00D"
+check "placement: endpoint on a TABLE is HV00D" \
+	"$(sqlstate_of "CREATE SERVER tmpsrv FOREIGN DATA WRAPPER pgcolumnar_parquet; CREATE FOREIGN TABLE ft_bad ($COLDEFS) SERVER tmpsrv OPTIONS (endpoint 'x')")" "HV00D"
+
+psql_run "CREATE SERVER csrv FOREIGN DATA WRAPPER pgcolumnar_parquet
+          OPTIONS (endpoint 'http://127.0.0.1:$S3_PORT', region '$REGION');"
+check "placement: endpoint and region on the SERVER are accepted" \
+	"$(q "SELECT count(*) FROM pg_foreign_server WHERE srvname = 'csrv'")" "1"
+check "placement: a credential on a USER MAPPING is accepted" \
+	"$(sqlstate_of "CREATE USER MAPPING FOR postgres SERVER csrv
+	   OPTIONS (access_key_id '$AKID', secret_access_key '$SECRET')")" ""
+check "placement: endpoint on a USER MAPPING is HV00D" \
+	"$(sqlstate_of "CREATE USER MAPPING FOR cred_alice SERVER csrv OPTIONS (endpoint 'x')")" "HV00D"
+
+psql_run "GRANT USAGE ON FOREIGN SERVER csrv TO cred_alice, cred_bob, cred_carol;"
+psql_run "CREATE USER MAPPING FOR cred_alice SERVER csrv
+          OPTIONS (access_key_id '$AKID', secret_access_key '$SECRET');"
+psql_run "CREATE USER MAPPING FOR cred_bob SERVER csrv
+          OPTIONS (access_key_id '$AKID', secret_access_key '$BADSECRET');"
+
+check "placement: a non-superuser cannot set credentials_required false (42501)" \
+	"$(sqlstate_of "ALTER USER MAPPING FOR cred_alice SERVER csrv OPTIONS (ADD credentials_required 'false')" cred_alice)" "42501"
+check "placement: a superuser can (for carol, used below)" \
+	"$(sqlstate_of "CREATE USER MAPPING FOR cred_carol SERVER csrv OPTIONS (credentials_required 'false')")" ""
+
+# ---- tables -----------------------------------------------------------------
+psql_run "CREATE FOREIGN TABLE flocal ($COLDEFS) SERVER csrv OPTIONS (path '$PGC_WORKDIR/$BUCKET/fixture.parquet');"
+psql_run "CREATE FOREIGN TABLE fs3 ($COLDEFS) SERVER csrv OPTIONS (path 's3://$BUCKET/fixture.parquet');"
+psql_run "GRANT SELECT ON flocal, fs3 TO cred_alice, cred_bob, cred_carol;"
+
+# ---- phase 1: NO AWS environment anywhere -----------------------------------
+# The premise and the point: the postmaster has no AWS_* variables, so every
+# green below can only have come from the catalogs.
+psql_run "DROP USER MAPPING FOR postgres SERVER csrv;"
+check "premise: without mapping or environment, even a superuser gets 28000" \
+	"$(sqlstate_of "SELECT count(*) FROM fs3")" "28000"
+psql_run "CREATE USER MAPPING FOR postgres SERVER csrv
+          OPTIONS (access_key_id '$AKID', secret_access_key '$SECRET');"
+
+check "catalog: mapping + server options reach the wire (differential)" \
+	"$(pgc_set_hash "SELECT * FROM fs3")" "$(pgc_set_hash "SELECT * FROM flocal")"
+check_num "catalog: count(*) with catalog credentials only" \
+	"$(q "SELECT count(*) FROM fs3")" "$((G * ROWS_PER_GROUP))"
+
+check_num "per-user: alice (good secret in her mapping) reads" \
+	"$(q_as cred_alice "SELECT count(*) FROM fs3")" "$((G * ROWS_PER_GROUP))"
+check "per-user: bob (wrong secret in his mapping) is refused 28000" \
+	"$(sqlstate_of "SELECT count(*) FROM fs3" cred_bob)" "28000"
+check "ambient-is-privilege: carol (credentials_required=false, but no env exists) is 28000" \
+	"$(sqlstate_of "SELECT count(*) FROM fs3" cred_carol)" "28000"
+
+# ---- no-leak arm ------------------------------------------------------------
+BOB_ERR="$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U cred_bob \
+	-d "$PGC_DB" -qtA 2>&1 <<SQLEOF
+\\set VERBOSITY verbose
+SELECT count(*) FROM fs3;
+SQLEOF
+)"
+EXPL="$(q "EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM fs3")"
+check_num "no-leak: bob's verbose error carries no secret" \
+	"$(grep -c -e "$SECRET" -e "$BADSECRET" <<<"$BOB_ERR")" "0"
+check "premise: bob's error was a real refusal, not silence" \
+	"$([ -n "$BOB_ERR" ] && echo yes)" "yes"
+check_num "no-leak: EXPLAIN VERBOSE carries no secret" \
+	"$(grep -c -e "$SECRET" -e "$BADSECRET" <<<"$EXPL")" "0"
+check_num "no-leak: srvoptions carry no secret (by construction)" \
+	"$(q "SELECT count(*) FROM pg_foreign_server WHERE srvoptions::text LIKE '%$SECRET%'")" "0"
+
+# ---- phase 2: environment present; ambient is still a privilege -------------
+pg_restart_env "AWS_ENDPOINT_URL='http://127.0.0.1:$S3_PORT'" \
+	"AWS_ACCESS_KEY_ID='$AKID'" "AWS_SECRET_ACCESS_KEY='$SECRET'" \
+	"AWS_REGION='$REGION'"
+
+check_num "ambient: carol (credentials_required=false) now reads via the environment" \
+	"$(q_as cred_carol "SELECT count(*) FROM fs3")" "$((G * ROWS_PER_GROUP))"
+psql_run "DROP USER MAPPING FOR cred_carol SERVER csrv;"
+check "ambient: without her mapping, carol is refused despite the environment" \
+	"$(sqlstate_of "SELECT count(*) FROM fs3" cred_carol)" "28000"
+psql_run "DROP USER MAPPING FOR postgres SERVER csrv;"
+check_num "ambient: a superuser with no mapping reads via the environment" \
+	"$(q "SELECT count(*) FROM fs3")" "$((G * ROWS_PER_GROUP))"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -147,6 +147,7 @@ SUITES=(
 	native_vecskip
 	native_writer
 	native_zonemap
+	objstore_credentials
 	objstore_http_read
 	objstore_module
 	objstore_s3_read


### PR DESCRIPTION
The last #393 milestone, on merged M1–M3. Design: `design/ISSUE_393_M4_CREDENTIALS.md` (in this PR).

## What lands

- **The placement policy, enforced at DDL time**: `endpoint`/`region` on the SERVER, the credential triple + `credentials_required` ONLY on a USER MAPPING, table options unchanged, every misplacement HV00D. The world-readable-secret outcome #393 opened with is now unreachable by any accepted statement.
- **Scan-time resolution**: user's mapping else PUBLIC (probed without erroring — a mapping is optional here, unlike postgres_fdw), mapping credentials win, server options else environment for endpoint/region. **Ambient becomes a privilege**: superuser, or a mapping a superuser marked `credentials_required 'false'` (`password_required`'s shape, superuser check in the validator → 42501). Half a credential pair refuses at scan time.
- **ABI 2**: `open()` gains the resolved config struct; `cfg == NULL` (function-API paths, no server object) stays ambient behind `pg_read_server_files` — recorded in the design doc as a decision, not a drift from the memo's stricter alternative.
- The memo's endpoint allow-list GUC is **not** here: it is a default-deny posture change that needs its own owner call; posted to the issue as the follow-on question.

## Suite design points

- The catalog arms run with **no AWS_\* environment at all**, premise-pinned (even a superuser is 28000 before the mapping exists) — a green read can only have come from the catalogs.
- Per-user proof: alice and bob read the same table over the same server; only their mappings differ; the SigV4-verifying fixture judges (alice reads, bob 28000).
- Ambient-as-privilege proven in both directions: carol reads via the environment only while her `credentials_required=false` mapping exists.
- No-leak arms: bob's verbose error and EXPLAIN VERBOSE grep-zero for both secret literals; `srvoptions` cannot carry one by construction.

## Proofs and gates

- RED-first on main (placement DDL rejected, no catalog plumbing) recorded.
- Removal proofs run: drop the validator superuser check → 42501 arm red; drop the mapping lookup → catalog/alice arms red.
- 21/21 on PG17 (lane), PG18, PG19; **ASAN+UBSAN gate passes all five objstore suites**; four merged objstore suites unregressed; `-Wshadow -Werror` clean.

## Reviewer note

PGXS tracks no header dependencies: an ABI bump needs a **clean rebuild of both the main library and the module** — during this work each side was the stale one once, and both misreport as "module not installed" (with the ABI WARNING in the log as the tell). Recorded in the commit and my memory notes; if your bench uses incremental builds, `make clean` both before judging a red.

With this merged, #393's four milestones are complete: ranged HTTP transport, SigV4, TLS, and the credential model. Remaining on the issue: the endpoint allow-list owner decision, ListObjectsV2/globs (deliberately deferred), and FDW streaming (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)