### PR TITLE
feat: the endpoint allow-list, empty by default (#393)

### DIFF
--- a/design/ISSUE_393_ENDPOINT_ALLOWLIST.md
+++ b/design/ISSUE_393_ENDPOINT_ALLOWLIST.md
@@ -1,0 +1,62 @@
+# Issue #393: the endpoint allow-list, empty by default
+
+Owner-decided 2026-08-13 (recorded on the issue): remote object-storage access
+is gated by `pgcolumnar.objstore_allowed_endpoints`, empty by default, with
+link-local ranges refused unconditionally. This document pins the enforcement
+semantics; the decision itself is not reopened.
+
+## The GUC
+
+- `pgcolumnar.objstore_allowed_endpoints`, string, default `''`, **PGC_SUSET**.
+  Superuser-only is load-bearing, not convention: a USERSET list would let any
+  role widen its own allow-list mid-session, which is the exact privilege the
+  list exists to withhold. Defined by the preloaded library (the module cannot
+  define it: `MarkGUCPrefixReserved` refuses placeholder GUCs, and the module
+  loads after configuration parsing); the module reads it with
+  `GetConfigOption`, so no cross-library symbol exists.
+- Format: comma-separated `host` or `host:port` entries. An entry without a
+  port matches any port on that host; matching is a case-insensitive string
+  comparison against the endpoint host the connection will use (the URL
+  authority, or the resolved `AWS_ENDPOINT_URL`/server-option endpoint for
+  s3://). Entries are what the operator wrote, compared before DNS: the list
+  authorizes names, and pinning games with resolution are handled by the
+  link-local check below, which runs after resolution.
+
+## Enforcement, in the module, on every scheme
+
+1. **Allow-list check before any resolution or connection.** The endpoint
+   host:port not matching any entry is SQLSTATE 42501 naming the GUC. Empty
+   list, empty match: all remote refused. Local paths never consult it.
+2. **Link-local refusal after resolution, unconditional.** If ANY address
+   getaddrinfo returns for the endpoint is in 169.254.0.0/16 or fe80::/10
+   (including v4-mapped forms), the connection is refused 42501 with a message
+   naming the range, whether or not the list contains the entry. Refusing the
+   whole connection, rather than skipping the offending address, prevents a
+   resolver that returns a mixed set from steering the choice. This is the
+   cloud-metadata (IMDS) credential-theft path; it has no legitimate
+   object-storage use. Loopback stays allowed: a trusted-network MinIO on
+   127.0.0.1 is a documented legitimate configuration and every suite uses it.
+
+Order relative to existing errors: credential and endpoint resolution (28000)
+precede the connection, so those messages are unchanged; the allow-list is the
+last gate before the socket.
+
+## Suite: `test/objstore_allowlist.sh`
+
+- RED lead: with the default empty list, http://, https://, and s3:// reads
+  all refuse 42501 naming the GUC (today they succeed).
+- Allowed: `127.0.0.1` entry admits the fixture; a `127.0.0.2` entry does
+  not; `127.0.0.1:<port>` admits only that port, the wrong port refuses.
+- SUSET: a non-superuser SET fails (core's 42501), premise-guarded by the
+  role's own session.
+- Link-local: with `169.254.169.254` explicitly IN the list, a read against
+  it still refuses 42501 before any connection exists (asserted by SQLSTATE:
+  a connect attempt would be 08006 or a timeout).
+- Existing objstore suites gain the conf line
+  (`pgcolumnar.objstore_allowed_endpoints='127.0.0.1'` via PGC_EXTRA_CONF),
+  which doubles as the documented configuration example;
+  objstore_module's remote-error grep accepts the new refusal.
+
+Removal proofs: delete the allow-list check and the deny-by-default arms red;
+delete the link-local check and the IMDS arm reds (whatever a real connect
+attempt produces, it is not 42501-before-connection).

--- a/objstore/columnar_objstore_module.c
+++ b/objstore/columnar_objstore_module.c
@@ -59,6 +59,7 @@
 #include "pgtime.h"
 #include "storage/fd.h"
 #include "storage/latch.h"
+#include "utils/guc.h"
 #include "utils/memutils.h"
 #include "utils/resowner.h"
 #include "utils/wait_event.h"
@@ -256,6 +257,105 @@ os_wait(PgColumnarObjHandle *h, uint32 sockEvents, int *quiet)
 
 /* ---------------------------------------------------------------- connect */
 
+/*
+ * The endpoint allow-list (#393, owner decision 2026-08-13). Empty, the
+ * default, refuses every remote endpoint: pg_read_server_files must not be an
+ * SSRF primitive out of the box. Entries are host or host:port, matched
+ * case-insensitively against the endpoint the connection will use, BEFORE any
+ * resolution: the list authorizes what the operator wrote. The GUC is defined
+ * by the preloaded library (SUSET there, which is load-bearing) and read here
+ * by name, so no cross-library symbol exists.
+ */
+static void
+os_check_endpoint_allowed(PgColumnarObjHandle *h)
+{
+	const char *list =
+		GetConfigOption("pgcolumnar.objstore_allowed_endpoints", true, false);
+	bool		ok = false;
+
+	if (list != NULL && list[0] != '\0')
+	{
+		char	   *copy = pstrdup(list);
+		char	   *save = NULL;
+		char	   *tok;
+
+		for (tok = strtok_r(copy, ",", &save); tok != NULL;
+			 tok = strtok_r(NULL, ",", &save))
+		{
+			char	   *entry = tok;
+			char	   *end;
+			char	   *colon;
+
+			while (*entry == ' ' || *entry == '\t')
+				entry++;
+			end = entry + strlen(entry);
+			while (end > entry && (end[-1] == ' ' || end[-1] == '\t'))
+				*--end = '\0';
+			if (entry[0] == '\0')
+				continue;
+
+			/*
+			 * An entry may pin a port. M1 accepts no IPv6 literals in URLs,
+			 * so a colon in the entry can only introduce a port.
+			 */
+			colon = strrchr(entry, ':');
+			if (colon != NULL && colon[1] != '\0' &&
+				strspn(colon + 1, "0123456789") == strlen(colon + 1))
+			{
+				if (atoi(colon + 1) != h->port)
+					continue;
+				*colon = '\0';
+			}
+			if (pg_strcasecmp(entry, h->host) == 0)
+			{
+				ok = true;
+				break;
+			}
+		}
+		pfree(copy);
+	}
+
+	if (!ok)
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 errmsg("columnar: endpoint \"%s:%d\" is not in "
+						"pgcolumnar.objstore_allowed_endpoints",
+						h->host, h->port),
+				 errhint("A superuser can permit it: ALTER SYSTEM SET "
+						 "pgcolumnar.objstore_allowed_endpoints = '%s'; "
+						 "SELECT pg_reload_conf();", h->host)));
+}
+
+/*
+ * Link-local refusal, UNCONDITIONAL (#393): 169.254.0.0/16 and fe80::/10 are
+ * the cloud-metadata credential-theft surface (IMDS lives at
+ * 169.254.169.254) and have no legitimate object-storage use. Checked after
+ * resolution so a name pinned to a link-local address is caught, and the
+ * whole connection is refused rather than the address skipped, so a resolver
+ * returning a mixed set cannot steer the choice.
+ */
+static bool
+os_addr_is_linklocal(const struct addrinfo *ai)
+{
+	if (ai->ai_family == AF_INET)
+	{
+		uint32		a = ntohl(((const struct sockaddr_in *) ai->ai_addr)->sin_addr.s_addr);
+
+		return (a & 0xFFFF0000U) == 0xA9FE0000U;	/* 169.254/16 */
+	}
+	if (ai->ai_family == AF_INET6)
+	{
+		const struct in6_addr *a6 =
+			&((const struct sockaddr_in6 *) ai->ai_addr)->sin6_addr;
+
+		if (IN6_IS_ADDR_LINKLOCAL(a6))
+			return true;
+		if (IN6_IS_ADDR_V4MAPPED(a6))
+			return a6->s6_addr[12] == 169 && a6->s6_addr[13] == 254;
+	}
+	return false;
+}
+
 static void
 os_connect(PgColumnarObjHandle *h)
 {
@@ -267,6 +367,8 @@ os_connect(PgColumnarObjHandle *h)
 	int			quiet = 0;
 
 	Assert(h->fd < 0);
+
+	os_check_endpoint_allowed(h);
 
 	if (!h->fd_reserved)
 	{
@@ -294,6 +396,20 @@ os_connect(PgColumnarObjHandle *h)
 				(errcode(ERRCODE_CONNECTION_FAILURE),
 				 errmsg("columnar: could not resolve \"%s\": %s",
 						h->host, gai_strerror(rc))));
+
+	for (ai = addrs; ai != NULL; ai = ai->ai_next)
+		if (os_addr_is_linklocal(ai))
+		{
+			freeaddrinfo(addrs);
+			ereport(ERROR,
+					(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+					 errmsg("columnar: \"%s\" resolves into a link-local range, "
+							"which object storage never legitimately uses",
+							h->host),
+					 errdetail("Link-local addresses (169.254.0.0/16, fe80::/10) "
+							   "are refused unconditionally: they are the cloud "
+							   "instance-metadata surface.")));
+		}
 
 	for (ai = addrs; ai != NULL; ai = ai->ai_next)
 	{

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -191,6 +191,7 @@ extern bool pgcolumnar_enable_column_projection;
 extern bool pgcolumnar_enable_custom_scan;
 extern bool pgcolumnar_enable_bloom_filter;	/* bloom equality skipping (I7) */
 extern bool pgcolumnar_objstore_buffered;	/* chunk-granular remote reads (#393) */
+extern char *pgcolumnar_objstore_allowed_endpoints; /* #393 allow-list, SUSET */
 
 /* Phase 6 GUCs (spec 8.3) */
 extern bool pgcolumnar_enable_vectorization;	/* vectorized aggregate path */

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -79,6 +79,7 @@ bool		pgcolumnar_enable_late_materialization = true;
 bool		pgcolumnar_enable_column_projection = true;
 bool		pgcolumnar_enable_bloom_filter = true;
 bool		pgcolumnar_objstore_buffered = true;	/* #393 */
+char	   *pgcolumnar_objstore_allowed_endpoints = NULL;	/* #393 allow-list */
 
 /* value set for columnar.compression (spec 5, 8.3) */
 static const struct config_enum_entry pgcolumnar_compression_options[] = {
@@ -2757,6 +2758,24 @@ _PG_init(void)
 							 PGC_USERSET,
 							 0,
 							 NULL, NULL, NULL);
+
+	/*
+	 * The endpoint allow-list (#393, owner decision 2026-08-13): empty (the
+	 * default) refuses every remote endpoint, so pg_read_server_files is not
+	 * an SSRF primitive out of the box. SUSET is load-bearing: a USERSET list
+	 * would let any role widen its own allow-list, which is the privilege the
+	 * list exists to withhold. The objstore module enforces it at connect
+	 * time via GetConfigOption; link-local ranges are refused there
+	 * unconditionally, list or no list.
+	 */
+	DefineCustomStringVariable("pgcolumnar.objstore_allowed_endpoints",
+							   "Remote endpoints the object-store module may connect to.",
+							   "Comma-separated host or host:port entries; empty refuses all remote access.",
+							   &pgcolumnar_objstore_allowed_endpoints,
+							   "",
+							   PGC_SUSET,
+							   GUC_LIST_INPUT,
+							   NULL, NULL, NULL);
 
 	/*
 	 * Dev fault injection for the export sink (#394): fail the sink, as

--- a/test/objstore_allowlist.sh
+++ b/test/objstore_allowlist.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# pgColumnar #393: the endpoint allow-list, empty by default.
+#
+# pgcolumnar.objstore_allowed_endpoints gates every remote scheme in the
+# object-store module: empty (the default) refuses all remote access, so
+# pg_read_server_files is not an SSRF primitive out of the box; and link-local
+# ranges (the cloud-metadata credential-theft path, 169.254.0.0/16) are
+# refused UNCONDITIONALLY, even when an operator lists them. The GUC is SUSET
+# because a USERSET list would let any role widen its own allow-list, which is
+# the exact privilege the list withholds. design/ISSUE_393_ENDPOINT_ALLOWLIST.md.
+#
+# The suite restarts its cluster between list values because the ordinary way
+# to set a SUSET GUC for a workload is the configuration file; a superuser
+# session SET is exercised once to prove per-session override works for
+# admins.
+#
+# Usage:  test/objstore_allowlist.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+python3 -c 'import pyarrow' 2>/dev/null || pgc_skip pyarrow "pyarrow is required to write the fixture"
+
+HTTP_PORT="$(pgc_pick_free_port "$PGC_AUX_PORT_LO" "$PGC_AUX_PORT_HI")"
+LOG="$PGC_WORKDIR/allow.log"
+SRV_PID=""
+
+objstore_allow_teardown() {
+	[ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null
+	pgc_teardown
+}
+trap objstore_allow_teardown EXIT INT TERM
+
+sqlstate_of() {  # sqlstate_of <sql> [role]
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U "${2:-postgres}" \
+		-d "$PGC_DB" -qtA 2>&1 <<SQLEOF | sed -n 's/^ERROR:  \([0-9A-Z]\{5\}\).*/\1/p' | head -1
+\\set VERBOSITY sqlstate
+$1;
+SQLEOF
+}
+
+set_list() {  # set_list <value>  (ALTER SYSTEM + reload: the operator's path)
+	psql_run "ALTER SYSTEM SET pgcolumnar.objstore_allowed_endpoints = '$1';"
+	psql_run "SELECT pg_reload_conf();"
+	sleep 0.5
+}
+
+# ---- fixture ----------------------------------------------------------------
+python3 - "$PGC_WORKDIR/fixture.parquet" <<'PYEOF'
+import sys
+import pyarrow as pa, pyarrow.parquet as pq
+pq.write_table(pa.table({"a": pa.array(range(1000), pa.int64())}), sys.argv[1])
+PYEOF
+python3 "$(dirname "${BASH_SOURCE[0]}")/objstore_http_server.py" \
+	--dir "$PGC_WORKDIR" --port "$HTTP_PORT" --log "$LOG" \
+	> "$PGC_WORKDIR/allow_server.out" 2>&1 &
+SRV_PID=$!
+for _ in $(seq 1 50); do
+	grep -q READY "$PGC_WORKDIR/allow_server.out" 2>/dev/null && break
+	sleep 0.1
+done
+check "premise: fixture server is up" \
+	"$(grep -c READY "$PGC_WORKDIR/allow_server.out" 2>/dev/null)" "1"
+
+URL="http://127.0.0.1:$HTTP_PORT/fixture.parquet"
+Q="SELECT count(*) FROM pgcolumnar.read_parquet('$URL') AS (a int8)"
+
+# ---- the default: deny everything remote ------------------------------------
+check "premise: the list defaults to empty" \
+	"$(q "SELECT current_setting('pgcolumnar.objstore_allowed_endpoints')")" ""
+check "default: an http read is refused 42501" "$(sqlstate_of "$Q")" "42501"
+check "default: the refusal names the GUC" \
+	"$([ "$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" -qtA \
+		-c "$Q" 2>&1 | grep -c objstore_allowed_endpoints)" -ge 1 ] && echo yes || echo no)" "yes"
+check "default: a local read is untouched by the list" \
+	"$(q "SELECT count(*) FROM pgcolumnar.read_parquet('$PGC_WORKDIR/fixture.parquet') AS (a int8)")" "1000"
+
+# ---- the list admits exactly what it names ----------------------------------
+set_list "127.0.0.1"
+check_num "listed host: the read works" "$(q "$Q")" "1000"
+set_list "127.0.0.2"
+check "unlisted host: refused 42501" "$(sqlstate_of "$Q")" "42501"
+set_list "127.0.0.1:$HTTP_PORT"
+check_num "host:port entry, right port: works" "$(q "$Q")" "1000"
+set_list "127.0.0.1:1"
+check "host:port entry, wrong port: refused 42501" "$(sqlstate_of "$Q")" "42501"
+set_list "other.example, 127.0.0.1"
+check_num "a multi-entry list matches any entry" "$(q "$Q")" "1000"
+
+# ---- SUSET: only a superuser may change it ----------------------------------
+psql_run "DROP ROLE IF EXISTS allow_nobody; CREATE ROLE allow_nobody LOGIN;"
+check "premise: the role can open a session" \
+	"$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U allow_nobody -d "$PGC_DB" -qtA -c 'SELECT 1' 2>&1)" "1"
+check "a non-superuser cannot widen the list (42501)" \
+	"$(sqlstate_of "SET pgcolumnar.objstore_allowed_endpoints = '10.0.0.1'" allow_nobody)" "42501"
+check_num "a superuser session SET works (admin override)" \
+	"$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" -qtA \
+		-c "SET pgcolumnar.objstore_allowed_endpoints = '127.0.0.1'" -c "$Q" 2>/dev/null | tail -1)" "1000"
+
+# ---- link-local: refused even when listed -----------------------------------
+# The IMDS credential-theft address, explicitly IN the list: still 42501, and
+# the SQLSTATE proves refusal happened BEFORE any connection existed (a real
+# connect attempt to 169.254/16 would surface 08006 or hang toward a timeout).
+set_list "169.254.169.254, 127.0.0.1"
+check "link-local: refused 42501 despite being listed" \
+	"$(sqlstate_of "SELECT count(*) FROM pgcolumnar.read_parquet('http://169.254.169.254:1/x.parquet') AS (a int8)")" "42501"
+check "link-local: the refusal names the range, not the list" \
+	"$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" -qtA \
+		-c "SELECT count(*) FROM pgcolumnar.read_parquet('http://169.254.169.254:1/x.parquet') AS (a int8)" 2>&1 \
+		| grep -c "link-local")" "1"
+check_num "link-local: the listed ordinary host still works beside it" "$(q "$Q")" "1000"
+
+pgc_summary

