### PR TITLE
feat: parse and report Parquet field IDs (#388 step 2)

### DIFF
--- a/pgcolumnar--1.0-alpha.sql
+++ b/pgcolumnar--1.0-alpha.sql
@@ -868,12 +868,12 @@ COMMENT ON FUNCTION pgcolumnar.import_parquet(regclass, text)
 	IS 'insert rows from a Parquet file, directory, or glob into a table; returns rows inserted (gap 27)';
 
 CREATE FUNCTION pgcolumnar.parquet_schema(path text)
-	RETURNS TABLE(column_name text, data_type text, nullable boolean)
+	RETURNS TABLE(column_name text, data_type text, nullable boolean, field_id integer)
 	LANGUAGE C STRICT
 	AS 'MODULE_PATHNAME', 'pgcolumnar_parquet_schema';
 
 COMMENT ON FUNCTION pgcolumnar.parquet_schema(text)
-	IS 'report the leaf columns of a Parquet file and the PostgreSQL type each maps to; for a directory or glob, of its first file (Phase G scan core)';
+	IS 'report the leaf columns of a Parquet file and the PostgreSQL type each maps to; for a directory or glob, of its first file; field_id is the SchemaElement field id Iceberg projects by, NULL when the writer emitted none (Phase G scan core, #388)';
 
 CREATE FUNCTION pgcolumnar.read_parquet(path text)
 	RETURNS SETOF record

--- a/src/columnar_parquet_reader.c
+++ b/src/columnar_parquet_reader.c
@@ -137,6 +137,9 @@ typedef struct PqSchemaCol
 	int			scale;			/* DECIMAL scale (0 if none) */
 	int			precision;		/* DECIMAL precision (0 if none) */
 	int			num_children;	/* >0 for a group */
+	int			field_id;		/* SchemaElement field 9, or -1 when absent:
+								 * 0 is a legal id, so absence needs its own
+								 * value. Iceberg projects by this (#388). */
 	char	   *name;
 } PqSchemaCol;
 
@@ -431,6 +434,7 @@ parse_schema_element(TCReader *r, PqSchemaCol *sc)
 	sc->scale = 0;
 	sc->precision = 0;
 	sc->num_children = 0;
+	sc->field_id = -1;
 	sc->name = NULL;
 
 	for (;;)
@@ -473,6 +477,9 @@ parse_schema_element(TCReader *r, PqSchemaCol *sc)
 				break;
 			case 8:				/* precision (DECIMAL) */
 				sc->precision = (int) PgColumnarThriftZigzag(r);
+				break;
+			case 9:				/* field_id (#388): Iceberg's projection key */
+				sc->field_id = (int) PgColumnarThriftZigzag(r);
 				break;
 			case 10:			/* logicalType */
 				parse_logical_type(r, sc);
@@ -3422,10 +3429,11 @@ pgcolumnar_parquet_schema(PG_FUNCTION_ARGS)
 	pq_source_open(path, &src, &pf);
 	pq_source_close(&src);
 
-	retdesc = CreateTemplateTupleDesc(3);
+	retdesc = CreateTemplateTupleDesc(4);
 	TupleDescInitEntry(retdesc, 1, "column_name", TEXTOID, -1, 0);
 	TupleDescInitEntry(retdesc, 2, "data_type", TEXTOID, -1, 0);
 	TupleDescInitEntry(retdesc, 3, "nullable", BOOLOID, -1, 0);
+	TupleDescInitEntry(retdesc, 4, "field_id", INT4OID, -1, 0);
 
 	oldContext = MemoryContextSwitchTo(rsinfo->econtext->ecxt_per_query_memory);
 	tupstore = tuplestore_begin_heap(true, false, work_mem);
@@ -3439,8 +3447,8 @@ pgcolumnar_parquet_schema(PG_FUNCTION_ARGS)
 		PqSchemaCol *sc = pf.leaves[i].sc;
 		Oid			typid;
 		int32		typmod;
-		Datum		values[3];
-		bool		nulls[3] = {false, false, false};
+		Datum		values[4];
+		bool		nulls[4] = {false, false, false, false};
 
 		values[0] = CStringGetTextDatum(sc->name != NULL ? sc->name : "");
 		if (pq_leaf_to_pgtype(sc, &typid, &typmod))
@@ -3450,6 +3458,11 @@ pgcolumnar_parquet_schema(PG_FUNCTION_ARGS)
 			nulls[1] = true;
 		/* a column is nullable iff it is OPTIONAL somewhere above the leaf */
 		values[2] = BoolGetDatum(pf.leaves[i].max_def > 0);
+		/* field_id (#388): NULL when the writer emitted none; 0 is a real id */
+		if (sc->field_id >= 0)
+			values[3] = Int32GetDatum(sc->field_id);
+		else
+			nulls[3] = true;
 
 		tuplestore_putvalues(tupstore, retdesc, values, nulls);
 	}

