### PR TITLE
feat: GCS gs:// scheme and S3 virtual-host addressing (#621)

### DIFF
--- a/design/ISSUE_621_SCHEMES_AND_ADDRESSING.md
+++ b/design/ISSUE_621_SCHEMES_AND_ADDRESSING.md
@@ -1,0 +1,87 @@
+# Issue #621: the GCS gs:// scheme and S3 virtual-host addressing
+
+Scope (owner decision, 2026-08-14): implement the `gs://` scheme and S3
+virtual-host addressing. **Azure (`az://`) is out of scope** and stays an
+unhandled scheme; it would need a SharedKey/SAS signer and new ABI credential
+fields, a decision deferred.
+
+Both features are additive to the existing S3 path and need no ABI change: GCS
+reuses the SigV4 signer with a default endpoint, and the addressing style is a
+GUC read inside the module, not a config-struct field.
+
+## GCS via the interoperable XML API
+
+`gs://` and `az://` were already recognized as remote by `PgColumnarPathIsRemote`
+but rejected at the module's `objstore_handles_url`. GCS's XML API is S3-shaped
+and accepts AWS Signature Version 4 with an HMAC key, so `gs://` folds onto the
+existing S3 resolver:
+
+- `objstore_handles_url` returns true for `gs://`.
+- `objstore_open` / `os_write_handle` route `gs://` to `os_resolve_s3` (both
+  schemes are five characters, so `url + 5` skips either).
+- `os_resolve_s3` learns the scheme. When no endpoint is configured it defaults
+  `gs://` to `https://storage.googleapis.com` (S3 has no single default, so it
+  still requires one); when no region is configured it defaults `gs://` to
+  `auto`. The signer, credentials, and request construction are unchanged: a GCS
+  HMAC key is the `access_key_id` / `secret_access_key` pair, service name `s3`.
+
+Verified against the S3 fixture (which is an independent SigV4 implementation)
+and, opt-in, live Garage. Real-GCS acceptance of the `s3` service scope is the
+one assumption not checkable here; it is the documented interop path.
+
+## Virtual-host addressing
+
+Path-style (`endpoint/bucket/key`) is the default and stays byte-identical.
+Virtual-host (`bucket.endpoint/key`) is selected by the GUC
+`pgcolumnar.objstore_s3_addressing = 'virtual'`, defined by the preloaded library
+and read inside `os_resolve_s3` by name (the same mechanism as
+`objstore_allowed_endpoints`), so no config-struct field and no ABI bump. Under
+virtual-host:
+
+- `h->host` becomes `bucket.authority` (the connect target, the Host header, and
+  the TLS cert name, all of which key off `h->host` already, so cert
+  verification and SNI need no change).
+- the request path is the key alone, not `bucket/key`.
+- `h->auth_host` carries the endpoint authority, and the endpoint allow-list
+  matches `auth_host` when set: the operator authorizes the endpoint, and
+  virtual-host must not force a per-bucket allow-list entry.
+
+The allow-list, link-local refusal, and signing are otherwise unchanged.
+Path-style leaves `auth_host` NULL, so the allow-list check falls back to
+`h->host` exactly as before, and the existing S3 suites stay byte-identical.
+
+## TDD
+
+`objstore_addressing.sh`, against the SigV4 fixture:
+
+- `gs://` reads and writes round-trip (scheme handled, HMAC creds reused, the
+  signature verified by the independent implementation).
+- `gs://` with no endpoint uses the storage.googleapis.com default (its error
+  does not demand `AWS_ENDPOINT_URL`, the contrast that proves the default,
+  where `s3://` still demands one).
+- virtual-host reads the same object as path-style; the fixture log shows the
+  key alone in the path under `virtual` and the bucket back in the path under
+  `path` (the removal proof of the addressing switch).
+
+Virtual-host is exercised with `/etc/hosts` names (`s3.local` and
+`pgc-bucket.s3.local` both resolve to 127.0.0.1), so the client's connect, Host
+header, and cert name are the real `bucket.endpoint` with no test-only code path.
+The suite skips cleanly where those names do not resolve.
+
+`objstore_module.sh`: the deliberate "unhandled scheme" probe migrates from
+`gs://` (now handled) to `az://` (still unhandled).
+
+## Gates
+
+PG17/18/19 over the objstore suites under `-Wshadow -Werror` (the new GUC backing
+variable needs an `extern` in columnar.h, which PG18/19's
+`-Wmissing-variable-declarations` enforces and PG17 does not). ASAN (pg18_san)
+over the gs:// read/write and virtual-host paths, which add handle-memory
+allocations (`auth_host`, the virtual-host `psprintf`/`pnstrdup`): clean, zero
+backend reports.
+
+## Docs
+
+The object-storage scheme table gains `gs://`; the addressing GUC is documented
+in the configuration reference and the object-storage notes; the
+`AWS_ENDPOINT_URL` row notes the GCS default.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -93,6 +93,7 @@ schemes and the credential model.
 | Setting | Type | Default | Description |
 | --- | --- | --- | --- |
 | `pgcolumnar.objstore_allowed_endpoints` | string | `''` (empty) | The endpoints the module may connect to, comma-separated as `host` or `host:port`. Empty refuses every remote endpoint, so a role that can read or write server files cannot reach an arbitrary host through the extension. Link-local addresses, including `169.254.169.254`, are refused whether or not they are listed. Superuser-only, so a role cannot widen its own reach. |
