### PR TITLE
feat: remote export sink — single-object and multipart (#394 step 3)

### DIFF
--- a/design/ISSUE_394_REMOTE_SINK.md
+++ b/design/ISSUE_394_REMOTE_SINK.md
@@ -1,0 +1,120 @@
+# Issue #394 steps 3-4: the remote sink
+
+Design before code. Step 1 (the local `PqSink` seam, checked writes,
+temp-and-rename, #612) is merged, and #393's close delivered everything this
+was sequenced behind: transport, SigV4, TLS, catalog credentials, and the
+endpoint allow-list, all built once in the objstore module. This document
+covers the remote implementation of the sink: single-object first (step 3),
+parallel per-worker objects after (step 4).
+
+## The ABI (bumps to 3)
+
+Write-side operations join `PgColumnarObjStoreApi`; the module has shipped in
+no release, so no compatibility shim is owed, and the loader's version check
+refuses a mismatch as always:
+
+    PgColumnarObjSink *(*sink_create)(const char *url,
+                                      const PgColumnarObjStoreConfig *cfg);
+    void (*sink_write)(PgColumnarObjSink *s, const void *buf, size_t n);
+    void (*sink_finish)(PgColumnarObjSink *s);
+    void (*sink_abort)(PgColumnarObjSink *s);     /* never raises */
+    void (*delete_object)(const char *url,
+                          const PgColumnarObjStoreConfig *cfg);
+
+`PgColumnarSinkOpenLocal` grows into `PgColumnarSinkOpen(path)`: local paths
+keep step 1's temp-and-rename exactly; remote paths route through the ABI.
+The export functions have no server object, so remote exports run under the
+M4 function-API rule: ambient credentials behind `pg_write_server_files`, the
+allow-list enforced in the module on every scheme, unconditional link-local
+refusal included — a remote write is off-box exfiltration, which is exactly
+what the empty-by-default list exists to gate.
+
+## S3 mechanics (single object, step 3)
+
+- **Small objects** (buffered total under one part size): one `PUT`, no
+  multipart protocol at all. This is also the whole story for most fixture
+  and metadata-sized exports.
+- **Large objects**: `CreateMultipartUpload` (POST `?uploads`, the UploadId
+  extracted with the same bounded tag scan the 403 body uses — a tag scan,
+  not a fourth parser); `UploadPart` (PUT `?partNumber=N&uploadId=...`,
+  staging 8 MiB parts, ETag taken from the response HEADER, not XML);
+  `CompleteMultipartUpload` (POST with the part list as XML we WRITE);
+  `AbortMultipartUpload` (DELETE `?uploadId=...`).
+- **The invariant is step 1's, verbatim**: nothing is ever visible at the
+  final name before finish() returns. S3 gives it natively — parts are
+  invisible until Complete — so local and remote expose identical semantics.
+- **Signing grows two things M2 did not need**: a canonical QUERY string
+  (sorted, UriEncode'd with the query variant that encodes `/`, since
+  UploadIds carry base64-ish bytes), and a real payload hash per request
+  (`x-amz-content-sha256` of the part body, computed with the same
+  pg_cryptohash the key derivation uses; no UNSIGNED-PAYLOAD).
+- **Abort discipline**: `sink_abort` runs from the exporter's PG_CATCH and
+  from the module's resource-release callback, so an ERROR-level unwind
+  always aborts the upload. A backend crash between part uploads cannot be
+  cleaned by us: the documentation states the standard mitigation (a bucket
+  lifecycle rule for incomplete multipart uploads), as the design already
+  promised.
+
+## Parallel export (step 4)
+
+One object per worker — `part-NNNN.parquet` keys under the destination
+prefix — exactly the local shape, so no shared upload id exists across
+backends. Worker failure aborts its own upload through its own sink; the
+dispatcher's cleanup deletes completed objects **by their known keys**
+through `delete_object` (the remote `pexport_remove_outputs`), so the #619
+ListObjectsV2 deferral holds. A worker the dispatcher terminates dies FATAL
+without PG_CATCH — locally that orphans a temp the dispatcher unlinks; the
+remote analogue is an incomplete upload, which the dispatcher cannot abort
+without the worker's UploadId, so the lifecycle-rule documentation covers it
+and the dispatcher deletes whatever keys DID complete.
+
+## The fixture and the suite (`objstore_sink_write.sh`)
+
+The fixture server grows PUT, POST, DELETE, and a faithful multipart
+emulation (uploads tracked in memory: create returns an id, parts accumulate,
+complete concatenates in part order, abort discards), all under the same
+SigV4 stdlib verifier — so every write arm is also a cross-implementation
+signature check, now including payload hashes and canonical query strings.
+Request-logged like everything else.
+
+Arms:
+
+- **Round trip through the module both ways**: `export_parquet('t',
+  's3://bucket/key')` then read back via the s3:// read path, hash-equal to
+  the source; a small (single PUT) and a large (multipart) fixture, the
+  multipart premise pinned by the request log showing create/parts/complete.
+- **Injection**: `pgcolumnar.sink_fail_after` mid-part; the export errors
+  53100, the fixture shows AbortMultipartUpload logged, the key does not
+  exist, and no parts remain server-side.
+- **Parallel**: `parallel_export_parquet` to an s3:// prefix; per-worker
+  objects; the read path unions them hash-equal to the source; the cancel
+  arm (the step-1 idiom, triggered on the fixture's first part upload)
+  leaves zero completed keys, with the dispatcher's delete_object calls in
+  the log.
+- **Taxonomy**: allow-list refusal (42501) before any write; 403 on a wrong
+  secret (28000) with zero server-side effects.
+- **Garage, opt-in** (`PGC_S3_INTEGRATION_*`): the same round trip and the
+  same mid-part abort against a real S3 implementation, asserting no
+  incomplete upload survives (Garage lists them via its admin API).
+
+Removal proofs: disable the abort call — the injection arm's no-parts-remain
+check reds; disable the multipart threshold — the large fixture's
+create/parts/complete premise reds (everything single-PUTs); disable the
+dispatcher's delete_object — the parallel cancel arm's zero-keys check reds.
+
+## Out of scope
+
+Anything requiring LIST (#619); GCS/Azure writes (#621); retry policies
+beyond the read path's single reconnect; parallelizing part uploads within
+one object (workers already parallelize across objects); resumable uploads.
+
+## Order of work (TDD)
+
+1. Fixture multipart emulation + suite, RED on main ("writing to object
+   storage is not supported" — today's sink refuses remote paths).
+2. ABI v3 + module PUT/multipart + query-string canonicalization + payload
+   hashes; `PgColumnarSinkOpen` dispatch. Step-3 arms green.
+3. Parallel wiring (worker sinks already route through the choke point;
+   dispatcher gains remote key cleanup). Step-4 arms green.
+4. Removal proofs; Garage integration run; gates (PG17 lane, PG18/19, ASAN
+   over the objstore + export suites; -Wshadow -Werror).

--- a/objstore/columnar_objstore_module.c
+++ b/objstore/columnar_objstore_module.c
@@ -135,6 +135,7 @@ typedef struct OsResponse
 	int64		content_length; /* -1 when absent */
 	bool		chunked;
 	bool		conn_close;
+	char		etag[80];		/* PUT part response ETag, "" when absent (#394) */
 } OsResponse;
 
 static dlist_head os_open_handles = DLIST_STATIC_INIT(os_open_handles);
@@ -799,6 +800,18 @@ os_read_head(PgColumnarObjHandle *h, OsResponse *resp)
 			else if (pg_strncasecmp(line, "Connection:", 11) == 0 &&
 					 strstr(line, "close") != NULL && strstr(line, "close") < eol)
 				resp->conn_close = true;
+			else if (pg_strncasecmp(line, "ETag:", 5) == 0)
+			{
+				const char *p = line + 5;
+				int			i = 0;
+
+				while (p < eol && (*p == ' ' || *p == '\t'))
+					p++;
+				while (p < eol && *p != '\r' && *p != '\n' &&
+					   i < (int) sizeof(resp->etag) - 1)
+					resp->etag[i++] = *p++;
+				resp->etag[i] = '\0';
+			}
 			line = eol + 1;
 		}
 	}
@@ -1508,12 +1521,461 @@ objstore_close(PgColumnarObjHandle *h)
 		os_free_handle(h);
 }
 
+/* ------------------------------------------------------------- write side */
+
+/* One staged part is 8 MiB, comfortably above S3's 5 MiB non-final minimum.
+ * A dev GUC lowers it so a small fixture exercises the multipart path without
+ * generating tens of MiB (the same shape as pgcolumnar.sink_fail_after). */
+#define OS_PART_SIZE_DEFAULT	(8 * 1024 * 1024)
+
+static int
+os_part_size(void)
+{
+	const char *v =
+		GetConfigOption("pgcolumnar.objstore_part_size", true, false);
+	int			n = (v != NULL && v[0] != '\0') ? atoi(v) : 0;
+
+	return n > 0 ? n : OS_PART_SIZE_DEFAULT;
+}
+
+struct PgColumnarObjSink
+{
+	PgColumnarObjHandle *h;		/* the resolved connection + credentials */
+	StringInfoData buf;			/* bytes not yet flushed as a part */
+	char	   *uploadId;		/* NULL until a multipart upload begins */
+	StringInfoData completeXml; /* <Part> list built as parts complete */
+	int			partNo;			/* next part number (1-based) */
+	int			partSize;		/* frozen at create from the GUC */
+	int64		total;			/* bytes handed to sink_write */
+};
+
+/*
+ * Resolve a write target into a connection handle exactly as the read path
+ * does (endpoint, credentials, path-style key, allow-list and link-local
+ * enforced at connect), minus the HEAD. Shares os_resolve_s3 for s3:// and
+ * the plain authority parse for http(s)://.
+ */
+static PgColumnarObjHandle *
+os_write_handle(const char *url, const PgColumnarObjStoreConfig *cfg)
+{
+	PgColumnarObjHandle *h;
+	bool		isS3 = (pg_strncasecmp(url, "s3://", 5) == 0);
+	MemoryContext oldcxt;
+
+	if (!os_callback_registered)
+	{
+		RegisterResourceReleaseCallback(os_resource_release, NULL);
+		os_callback_registered = true;
+	}
+
+	oldcxt = MemoryContextSwitchTo(TopMemoryContext);
+	h = (PgColumnarObjHandle *) palloc0(sizeof(PgColumnarObjHandle));
+	h->fd = -1;
+	h->url = pstrdup(url);
+	h->rb = (uint8 *) palloc(OS_RBUF);
+	MemoryContextSwitchTo(oldcxt);
+	dlist_push_head(&os_open_handles, &h->node);
+
+	if (isS3)
+		os_resolve_s3(h, url, cfg);
+	else
+	{
+		bool		isHttps = (pg_strncasecmp(url, "https://", 8) == 0);
+		const char *authority = url + (isHttps ? 8 : 7);
+		const char *slash = strchr(authority, '/');
+		const char *colon;
+
+		if (slash == NULL || slash == authority)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("columnar: \"%s\" has no object path", url)));
+		oldcxt = MemoryContextSwitchTo(TopMemoryContext);
+		h->abspath = pstrdup(slash);
+		colon = memchr(authority, ':', slash - authority);
+		if (colon != NULL)
+		{
+			h->host = pnstrdup(authority, colon - authority);
+			h->port = atoi(colon + 1);
+		}
+		else
+		{
+			h->host = pnstrdup(authority, slash - authority);
+			h->port = isHttps ? 443 : 80;
+		}
+		MemoryContextSwitchTo(oldcxt);
+		h->tls = isHttps;
+	}
+	if (h->port <= 0 || h->port > 65535 || h->host == NULL || h->host[0] == '\0')
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("columnar: \"%s\" has an invalid host or port", url)));
+	return h;
+}
+
+/*
+ * Sign a write request. Unlike the read signer this carries a canonical QUERY
+ * string (multipart uses ?uploads, ?partNumber=&uploadId=, ?uploadId=) and a
+ * REAL payload hash (the SHA-256 of the body), both of which SigV4 folds into
+ * the canonical request. Caller passes the already-canonicalized query (sorted,
+ * UriEncoded) and the payload hash hex.
+ */
+static void
+os_sign_write(PgColumnarObjHandle *h, const char *method, const char *canonPath,
+			  const char *canonQuery, const char *payloadHex, StringInfo headers)
+{
+	char		amzdate[20];
+	char		datestamp[9];
+	pg_time_t	now = (pg_time_t) time(NULL);
+	StringInfoData creq;
+	StringInfoData sts;
+	StringInfoData signedlist;
+	uint8		digest[PG_SHA256_DIGEST_LENGTH];
+	char		hexdigest[PG_SHA256_DIGEST_LENGTH * 2 + 1];
+	char		signature[PG_SHA256_DIGEST_LENGTH * 2 + 1];
+
+	pg_strftime(amzdate, sizeof(amzdate), "%Y%m%dT%H%M%SZ", pg_gmtime(&now));
+	memcpy(datestamp, amzdate, 8);
+	datestamp[8] = '\0';
+
+	if (strcmp(h->sigDate, datestamp) != 0)
+	{
+		StringInfoData seed;
+		uint8		k[PG_SHA256_DIGEST_LENGTH];
+
+		initStringInfo(&seed);
+		appendStringInfo(&seed, "AWS4%s", h->secret);
+		os_hmac256((uint8 *) seed.data, seed.len, (uint8 *) datestamp, 8, k);
+		os_hmac256(k, sizeof(k), (uint8 *) h->region, strlen(h->region), k);
+		os_hmac256(k, sizeof(k), (uint8 *) "s3", 2, k);
+		os_hmac256(k, sizeof(k), (uint8 *) "aws4_request", 12, k);
+		memcpy(h->sigKey, k, sizeof(k));
+		strlcpy(h->sigDate, datestamp, sizeof(h->sigDate));
+		pfree(seed.data);
+	}
+
+	initStringInfo(&signedlist);
+	appendStringInfoString(&signedlist,
+						   "host;x-amz-content-sha256;x-amz-date");
+	if (h->token != NULL)
+		appendStringInfoString(&signedlist, ";x-amz-security-token");
+
+	initStringInfo(&creq);
+	appendStringInfo(&creq, "%s\n%s\n%s\n", method, canonPath, canonQuery);
+	appendStringInfo(&creq, "host:%s:%d\n", h->host, h->port);
+	appendStringInfo(&creq, "x-amz-content-sha256:%s\n", payloadHex);
+	appendStringInfo(&creq, "x-amz-date:%s\n", amzdate);
+	if (h->token != NULL)
+		appendStringInfo(&creq, "x-amz-security-token:%s\n", h->token);
+	appendStringInfo(&creq, "\n%s\n%s", signedlist.data, payloadHex);
+
+	os_sha256((uint8 *) creq.data, creq.len, digest);
+	os_hex(digest, sizeof(digest), hexdigest);
+
+	initStringInfo(&sts);
+	appendStringInfo(&sts, "AWS4-HMAC-SHA256\n%s\n%s/%s/s3/aws4_request\n%s",
+					 amzdate, datestamp, h->region, hexdigest);
+	os_hmac256(h->sigKey, sizeof(h->sigKey),
+			   (uint8 *) sts.data, sts.len, digest);
+	os_hex(digest, sizeof(digest), signature);
+
+	appendStringInfo(headers, "x-amz-content-sha256: %s\r\n", payloadHex);
+	appendStringInfo(headers, "x-amz-date: %s\r\n", amzdate);
+	if (h->token != NULL)
+		appendStringInfo(headers, "x-amz-security-token: %s\r\n", h->token);
+	appendStringInfo(headers,
+					 "Authorization: AWS4-HMAC-SHA256 Credential=%s/%s/%s/s3/aws4_request, "
+					 "SignedHeaders=%s, Signature=%s\r\n",
+					 h->akid, datestamp, h->region, signedlist.data, signature);
+	pfree(creq.data);
+	pfree(sts.data);
+	pfree(signedlist.data);
+}
+
+/*
+ * One signed write request (PUT/POST/DELETE) with an optional body, a single
+ * reconnect on a stale keep-alive. `rawQuery` is the query as it goes on the
+ * wire (already sorted+encoded, so it doubles as the canonical query since our
+ * queries use only unreserved characters and already-encoded upload ids). The
+ * response body, if any, is captured into *outBody (palloc'd) for the caller.
+ */
+static void
+os_write_request(PgColumnarObjHandle *h, const char *method, const char *rawQuery,
+				 const uint8 *body, int64 bodylen, OsResponse *resp,
+				 char **outBody)
+{
+	uint8		phash[PG_SHA256_DIGEST_LENGTH];
+	char		payloadHex[PG_SHA256_DIGEST_LENGTH * 2 + 1];
+	int			attempt;
+
+	os_sha256(body, (size_t) bodylen, phash);
+	os_hex(phash, sizeof(phash), payloadHex);
+
+	for (attempt = 0;; attempt++)
+	{
+		StringInfoData req;
+		bool		fresh;
+
+		if (h->fd < 0)
+			os_connect(h);
+		fresh = (attempt == 0 && h->served == 0);
+
+		initStringInfo(&req);
+		appendStringInfo(&req, "%s %s%s%s HTTP/1.1\r\nHost: %s:%d\r\n",
+						 method, h->abspath, rawQuery[0] ? "?" : "", rawQuery,
+						 h->host, h->port);
+		appendStringInfo(&req, "Content-Length: %lld\r\n", (long long) bodylen);
+		os_sign_write(h, method, h->abspath, rawQuery, payloadHex, &req);
+		appendStringInfoString(&req, "User-Agent: pgcolumnar-objstore/1\r\n\r\n");
+
+		if (os_send_all(h, req.data, req.len) &&
+			(bodylen == 0 || os_send_all(h, (const char *) body, bodylen)) &&
+			os_read_head(h, resp))
+		{
+			pfree(req.data);
+			break;
+		}
+		pfree(req.data);
+		os_disconnect(h);
+		if (!fresh && attempt == 0)
+			continue;			/* stale keep-alive: one reconnect */
+		ereport(ERROR,
+				(errcode(ERRCODE_CONNECTION_FAILURE),
+				 errmsg("columnar: %s to \"%s\" failed before a response",
+						method, h->url)));
+	}
+
+	if (resp->status == 403)
+		os_reject_403(h, resp, true);
+
+	{
+		char	   *b = NULL;
+
+		if (!resp->chunked && resp->content_length > 0 &&
+			resp->content_length < 1024 * 1024)
+		{
+			b = palloc((Size) resp->content_length + 1);
+			os_read_exact(h, (uint8 *) b, resp->content_length);
+			b[resp->content_length] = '\0';
+		}
+		else if (resp->content_length > 0 || resp->chunked)
+			os_read_body(h, resp, NULL, 0);		/* drain */
+		if (outBody != NULL)
+			*outBody = b;
+		else if (b != NULL)
+			pfree(b);
+	}
+
+	if (resp->conn_close)
+		os_disconnect(h);
+	else
+		h->served++;
+}
+
+/* Upload the buffered bytes as the next multipart part; record its ETag. */
+static void
+os_flush_part(PgColumnarObjSink *s)
+{
+	OsResponse	resp;
+	char	   *body = NULL;
+	char		query[128];
+	char	   *etag;
+	char	   *etagEnd;
+
+	snprintf(query, sizeof(query), "partNumber=%d&uploadId=%s",
+			 s->partNo, s->uploadId);
+	os_write_request(s->h, "PUT", query, (uint8 *) s->buf.data, s->buf.len,
+					 &resp, &body);
+	if (resp.status != 200)
+		ereport(ERROR,
+				(errcode(ERRCODE_IO_ERROR),
+				 errmsg("columnar: uploading a part of \"%s\" failed (HTTP %d)",
+						s->h->url, resp.status)));
+	/* The part's ETag is the server's word for its bytes; CompleteMultipart
+	 * validates the list against it on a real S3, so echo it verbatim (already
+	 * quoted by the server). The fixture ignores it and concatenates by part
+	 * number, so both are satisfied. */
+	etag = resp.etag[0] ? resp.etag : "\"\"";
+	(void) etagEnd;
+	appendStringInfo(&s->completeXml,
+					 "<Part><PartNumber>%d</PartNumber><ETag>%s</ETag></Part>",
+					 s->partNo, etag);
+	if (body != NULL)
+		pfree(body);
+	resetStringInfo(&s->buf);
+	s->partNo++;
+}
+
+static void
+os_begin_multipart(PgColumnarObjSink *s)
+{
+	OsResponse	resp;
+	char	   *body = NULL;
+	char	   *idStart;
+	char	   *idEnd;
+	MemoryContext oldcxt;
+
+	os_write_request(s->h, "POST", "uploads=", NULL, 0, &resp, &body);
+	if (resp.status != 200 || body == NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_IO_ERROR),
+				 errmsg("columnar: could not start a multipart upload for \"%s\" (HTTP %d)",
+						s->h->url, resp.status)));
+	idStart = strstr(body, "<UploadId>");
+	idEnd = idStart ? strstr(idStart, "</UploadId>") : NULL;
+	if (idStart == NULL || idEnd == NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_IO_ERROR),
+				 errmsg("columnar: multipart upload for \"%s\" returned no UploadId",
+						s->h->url)));
+	oldcxt = MemoryContextSwitchTo(TopMemoryContext);
+	s->uploadId = pnstrdup(idStart + 10, idEnd - (idStart + 10));
+	MemoryContextSwitchTo(oldcxt);
+	s->partNo = 1;
+	pfree(body);
+}
+
+static PgColumnarObjSink *
+objstore_sink_create(const char *url, const PgColumnarObjStoreConfig *cfg)
+{
+	PgColumnarObjSink *s;
+	MemoryContext oldcxt;
+
+	oldcxt = MemoryContextSwitchTo(TopMemoryContext);
+	s = (PgColumnarObjSink *) palloc0(sizeof(PgColumnarObjSink));
+	initStringInfo(&s->buf);
+	initStringInfo(&s->completeXml);
+	MemoryContextSwitchTo(oldcxt);
+	s->partSize = os_part_size();
+	s->h = os_write_handle(url, cfg);
+	return s;
+}
+
+static void
+objstore_sink_write(PgColumnarObjSink *s, const void *buf, size_t n)
+{
+	MemoryContext oldcxt = MemoryContextSwitchTo(TopMemoryContext);
+
+	appendBinaryStringInfo(&s->buf, (const char *) buf, (int) n);
+	MemoryContextSwitchTo(oldcxt);
+	s->total += (int64) n;
+
+	while (s->buf.len >= s->partSize)
+	{
+		StringInfoData rest;
+		int			carry = s->buf.len - s->partSize;
+
+		/* peel exactly one part; keep the remainder for the next flush */
+		oldcxt = MemoryContextSwitchTo(TopMemoryContext);
+		initStringInfo(&rest);
+		if (carry > 0)
+			appendBinaryStringInfo(&rest, s->buf.data + s->partSize, carry);
+		s->buf.len = s->partSize;
+		s->buf.data[s->partSize] = '\0';
+		if (s->uploadId == NULL)
+			os_begin_multipart(s);
+		os_flush_part(s);
+		pfree(s->buf.data);
+		s->buf = rest;
+		MemoryContextSwitchTo(oldcxt);
+	}
+}
+
+static void
+objstore_sink_finish(PgColumnarObjSink *s)
+{
+	OsResponse	resp;
+
+	if (s->uploadId == NULL)
+	{
+		/* small object: a single PUT is the whole story */
+		os_write_request(s->h, "PUT", "", (uint8 *) s->buf.data, s->buf.len,
+						 &resp, NULL);
+		if (resp.status != 200)
+			ereport(ERROR,
+					(errcode(ERRCODE_IO_ERROR),
+					 errmsg("columnar: writing \"%s\" failed (HTTP %d)",
+							s->h->url, resp.status)));
+	}
+	else
+	{
+		StringInfoData xml;
+		char		query[96];
+
+		if (s->buf.len > 0)			/* the final (short) part */
+			os_flush_part(s);
+		initStringInfo(&xml);
+		appendStringInfo(&xml, "<CompleteMultipartUpload>%s</CompleteMultipartUpload>",
+						 s->completeXml.data);
+		snprintf(query, sizeof(query), "uploadId=%s", s->uploadId);
+		os_write_request(s->h, "POST", query, (uint8 *) xml.data, xml.len,
+						 &resp, NULL);
+		pfree(xml.data);
+		if (resp.status != 200)
+			ereport(ERROR,
+					(errcode(ERRCODE_IO_ERROR),
+					 errmsg("columnar: completing the upload of \"%s\" failed (HTTP %d)",
+							s->h->url, resp.status)));
+	}
+	os_free_handle(s->h);
+	s->h = NULL;
+}
+
+static void
+objstore_sink_abort(PgColumnarObjSink *s)
+{
+	if (s == NULL || s->h == NULL)
+		return;
+	/* best effort, never raises: an ABORT that itself failed must not mask
+	 * the error that triggered it */
+	PG_TRY();
+	{
+		if (s->uploadId != NULL)
+		{
+			OsResponse	resp;
+			char		query[96];
+
+			snprintf(query, sizeof(query), "uploadId=%s", s->uploadId);
+			os_write_request(s->h, "DELETE", query, NULL, 0, &resp, NULL);
+		}
+	}
+	PG_CATCH();
+	{
+		FlushErrorState();
+	}
+	PG_END_TRY();
+	os_free_handle(s->h);
+	s->h = NULL;
+}
+
+static void
+objstore_delete_object(const char *url, const PgColumnarObjStoreConfig *cfg)
+{
+	PgColumnarObjHandle *h = os_write_handle(url, cfg);
+	OsResponse	resp;
+
+	PG_TRY();
+	{
+		os_write_request(h, "DELETE", "", NULL, 0, &resp, NULL);
+	}
+	PG_CATCH();
+	{
+		FlushErrorState();		/* best effort, like the local unlink */
+	}
+	PG_END_TRY();
+	os_free_handle(h);
+}
+
 static const PgColumnarObjStoreApi objstore_api = {
 	.abi_version = PGCOLUMNAR_OBJSTORE_ABI,
 	.handles_url = objstore_handles_url,
 	.open = objstore_open,
 	.read = objstore_read,
 	.close = objstore_close,
+	.sink_create = objstore_sink_create,
+	.sink_write = objstore_sink_write,
+	.sink_finish = objstore_sink_finish,
+	.sink_abort = objstore_sink_abort,
+	.delete_object = objstore_delete_object,
 };
 
 const PgColumnarObjStoreApi *

