### PR TITLE
feat: the export byte sink — checked writes, temp-and-rename (#394 step 1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,8 @@ OBJS = \
 	src/columnar_parquet_reader.o \
 	src/columnar_parallel_copy.o \
 	src/columnar_parallel_export.o \
-	src/columnar_objstore.o
+	src/columnar_objstore.o \
+	src/columnar_sink.o
 
 EXTENSION = pgcolumnar
 DATA = pgcolumnar--1.0-alpha.sql pgcolumnar--1.0-dev--1.0-alpha.sql

--- a/src/columnar_arrow.c
+++ b/src/columnar_arrow.c
@@ -25,6 +25,7 @@
  */
 #include "columnar.h"
 #include "columnar_flatbuffers.h"
+#include "columnar_sink.h"
 
 #include "fmgr.h"
 #include "funcapi.h"
@@ -841,7 +842,7 @@ arrow_build_field(FBB *b, ArrowCol *c)
 
 /* build one RecordBatch (metadata + body) and write it */
 static void
-write_record_batch(FILE *f, ArrowCol *cols, int ncols, int64 nrows)
+write_record_batch(PqSink *snk, ArrowCol *cols, int ncols, int64 nrows)
 {
 	StringInfoData body;
 	FBB			b;
@@ -926,13 +927,13 @@ write_record_batch(FILE *f, ArrowCol *cols, int ncols, int64 nrows)
 		uint32		metaLenField = metaLen + metaPad;
 		static const char zeros[8] = {0};
 
-		fwrite(&cont, 4, 1, f);
-		fwrite(&metaLenField, 4, 1, f);
-		fwrite(b.buf + b.cap - b.tail, 1, metaLen, f);
+		PgColumnarSinkWrite(snk, &cont, 4);
+		PgColumnarSinkWrite(snk, &metaLenField, 4);
+		PgColumnarSinkWrite(snk, b.buf + b.cap - b.tail, metaLen);
 		if (metaPad)
-			fwrite(zeros, 1, metaPad, f);
+			PgColumnarSinkWrite(snk, zeros, metaPad);
 		if (body.len > 0)
-			fwrite(body.data, 1, body.len, f);
+			PgColumnarSinkWrite(snk, body.data, body.len);
 	}
 
 	pfree(b.buf);
@@ -962,7 +963,7 @@ pgcolumnar_export_arrow(PG_FUNCTION_ARGS)
 	uint64		rowNumber;
 	int64		total = 0;
 	int64		batchRows = 0;
-	FILE	   *f;
+	PqSink	   *snk;
 	FBB			b;
 	int			i;
 	uint32		vec,
@@ -1051,14 +1052,9 @@ pgcolumnar_export_arrow(PG_FUNCTION_ARGS)
 		arrowcol_reset(&cols[i]);
 	}
 
-	f = AllocateFile(path, PG_BINARY_W);
-	if (f == NULL)
+	snk = PgColumnarSinkOpenLocal(path);
+	PG_TRY();
 	{
-		table_close(rel, AccessShareLock);
-		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not open file \"%s\" for writing: %m", path)));
-	}
 
 	/* ---- Schema message ---- */
 	fieldOff = palloc(sizeof(uint32) * ncols);
@@ -1089,11 +1085,11 @@ pgcolumnar_export_arrow(PG_FUNCTION_ARGS)
 		uint32		metaLenField = metaLen + metaPad;
 		static const char zeros[8] = {0};
 
-		fwrite(&cont, 4, 1, f);
-		fwrite(&metaLenField, 4, 1, f);
-		fwrite(b.buf + b.cap - b.tail, 1, metaLen, f);
+		PgColumnarSinkWrite(snk, &cont, 4);
+		PgColumnarSinkWrite(snk, &metaLenField, 4);
+		PgColumnarSinkWrite(snk, b.buf + b.cap - b.tail, metaLen);
 		if (metaPad)
-			fwrite(zeros, 1, metaPad, f);
+			PgColumnarSinkWrite(snk, zeros, metaPad);
 	}
 	pfree(b.buf);
 
