### PR TITLE
test: portable expired certificate for objstore_tls_read

### DIFF
--- a/test/objstore_tls_read.sh
+++ b/test/objstore_tls_read.sh
@@ -80,6 +80,12 @@ gen_cert goodsig   ca1 "IP:127.0.0.1"
 gen_cert wronghost ca1 "DNS:other.example"
 gen_cert expired   ca1 "IP:127.0.0.1" \
 	-not_before 20200101000000Z -not_after 20200102000000Z
+# -not_before/-not_after need OpenSSL 3.4; on an older one (Ubuntu 24.04 CI
+# ships 3.0) the command fails and leaves no pem. Fall back to a zero-lifetime
+# certificate: notAfter equals the signing instant, so it is expired by the
+# time the server answers its first request. The premise check below still
+# proves the certificate is genuinely expired, whichever path produced it.
+[ -s "$PKI/expired.pem" ] || gen_cert expired ca1 "IP:127.0.0.1" -days 0
 gen_cert untrusted ca2 "IP:127.0.0.1"
 for f in ca1 ca2 good goodsig wronghost expired untrusted; do
 	[ -s "$PKI/$f.pem" ] || { echo "FATAL: PKI generation failed for $f"; exit 1; }


### PR DESCRIPTION
Now TLS-only: @ChronicallyJD's #650 and this PR were opened 31 seconds apart, both fixing `server_file_privilege` with independently **identical** five-row diffs. One author per fix keeps the cross-review clean, so #650 takes that one and this PR keeps the TLS half they cited as filed here.

**The defect** (pre-dating the gate repair; red in the 4a-era CI run `31861456837`): the expired-certificate arm minted its certificate with `-not_before`/`-not_after`, which need OpenSSL 3.4+. CI's Ubuntu 24.04 ships 3.0: the command failed inside `2>/dev/null` and PKI generation aborted with the suite's own `FATAL: PKI generation failed for expired`.

**The fix**: when the primary mint leaves no pem, a fallback mints a zero-lifetime certificate (`-days 0`: notAfter = the signing instant, expired by the time the server answers its first request). The genuinely-expired premise check (`-checkend 0`) covers both paths, so the 08006 expired arm exercises a real expired certificate whichever path produced it.

**Verified on the bench** (OpenSSL 3.5.5, PG17): primary path PASSED (19 checks), and with the primary deliberately broken (bogus `-not_before` value so the fallback runs), PASSED again.

With this and #650 merged, every suite in main's matrix is green: run `31866812487` failed on exactly these two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015j2iax4PZtYjcGT1G7JsFR