--- a/objstore/columnar_objstore_module.c
+++ b/objstore/columnar_objstore_module.c
@@ -1000,8 +1000,7 @@ os_hex(const uint8 *in, size_t n, char *out)	/* out: 2n+1 bytes */
  * AWS UriEncode for the path: unreserved bytes and '/' pass, everything else
  * is %XX with UPPERCASE hex. Hand-written per AWS's own recommendation:
  * platform encoders disagree on exactly the bytes that break signatures
- * (space, '+', '=', '~'). The query-string variant (encode '/') is not needed
- * until a listing operation exists.
+ * (space, '+', '=', '~').
  */
 static void
 os_uriencode_path(StringInfo out, const char *s)
@@ -1017,6 +1016,34 @@ os_uriencode_path(StringInfo out, const char *s)
 		else
 			appendStringInfo(out, "%%%02X", c);
 	}
+}
+
+/*
+ * The query-string variant: '/' is NOT exempt (SigV4 canonical-query encoding
+ * percent-encodes every reserved byte). Used for a multipart UploadId value,
+ * which S3 returns opaque and AWS ids can carry reserved characters; encoding
+ * it here means the query the client signs matches AWS's canonicalization
+ * regardless of what the server chose (#394 review). Garage/MinIO ids are
+ * unreserved, so this is a no-op there and byte-identical to before.
+ */
+static char *
+os_uriencode_query(const char *s)
+{
+	StringInfoData out;
+
+	initStringInfo(&out);
+	for (; *s != '\0'; s++)
+	{
+		unsigned char c = (unsigned char) *s;
+
+		if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+			(c >= '0' && c <= '9') ||
+			c == '-' || c == '.' || c == '_' || c == '~')
+			appendStringInfoChar(&out, (char) c);
+		else
+			appendStringInfo(&out, "%%%02X", c);
+	}
+	return out.data;
 }
 
 /*
@@ -1694,9 +1721,11 @@ os_sign_write(PgColumnarObjHandle *h, const char *method, const char *canonPath,
 /*
  * One signed write request (PUT/POST/DELETE) with an optional body, a single
  * reconnect on a stale keep-alive. `rawQuery` is the query as it goes on the
- * wire (already sorted+encoded, so it doubles as the canonical query since our
- * queries use only unreserved characters and already-encoded upload ids). The
- * response body, if any, is captured into *outBody (palloc'd) for the caller.
+ * wire AND the canonical query the signature covers: the caller builds it with
+ * keys already sorted (partNumber < uploadId; single-key queries are trivially
+ * sorted) and any UploadId value already percent-encoded through
+ * os_uriencode_query, so wire and canonical are byte-identical. The response
+ * body, if any, is captured into *outBody (palloc'd) for the caller.
  */
 static void
 os_write_request(PgColumnarObjHandle *h, const char *method, const char *rawQuery,
@@ -1777,14 +1806,14 @@ os_flush_part(PgColumnarObjSink *s)
 {
 	OsResponse	resp;
 	char	   *body = NULL;
-	char		query[128];
-	char	   *etag;
-	char	   *etagEnd;
+	char	   *encId = os_uriencode_query(s->uploadId);
+	char	   *query = psprintf("partNumber=%d&uploadId=%s", s->partNo, encId);
+	const char *etag;
 
-	snprintf(query, sizeof(query), "partNumber=%d&uploadId=%s",
-			 s->partNo, s->uploadId);
 	os_write_request(s->h, "PUT", query, (uint8 *) s->buf.data, s->buf.len,
 					 &resp, &body);
+	pfree(query);
+	pfree(encId);
 	if (resp.status != 200)
 		ereport(ERROR,
 				(errcode(ERRCODE_IO_ERROR),
@@ -1795,7 +1824,6 @@ os_flush_part(PgColumnarObjSink *s)
 	 * quoted by the server). The fixture ignores it and concatenates by part
 	 * number, so both are satisfied. */
 	etag = resp.etag[0] ? resp.etag : "\"\"";
-	(void) etagEnd;
 	appendStringInfo(&s->completeXml,
 					 "<Part><PartNumber>%d</PartNumber><ETag>%s</ETag></Part>",
 					 s->partNo, etag);
@@ -1832,6 +1860,24 @@ os_begin_multipart(PgColumnarObjSink *s)
 	MemoryContextSwitchTo(oldcxt);
 	s->partNo = 1;
 	pfree(body);
+}
+
+/*
+ * Free the sink and its TopMemoryContext-resident buffers (#394 review): the
+ * handle is freed by the caller (finish/abort) before this. Called at every
+ * terminal point so a long-lived session running many exports does not
+ * accumulate them.
+ */
+static void
+os_sink_free(PgColumnarObjSink *s)
+{
+	if (s->buf.data != NULL)
+		pfree(s->buf.data);
+	if (s->completeXml.data != NULL)
+		pfree(s->completeXml.data);
+	if (s->uploadId != NULL)
+		pfree(s->uploadId);
+	pfree(s);
 }
 
 static PgColumnarObjSink *
@@ -1899,17 +1945,19 @@ objstore_sink_finish(PgColumnarObjSink *s)
 	else
 	{
 		StringInfoData xml;
-		char		query[96];
+		char	   *encId = os_uriencode_query(s->uploadId);
+		char	   *query = psprintf("uploadId=%s", encId);
 
 		if (s->buf.len > 0)			/* the final (short) part */
 			os_flush_part(s);
 		initStringInfo(&xml);
 		appendStringInfo(&xml, "<CompleteMultipartUpload>%s</CompleteMultipartUpload>",
 						 s->completeXml.data);
-		snprintf(query, sizeof(query), "uploadId=%s", s->uploadId);
 		os_write_request(s->h, "POST", query, (uint8 *) xml.data, xml.len,
 						 &resp, NULL);
 		pfree(xml.data);
+		pfree(query);
+		pfree(encId);
 		if (resp.status != 200)
 			ereport(ERROR,
 					(errcode(ERRCODE_IO_ERROR),
@@ -1918,13 +1966,19 @@ objstore_sink_finish(PgColumnarObjSink *s)
 	}
 	os_free_handle(s->h);
 	s->h = NULL;
+	os_sink_free(s);
 }
 
 static void
 objstore_sink_abort(PgColumnarObjSink *s)
 {
-	if (s == NULL || s->h == NULL)
+	if (s == NULL)
 		return;
+	if (s->h == NULL)			/* finish already ran; just reclaim */
+	{
+		os_sink_free(s);
+		return;
+	}
 	/* best effort, never raises: an ABORT that itself failed must not mask
 	 * the error that triggered it */
 	PG_TRY();
@@ -1932,10 +1986,12 @@ objstore_sink_abort(PgColumnarObjSink *s)
 		if (s->uploadId != NULL)
 		{
 			OsResponse	resp;
-			char		query[96];
+			char	   *encId = os_uriencode_query(s->uploadId);
+			char	   *query = psprintf("uploadId=%s", encId);
 
-			snprintf(query, sizeof(query), "uploadId=%s", s->uploadId);
 			os_write_request(s->h, "DELETE", query, NULL, 0, &resp, NULL);
+			pfree(query);
+			pfree(encId);
 		}
 	}
 	PG_CATCH();
@@ -1945,6 +2001,7 @@ objstore_sink_abort(PgColumnarObjSink *s)
 	PG_END_TRY();
 	os_free_handle(s->h);
 	s->h = NULL;
+	os_sink_free(s);
 }
 
 static void

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -192,6 +192,7 @@ extern bool pgcolumnar_enable_custom_scan;
 extern bool pgcolumnar_enable_bloom_filter;	/* bloom equality skipping (I7) */
 extern bool pgcolumnar_objstore_buffered;	/* chunk-granular remote reads (#393) */
 extern char *pgcolumnar_objstore_allowed_endpoints; /* #393 allow-list, SUSET */
+extern int	pgcolumnar_objstore_part_size;	/* #394 remote multipart part size */
 
 /* Phase 6 GUCs (spec 8.3) */
 extern bool pgcolumnar_enable_vectorization;	/* vectorized aggregate path */

--- a/src/columnar_arrow.c
+++ b/src/columnar_arrow.c
@@ -1052,7 +1052,7 @@ pgcolumnar_export_arrow(PG_FUNCTION_ARGS)
 		arrowcol_reset(&cols[i]);
 	}
 
-	snk = PgColumnarSinkOpenLocal(path);
+	snk = PgColumnarSinkOpen(path);
 	PG_TRY();
 	{
 

--- a/src/columnar_objstore.h
+++ b/src/columnar_objstore.h
@@ -33,10 +33,11 @@
 
 #include "postgres.h"
 
-#define PGCOLUMNAR_OBJSTORE_ABI 2
+#define PGCOLUMNAR_OBJSTORE_ABI 3
 
-/* An open remote object. The module owns everything behind this. */
+/* An open remote object (read) / upload (write). Module owns both. */
 typedef struct PgColumnarObjHandle PgColumnarObjHandle;
+typedef struct PgColumnarObjSink PgColumnarObjSink;
 
 /*
  * Connection configuration resolved from the FDW catalogs (#393 M4). NULL
@@ -85,6 +86,25 @@ typedef struct PgColumnarObjStoreApi
 	void		(*read) (PgColumnarObjHandle *h, int64 off, void *buf, size_t n);
 
 	void		(*close) (PgColumnarObjHandle *h);
+
+	/*
+	 * Write side (#394). sink_create opens an upload for `url`; sink_write
+	 * appends (the module buffers into >= part-size chunks and starts a
+	 * multipart upload when the total crosses one part); sink_finish commits
+	 * (a single PUT for a small object, CompleteMultipartUpload otherwise) and
+	 * is the ONLY point the object becomes visible at its final name;
+	 * sink_abort tears down without publishing and never raises, so it is safe
+	 * from a PG_CATCH. delete_object removes a completed object by key (the
+	 * parallel dispatcher's remote cleanup). All raise on failure except
+	 * sink_abort. cfg may be NULL (the export function paths).
+	 */
+	PgColumnarObjSink *(*sink_create) (const char *url,
+									   const PgColumnarObjStoreConfig *cfg);
+	void		(*sink_write) (PgColumnarObjSink *s, const void *buf, size_t n);
+	void		(*sink_finish) (PgColumnarObjSink *s);
+	void		(*sink_abort) (PgColumnarObjSink *s);
+	void		(*delete_object) (const char *url,
+								  const PgColumnarObjStoreConfig *cfg);
 } PgColumnarObjStoreApi;
 
 /*

--- a/src/columnar_parquet.c
+++ b/src/columnar_parquet.c
@@ -999,7 +999,7 @@ PgColumnarWriteParquetFile(Relation rel, Snapshot snapshot, const char *filepath
 							format_type_be(att->atttypid))));
 	}
 
-	snk = PgColumnarSinkOpenLocal(filepath);
+	snk = PgColumnarSinkOpen(filepath);
 	PG_TRY();
 	{
 	PgColumnarSinkWrite(snk, "PAR1", 4);	/* magic header */

--- a/src/columnar_sink.c
+++ b/src/columnar_sink.c
@@ -19,16 +19,21 @@
 #include "miscadmin.h"
 #include "storage/fd.h"
 
+#include "columnar_objstore.h"
 #include "columnar_sink.h"
 
 int			pgcolumnar_sink_fail_after = -1;	/* dev injection; see header */
 
 struct PqSink
 {
+	/* local */
 	FILE	   *f;
 	char	   *finalPath;
 	char	   *tmpPath;
 	int64		written;
+	/* remote (#394): NULL api => local sink */
+	const PgColumnarObjStoreApi *api;
+	PgColumnarObjSink *rsink;
 };
 
 PqSink *
@@ -47,6 +52,42 @@ PgColumnarSinkOpenLocal(const char *path)
 	return snk;
 }
 
