### PR TITLE
feat: the Parquet FDW streams row groups instead of materializing a tuplestore (#620)

### DIFF
--- a/design/ISSUE_620_FDW_STREAMING.md
+++ b/design/ISSUE_620_FDW_STREAMING.md
@@ -1,0 +1,183 @@
+# Issue #620: the Parquet FDW streams instead of materializing a tuplestore
+
+Design before code. Today `pqfdwBeginForeignScan` opens every resolved file,
+decodes it whole, and drains all rows into one `randomAccess` tuplestore before
+it returns; `Iterate` just drains the tuplestore and `ReScan` is a free
+`tuplestore_rescan`. The whole file (really, every file the path resolves to)
+sits in `work_mem`-backed storage, spilling to disk past `work_mem`, and a
+`LIMIT k` still decodes every row group of every file. This issue makes the scan
+pull one row group at a time and stop when the executor stops asking.
+
+All line citations are `src/columnar_parquet_reader.c` at HEAD (`main`, post-#445).
+
+## The unit of streaming is one row group
+
+`pq_read_rows` (2941) is a push loop with two nested loops: an outer loop over
+row groups that decodes a whole group's needed leaves into `groupCtx` (the
+`decode_leaf_entries` block), and an inner loop that assembles each of the
+group's `n` rows and calls `sink(slot, arg)` per row. The natural resumable
+granularity is the row group: decode one group, hand out its `n` rows across
+successive `Iterate` calls, and reset `groupCtx` only when advancing to the next
+non-skipped group. `rowCtx` already resets per row.
+
+Memory drops from "every file" to "one row group's decoded columns". `LIMIT`
+stops after the groups whose rows it consumed. Correctness of row assembly is
+unchanged because the assembly code moves verbatim.
+
+## Shape: a resumable cursor, assembly code moved not rewritten
+
+Refactor `pq_read_rows`'s body into two reused pieces, called by both the eager
+SRF path (unchanged behaviour) and the new streaming FDW cursor:
+
+- `pq_decode_group(pf, src, leaves, ..., rg, groupCtx)` runs the existing
+  per-group decode (the `decode_leaf_entries` block) for group `rg` into
+  `groupCtx` and returns the group's row count `n` and the decoded per-leaf
+  entry state. This is lifted verbatim from the outer-loop body.
+- `pq_assemble_row(state, r, slot)` runs the existing per-row assembly (scalar,
+  list, struct, const/partition stamping, `ExecStoreVirtualTuple`) for row `r`
+  into `slot`. Lifted verbatim from the inner-loop body.
+
+`pq_read_rows` is then re-expressed as: `for each rg { n = pq_decode_group(...);
+for r in 0..n { pq_assemble_row(...); sink(...); MemoryContextReset(rowCtx); } }`
+so the SRF and import paths keep their exact current behaviour and stay eager.
+This keeps the refactor mechanical and lets the existing row-content suites prove
+the move introduced no assembly change.
+
+### The FDW cursor state (on `PqFdwScanState`)
+
+Replace `tupstore`/`readslot` with a cursor:
+
+- the resolved `files` list and a current-file index;
+- the current open `PqSource` (or a flag that none is open) and its `PqFile`
+  footer;
+- the projection/skip plan for the current file (`needLeaf`/`needTop`,
+  `skipGroup[]`), computed once per file as Begin does today;
+- the current row-group index `rg`, the decoded group's `n`, and the current row
+  index `r` within it;
+- `groupCtx` and `rowCtx` living in the scan's own long-lived context, not the
+  transient context Begin runs in (see winCtx note below);
+- the six EXPLAIN counters, plus one new counter (below).
+
+`Iterate`: if a group is loaded and `r < n`, assemble row `r`, `r++`, return the
+slot. Else advance `rg` to the next non-skipped group of the current file,
+`pq_decode_group` it, set `r = 0`, and retry. When the current file's groups are
+exhausted, `pq_source_close` it, advance the file index, open the next file,
+recompute its plan, and retry. When files are exhausted, return an empty slot.
+
+`Begin` no longer decodes: it resolves the file list and prunes (the
+`Files Pruned` path), sets `filesRead`, and leaves the cursor before the first
+file. The first `Iterate` opens the first file. (Open the first file in Begin if
+a suite needs open errors surfaced at Begin; decide by what the FDW suites
+expect. Default: lazy open in Iterate, which is the streaming point.)
+
+`ReScan`: close any open source, reset the file index and `rg`/`r` to the start,
+and stream again from the top. This re-opens and re-decodes; it is
+correctness-preserving. Today's free rescan is the eager model's benefit and is
+the deliberate trade. No existing suite asserts rescan *cost*, only *content*.
+
+`End`: close any open source (order-sensitive with dropping the slot, as today),
+delete the cursor contexts.
+
+## The remote-handle lifetime invariant
+
+The object-store module closes every open handle on abort through
+`os_resource_release` over `os_open_handles`
+(`objstore/columnar_objstore_module.c`). The stated invariant is "no handle
+survives its statement (every reader materializes and closes before returning)".
+A streamed scan holds one remote handle open across `Iterate` calls, so the
+"before returning" phrasing stops being literally true. The invariant that makes
+close-all-on-abort correct is still true: the handle belongs to the running
+statement, and the release callback walks the list regardless of who holds the
+pointer, so an error between `Iterate` calls is cleaned up. Action items:
+
+- Update the module header comment to state the invariant as "no handle survives
+  its *statement*", not "before returning".
+- `pq_source`'s prefetch window `winCtx` is captured at open as
+  `CurrentMemoryContext` (open runs inside Begin today, which is why it is safe).
+  Under streaming, open runs inside an `Iterate` call whose context is transient;
+  the window must live in the scan's long-lived context. Open the source with the
+  scan context current, or set `winCtx` explicitly to the scan context.
+- One remote handle and its ExternalFD reservation are held for the span of a
+  file's rows, not released immediately as in the eager model. This is a real
+  resource-occupancy change, bounded to one file at a time (single open handle),
+  and is the intended cost of streaming.
+
+## Out of scope: the SRF (`read_parquet`) stays eager
+
+`pgcolumnar_read_parquet` returns in `SFRM_Materialize` mode with a whole-set
+tuplestore. Streaming it means `SFRM_ValuePerCall`, a larger and separate change.
+This issue is the FDW. The SRF keeps calling `pq_read_rows` (now built on the two
+extracted helpers) and stays eager, byte-for-byte in behaviour.
+
+## TDD instrument: a groups-decoded counter (there is none today)
+
+The six EXPLAIN counters are all decode-*decision* counts. None reports rows
+produced or groups actually decoded, and `pq_read_rows`'s local `total` is
+`(void)`-discarded at the FDW call site. So today a suite cannot tell an eager
+`LIMIT 3` (decodes every group) from a streamed one (decodes one), because the
+counters read identically.
+
+Add `int groupsDecoded;` to `PqFdwScanState`, incremented once per
+`pq_decode_group` call in the cursor, and print it from
+`pqfdwExplainForeignScan` as `Row Groups Decoded`. This is the work-done
+instrument (per the discipline: measure the work, not the intent; assert the
+execution path on both arms).
+
+### RED / GREEN / removal proof
+
+- **RED**: on `main`, `EXPLAIN (ANALYZE)` of `SELECT * FROM ft LIMIT` over a
+  multi-row-group local file has no `Row Groups Decoded` line, and no counter
+  distinguishes `LIMIT 1` from a full scan. The new-counter assertion fails to
+  find the line; the streaming assertion (LIMIT-1 decodes 1 group of N) cannot
+  even be written against the eager code.
+- **GREEN**: with streaming, `Row Groups Decoded` appears, a full scan of an
+  `N`-group file reports `N`, and `LIMIT k` with `k` inside the first group
+  reports `1`. Row *content* for full scans is identical to `main` across every
+  existing FDW suite.
+- **Removal proof**: force the cursor to decode all groups up front (defeat the
+  lazy advance) and the `LIMIT 1 -> 1 group` arm reds (reports `N`). Separately,
+  neuter the `groupsDecoded++` and the counter line assertion reds. Each proves
+  a distinct claim: the streaming happened, and the instrument measures it.
+
+The `native_parquet_pushdown.sh` EXPLAIN-scraping arms are the template
+(`Row Groups Skipped` / `Row Groups:` via grep). Use a local file with several
+row groups (small `stripe_row_limit` on the source columnar table, exported to
+Parquet) so `LIMIT` inside the first group decodes 1 of N.
+
+## Regression surface (all local-file, no network)
+
+Must stay green with identical row content: `native_parquet_fdw.sh`,
+`native_parquet_pushdown.sh` (Row Groups Skipped counters), `native_parquet_projection.sh`
+(Columns Read/Total), `native_parquet_partition.sh` (Files Pruned + partition
+stamping), `native_parquet_multifile.sh` (multi-file drain + ReScan), the
+row-content suites (`native_parquet_stack.sh`, `_hardening.sh`, `_codecs.sh`,
+`_flba.sh`, `native_read_parquet.sh`), and the remote suite
+`objstore_s3_read.sh`. `native_parquet_streaming.sh` (today only footer
+streaming) is the home for the new LIMIT-reduces-work arm.
+
+ReScan is the specific risk: `native_parquet_multifile.sh` and any nested-loop
+plan re-scan the foreign table. Streaming ReScan re-decodes; content stays
+identical, which is what those suites assert.
+
+## Gates
+
+PG17 lane first (`-Wshadow -Werror`). Then PG18/19 over the FDW + objstore read
+suites. ASAN (pg18_san) over the FDW read path and `objstore_s3_read`: this is a
+per-scan memory-lifecycle change (group/row contexts now outlive a single call,
+a remote handle and its prefetch window now span Iterate calls), exactly the
+class the ASAN gate exists for. Both a local multi-group scan and a remote scan
+with a `LIMIT` (source closed early mid-file) must run clean.
+
+## Order of work
+
+1. Extract `pq_decode_group` / `pq_assemble_row`; re-express `pq_read_rows` on
+   them; prove every existing suite green (pure refactor, no behaviour change).
+2. Add `groupsDecoded` + `Row Groups Decoded` EXPLAIN line. Write the streaming
+   arm in `native_parquet_streaming.sh`; it is RED (counter absent).
+3. Convert the FDW Begin/Iterate/ReScan/End to the cursor. Green the streaming
+   arm; removal proofs; keep all regression suites green.
+4. Fix `winCtx`/scan-context lifetime; update the module invariant comment.
+5. Gates: PG17/18/19 + ASAN. Docs.
+6. Docs: note that the FDW streams row groups (bounded memory, early-exit on
+   LIMIT) while `read_parquet` materializes; `Row Groups Decoded` in the EXPLAIN
+   counter list.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -278,13 +278,18 @@ feeds three surfaces over the same file parse and type inference:
 - `import_parquet` inserts into a target table via `table_tuple_insert`.
 - `read_parquet` returns rows as a set-returning function, and `parquet_schema`
   reports the leaf columns and their inferred PostgreSQL types.
-- The `pgcolumnar_parquet` foreign-data wrapper materializes the file into a
-  tuplestore that the scan drains. It pushes predicates down: it skips a row
-  group when the minimum and maximum statistics prove that the group is empty.
-  This applies to fixed-width ordered types only, and it guards against NaN and
-  against an inverted interval. It also projects: it decodes only the columns
-  that the plan refers to. It computes that set from the reltarget and the quals
-  of the base rel.
+- The `pgcolumnar_parquet` foreign-data wrapper streams the file one row group
+  at a time. Each scan step decodes the next row group into a bounded buffer that
+  the executor drains. The scan holds one row group rather than the whole file. A
+  `LIMIT` that the plan satisfies early leaves the remaining groups and files
+  undecoded. `EXPLAIN ANALYZE` reports `Row Groups Decoded`, the number of groups
+  the scan actually decoded, which a `LIMIT` reduces. It pushes
+  predicates down: it skips a row group when the minimum and maximum statistics
+  prove that the group is empty. This applies to fixed-width ordered types only,
+  and it guards against NaN and against an inverted interval. It also projects:
+  it decodes only the columns that the plan refers to. It computes that set from
+  the reltarget and the quals of the base rel. `read_parquet`, a set-returning
+  function, still materializes its whole result.
 
 A `path` that is a directory or a glob resolves to a sorted list of files. The
 same core reads each file into the one sink. The decode buffers of a file are

--- a/docs/features.md
+++ b/docs/features.md
@@ -189,12 +189,15 @@ coverage.
 - A `path` that is a directory reads each `*.parquet` file below it, at any
   depth, as one relation. A glob pattern expands in the same way. Both use a
   sorted order that does not change between runs.
-- The foreign-table scan pushes work down. It skips a row group when the minimum
-  and maximum statistics exclude the predicate of the query. It decodes only the
-  columns that the query refers to. `EXPLAIN ANALYZE` reports the row groups read and
-  skipped, the columns read, and the number of files. Skipping applies to
-  `column op constant` clauses over integer and floating-point columns; see
-  [limitations.md](limitations.md) for the exact conditions.
+- The foreign-table scan streams one row group at a time. It holds one row group
+  rather than the whole file, and a `LIMIT` the plan meets early leaves the rest
+  undecoded. It pushes work down. It skips a row group when the
+  minimum and maximum statistics exclude the predicate of the query. It decodes
+  only the columns that the query refers to. `EXPLAIN ANALYZE` reports the row
+  groups read, skipped, and decoded, the columns read, and the number of files.
+  Skipping applies to `column op constant` clauses over integer and
+  floating-point columns; see [limitations.md](limitations.md) for the exact
+  conditions.
 - Hive-style partitioning. A foreign table that declares `partition_columns`
   reads a `col=value` directory name as a column. A predicate on such a column
   removes complete files before the reader opens them. A file that pruning

--- a/docs/sql-reference.md
+++ b/docs/sql-reference.md
@@ -560,12 +560,14 @@ SELECT * FROM pgcolumnar.parquet_schema('/data/events.parquet');
 
 ### The pgcolumnar_parquet foreign-data wrapper
 
-Exposes a Parquet file, directory, or glob as a foreign table. The scan pushes
-work down: row groups whose min/max statistics exclude the query's predicate are
-skipped, and only referenced columns are decoded. Skipping requires a
-`column op constant` clause over an integer or floating-point column with a
-constant of the same type; [limitations.md](limitations.md) lists the conditions.
-A scan that skips nothing still returns correct rows.
+Exposes a Parquet file, directory, or glob as a foreign table. The scan streams
+one row group at a time. It holds a single row group rather than the whole file.
+A `LIMIT` the plan satisfies early leaves the rest of the file undecoded. It
+pushes work down: row groups whose min/max statistics exclude the
+query's predicate are skipped, and only referenced columns are decoded. Skipping
+requires a `column op constant` clause over an integer or floating-point column
+with a constant of the same type; [limitations.md](limitations.md) lists the
+conditions. A scan that skips nothing still returns correct rows.
 
 The `path` option can name a local file, directory, or glob, or an
 object-storage URL for a single object. For a remote server the endpoint and
@@ -591,8 +593,8 @@ CREATE FOREIGN TABLE events_p (id int, amount numeric(12,2), dt date, region tex
 
 SELECT sum(amount) FROM events WHERE ts >= '2026-01-01';
 
--- EXPLAIN ANALYZE reports Row Groups, Row Groups Skipped, Columns Read,
--- Columns Total, and Files.
+-- EXPLAIN ANALYZE reports Row Groups, Row Groups Skipped, Row Groups Decoded,
+-- Columns Read, Columns Total, and Files.
 EXPLAIN (ANALYZE, COSTS OFF) SELECT id FROM events WHERE ts >= '2026-01-01';
 ```
 

--- a/objstore/columnar_objstore_module.c
+++ b/objstore/columnar_objstore_module.c
@@ -26,9 +26,12 @@
  *
  * - Sockets are cleaned up on abort through a resource-release callback over
  *   the open-handle list. The invariant that makes close-all-on-abort correct:
- *   no handle survives its statement (every reader materializes and closes
- *   before returning), so a live handle during an abort belongs to the
- *   statement being aborted.
+ *   no handle survives its statement, so a live handle during an abort belongs
+ *   to the statement being aborted. The streaming FDW (#620) holds a read
+ *   handle open across IterateForeignScan calls, so a handle no longer always
+ *   closes before its opener returns. The invariant still holds: the handle is
+ *   the running statement's, EndForeignScan closes it on the normal path, and
+ *   the release callback closes it on abort, whoever holds the pointer.
  *-------------------------------------------------------------------------
  */
 #include "postgres.h"

--- a/src/columnar_parquet_reader.c
+++ b/src/columnar_parquet_reader.c
@@ -4616,6 +4616,11 @@ pqfdwReScanForeignScan(ForeignScanState *node)
 	st->groupsDecoded = 0;
 	st->filesRead = 0;
 	st->filesPruned = 0;
+	/* colsTotal/colsRead are set per opened file; clear them too so a rescan
+	 * that opens zero files (every file partition-pruned on a nested loop's
+	 * inner side) does not leave the prior scan's column counts in EXPLAIN. */
+	st->colsTotal = 0;
+	st->colsRead = 0;
 }
 
 static void

--- a/src/columnar_parquet_reader.c
+++ b/src/columnar_parquet_reader.c
@@ -2943,7 +2943,7 @@ pq_read_rows(PqFile *pf, PqSource *src,
 			 TupleTableSlot *slot, PqRowSink sink, void *sinkarg,
 			 const bool *skipGroup, const bool *needTop,
 			 const Datum *constVals, const bool *constHas,
-			 const bool *constNull)
+			 const bool *constNull, int rgFrom, int rgTo)
 {
 	int			natts = slot->tts_tupleDescriptor->natts;
 	MemoryContext groupCtx;
@@ -2980,7 +2980,7 @@ pq_read_rows(PqFile *pf, PqSource *src,
 								   "columnar parquet read row",
 								   ALLOCSET_DEFAULT_SIZES);
 
-	for (rg = 0; rg < pf->nrowgroups; rg++)
+	for (rg = rgFrom; rg < rgTo; rg++)
 	{
 		PqRowGroup *g = &pf->rgs[rg];
 		int64		n = g->num_rows;
@@ -3219,7 +3219,8 @@ pq_read_file_into(const char *path, TupleDesc tupdesc, TupleTableSlot *slot,
 	pq_check_row_groups(&pf, path);
 	tops = build_imp_targets(tupdesc, &pf, &leaves, &ntops, NULL);
 	n = pq_read_rows(&pf, &src, tops, ntops, leaves,
-					 slot, sink, sinkarg, NULL, NULL, NULL, NULL, NULL);
+					 slot, sink, sinkarg, NULL, NULL, NULL, NULL, NULL,
+					 0, pf.nrowgroups);
 	pq_source_close(&src);
 	return n;
 }
@@ -3483,16 +3484,57 @@ pgcolumnar_parquet_schema(PG_FUNCTION_ARGS)
  *       OPTIONS (path '/data/f.parquet');
  * ------------------------------------------------------------------------- */
 
-/* per-scan state: the whole file materialized into a tuplestore, drained by
- * IterateForeignScan. Eager (reads the file up front); streaming is a follow-on.
- * readslot is a minimal-tuple slot the tuplestore drains into; each row is then
- * copied into the scan slot, whose ops are not guaranteed to be minimal-tuple. */
+/*
+ * per-scan state: streaming, one row group at a time (#620). Begin resolves the
+ * file list and prunes but decodes nothing; each refill decodes the next
+ * non-skipped row group of the current file into a bounded one-group tuplestore,
+ * which Iterate drains. Memory is one row group, not the whole file, and a LIMIT
+ * stops the scan after the groups it consumed. readslot is a minimal-tuple slot
+ * the tuplestore drains into; each row is then copied into the scan slot, whose
+ * ops are not guaranteed to be minimal-tuple.
+ *
+ * The whole-file materialize is retained only for read_parquet, which is an
+ * SFRM_Materialize SRF (see pq_read_file_into); this cursor is the FDW's.
+ */
 typedef struct PqFdwScanState
 {
-	Tuplestorestate *tupstore;
+	Tuplestorestate *tupstore;	/* holds one decoded row group at a time */
 	TupleTableSlot *readslot;
+	TupleTableSlot *rowslot;	/* virtual slot pq_read_rows assembles into */
+
+	/* the scan-wide inputs, resolved once in Begin and reused across refills */
+	List	   *files;			/* resolved paths, after pq_resolve_paths */
+	int			nfiles;
+	char	   *path;			/* the table's declared path option */
+	TupleDesc	tupdesc;
+	PgColumnarObjStoreConfig oscfg;
+	ForeignScanState *node;		/* for projection/skip pushdown helpers */
+	MemoryContext fileCtx;		/* per-file decode buffers; reset per file */
+
+	/* partition machinery, compiled once, applied to each file */
+	bool	   *partMask;
+	int			nPart;
+	List	   *partQuals;
+	TupleTableSlot *partSlot;
+
+	/* the streaming cursor */
+	int			fileIdx;		/* next file to open (0..nfiles) */
+	bool		srcOpen;		/* is src/pf below a live open file */
+	int			curRg;			/* next row group of the open file to decode */
+	PqSource	src;			/* the open file's source (remote handle here) */
+	PqFile		pf;				/* the open file's footer */
+	ImpTop	   *tops;
+	ImpLeaf    *leaves;
+	int			ntops;
+	bool	   *skipGroup;		/* per-group predicate-pushdown skip, this file */
+	bool	   *needTop;		/* projection: which top columns to decode */
+	Datum	   *partVals;		/* this file's partition-column values */
+	bool	   *partHas;
+	bool	   *partNull;
+
 	int			groupsTotal;	/* row groups across all files */
 	int			groupsSkipped;	/* skipped by predicate pushdown */
+	int			groupsDecoded;	/* row groups actually decoded (work done, #620) */
 	int			colsTotal;		/* top-level columns (same across files) */
 	int			colsRead;		/* decoded after projection pushdown */
 	int			filesRead;		/* files the path resolved to, after pruning */
@@ -4312,27 +4354,137 @@ pqfdw_objstore_config(Oid foreigntableid, PgColumnarObjStoreConfig *cfg)
 	cfg->allow_ambient = superuser() || !credRequired;
 }
 
+static bool
+pqfdw_open_next_file(PqFdwScanState *st)
+{
+	MemoryContext old;
+
+	/* close a previously open file and drop its per-file decode buffers */
+	if (st->srcOpen)
+	{
+		pq_source_close(&st->src);
+		st->srcOpen = false;
+	}
+	MemoryContextReset(st->fileCtx);
+
+	/*
+	 * The source and its footer, targets, and prefetch window are allocated in
+	 * fileCtx so they outlive a single Iterate call (the window's winCtx is the
+	 * context current at open). fileCtx lives until the next file is opened.
+	 */
+	old = MemoryContextSwitchTo(st->fileCtx);
+	while (st->fileIdx < st->nfiles)
+	{
+		char	   *file = (char *) list_nth(st->files, st->fileIdx);
+		int			nNeeded;
+
+		st->fileIdx++;
+
+		/*
+		 * Partition pruning, before the file is opened: a file whose directory
+		 * values fail a partition-only qual costs no I/O at all.
+		 */
+		if (st->partMask != NULL)
+		{
+			st->partVals = (Datum *) palloc0(sizeof(Datum) * Max(st->tupdesc->natts, 1));
+			st->partHas = (bool *) palloc0(sizeof(bool) * Max(st->tupdesc->natts, 1));
+			st->partNull = (bool *) palloc0(sizeof(bool) * Max(st->tupdesc->natts, 1));
+			pqfdw_partition_values(st->path, file, st->tupdesc, st->partMask,
+								   st->partVals, st->partHas, st->partNull);
+			if (pqfdw_partition_excludes_file(st->node, st->partSlot, st->partQuals,
+											  st->tupdesc, st->partVals, st->partHas,
+											  st->partNull))
+			{
+				st->filesPruned++;
+				MemoryContextReset(st->fileCtx);	/* drop this file's part arrays */
+				continue;
+			}
+		}
+		else
+		{
+			st->partVals = NULL;
+			st->partHas = NULL;
+			st->partNull = NULL;
+		}
+
+		st->filesRead++;
+		pq_source_open_cfg(file, &st->src, &st->pf, &st->oscfg);
+		pq_check_row_groups(&st->pf, file);
+		st->tops = build_imp_targets(st->tupdesc, &st->pf, &st->leaves,
+									 &st->ntops, st->partMask);
+
+		/* projection: decode only referenced columns (same set each file) */
+		st->needTop = pqfdw_compute_needed(st->node, st->tops, st->ntops, &nNeeded);
+		st->colsTotal = st->ntops;
+		st->colsRead = nNeeded;
+
+		st->groupsTotal += st->pf.nrowgroups;
+		st->skipGroup = (bool *) palloc0(sizeof(bool) * Max(st->pf.nrowgroups, 1));
+		st->groupsSkipped += pqfdw_compute_skip(st->node, &st->pf, st->tops,
+												st->ntops, st->leaves, st->skipGroup);
+		st->curRg = 0;
+		st->srcOpen = true;
+		MemoryContextSwitchTo(old);
+		return true;
+	}
+
+	MemoryContextSwitchTo(old);
+	return false;			/* no more files */
+}
+
+/*
+ * Decode the next non-skipped row group of the scan into the one-group
+ * tuplestore, opening and advancing files as needed. Returns false only when
+ * every group of every file has been decoded. This is the streaming producer:
+ * memory is bounded to a single row group, and a LIMIT that stops the scan
+ * leaves the remaining groups and files untouched.
+ */
+static bool
+pqfdw_refill(PqFdwScanState *st)
+{
+	/* open the first file lazily on the first refill */
+	if (!st->srcOpen && !pqfdw_open_next_file(st))
+		return false;
+
+	for (;;)
+	{
+		while (st->curRg < st->pf.nrowgroups)
+		{
+			int			rg = st->curRg++;
+			MemoryContext old;
+
+			/* predicate pushdown: a group that cannot match decodes nothing */
+			if (st->skipGroup != NULL && st->skipGroup[rg])
+				continue;
+
+			tuplestore_clear(st->tupstore);
+			old = MemoryContextSwitchTo(st->fileCtx);
+			(void) pq_read_rows(&st->pf, &st->src, st->tops, st->ntops, st->leaves,
+								st->rowslot, pq_tuplestore_sink, st->tupstore,
+								st->skipGroup, st->needTop,
+								st->partVals, st->partHas, st->partNull,
+								rg, rg + 1);
+			MemoryContextSwitchTo(old);
+			st->groupsDecoded++;
+			return true;		/* one group's rows are buffered */
+		}
+
+		/* the open file is drained; advance (open_next_file closes it) */
+		if (!pqfdw_open_next_file(st))
+			return false;
+	}
+}
+
 static void
 pqfdwBeginForeignScan(ForeignScanState *node, int eflags)
 {
 	Relation	rel = node->ss.ss_currentRelation;
 	TupleDesc	tupdesc = RelationGetDescr(rel);
 	char	   *path;
-	TupleTableSlot *slot;
 	PqFdwScanState *st;
-	bool	   *needTop;
-	int			nNeeded;
 	List	   *files;
-	ListCell   *lc;
-	MemoryContext fileCtx;
 	bool	   *partMask;
 	int			nPart;
-	Datum	   *partVals = NULL;
-	bool	   *partHas = NULL;
-	bool	   *partNull = NULL;
-	List	   *partQuals = NIL;
-	TupleTableSlot *partSlot = NULL;
-	PgColumnarObjStoreConfig oscfg;
 
 	/* nothing to do for a plan-only (EXPLAIN without ANALYZE) invocation */
 	if (eflags & EXEC_FLAG_EXPLAIN_ONLY)
@@ -4343,7 +4495,8 @@ pqfdwBeginForeignScan(ForeignScanState *node, int eflags)
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 				 errmsg("must be superuser or a member of the pg_read_server_files role to read a server file")));
 
-	pqfdw_objstore_config(RelationGetRelid(rel), &oscfg);
+	st = (PqFdwScanState *) palloc0(sizeof(PqFdwScanState));
+	pqfdw_objstore_config(RelationGetRelid(rel), &st->oscfg);
 
 	path = pqfdw_get_path(RelationGetRelid(rel));
 	if (path == NULL)
@@ -4353,90 +4506,38 @@ pqfdwBeginForeignScan(ForeignScanState *node, int eflags)
 						RelationGetRelationName(rel))));
 
 	files = pq_resolve_paths(path);
+
+	st->node = node;
+	st->tupdesc = tupdesc;
+	st->path = path;
+	st->files = files;
+	st->nfiles = list_length(files);
+
 	partMask = pqfdw_partition_mask(RelationGetRelid(rel), tupdesc, &nPart);
+	st->partMask = partMask;
+	st->nPart = nPart;
 	if (partMask != NULL)
 	{
 		/* compiled once, in the scan's own context, and reused for every file */
-		partQuals = pqfdw_partition_quals(node, tupdesc, partMask);
-		partSlot = MakeSingleTupleTableSlot(tupdesc, &TTSOpsVirtual);
+		st->partQuals = pqfdw_partition_quals(node, tupdesc, partMask);
+		st->partSlot = MakeSingleTupleTableSlot(tupdesc, &TTSOpsVirtual);
 	}
-
-	st = (PqFdwScanState *) palloc0(sizeof(PqFdwScanState));
-	/* randomAccess so ReScan can rewind the materialized rows */
-	st->tupstore = tuplestore_begin_heap(true, false, work_mem);
-	st->readslot = MakeSingleTupleTableSlot(tupdesc, &TTSOpsMinimalTuple);
-
-	slot = MakeSingleTupleTableSlot(tupdesc, &TTSOpsVirtual);
 
 	/*
-	 * Read each resolved file into the one tuplestore. Predicate pushdown is per
-	 * file (each file's own row-group statistics); projection is query-derived and
-	 * identical across files, since every file shares the target descriptor. The
-	 * EXPLAIN counters sum row groups across files while the column counts are the
-	 * same each file. The per-file decode is bounded by fileCtx.
+	 * One decoded row group at a time. Not randomAccess: ReScan re-streams from
+	 * the top rather than rewinding a whole-file buffer, which is the point of
+	 * not holding the whole file.
 	 */
-	fileCtx = AllocSetContextCreate(CurrentMemoryContext,
-									"pgcolumnar parquet fdw file",
-									ALLOCSET_DEFAULT_SIZES);
-	foreach(lc, files)
-	{
-		MemoryContext old = MemoryContextSwitchTo(fileCtx);
-		PqSource	src;
-		PqFile		pf;
-		ImpTop	   *tops;
-		ImpLeaf    *leaves;
-		int			ntops;
-		bool	   *skipGroup;
+	st->tupstore = tuplestore_begin_heap(false, false, work_mem);
+	st->readslot = MakeSingleTupleTableSlot(tupdesc, &TTSOpsMinimalTuple);
+	st->rowslot = MakeSingleTupleTableSlot(tupdesc, &TTSOpsVirtual);
 
-		/*
-		 * Partition pruning, before the file is opened: a file whose directory
-		 * values fail a partition-only qual costs no I/O at all, which is what
-		 * makes this cheaper than row-group skipping rather than a variant of it.
-		 */
-		if (partMask != NULL)
-		{
-			partVals = (Datum *) palloc0(sizeof(Datum) * Max(tupdesc->natts, 1));
-			partHas = (bool *) palloc0(sizeof(bool) * Max(tupdesc->natts, 1));
-			partNull = (bool *) palloc0(sizeof(bool) * Max(tupdesc->natts, 1));
-			pqfdw_partition_values(path, (char *) lfirst(lc), tupdesc, partMask,
-								   partVals, partHas, partNull);
-			if (pqfdw_partition_excludes_file(node, partSlot, partQuals, tupdesc,
-											  partVals, partHas, partNull))
-			{
-				st->filesPruned++;
-				MemoryContextSwitchTo(old);
-				MemoryContextReset(fileCtx);
-				continue;
-			}
-		}
-
-		st->filesRead++;
-		pq_source_open_cfg((char *) lfirst(lc), &src, &pf, &oscfg);
-		pq_check_row_groups(&pf, (char *) lfirst(lc));
-		tops = build_imp_targets(tupdesc, &pf, &leaves, &ntops, partMask);
-
-		/* projection: decode only referenced columns (same set each file) */
-		needTop = pqfdw_compute_needed(node, tops, ntops, &nNeeded);
-		st->colsTotal = ntops;
-		st->colsRead = nNeeded;
-
-		st->groupsTotal += pf.nrowgroups;
-		skipGroup = (bool *) palloc0(sizeof(bool) * Max(pf.nrowgroups, 1));
-		st->groupsSkipped += pqfdw_compute_skip(node, &pf, tops, ntops,
-												leaves, skipGroup);
-
-		(void) pq_read_rows(&pf, &src, tops, ntops, leaves,
-							slot, pq_tuplestore_sink, st->tupstore, skipGroup,
-							needTop, partVals, partHas, partNull);
-		pq_source_close(&src);
-
-		MemoryContextSwitchTo(old);
-		MemoryContextReset(fileCtx);
-	}
-	MemoryContextDelete(fileCtx);
-	ExecDropSingleTupleTableSlot(slot);
-	if (partSlot != NULL)
-		ExecDropSingleTupleTableSlot(partSlot);
+	st->fileCtx = AllocSetContextCreate(CurrentMemoryContext,
+										"pgcolumnar parquet fdw file",
+										ALLOCSET_DEFAULT_SIZES);
+	st->fileIdx = 0;
+	st->srcOpen = false;
+	st->curRg = 0;
 
 	node->fdw_state = st;
 }
@@ -4446,8 +4547,6 @@ pqfdwIterateForeignScan(ForeignScanState *node)
 {
 	PqFdwScanState *st = (PqFdwScanState *) node->fdw_state;
 	TupleTableSlot *slot = node->ss.ss_ScanTupleSlot;
-	MemoryContext oldcxt;
-	bool		got;
 
 	if (st == NULL)
 		return ExecClearTuple(slot);
@@ -4455,7 +4554,9 @@ pqfdwIterateForeignScan(ForeignScanState *node)
 	/*
 	 * Drain one row into our minimal-tuple readslot, then copy it into the scan
 	 * slot (a heap-tuple slot: table_slot_callbacks() hands foreign tables
-	 * TTSOpsHeapTuple, which cannot receive a minimal tuple directly).
+	 * TTSOpsHeapTuple, which cannot receive a minimal tuple directly). When the
+	 * one-group tuplestore is empty, decode the next row group; when every group
+	 * of every file is decoded, the scan is done.
 	 *
 	 * The fetch must run in a context that outlives the row. ForeignNext() calls
 	 * us in ecxt_per_tuple_memory, and ExecScan resets that before every fetch --
@@ -4467,13 +4568,21 @@ pqfdwIterateForeignScan(ForeignScanState *node)
 	 * even with copy=false (readtup palloc's and sets should_free), so pin the
 	 * context rather than the copy flag.
 	 */
-	oldcxt = MemoryContextSwitchTo(node->ss.ps.state->es_query_cxt);
-	got = tuplestore_gettupleslot(st->tupstore, true, false, st->readslot);
-	MemoryContextSwitchTo(oldcxt);
+	for (;;)
+	{
+		MemoryContext oldcxt;
+		bool		got;
 
-	if (!got)
-		return ExecClearTuple(slot);
-	return ExecCopySlot(slot, st->readslot);
+		oldcxt = MemoryContextSwitchTo(node->ss.ps.state->es_query_cxt);
+		got = tuplestore_gettupleslot(st->tupstore, true, false, st->readslot);
+		MemoryContextSwitchTo(oldcxt);
+
+		if (got)
+			return ExecCopySlot(slot, st->readslot);
+
+		if (!pqfdw_refill(st))
+			return ExecClearTuple(slot);
+	}
 }
 
 static void
@@ -4481,8 +4590,32 @@ pqfdwReScanForeignScan(ForeignScanState *node)
 {
 	PqFdwScanState *st = (PqFdwScanState *) node->fdw_state;
 
-	if (st != NULL && st->tupstore != NULL)
-		tuplestore_rescan(st->tupstore);
+	if (st == NULL)
+		return;
+
+	/*
+	 * Re-stream from the top: close any open file, drop its decode buffers,
+	 * empty the one-group tuplestore, and reset the cursor. The per-scan work
+	 * counters reset too, so EXPLAIN ANALYZE reports one scan's work, not the
+	 * sum over rescans (the eager model computed them once and rewound for free;
+	 * streaming re-decodes, which is the deliberate trade for bounded memory).
+	 */
+	if (st->srcOpen)
+	{
+		pq_source_close(&st->src);
+		st->srcOpen = false;
+	}
+	if (st->fileCtx != NULL)
+		MemoryContextReset(st->fileCtx);
+	if (st->tupstore != NULL)
+		tuplestore_clear(st->tupstore);
+	st->fileIdx = 0;
+	st->curRg = 0;
+	st->groupsTotal = 0;
+	st->groupsSkipped = 0;
+	st->groupsDecoded = 0;
+	st->filesRead = 0;
+	st->filesPruned = 0;
 }
 
 static void
@@ -4493,12 +4626,28 @@ pqfdwEndForeignScan(ForeignScanState *node)
 	if (st == NULL)
 		return;
 
-	/* drop the slot first: a non-copied fetch leaves it pointing into the
+	if (st->srcOpen)
+	{
+		pq_source_close(&st->src);
+		st->srcOpen = false;
+	}
+
+	/* drop the slots first: a non-copied fetch leaves readslot pointing into the
 	 * tuplestore's own memory, which tuplestore_end() releases */
 	if (st->readslot != NULL)
 	{
 		ExecDropSingleTupleTableSlot(st->readslot);
 		st->readslot = NULL;
+	}
+	if (st->rowslot != NULL)
+	{
+		ExecDropSingleTupleTableSlot(st->rowslot);
+		st->rowslot = NULL;
+	}
+	if (st->partSlot != NULL)
+	{
+		ExecDropSingleTupleTableSlot(st->partSlot);
+		st->partSlot = NULL;
 	}
 	if (st->tupstore != NULL)
 	{
@@ -4517,6 +4666,7 @@ pqfdwExplainForeignScan(ForeignScanState *node, ExplainState *es)
 		return;
 	ExplainPropertyInteger("Row Groups", NULL, st->groupsTotal, es);
 	ExplainPropertyInteger("Row Groups Skipped", NULL, st->groupsSkipped, es);
+	ExplainPropertyInteger("Row Groups Decoded", NULL, st->groupsDecoded, es);
 	ExplainPropertyInteger("Columns Read", NULL, st->colsRead, es);
 	ExplainPropertyInteger("Columns Total", NULL, st->colsTotal, es);
 	ExplainPropertyInteger("Files", NULL, st->filesRead, es);

--- a/test/native_parquet_streaming.sh
+++ b/test/native_parquet_streaming.sh
@@ -379,7 +379,49 @@ check "the uncompressed source file still reads" \
 	"$(q "SELECT count(*), sum(id) FROM pgcolumnar.read_parquet('$W/plain.parquet') AS t(id int);" | tr '|' ' ')" \
 	"200 19900"
 
+# ---- #620: the FDW streams row groups; a LIMIT decodes fewer ----------------
+# The FDW no longer materializes the whole file into a tuplestore. It decodes one
+# row group at a time, so a LIMIT that the executor satisfies early leaves the
+# rest of the file undecoded. "Row Groups Decoded" is the work-done counter added
+# for this: a full scan decodes every group; a LIMIT inside the first group
+# decodes one; a LIMIT that spills into the second decodes two. On the eager
+# model this counter did not exist and every group was decoded up front, so this
+# is the streaming proof. A four-row-group file (1000 rows each).
+STREAMP="$W/stream_groups.parquet"
+python3 - "$STREAMP" <<'PY'
+import sys, pyarrow as pa, pyarrow.parquet as pq
+n = 4000
+tbl = pa.table({"id": pa.array(range(n), pa.int32()),
+                "v":  pa.array([i * 2 for i in range(n)], pa.int64())})
+pq.write_table(tbl, sys.argv[1], row_group_size=1000)
+assert pq.ParquetFile(sys.argv[1]).num_row_groups == 4
+PY
+psql_run "CREATE SERVER pqs FOREIGN DATA WRAPPER pgcolumnar_parquet;"
+psql_run "CREATE FOREIGN TABLE fts (id int4, v int8) SERVER pqs OPTIONS (path '$STREAMP');"
+
+decoded_for() {  # decoded_for SQL -> the Row Groups Decoded count for that plan
+	q "EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) $1" \
+		| grep 'Row Groups Decoded' | grep -oE '[0-9]+' | head -1
+}
+
+check "streaming: full scan content is correct" \
+	"$(q 'SELECT count(*), sum(id), sum(v) FROM fts;' | tr '|' ' ')" \
+	"4000 7998000 15996000"
+check "streaming: a full scan decodes all four row groups" \
+	"$(decoded_for 'SELECT * FROM fts')" "4"
+check "streaming: LIMIT 10 (inside group 0) decodes one row group" \
+	"$(decoded_for 'SELECT * FROM fts LIMIT 10')" "1"
+check "streaming: LIMIT 1010 (into group 1) decodes two row groups" \
+	"$(decoded_for 'SELECT * FROM fts LIMIT 1010')" "2"
+# a rescan re-streams from the top rather than rewinding a buffer. Force a
+# nested loop so fts is re-scanned once per outer row, and check the result is
+# correct across rescans. outer2 = {1,2}; fts.id = o.k matches id 1 then id 2.
+psql_run "CREATE TABLE outer2 (k int); INSERT INTO outer2 VALUES (1),(2);"
+check "streaming: rescan under a nested loop is correct" \
+	"$(q "SET enable_hashjoin=off; SET enable_mergejoin=off;
+	      SELECT count(*) FROM outer2 o JOIN fts ON fts.id = o.k;" | tail -1)" "2"
+
 rm -f "$W/huge_sparse.parquet" "$W/zero_pages.parquet" "$W/bad_size.parquet" \
 	"$W/noise_pages.parquet" "$W/bad_offset.parquet" "$W/two_dicts.parquet" \
-	"$W/v2_levels.parquet" "$W/allnull.parquet"
+	"$W/v2_levels.parquet" "$W/allnull.parquet" "$W/stream_groups.parquet"
 pgc_summary


### PR DESCRIPTION
Closes #620.

## What changed

The `pgcolumnar_parquet` FDW used to open every resolved file in `BeginForeignScan`, decode it whole, and drain all rows into one `randomAccess` tuplestore before returning. `Iterate` drained the tuplestore; `ReScan` was a free rewind. The whole file set sat in `work_mem`-backed storage, and a `LIMIT` still decoded every row group of every file.

The scan now **streams one row group at a time**:
- `Begin` resolves the file list and prunes (`Files Pruned`) but decodes nothing.
- Each refill decodes the next non-skipped row group of the current file into a bounded one-group tuplestore that `Iterate` drains, opening and advancing files as the cursor reaches them.
- Memory is one row group, not the whole file, and a `LIMIT` the executor satisfies early leaves the remaining groups and files undecoded.
- `ReScan` re-streams from the top (close, reset, re-decode). The eager model's free rewind is the deliberate trade for bounded memory; no suite asserts rescan *cost*, only content.

The **correctness-critical row assembly is unchanged**: `pq_read_rows` gains an `[rgFrom, rgTo)` group range. `read_parquet` and `import_parquet` pass the full range and stay eager, byte-for-byte; the FDW drives one group per refill. `read_parquet` stays an `SFRM_Materialize` SRF — only the FDW streams.

## Remote-handle lifetime

A streamed remote scan holds one read handle across `Iterate` calls, so a handle no longer always closes *before its opener returns*. The module's abort invariant is restated: close-all-on-abort stays correct because the handle is the running statement's — `EndForeignScan` closes it normally and the release callback closes it on abort, whoever holds the pointer. The source opens in the scan's `fileCtx` so its prefetch window (`winCtx`) outlives a single `Iterate` call.

## TDD / prove-don't-trust

New arm in `native_parquet_streaming.sh` over a four-row-group file, using a new **`Row Groups Decoded`** EXPLAIN counter (there was no rows-produced or groups-decoded counter before — the old counters could not tell a `LIMIT` from a full scan):

- full scan decodes **4**; `LIMIT 10` (inside group 0) decodes **1**; `LIMIT 1010` (into group 1) decodes **2**.
- **RED on `main`**: the counter line is absent; no counter distinguishes a `LIMIT` from a full scan.
- **Removal proof (counter)**: neutering `groupsDecoded++` reds all three counter arms (report 0).
- **Removal proof (streaming)**: reverting to eager whole-file decode reds *exactly* the two `LIMIT` arms while full-scan and content stay green — proving the one-group streaming is load-bearing for early-exit.
- A forced nested-loop arm (`enable_hashjoin/mergejoin off`) covers the re-stream `ReScan`.

## Gates

- **PG17/18/19**, `-Wshadow -Werror`: the full FDW/read/remote set is green — `native_parquet_fdw`, `_pushdown` (Row Groups Skipped counters), `_projection`, `_partition` (Files Pruned + partition stamping), `_multifile` (multi-file drain + ReScan), `_streaming`, `native_read_parquet`, `_stack`, `_hardening`, `_codecs`, `_flba`, `objstore_s3_read`, plus `parquet_import` and `parquet_nested_import`.
- **ASAN (pg18_san)**: local multi-group scans, `LIMIT` early-close, nested-loop rescan, and a remote scan with `LIMIT` closing the handle mid-file — **zero backend sanitizer reports**. This is the per-scan memory-lifecycle gate: group/row contexts and a remote handle + prefetch window now span `Iterate` calls.

## Docs

`sql-reference.md`, `features.md`, and `ARCHITECTURE.md` note the streaming model, the `LIMIT` early-exit, and `Row Groups Decoded`; `read_parquet` is called out as still materializing. STE style gate passes. Design in `design/ISSUE_620_FDW_STREAMING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqFY4pifG7rp3a5fJREWnr