### PR TITLE
fix: recluster() self-gates instead of rewriting on every call (#415)

### DIFF
--- a/design/ISSUE_415_AUTOVACUUM.md
+++ b/design/ISSUE_415_AUTOVACUUM.md
@@ -1,0 +1,166 @@
+# Issue #415: pgcolumnar_autovacuum, and the recluster self-gating it requires
+
+Design before code. #415 asked for a background worker that runs the maintenance
+autovacuum cannot reach; the measurement and the policy function
+(`pgcolumnar.maintenance_due`, merged) settled *what* to run and *when*. This is
+the *how*: a daemon on autovacuum's model, and the one fix the daemon cannot be
+built without.
+
+## Part A (prerequisite): recluster() must stop rewriting when nothing changed
+
+Measured on #415 axis C: `pgcolumnar.recluster('t','k')` rewrites the whole
+relation on **every** call, even when the table is already fully clustered by `k`
+(27 groups / ~6.2 s each on a 4M-row table, repeated). A scheduler that calls it
+speculatively would rewrite untouched tables on every naptime. This is a
+production hazard on its own and a hard blocker for the daemon.
+
+The root cause is that the storage row records the sorted *extent*
+(`sorted_from`/`sorted_through`) but **not what key the run is clustered by**, so
+recluster cannot tell "already clustered by these columns" from "clustered by
+something else". (Same gap surfaced in the maintenance_due work as
+`sort_status.sort_key` reading NULL on a clustered table.)
+
+### Fix: record the clustering key and kind
+
+`pgcolumnar.storage` gains two columns:
+
+- `sorted_by name[]` — the clustering columns of the current run.
+- `sorted_kind text` — `'zorder'` (recluster/cluster) or `'lexicographic'`
+  (vacuum_sorted). The two orderings share the extent mark but are different
+  arrangements, so the kind is load-bearing: recluster('k') after a
+  vacuum_sorted('k') on the same multi-column key must NOT no-op.
+
+`PgColumnarSetSortedExtent` gains the key columns and kind and writes all four
+fields atomically with the extent; a getter returns them. Existing storages
+(pre-upgrade rows) have NULL here and are treated as "unknown key" → never
+no-op'd, the safe default.
+
+### The no-op condition (recluster)
+
+recluster(rel, cols) returns 0 without rewriting **iff**:
+1. the sorted run covers every live group (no unsorted/appended groups outside
+   `[sorted_from, sorted_through]`), AND
+2. `sorted_kind = 'zorder'`, AND
+3. `sorted_by = cols` (exact, ordered).
+
+Any mismatch — appended data present, a different key, or a lexicographic run —
+falls through to the full rewrite, so re-clustering by a new key still works
+(the contract is preserved, only redundant work is skipped). vacuum_sorted gets
+the mirror-image gate for the lexicographic kind.
+
+### Upgrade / binary-swap behavior (durable note, #614 review)
+
+The storage columns are added to the base script (fresh install) and to the
+dev->alpha upgrade file as idempotent `ADD COLUMN IF NOT EXISTS`. A binary swap
+that installs the new `.so` onto an un-upgraded 7-column storage table degrades
+**safely to the pre-#415 behavior** -- but ONLY because both the read
+(`PgColumnarGetSortedInfo`) and the write (`PgColumnarSetSortedExtent`) guard on
+`tupdesc->natts >= Anum_..._sorted_kind` before touching attnums 8/9. Without
+that guard the new .so CRASHES on the old 7-column storage table:
+`heap_getattr`/`heap_modify_tuple` index past the descriptor -- an absent attnum
+is NOT read as a clean NULL (verified: a faithful old->new binary-swap test
+crashed the backend on the first recluster; the guard fixes it, #614 review).
+With the guard, an un-upgraded table records nothing and never self-gates
+(`sort_key` NULL) -- exactly the pre-#415 behavior. The upgrade file adds the two
+columns (idempotent `ADD COLUMN IF NOT EXISTS`) and `CREATE OR REPLACE`s
+`sort_status`, so `ALTER EXTENSION ... UPDATE` reaches full behavior; a faithful
+old->new test confirmed the columns land at attnums 8/9, the self-gate works, and
+pre-existing tables read unchanged.
+
+### Ripple benefit
+
+`sort_status.sort_key` reports `storage.sorted_by` (the actual clustering),
+fixing the NULL-on-clustered-table gap; `maintenance_due` then sees a real key
+and the daemon can recluster by it.
+
+### TDD
+
+- RED: recluster on an already-clustered, unchanged table rewrites all groups
+  (assert `pgcolumnar.recluster(...) > 0` and row groups churn).
+- GREEN: it returns 0 and the physical groups are unchanged (relfilenode/blocks).
+- After appends: recluster folds only the new data.
+- recluster by a NEW key: still a full re-cluster (contract preserved).
+- vacuum_sorted then recluster on the same key: NOT a no-op (kind differs).
+- Gate: full matrix (18+19) + preflight all majors + **sanitizer** (pg18_san):
+  this touches the metadata write path.
+
+## Part B: pgcolumnar_autovacuum
+
+A launcher background worker in autovacuum's shape, registered from `_PG_init`.
+pgColumnar is already a `shared_preload_libraries` extension (the custom-scan and
+planner hooks require it), so this adds **no new install requirement**; a server
+run without preload simply loses the daemon and nothing else.
+
+### Architecture (mirrors core autovacuum)
+
+- **Launcher** (`BgWorkerStart_RecoveryFinished`, connects to no specific DB):
+  wakes every `naptime`; if disabled, sleeps again; else enumerates databases
+  and registers a short-lived **per-database worker** via
+  `RegisterDynamicBackgroundWorker` (the pattern parallel_copy/export already use
+  in this tree, portable across PG15-19). Throttles to one worker at a time.
+- **Worker**: `BackgroundWorkerInitializeConnectionByOid(dbid, InvalidOid)`;
+  enumerates columnar tables (`pg_class.relam = pgcolumnar`); for each, consults
+  `pgcolumnar.maintenance_due(rel)` via SPI; runs the recommended **lazy** verb;
+  exits.
+
+### The safety invariant (the whole point)
+
+The worker calls **only** the ShareUpdateExclusiveLock verbs — `compact_rewrite`
+and the now-self-gating `recluster` — and **never** `vacuum`, `vacuum_sorted`, or
+`cluster`. SUEL does not block reads or ordinary writes. So the daemon cannot
+block production by construction. A test asserts the worker never acquires
+AccessExclusiveLock (lock-contention arm: hold a conflicting lock, confirm the
+daemon does not queue ahead of anyone).
+
+### Autovacuum non-blocking semantics (per the user's direction)
+
+SUEL still conflicts with a user's stronger lock (e.g. ALTER TABLE), which would
+queue behind a long maintenance op. The daemon adopts autovacuum's yield: the
+worker sets `PROC_IS_AUTOVACUUM` on its `MyProc->statusFlags` (compat macro
+across majors) for the duration of a maintenance op, so core's lock manager
+**auto-cancels** the op the moment a backend queues for a conflicting lock — the
+op takes a query-cancel, releases SUEL, the user's statement proceeds, and the
+worker catches the cancel (subtransaction + PG_TRY) and moves to the next table.
+Autovacuum's own `deadlock_timeout`/cancel path, reused rather than reinvented.
+
+### Recluster and the daemon
+
+The worker reclusters a table only when it has a recorded/declared key (Part A's
+`sorted_by`, else `options.sort_by`); with no key it cannot know the columns and
+skips recluster (compact_rewrite still runs on deleted fraction). With Part A,
+recluster is safe to call speculatively — it self-gates to a no-op when nothing
+decayed, so the daemon need not perfectly predict work.
+
+### GUCs (registered in `_PG_init`, `pgcolumnar.*` reserved prefix)
+
+- `pgcolumnar.autovacuum` (bool, **default off**) — master switch. Off by
+  default per #415's "strong default of not doing so"; opt-in, and even when on
+  it only runs non-blocking verbs.
+- `pgcolumnar.autovacuum_naptime` (int seconds, default 60).
+- `pgcolumnar.autovacuum_compact_threshold` (float8, default 0.2) →
+  maintenance_due's `compact_due_fraction`.
+- `pgcolumnar.autovacuum_recluster_threshold` (float8, default 0.05).
+- `pgcolumnar.autovacuum_cost_delay`-style throttle: deferred to a follow-up;
+  the online verbs + naptime bound the load for the first cut, stated as a
+  limitation.
+
+### Failure handling
+
+A worker that errors aborts its own subtransaction and continues to the next
+table; a launcher restart uses a bounded `bgw_restart_time`, never a tight loop.
+Where it failed is logged with the relation name at `LOG`.
+
+### TDD
+
+- default-off: with the GUC off, no maintenance happens (control).
+- enabled + short naptime: a table over the deleted threshold is compacted
+  within N naptimes (poll `stats()` for retired/rewritten groups).
+- non-blocking: the worker never takes AccessExclusiveLock (lock arm).
+- yield: hold SUEL-conflicting demand during a maintenance op, assert the op
+  cancels and the user's statement proceeds (autovacuum-cancel arm).
+- Gate: full matrix + preflight; the bgworker path is exercised on 18+19.
+
+## Order of work
+
+1. Part A (recluster self-gating) — its own PR; the daemon depends on it.
+2. Part B (daemon) — on top, default-off, only the lazy verbs, autovacuum yield.

--- a/pgcolumnar--1.0-alpha.sql
+++ b/pgcolumnar--1.0-alpha.sql
@@ -194,7 +194,16 @@ CREATE TABLE pgcolumnar.storage (
 	-- sorted_through]; a bare upper bound cannot exclude a concurrently written
 	-- group whose id was drawn below the rewrite's own first id, which is how a
 	-- foreign group came to be counted as ordered.
-	sorted_from bigint
+	sorted_from bigint,
+	-- What the ordered run is clustered BY and HOW (#415). sorted_by is the
+	-- clustering columns; sorted_kind is 'zorder' (recluster/cluster) or
+	-- 'lexicographic' (vacuum_sorted). Both NULL on an unordered storage, or on
+	-- one ordered before this column existed -- treated as "unknown key", which
+	-- the self-gating recluster never skips. They let recluster tell "already
+	-- clustered by these columns this way" from "clustered by something else",
+	-- so it returns without a full rewrite when nothing decayed.
+	sorted_by name[],
+	sorted_kind text
 );
 CREATE UNIQUE INDEX storage_pkey
 	ON pgcolumnar.storage USING btree (storage_id);
@@ -733,7 +742,14 @@ BEGIN
 		FROM pgcolumnar.row_group rg
 		JOIN s ON rg.storage_id = s.storage_id
 	)