+/*
+ * The seam the exporters call (#394): a local path keeps step 1's
+ * temp-and-rename exactly; a remote URL routes through the object-store
+ * module, which is loaded on first use and gives the SAME
+ * nothing-visible-before-finish property from multipart completion.
+ */
+PqSink *
+PgColumnarSinkOpen(const char *path)
+{
+	if (PgColumnarPathIsRemote(path))
+	{
+		const PgColumnarObjStoreApi *api = PgColumnarObjStoreGet();
+		PqSink	   *snk;
+
+		if (api == NULL)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("columnar: writing \"%s\" requires the object-store module",
+							path),
+					 errdetail("Object storage support is a separate library, "
+							   "pgcolumnar_objstore, which is not installed.")));
+		if (!api->handles_url(path))
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("columnar: writing \"%s\" is not supported", path),
+					 errdetail("The installed object-store module handles no "
+							   "such URL scheme.")));
+		snk = (PqSink *) palloc0(sizeof(PqSink));
+		snk->finalPath = pstrdup(path);
+		snk->api = api;
+		snk->rsink = api->sink_create(path, NULL);
+		return snk;
+	}
+	return PgColumnarSinkOpenLocal(path);
+}
+
 void
 PgColumnarSinkWrite(PqSink *snk, const void *buf, size_t n)
 {
@@ -56,32 +97,37 @@ PgColumnarSinkWrite(PqSink *snk, const void *buf, size_t n)
 		return;
 
 	/*
-	 * Fault injection (dev): fail exactly as a full disk would, through the
-	 * same report below, once the running total would cross the limit.
+	 * Fault injection (dev) is shared: it fails the SAME way for both sinks,
+	 * so the remote abort path is exercised by the same GUC the local one is.
 	 */
 	if (pgcolumnar_sink_fail_after >= 0 &&
 		snk->written + (int64) n > (int64) pgcolumnar_sink_fail_after)
-	{
-		errno = ENOSPC;
-		wrote = 0;
-	}
-	else
-		wrote = fwrite(buf, 1, n, snk->f);
-
-	if (wrote != n)
-	{
-		/*
-		 * A short fwrite leaves the real cause in errno via the stream error;
-		 * a clean short count with no error is still a failed write, reported
-		 * as the device-full condition it almost always is.
-		 */
-		if (errno == 0)
-			errno = ENOSPC;
 		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not write to \"%s\": %m", snk->tmpPath),
+				(errcode(ERRCODE_DISK_FULL),
+				 errmsg("columnar: export write failed (injected fault)"),
 				 errdetail("The export had written %lld bytes.",
 						   (long long) snk->written)));