--- a/test/native_parquet_schema.sh
+++ b/test/native_parquet_schema.sh
@@ -103,8 +103,37 @@ PY
 		"$(q "SELECT nullable FROM pgcolumnar.parquet_schema('$REQ') WHERE column_name='opt_s';")" "t"
 	check "REQUIRED int32 maps to integer" \
 		"$(q "SELECT data_type FROM pgcolumnar.parquet_schema('$REQ') WHERE column_name='req_i';")" "integer"
+
+	# ---- field IDs (#388 step 2) ---------------------------------------------
+	# Iceberg selects columns by SchemaElement field_id (thrift field 9), which
+	# this reader used to skip. parquet_schema now reports it, with pyarrow as
+	# the independent writer: ids deliberately out of order and disjoint from
+	# the positional indices, so a reader that fabricated ids from position
+	# could not pass. A file written WITHOUT ids reports NULL, never 0: 0 is a
+	# legal field id, so absence must be distinguishable from it.
+	FID="$PGC_WORKDIR/fieldids.parquet"
+	python3 - "$FID" <<'PY'
+import sys, pyarrow as pa, pyarrow.parquet as pq
+schema = pa.schema([
+    pa.field("alpha", pa.int32(), metadata={b"PARQUET:field_id": b"7"}),
+    pa.field("beta", pa.string(), metadata={b"PARQUET:field_id": b"3"}),
+    pa.field("gamma", pa.float64(), metadata={b"PARQUET:field_id": b"12"}),
+])
+tbl = pa.table({"alpha": pa.array([1], pa.int32()),
+                "beta": pa.array(["x"], pa.string()),
+                "gamma": pa.array([1.5], pa.float64())}, schema=schema)
+pq.write_table(tbl, sys.argv[1])
+PY
+	check "premise: pyarrow wrote the field-id file" \
+		"$([ -s "$FID" ] && echo yes)" "yes"
+	check "field ids report as written, in schema order" \
+		"$(q "SELECT string_agg(field_id::text, ',' ORDER BY ord) FROM (SELECT field_id, row_number() OVER () AS ord FROM pgcolumnar.parquet_schema('$FID')) s;")" \
+		"7,3,12"
+	check "a file without field ids reports NULL, not zero" \
+		"$(q "SELECT count(*) FILTER (WHERE field_id IS NULL) || '/' || count(*) FROM pgcolumnar.parquet_schema('$REQ');")" \
+		"2/2"
 else
-	echo "SKIP  pyarrow not available; REQUIRED-column nullable check skipped"
+	echo "SKIP  pyarrow not available; REQUIRED-column and field-id checks skipped"
 fi
 
 pgc_summary

--- a/test/parquet_corpus.py
+++ b/test/parquet_corpus.py
@@ -110,6 +110,17 @@ def main():
     # --- an empty file still has a footer and a schema to walk.
     w(outdir, "empty", pa.table({"a": pa.array([], pa.int32())}))
 
+    # --- SchemaElement.field_id (thrift field 9, #388): the footer parse now
+    # consumes it instead of skipping, so the mutator must get to bend a footer
+    # that actually carries one.
+    w(outdir, "field_ids", pa.table(
+        {"a": pa.array(range(n), pa.int32()),
+         "b": pa.array([str(i) for i in range(n)], pa.string())},
+        schema=pa.schema([
+            pa.field("a", pa.int32(), metadata={b"PARQUET:field_id": b"7"}),
+            pa.field("b", pa.string(), metadata={b"PARQUET:field_id": b"0"}),
+        ])))
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Step 2 of the #388 phase order (@ChronicallyJD's), scoped per my correction on the issue: binding is positional, so there is no name-lookup to replace, and resolution-by-id waits for its Iceberg caller — an unused resolution API today would be dead code by the delete-and-stay-green standard.

## What lands

- `parse_schema_element` consumes **thrift field 9** into `PqSchemaCol.field_id` (−1 sentinel: 0 is a legal id, absence must be distinguishable).
- `pgcolumnar.parquet_schema()` gains a **`field_id` column** — the id as written, NULL when absent. This is the observable consumer that keeps the parse removal-provable.
- A **fuzz-corpus seed with field ids** (including id 0), so the mutator bends footers that actually carry field 9.

## Proofs

- RED-first: both new arms failed on main (no such column).
- The ids arm uses pyarrow as the independent writer with ids **out of order and disjoint from positions** (7, 3, 12) — a reader fabricating ids from position cannot pass.
- Removal proof run: disabling the case-9 arm reds the written-ids arm (`got [] want [7,3,12]`) while the NULL arm rightly stays green.

## Verification

`native_parquet_schema` 35/35 on PG17 (my lane), PG18, PG19. Eight-suite parquet family unregressed (fdw, projection, pushdown, units, read_parquet, import, export, fuzz). ASAN+UBSAN gate passes `native_parquet_schema` **and `fuzz_parquet`** over the new seed. `-Wshadow -Werror` clean.

Signature note: `parquet_schema`'s RETURNS TABLE gains the column in the base script per the alpha convention; no C symbol changes, so the extension-upgrade surface is untouched.

With this, your step 1 (Avro) has the Parquet-side id plumbed and observable whenever the filesystem-catalog reader (phase step 3) wants to project by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)