### PR TITLE
fix: refuse a duplicate requested field id in read_parquet (#638 review note)

### DIFF
--- a/src/columnar_parquet_reader.c
+++ b/src/columnar_parquet_reader.c
@@ -2708,6 +2708,23 @@ build_imp_targets_by_field_id(TupleDesc tupdesc, PqFile *pf,
 					 errmsg("no Parquet column has field id %d (requested for output column \"%s\")",
 							req, NameStr(att->attname))));
 
+		/*
+		 * Two output columns asking for the same id would bind twice to one file
+		 * leaf, which pq_read_rows cannot serve (a leaf's cursor is consumed
+		 * once) -- it would later fail deep in the decode and wrongly blame the
+		 * file. Refuse it here with a message that names the real cause.
+		 */
+		{
+			int			k;
+
+			for (k = 0; k < nt; k++)
+				if (tops[k].firstLeaf == found)
+					ereport(ERROR,
+							(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+							 errmsg("field id %d is requested more than once; each output column must select a distinct field id",
+									req)));
+		}
+
 		if (pf->leaves[found].max_rep != 0)
 			IMP_FAIL("Parquet column with field id %d is repeated; field-id projection binds scalar columns",
 					 req);

--- a/test/native_parquet_fieldid.sh
+++ b/test/native_parquet_fieldid.sh
@@ -86,6 +86,15 @@ check "a field_ids/column-count mismatch is refused (22023)" \
 	"$(sqlstate_of "SELECT * FROM pgcolumnar.read_parquet('$FID', ARRAY[7,3]) AS t(a int)")" "22023"
 check "a file with no field ids is refused (22023)" \
 	"$(sqlstate_of "SELECT * FROM pgcolumnar.read_parquet('$NOID', ARRAY[1]) AS t(x int)")" "22023"
+# a duplicate REQUESTED id (two output columns asking for one file column) is
+# refused up front with a clear cause, not left to fail deep in the decode with a
+# message that wrongly blames the file (ChronicallyJD's #638 note).
+check "a duplicate requested field id is refused (22023)" \
+	"$(sqlstate_of "SELECT * FROM pgcolumnar.read_parquet('$FID', ARRAY[7,7]) AS t(a1 int, a2 int)")" "22023"
+check "the duplicate-requested-id error names the id, not the file" \
+	"$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" -qtA \
+		-c "SELECT * FROM pgcolumnar.read_parquet('$FID', ARRAY[7,7]) AS t(a1 int, a2 int)" 2>&1 \
+		| grep -c 'requested more than once')" "1"
 check "backend still up after the refusals" "$(q 'SELECT 1')" "1"
 
 pgc_summary


### PR DESCRIPTION
Addresses ChronicallyJD's non-blocking note on #638.

`read_parquet(f, ARRAY[7,7]) AS t(a1 int, a2 int)` bound two output columns to the same file leaf, which `pq_read_rows` can't serve (a leaf's cursor is consumed once), so it failed deep in the decode with `ERROR: Parquet file has a malformed row group` — wrongly blaming the file for a caller error.

`build_imp_targets_by_field_id` now refuses a repeated requested id up front: `field id N is requested more than once` (`22023`, matching the other `field_ids` validation errors). It can't occur for `iceberg_scan` (a table's field ids are unique); this is for direct `read_parquet` callers.

**Tests:** two arms — the SQLSTATE (`22023`) and that the message names the id, not the file. **Removal proof:** without the guard the arm gets `XX001` (the file-blaming decode error). Green PG17/18/19 + ASAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqFY4pifG7rp3a5fJREWnr