### PR TITLE
feat: field-id projection through read_parquet (#388 phase 3c)

### DIFF
--- a/design/ISSUE_388_PHASE3C_FIELDID.md
+++ b/design/ISSUE_388_PHASE3C_FIELDID.md
@@ -1,0 +1,102 @@
+# #388 phase 3c - field-id projection through the Parquet reader
+
+Phase 2 of the #388 plan is "Field IDs through the Parquet reader, with name
+mapping as fallback. Useful to us independently of Iceberg." The parsing half
+landed in #613 (thrift field 9 -> `PqSchemaCol.field_id`, `-1` sentinel). This is
+the **using** half, which #613 deliberately deferred until it had a caller rather
+than ship an unused resolution API. The caller now exists: the Iceberg
+data-file list (#637) needs each Parquet file's columns resolved to the table
+schema by field id, because Iceberg selects columns by id, not by name or
+position (a data file written before a rename still carries the old name).
+
+Delivered as its own PR first (this doc), independently of Iceberg, then wired
+into an Iceberg scan.
+
+## The semantic difference from today's binding
+
+`build_imp_targets()` binds a tuple descriptor to a Parquet file **positionally**:
+a single `lf` counter walks the file's leaves in order, and the final identity
+check `lf == pf->ncols` requires the target to expand to *exactly* the file's
+leaf count. That is 1:1 by position.
+
+Field-id resolution is **projection**: bind each output column to the file leaf
+whose `field_id` matches, read a *subset* of the file's columns, in the output's
+order not the file's. The `lf == ncols` identity does not hold (you may read 2 of
+5 columns), and the order is driven by the request, not the file. So this is a
+separate binding path, not a tweak to the positional loop -- conflating them
+would weaken the positional identity check that a whole suite relies on.
+
+## Surface (this PR)
+
+A new overload:
+
+```sql
+SELECT * FROM pgcolumnar.read_parquet(path, field_ids => ARRAY[7, 3])
+  AS t(a int, b text);
+```
+
+`field_ids[i]` is the Parquet field id to bind output column `i` to. The array
+length must equal the column-definition-list length. This reads only the two
+named leaves, in the given order, regardless of their position in the file.
+
+Scope of this PR, kept tight because it touches the mature reader:
+- **Flat top-level scalars only.** Each requested id must resolve to exactly one
+  top-level leaf (`max_rep == 0`, not nested). A target that is an array or
+  composite in field-id mode is refused (`0A000` feature_not_supported) -- Iceberg
+  v1 tables here are flat; nested field-id projection is a later step.
+- **Unique ids.** A requested id absent from the file's top-level leaves, or
+  matching more than one, is an error (`22023` / `42702` ambiguous) -- never a
+  silent wrong column.
+- **No id in the file.** If the file carries no field ids at all (every leaf
+  `field_id == -1`), field-id mode errors and points at the positional overload.
+  Name-mapping fallback (the plan's documented fallback for id-less files) is the
+  immediate follow-on PR, not bundled here.
+
+## Implementation
+
+`build_imp_targets_by_field_id(tupdesc, pf, field_ids, n, &leaves, &ntops)`, a
+sibling of `build_imp_targets` that reuses the same `ImpTop` / `ImpLeaf` output
+structures (so `pq_read_rows` and the projection/skip machinery downstream are
+unchanged), but:
+1. builds a `field_id -> top-level leaf index` map over the file once, erroring on
+   a duplicate id;
+2. for each output attribute, looks up its requested id -> leaf index, validates
+   the leaf is a non-repeated scalar of a compatible physical type, and binds
+   `ImpTop{kind=IMP_SCALAR, firstLeaf=that index, nleaves=1}`;
+3. skips the `lf == ncols` identity check (projection reads a subset).
+
+`pq_read_rows` already decodes only the leaves the bound tops reference (the
+projection path keys off `tops[t].firstLeaf`), so reading a subset needs no
+change there -- confirm with a test that an unread column is never decoded.
+
+`pgcolumnar_read_parquet` gains the optional second argument; when present it
+calls the field-id binder instead of the positional one. The single-file helper
+`pq_read_file_into` grows a `const int *field_ids, int nfield` pair threaded
+through (NULL = positional, unchanged).
+
+## Tests (`test/native_parquet_fieldid.sh`)
+
+Independent writer: pyarrow, ids **out of order and disjoint from position**
+(e.g. columns a,b,c with field ids 7,3,12), same technique as #613's schema arm --
+a reader fabricating ids from position cannot pass.
+- **Projection + reorder.** `field_ids => ARRAY[12,7]` AS `t(c int, a int)` returns
+  the id-12 and id-7 columns, in that order, values matching a positional oracle
+  read of the full file. RED first (no such overload on main).
+- **Removal proof.** Positional binding (drop the field-id path) returns the wrong
+  columns -> the value arm reds. And: bind `ARRAY[3]` AS `t(b text)` alone, assert
+  only the id-3 column chunk is touched (projection reads a subset).
+- **Refusals**, each its SQLSTATE: an absent id, a duplicate id in the file, a
+  nested/array target, an id-less file (points at positional). Backend survives
+  each.
+- Matrix PG17/18/19 + ASAN (a binding/decode change earns the sanitizer).
+
+## Then: the Iceberg scan (follow-on PR, 3c end-to-end)
+
+`pgcolumnar.iceberg_scan(metadata_path) AS t(...)`: resolve the data files
+(#637), read the table's current schema from metadata.json (name -> field id),
+map each output column's name to its field id, and read each data file through
+this field-id path, streaming rows. **Reuse `ice_open_path`** to open each data
+file (the 3b review's symlink boundary -- a data-file path is opened here, so a
+traversal would be a content leak). Deletes already refused upstream by
+`iceberg_data_files`. That PR is where field-id projection becomes the Iceberg
+read it was built for.

--- a/docs/sql-reference.md
+++ b/docs/sql-reference.md
@@ -567,6 +567,30 @@ SELECT count(*) FROM pgcolumnar.read_parquet('/data/events/')
   AS t(id int, ts timestamp, amount numeric(12,2));
 ```
 
+### pgcolumnar.read_parquet(path text, field_ids integer[]) returns setof record
+
+Returns the rows of a Parquet file, binding output columns to file columns by
+Parquet field id rather than by position. Output column `i` is bound to the file
+column whose field id equals `field_ids[i]`. The reader decodes only those
+columns, in the order given, whatever their order in the file. The array length
+must equal the column definition list length. This is the projection form Apache
+Iceberg uses, where a data file written before a column rename still carries the
+old name and columns are selected by id (#388).
+
+The file must carry field ids. A file written without them is an error that
+directs you to the positional form above. Each requested id must match exactly
+one scalar column of a compatible type. A requested id that is absent, an id that
+matches more than one column, and an array or composite output column are each an
+error, not a silent wrong column. Read the ids a file carries with
+`parquet_schema`.
+
+```sql
+-- the file has columns alpha (id 7), beta (id 3), gamma (id 12);
+-- read gamma then alpha, by id, in that order
+SELECT * FROM pgcolumnar.read_parquet('/data/events.parquet', ARRAY[12, 7])
+  AS t(g int, a int);
+```
+
 ### pgcolumnar.parquet_schema(path text) returns table(column_name text, data_type text, nullable bool, field_id int)
 
 Reports the leaf columns of a Parquet file and the PostgreSQL type each maps to,

--- a/pgcolumnar--1.0-alpha.sql
+++ b/pgcolumnar--1.0-alpha.sql
@@ -899,6 +899,14 @@ CREATE FUNCTION pgcolumnar.read_parquet(path text)
 COMMENT ON FUNCTION pgcolumnar.read_parquet(text)
 	IS 'read a Parquet file, directory, or glob in place as a set of rows; requires a column definition list covering every leaf column, e.g. SELECT * FROM pgcolumnar.read_parquet(path) AS t(id int, name text) (Phase G)';
 
+CREATE FUNCTION pgcolumnar.read_parquet(path text, field_ids integer[])
+	RETURNS SETOF record
+	LANGUAGE C STRICT
+	AS 'MODULE_PATHNAME', 'pgcolumnar_read_parquet';
+
+COMMENT ON FUNCTION pgcolumnar.read_parquet(text, integer[])
+	IS 'read a Parquet file by field id: output column i is bound to the file column whose Parquet field id equals field_ids[i], reading only those columns in that order, e.g. SELECT * FROM pgcolumnar.read_parquet(path, ARRAY[12,7]) AS t(c int, a int) (#388)';
+
 CREATE FUNCTION pgcolumnar.read_avro_manifest(path text)
 	RETURNS TABLE(status integer, content integer, file_path text,
 				  file_format text, record_count bigint,

--- a/src/columnar_parquet_reader.c
+++ b/src/columnar_parquet_reader.c
@@ -2614,6 +2614,132 @@ build_imp_targets(TupleDesc tupdesc, PqFile *pf,
 	return tops;
 }
 
+/*
+ * Bind a tuple descriptor to a Parquet file by FIELD ID rather than by position
+ * (#388 phase 3c). Each output attribute i is bound to the file leaf whose
+ * field_id equals field_ids[i]; the file's other columns are not read. This is
+ * projection, so -- unlike build_imp_targets -- it does not require the target to
+ * expand to the file's full leaf count, and it reads columns in the output's
+ * order, not the file's.
+ *
+ * Scope: flat top-level scalars. A requested id must resolve to exactly one
+ * non-repeated scalar leaf of a compatible physical type; a nested/array output,
+ * an absent id, a duplicate id, or a file with no ids at all is refused rather
+ * than silently mis-bound. Reuses the same ImpTop/ImpLeaf output as the
+ * positional binder, so pq_read_rows is unchanged.
+ */
+static ImpTop *
+build_imp_targets_by_field_id(TupleDesc tupdesc, PqFile *pf,
+							  const int *field_ids, int nfield,
+							  ImpLeaf **pleaves, int *ntops)
+{
+	int			natts = tupdesc->natts;
+	ImpTop	   *tops = palloc0(sizeof(ImpTop) * Max(natts, 1));
+	ImpLeaf    *leaves = palloc0(sizeof(ImpLeaf) * Max(pf->ncols, 1));
+	int			nt = 0;
+	int			fi = 0;
+	int			outn = 0;
+	bool		anyId = false;
+	int			i;
+
+#define IMP_FAIL(...) \
+	ereport(ERROR, (errcode(ERRCODE_DATATYPE_MISMATCH), errmsg(__VA_ARGS__)))
+
+	/* the file must carry field ids for id resolution to mean anything */
+	for (i = 0; i < pf->ncols; i++)
+		if (pf->leaves[i].sc->field_id >= 0)
+		{
+			anyId = true;
+			break;
+		}
+	if (!anyId)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("the Parquet file carries no field ids; it cannot be read by field id"),
+				 errhint("Read it positionally: SELECT * FROM pgcolumnar.read_parquet(path) AS t(...).")));
+
+	for (i = 0; i < natts; i++)
+		if (!TupleDescAttr(tupdesc, i)->attisdropped)
+			outn++;
+	if (outn != nfield)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("field_ids has %d element(s) but the column definition list has %d column(s)",
+						nfield, outn)));
+
+	for (i = 0; i < natts; i++)
+	{
+		Form_pg_attribute att = TupleDescAttr(tupdesc, i);
+		Oid			typid;
+		int			req;
+		int			found = -1;
+		int			want;
+		int			j;
+		ImpTop	   *t;
+		ImpLeaf    *l;
+
+		if (att->attisdropped)
+			continue;
+		req = field_ids[fi++];
+		typid = att->atttypid;
+
+		if (OidIsValid(get_element_type(typid)) || type_is_rowtype(typid))
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("field-id projection supports only scalar columns, but output column \"%s\" is not scalar",
+							NameStr(att->attname))));
+
+		/* the unique top-level leaf carrying this field id */
+		for (j = 0; j < pf->ncols; j++)
+		{
+			if (pf->leaves[j].sc->field_id == req)
+			{
+				if (found >= 0)
+					ereport(ERROR,
+							(errcode(ERRCODE_AMBIGUOUS_COLUMN),
+							 errmsg("field id %d is not unique among the Parquet file's columns",
+									req)));
+				found = j;
+			}
+		}
+		if (found < 0)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("no Parquet column has field id %d (requested for output column \"%s\")",
+							req, NameStr(att->attname))));
+
+		if (pf->leaves[found].max_rep != 0)
+			IMP_FAIL("Parquet column with field id %d is repeated; field-id projection binds scalar columns",
+					 req);
+		want = pq_want_phys_for(typid, pq_leaf_sc(pf, found));
+		if (want < 0)
+			IMP_FAIL("output column \"%s\" has type %s, which columnar.read_parquet does not support",
+					 NameStr(att->attname), format_type_be(typid));
+		if (pf->leaves[found].sc->phys_type != want)
+			IMP_FAIL("Parquet column with field id %d has a physical type incompatible with output column \"%s\" (%s)",
+					 req, NameStr(att->attname), format_type_be(typid));
+
+		t = &tops[nt];
+		t->attno = i;
+		t->kind = IMP_SCALAR;
+		t->firstLeaf = found;
+		t->nleaves = 1;
+		l = &leaves[found];
+		l->plan.typid = typid;
+		get_typlenbyval(typid, &l->plan.typlen, &l->plan.typbyval);
+		l->plan.expect_phys = want;
+		pq_plan_bind_schema(&l->plan, pf->leaves[found].sc);
+		l->max_def = pf->leaves[found].max_def;
+		l->max_rep = pf->leaves[found].max_rep;
+		nt++;
+	}
+#undef IMP_FAIL
+
+	*pleaves = leaves;
+	*ntops = nt;
+	return tops;
+}
+
 /* strcmp comparator for list_sort over a List of cstrings */
 static int
 pq_list_str_cmp(const ListCell *a, const ListCell *b)
@@ -3269,7 +3395,8 @@ pq_read_rows(PqFile *pf, PqSource *src,
  */
 static int64
 pq_read_file_into(const char *path, TupleDesc tupdesc, TupleTableSlot *slot,
-				  PqRowSink sink, void *sinkarg)
+				  PqRowSink sink, void *sinkarg,
+				  const int *field_ids, int nfield)
 {
 	PqSource	src;
 	PqFile		pf;
@@ -3280,7 +3407,11 @@ pq_read_file_into(const char *path, TupleDesc tupdesc, TupleTableSlot *slot,
 
 	pq_source_open(path, &src, &pf);
 	pq_check_row_groups(&pf, path);
-	tops = build_imp_targets(tupdesc, &pf, &leaves, &ntops, NULL);
+	if (field_ids != NULL)
+		tops = build_imp_targets_by_field_id(tupdesc, &pf, field_ids, nfield,
+											 &leaves, &ntops);
+	else
+		tops = build_imp_targets(tupdesc, &pf, &leaves, &ntops, NULL);
 	n = pq_read_rows(&pf, &src, tops, ntops, leaves,
 					 slot, sink, sinkarg, NULL, NULL, NULL, NULL, NULL,
 					 0, pf.nrowgroups);
@@ -3351,7 +3482,7 @@ pgcolumnar_import_parquet(PG_FUNCTION_ARGS)
 		MemoryContext old = MemoryContextSwitchTo(fileCtx);
 
 		total += pq_read_file_into((char *) lfirst(lc), tupdesc, slot,
-								   pq_insert_sink, &sinkarg);
+								   pq_insert_sink, &sinkarg, NULL, 0);
 		MemoryContextSwitchTo(old);
 		MemoryContextReset(fileCtx);
 	}
@@ -3376,18 +3507,20 @@ pgcolumnar_import_parquet(PG_FUNCTION_ARGS)
 }
 
 /*
- * pgcolumnar.read_parquet(path text) returns setof record
+ * pgcolumnar.read_parquet(path text [, field_ids int[]]) returns setof record
  *
  * Stream a server-side Parquet file's rows in place, without importing. The caller
  * supplies a column definition list:
  *
  *   SELECT * FROM pgcolumnar.read_parquet('/data/f.parquet') AS t(id int, name text);
  *
- * The declared descriptor is bound against the file's leaf columns by position,
- * exactly as import binds a target table's descriptor (same type-compatibility
- * rules, same "declared column count must equal the file's" contract), and rows are
- * produced through the shared scan core. Superuser only (reads a server-side file);
- * materialize-mode SRF.
+ * Without field_ids, the declared descriptor is bound against the file's leaf
+ * columns by position (same type-compatibility rules and "declared column count
+ * must equal the file's" contract as import). With field_ids, output column i is
+ * bound to the file column whose Parquet field id equals field_ids[i] -- a
+ * projection that reads only those columns, in the given order, regardless of the
+ * file's own column order (#388 phase 3c). Superuser only (reads a server-side
+ * file); materialize-mode SRF.
  */
 Datum
 pgcolumnar_read_parquet(PG_FUNCTION_ARGS)
@@ -3401,6 +3534,31 @@ pgcolumnar_read_parquet(PG_FUNCTION_ARGS)
 	MemoryContext fileCtx;
 	List	   *files;
 	ListCell   *lc;
+	int		   *field_ids = NULL;
+	int			nfield = 0;
+
+	/* optional field_ids int[]: switches binding from positional to by-field-id */
+	if (PG_NARGS() >= 2 && !PG_ARGISNULL(1))
+	{
+		ArrayType  *arr = PG_GETARG_ARRAYTYPE_P(1);
+		Datum	   *elems;
+		bool	   *nulls;
+		int			k;
+
+		if (ARR_HASNULL(arr))
+			ereport(ERROR,
+					(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+					 errmsg("field_ids must not contain NULL")));
+		deconstruct_array(arr, INT4OID, sizeof(int32), true, TYPALIGN_INT,
+						  &elems, &nulls, &nfield);
+		if (nfield == 0)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("field_ids must not be empty")));
+		field_ids = (int *) palloc(sizeof(int) * nfield);
+		for (k = 0; k < nfield; k++)
+			field_ids[k] = DatumGetInt32(elems[k]);
+	}
 
 	if (!has_privs_of_role(GetUserId(), ROLE_PG_READ_SERVER_FILES))
 		ereport(ERROR,
@@ -3443,7 +3601,7 @@ pgcolumnar_read_parquet(PG_FUNCTION_ARGS)
 		MemoryContext old = MemoryContextSwitchTo(fileCtx);
 
 		(void) pq_read_file_into((char *) lfirst(lc), retdesc, slot,
-								 pq_tuplestore_sink, tupstore);
+								 pq_tuplestore_sink, tupstore, field_ids, nfield);
 		MemoryContextSwitchTo(old);
 		MemoryContextReset(fileCtx);
 	}

--- a/test/native_parquet_fieldid.sh
+++ b/test/native_parquet_fieldid.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# pgColumnar field-id projection through read_parquet (#388 phase 3c). pyarrow --
+# an independent writer -- writes a Parquet file whose columns carry field ids
+# that are OUT OF ORDER and disjoint from position (alpha=7, beta=3, gamma=12).
+# read_parquet(path, field_ids) must bind each output column to the file column
+# with the requested id, reading a subset in the requested order, not the file's.
+# A reader fabricating ids from position cannot pass.
+#
+# Usage:  test/native_parquet_fieldid.sh [PG_CONFIG]
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+sqlstate_of() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -qtA 2>&1 <<SQLEOF | sed -n 's/^ERROR:  \([0-9A-Z]\{5\}\).*/\1/p' | head -1
+\\set VERBOSITY sqlstate
+$1;
+SQLEOF
+}
+
+python3 -c 'import pyarrow.parquet' 2>/dev/null || pgc_skip pyarrow "pyarrow is needed to write the field-id fixture"
+
+FID="$PGC_WORKDIR/fieldid.parquet"       # alpha=7, beta=3, gamma=12
+NOID="$PGC_WORKDIR/noid.parquet"         # no field ids at all
+DUP="$PGC_WORKDIR/dup.parquet"           # two columns share id 5
+python3 - "$FID" "$NOID" "$DUP" <<'PY'
+import sys, pyarrow as pa, pyarrow.parquet as pq
+fid, noid, dup = sys.argv[1], sys.argv[2], sys.argv[3]
+
+schema = pa.schema([
+    pa.field("alpha", pa.int32(),  metadata={b"PARQUET:field_id": b"7"}),
+    pa.field("beta",  pa.string(), metadata={b"PARQUET:field_id": b"3"}),
+    pa.field("gamma", pa.int32(),  metadata={b"PARQUET:field_id": b"12"}),
+])
+pq.write_table(pa.table({
+    "alpha": pa.array([10, 20, 30], pa.int32()),
+    "beta":  pa.array(["x", "y", "z"], pa.string()),
+    "gamma": pa.array([100, 200, 300], pa.int32()),
+}, schema=schema), fid)
+
+# a file with no field ids at all
+pq.write_table(pa.table({"n": pa.array([1, 2], pa.int32())}), noid)
+
+# a file where two columns carry the SAME field id (5)
+dschema = pa.schema([
+    pa.field("p", pa.int32(), metadata={b"PARQUET:field_id": b"5"}),
+    pa.field("q", pa.int32(), metadata={b"PARQUET:field_id": b"5"}),
+])
+pq.write_table(pa.table({"p": pa.array([1], pa.int32()),
+                         "q": pa.array([2], pa.int32())}, schema=dschema), dup)
+PY
+chmod 644 "$FID" "$NOID" "$DUP"
+
+# ---- projection + reorder: bind by id, not position ------------------------
+# ARRAY[12,7] AS t(g int, a int): output g <- id 12 (gamma), a <- id 7 (alpha),
+# in THAT order. Positional binding would put alpha(10,20,30) in g -- the value
+# is the discriminator, so this arm alone proves id binding.
+check "field-id projection binds and reorders by id (g=gamma, a=alpha)" \
+	"$(q "SELECT g || '|' || a FROM pgcolumnar.read_parquet('$FID', ARRAY[12,7])
+	      AS t(g int, a int) ORDER BY a")" \
+	"$(printf '100|10\n200|20\n300|30')"
+
+# ---- projection subset: read one of three columns --------------------------
+check "field-id projection reads a subset (only id 3 = beta)" \
+	"$(q "SELECT b FROM pgcolumnar.read_parquet('$FID', ARRAY[3]) AS t(b text) ORDER BY b")" \
+	"$(printf 'x\ny\nz')"
+
+# positional read still works unchanged (regression guard on the shared path)
+check "positional read_parquet is unaffected" \
+	"$(q "SELECT alpha || '|' || beta || '|' || gamma
+	      FROM pgcolumnar.read_parquet('$FID') AS t(alpha int, beta text, gamma int)
+	      ORDER BY alpha")" \
+	"$(printf '10|x|100\n20|y|200\n30|z|300')"
+
+# ---- refusals, each its own SQLSTATE ---------------------------------------
+check "an absent field id is refused (22023)" \
+	"$(sqlstate_of "SELECT * FROM pgcolumnar.read_parquet('$FID', ARRAY[999]) AS t(x int)")" "22023"
+check "a duplicate field id in the file is refused (42702)" \
+	"$(sqlstate_of "SELECT * FROM pgcolumnar.read_parquet('$DUP', ARRAY[5]) AS t(x int)")" "42702"
+check "a nested/array output column is refused (0A000)" \
+	"$(sqlstate_of "SELECT * FROM pgcolumnar.read_parquet('$FID', ARRAY[7]) AS t(a int[])")" "0A000"
+check "a field_ids/column-count mismatch is refused (22023)" \
+	"$(sqlstate_of "SELECT * FROM pgcolumnar.read_parquet('$FID', ARRAY[7,3]) AS t(a int)")" "22023"
+check "a file with no field ids is refused (22023)" \
+	"$(sqlstate_of "SELECT * FROM pgcolumnar.read_parquet('$NOID', ARRAY[1]) AS t(x int)")" "22023"
+check "backend still up after the refusals" "$(q 'SELECT 1')" "1"
+
+pgc_summary


### PR DESCRIPTION
## What

The **using-half of phase 2** (field ids through the Parquet reader), which #613 deferred until it had a caller. New overload:

```sql
-- file has alpha (id 7), beta (id 3), gamma (id 12); read gamma then alpha, by id
SELECT * FROM pgcolumnar.read_parquet('/data/f.parquet', ARRAY[12, 7]) AS t(g int, a int);
```

Output column `i` binds to the file column whose Parquet field id equals `field_ids[i]`, decoding only those columns in the given order — whatever the file's own order. This is the projection form Iceberg needs: a data file written before a column rename still carries the old name, so columns are selected by id.

## Why a sibling binder, not a tweak

Today's `build_imp_targets` binds **positionally** — one `lf` counter, and a final `lf == pf->ncols` identity check requiring the target to expand to the file's full leaf count. Field-id resolution is **projection** (a subset, reordered by id), so that identity doesn't hold. Conflating the two would weaken the positional check a whole suite relies on, so this adds `build_imp_targets_by_field_id` reusing the same `ImpTop`/`ImpLeaf` output — `pq_read_rows` is unchanged.

## Scope (tight — mature reader code)

Flat top-level scalars. A requested id must resolve to exactly one non-repeated scalar leaf of a compatible type. Refused, each with its SQLSTATE:

| input | result |
|---|---|
| file with no field ids | `22023` (points at the positional form) |
| absent id | `22023` |
| duplicate id in the file | `42702` |
| nested/array output column | `0A000` |
| `field_ids`/column-count mismatch | `22023` |

Name-mapping fallback for id-less files is the follow-on PR.

## Testing — `test/native_parquet_fieldid.sh`, 9 arms

- **Independent writer.** pyarrow writes ids **out of order, disjoint from position** (7, 3, 12) — a reader fabricating ids from position can't pass.
- **Projection + reorder.** `ARRAY[12,7] AS t(g int, a int)` returns gamma then alpha; the *values* discriminate id-binding from positional.
- **Subset.** reads 1 of 3 columns by id.
- **Removal proof.** Forcing the positional binder reds both projection arms while the positional arm stays green.
- Five refusal arms + backend-survives.
- **Matrix.** PG17/18/19 + **ASAN**; the eight-suite parquet family is **unregressed**.

## Next (design/ISSUE_388_PHASE3C_FIELDID.md)

`iceberg_scan(metadata_path) AS t(...)` — ties it end-to-end: data files (#637) → read each Parquet by the table's field ids → stream rows, reusing `ice_open_path` so the 3b symlink boundary covers the data-file opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqFY4pifG7rp3a5fJREWnr