### PR TITLE
feat: decode the Iceberg snapshot manifest-list (#388 step 2)

### DIFF
--- a/docs/sql-reference.md
+++ b/docs/sql-reference.md
@@ -598,6 +598,24 @@ SELECT file_path, record_count, partition
   FROM pgcolumnar.read_avro_manifest('/data/warehouse/db/events/metadata/abc.avro');
 ```
 
+### pgcolumnar.read_manifest_list(path text) returns table(manifest_path text, manifest_length bigint, content int, partition_spec_id int, added_files_count int, existing_files_count int, deleted_files_count int, added_rows_count bigint, existing_rows_count bigint, deleted_rows_count bigint, sequence_number bigint, min_sequence_number bigint, added_snapshot_id bigint)
+
+Decodes an Apache Iceberg snapshot manifest-list Avro file and reports its
+`manifest_file` entries. Each row names one manifest the snapshot points at,
+with its length, content type (0 data, 1 deletes), partition spec, and the
+added, existing, and deleted file and row counts the writer recorded. The
+caller needs the `pg_read_server_files` role, which superusers hold. This is
+step two of Iceberg support (#388): it reads the same Avro object-container
+format as `read_avro_manifest`, decoded against the schema embedded in the
+file, so a v3 manifest list reads structurally. It reads a local file. It does
+not resolve a table's current snapshot or open the manifests it names, which
+are later steps.
+
+```sql
+SELECT manifest_path, added_files_count, added_rows_count
+  FROM pgcolumnar.read_manifest_list('/data/warehouse/db/events/metadata/snap-123.avro');
+```
+
 ### The pgcolumnar_parquet foreign-data wrapper
 
 Exposes a Parquet file, directory, or glob as a foreign table. The scan streams

--- a/pgcolumnar--1.0-alpha.sql
+++ b/pgcolumnar--1.0-alpha.sql
@@ -909,6 +909,19 @@ CREATE FUNCTION pgcolumnar.read_avro_manifest(path text)
 COMMENT ON FUNCTION pgcolumnar.read_avro_manifest(text)
 	IS 'decode an Apache Iceberg Avro manifest file and report its data-file entries; the first step of Iceberg read support (#388)';
 
+CREATE FUNCTION pgcolumnar.read_manifest_list(path text)
+	RETURNS TABLE(manifest_path text, manifest_length bigint, content integer,
+				  partition_spec_id integer, added_files_count integer,
+				  existing_files_count integer, deleted_files_count integer,
+				  added_rows_count bigint, existing_rows_count bigint,
+				  deleted_rows_count bigint, sequence_number bigint,
+				  min_sequence_number bigint, added_snapshot_id bigint)
+	LANGUAGE C STRICT
+	AS 'MODULE_PATHNAME', 'pgcolumnar_read_manifest_list';
+
+COMMENT ON FUNCTION pgcolumnar.read_manifest_list(text)
+	IS 'decode an Apache Iceberg snapshot manifest-list Avro file and report the manifest files it points at (#388)';
+
 /* ---------------------------------------------------------------------------
  * Parquet foreign-data wrapper (Phase G)
  *

--- a/src/columnar_avro.c
+++ b/src/columnar_avro.c
@@ -631,6 +631,54 @@ av_decode_entry(AvReader *r, AvSchema *s, PgColumnarAvroManifestEntry *e)
 	}
 }
 
+/* decode one manifest_file record (a manifest-list entry) into a projection */
+static void
+av_decode_manifest_file(AvReader *r, AvSchema *s, PgColumnarAvroManifestFile *e)
+{
+	int			i;
+
+	if (s->kind != AV_RECORD)
+	{
+		r->error = true;
+		return;
+	}
+	for (i = 0; i < s->n && !r->error; i++)
+	{
+		const char *nm = s->fields[i].name;
+		AvSchema   *ft = s->fields[i].type;
+		bool		have;
+
+		if (strcmp(nm, "manifest_path") == 0)
+			e->manifest_path = av_read_string(r, ft);
+		else if (strcmp(nm, "manifest_length") == 0)
+			e->manifest_length = av_read_long(r, ft, &have);
+		else if (strcmp(nm, "partition_spec_id") == 0)
+			e->partition_spec_id = (int32) av_read_long(r, ft, &have);
+		else if (strcmp(nm, "content") == 0)
+			e->content = (int32) av_read_long(r, ft, &have);
+		else if (strcmp(nm, "sequence_number") == 0)
+			e->sequence_number = av_read_long(r, ft, &have);
+		else if (strcmp(nm, "min_sequence_number") == 0)
+			e->min_sequence_number = av_read_long(r, ft, &have);
+		else if (strcmp(nm, "added_snapshot_id") == 0)
+			e->added_snapshot_id = av_read_long(r, ft, &have);
+		else if (strcmp(nm, "added_files_count") == 0)
+			e->added_files_count = (int32) av_read_long(r, ft, &have);
+		else if (strcmp(nm, "existing_files_count") == 0)
+			e->existing_files_count = (int32) av_read_long(r, ft, &have);
+		else if (strcmp(nm, "deleted_files_count") == 0)
+			e->deleted_files_count = (int32) av_read_long(r, ft, &have);
+		else if (strcmp(nm, "added_rows_count") == 0)
+			e->added_rows_count = av_read_long(r, ft, &have);
+		else if (strcmp(nm, "existing_rows_count") == 0)
+			e->existing_rows_count = av_read_long(r, ft, &have);
+		else if (strcmp(nm, "deleted_rows_count") == 0)
+			e->deleted_rows_count = av_read_long(r, ft, &have);
+		else
+			av_skip(r, ft);
+	}
+}
+
 /* ---------------------------------------------------- object-container file */
 
 /* decode the header metadata map (Avro map<string,bytes>) into schema + codec */
@@ -750,8 +798,17 @@ av_inflate(const uint8 *in, int64 inlen, int64 *outlen)
 	return out;
 }
 
-PgColumnarAvroManifestEntry *
-PgColumnarAvroReadManifest(const uint8 *buf, int64 len, int *nout)
+/*
+ * Read an Avro object-container file, decoding each record with `decode` into a
+ * fresh element of an array of `elemsize`-byte elements. Shared by the manifest
+ * and manifest-list readers: only the per-record projection differs; the OCF
+ * framing, deflate codec, caps and sync-marker checks are identical and live
+ * here, in one place. Returns the palloc'd array; *nout is the count.
+ */
+static void *
+av_read_ocf(const uint8 *buf, int64 len, Size elemsize,
+			void (*decode) (AvReader *br, AvSchema *schema, void *elem),
+			int *nout)
 {
 	AvReader	r = {buf, len, 0, false};
 	char	   *schema_json;
@@ -761,7 +818,7 @@ PgColumnarAvroReadManifest(const uint8 *buf, int64 len, int *nout)
 	AvSchema   *schema;
 	JsonbValue	rootv;
 	Jsonb	   *j;
-	PgColumnarAvroManifestEntry *out = NULL;
+	char	   *out = NULL;
 	int			nalloc = 0;
 	int			n = 0;
 
@@ -862,15 +919,15 @@ PgColumnarAvroReadManifest(const uint8 *buf, int64 len, int *nout)
 		{
 			nalloc = (int) Max((int64) (n + count), (int64) 16);
 			out = out == NULL
-				? (PgColumnarAvroManifestEntry *) palloc0(sizeof(*out) * nalloc)
-				: (PgColumnarAvroManifestEntry *) repalloc(out, sizeof(*out) * nalloc);
-			memset(out + n, 0, sizeof(*out) * (nalloc - n));
+				? (char *) palloc0(elemsize * nalloc)
+				: (char *) repalloc(out, elemsize * nalloc);
+			memset(out + (Size) n * elemsize, 0, (Size) (nalloc - n) * elemsize);
 		}
 		for (i = 0; i < count; i++)
 		{
 			if ((i & 0xFFF) == 0)
 				CHECK_FOR_INTERRUPTS();
-			av_decode_entry(&br, schema, &out[n]);
+			decode(&br, schema, out + (Size) n * elemsize);
 			if (br.error)
 				ereport(ERROR,
 						(errcode(ERRCODE_DATA_CORRUPTED),
@@ -895,42 +952,45 @@ PgColumnarAvroReadManifest(const uint8 *buf, int64 len, int *nout)
 	return out;
 }
 
+/* thin callbacks so av_read_ocf can decode either record type */
+static void
+av_entry_cb(AvReader *br, AvSchema *s, void *e)
+{
+	av_decode_entry(br, s, (PgColumnarAvroManifestEntry *) e);
+}
+
+static void
+av_manifest_file_cb(AvReader *br, AvSchema *s, void *e)
+{
+	av_decode_manifest_file(br, s, (PgColumnarAvroManifestFile *) e);
+}
+
+PgColumnarAvroManifestEntry *
+PgColumnarAvroReadManifest(const uint8 *buf, int64 len, int *nout)
+{
+	return (PgColumnarAvroManifestEntry *)
+		av_read_ocf(buf, len, sizeof(PgColumnarAvroManifestEntry),
+					av_entry_cb, nout);
+}
+
+PgColumnarAvroManifestFile *
+PgColumnarAvroReadManifestList(const uint8 *buf, int64 len, int *nout)
+{
+	return (PgColumnarAvroManifestFile *)
+		av_read_ocf(buf, len, sizeof(PgColumnarAvroManifestFile),
+					av_manifest_file_cb, nout);
+}
+
 /* ------------------------------------------------------ SQL introspection */
 
-PG_FUNCTION_INFO_V1(pgcolumnar_read_avro_manifest);
-
-Datum
-pgcolumnar_read_avro_manifest(PG_FUNCTION_ARGS)
+/* slurp a whole (small) local Avro file into a palloc'd buffer */
+static uint8 *
+av_slurp_file(const char *path, int64 *outlen)
 {
-	char	   *path = text_to_cstring(PG_GETARG_TEXT_PP(0));
-	ReturnSetInfo *rsinfo = (ReturnSetInfo *) fcinfo->resultinfo;
-	TupleDesc	tupdesc;
-	Tuplestorestate *tupstore;
-	MemoryContext oldcxt;
-	FILE	   *f;
+	FILE	   *f = AllocateFile(path, PG_BINARY_R);
 	int64		flen;
 	uint8	   *buf;
-	PgColumnarAvroManifestEntry *entries;
-	int			n,
-				i;
 
-	if (!has_privs_of_role(GetUserId(), ROLE_PG_READ_SERVER_FILES))
-		ereport(ERROR,
-				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-				 errmsg("must be superuser or a member of the pg_read_server_files role to read a server file")));
-
-	if (rsinfo == NULL || !IsA(rsinfo, ReturnSetInfo) ||
-		(rsinfo->allowedModes & SFRM_Materialize) == 0)
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("set-valued function called in a context that cannot accept a set")));
-	if (get_call_result_type(fcinfo, NULL, &tupdesc) != TYPEFUNC_COMPOSITE)
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("function returning record called in a context that cannot accept it")));
-
-	/* slurp the whole (small) manifest into memory */
-	f = AllocateFile(path, PG_BINARY_R);
 	if (f == NULL)
 		ereport(ERROR,
 				(errcode_for_file_access(),
@@ -951,18 +1011,60 @@ pgcolumnar_read_avro_manifest(PG_FUNCTION_ARGS)
 		ereport(ERROR, (errcode_for_file_access(),
 						errmsg("could not read \"%s\": %m", path)));
 	FreeFile(f);
+	*outlen = flen;
+	return buf;
+}
 
-	entries = PgColumnarAvroReadManifest(buf, flen, &n);
+/* the shared SRF preamble: privilege gate, result-set checks, tupdesc, and the
+ * per-query-context tuplestore (the per-call context frees before the executor
+ * drains it -- ASAN caught a heap-use-after-free in tuplestore_gettuple). */
+static Tuplestorestate *
+av_srf_begin(FunctionCallInfo fcinfo, TupleDesc *tupdesc)
+{
+	ReturnSetInfo *rsinfo = (ReturnSetInfo *) fcinfo->resultinfo;
+	Tuplestorestate *tupstore;
+	MemoryContext oldcxt;
 
-	/* the tuplestore must live in the per-query context, not this per-call one,
-	 * or the executor reads freed memory when it drains the result (ASAN caught
-	 * exactly this: a heap-use-after-free in tuplestore_gettuple). */
+	if (!has_privs_of_role(GetUserId(), ROLE_PG_READ_SERVER_FILES))
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 errmsg("must be superuser or a member of the pg_read_server_files role to read a server file")));
+	if (rsinfo == NULL || !IsA(rsinfo, ReturnSetInfo) ||
+		(rsinfo->allowedModes & SFRM_Materialize) == 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("set-valued function called in a context that cannot accept a set")));
+	if (get_call_result_type(fcinfo, NULL, tupdesc) != TYPEFUNC_COMPOSITE)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("function returning record called in a context that cannot accept it")));
+
 	oldcxt = MemoryContextSwitchTo(rsinfo->econtext->ecxt_per_query_memory);
 	tupstore = tuplestore_begin_heap(false, false, work_mem);
 	rsinfo->returnMode = SFRM_Materialize;
 	rsinfo->setResult = tupstore;
-	rsinfo->setDesc = CreateTupleDescCopy(tupdesc);
+	rsinfo->setDesc = CreateTupleDescCopy(*tupdesc);
 	MemoryContextSwitchTo(oldcxt);
+	return tupstore;
+}
+
+PG_FUNCTION_INFO_V1(pgcolumnar_read_avro_manifest);
+
+Datum
+pgcolumnar_read_avro_manifest(PG_FUNCTION_ARGS)
+{
+	char	   *path = text_to_cstring(PG_GETARG_TEXT_PP(0));
+	TupleDesc	tupdesc;
+	Tuplestorestate *tupstore;
+	int64		flen;
+	uint8	   *buf;
+	PgColumnarAvroManifestEntry *entries;
+	int			n,
+				i;
+
+	tupstore = av_srf_begin(fcinfo, &tupdesc);
+	buf = av_slurp_file(path, &flen);
+	entries = PgColumnarAvroReadManifest(buf, flen, &n);
 
 	for (i = 0; i < n; i++)
 	{
@@ -986,6 +1088,51 @@ pgcolumnar_read_avro_manifest(PG_FUNCTION_ARGS)
 			values[6] = CStringGetTextDatum(e->partition);
 		else
 			nulls[6] = true;
+		tuplestore_putvalues(tupstore, tupdesc, values, nulls);
+	}
+	return (Datum) 0;
+}
+
+PG_FUNCTION_INFO_V1(pgcolumnar_read_manifest_list);
+
+Datum
+pgcolumnar_read_manifest_list(PG_FUNCTION_ARGS)
+{
+	char	   *path = text_to_cstring(PG_GETARG_TEXT_PP(0));
+	TupleDesc	tupdesc;
+	Tuplestorestate *tupstore;
+	int64		flen;
+	uint8	   *buf;
+	PgColumnarAvroManifestFile *files;
+	int			n,
+				i;
+
+	tupstore = av_srf_begin(fcinfo, &tupdesc);
+	buf = av_slurp_file(path, &flen);
+	files = PgColumnarAvroReadManifestList(buf, flen, &n);
+
+	for (i = 0; i < n; i++)
+	{
+		Datum		values[13];
+		bool		nulls[13] = {false};
+		PgColumnarAvroManifestFile *e = &files[i];
+
+		if (e->manifest_path)
+			values[0] = CStringGetTextDatum(e->manifest_path);
+		else
+			nulls[0] = true;
+		values[1] = Int64GetDatum(e->manifest_length);
+		values[2] = Int32GetDatum(e->content);
+		values[3] = Int32GetDatum(e->partition_spec_id);
+		values[4] = Int32GetDatum(e->added_files_count);
+		values[5] = Int32GetDatum(e->existing_files_count);
+		values[6] = Int32GetDatum(e->deleted_files_count);
+		values[7] = Int64GetDatum(e->added_rows_count);
+		values[8] = Int64GetDatum(e->existing_rows_count);
+		values[9] = Int64GetDatum(e->deleted_rows_count);
+		values[10] = Int64GetDatum(e->sequence_number);
+		values[11] = Int64GetDatum(e->min_sequence_number);
+		values[12] = Int64GetDatum(e->added_snapshot_id);
 		tuplestore_putvalues(tupstore, tupdesc, values, nulls);
 	}
 	return (Datum) 0;

--- a/src/columnar_avro.h
+++ b/src/columnar_avro.h
@@ -31,12 +31,37 @@ typedef struct PgColumnarAvroManifestEntry
 } PgColumnarAvroManifestEntry;
 
 /*
- * Decode an Avro manifest file (already slurped into memory) into a palloc'd
- * array of entries in the current memory context. Raises on any malformed
- * input rather than returning a partial result. *nout is set to the count.
+ * One decoded manifest_file entry from a snapshot's manifest list: which
+ * manifest files the snapshot points at, and their summary counts.
+ */
+typedef struct PgColumnarAvroManifestFile
+{
+	char	   *manifest_path;
+	int64		manifest_length;
+	int32		partition_spec_id;
+	int32		content;		/* 0 DATA, 1 DELETES */
+	int64		sequence_number;
+	int64		min_sequence_number;
+	int64		added_snapshot_id;
+	int32		added_files_count;
+	int32		existing_files_count;
+	int32		deleted_files_count;
+	int64		added_rows_count;
+	int64		existing_rows_count;
+	int64		deleted_rows_count;
+} PgColumnarAvroManifestFile;
+
+/*
+ * Decode an Avro manifest file, or a manifest LIST file, (already slurped into
+ * memory) into a palloc'd array of entries in the current memory context. Raises
+ * on any malformed input rather than returning a partial result. *nout is set to
+ * the count.
  */
 extern PgColumnarAvroManifestEntry *PgColumnarAvroReadManifest(const uint8 *buf,
 															   int64 len,
 															   int *nout);
+extern PgColumnarAvroManifestFile *PgColumnarAvroReadManifestList(const uint8 *buf,
+																  int64 len,
+																  int *nout);
 
 #endif							/* COLUMNAR_AVRO_H */

--- a/test/avro_manifest.sh
+++ b/test/avro_manifest.sh
@@ -64,6 +64,32 @@ check "every entry's file_path ends in .parquet" \
 check "all entries are ADDED data files (status=1, content=0)" \
 	"$(q "SELECT bool_and(status = 1 AND content = 0) FROM pgcolumnar.read_avro_manifest('$M0')")" "t"
 
+# ---- the manifest LIST (a snapshot's manifest_file entries) -----------------
+# The same object-container machinery, a different embedded record. Decode the
+# committed real manifest-list and assert its manifest_file entry against the
+# writer's oracle (expected_list.json).
+ML="$PGC_WORKDIR/manifest-list.avro"
+cp "$FX/manifest-list.avro" "$ML"; chmod 644 "$ML"
+LORACLE="$(python3 - "$FX/expected_list.json" <<'PY'
+import json, sys
+m = json.load(open(sys.argv[1]))["manifest_files"]
+r = m[0]
+print("%d|%d|%d|%d|%d|%d|%d" % (r["manifest_length"], r["content"],
+      r["partition_spec_id"], r["added_files_count"], r["added_rows_count"],
+      r["sequence_number"], r["added_snapshot_id"]))
+PY
+)"
+check "manifest-list entry count == oracle (1)" \
+	"$(q "SELECT count(*) FROM pgcolumnar.read_manifest_list('$ML')")" "1"
+check "manifest-list entry == oracle (len|content|spec|files|rows|seq|snap)" \
+	"$(q "SELECT manifest_length || '|' || content || '|' || partition_spec_id || '|' ||
+	             added_files_count || '|' || added_rows_count || '|' ||
+	             sequence_number || '|' || added_snapshot_id
+	      FROM pgcolumnar.read_manifest_list('$ML')")" "$LORACLE"
+check "manifest-list points at an .avro manifest, no existing/deleted files" \
+	"$(q "SELECT bool_and(manifest_path LIKE '%.avro' AND existing_files_count = 0
+	                      AND deleted_files_count = 0) FROM pgcolumnar.read_manifest_list('$ML')")" "t"
+
 # ---- privilege: needs pg_read_server_files ---------------------------------
 psql_run "DROP ROLE IF EXISTS avro_unpriv; CREATE ROLE avro_unpriv LOGIN;"
 check "an unprivileged role is refused (42501)" \

--- a/test/avro_manifest.sh
+++ b/test/avro_manifest.sh
@@ -70,25 +70,36 @@ check "all entries are ADDED data files (status=1, content=0)" \
 # writer's oracle (expected_list.json).
 ML="$PGC_WORKDIR/manifest-list.avro"
 cp "$FX/manifest-list.avro" "$ML"; chmod 644 "$ML"
+# every scalar the manifest_file record carries, so the arm is not vacuous on the
+# columns the decoder fills to zero for this fixture (min_sequence_number,
+# existing/deleted rows). Field order matches the SELECT below.
 LORACLE="$(python3 - "$FX/expected_list.json" <<'PY'
 import json, sys
 m = json.load(open(sys.argv[1]))["manifest_files"]
 r = m[0]
-print("%d|%d|%d|%d|%d|%d|%d" % (r["manifest_length"], r["content"],
-      r["partition_spec_id"], r["added_files_count"], r["added_rows_count"],
-      r["sequence_number"], r["added_snapshot_id"]))
+print("%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%d|%s" % (
+      r["manifest_length"], r["content"], r["partition_spec_id"],
+      r["added_files_count"], r["existing_files_count"], r["deleted_files_count"],
+      r["added_rows_count"], r["existing_rows_count"], r["deleted_rows_count"],
+      r["sequence_number"], r["min_sequence_number"], r["added_snapshot_id"]))
 PY
 )"
+# the manifest_path the snapshot points at, matched by basename against the oracle
+# (the fixture stores an absolute file:// path the writer chose; only the basename
+# is stable across warehouses)
+LPATH="$(python3 -c "import json;print(json.load(open('$FX/expected_list.json'))['manifest_files'][0]['manifest_path_basename'])")"
 check "manifest-list entry count == oracle (1)" \
 	"$(q "SELECT count(*) FROM pgcolumnar.read_manifest_list('$ML')")" "1"
-check "manifest-list entry == oracle (len|content|spec|files|rows|seq|snap)" \
+check "manifest-list entry == oracle (all scalar fields)" \
 	"$(q "SELECT manifest_length || '|' || content || '|' || partition_spec_id || '|' ||
-	             added_files_count || '|' || added_rows_count || '|' ||
-	             sequence_number || '|' || added_snapshot_id
+	             added_files_count || '|' || existing_files_count || '|' ||
+	             deleted_files_count || '|' || added_rows_count || '|' ||
+	             existing_rows_count || '|' || deleted_rows_count || '|' ||
+	             sequence_number || '|' || min_sequence_number || '|' || added_snapshot_id
 	      FROM pgcolumnar.read_manifest_list('$ML')")" "$LORACLE"
-check "manifest-list points at an .avro manifest, no existing/deleted files" \
-	"$(q "SELECT bool_and(manifest_path LIKE '%.avro' AND existing_files_count = 0
-	                      AND deleted_files_count = 0) FROM pgcolumnar.read_manifest_list('$ML')")" "t"
+check "manifest-list manifest_path basename == oracle" \
+	"$(q "SELECT (regexp_match(manifest_path, '[^/]+\$'))[1]
+	      FROM pgcolumnar.read_manifest_list('$ML')")" "$LPATH"
 
 # ---- privilege: needs pg_read_server_files ---------------------------------
 psql_run "DROP ROLE IF EXISTS avro_unpriv; CREATE ROLE avro_unpriv LOGIN;"

--- a/test/fixtures/iceberg/expected_list.json
+++ b/test/fixtures/iceberg/expected_list.json
@@ -1,0 +1,19 @@
+{
+  "manifest_files": [
+    {
+      "added_files_count": 2,
+      "added_rows_count": 5,
+      "added_snapshot_id": 1015321693306905452,
+      "content": 0,
+      "deleted_files_count": 0,
+      "deleted_rows_count": 0,
+      "existing_files_count": 0,
+      "existing_rows_count": 0,
+      "manifest_length": 4852,
+      "manifest_path_basename": "070dea05-1705-402a-82cc-14b56e17cb1c-m0.avro",
+      "min_sequence_number": 1,
+      "partition_spec_id": 0,
+      "sequence_number": 1
+    }
+  ]
+}

--- a/test/fixtures/iceberg/gen_iceberg_fixture.py
+++ b/test/fixtures/iceberg/gen_iceberg_fixture.py
@@ -79,6 +79,27 @@ for i, m in enumerate(manifests):
 with open(os.path.join(OUT, "expected.json"), "w") as f:
     json.dump(report, f, indent=2, sort_keys=True)
 
+# the manifest-list oracle: the manifest_file entries the snapshot points at
+list_report = {"manifest_files": []}
+for m in manifests:
+    list_report["manifest_files"].append({
+        "manifest_path_basename": os.path.basename(m.manifest_path),
+        "manifest_length": m.manifest_length,
+        "partition_spec_id": m.partition_spec_id,
+        "content": int(m.content),
+        "sequence_number": m.sequence_number,
+        "min_sequence_number": m.min_sequence_number,
+        "added_snapshot_id": m.added_snapshot_id,
+        "added_files_count": m.added_files_count,
+        "existing_files_count": m.existing_files_count,
+        "deleted_files_count": m.deleted_files_count,
+        "added_rows_count": m.added_rows_count,
+        "existing_rows_count": m.existing_rows_count,
+        "deleted_rows_count": m.deleted_rows_count,
+    })
+with open(os.path.join(OUT, "expected_list.json"), "w") as f:
+    json.dump(list_report, f, indent=2, sort_keys=True)
+
 # report the avro header of the first manifest so we know the codec/schema shape
 with open(os.path.join(OUT, "manifest-0.avro"), "rb") as f:
     head = f.read(4)

--- a/test/fuzz_avro.sh
+++ b/test/fuzz_avro.sh
@@ -35,15 +35,24 @@ python3 -c 'import hashlib' 2>/dev/null || pgc_skip python "python3 is required"
 SEED="${PGC_SEED:-20260814}"
 ITERS="${PGC_ITERS:-300}"
 BASE="$FX/manifest-0.avro"
+BASE_LIST="$FX/manifest-list.avro"
 MUT="$PGC_WORKDIR/mutant.avro"
 NEWLOG="$PGC_WORKDIR/newlog.txt"
 
-RD="SELECT count(*) FROM pgcolumnar.read_avro_manifest('$MUT')"
+# two decode targets share one Avro reader: the manifest (manifest_entry) and the
+# manifest LIST (manifest_file). Alternate mutants between them by seed parity so
+# the fuzzer exercises both projections, not just the manifest one.
+RD_MANIFEST="SELECT count(*) FROM pgcolumnar.read_avro_manifest('$MUT')"
+RD_LIST="SELECT count(*) FROM pgcolumnar.read_manifest_list('$MUT')"
 
-# control: the unmutated manifest decodes to its entries, proving the decoder is
-# reached (without this the three "no finding" checks could pass vacuously).
+# control: each unmutated file decodes to its entries, proving both decoders are
+# reached (without this the "no finding" checks could pass vacuously).
 python3 "$CORPUS" "$BASE" valid "$MUT"; chmod 644 "$MUT"
-check "control: the valid manifest reaches the decoder (2 entries)" "$(q "$RD")" "2"
+check "control: the valid manifest reaches the decoder (2 entries)" \
+	"$(q "$RD_MANIFEST")" "2"
+python3 "$CORPUS" "$BASE_LIST" valid "$MUT"; chmod 644 "$MUT"
+check "control: the valid manifest-list reaches the decoder (1 entry)" \
+	"$(q "$RD_LIST")" "1"
 
 LOGPOS=0
 crashes=0; hangs=0; sanitizer=0; errors=0; clean=0
@@ -67,7 +76,9 @@ log_since
 echo "-- fuzzing $ITERS Avro manifest mutants (seed base $SEED)"
 for ((i = 0; i < ITERS; i++)); do
 	s=$((SEED + i))
-	python3 "$CORPUS" "$BASE" "$s" "$MUT"; chmod 644 "$MUT" 2>/dev/null
+	if (( i % 2 == 0 )); then base="$BASE"; RD="$RD_MANIFEST"
+	else base="$BASE_LIST"; RD="$RD_LIST"; fi
+	python3 "$CORPUS" "$base" "$s" "$MUT"; chmod 644 "$MUT" 2>/dev/null
 	log_since
 	out="$(timeout 30 env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" \
 		-U postgres -d "$PGC_DB" -v ON_ERROR_STOP=0 \


### PR DESCRIPTION
## What

Step two of Iceberg read support (#388). Decodes a snapshot's **manifest-list** Avro file (the `manifest_file` record) and surfaces its entries through a new SRF:

```sql
SELECT manifest_path, added_files_count, added_rows_count
  FROM pgcolumnar.read_manifest_list('/warehouse/db/events/metadata/snap-123.avro');
```

Each row names one manifest the snapshot points at, with its length, content type (0 data / 1 deletes), partition spec, and the added/existing/deleted file and row counts the writer recorded (13 columns).

## How it fits step 1

Rather than duplicate the Avro object-container reader, the block loop, deflate handling, schema-driven projection, and all the bounds / zip-bomb caps (`AV_MAX_TOTAL`, per-block free, `CHECK_FOR_INTERRUPTS`) are refactored into a shared `av_read_ocf(buf, len, elemsize, decode_cb, nout)`. `read_avro_manifest` and `read_manifest_list` are now two thin callers over it, each supplying a per-record decode callback. No decode-path behavior changed for step 1 (its suite is unchanged and still green).

Decoding stays schema-driven — `manifest_file` fields are matched by name against the embedded `avro.schema` — so a v2 or v3 manifest list reads structurally.

Scope, unchanged from the #388 plan: local file, `pg_read_server_files` required, read-only. It does **not** yet resolve a table's current snapshot or open the manifests it names — those are later steps.

## Testing (prove, don't trust)

- **Independent oracle.** The `avro_manifest` suite gains a manifest-list arm asserting the decoded `manifest_file` entry (`len|content|spec|files|rows|seq|snap`) against `expected_list.json`, extracted by pyiceberg from the same real v2 warehouse as step 1. An independent writer is the oracle, not our own encoder.
- **Removal proof.** Mutating the `added_files_count` field mapping turns the oracle arm red (`got 102, want 2`) — the arm exercises the decoder, it is not vacuous.
- **Fuzzing.** `fuzz_avro` now alternates mutants between the manifest and the manifest-list by seed parity, so `av_decode_manifest_file` is fuzzed too. 300 mutants, no crash / hang / sanitizer finding; both valid-file controls reach their decoders.
- **Sanitizer gate.** `avro_manifest` + `fuzz_avro` clean under the ASAN+UBSAN build (`run_san.sh`).
- **Matrix.** Green on PG17 / PG18 / PG19 assert builds.

## Docs

`pgcolumnar.read_manifest_list` documented in `docs/sql-reference.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqFY4pifG7rp3a5fJREWnr