### PR TITLE
fix: pgcolumnar.sort_status() SECURITY DEFINER so a table's owner can read it (#608)

### DIFF
--- a/pgcolumnar--1.0-alpha.sql
+++ b/pgcolumnar--1.0-alpha.sql
@@ -699,8 +699,17 @@ CREATE FUNCTION pgcolumnar.sort_status(
 	OUT sorted_rows bigint,
 	OUT appended_rows bigint)
 	RETURNS record
-	LANGUAGE sql STABLE
+	-- SECURITY DEFINER, like stats() (#560): the body reads pgcolumnar's internal
+	-- catalogs (storage, row_group, options), which carry no GRANT, so an
+	-- invoker-rights function false-denied a table's own owner on their own table
+	-- (#608). require_caller_select gates the REAL caller via GetOuterUserId(), so
+	-- definer rights do not widen who may read a table's sort status. search_path
+	-- is pinned as a definer function must.
+	LANGUAGE plpgsql STABLE SECURITY DEFINER
+	SET search_path = pg_catalog, pg_temp
 	AS $sort_status$
+BEGIN
+	PERFORM pgcolumnar.require_caller_select(rel);
 	WITH s AS (
 		SELECT st.storage_id, st.sorted_through, st.sorted_from
 		FROM pgcolumnar.storage st
@@ -729,7 +738,9 @@ CREATE FUNCTION pgcolumnar.sort_status(
 		   (SELECT count(*)::bigint FROM g WHERE g.in_run),
 		   (SELECT count(*)::bigint FROM g WHERE NOT g.in_run),
 		   COALESCE((SELECT sum(g.row_count)::bigint FROM g WHERE g.in_run), 0::bigint),
-		   COALESCE((SELECT sum(g.row_count)::bigint FROM g WHERE NOT g.in_run), 0::bigint);
+		   COALESCE((SELECT sum(g.row_count)::bigint FROM g WHERE NOT g.in_run), 0::bigint)
+	INTO sort_key, total_groups, sorted_groups, appended_groups, sorted_rows, appended_rows;
+END;
 $sort_status$;
 
 COMMENT ON FUNCTION pgcolumnar.sort_status(regclass)

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -185,6 +185,7 @@ SUITES=(
 	server_file_privilege
 	smoke
 	sort_status
+	sort_status_privilege
 	sorted_projection
 	stats_privilege
 	temporal

--- a/test/sort_status_privilege.sh
+++ b/test/sort_status_privilege.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# pgColumnar: pgcolumnar.sort_status is usable by a table's owner, and only by a
+# caller who may read the table (#608).
+#
+# Same class as stats() (#560): sort_status was LANGUAGE sql and selected
+# straight from pgcolumnar.storage, row_group and options, which carry no GRANT,
+# so those tables are owner-only and a COLUMNAR table's own owner is not their
+# owner. The function therefore false-denied the owner of the table it reports on
+# with 42501 on an internal catalog. GRANTing the catalog to PUBLIC is the wrong
+# fix -- it would publish zone_map's per-column min/max/sum -- so the function
+# runs SECURITY DEFINER and does the privilege check itself.
+#
+# THE ARMS THAT MATTER (the #607 review lesson): a deny arm alone is vacuous --
+# an invoker-rights function denies EVERYONE and still passes it. So the owner
+# and a SELECT-holder each getting a row are the arms that RED on the invoker
+# shape, and the deny arm asserts "permission denied for table" AND that the
+# refusal names the TABLE, not the internal catalog it never asked about (which
+# is exactly what the invoker-rights bug refused with).
+#
+# Usage:  test/sort_status_privilege.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+ROWS=500
+
+psql_run "DROP ROLE IF EXISTS t_ssowner;"
+psql_run "DROP ROLE IF EXISTS t_ssnone;"
+psql_run "DROP ROLE IF EXISTS t_sssel;"
+psql_run "CREATE ROLE t_ssowner NOSUPERUSER LOGIN;"
+psql_run "CREATE ROLE t_ssnone NOSUPERUSER LOGIN;"
+psql_run "CREATE ROLE t_sssel NOSUPERUSER LOGIN;"
+for r in t_ssowner t_ssnone t_sssel; do
+	psql_run "GRANT USAGE ON SCHEMA pgcolumnar TO $r;"
+done
+psql_run "CREATE TABLE ss_t (id int, ts int) USING pgcolumnar;"
+psql_run "INSERT INTO ss_t SELECT g, g FROM generate_series(1,$ROWS) g;"
+psql_run "SELECT pgcolumnar.vacuum_sorted('ss_t','ts');"   -- give it a sorted run
+psql_run "ALTER TABLE ss_t OWNER TO t_ssowner;"
+psql_run "REVOKE ALL ON ss_t FROM PUBLIC;"
+psql_run "GRANT SELECT ON ss_t TO t_sssel;"
+
+as() { env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U "$1" \
+	-d "$PGC_DB" -At -v ON_ERROR_STOP=0 -c "$2" 2>&1 | head -1; }
+
+# ---- premises, each run by the role it is about ----------------------------
+check "premise: the owner can open a session" "$(as t_ssowner 'SELECT 1;')" "1"
+check "premise: the no-privilege role can open a session" "$(as t_ssnone 'SELECT 1;')" "1"
+check "premise: t_ssowner really owns the table" \
+	"$(q "SELECT pg_get_userbyid(relowner) FROM pg_class WHERE relname='ss_t';")" "t_ssowner"
+check "premise: none of these roles is a superuser" \
+	"$(q "SELECT bool_and(NOT rolsuper) FROM pg_roles WHERE rolname LIKE 't_ss%';")" "t"
+check "premise: the owner can read its own table by ordinary SQL" \
+	"$(as t_ssowner 'SELECT count(*) FROM ss_t;')" "$ROWS"
+check "premise: the no-privilege role cannot read it by ordinary SQL" \
+	"$(as t_ssnone 'SELECT count(*) FROM ss_t;' | grep -c 'permission denied')" "1"
+check "premise: the catalog tables are NOT readable by these roles, so a GRANT is not the fix" \
+	"$(as t_sssel 'SELECT count(*) FROM pgcolumnar.row_group;' | grep -c 'permission denied')" "1"
+
+# ---- the defect (positive controls: these RED on the invoker-rights shape) --
+check_num "the OWNER of the table can read its sort status" \
+	"$(as t_ssowner "SELECT count(*) FROM pgcolumnar.sort_status('ss_t');")" "1"
+check_num "a role merely GRANTed select can read it too" \
+	"$(as t_sssel "SELECT count(*) FROM pgcolumnar.sort_status('ss_t');")" "1"
+# and the value is real, not an empty row
+check "the owner sees its sorted run, not a false empty" \
+	"$(as t_ssowner "SELECT sorted_groups > 0 FROM pgcolumnar.sort_status('ss_t');")" "t"
+
+# ---- the bar (deny, and it must name the TABLE not the catalog) -------------
+check "a role with no privilege on the table is refused" \
+	"$(as t_ssnone "SELECT count(*) FROM pgcolumnar.sort_status('ss_t');" | grep -c 'permission denied for table')" "1"
+check "and the refusal names the TABLE, not a catalog table it never asked about" \
+	"$(as t_ssnone "SELECT count(*) FROM pgcolumnar.sort_status('ss_t');" | grep -c 'ss_t')" "1"
+
+# ---- the superuser path still works ----------------------------------------
+check_num "a superuser still reads sort status" \
+	"$(q "SELECT count(*) FROM pgcolumnar.sort_status('ss_t');")" "1"
+
+pgc_summary


### PR DESCRIPTION
Fixes #608.

`pgcolumnar.sort_status()` was `LANGUAGE sql` and read pgcolumnar's internal
catalogs (`storage`, `row_group`, `options`) directly. Those carry no GRANT, so
an ordinary role — **including the table's own owner** — got 42501 on an internal
catalog rather than the run/append counts for a table they own. Same class as
`stats()` (#560); surfaced by @jdatcmd reviewing #607 (`maintenance_due`, which
calls `sort_status`).

## Fix

Convert `sort_status` to `plpgsql` `SECURITY DEFINER` with `SET search_path =
pg_catalog, pg_temp` and a first-statement `PERFORM
pgcolumnar.require_caller_select(rel)`, exactly as `stats()`. `require_caller_select`
uses `GetOuterUserId()`, so definer rights do **not** widen who may read a table's
sort status — a caller still needs SELECT on `rel` — while the body reaches the
catalog as the owner. GRANTing the catalog to PUBLIC would have been the wrong
fix: it publishes `zone_map`'s per-column min/max/sum. Body references were
already schema-qualified.

## Test — `test/sort_status_privilege.sh`, mirroring `stats_privilege.sh`

The #607 review lesson, applied: a deny arm alone is vacuous — an invoker-rights
function denies everyone and passes it. So the suite leads with **positive
controls**:

- the table's **owner** reads its sort status (a row);
- a role merely GRANTed SELECT reads it too;
- the owner sees its sorted run (`sorted_groups > 0`), not a false empty.

These are the arms that **red on the invoker shape** and would have caught this
(proven RED-first: each failed with `permission denied for table row_group`
before the fix, then passed after). The deny arm asserts `permission denied for
table` **naming the TABLE** (`ss_t`), not the internal catalog the invoker-rights
bug refused with, and the superuser path is checked unchanged.

## Proofs and gate

- **RED first**: the three positive controls failed on invoker rights; recorded.
- **GREEN**: 13/13 on pg18a and pg19a.
- **Removal proof**: dropping `require_caller_select` from the fixed function
  reddens the deny arm (a no-privilege role reads the catalog as the owner and
  gets a row) — the gate is load-bearing.
- Functional `sort_status.sh` unchanged (49/49): the superuser path is untouched.
- Preflight (build + suite) on pg15a/16a/17a and the full assert matrix on
  pg18a + pg19a: results below.

## Scope

Pure SQL, no C, no new GUC. The function is added to the base extension script
(the alpha convention). It composes cleanly with #607: `maintenance_due` is
itself DEFINER, so it never depended on this, but `sort_status` standalone now
stops false-denying owners — defense in depth on the same call path.

---

**Gate, ca594a4:** removal proof confirms the gate is load-bearing (deny arm reds when `require_caller_select` is dropped); preflight pg15a/16a/17a PASSED; full assert matrix **ALL VERSIONS PASSED** — PG18 (157 ran, 2 skipped), PG19 (159 ran, 0 skipped), `sort_status` + `sort_status_privilege` green, no regressions.