@@ -1119,7 +1115,7 @@ pgcolumnar_export_arrow(PG_FUNCTION_ARGS)
 		if (batchRows == ARROW_BATCH_ROWS)
 		{
 			oldCtx = MemoryContextSwitchTo(batchCtx);
-			write_record_batch(f, cols, ncols, batchRows);
+			write_record_batch(snk, cols, ncols, batchRows);
 			MemoryContextSwitchTo(oldCtx);
 			MemoryContextReset(batchCtx);
 			for (i = 0; i < ncols; i++)
@@ -1132,7 +1128,7 @@ pgcolumnar_export_arrow(PG_FUNCTION_ARGS)
 	if (batchRows > 0)
 	{
 		oldCtx = MemoryContextSwitchTo(batchCtx);
-		write_record_batch(f, cols, ncols, batchRows);
+		write_record_batch(snk, cols, ncols, batchRows);
 		MemoryContextSwitchTo(oldCtx);
 	}
 
@@ -1141,17 +1137,23 @@ pgcolumnar_export_arrow(PG_FUNCTION_ARGS)
 		uint32		cont = 0xFFFFFFFF;
 		uint32		zero = 0;
 
-		fwrite(&cont, 4, 1, f);
-		fwrite(&zero, 4, 1, f);
+		PgColumnarSinkWrite(snk, &cont, 4);
+		PgColumnarSinkWrite(snk, &zero, 4);
 	}
 
-	if (FreeFile(f) != 0)
-	{
-		table_close(rel, AccessShareLock);
-		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not write file \"%s\": %m", path)));
+	/*
+	 * Commit: the final name appears only here, whole (#394). Any failure
+	 * above unwinds through the CATCH, which removes the temp file; the
+	 * final path is never touched on error.
+	 */
+	PgColumnarSinkFinish(snk);
 	}
+	PG_CATCH();
+	{
+		PgColumnarSinkAbort(snk);
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
 
 	table_close(rel, AccessShareLock);
 	PG_RETURN_INT64(total);

--- a/src/columnar_parallel_export.c
+++ b/src/columnar_parallel_export.c
@@ -228,11 +228,17 @@ pexport_prepare_dir(const char *dir)
 
 /*
  * pexport_remove_outputs
- *		Best-effort removal of the *.parquet this export wrote. A failed or
+ *		Best-effort removal of everything this export wrote. A failed or
  *		cancelled run must not leave part files behind: read_parquet unions
  *		whatever is present (so a partial set reads as a complete export), and the
  *		require-empty-directory guard would block a retry. The output directory was
  *		created or required empty at entry, so every *.parquet in it is ours.
+ *
+ *		Since #394 the workers write through the sink, so an in-flight part is
+ *		part-NNNN.parquet.tmp.<pid>. A worker that ERRORs unlinks its own temp
+ *		through the sink's abort, but a worker the dispatcher TERMINATES dies
+ *		FATAL, which does not unwind through PG_CATCH, so its temp survives the
+ *		worker. It is still ours by construction; remove it here.
  */
 static void
 pexport_remove_outputs(const char *dir)
@@ -249,8 +255,13 @@ pexport_remove_outputs(const char *dir)
 	while ((de = ReadDir(d, dir)) != NULL)
 	{
 		size_t		len = strlen(de->d_name);
+		bool		ours = false;
 
-		if (len < 8 || strcmp(de->d_name + len - 8, ".parquet") != 0)
+		if (len >= 8 && strcmp(de->d_name + len - 8, ".parquet") == 0)
+			ours = true;
+		else if (strstr(de->d_name, ".parquet.tmp.") != NULL)
+			ours = true;
+		if (!ours)
 			continue;
 		snprintf(fp, sizeof(fp), "%s/%s", dir, de->d_name);
 		(void) unlink(fp);

--- a/src/columnar_parquet.c
+++ b/src/columnar_parquet.c
@@ -23,6 +23,7 @@
  */
 #include "columnar.h"
 #include "columnar_parquet_format.h"
+#include "columnar_sink.h"
 #include "columnar_thrift.h"
 
 #include "fmgr.h"
@@ -958,7 +959,7 @@ PgColumnarWriteParquetFile(Relation rel, Snapshot snapshot, const char *filepath
 	int64		total = 0;
 	int64		groupRows = 0;
 	int64		offset = 0;
-	FILE	   *f;
+	PqSink	   *snk;
 	int			i;
 	PqRowGroup *rgs = NULL;
 	int			nrgs = 0;
@@ -998,13 +999,10 @@ PgColumnarWriteParquetFile(Relation rel, Snapshot snapshot, const char *filepath
 							format_type_be(att->atttypid))));
 	}
 
