### PR TITLE
feat: decode the manifest entry data sequence number (#388 phase 4 prep)

### DIFF
--- a/design/ISSUE_388_PHASE4_DELETES.md
+++ b/design/ISSUE_388_PHASE4_DELETES.md
@@ -1,0 +1,89 @@
+# #388 phase 4 - deletes
+
+Phase 4 of the #388 plan: apply row-level deletes instead of refusing tables
+that carry them. Phases 1-3 (Avro decode, field-id projection, filesystem
+catalog + current-snapshot scan) are merged; `iceberg_scan` today refuses any
+snapshot with delete files (`0A000`). This phase reads them correctly.
+
+"A reader that ignores deletes silently returns rows the table says are gone" --
+the plan's worst failure mode. So correctness, not breadth, is the bar: every
+increment either applies its delete kind correctly or keeps refusing the kinds it
+does not yet handle. We never silently drop a delete.
+
+## The Iceberg v2 delete model (from the spec)
+
+Two merge-on-read delete kinds, both tracked in **delete manifests**
+(`manifest_file.content = 1`), each entry's `data_file.content` distinguishing:
+
+- **Position deletes** (`content = 1`). A Parquet file with two columns:
+  `file_path` (string, field id 2147483546) and `pos` (long, field id
+  2147483545). Each row names a (data file, row ordinal) to drop. A position
+  delete may also be "path-scoped" (applies to one data file) or global.
+- **Equality deletes** (`content = 2`). A Parquet file carrying the columns named
+  by the manifest entry's `equality_ids`. Any data row equal to a delete row on
+  those columns is dropped.
+
+**Sequence-number ordering is the correctness crux.** A delete file applies only
+to data files with a **lower** data sequence number (deletes affect data written
+before them). Get this wrong and the table reads subtly wrong -- deletes bleed
+onto newer data, or fail to apply to older data. Every delete application is
+gated on `delete.sequence_number > datafile.sequence_number` (position deletes
+also match `file_path`).
+
+## Fixture tooling (the gating constraint)
+
+pyiceberg 0.11.1 -- the only available writer, and the current release -- CANNOT
+write merge-on-read deletes (it warns and falls back to copy-on-write). No Spark
+in the containers. So delete fixtures are **constructed**, not written by an
+independent engine:
+
+1. pyiceberg writes the data (a normal append) -- the data files are real.
+2. A generator hand-crafts the delete Parquet (via pyarrow) and the delete
+   manifest (Avro OCF, the same crafting the delete-refusal arm already uses),
+   wires them into a new manifest-list + metadata.json snapshot, and sets the
+   sequence numbers.
+3. The oracle is computed: appended rows **minus** the positions/values the
+   generator deleted. The independence we keep is pyarrow-for-data and an
+   explicit hand-computed expected set; document that the delete wiring is ours
+   (no independent delete writer exists), and cross-check the crafted manifest by
+   decoding it back through `read_manifest_list` / `read_avro_manifest`.
+
+A sequence-number arm is essential precisely because the oracle is ours: craft a
+delete whose sequence number is NOT greater than the data file's and assert the
+row survives (the delete must NOT apply), so the ordering rule is load-bearing,
+not decorative.
+
+## Architecture
+
+The scan must, per data file, know each row's **ordinal position** to apply
+position deletes, and must evaluate **equality** on the delete columns. Open
+question for the reader (investigate before coding): does `pq_read_rows` expose a
+per-row ordinal, and can a custom sink filter rows? Likely shape:
+
+- The walk (`ice_walk_data_files`) stops refusing deletes and instead **collects**
+  the delete entries (path, content, sequence_number, equality_ids) alongside the
+  data entries, so the scan sees both.
+- For each data file D (sequence S_d): gather applicable position-delete files
+  (matching D's path, sequence > S_d) -> a sorted set of positions; and
+  applicable equality-delete files (sequence > S_d) -> their rows.
+- Read D through a **position-aware sink**: track the row ordinal, skip a row
+  whose ordinal is in the position set or whose equality-column tuple matches an
+  equality-delete row.
+
+This needs the reader to either expose row ordinals to a sink, or accept a
+skip-set. Reuse `ice_open_path` to open each delete file (a delete-file path is
+opened here too -- same content-leak surface as data files).
+
+## Sub-increments (each its own PR, each provable)
+
+- **4a - position deletes.** The common case. Single data file, a path-scoped
+  position-delete file dropping known ordinals; oracle = data minus those rows.
+  Plus the sequence-number arm (a too-old delete does not apply). Still refuse
+  equality (`content = 2`) and v3 until their increments.
+- **4b - equality deletes.** Add equality evaluation on `equality_ids` columns.
+- **4c - v3 deletion vectors (Puffin).** A new container format (Puffin) holding
+  a roaring bitmap of deleted positions -- a decoder like the Avro one. Largest.
+
+Held out: pruning/partition transforms (phase 5), object storage + REST (phase
+6). Multiple delete files, and delete + data in one snapshot, are covered within
+4a/4b.

--- a/docs/sql-reference.md
+++ b/docs/sql-reference.md
@@ -607,15 +607,19 @@ mean different things.
 SELECT * FROM pgcolumnar.parquet_schema('/data/events.parquet');
 ```
 
-### pgcolumnar.read_avro_manifest(path text) returns table(status int, content int, file_path text, file_format text, record_count bigint, file_size_in_bytes bigint, partition text)
+### pgcolumnar.read_avro_manifest(path text) returns table(status int, content int, file_path text, file_format text, record_count bigint, file_size_in_bytes bigint, partition text, sequence_number bigint)
 
 Decodes an Apache Iceberg Avro manifest file and reports its data-file entries.
-Each row is one entry: the file path, format, row count, byte size, and the
-partition rendered as `name=value`. The caller needs the `pg_read_server_files`
-role, which superusers hold. This is the first step of Iceberg support (#388). It
-is a standalone Avro object-container reader, decoded against the schema embedded
-in the file, so a v3 manifest reads structurally. It reads a local file. It does
-not resolve a table's snapshot or apply delete files, which are later steps.
+Each row is one entry: the file path, format, row count, byte size, the
+partition rendered as `name=value`, and the entry's data sequence number. The
+sequence number is NULL when the entry inherits it from the manifest (the usual
+case for a freshly written manifest); a delete file applies only to data files
+with a lower sequence number, so it is the ordering key for reading tables with
+deletes. The caller needs the `pg_read_server_files` role, which superusers
+hold. This is the first step of Iceberg support (#388). It is a standalone Avro
+object-container reader, decoded against the schema embedded in the file, so a
+v3 manifest reads structurally. It reads a local file. It does not resolve a
+table's snapshot or apply delete files, which are later steps.
 
 ```sql
 SELECT file_path, record_count, partition

--- a/pgcolumnar--1.0-alpha.sql
+++ b/pgcolumnar--1.0-alpha.sql
@@ -910,7 +910,8 @@ COMMENT ON FUNCTION pgcolumnar.read_parquet(text, integer[])
 CREATE FUNCTION pgcolumnar.read_avro_manifest(path text)
 	RETURNS TABLE(status integer, content integer, file_path text,
 				  file_format text, record_count bigint,
-				  file_size_in_bytes bigint, partition text)
+				  file_size_in_bytes bigint, partition text,
+				  sequence_number bigint)
 	LANGUAGE C STRICT
 	AS 'MODULE_PATHNAME', 'pgcolumnar_read_avro_manifest';
 

--- a/src/columnar_avro.c
+++ b/src/columnar_avro.c
@@ -618,6 +618,15 @@ av_decode_entry(AvReader *r, AvSchema *s, PgColumnarAvroManifestEntry *e)
 
 		if (strcmp(nm, "status") == 0)
 			e->status = (int32) av_read_long(r, ft, &have);
+		/* the data sequence number; "sequence_number" in v2 manifests as
+		 * pyiceberg writes them, "data_sequence_number" in the newer spec name.
+		 * Nullable: null means inherit the manifest's sequence number. */
+		else if (strcmp(nm, "sequence_number") == 0 ||
+				 strcmp(nm, "data_sequence_number") == 0)
+		{
+			e->sequence_number = av_read_long(r, ft, &have);
+			e->has_sequence_number = have;
+		}
 		else if (strcmp(nm, "data_file") == 0)
 		{
 			bool		isnull;
@@ -1068,8 +1077,8 @@ pgcolumnar_read_avro_manifest(PG_FUNCTION_ARGS)
 
 	for (i = 0; i < n; i++)
 	{
-		Datum		values[7];
-		bool		nulls[7] = {false, false, false, false, false, false, false};
+		Datum		values[8];
+		bool		nulls[8] = {false, false, false, false, false, false, false, false};
 		PgColumnarAvroManifestEntry *e = &entries[i];
 
 		values[0] = Int32GetDatum(e->status);
@@ -1088,6 +1097,11 @@ pgcolumnar_read_avro_manifest(PG_FUNCTION_ARGS)
 			values[6] = CStringGetTextDatum(e->partition);
 		else
 			nulls[6] = true;
+		/* the data sequence number, NULL when the entry inherits it */
+		if (e->has_sequence_number)
+			values[7] = Int64GetDatum(e->sequence_number);
+		else
+			nulls[7] = true;
 		tuplestore_putvalues(tupstore, tupdesc, values, nulls);
 	}
 	return (Datum) 0;

--- a/src/columnar_avro.h
+++ b/src/columnar_avro.h
@@ -28,6 +28,8 @@ typedef struct PgColumnarAvroManifestEntry
 	int64		record_count;
 	int64		file_size_in_bytes;
 	char	   *partition;		/* the partition struct rendered as text, or NULL */
+	int64		sequence_number;	/* the entry's data sequence number, when present */
+	bool		has_sequence_number;	/* false when the field is null (inherited) */
 } PgColumnarAvroManifestEntry;
 
 /*

--- a/src/columnar_iceberg.c
+++ b/src/columnar_iceberg.c
@@ -495,15 +495,15 @@ typedef void (*IceDataFileCb) (void *ctx, PgColumnarAvroManifestEntry *e,
 
 /*
  * Walk the current snapshot's live data-file entries and hand each to `cb`.
- * Resolves the snapshot, reads its manifest list and each manifest (opening both
- * through ice_open_path's path boundary), and refuses deletes loudly. Does
- * nothing when the table has no current snapshot.
+ * Resolves the snapshot from an already-parsed metadata.json `root` (so the file
+ * is read and parsed once per call, not again here), reads its manifest list and
+ * each manifest (opening both through ice_open_path's path boundary), and refuses
+ * deletes loudly. Does nothing when the table has no current snapshot.
  */
 static void
-ice_walk_data_files(const char *path, IceDataFileCb cb, void *ctx)
+ice_walk_data_files(const char *path, JsonbContainer *root,
+					IceDataFileCb cb, void *ctx)
 {
-	char	   *json;
-	Jsonb	   *jb;
 	JsonbContainer *sc;
 	int64		cur;
 	const char *recorded_root;
@@ -515,17 +515,14 @@ ice_walk_data_files(const char *path, IceDataFileCb cb, void *ctx)
 	int			nmf;
 	int			mi;
 
-	json = ice_slurp_text(path);
-	jb = DatumGetJsonbP(DirectFunctionCall1(jsonb_in, CStringGetDatum(json)));
-
-	sc = ice_current_snapshot(&jb->root, path, &cur);
+	sc = ice_current_snapshot(root, path, &cur);
 	if (sc == NULL)
 		return;					/* no current snapshot -> no data files */
 
 	/* the recorded table root, and where the table actually sits now. The
 	 * actual root is resolved with realpath once here so the files we open can
 	 * be re-checked for containment against a symlink-resolved form. */
-	recorded_root = ice_strip_scheme(ice_str_required(&jb->root, "location", path));
+	recorded_root = ice_strip_scheme(ice_str_required(root, "location", path));
 	{
 		char	   *raw = ice_actual_location(path);
 		char	   *real = realpath(raw, NULL);
@@ -652,9 +649,12 @@ pgcolumnar_iceberg_data_files(PG_FUNCTION_ARGS)
 {
 	char	   *path = text_to_cstring(PG_GETARG_TEXT_PP(0));
 	IceListCtx	ctx;
+	Jsonb	   *jb;
 
 	ctx.tupstore = ice_srf_begin(fcinfo, &ctx.tupdesc);
-	ice_walk_data_files(path, ice_list_cb, &ctx);
+	jb = DatumGetJsonbP(DirectFunctionCall1(jsonb_in,
+											CStringGetDatum(ice_slurp_text(path))));
+	ice_walk_data_files(path, &jb->root, ice_list_cb, &ctx);
 	return (Datum) 0;
 }
 
@@ -878,7 +878,9 @@ pgcolumnar_iceberg_scan(PG_FUNCTION_ARGS)
 										"pgcolumnar iceberg_scan file",
 										ALLOCSET_DEFAULT_SIZES);
 
-	ice_walk_data_files(path, ice_scan_cb, &ctx);
+	/* reuse the metadata we already parsed for the schema, so the file is read
+	 * and parsed once, not again inside the walk */
+	ice_walk_data_files(path, &jb->root, ice_scan_cb, &ctx);
 
 	MemoryContextDelete(ctx.filectx);
 	ExecDropSingleTupleTableSlot(ctx.slot);

--- a/test/avro_manifest.sh
+++ b/test/avro_manifest.sh
@@ -64,6 +64,48 @@ check "every entry's file_path ends in .parquet" \
 check "all entries are ADDED data files (status=1, content=0)" \
 	"$(q "SELECT bool_and(status = 1 AND content = 0) FROM pgcolumnar.read_avro_manifest('$M0')")" "t"
 
+# ---- the entry's data sequence number (#388 phase 4) ------------------------
+# The committed manifest was a first append: its entries carry a NULL
+# sequence_number (inherited from the manifest's, per the v2 spec).
+check "the committed entries have a NULL (inherited) sequence_number" \
+	"$(q "SELECT count(*) FILTER (WHERE sequence_number IS NULL) || '/' || count(*)
+	      FROM pgcolumnar.read_avro_manifest('$M0')")" \
+	"$(q "SELECT count(*)::text || '/' || count(*) FROM pgcolumnar.read_avro_manifest('$M0')")"
+# A crafted manifest_entry with an EXPLICIT sequence_number = 42, so the decode of
+# a present (non-null) value is proven, not just the null case. Reduced schema
+# (the decoder projects by field name and skips the rest).
+python3 - "$PGC_WORKDIR/seq.avro" <<'PY'
+import sys
+def zz(n):
+    u = (n << 1) ^ (n >> 63) if n < 0 else (n << 1)
+    out = bytearray()
+    while True:
+        b = u & 0x7f; u >>= 7
+        out.append(b | 0x80 if u else b)
+        if not u: break
+    return bytes(out)
+def s(bs): return zz(len(bs)) + bs
+schema = (b'{"type":"record","name":"manifest_entry","fields":['
+          b'{"name":"status","type":"int"},'
+          b'{"name":"sequence_number","type":["null","long"]},'
+          b'{"name":"data_file","type":{"type":"record","name":"df","fields":['
+          b'{"name":"content","type":"int"},'
+          b'{"name":"file_path","type":"string"},'
+          b'{"name":"file_format","type":"string"},'
+          b'{"name":"record_count","type":"long"},'
+          b'{"name":"file_size_in_bytes","type":"long"}]}}]}')
+# one entry: status=1, sequence_number=union(1)->42, data_file{0,"d.parquet","PARQUET",5,100}
+rec  = zz(1) + zz(1) + zz(42)
+rec += zz(0) + s(b"d.parquet") + s(b"PARQUET") + zz(5) + zz(100)
+sync = b"\x00" * 16
+meta = zz(2) + s(b"avro.schema") + s(schema) + s(b"avro.codec") + s(b"null") + zz(0)
+ocf  = b"Obj\x01" + meta + sync + zz(1) + zz(len(rec)) + rec + sync
+open(sys.argv[1], "wb").write(ocf)
+PY
+chmod 644 "$PGC_WORKDIR/seq.avro"
+check "an explicit entry sequence_number is decoded (42)" \
+	"$(q "SELECT sequence_number FROM pgcolumnar.read_avro_manifest('$PGC_WORKDIR/seq.avro')")" "42"
+
 # ---- the manifest LIST (a snapshot's manifest_file entries) -----------------
 # The same object-container machinery, a different embedded record. Decode the
 # committed real manifest-list and assert its manifest_file entry against the


### PR DESCRIPTION
First increment of **phase 4 (deletes)**. Applying a delete file correctly hinges on the **data sequence number**: a delete applies only to data files with a *lower* sequence number (deletes affect data written before them). That number is on each manifest entry, and the decoder skipped it.

## What lands

- The Avro `manifest_entry` decoder reads it into `PgColumnarAvroManifestEntry.sequence_number` + a `has_sequence_number` flag (the field is nullable — null means inherit the manifest's number). Matches both `sequence_number` (pyiceberg 0.11.1 / v2 manifests) and the newer spec name `data_sequence_number`.
- `read_avro_manifest` gains a `sequence_number` column (NULL when inherited) — the observable consumer that keeps the parse removal-provable, same pattern as #613's `field_id` column.

## Tests (`avro_manifest.sh`)

- The committed first-append manifest's entries decode to **NULL** (inherited, per the v2 spec).
- A **crafted** `manifest_entry` with an explicit `sequence_number` decodes to **42** — so a present (non-null) value is proven, not just the null path.
- **Removal proof:** skipping the field reds the explicit arm (`NULL` vs `42`) while the inherited arm stays green.
- Green PG17/18/19, under **ASAN**, and the **fuzzer** (300 mutants alternating manifest + manifest-list) is clean over the new nullable-union read.

## Context

Phase-4 design (position → equality → v3 Puffin deletes, the fixture-crafting approach since no available writer emits merge-on-read deletes, and the sub-increment plan) is in `design/ISSUE_388_PHASE4_DELETES.md`. The next increment (4a) is the big one: collect delete entries in the walk, add ordinal-based row skipping to the reader, and apply position deletes in `iceberg_scan`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqFY4pifG7rp3a5fJREWnr