--- a/test/objstore_credentials.sh
+++ b/test/objstore_credentials.sh
@@ -22,6 +22,10 @@
 
 set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# The endpoint allow-list (#393) defaults to deny-all; this suite's fixture is
+# the documented configuration example for a trusted local endpoint.
+export PGC_EXTRA_CONF="pgcolumnar.objstore_allowed_endpoints='127.0.0.1'"
+
 pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
 
 python3 -c 'import pyarrow' 2>/dev/null || pgc_skip pyarrow "pyarrow is required to write the fixture"

--- a/test/objstore_http_read.sh
+++ b/test/objstore_http_read.sh
@@ -26,6 +26,10 @@
 
 set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# The endpoint allow-list (#393) defaults to deny-all; this suite's fixture is
+# the documented configuration example for a trusted local endpoint.
+export PGC_EXTRA_CONF="pgcolumnar.objstore_allowed_endpoints='127.0.0.1'"
+
 pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
 
 python3 -c 'import pyarrow' 2>/dev/null || pgc_skip pyarrow "pyarrow is required to write the fixture"

--- a/test/objstore_module.sh
+++ b/test/objstore_module.sh
@@ -106,7 +106,7 @@ check_num "positive control: it IS defined in the module, so nm really looked" \
 for url in "s3://bucket/key.parquet" "gs://bucket/key.parquet" "https://host/key.parquet"; do
 	out=$(psql_run "SELECT * FROM pgcolumnar.read_parquet('$url') AS (a int)" 2>&1)
 	check "a $(cut -d: -f1 <<<"$url") URL reports an object-storage error, not a missing file" \