-	f = AllocateFile(filepath, PG_BINARY_W);
-	if (f == NULL)
-		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not open file \"%s\" for writing: %m", filepath)));
-
-	fwrite("PAR1", 1, 4, f);		/* magic header */
+	snk = PgColumnarSinkOpenLocal(filepath);
+	PG_TRY();
+	{
+	PgColumnarSinkWrite(snk, "PAR1", 4);	/* magic header */
 	offset = 4;
 
 	values = palloc(sizeof(Datum) * ntop);
@@ -1062,8 +1060,8 @@ PgColumnarWriteParquetFile(Relation rel, Snapshot snapshot, const char *filepath
 				initStringInfo(&ph);
 				write_page_header(&ph, leaves[i].nEntries, (int32) body.len);
 
-				fwrite(ph.data, 1, ph.len, f);
-				fwrite(body.data, 1, body.len, f);
+				PgColumnarSinkWrite(snk, ph.data, ph.len);
+				PgColumnarSinkWrite(snk, body.data, body.len);
 				offset += ph.len + body.len;
 
 				rg->cols[i].dataPageOffset = pageStart;
@@ -1110,17 +1108,26 @@ PgColumnarWriteParquetFile(Relation rel, Snapshot snapshot, const char *filepath
 		PgColumnarThriftPutStringField(&fmd, &last, 6, "pgColumnar", 10);	/* created_by */
 		PgColumnarThriftPutStop(&fmd);
 
-		fwrite(fmd.data, 1, fmd.len, f);
+		PgColumnarSinkWrite(snk, fmd.data, fmd.len);
 		footerLen = fmd.len;
-		fwrite(&footerLen, 4, 1, f);	/* footer length, LE */
-		fwrite("PAR1", 1, 4, f);		/* magic footer */
+		PgColumnarSinkWrite(snk, &footerLen, 4);	/* footer length, LE */
+		PgColumnarSinkWrite(snk, "PAR1", 4);	/* magic footer */
 		pfree(fmd.data);
 	}
 
-	if (FreeFile(f) != 0)
-		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not write file \"%s\": %m", filepath)));
+	/*
+	 * Commit: the final name appears only here, whole (#394). Any failure
+	 * above, including inside a write, unwinds through the CATCH, which
+	 * removes the temp file; the final path is never touched on error.
+	 */
+	PgColumnarSinkFinish(snk);
+	}
+	PG_CATCH();
+	{
+		PgColumnarSinkAbort(snk);
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
 
 	return total;
 }

