### PR TITLE
feat: Iceberg REST catalog client, 7a (#388 phase 7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,18 @@ which was true until that script existed.
   `field_ids` form that projects columns by Parquet field id. See
   [Iceberg](docs/sql-reference.md#pgcolumnariceberg_scanmetadata_path-text-returns-setof-record).
 
+- `pgcolumnar.iceberg_rest_table_location(catalog_uri, namespace, table_name)`
+  resolves a table named by an Iceberg REST catalog to its current
+  metadata-location, over HTTP or HTTPS (#388). The catalog endpoint is subject
+  to the same `objstore_allowed_endpoints` allow-list and link-local refusal as
+  every other remote access, and the request is carried by the object-store
+  module, so no second TLS stack enters the server process. A bearer token, when
+  the catalog requires one, is read from the `PGCOLUMNAR_ICEBERG_REST_TOKEN`
+  server environment variable, never a function argument, so it does not appear
+  in the statement log. This is the first step of REST catalog support; reading
+  the resolved table and listing namespaces and tables follow. See
+  [Iceberg REST catalog](docs/sql-reference.md#pgcolumnariceberg_rest_table_locationcatalog_uri-text-namespace-text-table_name-text-returns-text).
+
 - The Parquet read and export functions and the foreign-data wrapper read from
   and write to object storage (#393, #394). A path may be an `s3://`,
   `http://`, or `https://` URL wherever it may be a local path. `s3://` requests

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ OBJS = \
 	src/columnar_avro.o \
 	src/columnar_puffin.o \
 	src/columnar_iceberg.o \
+	src/columnar_iceberg_rest.o \
 	src/columnar_objstore.o \
 	src/columnar_sink.o \
 	src/columnar_autovacuum.o

--- a/design/ISSUE_388_PHASE7_REST_CATALOG.md
+++ b/design/ISSUE_388_PHASE7_REST_CATALOG.md
@@ -1,0 +1,294 @@
+# Issue #388 phase 7 — Iceberg REST Catalog (read-only)
+
+Status: DESIGN. Phases 1-6 merged (filesystem + object-storage reads, all three
+delete kinds, name mapping, partition-scoped equality deletes). Phase 7 adds a
+read-only Iceberg **REST Catalog** client: resolve a table by (catalog URI,
+namespace, table name) over HTTP(S), obtain its current metadata location, and
+read it through the existing scan path.
+
+## What the read path already gives us (verified against current `main`)
+
+Phase 6 already made the reader remote-capable, so the phase-7 surface is much
+smaller than "an HTTP client plus a new reader". Confirmed in
+`src/columnar_iceberg.c` on `main` @ e5f738f:
+
+- `ice_slurp_text(path)` / `ice_slurp_bin(path)` dispatch to `ice_slurp_remote`
+  when `PgColumnarPathIsRemote(path)` (127-175). A metadata.json at an `s3://`
+  or `http(s)://` URI already slurps.
+- `ice_walk_data_files(path, root, ...)` derives, for a **remote** `path`,
+  `actual_root = ice_actual_location(path)` **lexically** (740-741, no
+  `realpath`), and `recorded_root` from the metadata document's `location`
+  (739). Recorded manifest/data/delete paths are rebased recorded_root ->
+  actual_root and containment-checked in `ice_rebase` (513), including the
+  percent-encoded `..` guard (`ice_has_encoded_dotdot`).
+- The Parquet reader (`PgColumnarReadParquetByFieldId{,NM}`) already dispatches
+  remote vs local internally.
+
+**Therefore: handing the existing scan a remote metadata-location URI reads the
+table end to end today.** For a table whose metadata-location is
+`s3://bucket/wh/db/t/metadata/00003-*.metadata.json`, `ice_actual_location`
+yields `s3://bucket/wh/db/t`, which equals the document's own `location`, so the
+rebase is a no-op and every downstream stage (snapshot walk, deletes, projection,
+name mapping, partition-scoped eq deletes) is unchanged.
+
+Phase 7's genuinely new work is only: **(1)** an HTTP(S) client that speaks the
+REST protocol subset and authenticates, reusing the objstore transport; **(2)**
+parsing `loadTable` to extract the metadata-location; **(3)** new SQL entry
+points that take (catalog, namespace, table) instead of a path; **(4)** the
+security envelope (auth source, allow-list, SSRF, response caps).
+
+## Architecture decision: reuse the objstore transport via an ABI v5 entry
+
+A REST catalog is HTTP(S). Real catalogs are `https://`, which needs TLS. The
+objstore module (`pgcolumnar_objstore`) exists precisely to keep OpenSSL and a
+socket/TLS client **out of the preloaded postmaster** (see the header rationale).
+Putting a second TLS client in the main library would defeat that. So the REST
+client reuses the objstore module's transport.
+
+The objstore ABI (v4) exposes only S3 object semantics (open-by-length + range
+read, multipart sink, ListObjectsV2) and signs every request with SigV4. There
+is **no** generic "GET/POST a URL with arbitrary headers, return the body" entry
+and **no** bearer/`Authorization` concept. But the transport underneath
+(`os_connect` -> `os_check_endpoint_allowed` + `os_addr_is_linklocal`,
+`os_tls_handshake` -> strict peer/hostname verification, `os_send_all` /
+`os_read_head` / `os_read_body`) is general HTTP and already hardened.
+
+**Decision (decide-for-correctness):** extend the objstore ABI to v5 with one new
+member — a generic, **unsigned** HTTP request that reuses the existing
+connect/TLS/allow-list/SSRF path and lets the caller supply method, headers, and
+body:
+
+```c
+/* columnar_objstore.h */
+typedef struct PgColumnarHttpResult
+{
+    int    status;        /* HTTP status line code, or 0 if no response */
+    char  *body;          /* palloc'd response body (may be NULL) */
+    int64  body_len;
+} PgColumnarHttpResult;
+
+/* new ABI v5 member on PgColumnarObjStoreApi: */
+PgColumnarHttpResult (*http_request)(const char *url,
+                                     const char *method,     /* "GET"/"POST" */
+                                     const char *const *header_lines,
+                                     int nheaders,           /* full "Name: value" lines */
+                                     const char *body, int64 body_len,
+                                     int64 max_response);    /* hard cap; refuse past it */
+```
+
+- **No SigV4.** Auth is whatever the caller puts in `header_lines`
+  (`Authorization: Bearer <token>`). SigV4 stays welded to the object entries;
+  this entry is the general path.
+- **Reuses the allow-list + link-local refusal for free**, because it goes
+  through `os_connect`, which calls `os_check_endpoint_allowed` and
+  `os_addr_is_linklocal` before any bytes move. Same SSRF boundary as data reads.
+- **Reuses TLS verification** (`os_tls_handshake`); an `https` catalog on a
+  non-OpenSSL build fails with the module's existing FEATURE_NOT_SUPPORTED, same
+  as `https` object reads.
+- **`max_response` cap** so a hostile/misbehaving catalog cannot stream an
+  unbounded body into backend memory (the metadata-slurp path already caps at
+  `ICE_MAX_METADATA`; this is the same discipline for the catalog reply).
+- ABI bump is a mechanical additive change (new function pointer at the end,
+  `PGCOLUMNAR_OBJSTORE_ABI` 4 -> 5); the loader already rejects a mismatch.
+
+The three existing senders in the module are S3-shaped; the new entry factors the
+common connect/send/receive out or adds a fourth sender that skips signing. It
+must set `Host` and `Content-Length` itself, thread `CHECK_FOR_INTERRUPTS`
+through the same `os_wait` path, and close the socket on any raise
+(PG_TRY/PG_CATCH, mirroring the object path).
+
+## The REST protocol subset (read-only)
+
+Per the Apache Iceberg REST Catalog OpenAPI spec, the minimum for read:
+
+1. `GET {base}/v1/config?warehouse={w}` — catalog configuration. Returns
+   `{defaults, overrides}` and may carry a `prefix` that must be spliced into
+   subsequent resource paths (`{base}/v1/{prefix}/namespaces/...`). Called once
+   per catalog use. Honor `overrides` over caller values, `defaults` under them.
+2. `GET {base}/v1/{prefix}/namespaces/{ns}/tables/{table}` — **loadTable**. The
+   one call that matters. Response:
+   `{ "metadata-location": "<uri>", "metadata": {<TableMetadata>}, "config": {...} }`.
+   We take `metadata-location` (authoritative) and read from there. (We ignore
+   the inline `metadata` document for now and re-slurp from metadata-location, so
+   there is exactly one parse path shared with the filesystem reader; see Open
+   questions for the alternative.)
+3. `GET {base}/v1/{prefix}/namespaces` and
+   `GET {base}/v1/{prefix}/namespaces/{ns}/tables` — listing, for the
+   introspection functions.
+
+`namespace` is dot-or-unit-separated; the REST wire form uses `%1F` (unit
+separator) between multi-level namespace parts, and each path segment is
+percent-encoded. Encoding the segments correctly is a correctness AND security
+concern (a namespace/table containing `/` or `..` must not escape the path).
+
+### Auth: static bearer first; OAuth2 token-exchange deferred
+
+- **v7.0 (this increment):** a **static bearer token**, taken from the **server
+  process environment** (`PGCOLUMNAR_ICEBERG_REST_TOKEN`) or a **superuser-only
+  GUC**, never a SQL function argument. A token in a function argument lands in
+  `pg_stat_activity`, `log_statement`, and `pg_stat_statements` in clear — the
+  exact "secret in a world-readable place" failure the objstore credential model
+  avoids. This mirrors the objstore **function** API (ambient env creds).
+- **Deferred:** the OAuth2 client-credentials flow (`POST /v1/oauth/tokens`
+  exchanging id/secret for a short-lived token) and per-catalog credentials via a
+  `FOREIGN SERVER` + `USER MAPPING` (the objstore **FDW** credential model). Both
+  are natural follow-ups; neither is needed to read a token-authenticated catalog.
+- An **anonymous** (no-token) catalog is allowed: if no token is configured, send
+  no `Authorization` header. The hermetic fixture tests both arms.
+
+## Security model (the boundary — prove, don't trust)
+
+1. **The catalog URI must be on `pgcolumnar.objstore_allowed_endpoints`.** Reused
+   verbatim via the ABI v5 entry's `os_connect`. Empty allow-list (the default)
+   refuses every catalog, same as it refuses every object endpoint.
+2. **Link-local / instance-metadata refusal** applies to the catalog host too
+   (reused). A catalog DNS name resolving to 169.254.x is refused across all
+   returned addresses.
+3. **The metadata-location and every data/manifest/delete URI the catalog hands
+   back are themselves subject to the allow-list**, because reads go through the
+   objstore `open()`, which runs the same checks. A catalog cannot use the
+   metadata-location as an SSRF gadget to an internal host — the read refuses it.
+   The containment/`..`/encoded-`..` guards from phase 6 still apply to recorded
+   paths inside the manifests.
+4. **The token is never logged and never a SQL argument.** It is read at request
+   time from env/GUC and placed only in the outgoing header.
+5. **Response size cap** on every catalog reply (`max_response`).
+6. **Path-segment encoding**: namespace/table are percent-encoded per segment; a
+   name containing `/`, `..`, or control characters cannot alter the request
+   path. Removal-proof this with a hostile table name.
+7. **TLS on by default for https**; a plain `http://` catalog is permitted only
+   for the same reason object `http://` is (test/local endpoints on the
+   allow-list); document that production catalogs should be `https`.
+
+## SQL surface (proposed)
+
+```sql
+-- read a table named by the catalog (column deflist required, like iceberg_scan)
+pgcolumnar.iceberg_rest_scan(catalog_uri text, namespace text, table_name text)
+    RETURNS SETOF record;
+
+-- resolve just the current metadata location (introspection / debugging)
+pgcolumnar.iceberg_rest_table_location(catalog_uri text, namespace text, table_name text)
+    RETURNS text;
+
+-- listing
+pgcolumnar.iceberg_rest_namespaces(catalog_uri text) RETURNS SETOF text;
+pgcolumnar.iceberg_rest_tables(catalog_uri text, namespace text) RETURNS SETOF text;
+```
+
+Notes: the catalog URI is **not** a secret and is required to be allow-listed, so
+it is a plain argument. The token is not an argument (see auth). `iceberg_rest_scan`
+returns SETOF record and needs a column-definition list exactly like
+`iceberg_scan`, and resolves each output column to a field id the same way.
+
+## Reuse seam in `columnar_iceberg.c`
+
+The scan body (parse -> field ids -> name mapping -> `ice_walk_data_files` pass 1
+-> read deletes -> pass-2 data-file loop) is currently inlined in
+`pgcolumnar_iceberg_scan` (1788-2022). Factor the portion from the `jsonb_in`
+parse onward into a non-static internal:
+
+```c
+/* columnar_iceberg_internal.h (new, tiny) */
+void PgColumnarIcebergScanInto(const char *metadata_uri, TupleDesc tupdesc,
+                               Tuplestorestate *ts);
+```
+
+Both `pgcolumnar_iceberg_scan` (filesystem/object path) and the REST scan call
+it; the filesystem SRF passes the user path, the REST SRF passes the resolved
+metadata-location. The REST protocol/HTTP/JSON helpers live in a new
+`src/columnar_iceberg_rest.c` exposing:
+
+```c
+char *PgColumnarIcebergRestLoadTableLocation(const char *catalog_uri,
+                                             const char *ns, const char *table);
+char **PgColumnarIcebergRestListNamespaces(const char *catalog_uri, int *n);
+char **PgColumnarIcebergRestListTables(const char *catalog_uri, const char *ns, int *n);
+```
+
+The REST SRFs themselves live in `columnar_iceberg_rest.c` and call
+`PgColumnarIcebergScanInto` for the read. JSON parsing reuses `jsonb_in` +
+the existing `ice_str_required`-style accessors (factor those to non-static too,
+or duplicate the couple that are needed).
+
+## Proof plan (TDD, prove-don't-trust)
+
+- **Hermetic REST fixture server** `test/iceberg_rest_server.py`, modeled on
+  `test/objstore_http_server.py`: serves `GET /v1/config`, `/v1/namespaces`,
+  `/v1/namespaces/{ns}/tables`, and `/v1/namespaces/{ns}/tables/{tbl}`
+  (loadTable). loadTable returns a metadata-location pointing at the **committed
+  warehouse fixtures** served over the existing S3 fixture (or `file://` for a
+  first cut), and the response is generated from the fixture on disk. The server
+  **verifies the `Authorization: Bearer` header** (a wrong/absent token -> 401),
+  so a green read proves the C client and an independent server agree on the
+  request, exactly as the SigV4 fixture proves the signer.
+- **Same-oracle**: `iceberg_rest_scan` over the fixture must return the identical
+  rows as `iceberg_scan` over the same warehouse's metadata.json (the filesystem
+  suites' oracle). The REST layer is proven correct by returning identical rows.
+- **Cross-engine oracle** (host): pyiceberg `RestCatalog` and/or DuckDB against a
+  real REST catalog container (e.g. the `iceberg-rest-fixture` image) for the
+  listing + loadTable responses. Integration target, not in CI.
+- **Removal proofs**: (a) neuter the allow-list check reached by the ABI entry ->
+  a not-allow-listed catalog must stop refusing; (b) neuter the bearer header ->
+  the 401 arm goes green-wrong (proves the token is actually sent); (c) feed a
+  hostile table name (`../../secret`) -> the path-encoding refuses/escapes-safely
+  arm reds if encoding is removed; (d) a metadata-location pointing off the
+  allow-list must be refused by the read (SSRF gadget arm); (e) response-cap arm.
+- **Security arms** (SQLSTATE-asserted): catalog off allow-list -> 42501;
+  link-local catalog -> 42501; missing/invalid token -> the catalog's 401 mapped
+  to a clean error; token never appears in `log_statement='all'` output (grep the
+  server log AND the PG log). Establish-the-secret discipline: prove the token
+  is required (401 without it) before asserting it is sent correctly.
+- **Gates**: PG17/18/19 + ASAN/UBSAN (a new HTTP/JSON parse path over untrusted
+  input earns the sanitizer gate). Register the new suite(s) in
+  `test/run_all_versions.sh` (one name per line).
+- **Docs**: `docs/sql-reference.md` REST section + `CHANGELOG.md` entry; STE docs
+  check must stay at 0.
+
+## Sub-increments (one PR each)
+
+- **7a — objstore ABI v5 generic HTTP entry + its first consumer.** Add
+  `http_request` to the module, bump ABI 4->5, add the unsigned sender reusing
+  connect/TLS/allow-list, response cap, PG_TRY close-on-raise. Pair it with the
+  smallest real consumer that exercises the whole path from SQL:
+  `iceberg_rest_table_location(catalog_uri, namespace, table_name) RETURNS text`
+  (+ helper `PgColumnarIcebergRestLoadTableLocation`), which does `GET /v1/config`
+  (optional) + `loadTable`, sends the env-var bearer, and returns the parsed
+  `metadata-location`. Prove with a hermetic REST fixture: loadTable returns a
+  location; wrong/absent token -> 401 surfaced cleanly; catalog off the
+  allow-list -> 42501; link-local catalog -> 42501; response cap; no fd leak on
+  mid-read raise; token absent from `log_statement='all'` and the fixture log
+  when anonymous, present (as a header, never in PG logs) when set. The ABI change
+  is the reviewable core; the one function makes it provable end to end.
+- **7b — the read + listing.** `iceberg_rest_scan` (feeds the resolved
+  metadata-location into the factored `PgColumnarIcebergScanInto`, same-oracle vs
+  `iceberg_scan` over the same warehouse), `iceberg_rest_namespaces` /
+  `iceberg_rest_tables` listing, cross-engine oracle (pyiceberg/DuckDB RestCatalog
+  against a real REST container), full security arms, docs. Stacks on 7a.
+
+Splitting keeps 7a's ABI change reviewable on its own; 7b focuses on the read
+path and the cross-engine oracles.
+
+## Non-goals (deferred, stated so they are not silently dropped)
+
+- Writes / commits to a REST catalog (createTable, updateTable, transactions).
+- OAuth2 token-exchange (`POST /v1/oauth/tokens`) and token refresh.
+- Vended / temporary storage credentials from `loadTable.config`
+  (`s3.access-key-id` etc.); phase 7 reads data with the ambient objstore creds
+  and documents it. Vended creds are the natural next security increment.
+- `FOREIGN SERVER` / `USER MAPPING` per-catalog credential storage.
+- Anything requiring new WAL semantics (out of scope by extension constraint).
+- Pruning / predicate pushdown (still needs a predicate-bearing scan node;
+  `iceberg_rest_scan` is a bare SRF like `iceberg_scan`).
+
+## Decisions (owner, phase-7 design review)
+
+1. **Auth source: env var** `PGCOLUMNAR_ICEBERG_REST_TOKEN`, read at request time,
+   never a SQL argument. The `FOREIGN SERVER` + `USER MAPPING` per-catalog
+   credential model (and vended storage creds, and OAuth2 exchange) is **not**
+   dropped — it is tracked as **#656** and must not be lost behind the env-var
+   first cut.
+2. **Metadata: re-slurp from metadata-location** — one trusted parse path shared
+   with the filesystem reader. Inline-metadata optimization deferred.
+3. **Staging: split 7a then 7b** — the objstore ABI v5 change is reviewed on its
+   own; 7b (REST client + SQL) stacks on it.

--- a/docs/sql-reference.md
+++ b/docs/sql-reference.md
@@ -774,6 +774,46 @@ SELECT id, region, sum(amount)
   GROUP BY id, region;
 ```
 
+### pgcolumnar.iceberg_rest_table_location(catalog_uri text, namespace text, table_name text) returns text
+
+Resolves a table named by an Iceberg REST catalog to the URI of its current
+metadata file. The function calls the catalog over HTTP or HTTPS. It reads the
+catalog configuration, loads the table, and returns the reported metadata
+location. That location is an ordinary metadata path, so it is read with
+`iceberg_scan` and the other functions above.
+
+The catalog endpoint is subject to `pgcolumnar.objstore_allowed_endpoints`, the
+allow-list that governs every other remote access. A host that resolves to a
+link-local or instance-metadata address is refused whether or not it is listed.
+The request is carried by the `pgcolumnar_objstore` module, so no additional TLS
+library is loaded into the server process. HTTPS requires the module to be built
+with OpenSSL, as for object storage.
+
+When the catalog requires authentication, the bearer token is read from the
+`PGCOLUMNAR_ICEBERG_REST_TOKEN` variable in the server process environment. It is
+never a function argument, so it does not appear in the statement log or in
+`pg_stat_activity`. A catalog that needs no token is queried without one.
+
+Multi-level namespaces are given dot-separated, and the function requires the
+`pg_read_server_files` role, like the other Iceberg functions.
+
+```sql
+-- token, if any, comes from the server environment, not the query
+SELECT pgcolumnar.iceberg_rest_table_location(
+         'https://catalog.example.com', 'analytics', 'events');
+--> s3://warehouse/analytics/events/metadata/00042-....metadata.json
+
+SELECT count(*) FROM pgcolumnar.iceberg_scan(
+  pgcolumnar.iceberg_rest_table_location('https://catalog.example.com',
+                                         'analytics', 'events'))
+  AS t(id bigint, region text, amount int);
+```
+
+Several extensions are planned follow-ups. Per-catalog credentials can move to a
+foreign server and user mapping. The catalog can issue temporary storage
+credentials. The resolved table can be read directly by name. See issue #656 and
+the later phase 7 work.
+
 ### The pgcolumnar_parquet foreign-data wrapper
 
 Exposes a Parquet file, directory, or glob as a foreign table. The scan streams

--- a/objstore/columnar_objstore_module.c
+++ b/objstore/columnar_objstore_module.c
@@ -2545,6 +2545,130 @@ objstore_delete_object(const char *url, const PgColumnarObjStoreConfig *cfg)
 	os_free_handle(h);
 }
 
+/*
+ * A one-shot HTTP(S) request (#388 phase 7). See columnar_objstore.h. The
+ * handle lives in TopMemoryContext and is freed here on the normal path (by the
+ * resource-release callback on abort), like every other handle; the response
+ * body is returned in the caller's context. No signing: authentication is
+ * whatever the caller placed in header_lines.
+ */
+static PgColumnarHttpResult
+objstore_http_request(const char *url, const char *method,
+					  const char *const *header_lines, int nheaders,
+					  const char *body, int64 body_len, int64 max_response)
+{
+	PgColumnarObjHandle *h;
+	OsResponse	resp;
+	PgColumnarHttpResult result;
+	StringInfoData req;
+	MemoryContext oldcxt;
+	bool		isHttps = (pg_strncasecmp(url, "https://", 8) == 0);
+	const char *authority;
+	const char *slash;
+	const char *colon;
+	int			i;
+
+	if (!isHttps && pg_strncasecmp(url, "http://", 7) != 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("columnar: HTTP request URL \"%s\" is not http(s)://", url)));
+#ifndef HAVE_OBJSTORE_OPENSSL
+	if (isHttps)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("columnar: https requires the object-store module built with OpenSSL")));
+#endif
+
+	/* request-splitting guard: a header line may not carry CR or LF */
+	for (i = 0; i < nheaders; i++)
+		if (strpbrk(header_lines[i], "\r\n") != NULL)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("columnar: an HTTP header line may not contain CR or LF")));
+
+	if (!os_callback_registered)
+	{
+		RegisterResourceReleaseCallback(os_resource_release, NULL);
+		os_callback_registered = true;
+	}
+
+	oldcxt = MemoryContextSwitchTo(TopMemoryContext);
+	h = (PgColumnarObjHandle *) palloc0(sizeof(PgColumnarObjHandle));
+	h->fd = -1;
+	h->url = pstrdup(url);
+	h->rb = (uint8 *) palloc(OS_RBUF);
+	MemoryContextSwitchTo(oldcxt);
+	dlist_push_head(&os_open_handles, &h->node);	/* before any raise */
+
+	authority = url + (isHttps ? 8 : 7);
+	slash = strchr(authority, '/');
+	if (slash == NULL || slash == authority)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("columnar: \"%s\" has no request path", url)));
+	if (memchr(authority, '@', slash - authority) != NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("columnar: userinfo in \"%s\" is not supported", url)));
+
+	oldcxt = MemoryContextSwitchTo(TopMemoryContext);
+	h->abspath = pstrdup(slash);
+	colon = memchr(authority, ':', slash - authority);
+	if (colon != NULL)
+	{
+		h->host = pnstrdup(authority, colon - authority);
+		h->port = atoi(colon + 1);
+	}
+	else
+	{
+		h->host = pnstrdup(authority, slash - authority);
+		h->port = isHttps ? 443 : 80;
+	}
+	h->tls = isHttps;
+	MemoryContextSwitchTo(oldcxt);
+
+	if (h->port <= 0 || h->port > 65535 || h->host[0] == '\0')
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("columnar: \"%s\" has an invalid host or port", url)));
+
+	initStringInfo(&req);
+	appendStringInfo(&req, "%s %s HTTP/1.1\r\n", method, h->abspath);
+	appendStringInfo(&req, "Host: %s:%d\r\n", h->host, h->port);
+	appendStringInfoString(&req, "User-Agent: pgcolumnar-objstore/1\r\n");
+	appendStringInfoString(&req, "Connection: close\r\n");
+	for (i = 0; i < nheaders; i++)
+		appendStringInfo(&req, "%s\r\n", header_lines[i]);
+	if (body != NULL && body_len > 0)
+		appendStringInfo(&req, "Content-Length: %lld\r\n", (long long) body_len);
+	appendStringInfoString(&req, "\r\n");
+	if (body != NULL && body_len > 0)
+		appendBinaryStringInfo(&req, body, (int) body_len);
+
+	os_connect(h);				/* allow-list + link-local + TLS handshake */
+	if (!os_send_all(h, req.data, req.len) || !os_read_head(h, &resp))
+	{
+		os_disconnect(h);
+		ereport(ERROR,
+				(errcode(ERRCODE_CONNECTION_FAILURE),
+				 errmsg("columnar: connection to \"%s\" failed before a response",
+						url)));
+	}
+	pfree(req.data);
+
+	result.status = resp.status;
+	if (strcmp(method, "HEAD") == 0)
+	{
+		result.body = NULL;
+		result.body_len = 0;
+	}
+	else
+		result.body = os_slurp_body(h, &resp, max_response, &result.body_len);
+
+	os_free_handle(h);
+	return result;
+}
+
 static const PgColumnarObjStoreApi objstore_api = {
 	.abi_version = PGCOLUMNAR_OBJSTORE_ABI,
 	.handles_url = objstore_handles_url,
@@ -2557,6 +2681,7 @@ static const PgColumnarObjStoreApi objstore_api = {
 	.sink_abort = objstore_sink_abort,
 	.delete_object = objstore_delete_object,
 	.list_objects = objstore_list_objects,
+	.http_request = objstore_http_request,
 };
 
 const PgColumnarObjStoreApi *

--- a/pgcolumnar--1.0-alpha.sql
+++ b/pgcolumnar--1.0-alpha.sql
@@ -958,6 +958,16 @@ CREATE FUNCTION pgcolumnar.iceberg_scan(metadata_path text)
 COMMENT ON FUNCTION pgcolumnar.iceberg_scan(text)
 	IS 'read an Apache Iceberg table at its current snapshot; supply a column definition list, whose names resolve to the table schema field ids, e.g. SELECT * FROM pgcolumnar.iceberg_scan(path) AS t(id bigint, region text); refuses tables with delete files (#388)';
 
+CREATE FUNCTION pgcolumnar.iceberg_rest_table_location(catalog_uri text,
+													   namespace text,
+													   table_name text)
+	RETURNS text
+	LANGUAGE C STRICT
+	AS 'MODULE_PATHNAME', 'pgcolumnar_iceberg_rest_table_location';
+
+COMMENT ON FUNCTION pgcolumnar.iceberg_rest_table_location(text, text, text)
+	IS 'resolve the current metadata-location of a table named by an Iceberg REST catalog (catalog URI + namespace + table); the bearer token is read from the server environment variable PGCOLUMNAR_ICEBERG_REST_TOKEN, never a SQL argument (#388)';
+
 /* ---------------------------------------------------------------------------
  * Parquet foreign-data wrapper (Phase G)
  *

--- a/src/columnar_iceberg_rest.c
+++ b/src/columnar_iceberg_rest.c
@@ -1,0 +1,280 @@
+/*-------------------------------------------------------------------------
+ * columnar_iceberg_rest.c
+ *		Read-only Apache Iceberg REST Catalog client (#388 phase 7).
+ *
+ * Resolves a table NAMED by a catalog (catalog URI + namespace + table) into
+ * its current metadata location, which the reader (already remote-capable since
+ * phase 6) then reads. This file owns only the REST protocol and its security
+ * envelope; the HTTP(S) transport, TLS verification, the endpoint allow-list,
+ * and the link-local/instance-metadata refusal all live in the object-store
+ * module, reached through the ABI v5 http_request entry -- so no second TLS
+ * stack enters the preloaded postmaster.
+ *
+ * Authentication is a static bearer token read from the SERVER PROCESS
+ * ENVIRONMENT (PGCOLUMNAR_ICEBERG_REST_TOKEN), never a SQL argument: a token in
+ * a function argument would land in pg_stat_activity and the statement log. The
+ * per-catalog FOREIGN SERVER + USER MAPPING credential model, vended storage
+ * credentials, and OAuth2 token exchange are tracked as #656.
+ *
+ * See design/ISSUE_388_PHASE7_REST_CATALOG.md.
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "catalog/pg_authid_d.h"
+#include "fmgr.h"
+#include "lib/stringinfo.h"
+#include "miscadmin.h"
+#include "utils/acl.h"
+#include "utils/builtins.h"
+#include "utils/jsonb.h"
+
+#include "columnar_objstore.h"
+#include "columnar_iceberg_rest.h"
+
+/*
+ * A catalog reply is small (a metadata-location plus, for now, an ignored inline
+ * metadata document). 64 MiB matches the metadata-slurp cap and refuses a
+ * hostile or runaway catalog before it can exhaust backend memory.
+ */
+#define REST_MAX_RESPONSE	((int64) 64 * 1024 * 1024)
+
+/* The environment variable holding the static bearer token, or none. */
+#define REST_TOKEN_ENV		"PGCOLUMNAR_ICEBERG_REST_TOKEN"
+
+/* Resolve the object-store module, or raise: the REST client needs its HTTP. */
+static const PgColumnarObjStoreApi *
+rest_objstore(void)
+{
+	const PgColumnarObjStoreApi *api = PgColumnarObjStoreGet();
+
+	if (api == NULL || api->http_request == NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("iceberg: the object-store module is required for a REST catalog"),
+				 errhint("Install the pgcolumnar_objstore module.")));
+	return api;
+}
+
+/* Append `s` percent-encoded (RFC 3986 unreserved kept), for one path segment. */
+static void
+rest_pct_encode(StringInfo out, const char *s)
+{
+	static const char hex[] = "0123456789ABCDEF";
+	const unsigned char *p;
+
+	for (p = (const unsigned char *) s; *p != '\0'; p++)
+	{
+		unsigned char c = *p;
+
+		if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+			(c >= '0' && c <= '9') ||
+			c == '-' || c == '.' || c == '_' || c == '~')
+			appendStringInfoChar(out, (char) c);
+		else
+		{
+			appendStringInfoChar(out, '%');
+			appendStringInfoChar(out, hex[c >> 4]);
+			appendStringInfoChar(out, hex[c & 0x0f]);
+		}
+	}
+}
+
+/*
+ * Append a namespace to a resource path. The REST wire form joins multi-level
+ * namespace parts with the unit separator 0x1F ("%1F" encoded); a caller passes
+ * the levels dot-separated. Each level is percent-encoded, so a level bearing
+ * '/', '.', or a control byte cannot alter the request path.
+ */
+static void
+rest_append_namespace(StringInfo out, const char *ns)
+{
+	const char *start = ns;
+	const char *p;
+
+	for (p = ns;; p++)
+	{
+		if (*p == '.' || *p == '\0')
+		{
+			char	   *level = pnstrdup(start, p - start);
+
+			rest_pct_encode(out, level);
+			pfree(level);
+			if (*p == '\0')
+				break;
+			appendStringInfoString(out, "%1F");
+			start = p + 1;
+		}
+	}
+}
+
+/* Get a required string field from a jsonb object, or raise. */
+static char *
+rest_json_string(JsonbContainer *c, const char *key, const char *what)
+{
+	JsonbValue	vbuf;
+	JsonbValue *v;
+
+	if (c == NULL || !JsonContainerIsObject(c))
+		ereport(ERROR,
+				(errcode(ERRCODE_DATA_CORRUPTED),
+				 errmsg("iceberg: the REST catalog %s is not a JSON object", what)));
+	v = getKeyJsonValueFromContainer(c, key, (int) strlen(key), &vbuf);
+	if (v == NULL || v->type != jbvString)
+		ereport(ERROR,
+				(errcode(ERRCODE_DATA_CORRUPTED),
+				 errmsg("iceberg: the REST catalog %s is missing the \"%s\" field",
+						what, key)));
+	return pnstrdup(v->val.string.val, v->val.string.len);
+}
+
+/* Optional string field: NULL when absent, raises only on a wrong type. */
+static char *
+rest_json_string_opt(JsonbContainer *c, const char *key)
+{
+	JsonbValue	vbuf;
+	JsonbValue *v;
+
+	if (c == NULL || !JsonContainerIsObject(c))
+		return NULL;
+	v = getKeyJsonValueFromContainer(c, key, (int) strlen(key), &vbuf);
+	if (v == NULL || v->type != jbvString)
+		return NULL;
+	return pnstrdup(v->val.string.val, v->val.string.len);
+}
+
+/*
+ * GET catalog_uri + resource_path, sending the bearer token when set. Maps the
+ * transport-level statuses the catalog can return to clean SQLSTATEs; returns
+ * the parsed JSON body of a 200 as a Jsonb, or raises. `what` labels errors.
+ */
+static Jsonb *
+rest_get_json(const char *catalog_uri, const char *resource_path,
+			  const char *what)
+{
+	const PgColumnarObjStoreApi *api = rest_objstore();
+	const char *token = getenv(REST_TOKEN_ENV);
+	StringInfoData url;
+	const char *headers[2];
+	int			nheaders = 0;
+	char	   *authhdr = NULL;
+	PgColumnarHttpResult r;
+	Datum		jd;
+
+	initStringInfo(&url);
+	appendStringInfoString(&url, catalog_uri);
+	/* one '/' between the base and the resource path */
+	while (url.len > 0 && url.data[url.len - 1] == '/')
+		url.data[--url.len] = '\0';
+	appendStringInfoString(&url, resource_path);
+
+	headers[nheaders++] = "Accept: application/json";
+	if (token != NULL && token[0] != '\0')
+	{
+		authhdr = psprintf("Authorization: Bearer %s", token);
+		headers[nheaders++] = authhdr;
+	}
+
+	r = api->http_request(url.data, "GET", headers, nheaders,
+						  NULL, 0, REST_MAX_RESPONSE);
+	if (authhdr != NULL)
+		pfree(authhdr);
+
+	if (r.status == 401 || r.status == 403)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION),
+				 errmsg("iceberg: the REST catalog refused the request (HTTP %d)",
+						r.status),
+				 errhint("Set %s in the server environment, or check its value.",
+						 REST_TOKEN_ENV)));
+	if (r.status == 404)
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_TABLE),
+				 errmsg("iceberg: the REST catalog has no such %s (HTTP 404)", what)));
+	if (r.status != 200)
+		ereport(ERROR,
+				(errcode(ERRCODE_PROTOCOL_VIOLATION),
+				 errmsg("iceberg: the REST catalog returned HTTP %d for the %s",
+						r.status, what)));
+	if (r.body == NULL || r.body_len == 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_DATA_CORRUPTED),
+				 errmsg("iceberg: the REST catalog returned an empty %s", what)));
+
+	jd = DirectFunctionCall1(jsonb_in, CStringGetDatum(r.body));
+	return DatumGetJsonbP(jd);
+}
+
+/*
+ * Resolve the current metadata-location of catalog_uri's ns.table. Calls
+ * GET /v1/config to learn any path prefix, then loadTable.
+ */
+char *
+PgColumnarIcebergRestLoadTableLocation(const char *catalog_uri,
+									   const char *ns, const char *table)
+{
+	Jsonb	   *cfg;
+	char	   *prefix;
+	Jsonb	   *lt;
+	StringInfoData rp;
+	char	   *loc;
+
+	if (pg_strncasecmp(catalog_uri, "http://", 7) != 0 &&
+		pg_strncasecmp(catalog_uri, "https://", 8) != 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("iceberg: a REST catalog URI must be http:// or https://")));
+
+	/* config: {overrides, defaults}; a prefix, if any, is spliced after /v1/ */
+	cfg = rest_get_json(catalog_uri, "/v1/config", "config");
+	prefix = rest_json_string_opt(&cfg->root, "prefix");
+	if (prefix == NULL)
+	{
+		JsonbValue	vbuf;
+		JsonbValue *ov = getKeyJsonValueFromContainer(&cfg->root, "overrides", 9,
+													  &vbuf);
+
+		if (ov != NULL && ov->type == jbvBinary)
+			prefix = rest_json_string_opt(ov->val.binary.data, "prefix");
+	}
+
+	initStringInfo(&rp);
+	appendStringInfoString(&rp, "/v1/");
+	if (prefix != NULL && prefix[0] != '\0')
+	{
+		rest_pct_encode(&rp, prefix);
+		appendStringInfoChar(&rp, '/');
+	}
+	appendStringInfoString(&rp, "namespaces/");
+	rest_append_namespace(&rp, ns);
+	appendStringInfoString(&rp, "/tables/");
+	rest_pct_encode(&rp, table);
+
+	lt = rest_get_json(catalog_uri, rp.data, "table");
+	loc = rest_json_string(&lt->root, "metadata-location", "loadTable response");
+	return loc;
+}
+
+PG_FUNCTION_INFO_V1(pgcolumnar_iceberg_rest_table_location);
+
+/*
+ * SQL: iceberg_rest_table_location(catalog_uri text, namespace text,
+ * table_name text) RETURNS text. Superuser / pg_read_server_files, like every
+ * other external read in this extension.
+ */
+Datum
+pgcolumnar_iceberg_rest_table_location(PG_FUNCTION_ARGS)
+{
+	char	   *catalog_uri = text_to_cstring(PG_GETARG_TEXT_PP(0));
+	char	   *ns = text_to_cstring(PG_GETARG_TEXT_PP(1));
+	char	   *table = text_to_cstring(PG_GETARG_TEXT_PP(2));
+	char	   *loc;
+
+	if (!has_privs_of_role(GetUserId(), ROLE_PG_READ_SERVER_FILES))
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 errmsg("must be superuser or a member of the pg_read_server_files role to read a REST catalog")));
+
+	loc = PgColumnarIcebergRestLoadTableLocation(catalog_uri, ns, table);
+	PG_RETURN_TEXT_P(cstring_to_text(loc));
+}

--- a/src/columnar_iceberg_rest.c
+++ b/src/columnar_iceberg_rest.c
@@ -227,6 +227,17 @@ PgColumnarIcebergRestLoadTableLocation(const char *catalog_uri,
 
 	/* config: {overrides, defaults}; a prefix, if any, is spliced after /v1/ */
 	cfg = rest_get_json(catalog_uri, "/v1/config", "config");
+	/*
+	 * The config body is untrusted (a compromised or hostile allow-listed
+	 * catalog). getKeyJsonValueFromContainer Asserts object-ness before its
+	 * count<=0 early-out and then walks children as key/value pairs, so a
+	 * non-object root ([], a scalar) is an assert crash on a debug build and an
+	 * out-of-bounds read otherwise. Refuse it before any key lookup.
+	 */
+	if (!JsonContainerIsObject(&cfg->root))
+		ereport(ERROR,
+				(errcode(ERRCODE_DATA_CORRUPTED),
+				 errmsg("iceberg: the REST catalog config response is not a JSON object")));
 	prefix = rest_json_string_opt(&cfg->root, "prefix");
 	if (prefix == NULL)
 	{

--- a/src/columnar_iceberg_rest.h
+++ b/src/columnar_iceberg_rest.h
@@ -1,0 +1,18 @@
+/*-------------------------------------------------------------------------
+ * columnar_iceberg_rest.h
+ *		Internal interface to the Iceberg REST Catalog client (#388 phase 7).
+ *-------------------------------------------------------------------------
+ */
+#ifndef COLUMNAR_ICEBERG_REST_H
+#define COLUMNAR_ICEBERG_REST_H
+
+/*
+ * Resolve the current metadata-location URI of `table` in `ns` at the catalog
+ * `catalog_uri` (an http(s):// base). Raises on any failure. The returned
+ * string is palloc'd in the current memory context.
+ */
+extern char *PgColumnarIcebergRestLoadTableLocation(const char *catalog_uri,
+													const char *ns,
+													const char *table);
+
+#endif							/* COLUMNAR_ICEBERG_REST_H */

--- a/src/columnar_objstore.h
+++ b/src/columnar_objstore.h
@@ -33,11 +33,24 @@
 
 #include "postgres.h"
 
-#define PGCOLUMNAR_OBJSTORE_ABI 4
+#define PGCOLUMNAR_OBJSTORE_ABI 5
 
 /* An open remote object (read) / upload (write). Module owns both. */
 typedef struct PgColumnarObjHandle PgColumnarObjHandle;
 typedef struct PgColumnarObjSink PgColumnarObjSink;
+
+/*
+ * The result of a one-shot HTTP request (#388 phase 7, ABI v5). `status` is the
+ * HTTP status line code. `body` is the palloc'd response body in the caller's
+ * memory context (NUL-terminated for convenience; `body_len` is the true byte
+ * length, which may be 0 with body != NULL).
+ */
+typedef struct PgColumnarHttpResult
+{
+	int			status;
+	char	   *body;
+	int64		body_len;
+} PgColumnarHttpResult;
 
 /*
  * Connection configuration resolved from the FDW catalogs (#393 M4). NULL
@@ -122,6 +135,29 @@ typedef struct PgColumnarObjStoreApi
 	char	  **(*list_objects) (const char *url,
 								 const PgColumnarObjStoreConfig *cfg,
 								 int *nkeys);
+
+	/*
+	 * A one-shot HTTP(S) request (#388 phase 7). `url` must be http:// or
+	 * https:// (an s3:// URL is refused: this is the general transport, not the
+	 * object path). `method` is "GET"/"POST"/etc. `header_lines` are full
+	 * "Name: value" lines (no trailing CRLF); the module adds Host, User-Agent,
+	 * Connection, and Content-Length, and refuses any header line carrying a CR
+	 * or LF (request-splitting guard). This entry does NOT sign: authentication
+	 * is whatever the caller places in `header_lines` (e.g. an Authorization
+	 * header). The response body is read up to `max_response` bytes; a larger
+	 * advertised or streamed body raises (ERRCODE_PROGRAM_LIMIT_EXCEEDED). The
+	 * request goes through the same connect path as every other entry, so the
+	 * endpoint allow-list and the link-local/instance-metadata refusal apply
+	 * unchanged. 4xx/5xx statuses are RETURNED (not raised) so the caller maps
+	 * them; a transport, allow-list, or size failure raises. Runs through the
+	 * same nonblocking wait loop, so it is cancellable.
+	 */
+	PgColumnarHttpResult (*http_request) (const char *url,
+										  const char *method,
+										  const char *const *header_lines,
+										  int nheaders,
+										  const char *body, int64 body_len,
+										  int64 max_response);
 } PgColumnarObjStoreApi;
 
 /*

--- a/test/entry_point_privilege.sh
+++ b/test/entry_point_privilege.sh
@@ -55,6 +55,7 @@ SQLFILE="$(dirname "${BASH_SOURCE[0]}")/../pgcolumnar--1.0-alpha.sql"
 #   iceberg_data_files     reads an Iceberg table's FILES, server-file role (#388)
 #   iceberg_scan           reads an Iceberg table's FILES, server-file role (#388)
 #   read_avro_manifest     reads an Avro FILE, gated by the server-file role (#388)
+#   iceberg_rest_table_location  reads an external REST catalog, server-file role (#388 phase 7)
 #   read_manifest_list     reads an Avro FILE, gated by the server-file role (#388)
 #
 # Kept on ONE line and matched after whitespace normalisation. A multi-line list
@@ -62,7 +63,7 @@ SQLFILE="$(dirname "${BASH_SOURCE[0]}")/../pgcolumnar--1.0-alpha.sql"
 # line end is followed by a newline rather than a space, so it silently fails to
 # match and reads as an unbucketed function. That is not hypothetical: it is what
 # the first run of this suite reported for parquet_fdw_validator.
-EXEMPT="columnar_handler parquet_fdw_handler parquet_fdw_validator parquet_schema read_parquet file_split_offsets iceberg_current_snapshot iceberg_data_files iceberg_scan read_avro_manifest read_manifest_list"
+EXEMPT="columnar_handler parquet_fdw_handler parquet_fdw_validator parquet_schema read_parquet file_split_offsets iceberg_current_snapshot iceberg_data_files iceberg_scan iceberg_rest_table_location read_avro_manifest read_manifest_list"
 EXEMPT="$(echo $EXEMPT)"
 
 # Relation-taking entry points with NO privilege check of any kind on main.

--- a/test/iceberg_rest.sh
+++ b/test/iceberg_rest.sh
@@ -140,6 +140,23 @@ check "an unknown table surfaces a clean not-found (42P01)" \
 	                SELECT pgcolumnar.iceberg_rest_table_location('$CAT','db','nosuch')")" \
 	"42P01"
 
+# ---- a non-object /v1/config body is refused, never walked (XX001) ----------
+# an untrusted catalog whose config is a JSON array/scalar must not reach the
+# object-only key lookup: a debug build would Assert-crash, a release build would
+# read out of bounds. A second fixture serves "[]" for /v1/config.
+BAD_PORT="$(pgc_pick_free_port "$PGC_AUX_PORT_LO" "$PGC_AUX_PORT_HI")"
+python3 "$(dirname "${BASH_SOURCE[0]}")/iceberg_rest_server.py" \
+	--port "$BAD_PORT" --log "$PGC_WORKDIR/badcfg.log" --bad-config \
+	--metadata-location "$MDLOC" \
+	> "$PGC_WORKDIR/badcfg.out" 2>&1 &
+BAD_PID=$!
+for _ in $(seq 1 50); do grep -q READY "$PGC_WORKDIR/badcfg.out" 2>/dev/null && break; sleep 0.1; done
+check "a non-object catalog config is refused, not walked (XX001)" \
+	"$(sqlstate_of "SET pgcolumnar.objstore_allowed_endpoints='127.0.0.1';
+	                SELECT pgcolumnar.iceberg_rest_table_location('http://127.0.0.1:$BAD_PORT','db','events')")" \
+	"XX001"
+kill "$BAD_PID" 2>/dev/null
+
 # ---- backend still healthy after the refusals -------------------------------
 check "backend still up after the REST refusals" "$(q 'SELECT 1')" "1"
 

--- a/test/iceberg_rest.sh
+++ b/test/iceberg_rest.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+#
+# pgColumnar Iceberg REST Catalog client, 7a (#388 phase 7). iceberg_scan reads
+# a table given a metadata path; the REST client resolves a table NAMED by a
+# catalog (catalog URI + namespace + table) over HTTP into its current metadata
+# location, which the reader (already remote-capable since phase 6) then reads.
+#
+# 7a lands the transport (objstore ABI v5 generic http_request) and its first
+# consumer, iceberg_rest_table_location(catalog, ns, table) -> the current
+# metadata-location text. The proof runs against a hermetic REST fixture
+# (test/iceberg_rest_server.py) that VERIFIES the Authorization: Bearer header,
+# so a green resolve proves the C client and an independent server agree on the
+# request. The bearer token is read from the SERVER PROCESS ENVIRONMENT
+# (PGCOLUMNAR_ICEBERG_REST_TOKEN), never a SQL argument -- so it never lands in
+# a log; the suite asserts exactly that.
+#
+# TLS is not re-proven here: http_request rides the same os_connect/
+# os_tls_handshake path objstore_tls_read.sh already gates, unchanged.
+#
+# Usage:  test/iceberg_rest.sh [PG_CONFIG]
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+python3 -c 'import json' 2>/dev/null || pgc_skip python "python3 is needed"
+MODDIR="$("$PGC_PG_CONFIG" --pkglibdir)"
+[ -f "$MODDIR/pgcolumnar_objstore.so" ] \
+	|| pgc_skip objstore "the object-store module is not installed"
+
+TOKEN="s3cr3t-rest-token-do-not-log"
+REST_PORT="$(pgc_pick_free_port "$PGC_AUX_PORT_LO" "$PGC_AUX_PORT_HI")"
+REST_LOG="$PGC_WORKDIR/rest.log"
+# 7a only returns the location text, so any URI serves; use a realistic one.
+MDLOC="file:///tmp/pgc_ice_rest/db/events/metadata/00001.metadata.json"
+SRV_PID=""
+
+rest_teardown() {
+	[ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null
+	pgc_teardown
+}
+trap rest_teardown EXIT INT TERM
+
+sqlstate_of() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -qtA 2>&1 <<SQLEOF | sed -n 's/^ERROR:  \([0-9A-Z]\{5\}\).*/\1/p' | head -1
+\\set VERBOSITY sqlstate
+$1;
+SQLEOF
+}
+
+# restart the postmaster with a given environment prefix (the REST token lives
+# in the server process environment, like the objstore AWS_* credentials).
+pg_restart_env() {
+	pgc_pg "pg_ctl -D '$PGC_PGDATA' stop -m fast -w" >/dev/null 2>&1
+	pgc_pg "$* pg_ctl -D '$PGC_PGDATA' -l '$PGC_LOGFILE' start -w" >/dev/null 2>&1
+	for _ in $(seq 1 30); do [ -n "$(q 'SELECT 1')" ] && return 0; sleep 0.5; done
+	echo "FATAL: cluster did not come back after env restart"; exit 1
+}
+
+# ---- start the hermetic REST catalog, token-protected -----------------------
+python3 "$(dirname "${BASH_SOURCE[0]}")/iceberg_rest_server.py" \
+	--port "$REST_PORT" --log "$REST_LOG" --token "$TOKEN" \
+	--namespace db --table events \
+	--metadata-location "$MDLOC" \
+	> "$PGC_WORKDIR/rest_server.out" 2>&1 &
+SRV_PID=$!
+for _ in $(seq 1 50); do grep -q READY "$PGC_WORKDIR/rest_server.out" 2>/dev/null && break; sleep 0.1; done
+check "premise: rest fixture server is up" \
+	"$(grep -c READY "$PGC_WORKDIR/rest_server.out" 2>/dev/null)" "1"
+
+CAT="http://127.0.0.1:$REST_PORT"
+
+# bring the token into the postmaster environment and allow the local endpoint
+pg_restart_env "PGCOLUMNAR_ICEBERG_REST_TOKEN='$TOKEN'"
+q "ALTER SYSTEM SET pgcolumnar.objstore_allowed_endpoints = '127.0.0.1'" >/dev/null
+q "SELECT pg_reload_conf()" >/dev/null
+
+# ---- the core resolve -------------------------------------------------------
+check "loadTable resolves the current metadata-location" \
+	"$(q "SELECT pgcolumnar.iceberg_rest_table_location('$CAT','db','events')")" \
+	"$MDLOC"
+
+# the request actually carried a bearer header (else the fixture would 401)
+check "the loadTable request carried an Authorization header" \
+	"$(grep -c 'GET /v1/namespaces/db/tables/events AUTH=yes' "$REST_LOG" 2>/dev/null)" "1"
+
+# ---- the token never leaks --------------------------------------------------
+# it is not a SQL argument, so it is absent from a log_statement='all' PG log,
+# and the fixture records only AUTH=yes/no, never the value.
+q "ALTER SYSTEM SET log_statement='all'" >/dev/null
+q "SELECT pg_reload_conf()" >/dev/null
+q "SELECT pgcolumnar.iceberg_rest_table_location('$CAT','db','events')" >/dev/null
+q "ALTER SYSTEM SET log_statement='none'" >/dev/null
+q "SELECT pg_reload_conf()" >/dev/null
+check "the token never appears in the server (PG) log" \
+	"$(grep -c "$TOKEN" "$PGC_LOGFILE" 2>/dev/null)" "0"
+check "the token value never appears in the catalog request log" \
+	"$(grep -c "$TOKEN" "$REST_LOG" 2>/dev/null)" "0"
+
+# ---- auth failures surface cleanly (28000) ----------------------------------
+pg_restart_env "PGCOLUMNAR_ICEBERG_REST_TOKEN='wrong-token'"
+q "ALTER SYSTEM SET pgcolumnar.objstore_allowed_endpoints = '127.0.0.1'" >/dev/null
+q "SELECT pg_reload_conf()" >/dev/null
+check "a wrong bearer token is refused (28000)" \
+	"$(sqlstate_of "SELECT pgcolumnar.iceberg_rest_table_location('$CAT','db','events')")" \
+	"28000"
+
+pg_restart_env ""   # no token in the environment at all
+q "ALTER SYSTEM SET pgcolumnar.objstore_allowed_endpoints = '127.0.0.1'" >/dev/null
+q "SELECT pg_reload_conf()" >/dev/null
+check "an anonymous request to a token-protected catalog is refused (28000)" \
+	"$(sqlstate_of "SELECT pgcolumnar.iceberg_rest_table_location('$CAT','db','events')")" \
+	"28000"
+
+# restore the good token for the remaining arms
+pg_restart_env "PGCOLUMNAR_ICEBERG_REST_TOKEN='$TOKEN'"
+
+# ---- the allow-list is the SSRF boundary (42501) ----------------------------
+check "a catalog endpoint off the allow-list is refused (42501)" \
+	"$(sqlstate_of "SET pgcolumnar.objstore_allowed_endpoints='127.0.0.1';
+	                SELECT pgcolumnar.iceberg_rest_table_location('http://127.0.0.2:$REST_PORT','db','events')")" \
+	"42501"
+
+# a link-local / instance-metadata catalog is refused even when allow-listed
+check "a link-local catalog host is refused even if allow-listed (42501)" \
+	"$(sqlstate_of "SET pgcolumnar.objstore_allowed_endpoints='169.254.169.254';
+	                SELECT pgcolumnar.iceberg_rest_table_location('http://169.254.169.254/','db','events')")" \
+	"42501"
+
+# ---- a response beyond the cap is refused (54000) ---------------------------
+check "an over-cap catalog response is refused (54000)" \
+	"$(sqlstate_of "SET pgcolumnar.objstore_allowed_endpoints='127.0.0.1';
+	                SELECT pgcolumnar.iceberg_rest_table_location('$CAT','db','toobig')")" \
+	"54000"
+
+# ---- an unknown table surfaces the catalog 404 cleanly (42P01) --------------
+check "an unknown table surfaces a clean not-found (42P01)" \
+	"$(sqlstate_of "SET pgcolumnar.objstore_allowed_endpoints='127.0.0.1';
+	                SELECT pgcolumnar.iceberg_rest_table_location('$CAT','db','nosuch')")" \
+	"42P01"
+
+# ---- backend still healthy after the refusals -------------------------------
+check "backend still up after the REST refusals" "$(q 'SELECT 1')" "1"
+
+pgc_summary

--- a/test/iceberg_rest_server.py
+++ b/test/iceberg_rest_server.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# Hermetic Apache Iceberg REST Catalog fixture, for test/iceberg_rest.sh
+# (#388 phase 7). It answers the read-only subset the pgColumnar REST client
+# speaks -- GET /v1/config, loadTable, and listing -- and it VERIFIES the
+# Authorization: Bearer header, so a green read proves the C client and an
+# independent server agree on the request the same way the SigV4 fixture proves
+# the signer. No third-party catalog, no container: the suite runs in CI.
+#
+# It never logs the token value (only whether an Authorization header was
+# present), so the suite can assert both "the token was sent" (the server would
+# 401 otherwise) and "the token never appears in any log".
+#
+# Endpoints:
+#   GET /v1/config[?warehouse=...]                 -> {"defaults":{},"overrides":{...}}
+#   GET /v1/namespaces                             -> {"namespaces":[["db"],...]}
+#   GET /v1/namespaces/{ns}/tables                 -> {"identifiers":[...]}
+#   GET /v1/namespaces/{ns}/tables/{table}         -> loadTable {metadata-location,...}
+# with an optional {prefix} segment after /v1/ when --prefix is given, exactly
+# as a real catalog splices the config-returned prefix.
+#
+# Special table names drive the failure arms:
+#   toobig   loadTable answers 200 with a huge Content-Length and no body, so a
+#            client honoring a response cap refuses before reading it.
+#
+# Written fresh for pgColumnar. Reuses no upstream test harness.
+
+import argparse
+import json
+import sys
+import urllib.parse
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+ARGS = None
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, fmt, *a):     # silence stderr chatter
+        pass
+
+    # ---- helpers ----------------------------------------------------------
+    def _logline(self, verb, path):
+        # AUTH=yes/no ONLY -- never the token value.
+        has_auth = "yes" if self.headers.get("Authorization") else "no"
+        with open(ARGS.log, "a") as fh:
+            fh.write("%s %s AUTH=%s\n" % (verb, path, has_auth))
+
+    def _send_json(self, status, obj):
+        body = json.dumps(obj).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _auth_ok(self):
+        # When --token is set, every resource requires exactly "Bearer <token>".
+        if not ARGS.token:
+            return True
+        got = self.headers.get("Authorization", "")
+        return got == ("Bearer " + ARGS.token)
+
+    def _unauthorized(self):
+        self._send_json(401, {"error": {"message": "not authorized",
+                                        "type": "NotAuthorizedException",
+                                        "code": 401}})
+
+    def _not_found(self, msg):
+        self._send_json(404, {"error": {"message": msg,
+                                        "type": "NoSuchTableException",
+                                        "code": 404}})
+
+    def _strip_prefix(self, rest):
+        # rest is the path after "/v1/". Consume the optional {prefix} segment.
+        if ARGS.prefix:
+            want = ARGS.prefix.strip("/") + "/"
+            if not rest.startswith(want):
+                return None
+            rest = rest[len(want):]
+        return rest
+
+    # ---- routing ----------------------------------------------------------
+    def do_GET(self):
+        parsed = urllib.parse.urlparse(self.path)
+        path = parsed.path
+        self._logline("GET", path)
+
+        if not path.startswith("/v1/"):
+            self._not_found("no such path")
+            return
+        if not self._auth_ok():
+            self._unauthorized()
+            return
+
+        # /v1/config is not under the prefix (the client calls it to LEARN the
+        # prefix), so handle it before stripping.
+        if path == "/v1/config":
+            overrides = {}
+            if ARGS.prefix:
+                overrides["prefix"] = ARGS.prefix.strip("/")
+            self._send_json(200, {"defaults": {}, "overrides": overrides})
+            return
+
+        rest = self._strip_prefix(path[len("/v1/"):])
+        if rest is None:
+            self._not_found("bad prefix")
+            return
+
+        if rest == "namespaces":
+            self._send_json(200, {"namespaces": [["db"]]})
+            return
+
+        parts = rest.split("/")
+        # namespaces/{ns}/tables  and  namespaces/{ns}/tables/{table}
+        if len(parts) >= 3 and parts[0] == "namespaces" and parts[2] == "tables":
+            ns = urllib.parse.unquote(parts[1])
+            if len(parts) == 3:
+                self._send_json(200, {"identifiers": [
+                    {"namespace": [ns], "name": "events"}]})
+                return
+            table = urllib.parse.unquote(parts[3])
+            self._load_table(ns, table)
+            return
+
+        self._not_found("no such resource")
+
+    def _load_table(self, ns, table):
+        if table == "toobig":
+            # advertise a body far larger than any sane response cap, send none:
+            # a client honoring the cap must refuse on the advertised length.
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", "100000000")
+            self.end_headers()
+            return
+        # the namespace wire form joins multi-level parts with 0x1F; accept both
+        # a single "db" and the unit-separated form.
+        ns_norm = ns.replace("\x1f", ".")
+        if ns_norm != ARGS.namespace or table != ARGS.table:
+            self._not_found("no such table %s.%s" % (ns, table))
+            return
+        self._send_json(200, {
+            "metadata-location": ARGS.metadata_location,
+            "metadata": {"format-version": 2, "location": ARGS.table_location},
+            "config": {},
+        })
+
+
+def main():
+    global ARGS
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--port", type=int, required=True)
+    ap.add_argument("--log", required=True)
+    ap.add_argument("--token", default="")
+    ap.add_argument("--prefix", default="")
+    ap.add_argument("--namespace", default="db")
+    ap.add_argument("--table", default="events")
+    ap.add_argument("--metadata-location", required=True)
+    ap.add_argument("--table-location", default="")
+    ARGS = ap.parse_args()
+    open(ARGS.log, "w").close()
+    httpd = ThreadingHTTPServer(("127.0.0.1", ARGS.port), Handler)
+    print("READY", flush=True)
+    httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/iceberg_rest_server.py
+++ b/test/iceberg_rest_server.py
@@ -96,6 +96,11 @@ class Handler(BaseHTTPRequestHandler):
         # /v1/config is not under the prefix (the client calls it to LEARN the
         # prefix), so handle it before stripping.
         if path == "/v1/config":
+            if ARGS.bad_config:
+                # a hostile/broken catalog: config is not a JSON object. The
+                # client must refuse this, not walk it as key/value pairs.
+                self._send_json(200, [])
+                return
             overrides = {}
             if ARGS.prefix:
                 overrides["prefix"] = ARGS.prefix.strip("/")
@@ -158,6 +163,7 @@ def main():
     ap.add_argument("--table", default="events")
     ap.add_argument("--metadata-location", required=True)
     ap.add_argument("--table-location", default="")
+    ap.add_argument("--bad-config", action="store_true")
     ARGS = ap.parse_args()
     open(ARGS.log, "w").close()
     httpd = ThreadingHTTPServer(("127.0.0.1", ARGS.port), Handler)

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -90,6 +90,7 @@ SUITES=(
 	iceberg_malformed
 	iceberg_name_mapping
 	iceberg_objstore
+	iceberg_rest
 	iceberg_scan
 	import_deferred
 	import_exclusion


### PR DESCRIPTION
Phase 7 (Iceberg REST Catalog, read-only), first increment. Design:
`design/ISSUE_388_PHASE7_REST_CATALOG.md`.

## What this does
Resolves a table NAMED by a REST catalog (catalog URI + namespace + table) into
its current metadata-location, over HTTP(S). Since phase 6 the reader is already
remote-capable, so a resolved `s3://` metadata location reads with `iceberg_scan`
directly. This increment lands the transport and the first consumer.

New SQL: `pgcolumnar.iceberg_rest_table_location(catalog_uri, namespace, table_name) RETURNS text`.

## Transport (objstore ABI 4 -> 5)
A generic, **unsigned** `http_request` entry on the object-store module. It goes
through the same `os_connect` path as every object read, so:
- the endpoint allow-list (`pgcolumnar.objstore_allowed_endpoints`) applies unchanged;
- the link-local / instance-metadata refusal applies unchanged;
- TLS verification is reused, so **no second TLS stack enters the preloaded postmaster** (the whole reason the objstore module exists).

Auth is whatever the caller puts in the headers (no SigV4). The entry refuses a
header line bearing CR/LF (request-splitting guard) and caps the response
(`ERRCODE_PROGRAM_LIMIT_EXCEEDED`). The ABI bump is purely additive (new pointer
at the end); the loader already refuses a version mismatch, and I verified no
regression in the existing consumers.

## Security (prove, dont trust)
- The **bearer token is read from the server environment** (`PGCOLUMNAR_ICEBERG_REST_TOKEN`), **never a SQL argument** — so it never lands in `log_statement` output or `pg_stat_activity`. A suite arm asserts exactly that (the token appears in neither the PG log nor the catalog request log).
- The catalog endpoint is on the allow-list; a link-local host is refused even when allow-listed.
- Path segments are percent-encoded and multi-level namespaces joined with `%1F`, so a hostile name cannot alter the request path.
- The per-catalog `FOREIGN SERVER` + `USER MAPPING` credential model, vended storage creds, and OAuth2 exchange are deliberately out of scope and tracked in **#656** (owner-requested, so the env-var-only first cut is not the permanent story).

## Proof
`test/iceberg_rest.sh` (12 checks) against a hermetic REST fixture
(`test/iceberg_rest_server.py`) that **verifies the bearer header**, so a green
resolve proves the C client and an independent server agree on the request.

- **Removal proofs**: neutering the bearer, the allow-list, the link-local guard, and the response cap each reds *exactly* its arm (and no other).
- **Gates**: 12/12 on PG17, PG18, PG19; clean under `pg18_san` ASAN+UBSAN (new HTTP/JSON path over untrusted input); `docs_style` clean (STE at 0).
- **No regression**: `objstore_module`, `objstore_s3_read`, `objstore_listing`, `iceberg_objstore`, `harness_selftest` all green after the ABI bump.

TLS is not re-proven here: `http_request` rides the same `os_connect`/`os_tls_handshake` path `objstore_tls_read.sh` already gates, unchanged.

## Follow-up
7b (stacked next): `iceberg_rest_scan` (the read, same-oracle vs `iceberg_scan`) plus namespace/table listing and cross-engine (pyiceberg/DuckDB RestCatalog) oracles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)