+
+	if (snk->api != NULL)
+		snk->api->sink_write(snk->rsink, buf, n);
+	else
+	{
+		wrote = fwrite(buf, 1, n, snk->f);
+		if (wrote != n)
+		{
+			/*
+			 * A short fwrite leaves the real cause in errno via the stream
+			 * error; a clean short count with no error is still a failed
+			 * write, reported as the device-full condition it usually is.
+			 */
+			if (errno == 0)
+				errno = ENOSPC;
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not write to \"%s\": %m", snk->tmpPath),
+					 errdetail("The export had written %lld bytes.",
+							   (long long) snk->written)));
+		}
 	}
 	snk->written += (int64) n;
 }
@@ -89,8 +135,15 @@ PgColumnarSinkWrite(PqSink *snk, const void *buf, size_t n)
 void
 PgColumnarSinkFinish(PqSink *snk)
 {
-	FILE	   *f = snk->f;
+	FILE	   *f;
 
+	if (snk->api != NULL)
+	{
+		snk->api->sink_finish(snk->rsink);
+		snk->rsink = NULL;
+		return;
+	}
+	f = snk->f;
 	snk->f = NULL;
 	if (fflush(f) != 0 || pg_fsync(fileno(f)) != 0)
 	{
@@ -116,6 +169,15 @@ PgColumnarSinkAbort(PqSink *snk)
 {
 	if (snk == NULL)
 		return;
+	if (snk->api != NULL)
+	{
+		if (snk->rsink != NULL)
+		{
+			snk->api->sink_abort(snk->rsink);
+			snk->rsink = NULL;
+		}
+		return;
+	}
 	if (snk->f != NULL)
 	{
 		FreeFile(snk->f);

--- a/src/columnar_sink.h
+++ b/src/columnar_sink.h
@@ -18,7 +18,10 @@
 
 typedef struct PqSink PqSink;
 
-/* Open <path>.tmp.<pid> for writing; the final name stays untouched. */
+/* Open a sink for `path`: local (temp-and-rename) or remote (#394) by scheme. */
+extern PqSink *PgColumnarSinkOpen(const char *path);
+
+/* The local implementation; PgColumnarSinkOpen dispatches to it for a path. */
 extern PqSink *PgColumnarSinkOpenLocal(const char *path);
 
 /* Append exactly n bytes; a short write is an error AT THE CALL (#394). */

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -79,6 +79,7 @@ bool		pgcolumnar_enable_late_materialization = true;
 bool		pgcolumnar_enable_column_projection = true;
 bool		pgcolumnar_enable_bloom_filter = true;
 bool		pgcolumnar_objstore_buffered = true;	/* #393 */
+int			pgcolumnar_objstore_part_size = 0;	/* #394 remote part size */
 char	   *pgcolumnar_objstore_allowed_endpoints = NULL;	/* #393 allow-list */
 
 /* value set for columnar.compression (spec 5, 8.3) */
@@ -2785,6 +2786,22 @@ _PG_init(void)
 	 * that land inside write_record_batch, the helper the 13-site census
 	 * missed.
 	 */
+	/*
+	 * Multipart part size for remote export (#394). Default 0 means the
+	 * module's built-in 8 MiB; a small value forces the multipart path on a
+	 * small fixture. Read by the objstore module via GetConfigOption; defined
+	 * here because the module loads after configuration parsing.
+	 */
+	DefineCustomIntVariable("pgcolumnar.objstore_part_size",
+							"Multipart part size in bytes for remote export (0 = module default 8 MiB).",
+							NULL,
+							&pgcolumnar_objstore_part_size,
+							0,
+							0, INT_MAX,
+							PGC_USERSET,
+							0,
+							NULL, NULL, NULL);
+
 	DefineCustomIntVariable("pgcolumnar.sink_fail_after",
 							"Fail export writes after this many bytes (dev fault injection).",
 							"-1 disables. The failure takes the same path a full disk takes.",

--- a/test/objstore_http_read.sh
+++ b/test/objstore_http_read.sh
@@ -145,8 +145,10 @@ check_ratio "B: buffered/unbuffered request ratio" "$FULL_BUF" "$FULL_UNBUF" "0.
 # on an empty log, which is exactly what the RED run produced.
 : > "$HTTP_LOG"
 q "SELECT sum(c0) FROM fhttp" >/dev/null
+# log columns since #394: METHOD path query range ($4 is the range; a GET's
+# query is always "-", so the range moved from $3 to $4).
 NGETS="$(awk '$1 == "GET"' "$HTTP_LOG" | wc -l | tr -d ' ')"
-NORANGE="$(awk '$1 == "GET" && $3 == "-"' "$HTTP_LOG" | wc -l | tr -d ' ')"
+NORANGE="$(awk '$1 == "GET" && $4 == "-"' "$HTTP_LOG" | wc -l | tr -d ' ')"
 check "premise: the range-audit phase logged GETs" \
 	"$([ "${NGETS:-0}" -gt 0 ] 2>/dev/null && echo yes)" "yes"
 check_num "B: every GET carried a Range header" "$NORANGE" "0"

--- a/test/objstore_http_server.py
+++ b/test/objstore_http_server.py
@@ -66,11 +66,25 @@ AUTH_RE = re.compile(
     r"SignedHeaders=([^,]+),\s*Signature=([0-9a-f]{64})$")
 
 
-def sigv4_expected(secret, method, path, headers, signed_headers, amzdate,
-                   datestamp, region, payload_hash):
+def canonical_query(qs):
+    """AWS canonical query: sorted, strictly UriEncoded (the query variant
+    encodes '/'). qs is the raw string after '?'."""
+    if not qs:
+        return ""
+    def enc(x):
+        return urllib.parse.quote(urllib.parse.unquote_plus(x), safe="-._~")
+    pairs = []
+    for part in qs.split("&"):
+        k, _, v = part.partition("=")
+        pairs.append((enc(k), enc(v)))
+    return "&".join("%s=%s" % kv for kv in sorted(pairs))
+
+
+def sigv4_expected(secret, method, path, query, headers, signed_headers,
+                   amzdate, datestamp, region, payload_hash):
     canon_headers = "".join(
         "%s:%s\n" % (h, headers.get(h, "").strip()) for h in signed_headers)
-    creq = "\n".join([method, path, "", canon_headers,
+    creq = "\n".join([method, path, canonical_query(query), canon_headers,
                       ";".join(signed_headers), payload_hash])
     scope = "%s/%s/s3/aws4_request" % (datestamp, region)
     sts = "\n".join(["AWS4-HMAC-SHA256", amzdate, scope,
@@ -89,13 +103,16 @@ class Handler(BaseHTTPRequestHandler):
 
     def _log_line(self):
         rng = self.headers.get("Range", "-").replace(" ", "")
+        rawpath, _, query = self.path.partition("?")
         with open(self.server.reqlog, "a") as f:
-            f.write("%s %s %s\n" % (self.command, self.path, rng))
+            f.write("%s %s %s %s\n" % (self.command, rawpath,
+                                        query or "-", rng))
 
     def _resolve(self):
         # SigV4 verification runs over the RAW request target (that is what
-        # the client signed); only the filesystem lookup decodes it.
-        path = urllib.parse.unquote(self.path)
+        # the client signed); only the filesystem lookup decodes it, and the
+        # query never names a file.
+        path = urllib.parse.unquote(self.path.partition("?")[0])
         mode = "normal"
         for prefix in ("/norange/", "/stall/"):
             if path.startswith(prefix):
@@ -151,12 +168,21 @@ class Handler(BaseHTTPRequestHandler):
             return False
         amzdate = self.headers.get("x-amz-date", "")
         payload_hash = self.headers.get("x-amz-content-sha256", "")
-        want = sigv4_expected(secret, self.command, self.path, self.headers,
-                              signed_headers, amzdate, datestamp, region,
-                              payload_hash)
+        rawpath, _, query = self.path.partition("?")
+        want = sigv4_expected(secret, self.command, rawpath, query,
+                              self.headers, signed_headers, amzdate,
+                              datestamp, region, payload_hash)
         if not hmac.compare_digest(want, got_sig):
             self._deny(403, "SignatureDoesNotMatch")
             return False
+        # Requests carrying a body must hash it truthfully (#394): the write
+        # arms are cross-implementation checks of the payload hash too.
+        clen = int(self.headers.get("Content-Length", "0") or "0")
+        if self.command in ("PUT", "POST") :
+            self._body = self.rfile.read(clen) if clen else b""
+            if payload_hash != "UNSIGNED-PAYLOAD" and                hashlib.sha256(self._body).hexdigest() != payload_hash:
+                self._deny(403, "XAmzContentSHA256Mismatch")
+                return False
         return True
 
     def _head_common(self, local):
@@ -228,6 +254,92 @@ class Handler(BaseHTTPRequestHandler):
         self.wfile.write(body)
 
 
+    # ---- write side (#394): plain PUT, and a faithful multipart emulation --
+    def _qdict(self):
+        q = {}
+        for part in self.path.partition("?")[2].split("&"):
+            if part:
+                k, _, v = part.partition("=")
+                q[urllib.parse.unquote(k)] = urllib.parse.unquote(v)
+        return q
+
+    def do_PUT(self):
+        self._log_line()
+        if not self._sigv4_check():
+            return
+        q = self._qdict()
+        _, local = self._resolve()
+        if "uploadId" in q and "partNumber" in q:
+            up = self.server.uploads.get(q["uploadId"])
+            if up is None or up["local"] != local:
+                self._deny(404, "NoSuchUpload")
+                return
+            up["parts"][int(q["partNumber"])] = self._body
+            etag = hashlib.md5(self._body).hexdigest()
+            self.send_response(200)
+            self.send_header("ETag", '"%s"' % etag)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+        os.makedirs(os.path.dirname(local), exist_ok=True)
+        with open(local, "wb") as f:
+            f.write(self._body)
+        self.send_response(200)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def do_POST(self):
+        self._log_line()
+        if not self._sigv4_check():
+            return
+        q = self._qdict()
+        _, local = self._resolve()
+        if "uploads" in q:
+            uid = "up-%d" % (len(self.server.uploads) + 1)
+            self.server.uploads[uid] = {"local": local, "parts": {}}
+            body = ("<?xml version=\"1.0\"?><InitiateMultipartUploadResult>"
+                    "<UploadId>%s</UploadId>"
+                    "</InitiateMultipartUploadResult>" % uid).encode()
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        if "uploadId" in q:
+            up = self.server.uploads.pop(q["uploadId"], None)
+            if up is None or up["local"] != local:
+                self._deny(404, "NoSuchUpload")
+                return
+            os.makedirs(os.path.dirname(local), exist_ok=True)
+            with open(local, "wb") as f:
+                for n in sorted(up["parts"]):
+                    f.write(up["parts"][n])
+            body = b"<?xml version=\"1.0\"?><CompleteMultipartUploadResult/>"
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        self._deny(400, "InvalidRequest")
+
+    def do_DELETE(self):
+        self._log_line()
+        if not self._sigv4_check():
+            return
+        q = self._qdict()
+        _, local = self._resolve()
+        if "uploadId" in q:
+            up = self.server.uploads.pop(q["uploadId"], None)
+            if up is None:
+                self._deny(404, "NoSuchUpload")
+                return
+        elif os.path.isfile(local):
+            os.unlink(local)
+        self.send_response(204)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--dir", required=True)
@@ -254,6 +366,7 @@ def main():
     srv.sigv4_region = args.sigv4_region
     srv.sigv4_token = args.sigv4_token
     srv.tamper_bucket = args.tamper_bucket
+    srv.uploads = {}
     open(args.log, "a").close()
     # Readiness marker for the suite: print once the socket is bound.
     print("READY", flush=True)

--- a/test/objstore_http_server.py
+++ b/test/objstore_http_server.py
@@ -295,7 +295,12 @@ class Handler(BaseHTTPRequestHandler):
         q = self._qdict()
         _, local = self._resolve()
         if "uploads" in q:
-            uid = "up-%d" % (len(self.server.uploads) + 1)
+            # A reserved character ('/', '+') in the id on purpose: a real AWS
+            # UploadId can carry them, and the client must percent-encode the id
+            # in the canonical query or its signature diverges. With this id the
+            # multipart round trip passes ONLY if that encoding is correct
+            # (#394 review turned from "unproven" to pinned).
+            uid = "up/%d+x" % (len(self.server.uploads) + 1)
             self.server.uploads[uid] = {"local": local, "parts": {}}
             body = ("<?xml version=\"1.0\"?><InitiateMultipartUploadResult>"
                     "<UploadId>%s</UploadId>"

--- a/test/objstore_sink_write.sh
+++ b/test/objstore_sink_write.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+#
+# pgColumnar #394 steps 3-4: the remote sink - exports to s3://, multipart
+# above the part size, complete-or-abort, parallel per-worker objects.
+#
+# The fixture server emulates multipart faithfully (create/parts/complete/
+# abort, parts invisible until complete) under the same stdlib SigV4 verifier
+# as the read side - now including PAYLOAD HASHES and canonical QUERY strings,
+# so every write arm is a cross-implementation signature check of the parts
+# M2's read-only signing never exercised. design/ISSUE_394_REMOTE_SINK.md.
+#
+# The invariant under test is step 1's, verbatim: nothing is ever visible at
+# the final name before finish() returns. S3 gives it via multipart; the arms
+# that matter are the failure ones - an aborted upload leaves NOTHING, keyed
+# or partial.
+#
+# Usage:  test/objstore_sink_write.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+export PGC_EXTRA_CONF=$'pgcolumnar.objstore_allowed_endpoints=\'127.0.0.1\'\nmax_worker_processes=16'
+
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+S3_PORT="$(pgc_pick_free_port "$PGC_AUX_PORT_LO" "$PGC_AUX_PORT_HI")"
+S3_LOG="$PGC_WORKDIR/sink.log"
+SRV_PID=""
+AKID="PGCTESTKEYID"
+SECRET="pgctest-secret-shhh"
+REGION="pgc-test-1"
+BUCKET="pgc-bucket"
+
+objstore_sink_teardown() {
+	[ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null
+	pgc_teardown
+}
+trap objstore_sink_teardown EXIT INT TERM
+
+pg_restart_env() {
+	pgc_pg "pg_ctl -D '$PGC_PGDATA' stop -m fast -w" >/dev/null 2>&1
+	pgc_pg "$* pg_ctl -D '$PGC_PGDATA' -l '$PGC_LOGFILE' start -w" >/dev/null 2>&1
+	for _ in $(seq 1 30); do [ -n "$(q 'SELECT 1')" ] && return 0; sleep 0.5; done
+	echo "FATAL: cluster did not come back"; exit 1
+}
+sqlstate_of() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -qtA 2>&1 <<SQLEOF | sed -n 's/^ERROR:  \([0-9A-Z]\{5\}\).*/\1/p' | head -1
+\\set VERBOSITY sqlstate
+$1;
+SQLEOF
+}
+logn() { grep -cE "$1" "$S3_LOG" | tr -d ' '; }
+
+mkdir -p "$PGC_WORKDIR/$BUCKET"
+python3 "$(dirname "${BASH_SOURCE[0]}")/objstore_http_server.py" \
+	--dir "$PGC_WORKDIR" --port "$S3_PORT" --log "$S3_LOG" \
+	--sigv4-key "$AKID" --sigv4-secret "$SECRET" --sigv4-region "$REGION" \
+	> "$PGC_WORKDIR/sink_server.out" 2>&1 &
+SRV_PID=$!
+for _ in $(seq 1 50); do
+	grep -q READY "$PGC_WORKDIR/sink_server.out" 2>/dev/null && break
+	sleep 0.1
+done
+check "premise: sigv4 fixture server is up" \
+	"$(grep -c READY "$PGC_WORKDIR/sink_server.out" 2>/dev/null)" "1"
+
+pg_restart_env "AWS_ENDPOINT_URL='http://127.0.0.1:$S3_PORT'" \
+	"AWS_ACCESS_KEY_ID='$AKID'" "AWS_SECRET_ACCESS_KEY='$SECRET'" \
+	"AWS_REGION='$REGION'"
+
+# ---- fixtures: small (single PUT) and large (multipart) ---------------------
+psql_run "CREATE TABLE es_small (id int, t text) USING pgcolumnar;"
+psql_run "INSERT INTO es_small SELECT g, 'row-'||g FROM generate_series(1,1000) g;"
+psql_run "CREATE TABLE es_big (id int8, pad text) USING pgcolumnar;"
+psql_run "INSERT INTO es_big SELECT g, md5(g::text)||md5((g+1)::text) FROM generate_series(1,400000) g;"
+psql_run "CREATE SERVER wsrv FOREIGN DATA WRAPPER pgcolumnar_parquet;"
+
+# Force the multipart path on this modest fixture: a 256 KB part means the big
+# export crosses several parts without generating tens of MiB. Set inline in
+# the same session as the big export (below), the form the injection GUC uses.
+PART="SET pgcolumnar.objstore_part_size = 262144;"
+qset() {  # qset <sql>  -- scalar under the small-part GUC
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -At -c "$PART $1" 2>/dev/null | tail -1
+}
+
+# ---- step 3: single-object round trips through the module BOTH ways ---------
+: > "$S3_LOG"
+check_num "small export to s3:// succeeds" \
+	"$(q "SELECT pgcolumnar.export_parquet('es_small', 's3://$BUCKET/small.parquet')")" "1000"
+check_num "small object went as ONE plain PUT (no multipart)" \
+	"$(logn '^PUT /pgc-bucket/small.parquet -')" "1"
+psql_run "CREATE FOREIGN TABLE f_small (id int, t text) SERVER wsrv OPTIONS (path 's3://$BUCKET/small.parquet');"
+check "small round trip: s3 read-back == source" \
+	"$(pgc_set_hash "SELECT * FROM f_small")" "$(pgc_set_hash "SELECT * FROM es_small")"
+
+: > "$S3_LOG"
+BIGROWS="$(q "SELECT count(*) FROM es_big")"
+check_num "large export to s3:// succeeds" \
+	"$(qset "SELECT pgcolumnar.export_parquet('es_big', 's3://$BUCKET/big.parquet')")" "$BIGROWS"
+check "premise: the large export took the multipart protocol" \
+	"$([ "$(logn '^POST /pgc-bucket/big.parquet uploads=')" -ge 1 ] && [ "$(logn '^PUT /pgc-bucket/big.parquet partNumber=')" -ge 2 ] && echo yes || echo no)" "yes"
+check_num "and completed it exactly once (POST with uploadId, no partNumber)" \
+	"$(logn '^POST /pgc-bucket/big.parquet uploadId=')" "1"
+psql_run "CREATE FOREIGN TABLE f_big (id int8, pad text) SERVER wsrv OPTIONS (path 's3://$BUCKET/big.parquet');"
+check "large round trip: s3 read-back == source" \
+	"$(pgc_set_hash "SELECT * FROM f_big")" "$(pgc_set_hash "SELECT * FROM es_big")"
+
+# ---- injection: abort mid-part leaves NOTHING -------------------------------
+: > "$S3_LOG"
+# fail_after well above one part so the fault lands mid-multipart, after at
+# least one part and the CreateMultipartUpload.
+check "inject: mid-upload failure surfaces as disk-full (53100)" \
+	"$(sqlstate_of "$PART SET pgcolumnar.sink_fail_after = 900000; SELECT pgcolumnar.export_parquet('es_big', 's3://$BUCKET/fail.parquet')")" "53100"
+check "inject: the key does not exist" \
+	"$([ ! -e "$PGC_WORKDIR/$BUCKET/fail.parquet" ] && echo clean)" "clean"
+# the money check: every multipart upload STARTED for this key was ABORTED, so
+# nothing dangles to bill (robust to exactly where the injected fault landed -
+# if it landed before multipart began, both counts are 0).
+STARTED="$(logn '^POST /pgc-bucket/fail.parquet uploads=')"
+ABORTED="$(logn '^DELETE /pgc-bucket/fail.parquet uploadId=')"
+check "premise: the fault landed mid-multipart (an upload was started)" \
+	"$([ "${STARTED:-0}" -ge 1 ] && echo yes)" "yes"
+check_num "inject: every upload started was aborted (no billable orphan)" \
+	"$ABORTED" "$STARTED"
+
+# ---- taxonomy: the write side wears the same gates as the read side ---------
+check "allow-list: an unlisted endpoint refuses 42501 before any write" \
+	"$(sqlstate_of "SELECT pgcolumnar.export_parquet('es_small', 'http://127.0.0.2:1/x.parquet')")" "42501"
+check "arrow export to s3:// also round-trips" \
+	"$(q "SELECT pgcolumnar.export_arrow('es_small', 's3://$BUCKET/small.arrow') > 0")" "t"
+
+# Parallel export to a remote prefix is step 4 (the dispatcher's local
+# directory prep and key cleanup need remote-awareness); tracked separately.
+
+# ---- optional: a real S3 implementation (Garage) ----------------------------
+if [ -n "${PGC_S3_INTEGRATION_ENDPOINT:-}" ]; then
+	pg_restart_env "AWS_ENDPOINT_URL='$PGC_S3_INTEGRATION_ENDPOINT'" \
+		"AWS_ACCESS_KEY_ID='$PGC_S3_INTEGRATION_KEY'" \
+		"AWS_SECRET_ACCESS_KEY='$PGC_S3_INTEGRATION_SECRET'" \
+		"AWS_REGION='${PGC_S3_INTEGRATION_REGION:-garage}'"
+	pgc_pg "echo \"pgcolumnar.objstore_allowed_endpoints='$(echo "${PGC_S3_INTEGRATION_ENDPOINT#http://}" | cut -d/ -f1 | cut -d: -f1)'\" >> '$PGC_PGDATA/postgresql.conf'"
+	psql_run "SELECT pg_reload_conf();"
+	IB="${PGC_S3_INTEGRATION_BUCKET:-pgcolumnar-test}"
+	check_num "integration: multipart export to real S3 succeeds" \
+		"$(q "SELECT pgcolumnar.export_parquet('es_big', 's3://$IB/m2sink-$$.parquet')")" "$BIGROWS"
+	psql_run "CREATE FOREIGN TABLE f_real (id int8, pad text) SERVER wsrv OPTIONS (path 's3://$IB/m2sink-$$.parquet');"
+	check "integration: real S3 read-back == source" \
+		"$(pgc_set_hash "SELECT * FROM f_real")" "$(pgc_set_hash "SELECT * FROM es_big")"
+else
+	echo "note: PGC_S3_INTEGRATION_ENDPOINT unset; the stdlib-verifier arms carry the proof alone"
+fi
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -154,6 +154,7 @@ SUITES=(
 	objstore_http_read
 	objstore_module
 	objstore_s3_read
+	objstore_sink_write
 	objstore_stash_recovery
 	objstore_tls_read
 	parallel


### PR DESCRIPTION
Step 3 of the #394 order of work, on the merged local sink (#612) and everything #393 built. Design: `design/ISSUE_394_REMOTE_SINK.md` (in this PR).

## What lands

- **`export_parquet`/`export_arrow` to `s3://`** through the module: `PgColumnarSinkOpen` dispatches by scheme; remote gets the same nothing-visible-before-`finish` property from multipart completion that the local sink gets from temp-and-rename.
- **ABI v3**: `sink_create/write/finish/abort` + `delete_object`. Small object = one PUT; large = Create/Upload(8 MiB)/Complete multipart, with Abort from both the exporter's `PG_CATCH` and the module's resource-release callback.
- **Signing grew what the read path never needed**: canonical **query** strings (a valueless key like `?uploads` canonicalizes to `uploads=` — this cost exactly one debugging cycle, caught by the fixture verifier) and a **real per-request payload hash**. ETags captured from the PUT header and echoed in Complete, which a real S3 validates.
- Remote writes wear the M4 + allow-list gates: ambient behind `pg_write_server_files`, allow-list enforced at connect, link-local refused unconditionally (a remote write is off-box exfiltration).

## The oracle, and the money check

The fixture emulates multipart faithfully under the **same stdlib SigV4 verifier** as the read side, now checking payload hashes and canonical queries too — every write arm is a cross-implementation signature check. The failure arm is the one the design calls "the path that leaks money and never gets exercised by accident": a mid-upload injected fault (53100) must leave **no key AND every upload started aborted** (asserted as `DELETE uploadId count == POST uploads count`, robust to where the fault lands).

**Live Garage arm passed**: a real S3 implementation accepted the multipart upload with real ETags and the read-back matched.

## Proofs

- RED-first on main (today's sink refuses remote paths, 58P01).
- Removal proofs both run: neuter the abort DELETE → the no-orphan check reds; force single-PUT → the multipart premise reds.
- 14/14 on PG17 (lane), PG18, PG19; +2 live Garage arms; ASAN+UBSAN gate green over `objstore_sink_write`, `export_sink`, `objstore_s3_read`; objstore + export family unregressed; `-Wshadow -Werror` clean.

## Scope

Parallel export to a remote prefix is **step 4** — the dispatcher's local directory prep and key cleanup need remote-awareness (its worker sinks already route through the choke point). Not here. Drive-by: the fixture log gained a query column, so `objstore_http_read`'s range check moves `$3`→`$4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)