+| `pgcolumnar.objstore_s3_addressing` | string | `path` | The S3 request addressing style. `path` sends `s3://bucket/key` to `endpoint/bucket/key`; `virtual` sends it to `bucket.endpoint/key`, which is what AWS now prefers. Under virtual-host addressing the allow-list still authorizes the endpoint, not the per-bucket hostname. |
 
 ### Concurrent unique inserts
 

--- a/docs/sql-reference.md
+++ b/docs/sql-reference.md
@@ -599,14 +599,20 @@ EXPLAIN (ANALYZE, COSTS OFF) SELECT id FROM events WHERE ts >= '2026-01-01';
 ## Object storage
 
 The Parquet read and export functions, and the foreign-data wrapper, accept an
-object-storage URL wherever they accept a local path. Three URL schemes are
+object-storage URL wherever they accept a local path. These URL schemes are
 recognized:
 
 | Scheme | Meaning |
 | --- | --- |
 | `s3://bucket/key` | An S3 or S3-compatible object. The request is signed with AWS Signature Version 4. |
+| `gs://bucket/key` | A Google Cloud Storage object, read and written through the interoperable XML API. It signs with the same Signature Version 4 as `s3://`, so a GCS HMAC key is given as `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`. The endpoint defaults to `https://storage.googleapis.com` and the region to `auto`; set `AWS_ENDPOINT_URL` to override. |
 | `http://host[:port]/path` | A plain-HTTP object. For a trusted network only, because a plain-HTTP request carries any credential in clear. |
 | `https://host[:port]/path` | An HTTPS object. Available when the object-store module was built with OpenSSL. The server certificate is verified. |
+
+S3 requests use path-style addressing (`endpoint/bucket/key`) by default. Set
+`pgcolumnar.objstore_s3_addressing` to `virtual` for virtual-host addressing
+(`bucket.endpoint/key`), which is what AWS now prefers; the endpoint allow-list
+still authorizes the endpoint, not the per-bucket hostname.
 
 Object-storage support lives in a separate module, `pgcolumnar_objstore`, which
 loads on the first use of a remote URL and never before. A build or an install
@@ -629,7 +635,7 @@ credentials come from the environment of the server process:
 
 | Variable | Meaning |
 | --- | --- |
