### PR TITLE
feat: _SUCCESS completion marker for parallel_export_parquet (#394)

### DIFF
--- a/design/ISSUE_394_OBJECT_STORAGE_SINK.md
+++ b/design/ISSUE_394_OBJECT_STORAGE_SINK.md
@@ -164,3 +164,18 @@ values) is deliberately NOT this: that is the Iceberg metadata layer, which
 belongs to #388, and the issue itself noted this is "the point where this starts
 to touch #388". `_SUCCESS` is the minimal, standard, format-neutral signal; the
 manifest is the format-specific one and is scoped there.
+
+## Remote reconcile before the marker (#632 review, 2026-08-14)
+
+An adversarial review reproduced, on live Garage, a real gap: the remote path
+allows an overwrite re-run into a used prefix (#619 require-empty is deferred), so
+a smaller run overwrites the low-numbered parts and leaves the larger prior run's
+higher-numbered parts behind, then stamps `_SUCCESS` on top -- certifying a mixed
+set as one complete run. The local path is safe (prepare_dir require-empty refuses
+a non-empty directory first). Fixed by making the remote success path, now that
+#619 listing exists, delete any `part-NNNN.parquet` at the prefix whose index is
+at or above this run's key count (the stale tail) before writing the marker, so
+the marker certifies exactly this run's parts. A regression arm runs a 4-worker
+then a 2-worker export into one prefix and asserts the stale parts are gone; the
+removal proof (disable the reconcile) reds it with 4 parts left, the review's
+reproduction.

--- a/design/ISSUE_394_OBJECT_STORAGE_SINK.md
+++ b/design/ISSUE_394_OBJECT_STORAGE_SINK.md
@@ -136,3 +136,31 @@ module, shared by source and sink.
    mid-upload asserting abort ran (the arm that "leaks money and never gets
    exercised by accident").
 4. Parallel-to-remote, per-worker objects, dispatcher key-wise cleanup.
+
+## Completion marker (decided, 2026-08-14)
+
+The issue's step 3 asked whether a completion marker or manifest is wanted for
+`parallel_export_parquet`, since a directory or bucket of `part-NNNN.parquet`
+objects carries no record of whether a run finished. Decided: an empty
+`_SUCCESS` marker at the destination, the Hadoop/Spark `FileOutputCommitter`
+convention that Spark, Hive and Trino directory readers already recognize.
+
+- Written **last**, only after every worker reports success and past the
+  error-cleanup region, so a failed or cancelled run (whose parts the dispatcher
+  removes) leaves none. Its presence is the "a complete run's output is here"
+  signal; its absence means incomplete.
+- Written through the same `PqSink` seam as the data, so it is temp-and-rename
+  locally and a single object remotely, with no new code path.
+- The failure cleanup also drops any stale `_SUCCESS`, so a failed re-run into a
+  prefix that held a prior run's marker does not leave a misleading one.
+- The read path already skips `_`-prefixed names, so the marker is never folded
+  into a `read_parquet` or FDW scan.
+- If the marker write itself fails, it raises without deleting the parts (it is
+  past the cleanup region): the committed data is preserved and the caller learns
+  the signal could not be written, rather than losing a good export.
+
+A **richer manifest** (the part list with row counts, schema and partition
+values) is deliberately NOT this: that is the Iceberg metadata layer, which
+belongs to #388, and the issue itself noted this is "the point where this starts
+to touch #388". `_SUCCESS` is the minimal, standard, format-neutral signal; the
+manifest is the format-specific one and is scoped there.

--- a/docs/sql-reference.md
+++ b/docs/sql-reference.md
@@ -511,6 +511,13 @@ mid-upload can leave one incomplete multipart upload that the dispatcher cannot
 address. Set a bucket lifecycle rule that expires incomplete multipart uploads to
 reclaim it, as the object-storage notes recommend for `export_parquet`.
 
+On success the function writes an empty `_SUCCESS` marker at the destination, the
+Hadoop and Spark convention. Its presence means a complete run's output is there;
+a failed or cancelled run, whose part files the dispatcher removes, leaves none.
+The marker is written last, after every worker has finished, so a directory or
+prefix that carries it is a whole export. `read_parquet` and the foreign-data
+wrapper skip it, as they skip any name beginning with an underscore.
+
 When `workers` is omitted the function derives a value from the target.
 
 ```sql
@@ -641,9 +648,10 @@ dot-hidden names are skipped, as they are for a local directory. Hive
 `partition_columns` work over a remote prefix. A pattern or a prefix requires the
 object-store module, since only it can issue the listing.
 
-On write, `parallel_export_parquet` treats a remote URL as a prefix, writing one
-`part-NNNN.parquet` object under it per worker; every other function writes a
-single object at the exact key.
+On write, `parallel_export_parquet` treats a remote URL as a prefix. It writes one
+`part-NNNN.parquet` object under the prefix per worker, and an empty `_SUCCESS`
+marker beside them on completion. Every other write function writes a single
+object at the exact key.
 
 Remote paths carry the same privilege as local ones. A read needs
 `pg_read_server_files` and a write needs `pg_write_server_files`, over and above

--- a/docs/sql-reference.md
+++ b/docs/sql-reference.md
@@ -515,8 +515,11 @@ On success the function writes an empty `_SUCCESS` marker at the destination, th
 Hadoop and Spark convention. Its presence means a complete run's output is there;
 a failed or cancelled run, whose part files the dispatcher removes, leaves none.
 The marker is written last, after every worker has finished, so a directory or
-prefix that carries it is a whole export. `read_parquet` and the foreign-data
-wrapper skip it, as they skip any name beginning with an underscore.
+prefix that carries it is a whole export. A remote prefix allows a re-run to
+overwrite a used prefix. A smaller re-run there first removes the stale
+higher-numbered parts a larger prior run left, so the marker certifies exactly
+the parts this run wrote. `read_parquet` and the foreign-data wrapper skip it, as
+they skip any name beginning with an underscore.
 
 When `workers` is omitted the function derives a value from the target.
 

--- a/src/columnar_parallel_export.c
+++ b/src/columnar_parallel_export.c
@@ -36,6 +36,7 @@
 
 #include "columnar.h"
 #include "columnar_objstore.h"
+#include "columnar_sink.h"
 
 #include "access/relation.h"
 #include "access/table.h"
@@ -305,6 +306,10 @@ pexport_remove_outputs(const char *dir, int nkeys)
 			snprintf(fp, sizeof(fp), "%s/part-%04d.parquet", dir, i);
 			api->delete_object(fp, NULL);
 		}
+		/* also drop any _SUCCESS marker (#394): a failed or cancelled run must
+		 * not leave a stale completion marker from an earlier run at the prefix */
+		snprintf(fp, sizeof(fp), "%s/_SUCCESS", dir);
+		api->delete_object(fp, NULL);
 		return;
 	}
 
@@ -326,6 +331,41 @@ pexport_remove_outputs(const char *dir, int nkeys)
 		(void) unlink(fp);
 	}
 	FreeDir(d);
+	/* the completion marker (#394) is not a *.parquet name; drop it explicitly */
+	snprintf(fp, sizeof(fp), "%s/_SUCCESS", dir);
+	(void) unlink(fp);
+}
+
+/*
+ * Write the _SUCCESS completion marker (#394). parallel_export_parquet writes a
+ * directory or prefix of part-NNNN.parquet objects, and a bucket (or a directory)
+ * carries no record of which run produced which objects, nor whether the run
+ * finished. This is the Hadoop/Spark convention a consumer already recognizes: an
+ * empty _SUCCESS object at the destination, written ONLY after every worker
+ * completed. Its presence means "a complete run's output is here"; its absence
+ * (a failed or cancelled run, whose parts the cleanup removes) means it is not.
+ * The read path already skips '_'-prefixed names, so the marker is never folded
+ * into a read. Written through the same sink seam as the data, so it is
+ * temp-and-rename locally and a single object remotely.
+ */
+static void
+pexport_write_success_marker(const char *dir)
+{
+	char		fp[MAXPGPATH];
+	PqSink	   *snk;
+
+	snprintf(fp, sizeof(fp), "%s/_SUCCESS", dir);
+	snk = PgColumnarSinkOpen(fp);
+	PG_TRY();
+	{
+		PgColumnarSinkFinish(snk);	/* empty marker */
+	}
+	PG_CATCH();
+	{
+		PgColumnarSinkAbort(snk);
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
 }
 
 /* error-cleanup: stop every worker so a dispatcher FATAL cannot leave them
@@ -762,5 +802,15 @@ pgcolumnar_parallel_export_parquet(PG_FUNCTION_ARGS)
 	if (pushed)
 		PopActiveSnapshot();
 	table_close(rel, AccessShareLock);
+
+	/*
+	 * Every worker completed: write the _SUCCESS marker (#394). This is past the
+	 * error-cleanup region (PG_END_ENSURE_ERROR_CLEANUP above), so if the marker
+	 * write itself fails it raises without deleting the parts the workers already
+	 * committed -- the data is preserved and the caller learns the completion
+	 * signal could not be written, rather than losing a good export to a marker
+	 * hiccup.
+	 */
+	pexport_write_success_marker(dir);
 	PG_RETURN_INT64(total);
 }

--- a/src/columnar_parallel_export.c
+++ b/src/columnar_parallel_export.c
@@ -336,6 +336,60 @@ pexport_remove_outputs(const char *dir, int nkeys)
 	(void) unlink(fp);
 }
 
+/* match exactly "part-<digits>.parquet"; on success set *idx to the index */
+static bool
+pexport_part_index(const char *base, int *idx)
+{
+	const char *p = base;
+	const char *digits;
+
+	if (strncmp(p, "part-", 5) != 0)
+		return false;
+	p += 5;
+	digits = p;
+	while (*p >= '0' && *p <= '9')
+		p++;
+	if (p == digits || strcmp(p, ".parquet") != 0)
+		return false;
+	*idx = atoi(digits);
+	return true;
+}
+
+/*
+ * Reconcile a remote prefix before stamping the completion marker (#394, #632
+ * review). The remote path allows an overwrite re-run into a used prefix
+ * (#619's require-empty is deferred), so a smaller run leaves the stale
+ * higher-numbered parts of a larger prior run behind: run A writes
+ * part-0000..0007, run B with fewer workers overwrites part-0000..0003 and
+ * leaves 0004..0007. Writing _SUCCESS on top would certify a mixed set as one
+ * complete run. Now that listing exists (#619), the dispatcher deletes any
+ * part-NNNN.parquet at the prefix whose index is >= this run's key count -- the
+ * stale tail -- so the marker means what it says: the prefix holds exactly this
+ * run's parts. The local path needs none of this: prepare_dir require-empty
+ * already refuses a non-empty directory before any worker spawns.
+ */
+static void
+pexport_remove_stale_remote_parts(const char *dir, int nkeys)
+{
+	const PgColumnarObjStoreApi *api = PgColumnarObjStoreGet();
+	char	  **keys;
+	int			n = 0;
+	int			i;
+
+	if (api == NULL || api->list_objects == NULL)
+		return;
+	keys = api->list_objects(dir, NULL, &n);
+	for (i = 0; i < n; i++)
+	{
+		const char *slash = strrchr(keys[i], '/');
+		const char *base = slash ? slash + 1 : keys[i];
+		int			idx;
+
+		if (pexport_part_index(base, &idx) && idx >= nkeys)
+			api->delete_object(keys[i], NULL);
+	}
+}
+
 /*
  * Write the _SUCCESS completion marker (#394). parallel_export_parquet writes a
  * directory or prefix of part-NNNN.parquet objects, and a bucket (or a directory)
@@ -804,13 +858,17 @@ pgcolumnar_parallel_export_parquet(PG_FUNCTION_ARGS)
 	table_close(rel, AccessShareLock);
 
 	/*
-	 * Every worker completed: write the _SUCCESS marker (#394). This is past the
-	 * error-cleanup region (PG_END_ENSURE_ERROR_CLEANUP above), so if the marker
-	 * write itself fails it raises without deleting the parts the workers already
-	 * committed -- the data is preserved and the caller learns the completion
-	 * signal could not be written, rather than losing a good export to a marker
-	 * hiccup.
+	 * Every worker completed. On a remote prefix, first drop any stale
+	 * higher-numbered parts a larger prior run left (see
+	 * pexport_remove_stale_remote_parts), so the marker certifies exactly this
+	 * run's parts. Then write the _SUCCESS marker (#394). Both are past the
+	 * error-cleanup region (PG_END_ENSURE_ERROR_CLEANUP above), so a failure here
+	 * raises without deleting the parts the workers already committed -- the data
+	 * is preserved and the caller learns the completion signal could not be
+	 * finalized, rather than losing a good export to a marker hiccup.
 	 */
+	if (PgColumnarPathIsRemote(dir))
+		pexport_remove_stale_remote_parts(dir, single_table ? workers : npart);
 	pexport_write_success_marker(dir);
 	PG_RETURN_INT64(total);
 }

--- a/test/objstore_sink_write.sh
+++ b/test/objstore_sink_write.sh
@@ -148,6 +148,13 @@ NOBJ="$(ls "$PGC_WORKDIR/$BUCKET/par/" 2>/dev/null | grep -c 'part-.*\.parquet$'
 check "parallel: one object per worker was written (4)" "$NOBJ" "4"
 check "parallel: every worker PUT went to the prefix" \
 	"$([ "$(logn '^PUT /pgc-bucket/par/part-')" -ge 4 ] && echo yes)" "yes"
+# #394: a completed remote export writes a _SUCCESS marker object at the prefix,
+# put through the same remote sink (a single PUT), so a consumer listing the
+# prefix sees the run completed. It is not a part object (NOBJ==4 above).
+check "parallel remote: a _SUCCESS marker object exists at the prefix" \
+	"$([ -f "$PGC_WORKDIR/$BUCKET/par/_SUCCESS" ] && echo yes || echo no)" "yes"
+check "parallel remote: the marker went to the prefix as a PUT" \
+	"$([ "$(logn '^PUT /pgc-bucket/par/_SUCCESS')" -ge 1 ] && echo yes)" "yes"
 # read each key back and union; the union equals the source (prefix-union read
 # is #619, so this reads the four exact keys, not the prefix).
 for i in 0 1 2 3; do
@@ -193,6 +200,10 @@ check "cancel: the dispatcher issued DELETE over the known keys" \
 	"$([ "$(logn '^DELETE /pgc-bucket/cx/part-')" -ge 1 ] && echo yes)" "yes"
 check_num "cancel: no completed object remains at the prefix" \
 	"$(ls "$PGC_WORKDIR/$BUCKET/cx/" 2>/dev/null | grep -c 'part-.*\.parquet$')" "0"
+# #394: a cancelled remote run writes no completion marker (it is written last,
+# only on full success), and the dispatcher's cleanup also drops any stale one.
+check "cancel: no _SUCCESS marker at the prefix" \
+	"$([ -e "$PGC_WORKDIR/$BUCKET/cx/_SUCCESS" ] && echo present || echo absent)" "absent"
 
 # ---- optional: a real S3 implementation (Garage) ----------------------------
 if [ -n "${PGC_S3_INTEGRATION_ENDPOINT:-}" ]; then

--- a/test/objstore_sink_write.sh
+++ b/test/objstore_sink_write.sh
@@ -170,6 +170,21 @@ check "parallel: the union of the per-worker objects == source" \
 check_num "parallel: a re-run into the same prefix succeeds (overwrite)" \
 	"$(q "SELECT pgcolumnar.parallel_export_parquet('es_par'::regclass, 's3://$BUCKET/par', 4)")" "$PARROWS"
 
+# #632 review: a SMALLER re-run into a used prefix must not leave the prior
+# larger run's higher-numbered parts under a freshly-stamped _SUCCESS. First 4
+# workers, then 2: the reconcile drops the stale part-0002/0003, so the marker
+# certifies exactly the 2 parts this run wrote.
+q "SELECT pgcolumnar.parallel_export_parquet('es_par'::regclass, 's3://$BUCKET/sr', 4)" >/dev/null
+check "shrink: the 4-worker run wrote 4 parts + marker" \
+	"$([ "$(ls "$PGC_WORKDIR/$BUCKET/sr/" 2>/dev/null | grep -c 'part-.*parquet$')" = 4 ] && [ -f "$PGC_WORKDIR/$BUCKET/sr/_SUCCESS" ] && echo ok)" "ok"
+q "SELECT pgcolumnar.parallel_export_parquet('es_par'::regclass, 's3://$BUCKET/sr', 2)" >/dev/null
+check_num "shrink: a smaller re-run leaves exactly its own 2 parts (stale tail dropped)" \
+	"$(ls "$PGC_WORKDIR/$BUCKET/sr/" 2>/dev/null | grep -c 'part-.*parquet$')" "2"
+check "shrink: parts 0002/0003 from the larger run are gone" \
+	"$([ ! -e "$PGC_WORKDIR/$BUCKET/sr/part-0002.parquet" ] && [ ! -e "$PGC_WORKDIR/$BUCKET/sr/part-0003.parquet" ] && echo gone)" "gone"
+check "shrink: _SUCCESS certifies the reconciled prefix" \
+	"$([ -f "$PGC_WORKDIR/$BUCKET/sr/_SUCCESS" ] && echo yes)" "yes"
+
 # cancel mid-run: the dispatcher removes the completed keys it wrote. Big table
 # + small parts so a worker is mid-multipart when the cancel lands.
 psql_run "DROP TABLE IF EXISTS es_parbig;

--- a/test/parallel_export_parquet.sh
+++ b/test/parallel_export_parquet.sh
@@ -70,6 +70,13 @@ for W in 1 2 4; do
 	check "single($W): read-back == source" "$rb" "$SRC"
 	check "single($W): read-back == serial export" "$rb" "$SER_HASH"
 	check "single($W): wrote exactly $W files (distinct per worker)" "$(nfiles "$D")" "$W"
+	# #394: a completed export writes a _SUCCESS marker. nfiles==W above already
+	# proves it is not counted as a part, and read-back==source proves read_parquet
+	# ignores it; here assert it is present and empty.
+	check "single($W): a _SUCCESS completion marker is written" \
+		"$([ -f "$D/_SUCCESS" ] && echo yes || echo no)" yes
+	check "single($W): the _SUCCESS marker is empty" \
+		"$([ -f "$D/_SUCCESS" ] && [ ! -s "$D/_SUCCESS" ] && echo empty || echo no)" empty
 done
 
 # ---- partitioned columnar table: one file per partition ---------------------
@@ -171,10 +178,17 @@ check "the export was cancelled mid-flight, not completed first (fixture premise
 # by each worker's own sink abort (#394) - a cancelled export leaves NOTHING.
 check "a cancelled export leaves no partial files (item 2)" \
 	"$(anyfiles "$DCX")" 0
+# #394: the completion marker is written LAST, only after every worker finishes,
+# so a cancelled run leaves none -- the absence of _SUCCESS is what tells a
+# consumer the run did not complete.
+check "a cancelled export writes no _SUCCESS marker" \
+	"$([ -e "$DCX/_SUCCESS" ] && echo present || echo absent)" absent
 # and the cleaned directory is reusable (require-empty does not block a retry)
 q "SELECT pgcolumnar.parallel_export_parquet('t_col'::regclass, '$DCX', 2)" >/dev/null 2>&1
 check "retry into the cleaned directory succeeds" \
 	"$([ "$(nfiles "$DCX")" -ge 1 ] && echo yes || echo no)" yes
+check "the retry writes a fresh _SUCCESS marker" \
+	"$([ -f "$DCX/_SUCCESS" ] && echo yes || echo no)" yes
 
 # ---- error cases ------------------------------------------------------------
 # st_1 was written above, so it is non-empty


### PR DESCRIPTION
Closes the remaining piece of #394 (the issue's step 3: a completion marker).

## What & why

`parallel_export_parquet` writes a directory or an `s3://` prefix of `part-NNNN.parquet` objects. Neither a directory nor a bucket records whether a run finished or which run produced which objects — the exact gap the issue flagged for the parallel case. This adds the **Hadoop/Spark `_SUCCESS` convention** that Spark, Hive and Trino directory readers already recognize: an empty `_SUCCESS` marker at the destination, written **only after every worker completes**.

- `pexport_write_success_marker` uses the same `PqSink` seam as the data → temp-and-rename locally, a single object remotely, no new code path.
- Written **last, past the error-cleanup region**, so a marker-write failure raises *without* deleting the parts the workers already committed (data preserved).
- A failed/cancelled run leaves **no** marker, and `pexport_remove_outputs` now also drops any stale `_SUCCESS` (so a failed re-run into a used prefix can't leave a misleading one).
- The read path already skips `_`-prefixed names, so the marker is never folded into a `read_parquet`/FDW scan.

**Scope decision:** this is the minimal, format-neutral "did the run complete" signal. A *richer manifest* (part list, row counts, schema, partition values) is the Iceberg metadata layer and is deliberately scoped to **#388** — as the issue itself noted, step 3 is "where this starts to touch #388".

## TDD / prove-don't-trust

- `parallel_export_parquet.sh` (local): a completed export writes an empty `_SUCCESS` that is **not** a part file and doesn't affect the read-back; a cancelled export leaves none; a retry writes a fresh one.
- `objstore_sink_write.sh` (remote): the marker object + its PUT appear at the prefix on success, none after cancel.
- **RED** on `main` (no marker). **Removal proof**: disabling the marker write reds the "marker written" arms while the "absent" arms stay green.

## Gates

- **PG17/18/19** under `-Wshadow -Werror`.
- **ASAN (pg18_san)** over the remote parallel export (which now writes and cleans up the marker): **zero reports**.
- **Live Garage**: an independent client (`awscli`) sees a **0-byte `_SUCCESS`** beside the four `part-000N.parquet` objects at a real Garage prefix.

## Docs

The `parallel_export_parquet` reference documents the marker and the partial-failure guarantee; the decision is recorded in `design/ISSUE_394_OBJECT_STORAGE_SINK.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqFY4pifG7rp3a5fJREWnr