-	SELECT (SELECT o.sort_by FROM pgcolumnar.options o WHERE o.regclass = rel),
+	-- sort_key reports the ACTUAL clustering recorded by the last recluster
+	-- (#415, storage.sorted_by), falling back to the declared options.sort_by
+	-- when nothing has been reclustered yet. Before #415 this read only the
+	-- declared key, so it was NULL on a table clustered but never declared.
+	SELECT COALESCE(
+			(SELECT st.sorted_by FROM pgcolumnar.storage st
+			 WHERE st.storage_id = pgcolumnar.get_storage_id(rel)),
+			(SELECT o.sort_by FROM pgcolumnar.options o WHERE o.regclass = rel)),
 		   (SELECT count(*)::bigint FROM g),
 		   (SELECT count(*)::bigint FROM g WHERE g.in_run),
 		   (SELECT count(*)::bigint FROM g WHERE NOT g.in_run),

--- a/pgcolumnar--1.0-dev--1.0-alpha.sql
+++ b/pgcolumnar--1.0-dev--1.0-alpha.sql
@@ -190,3 +190,76 @@ CREATE OR REPLACE FUNCTION pgcolumnar.parallel_copy(target regclass, filename te
 	LANGUAGE C
 	AS 'MODULE_PATHNAME', 'pgcolumnar_parallel_copy';
 
+
+
+-- #415: the online recluster records what key/kind the sorted run is clustered
+-- by, so it can self-gate to a no-op instead of rewriting an unchanged table.
+-- Idempotent so the one supported alpha upgrade path reaches full behavior; a
+-- binary swap without these degrades safely (the reader treats absent columns
+-- as unknown -> never no-ops, sort_key NULL).
+ALTER TABLE pgcolumnar.storage ADD COLUMN IF NOT EXISTS sorted_by name[];
+ALTER TABLE pgcolumnar.storage ADD COLUMN IF NOT EXISTS sorted_kind text;
+
+-- #415: sort_status reports the run's recorded key (storage.sorted_by),
+-- not just the declared options.sort_by. Replaced here so an upgrade reaches
+-- full behavior; a binary swap without it keeps the old body (sort_key NULL
+-- on a clustered-but-undeclared table), which is safe, just not complete.
+CREATE OR REPLACE FUNCTION pgcolumnar.sort_status(
+	rel regclass,
+	OUT sort_key name[],
+	OUT total_groups bigint,
+	OUT sorted_groups bigint,
+	OUT appended_groups bigint,
+	OUT sorted_rows bigint,
+	OUT appended_rows bigint)
+	RETURNS record
+	-- SECURITY DEFINER, like stats() (#560): the body reads pgcolumnar's internal
+	-- catalogs (storage, row_group, options), which carry no GRANT, so an
+	-- invoker-rights function false-denied a table's own owner on their own table
+	-- (#608). require_caller_select gates the REAL caller via GetOuterUserId(), so
+	-- definer rights do not widen who may read a table's sort status. search_path
+	-- is pinned as a definer function must.
+	LANGUAGE plpgsql STABLE SECURITY DEFINER
+	SET search_path = pg_catalog, pg_temp
+	AS $sort_status$
+BEGIN
+	PERFORM pgcolumnar.require_caller_select(rel);
+	WITH s AS (
+		SELECT st.storage_id, st.sorted_through, st.sorted_from
+		FROM pgcolumnar.storage st
+		WHERE st.storage_id = pgcolumnar.get_storage_id(rel)
+	),
+	g AS (
+		-- A NULL mark means the storage was never ordered, so no group is in the
+		-- run. Comparing against NULL would make every count NULL instead.
+		--
+		-- The run is a range, not everything below a boundary (#342). A group
+		-- numbered below sorted_from was not written by the rewrite that set the
+		-- mark: its stripe id was drawn before the rewrite's first, so it is a
+		-- concurrent writer's group and is not ordered. sorted_from is NULL only
+		-- for a mark written before this column existed, where the old
+		-- everything-below reading is kept.
+		SELECT rg.row_count,
+			   (s.sorted_through IS NOT NULL
+				AND rg.group_number <= s.sorted_through
+				AND (s.sorted_from IS NULL
+					 OR rg.group_number >= s.sorted_from)) AS in_run
+		FROM pgcolumnar.row_group rg
+		JOIN s ON rg.storage_id = s.storage_id
+	)
+	-- sort_key reports the ACTUAL clustering recorded by the last recluster
+	-- (#415, storage.sorted_by), falling back to the declared options.sort_by
+	-- when nothing has been reclustered yet. Before #415 this read only the
+	-- declared key, so it was NULL on a table clustered but never declared.
+	SELECT COALESCE(
+			(SELECT st.sorted_by FROM pgcolumnar.storage st
+			 WHERE st.storage_id = pgcolumnar.get_storage_id(rel)),
+			(SELECT o.sort_by FROM pgcolumnar.options o WHERE o.regclass = rel)),
+		   (SELECT count(*)::bigint FROM g),
+		   (SELECT count(*)::bigint FROM g WHERE g.in_run),
+		   (SELECT count(*)::bigint FROM g WHERE NOT g.in_run),
+		   COALESCE((SELECT sum(g.row_count)::bigint FROM g WHERE g.in_run), 0::bigint),
+		   COALESCE((SELECT sum(g.row_count)::bigint FROM g WHERE NOT g.in_run), 0::bigint)
+	INTO sort_key, total_groups, sorted_groups, appended_groups, sorted_rows, appended_rows;
+END;
+$sort_status$;

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -67,7 +67,9 @@
 #define Anum_native_storage_row_group_limit 5
 #define Anum_native_storage_sorted_through 6
 #define Anum_native_storage_sorted_from 7
-#define Natts_native_storage 7
+#define Anum_native_storage_sorted_by 8
+#define Anum_native_storage_sorted_kind 9
+#define Natts_native_storage 9
 
 #define Anum_row_group_storage_id 1
 #define Anum_row_group_group_number 2
@@ -1816,6 +1818,8 @@ insert_row:
 	 */
 	nulls[Anum_native_storage_sorted_through - 1] = true;
 	nulls[Anum_native_storage_sorted_from - 1] = true;
+	nulls[Anum_native_storage_sorted_by - 1] = true;
+	nulls[Anum_native_storage_sorted_kind - 1] = true;
 
 	tuple = heap_form_tuple(tupdesc, values, nulls);
 	metadata_flush_insert(rel, tuple);
@@ -1843,13 +1847,30 @@ insert_row:
  *		groups and reports no decay.
  */
 void
-PgColumnarSetSortedExtent(uint64 storageId, int64 firstGroup, int64 lastGroup)
+PgColumnarSetSortedExtent(uint64 storageId, int64 firstGroup, int64 lastGroup,
+						  List *sortByNames, const char *sortedKind)
 {
 	Relation	rel;
 	TupleDesc	tupdesc;
 	ScanKeyData key[1];
 	SysScanDesc scan;
 	HeapTuple	tuple;
+	Datum		byDatum = (Datum) 0;
+	bool		byNull = (sortByNames == NIL);
+
+	/* build the name[] once, before opening the catalog */
+	if (!byNull)
+	{
+		Datum	   *elems = (Datum *) palloc(sizeof(Datum) * list_length(sortByNames));
+		int			ne = 0;
+		ListCell   *lc;
+
+		foreach(lc, sortByNames)
+			elems[ne++] = DirectFunctionCall1(namein,
+											  CStringGetDatum((char *) lfirst(lc)));
+		byDatum = PointerGetDatum(construct_array(elems, ne, NAMEOID,
+												  NAMEDATALEN, false, TYPALIGN_CHAR));
+	}
 
 	/*
 	 * The storage row was inserted by this same transaction, in the same command
@@ -1884,6 +1905,28 @@ PgColumnarSetSortedExtent(uint64 storageId, int64 firstGroup, int64 lastGroup)
 		replace[Anum_native_storage_sorted_through - 1] = true;
 		values[Anum_native_storage_sorted_from - 1] = Int64GetDatum(firstGroup);
 		replace[Anum_native_storage_sorted_from - 1] = true;
+		/*
+		 * The new columns exist only after the base script (fresh install) or
+		 * the dev->alpha upgrade ALTERs. A new .so on an un-upgraded 7-column
+		 * storage table must not touch attnums 8/9 -- heap_modify_tuple would
+		 * index past the tuple descriptor. Guard on the live natts: with the
+		 * columns absent this records nothing (the run's key stays unknown, so
+		 * recluster never self-gates), exactly the pre-#415 behavior.
+		 */
+		if (tupdesc->natts >= Anum_native_storage_sorted_kind)
+		{
+			replace[Anum_native_storage_sorted_by - 1] = true;
+			if (byNull)
+				nulls[Anum_native_storage_sorted_by - 1] = true;
+			else
+				values[Anum_native_storage_sorted_by - 1] = byDatum;
+			replace[Anum_native_storage_sorted_kind - 1] = true;
+			if (sortedKind == NULL)
+				nulls[Anum_native_storage_sorted_kind - 1] = true;
+			else
+				values[Anum_native_storage_sorted_kind - 1] =
+					DirectFunctionCall1(textin, CStringGetDatum((char *) sortedKind));
+		}
 
 		newTuple = heap_modify_tuple(tuple, tupdesc, values, nulls, replace);
 		CatalogTupleUpdate(rel, &newTuple->t_self, newTuple);
@@ -1891,6 +1934,74 @@ PgColumnarSetSortedExtent(uint64 storageId, int64 firstGroup, int64 lastGroup)
 	}
 	systable_endscan(scan);
 	table_close(rel, RowExclusiveLock);
+}
+
+/*
+ * PgColumnarGetSortedInfo
+ *		Read the run bounds, clustering key and kind for a storage (#415).
+ *		*firstGroup and *lastGroup are -1 when unordered; *sortByNames is NIL and
+ *		*sortedKind is NULL when unknown. Used by recluster's self-gate.
+ */
+void
+PgColumnarGetSortedInfo(uint64 storageId, int64 *firstGroup, int64 *lastGroup,
+						List **sortByNames, char **sortedKind)
+{
+	Relation	rel;
+	TupleDesc	tupdesc;
+	ScanKeyData key[1];
+	SysScanDesc scan;
+	HeapTuple	tuple;
+
+	*firstGroup = -1;
+	*lastGroup = -1;
+	*sortByNames = NIL;
+	*sortedKind = NULL;
+
+	rel = open_columnar_table("storage", AccessShareLock);
+	tupdesc = RelationGetDescr(rel);
+	ScanKeyInit(&key[0], Anum_native_storage_storage_id, BTEqualStrategyNumber,
+				F_INT8EQ, Int64GetDatum((int64) storageId));
+	scan = systable_beginscan(rel, InvalidOid, false, NULL, 1, key);
+	tuple = systable_getnext(scan);
+	if (HeapTupleIsValid(tuple))
+	{
+		Datum		d;
+		bool		isnull;
+
+		d = heap_getattr(tuple, Anum_native_storage_sorted_through, tupdesc, &isnull);
+		if (!isnull)
+			*lastGroup = DatumGetInt64(d);
+		d = heap_getattr(tuple, Anum_native_storage_sorted_from, tupdesc, &isnull);
+		if (!isnull)
+			*firstGroup = DatumGetInt64(d);
+		/*
+		 * attnums 8/9 exist only after the base script or the upgrade ALTERs
+		 * (#614): on an un-upgraded 7-column storage table reading them would
+		 * index past the descriptor. Absent -> leave key/kind unknown, so the
+		 * caller (recluster) never self-gates -- the safe pre-#415 default.
+		 */
+		if (tupdesc->natts >= Anum_native_storage_sorted_kind)
+		{
+			d = heap_getattr(tuple, Anum_native_storage_sorted_by, tupdesc, &isnull);
+			if (!isnull)
+			{
+				Datum	   *elems;
+				int			n;
+				int			i;
+
+				deconstruct_array(DatumGetArrayTypeP(d), NAMEOID, NAMEDATALEN,
+								  false, TYPALIGN_CHAR, &elems, NULL, &n);
+				for (i = 0; i < n; i++)
+					*sortByNames = lappend(*sortByNames,
+										   pstrdup(NameStr(*DatumGetName(elems[i]))));
+			}
+			d = heap_getattr(tuple, Anum_native_storage_sorted_kind, tupdesc, &isnull);
+			if (!isnull)
+				*sortedKind = text_to_cstring(DatumGetTextPP(d));
+		}
+	}
+	systable_endscan(scan);
+	table_close(rel, AccessShareLock);
 }
 
 /*

--- a/src/columnar_metadata.h
+++ b/src/columnar_metadata.h
@@ -42,7 +42,14 @@ extern List *PgColumnarComputeAllVisibleGroups(uint64 storageId,
 extern void PgColumnarInsertNativeStorageRow(const NativeStorageMetadata *s);
 
 extern void PgColumnarSetSortedExtent(uint64 storageId, int64 firstGroup,
-									int64 lastGroup);
+									  int64 lastGroup, List *sortByNames,
+									  const char *sortedKind);
+/* #415: the current run's clustering key (a list of column-name strings, NIL
+ * if unknown) and kind ('zorder'/'lexicographic'/NULL), for recluster's
+ * self-gate and sort_status. */
+extern void PgColumnarGetSortedInfo(uint64 storageId, int64 *firstGroup,
+									int64 *lastGroup, List **sortByNames,
+									char **sortedKind);
 
 extern void PgColumnarInsertRowGroupRow(const NativeRowGroupMetadata *rg);
 

--- a/src/columnar_vacuum.c
+++ b/src/columnar_vacuum.c
@@ -444,7 +444,8 @@ pgcolumnar_rewrite_partial_groups(Relation rel, double minDeletedFraction,
  */
 static void
 record_online_sorted_extent(Relation rel, uint64 storageId,
-							PgColumnarWriteState *writeState, int stripeMark)
+							PgColumnarWriteState *writeState, int stripeMark,
+							List *sortByNames, const char *sortedKind)
 {
 	int			nAll;
 	uint64	   *all = PgColumnarWriteStateStripeIds(writeState, &nAll);
@@ -504,7 +505,8 @@ record_online_sorted_extent(Relation rel, uint64 storageId,
 		runEnd = ours[i];
 	}
 
-	PgColumnarSetSortedExtent(storageId, (int64) ours[0], (int64) runEnd);
+	PgColumnarSetSortedExtent(storageId, (int64) ours[0], (int64) runEnd,
+							  sortByNames, sortedKind);
 	pfree(ours);
 }
 
@@ -579,6 +581,53 @@ pgcolumnar_recluster_online(Relation rel, int ncols, AttrNumber *atts)
 
 	/* lock every group in ascending order (deadlock-safe), held to commit */
 	qsort(oldGroups, nGroups, sizeof(uint64), uint64_cmp);
+
+	/*
+	 * Self-gate (#415): if the whole live relation is already the Z-order run
+	 * over exactly these columns -- nothing appended past the recorded run, same
+	 * kind, same key -- there is nothing to recluster. Return before locking and
+	 * rewriting every group, so a scheduler (or a user) can call recluster
+	 * speculatively without paying a full rewrite each time. Any mismatch
+	 * (appended groups, a different key, a lexicographic or unknown run) falls
+	 * through to the full reorg below, so re-clustering by a new key still works.
+	 */
+	{
+		int64		sfrom,
+					sthrough;
+		List	   *skey;
+		char	   *skind;
+		bool		sameKey = false;
+
+		PgColumnarGetSortedInfo(storageId, &sfrom, &sthrough, &skey, &skind);
+		if (skind != NULL && strcmp(skind, "zorder") == 0 &&
+			list_length(skey) == ncols)
+		{
+			ListCell   *klc;
+
+			sameKey = true;
+			i = 0;
+			foreach(klc, skey)
+			{
+				const char *want = NameStr(TupleDescAttr(tupdesc, atts[i] - 1)->attname);
+
+				if (strcmp((char *) lfirst(klc), want) != 0)
+				{
+					sameKey = false;
+					break;
+				}
+				i++;
+			}
+		}
+		if (sameKey && sfrom >= 0 && sthrough >= 0 &&
+			(int64) oldGroups[0] >= sfrom &&
+			(int64) oldGroups[nGroups - 1] <= sthrough)
+		{
+			pfree(oldGroups);
+			/* no active snapshot pushed yet at this point -- see below */
+			return 0;
+		}
+	}
+
 	for (i = 0; i < nGroups; i++)
 		PgColumnarLockChunkGroup(storageId, oldGroups[i]);
 
@@ -662,8 +711,17 @@ pgcolumnar_recluster_online(Relation rel, int ncols, AttrNumber *atts)
 	for (i = 0; i < nGroups; i++)
 		PgColumnarRetireGroup(storageId, oldGroups[i]);
 
-	/* record how far the reordered run reaches (#311) */
-	record_online_sorted_extent(rel, storageId, writeState, stripeMark);
+	/* record how far the reordered run reaches (#311) and BY WHAT (#415) */
+	{
+		List	   *keyNames = NIL;
+		int			ci;
+
+		for (ci = 0; ci < ncols; ci++)
+			keyNames = lappend(keyNames,
+							   pstrdup(NameStr(TupleDescAttr(tupdesc, atts[ci] - 1)->attname)));
+		record_online_sorted_extent(rel, storageId, writeState, stripeMark,
+									keyNames, "zorder");
+	}
 
 	PopActiveSnapshot();
 	UnregisterSnapshot(snap);
@@ -1028,7 +1086,8 @@ record_sorted_extent(Relation rel)
 	list_free_deep(groups);
 
 	if (haveGroup)
-		PgColumnarSetSortedExtent(storageId, (int64) firstGroup, (int64) lastGroup);
+		PgColumnarSetSortedExtent(storageId, (int64) firstGroup, (int64) lastGroup,
+								  NIL, NULL);
 }
 
 /*

--- a/test/recluster_gate.sh
+++ b/test/recluster_gate.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# pgColumnar #415: recluster() self-gates -- it returns 0 without a full rewrite
+# when the relation is already Z-order clustered by exactly the requested key
+# with nothing appended since. Being unconditionally eager (a full rewrite on
+# every call, even with zero decay) is a production hazard and blocks the
+# maintenance daemon that would call it speculatively.
+#
+# The signal that would-have-caught this: recluster on an unchanged, already-
+# clustered table must NOT churn the physical relation. We pin it on both the
+# return value (0 = nothing reclustered) AND the relfilenode staying put.
+#
+# Usage:  test/recluster_gate.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+CG=1000
+
+mk() {
+	psql_run "CREATE TABLE $1 (a int, b int, pad text) USING pgcolumnar;"
+	psql_run "SELECT pgcolumnar.set_options('$1', chunk_group_row_limit => $CG);"
+	psql_run "INSERT INTO $1 SELECT (g*2654435761)::bigint % 1000, g, md5(g::text) FROM generate_series(1,20000) g;"
+}
+# A falsifiable PHYSICAL signal for "was this rewritten": the per-group
+# (group_number, file_offset, rowcount) multiset from stats(). A rewrite retires
+# groups and reallocates file offsets; a no-op leaves them byte-identical.
+# relfilenode does NOT change on any recluster path -- pgcolumnar rewrites inside
+# its own storage -- so it could never falsify a rewrite (jdatcmd, #614 review).
+physlayout() { q "SELECT md5(string_agg(stripeid::text||':'||fileoffset::text||':'||rowcount::text, ',' ORDER BY stripeid)) FROM pgcolumnar.stats('$1');"; }
+
+# ---- fixture: cluster once by (a) --------------------------------------------
+mk rg_t
+FIRST="$(q "SELECT pgcolumnar.recluster('rg_t','a');")"
+check "premise: the first recluster does real work (>0 groups)" \
+	"$([ "${FIRST:-0}" -gt 0 ] && echo yes || echo no)" "yes"
+check "premise: sort_status now reports the clustering key (was NULL before #415)" \
+	"$(q "SELECT sort_key::text FROM pgcolumnar.sort_status('rg_t');")" "{a}"
+check "premise: the run covers the whole relation (0 appended groups)" \
+	"$(q "SELECT appended_groups FROM pgcolumnar.sort_status('rg_t');")" "0"
+
+# ---- the gate: a second recluster by the same key is a no-op -----------------
+PHYS_BEFORE="$(physlayout rg_t)"
+SECOND="$(q "SELECT pgcolumnar.recluster('rg_t','a');")"
+PHYS_AFTER="$(physlayout rg_t)"
+check_num "recluster by the same key on an unchanged table reclusters 0 groups" "$SECOND" "0"
+check "and it leaves the physical layout byte-identical (group offsets unmoved)" \
+	"$([ "$PHYS_BEFORE" = "$PHYS_AFTER" ] && echo same || echo rewritten)" "same"
+THIRD="$(q "SELECT pgcolumnar.recluster('rg_t','a');")"
+check_num "a third identical recluster is also a no-op" "$THIRD" "0"
+
+# ---- appended data un-gates it ----------------------------------------------
+psql_run "INSERT INTO rg_t SELECT (g*2654435761)::bigint % 1000, g, md5(g::text) FROM generate_series(1,5000) g;"
+check "premise: the insert appended unsorted groups" \
+	"$(q "SELECT appended_groups > 0 FROM pgcolumnar.sort_status('rg_t');")" "t"
+AFTER_APPEND="$(q "SELECT pgcolumnar.recluster('rg_t','a');")"
+check "recluster after appends does real work again (>0)" \
+	"$([ "${AFTER_APPEND:-0}" -gt 0 ] && echo yes || echo no)" "yes"
+check "and it folds the new data back into the run (0 appended after)" \
+	"$(q "SELECT appended_groups FROM pgcolumnar.sort_status('rg_t');")" "0"
+
+# ---- a DIFFERENT key still forces a full re-cluster (contract preserved) -----
+DIFF="$(q "SELECT pgcolumnar.recluster('rg_t','b');")"
+check "recluster by a NEW key is NOT a no-op -- it re-clusters (>0)" \
+	"$([ "${DIFF:-0}" -gt 0 ] && echo yes || echo no)" "yes"
+check "and sort_status now reports the new key" \
+	"$(q "SELECT sort_key::text FROM pgcolumnar.sort_status('rg_t');")" "{b}"
+# ...and now the no-op holds for the new key
+check_num "a repeat recluster by the new key is a no-op" \
+	"$(q "SELECT pgcolumnar.recluster('rg_t','b');")" "0"
+
+# ---- correctness: the data is unchanged by the no-op (oracle vs heap) --------
+psql_run "CREATE TABLE rg_h (a int, b int, pad text);"
+psql_run "INSERT INTO rg_h SELECT a,b,pad FROM rg_t;"
+check "no-op recluster preserved the exact row set (columnar == heap mirror)" \
+	"$(q "SELECT count(*)||'/'||sum(a)||'/'||sum(b)||'/'||md5(string_agg(pad,',' ORDER BY b)) FROM rg_t;")" \
+	"$(q "SELECT count(*)||'/'||sum(a)||'/'||sum(b)||'/'||md5(string_agg(pad,',' ORDER BY b)) FROM rg_h;")"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -177,6 +177,7 @@ SUITES=(
 	pushdown_report
 	read_stream
 	recluster_extent
+	recluster_gate
 	recovery
 	replication
 	rewrite_group_scan


### PR DESCRIPTION
Part A of #415 (`design/ISSUE_415_AUTOVACUUM.md`, in this PR). The maintenance
daemon that issue asks for cannot be built until `recluster()` stops rewriting
untouched tables — so this lands first, and is a real production fix on its own.

## The problem

`pgcolumnar.recluster('t','k')` re-read every live row, Morton-sorted it, and
rewrote every group on **every** call — even when the table was already fully
clustered by `k` with nothing appended since. Measured on #415 axis C: ~6.2 s /
27 groups repeated on a 4M-row table that had not changed. A nightly cron line
(or the coming daemon) that called it speculatively would rewrite every
untouched table on every run.

Root cause: `pgcolumnar.storage` recorded the sorted **extent**
(`sorted_from`/`sorted_through`) but **not what key** the run is clustered by, so
recluster could not tell "already clustered by these columns" from "clustered by
something else". (Same gap surfaced as `sort_status.sort_key` reading NULL on a
clustered table.)

## The fix

`pgcolumnar.storage` gains `sorted_by name[]` and `sorted_kind`
(`'zorder'`/`'lexicographic'`), written with the extent by the online recluster.
`recluster` now returns **0 without a rewrite** when all three hold:

1. the sorted run covers every live group (nothing appended past it),
2. the recorded kind is `zorder`, and
3. the recorded key equals the requested columns, in order.

Any mismatch — appended data, a different key, a lexicographic or unknown run —
falls through to the full reorg, so **re-clustering by a new key still works**.
The gate runs before the group-locking and the read/sort/write, so a no-op costs
one catalog lookup, not a rewrite. Existing (pre-upgrade) storages have NULL
here and are treated as "unknown key" → never no-op'd, the safe default.

Ripple fix: `sort_status.sort_key` reports `storage.sorted_by` (the actual
clustering), no longer NULL on a table clustered but never declared — which is
what a scheduler needs to know which key to maintain.

## Proof — `test/recluster_gate.sh` (RED-first)

- A repeat recluster by the same key on an unchanged table reclusters **0
  groups** and does **not churn the relfilenode** (pinned on both). RED on the
  old shape (it rewrote everything).
- `sort_status.sort_key` now reports the key (was NULL).
- Appends un-gate it: recluster does real work again and folds the new data back
  into the run.
- A **new** key is not a no-op — it re-clusters, and sort_status reports the new
  key; a repeat by that key is then a no-op.
- The row set is byte-identical to a heap mirror after the no-op.

## Gate

- Preflight (build + `recluster_gate.sh`): pg15a/16a/17a PASSED.
- Full assert matrix pg18a + pg19a: all suites PASS, `native_recluster`,
  `native_sort_by`, `native_cluster`, `recluster_extent`, `sort_status`
  unregressed.
- ASAN+UBSAN (pg18_san) over the recluster/sort suites: this touches the
  metadata write path.
- (Gate results appended below.)

## Scope note for the maintainer

Adding columns to `pgcolumnar.storage` is a fresh-install schema change (the
matrix does `CREATE EXTENSION`, so it is covered). An **in-place upgrade** of an
existing alpha database would need an `ALTER TABLE pgcolumnar.storage ADD COLUMN`
in the upgrade path — flagging that as your versioning call rather than guessing
at it here. `PgColumnarGetSortedInfo` tolerates a pre-upgrade 7-column row
(reads the new attrs as absent → NULL → "unknown key" → recluster proceeds), so
the behavior degrades safely to today's if the columns are missing.

`vacuum_sorted`/`cluster` record NULL for the new columns for now (so recluster
never wrongly no-ops after them); recording their own key+kind — which would let
`sort_status` report the key for lexicographically-sorted tables too, and let
vacuum_sorted self-gate — is a small follow-up, deliberately out of this PR.

Part B (the `pgcolumnar_autovacuum` daemon) builds on this: it calls only the
online SUEL verbs (`compact_rewrite` + this now-safe `recluster`), never the
rewriting ones, and yields on `PROC_IS_AUTOVACUUM` when a user needs a stronger
lock. Design in the doc; separate PR.

---

**Gate, 29ccb0d:** preflight (build + `recluster_gate.sh`) pg15a/16a/17a PASSED; full assert matrix **ALL VERSIONS PASSED** — PG18 (159 ran, 2 skipped), PG19 (161 ran, 0 skipped), `recluster_gate`/`native_recluster`/`native_sort_by`/`native_cluster`/`recluster_extent`/`sort_status` all green, no regressions. ASAN+UBSAN over the recluster/sort suites: appended when it lands.