--- a/src/columnar_sink.c
+++ b/src/columnar_sink.c
@@ -1,0 +1,125 @@
+/*-------------------------------------------------------------------------
+ * columnar_sink.c
+ *		Local byte sink for the export writers (#394 step 1).
+ *
+ * Fixes the two defects the write-path mapping found (PR #604): all 17 fwrite
+ * sites ignored their return values (a disk-full mid-export was detected only
+ * if the final flush failed), and serial exports wrote directly to the final
+ * path, leaving a partial file there on error. Every write is checked here,
+ * at the call; the bytes go to <path>.tmp.<pid>; and the final name appears
+ * only through finish()'s durable rename, so a reader never sees a partial
+ * file under the name it trusts - the same appears-whole-or-not-at-all
+ * property the future remote sink gets from multipart completion.
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include <unistd.h>
+
+#include "miscadmin.h"
+#include "storage/fd.h"
+
+#include "columnar_sink.h"
+
+int			pgcolumnar_sink_fail_after = -1;	/* dev injection; see header */
+
+struct PqSink
+{
+	FILE	   *f;
+	char	   *finalPath;
+	char	   *tmpPath;
+	int64		written;
+};
+
+PqSink *
+PgColumnarSinkOpenLocal(const char *path)
+{
+	PqSink	   *snk = (PqSink *) palloc0(sizeof(PqSink));
+
+	snk->finalPath = pstrdup(path);
+	snk->tmpPath = psprintf("%s.tmp.%d", path, MyProcPid);
+	snk->f = AllocateFile(snk->tmpPath, PG_BINARY_W);
+	if (snk->f == NULL)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not open file \"%s\" for writing: %m",
+						snk->tmpPath)));
+	return snk;
+}
+
+void
+PgColumnarSinkWrite(PqSink *snk, const void *buf, size_t n)
+{
+	size_t		wrote;
+
+	if (n == 0)
+		return;
+
+	/*
+	 * Fault injection (dev): fail exactly as a full disk would, through the
+	 * same report below, once the running total would cross the limit.
+	 */
+	if (pgcolumnar_sink_fail_after >= 0 &&
+		snk->written + (int64) n > (int64) pgcolumnar_sink_fail_after)
+	{
+		errno = ENOSPC;
+		wrote = 0;
+	}
+	else
+		wrote = fwrite(buf, 1, n, snk->f);
+
+	if (wrote != n)
+	{
+		/*
+		 * A short fwrite leaves the real cause in errno via the stream error;
+		 * a clean short count with no error is still a failed write, reported
+		 * as the device-full condition it almost always is.
+		 */
+		if (errno == 0)
+			errno = ENOSPC;
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not write to \"%s\": %m", snk->tmpPath),
+				 errdetail("The export had written %lld bytes.",
+						   (long long) snk->written)));
+	}
+	snk->written += (int64) n;
+}
+
+void
+PgColumnarSinkFinish(PqSink *snk)
+{
+	FILE	   *f = snk->f;
+
+	snk->f = NULL;
+	if (fflush(f) != 0 || pg_fsync(fileno(f)) != 0)
+	{
+		int			save_errno = errno;
+
+		FreeFile(f);
+		errno = save_errno;
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not flush \"%s\": %m", snk->tmpPath)));
+	}
+	if (FreeFile(f) != 0)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not write file \"%s\": %m", snk->tmpPath)));
+
+	/* fsyncs the new name and its directory; raises on failure */
+	durable_rename(snk->tmpPath, snk->finalPath, ERROR);
+}
+
+void
+PgColumnarSinkAbort(PqSink *snk)
+{
+	if (snk == NULL)
+		return;
+	if (snk->f != NULL)
+	{
+		FreeFile(snk->f);
+		snk->f = NULL;
+	}
+	(void) unlink(snk->tmpPath);
+}

--- a/src/columnar_sink.h
+++ b/src/columnar_sink.h
@@ -1,0 +1,42 @@
+/*-------------------------------------------------------------------------
+ * columnar_sink.h
+ *		The byte sink behind the export writers (#394 step 1).
+ *
+ * Mirrors the read side's PqSource seam: every export byte goes through ONE
+ * checked write, so "no fwrite remains in the export files" becomes a suite
+ * check instead of a hand-maintained census (the 13-vs-17 lesson, PR #604).
+ * The invariant both implementations share: NOTHING is ever visible at the
+ * final name before finish() returns. Locally that is write-to-temp plus
+ * durable rename; the remote implementation (later, in the objstore module)
+ * gets the same property from multipart completion.
+ *-------------------------------------------------------------------------
+ */
+#ifndef COLUMNAR_SINK_H
+#define COLUMNAR_SINK_H
+
+#include "postgres.h"
+
+typedef struct PqSink PqSink;
+
+/* Open <path>.tmp.<pid> for writing; the final name stays untouched. */
+extern PqSink *PgColumnarSinkOpenLocal(const char *path);
+
+/* Append exactly n bytes; a short write is an error AT THE CALL (#394). */
+extern void PgColumnarSinkWrite(PqSink *snk, const void *buf, size_t n);
+
+/* Commit: flush, fsync, durable rename to the final name. */
+extern void PgColumnarSinkFinish(PqSink *snk);
+
+/* Error-path cleanup: close and unlink the temp file. Never raises. */
+extern void PgColumnarSinkAbort(PqSink *snk);
+
+/*
+ * Dev fault injection: the sink fails (as ENOSPC would) once total bytes
+ * written would exceed this. -1 (default) disables. It drives the SAME error
+ * path a real short write takes, so the suite's failure arms exercise the
+ * code that a full disk reaches, chosen to land inside write_record_batch
+ * (the helper the 13-site census missed).
+ */
+extern int	pgcolumnar_sink_fail_after;
+
+#endif							/* COLUMNAR_SINK_H */

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -14,6 +14,7 @@
 #include "columnar.h"
 
 #include "columnar_customscan.h"
+#include "columnar_sink.h"
 #include "columnar_delete_vector.h"
 #include "columnar_metadata.h"
 #include "columnar_reader.h"