-		"$([ "$(grep -c 'object storage is not implemented\|is not supported\|requires the object-store module\|requires AWS_\|could not resolve\|could not connect' <<<"$out")" -ge 1 ] && echo yes || echo no)" "yes"
+		"$([ "$(grep -c 'object storage is not implemented\|is not supported\|requires the object-store module\|requires AWS_\|could not resolve\|could not connect\|objstore_allowed_endpoints' <<<"$out")" -ge 1 ] && echo yes || echo no)" "yes"
 	check_num "and does NOT report it as a missing file" \
 		"$(grep -c 'No such file or directory' <<<"$out")" "0"
 done

--- a/test/objstore_s3_read.sh
+++ b/test/objstore_s3_read.sh
@@ -36,6 +36,10 @@
 
 set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# The endpoint allow-list (#393) defaults to deny-all; this suite's fixture is
+# the documented configuration example for a trusted local endpoint.
+export PGC_EXTRA_CONF="pgcolumnar.objstore_allowed_endpoints='127.0.0.1'"
+
 pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
 
 python3 -c 'import pyarrow' 2>/dev/null || pgc_skip pyarrow "pyarrow is required to write the fixture"

--- a/test/objstore_tls_read.sh
+++ b/test/objstore_tls_read.sh
@@ -32,6 +32,10 @@
 
 set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# The endpoint allow-list (#393) defaults to deny-all; this suite's fixture is