-| `AWS_ENDPOINT_URL` | The object-storage endpoint, `http://...` or `https://...`. Required for an `s3://` URL. |
+| `AWS_ENDPOINT_URL` | The object-storage endpoint, `http://...` or `https://...`. Required for an `s3://` URL; optional for `gs://`, which defaults to `https://storage.googleapis.com`. |
 | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` | The access key pair. |
 | `AWS_SESSION_TOKEN` | A session token, when the credentials are temporary. Optional. |
 | `AWS_REGION` or `AWS_DEFAULT_REGION` | The signing region. |

--- a/objstore/columnar_objstore_module.c
+++ b/objstore/columnar_objstore_module.c
@@ -81,7 +81,10 @@ PGDLLEXPORT const PgColumnarObjStoreApi *pgcolumnar_objstore_init(void);
 struct PgColumnarObjHandle
 {
 	char	   *url;			/* full URL, for error messages */
-	char	   *host;			/* authority, split for connect */
+	char	   *host;			/* authority, split for connect (and Host header) */
+	char	   *auth_host;		/* endpoint authority for the allow-list, NULL =
+								 * use host (#621: virtual-host puts the bucket in
+								 * host, but the operator authorizes the endpoint) */
 	int			port;
 	char	   *abspath;		/* request-target, always starts with '/' */
 
@@ -272,6 +275,9 @@ os_check_endpoint_allowed(PgColumnarObjHandle *h)
 {
 	const char *list =
 		GetConfigOption("pgcolumnar.objstore_allowed_endpoints", true, false);
+	/* the operator authorizes the endpoint; under virtual-host addressing the
+	 * connect host carries the bucket, so match the endpoint authority (#621) */
+	const char *checkhost = (h->auth_host != NULL) ? h->auth_host : h->host;
 	bool		ok = false;
 
 	if (list != NULL && list[0] != '\0')
@@ -307,7 +313,7 @@ os_check_endpoint_allowed(PgColumnarObjHandle *h)
 					continue;
 				*colon = '\0';
 			}
-			if (pg_strcasecmp(entry, h->host) == 0)
+			if (pg_strcasecmp(entry, checkhost) == 0)
 			{
 				ok = true;
 				break;
@@ -321,10 +327,10 @@ os_check_endpoint_allowed(PgColumnarObjHandle *h)
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 				 errmsg("columnar: endpoint \"%s:%d\" is not in "
 						"pgcolumnar.objstore_allowed_endpoints",
-						h->host, h->port),
+						checkhost, h->port),
 				 errhint("A superuser can permit it: ALTER SYSTEM SET "
 						 "pgcolumnar.objstore_allowed_endpoints = '%s'; "
-						 "SELECT pg_reload_conf();", h->host)));
+						 "SELECT pg_reload_conf();", checkhost)));
 }
 
 /*
@@ -1255,7 +1261,8 @@ objstore_handles_url(const char *url)
 		return true;
 #endif
 	return pg_strncasecmp(url, "http://", 7) == 0 ||
-		pg_strncasecmp(url, "s3://", 5) == 0;
+		pg_strncasecmp(url, "s3://", 5) == 0 ||
+		pg_strncasecmp(url, "gs://", 5) == 0;	/* GCS via the interop XML API (#621) */
 }
 
 /* A required credential-environment variable, or the 28000 the design owes. */
@@ -1287,14 +1294,18 @@ static void
 os_resolve_s3(PgColumnarObjHandle *h, const char *url,
 			  const PgColumnarObjStoreConfig *cfg)
 {
-	const char *bucket = url + 5;
+	const char *bucket = url + 5;	/* both "s3://" and "gs://" are 5 chars */
 	const char *slash = strchr(bucket, '/');
+	bool		isGs = (pg_strncasecmp(url, "gs://", 5) == 0);
 	const char *ep;
 	const char *ephost;
 	const char *epslash;
 	const char *epcolon;
 	const char *region;
 	const char *token;
+	const char *addr;
+	char	   *authhost;
+	bool		virtualHost;
 	bool		ambientOk = (cfg == NULL || cfg->allow_ambient);
 	StringInfoData path;
 	MemoryContext oldcxt;
@@ -1302,12 +1313,24 @@ os_resolve_s3(PgColumnarObjHandle *h, const char *url,
 	if (slash == NULL || slash == bucket || slash[1] == '\0')
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("columnar: \"%s\" is not s3://bucket/key", url)));
+				 errmsg("columnar: \"%s\" is not %s://bucket/key", url,
+						isGs ? "gs" : "s3")));
 
 	if (cfg != NULL && cfg->endpoint != NULL)
 		ep = cfg->endpoint;
 	else
-		ep = os_require_env("AWS_ENDPOINT_URL", url);
+	{
+		ep = getenv("AWS_ENDPOINT_URL");
+		if (ep == NULL || ep[0] == '\0')
+		{
+			/* GCS has a well-known interop endpoint; S3 requires an explicit
+			 * one, since there is no single default S3 authority (#621). */
+			if (isGs)
+				ep = "https://storage.googleapis.com";
+			else
+				ep = os_require_env("AWS_ENDPOINT_URL", url);
+		}
+	}
 	if (pg_strncasecmp(ep, "https://", 8) == 0)
 	{
 #ifdef HAVE_OBJSTORE_OPENSSL
@@ -1335,11 +1358,18 @@ os_resolve_s3(PgColumnarObjHandle *h, const char *url,
 		if (region == NULL || region[0] == '\0')
 			region = getenv("AWS_DEFAULT_REGION");
 		if (region == NULL || region[0] == '\0')
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION),
-					 errmsg("columnar: reading \"%s\" requires a region option "
-							"on the server, or AWS_REGION in the server "
-							"environment", url)));
+		{
+			/* GCS interop accepts "auto"; S3 needs a real region for the
+			 * signature scope (#621). */
+			if (isGs)
+				region = "auto";
+			else
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION),
+						 errmsg("columnar: reading \"%s\" requires a region option "
+								"on the server, or AWS_REGION in the server "
+								"environment", url)));
+		}
 	}
 
 	oldcxt = MemoryContextSwitchTo(TopMemoryContext);
@@ -1382,19 +1412,43 @@ os_resolve_s3(PgColumnarObjHandle *h, const char *url,
 	epcolon = memchr(ephost, ':', epslash - ephost);
 	if (epcolon != NULL)
 	{
-		h->host = pnstrdup(ephost, epcolon - ephost);
+		authhost = pnstrdup(ephost, epcolon - ephost);
 		h->port = atoi(epcolon + 1);
 	}
 	else
 	{
-		h->host = pnstrdup(ephost, epslash - ephost);
+		authhost = pnstrdup(ephost, epslash - ephost);
 		h->port = h->tls ? 443 : 80;
 	}
 
-	/* path-style, encoded exactly as signed */
+	/*
+	 * Addressing style (#621). Path-style (the default, byte-identical to
+	 * before) sends every request to the endpoint authority with the bucket as
+	 * the first path segment. Virtual-host addressing puts the bucket in the
+	 * host (bucket.s3.region.amazonaws.com) and the key alone in the path, which
+	 * is what AWS now prefers and what the cert is verified against. The
+	 * endpoint allow-list still authorizes the endpoint authority, so auth_host
+	 * carries it under virtual-host.
+	 */
+	addr = GetConfigOption("pgcolumnar.objstore_s3_addressing", true, false);
+	virtualHost = (addr != NULL && pg_strcasecmp(addr, "virtual") == 0);
+
 	initStringInfo(&path);
 	appendStringInfoChar(&path, '/');
-	os_uriencode_path(&path, bucket);	/* bucket/key together; '/' passes */
+	if (virtualHost)
+	{
+		char	   *bname = pnstrdup(bucket, slash - bucket);
+
+		h->host = psprintf("%s.%s", bname, authhost);
+		h->auth_host = authhost;
+		os_uriencode_path(&path, slash + 1);	/* the key alone */
+	}
+	else
+	{
+		h->host = authhost;
+		h->auth_host = NULL;
+		os_uriencode_path(&path, bucket);	/* bucket/key together; '/' passes */
+	}
 	h->abspath = path.data;
 	MemoryContextSwitchTo(oldcxt);
 
@@ -1406,7 +1460,8 @@ objstore_open(const char *url, const PgColumnarObjStoreConfig *cfg, int64 *len)
 {
 	PgColumnarObjHandle *h;
 	OsResponse	resp;
-	bool		isS3 = (pg_strncasecmp(url, "s3://", 5) == 0);
+	bool		isS3 = (pg_strncasecmp(url, "s3://", 5) == 0 ||
+						pg_strncasecmp(url, "gs://", 5) == 0);	/* #621: GCS interop */
 	MemoryContext oldcxt;
 
 	if (!os_callback_registered)
@@ -1586,7 +1641,8 @@ static PgColumnarObjHandle *
 os_write_handle(const char *url, const PgColumnarObjStoreConfig *cfg)
 {
 	PgColumnarObjHandle *h;
-	bool		isS3 = (pg_strncasecmp(url, "s3://", 5) == 0);
+	bool		isS3 = (pg_strncasecmp(url, "s3://", 5) == 0 ||
+						pg_strncasecmp(url, "gs://", 5) == 0);	/* #621: GCS interop */
 	MemoryContext oldcxt;
 
 	if (!os_callback_registered)

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -193,6 +193,7 @@ extern bool pgcolumnar_enable_bloom_filter;	/* bloom equality skipping (I7) */
 extern bool pgcolumnar_objstore_buffered;	/* chunk-granular remote reads (#393) */
 extern char *pgcolumnar_objstore_allowed_endpoints; /* #393 allow-list, SUSET */
 extern int	pgcolumnar_objstore_part_size;	/* #394 remote multipart part size */
+extern char *pgcolumnar_objstore_s3_addressing; /* #621 path|virtual addressing */
 /* #415 autovacuum daemon */
 extern bool pgcolumnar_autovacuum;
 extern int	pgcolumnar_autovacuum_naptime;

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -81,6 +81,7 @@ bool		pgcolumnar_enable_bloom_filter = true;
 bool		pgcolumnar_objstore_buffered = true;	/* #393 */
 int			pgcolumnar_objstore_part_size = 0;	/* #394 remote part size */
 char	   *pgcolumnar_objstore_allowed_endpoints = NULL;	/* #393 allow-list */
+char	   *pgcolumnar_objstore_s3_addressing = NULL;	/* #621 path|virtual */
 bool		pgcolumnar_autovacuum = false;		/* #415 daemon master switch */
 int			pgcolumnar_autovacuum_naptime = 60;
 double		pgcolumnar_autovacuum_compact_threshold = 0.2;
@@ -2781,6 +2782,21 @@ _PG_init(void)
 							   "",
 							   PGC_SUSET,
 							   GUC_LIST_INPUT,
+							   NULL, NULL, NULL);
+
+	/*
+	 * S3 addressing style (#621), read by the object-store module via
+	 * GetConfigOption. "path" (the default) sends s3://bucket/key to
+	 * endpoint/bucket/key; "virtual" sends it to bucket.endpoint/key, which is
+	 * what AWS now prefers. Any value other than "virtual" is treated as path.
+	 */
+	DefineCustomStringVariable("pgcolumnar.objstore_s3_addressing",
+							   "S3 request addressing style: 'path' or 'virtual'.",
+							   "Virtual-host puts the bucket in the hostname (bucket.endpoint); path keeps it as the first path segment.",
+							   &pgcolumnar_objstore_s3_addressing,
+							   "path",
+							   PGC_USERSET,
+							   0,
 							   NULL, NULL, NULL);
 
 	/*

--- a/test/objstore_addressing.sh
+++ b/test/objstore_addressing.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# pgColumnar #621: the GCS gs:// scheme and S3 virtual-host addressing.
+#
+# gs:// is read and written through the interoperable XML API: the module reuses
+# the S3 SigV4 signing (an HMAC key maps onto access_key_id/secret_access_key)
+# and defaults the endpoint to storage.googleapis.com. Virtual-host addressing
+# puts the bucket in the hostname (bucket.endpoint) instead of the first path
+# segment, selected by the pgcolumnar.objstore_s3_addressing GUC.
+#
+# The fixture verifies every request's SigV4 against an independent
+# implementation, so a gs:// or virtual-host read that returns data proves the C
+# signer signed the exact bytes the endpoint expects. Virtual-host is exercised
+# with /etc/hosts names (s3.local and pgc-bucket.s3.local both resolve to
+# 127.0.0.1), so the client's connect, Host header, and cert name are the real
+# bucket.endpoint with no test-only code path.
+#
+# Usage:  test/objstore_addressing.sh [PG_CONFIG]
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+export PGC_EXTRA_CONF="pgcolumnar.objstore_allowed_endpoints='s3.local'"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+python3 -c 'import pyarrow' 2>/dev/null || pgc_skip pyarrow "pyarrow is required to write the fixture"
+# Virtual-host needs bucket.endpoint to resolve; skip cleanly where it does not.
+getent hosts pgc-bucket.s3.local >/dev/null 2>&1 || \
+	pgc_skip vhost "pgc-bucket.s3.local does not resolve; add it to /etc/hosts (-> 127.0.0.1)"
+
+S3_PORT="$(pgc_pick_free_port "$PGC_AUX_PORT_LO" "$PGC_AUX_PORT_HI")"
+S3_LOG="$PGC_WORKDIR/s3.log"
+SRV_PID=""
+AKID="PGCTESTKEYID"; SECRET="pgctest-secret"; REGION="pgc-test-1"; BUCKET="pgc-bucket"
+
+addr_teardown() { [ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null; pgc_teardown; }
+trap addr_teardown EXIT INT TERM
+
+pg_restart_env() {
+	pgc_pg "pg_ctl -D '$PGC_PGDATA' stop -m fast -w" >/dev/null 2>&1
+	pgc_pg "$* pg_ctl -D '$PGC_PGDATA' -l '$PGC_LOGFILE' start -w" >/dev/null 2>&1
+	for _ in $(seq 1 30); do [ -n "$(q 'SELECT 1')" ] && return 0; sleep 0.5; done
+	echo "FATAL: cluster did not restart"; exit 1
+}
+msg_of() {  # msg_of <sql> -> the ERROR message text
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -qtA -c "$1" 2>&1 | sed -n 's/^ERROR:  //p' | head -1
+}
+qset() {  # qset <sql...> -- run several -c statements, return the last line
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -Atq "$@" 2>/dev/null | tail -1
+}
+gets() { grep -oE "GET /[^ ]*" "$S3_LOG" | awk '{print $2}'; }
+
+mkdir -p "$PGC_WORKDIR/$BUCKET"
+python3 - "$PGC_WORKDIR/$BUCKET/vh.parquet" <<'PY'
+import sys, pyarrow as pa, pyarrow.parquet as pq
+pq.write_table(pa.table({"id": pa.array([1, 2, 3, 4], pa.int64())}), sys.argv[1])
+PY
+
+python3 "$(dirname "${BASH_SOURCE[0]}")/objstore_http_server.py" \
+	--dir "$PGC_WORKDIR" --port "$S3_PORT" --log "$S3_LOG" \
+	--sigv4-key "$AKID" --sigv4-secret "$SECRET" --sigv4-region "$REGION" \
+	--virtual-host-base s3.local > "$PGC_WORKDIR/s3_server.out" 2>&1 &
+SRV_PID=$!
+for _ in $(seq 1 50); do grep -q READY "$PGC_WORKDIR/s3_server.out" 2>/dev/null && break; sleep 0.1; done
+check "premise: fixture up" "$(grep -c READY "$PGC_WORKDIR/s3_server.out" 2>/dev/null)" "1"
+
+# ---- phase 1: an explicit endpoint (s3.local -> 127.0.0.1) ------------------
+pg_restart_env "AWS_ENDPOINT_URL='http://s3.local:$S3_PORT'" \
+	"AWS_ACCESS_KEY_ID='$AKID'" "AWS_SECRET_ACCESS_KEY='$SECRET'" "AWS_REGION='$REGION'"
+
+RD="SELECT count(*), sum(id) FROM pgcolumnar.read_parquet"
+
+# path-style s3:// (the default addressing) reads the object, bucket in the path
+: > "$S3_LOG"
+check "s3:// path-style read" "$(q "$RD('s3://$BUCKET/vh.parquet') AS t(id int8)" | tr '|' ' ')" "4 10"
+check "path-style put the bucket in the request path" \
+	"$([ "$(gets | grep -c '^/pgc-bucket/vh.parquet$')" -ge 1 ] && echo yes)" "yes"
+
+# gs:// round-trips through the interop API against the same overridden endpoint
+: > "$S3_LOG"
+check "gs:// read round-trips (scheme handled, HMAC creds reused)" \
+	"$(q "$RD('gs://$BUCKET/vh.parquet') AS t(id int8)" | tr '|' ' ')" "4 10"
+psql_run "CREATE TABLE gct (id int8) USING pgcolumnar; INSERT INTO gct VALUES (5),(6),(7);"
+check "gs:// write round-trips" \
+	"$(q "SELECT pgcolumnar.export_parquet('gct', 'gs://$BUCKET/out.parquet') > 0")" "t"
+check "gs:// read-back of the written object" \
+	"$(q "$RD('gs://$BUCKET/out.parquet') AS t(id int8)" | tr '|' ' ')" "3 18"
+
+# ---- virtual-host addressing: the bucket moves into the hostname ------------
+: > "$S3_LOG"
+check "virtual-host read == path-style read (same object, different addressing)" \
+	"$(qset -c "SET pgcolumnar.objstore_s3_addressing='virtual'" \
+	        -c "$RD('s3://$BUCKET/vh.parquet') AS t(id int8)" | tr '|' ' ')" "4 10"
+check "virtual-host put the KEY ALONE in the path (no bucket segment)" \
+	"$([ "$(gets | grep -c '^/vh.parquet$')" -ge 1 ] && [ "$(gets | grep -c '^/pgc-bucket/vh.parquet$')" -eq 0 ] && echo yes)" "yes"
+# removal proof of the addressing switch: path-style (default) keeps the bucket
+: > "$S3_LOG"
+check "removal proof: with addressing=path the bucket is back in the path" \
+	"$(qset -c "SET pgcolumnar.objstore_s3_addressing='path'" \
+	        -c "$RD('s3://$BUCKET/vh.parquet') AS t(id int8)" | tr '|' ' ')" "4 10"
+check "and the request path carried the bucket again" \
+	"$([ "$(gets | grep -c '^/pgc-bucket/vh.parquet$')" -ge 1 ] && echo yes)" "yes"
+
+# ---- phase 2: NO endpoint -> gs:// has a default, s3:// does not -------------
+pg_restart_env "AWS_ACCESS_KEY_ID='$AKID'" "AWS_SECRET_ACCESS_KEY='$SECRET'" "AWS_REGION='$REGION'"
+check "s3:// with no endpoint demands one (names AWS_ENDPOINT_URL)" \
+	"$([ "$(msg_of "$RD('s3://$BUCKET/vh.parquet') AS t(id int8)" | grep -c 'AWS_ENDPOINT_URL')" -ge 1 ] && echo yes)" "yes"
+check "gs:// with no endpoint uses the storage.googleapis.com default (does not demand AWS_ENDPOINT_URL)" \
+	"$([ "$(msg_of "$RD('gs://$BUCKET/vh.parquet') AS t(id int8)" | grep -c 'AWS_ENDPOINT_URL')" -eq 0 ] && echo yes)" "yes"
+
+pgc_summary

--- a/test/objstore_http_server.py
+++ b/test/objstore_http_server.py
@@ -119,6 +119,15 @@ class Handler(BaseHTTPRequestHandler):
                 mode = prefix.strip("/")
                 path = "/" + path[len(prefix):]
                 break
+        # virtual-host addressing (#621): the bucket is the leftmost Host
+        # label(s) before the configured base, and the request path is the key
+        # alone, so re-attach the bucket for the on-disk lookup.
+        base = getattr(self.server, "vhost_base", None)
+        if base:
+            hosthdr = self.headers.get("Host", "").split(":", 1)[0]
+            if hosthdr.endswith("." + base):
+                bucket = hosthdr[: -len(base) - 1]
+                path = "/" + bucket + path
         local = os.path.join(self.server.rootdir, path.lstrip("/"))
         return mode, local
 
@@ -357,6 +366,9 @@ def main():
     ap.add_argument("--tamper-bucket")
     ap.add_argument("--tls-cert")
     ap.add_argument("--tls-key")
+    ap.add_argument("--virtual-host-base",
+                    help="base host under which the leftmost Host label is the "
+                         "bucket (S3 virtual-host addressing, #621)")
     args = ap.parse_args()
 
     if args.tls_cert:
@@ -371,6 +383,7 @@ def main():
     srv.sigv4_region = args.sigv4_region
     srv.sigv4_token = args.sigv4_token
     srv.tamper_bucket = args.tamper_bucket
+    srv.vhost_base = args.virtual_host_base
     srv.uploads = {}
     open(args.log, "a").close()
     # Readiness marker for the suite: print once the socket is bound.

--- a/test/objstore_module.sh
+++ b/test/objstore_module.sh
@@ -206,12 +206,12 @@ mv "$MOD.probe" "$MOD" 2>/dev/null
 #    queries, one session, two different errors, the second one plausible.
 #
 # Both reads run in ONE psql session on purpose. Separate sessions cannot see it.
-# gs:// deliberately: the scheme must be one the module recognizes as remote
-# but does NOT handle. s3:// stopped qualifying when #393 M2 implemented it
-# (its no-environment error is pinned in the loop above and in
-# objstore_s3_read.sh); gs:// stays unhandled until a GCS milestone exists,
-# at which point this becomes az:// or a reserved test scheme.
-Q="SELECT * FROM pgcolumnar.read_parquet('gs://bucket/key.parquet') AS (a int)"
+# az:// deliberately: the scheme must be one the module recognizes as remote
+# but does NOT handle. s3:// stopped qualifying when #393 M2 implemented it, and
+# gs:// stopped qualifying when #621 implemented GCS interop (their no-endpoint
+# errors are pinned in the loop above and in the addressing suite); az:// stays
+# unhandled until an Azure milestone exists, if one ever does.
+Q="SELECT * FROM pgcolumnar.read_parquet('az://bucket/key.parquet') AS (a int)"
 two_reads() {
 	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" \
 		-At -q -c "$Q" -c "$Q" 2>&1


### PR DESCRIPTION
Addresses #621. **Scope (owner decision, 2026-08-14): `gs://` and S3 virtual-host addressing. Azure (`az://`) is explicitly out of scope** — it would need a SharedKey/SAS signer and new ABI credential fields, deferred; it stays an unhandled scheme. Both features here are additive and need **no ABI change**.