@@ -2756,6 +2757,24 @@ _PG_init(void)
 							 PGC_USERSET,
 							 0,
 							 NULL, NULL, NULL);
+
+	/*
+	 * Dev fault injection for the export sink (#394): fail the sink, as
+	 * ENOSPC would, once the export has written this many bytes. Exists so
+	 * the export failure paths (error, no partial file at the final name, no
+	 * temp debris) are testable deterministically; the suite chooses values
+	 * that land inside write_record_batch, the helper the 13-site census
+	 * missed.
+	 */
+	DefineCustomIntVariable("pgcolumnar.sink_fail_after",
+							"Fail export writes after this many bytes (dev fault injection).",
+							"-1 disables. The failure takes the same path a full disk takes.",
+							&pgcolumnar_sink_fail_after,
+							-1,
+							-1, INT_MAX,
+							PGC_USERSET,
+							0,
+							NULL, NULL, NULL);
 
 	DefineCustomIntVariable("pgcolumnar.unique_lock_buckets",
 							"Advisory-lock buckets per unique index for same-key "

--- a/test/export_sink.sh
+++ b/test/export_sink.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# pgColumnar #394 step 1: the export byte sink — every write checked, and
+# nothing ever visible at the final name before the export commits.
+#
+# The two defects this pins (found mapping the write path, PR #604): all 17
+# fwrite sites ignored their return values, so a disk-full mid-export was
+# detected only if the final flush happened to fail; and serial exports wrote
+# directly to the final path, leaving a partial file there on error.
+#
+# Arms:
+#   census    zero fwrite calls remain in either export file. The 13-vs-17
+#             lesson made a property of the tree, so the count can never be
+#             hand-maintained (and never wrong) again. RED on the old shape.
+#   round     exports still round-trip: parquet and arrow files import back
+#             into tables that hash-match the source, and no *.tmp.* debris
+#             remains after success.
+#   inject    pgcolumnar.sink_fail_after drives the SAME error path a full
+#             disk takes: the export errors SQLSTATE 53100, the FINAL path
+#             does not exist, and no temp file remains. The arrow arm's
+#             fail_after is derived from the measured full size so the
+#             failure lands inside write_record_batch — the helper the
+#             13-site census missed, which the design doc requires the proof
+#             to reach.
+#
+# Usage:  test/export_sink.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+SRC="$(dirname "${BASH_SOURCE[0]}")/../src"
+
+sqlstate_of() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -qtA 2>&1 <<SQLEOF | sed -n 's/^ERROR:  \([0-9A-Z]\{5\}\).*/\1/p' | head -1
+\\set VERBOSITY sqlstate
+$1;
+SQLEOF
+}
+no_debris() { find "$PGC_WORKDIR" -name '*.tmp.*' | wc -l | tr -d ' '; }
+
+# ---- census -----------------------------------------------------------------
+check_num "census: zero fwrite remain in columnar_parquet.c" \
+	"$(grep -c 'fwrite(' "$SRC/columnar_parquet.c")" "0"
+check_num "census: zero fwrite remain in columnar_arrow.c" \
+	"$(grep -c 'fwrite(' "$SRC/columnar_arrow.c")" "0"
+
+# ---- fixture ----------------------------------------------------------------
+ROWS=40000
+psql_run "CREATE TABLE es_src (id int, v int8, t text) USING pgcolumnar;"
+psql_run "INSERT INTO es_src SELECT g, g*17, 'row-'||g FROM generate_series(1,$ROWS) g;"
+
+# ---- round-trip and no-debris ----------------------------------------------
+PQF="$PGC_WORKDIR/es.parquet"
+ARF="$PGC_WORKDIR/es.arrow"
+check_num "parquet export succeeds through the sink" \
+	"$(q "SELECT pgcolumnar.export_parquet('es_src', '$PQF')")" "$ROWS"
+check_num "arrow export succeeds through the sink" \
+	"$(q "SELECT pgcolumnar.export_arrow('es_src', '$ARF')")" "$ROWS"
+check_num "no temp debris after successful exports" "$(no_debris)" "0"
+
+psql_run "CREATE TABLE es_back_pq (id int, v int8, t text) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.import_parquet('es_back_pq', '$PQF');"
+check "parquet round-trip hash-matches the source" \
+	"$(pgc_set_hash "SELECT * FROM es_back_pq")" "$(pgc_set_hash "SELECT * FROM es_src")"
+psql_run "CREATE TABLE es_back_ar (id int, v int8, t text) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.import_arrow('es_back_ar', '$ARF');"
+check "arrow round-trip hash-matches the source" \
+	"$(pgc_set_hash "SELECT * FROM es_back_ar")" "$(pgc_set_hash "SELECT * FROM es_src")"
+
+ARROW_SIZE="$(stat -c %s "$ARF" 2>/dev/null || echo 0)"
+check "premise: measured arrow size supports a mid-batch injection point" \
+	"$([ "${ARROW_SIZE:-0}" -gt 4200 ] 2>/dev/null && echo yes)" "yes"
+
+# ---- injection: parquet, mid page body -------------------------------------
+FAILP="$PGC_WORKDIR/es_fail.parquet"
+check "inject: parquet export fails as disk-full (53100)" \
+	"$(sqlstate_of "SET pgcolumnar.sink_fail_after = 8192; SELECT pgcolumnar.export_parquet('es_src', '$FAILP')")" "53100"
+check "inject: nothing exists at the parquet FINAL path" \
+	"$([ ! -e "$FAILP" ] && echo clean)" "clean"
+check_num "inject: no parquet temp debris" "$(no_debris)" "0"
+
+# ---- injection: arrow, inside write_record_batch ----------------------------
+# fail_after = fullsize - 100: the last 100 bytes belong to the final record
+# batch (only the 8-byte EOS marker follows it), so the failing write is
+# inside the helper by arithmetic, not by luck. The schema message is bounded
+# well under the premise-checked 4200.
+FAILA="$PGC_WORKDIR/es_fail.arrow"
+check "inject: arrow export fails inside write_record_batch (53100)" \
+	"$(sqlstate_of "SET pgcolumnar.sink_fail_after = $((ARROW_SIZE - 100)); SELECT pgcolumnar.export_arrow('es_src', '$FAILA')")" "53100"
+check "inject: nothing exists at the arrow FINAL path" \
+	"$([ ! -e "$FAILA" ] && echo clean)" "clean"
+check_num "inject: no arrow temp debris" "$(no_debris)" "0"
+
+# ---- the injection is session state, not lingering damage -------------------
+check_num "after RESET, exports work again" \
+	"$(q "SELECT pgcolumnar.export_parquet('es_src', '$PGC_WORKDIR/es2.parquet')")" "$ROWS"
+
+pgc_summary