+# the documented configuration example for a trusted local endpoint.
+export PGC_EXTRA_CONF="pgcolumnar.objstore_allowed_endpoints='127.0.0.1'"
+
 pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
 
 python3 -c 'import pyarrow' 2>/dev/null || pgc_skip pyarrow "pyarrow is required to write the fixture"

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -148,6 +148,7 @@ SUITES=(
 	native_vecskip
 	native_writer
 	native_zonemap
+	objstore_allowlist
 	objstore_credentials
 	objstore_http_read
 	objstore_module


### PR DESCRIPTION
Implements the owner decision recorded on #393 (2026-08-13): remote object-storage access is default-deny. Design: `design/ISSUE_393_ENDPOINT_ALLOWLIST.md` (in this PR).

## What lands

- **`pgcolumnar.objstore_allowed_endpoints`**, string, **SUSET**, default empty = all remote refused (42501, before any socket exists). SUSET is load-bearing: a USERSET list would let any role widen its own allow-list — the suite proves a non-superuser SET fails, by that role's own session.
- Entries are `host` or `host:port`, matched **before resolution** (the list authorizes what the operator wrote). Defined in the preloaded library, read by the module via `GetConfigOption` — no cross-library symbol.
- **Link-local refused unconditionally** after resolution (169.254/16, fe80::/10, v4-mapped), even when explicitly listed; the whole connection refuses if *any* resolved address is link-local, so a mixed-answer resolver cannot steer the pick. Loopback deliberately stays allowed (trusted-network MinIO, and every suite).

## Proofs

- RED-first on main: the deny arms showed today's world — reads succeeding, and the IMDS arm making a genuine connection attempt (08006).
- Removal proofs both run: skip the list check → deny arms red; skip the link-local block → the IMDS arm reds at **`got [08006]`** — a real connection attempt into metadata space, exactly the world the check forbids.
- The IMDS arm keeps `169.254.169.254` explicitly **in** the list and still expects 42501, pinning "unconditional".

## Suite ecology

The four remote-reading suites gain `PGC_EXTRA_CONF="pgcolumnar.objstore_allowed_endpoints='127.0.0.1'"`, which doubles as the documented configuration example; `objstore_module`'s remote-error grep accepts the new refusal. 16/16 on PG17 (lane), PG18, PG19; sanitizer gate green across all six objstore suites; `export_sink` and the family unregressed; `-Wshadow -Werror` clean.

This closes the last open decision on #393.

🤖 Generated with [Claude Code](https://claude.com/claude-code)