## GCS via the interoperable XML API

`gs://` (and `az://`) were already recognized as remote by `PgColumnarPathIsRemote` but rejected at the module's `handles_url`. GCS's XML API is S3-shaped and takes AWS SigV4 with an HMAC key, so `gs://` folds onto the S3 resolver:
- `handles_url` accepts `gs://`; `objstore_open` / `os_write_handle` route it to `os_resolve_s3` (both schemes are 5 chars, so `url+5` skips either).
- `os_resolve_s3` defaults the endpoint to `https://storage.googleapis.com` and the region to `auto` when none is configured (S3 still requires an explicit endpoint). The signer, credentials (a GCS HMAC key is the `access_key_id`/`secret_access_key` pair), and request construction are unchanged.

Verified against the SigV4 fixture (an independent signer) and, opt-in, live Garage. Real-GCS acceptance of the `s3` service scope is the one assumption not checkable here; it's the documented interop path.

## Virtual-host addressing

Path-style (`endpoint/bucket/key`) stays the default and byte-identical. `pgcolumnar.objstore_s3_addressing='virtual'` selects virtual-host (`bucket.endpoint/key`). The GUC is defined by the preloaded library and read in `os_resolve_s3` **by name** (same mechanism as `objstore_allowed_endpoints`), so **no config-struct field and no ABI bump**. Under virtual-host:
- `h->host` becomes `bucket.authority` — the connect target, Host header, and TLS cert name all key off `h->host` already, so cert verification and SNI need no change.
- the request path is the key alone.
- a new module-private `auth_host` carries the endpoint authority, and the allow-list matches it: the operator authorizes the endpoint, not the per-bucket hostname. Path-style leaves `auth_host` NULL, so the allow-list check falls back to `h->host` exactly as before (existing S3 suites stay byte-identical).