--- a/test/parallel_export_parquet.sh
+++ b/test/parallel_export_parquet.sh
@@ -29,6 +29,9 @@ COLS="id int, k int, v float8, txt text"
 RB="id int, k int, v float8, txt text"		# read_parquet column list
 
 nfiles() { ls "$1"/*.parquet 2>/dev/null | wc -l | tr -d ' '; }
+# every file including in-flight temps: the #394 sink writes part-N.parquet.tmp.PID
+# and renames at completion, so *.parquet appears only when a part is DONE.
+anyfiles() { find "$1" -type f 2>/dev/null | wc -l | tr -d ' '; }
 
 # run a query, echo stdout+stderr (capture-then-grep, so pipefail cannot hide it)
 err_of() {
@@ -146,10 +149,14 @@ env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$P
 bgpid=$!
 wrote=no
 for i in $(seq 1 200); do
-	[ "$(nfiles "$DCX")" -ge 1 ] && { wrote=yes; break; }
+	[ "$(anyfiles "$DCX")" -ge 1 ] && { wrote=yes; break; }
 	sleep 0.1
 done
-check "a part file was on disk before the cancel (cleanup has files to remove)" "$wrote" yes
+# anyfiles, not nfiles: since the #394 sink, a part's FINAL name appears only at
+# completion, so waiting for *.parquet meant waiting for a whole part to finish
+# and the cancel raced the end of the run. The temp appears at worker open,
+# which is the earliest "the run reached execution" signal there is.
+check "a file was on disk before the cancel (cleanup has work to do)" "$wrote" yes
 q "SELECT pg_cancel_backend(pid) FROM pg_stat_activity
    WHERE query LIKE '%parallel_export_parquet%' AND state = 'active'
      AND pid <> pg_backend_pid()" >/dev/null
@@ -160,8 +167,10 @@ wait "$bgpid" 2>/dev/null || true
 # the file-count check failing as if cleanup were broken. Grow t_big if it does.
 check "the export was cancelled mid-flight, not completed first (fixture premise)" \
 	"$(grep -qiE 'canceling statement|canceled on user request' "$BGLOG" && echo cancelled || echo completed)" cancelled
+# anyfiles: completed parts are removed by the dispatcher, and in-flight temps
+# by each worker's own sink abort (#394) - a cancelled export leaves NOTHING.
 check "a cancelled export leaves no partial files (item 2)" \
-	"$(nfiles "$DCX")" 0
+	"$(anyfiles "$DCX")" 0
 # and the cleaned directory is reusable (require-empty does not block a retry)
 q "SELECT pgcolumnar.parallel_export_parquet('t_col'::regclass, '$DCX', 2)" >/dev/null 2>&1
 check "retry into the cleaned directory succeeds" \

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -68,6 +68,7 @@ SUITES=(
 	encode_effort
 	encode_invariants
 	entry_point_privilege
+	export_sink
 	fk_referencing
 	fsst_margin
 	fsst_verdict_cache


### PR DESCRIPTION
Step 1 of the #394 order of work (`design/ISSUE_394_OBJECT_STORAGE_SINK.md`, merged): the local `PqSink` seam, fixing the two defects the write-path mapping found, useful standalone and blocking on nothing.

## What lands

- **One checked write replaces all 17 `fwrite` sites** (6 parquet + 11 arrow, per the corrected census): a short write errors at the call, the way `pq_source_read` treats a short read. Disk-full is no longer detectable only when the final flush happens to fail.
- **Nothing visible at the final name before commit**: exports write `<path>.tmp.<pid>`, `finish` does flush + fsync + `durable_rename`, `abort` unlinks from `PG_CATCH`. A FATAL mid-export leaves only pid-tagged debris, never a plausible half-file under the trusted name.
- **`write_record_batch` takes the sink** — the helper the 13-site census missed, with the suite's failure injection reaching into it by arithmetic (fail_after derived from the measured file size, landing in the final batch body).
- Dev GUC `pgcolumnar.sink_fail_after` drives the *same* error path a full disk takes, making the failure arms deterministic.

## The interaction the strengthened suite caught (the interesting part)

The parallel exporter's cancel arm originally waited for a `part-*.parquet` to appear before cancelling. With temp-and-rename, a final name appears only at *completion*, so the arm was cancelling a nearly-finished run — fixed to trigger on the temp (which appears at worker open, the earliest in-flight signal). The genuinely-mid-flight cancel then found a real defect of this change: **a worker the dispatcher terminates dies FATAL, which skips `PG_CATCH`, orphaning its temp** (measured: 4 files after a cancel). `pexport_remove_outputs` now also removes `*.parquet.tmp.*`, and the post-cancel arm asserts the directory *completely* empty, covering both cleanup paths. The un-widened dispatcher against the strengthened arm reds at exactly `got [4] want [0]` — the removal proof happened organically.

## Proofs

- RED-first: census arms read exactly main's 6 and 11; injection arms fail on the missing GUC with the final files present.
- Removal proofs both run: unlink deleted → the two injection debris arms red (1 and 2 leftovers) while the success-path arm stays green; short-write check made inert → both 53100 arms red (silent success past a failed write — the pre-fix defect reproduced).

## Verification

`export_sink` 15/15 and `parallel_export_parquet` 35/35 on PG17 (lane), PG18, PG19. `parquet_export`, `arrow_export`, `import_export_privilege` unregressed. ASAN+UBSAN gate passes `export_sink`, `parquet_export`, `arrow_export` (the dispatcher change is a five-line dirent name match, no new memory lifecycle). `-Wshadow -Werror` clean.

One bench note for the reviewer: a `run_san.sh` build leaves ASAN objects in the tree, and a later incremental non-ASAN relink sweeps them into the .so, which then fails to load with `undefined symbol: __asan_option_detect_stack_use_after_return` — every suite reds at cluster start. `make clean` between a sanitizer run and a normal one; recorded in my gotcha notes alongside the zero-byte-install variant.

Next per the design doc: step 2 (parallel workers already ride the seam via `PgColumnarWriteParquetFile`; arrow parallel does not exist), then the remote sink behind the module ABI once #394's write-side milestones start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)