## TDD

`objstore_addressing.sh`, against the SigV4 fixture:
- `gs://` reads and writes round-trip (scheme handled, HMAC creds reused, signature verified by the independent implementation).
- `gs://` with no endpoint uses the `storage.googleapis.com` default — its error does **not** demand `AWS_ENDPOINT_URL`, the contrast that proves the default (`s3://` still demands one).
- virtual-host reads the same object as path-style; the fixture log shows the **key alone** in the path under `virtual` and the **bucket back** under `path` (the removal proof of the switch).

Virtual-host is exercised with `/etc/hosts` names (`bucket.s3.local` → 127.0.0.1), so the client's connect, Host header, and cert name are the real `bucket.endpoint` with **no test-only code path**; the suite skips cleanly where those names don't resolve. `objstore_module.sh`'s deliberate unhandled-scheme probe migrates from `gs://` to `az://`.

## Gates

- **PG17/18/19** over the objstore suites under `-Wshadow -Werror`. (The new GUC backing variable needs an `extern` in `columnar.h`, which PG18/19's `-Wmissing-variable-declarations` enforces and PG17 does not — caught in gating.)
- **ASAN (pg18_san)** over the gs:// read/write and virtual-host paths, which add handle-memory allocations (`auth_host`, the virtual-host `psprintf`/`pnstrdup`): **zero backend reports**.

## Docs

The object-storage scheme table gains `gs://`; the addressing GUC is documented in the configuration reference and the object-storage notes; the `AWS_ENDPOINT_URL` row notes the GCS default. Design in `design/ISSUE_621_SCHEMES_AND_ADDRESSING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqFY4pifG7rp3a5fJREWnr