### PR TITLE
feat: read + list an Iceberg REST catalog, 7b (#388 phase 7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,17 +54,23 @@ which was true until that script existed.
   `field_ids` form that projects columns by Parquet field id. See
   [Iceberg](docs/sql-reference.md#pgcolumnariceberg_scanmetadata_path-text-returns-setof-record).
 
-- `pgcolumnar.iceberg_rest_table_location(catalog_uri, namespace, table_name)`
-  resolves a table named by an Iceberg REST catalog to its current
-  metadata-location, over HTTP or HTTPS (#388). The catalog endpoint is subject
-  to the same `objstore_allowed_endpoints` allow-list and link-local refusal as
-  every other remote access, and the request is carried by the object-store
-  module, so no second TLS stack enters the server process. A bearer token, when
-  the catalog requires one, is read from the `PGCOLUMNAR_ICEBERG_REST_TOKEN`
-  server environment variable, never a function argument, so it does not appear
-  in the statement log. This is the first step of REST catalog support; reading
-  the resolved table and listing namespaces and tables follow. See
-  [Iceberg REST catalog](docs/sql-reference.md#pgcolumnariceberg_rest_table_locationcatalog_uri-text-namespace-text-table_name-text-returns-text).
+- Read-only Apache Iceberg **REST catalog** support (#388). A table is named by a
+  catalog (catalog URI, namespace, table) rather than a metadata path.
+  `pgcolumnar.iceberg_rest_scan(catalog_uri, namespace, table_name)` reads it at
+  its current snapshot, taking a column definition list exactly like
+  `iceberg_scan`: the catalog resolves the table to its metadata location, which
+  is then read through the same path, so every projection and delete rule
+  applies unchanged. `pgcolumnar.iceberg_rest_table_location` returns that
+  resolved metadata location on its own, and
+  `pgcolumnar.iceberg_rest_namespaces` and `pgcolumnar.iceberg_rest_tables` list
+  a catalog. Requests go over HTTP or HTTPS. The catalog endpoint is subject to
+  the same `objstore_allowed_endpoints` allow-list and link-local refusal as
+  every other remote access, and is carried by the object-store module, so no
+  second TLS stack enters the server process. A bearer token, when the catalog
+  requires one, is read from the `PGCOLUMNAR_ICEBERG_REST_TOKEN` server
+  environment variable, never a function argument, so it does not appear in the
+  statement log. See
+  [Iceberg REST catalog](docs/sql-reference.md#pgcolumnariceberg_rest_scancatalog_uri-text-namespace-text-table_name-text-returns-setof-record).
 
 - The Parquet read and export functions and the foreign-data wrapper read from
   and write to object storage (#393, #394). A path may be an `s3://`,

--- a/docs/sql-reference.md
+++ b/docs/sql-reference.md
@@ -809,10 +809,40 @@ SELECT count(*) FROM pgcolumnar.iceberg_scan(
   AS t(id bigint, region text, amount int);
 ```
 
-Several extensions are planned follow-ups. Per-catalog credentials can move to a
-foreign server and user mapping. The catalog can issue temporary storage
-credentials. The resolved table can be read directly by name. See issue #656 and
-the later phase 7 work.
+Per-catalog credentials can move to a foreign server and user mapping. The
+catalog can issue temporary storage credentials. See issue #656 and the later
+phase 7 work.
+
+### pgcolumnar.iceberg_rest_scan(catalog_uri text, namespace text, table_name text) returns setof record
+
+Reads a table named by an Iceberg REST catalog at its current snapshot. It takes
+a column definition list exactly like `iceberg_scan`. The catalog resolves the
+table to its metadata location. That location is read through the same path, so
+field-id projection and every delete rule apply unchanged. The catalog and
+authentication rules are those of `iceberg_rest_table_location` above, including
+the allow-list, the link-local refusal, and the environment bearer token.
+
+```sql
+SELECT region, sum(amount)
+  FROM pgcolumnar.iceberg_rest_scan('https://catalog.example.com',
+                                    'analytics', 'events')
+    AS t(id bigint, region text, amount int)
+  GROUP BY region;
+```
+
+### pgcolumnar.iceberg_rest_namespaces(catalog_uri text) returns setof text
+
+Lists the namespaces of a catalog, one per row. A multi-level namespace is
+returned dot-joined. Same catalog and authentication rules as above.
+
+### pgcolumnar.iceberg_rest_tables(catalog_uri text, namespace text) returns setof text
+
+Lists the table names in a namespace, one per row.
+
+```sql
+SELECT * FROM pgcolumnar.iceberg_rest_namespaces('https://catalog.example.com');
+SELECT * FROM pgcolumnar.iceberg_rest_tables('https://catalog.example.com', 'analytics');
+```
 
 ### The pgcolumnar_parquet foreign-data wrapper
 

--- a/pgcolumnar--1.0-alpha.sql
+++ b/pgcolumnar--1.0-alpha.sql
@@ -968,6 +968,32 @@ CREATE FUNCTION pgcolumnar.iceberg_rest_table_location(catalog_uri text,
 COMMENT ON FUNCTION pgcolumnar.iceberg_rest_table_location(text, text, text)
 	IS 'resolve the current metadata-location of a table named by an Iceberg REST catalog (catalog URI + namespace + table); the bearer token is read from the server environment variable PGCOLUMNAR_ICEBERG_REST_TOKEN, never a SQL argument (#388)';
 
+CREATE FUNCTION pgcolumnar.iceberg_rest_scan(catalog_uri text,
+											 namespace text,
+											 table_name text)
+	RETURNS SETOF record
+	LANGUAGE C STRICT
+	AS 'MODULE_PATHNAME', 'pgcolumnar_iceberg_rest_scan';
+
+COMMENT ON FUNCTION pgcolumnar.iceberg_rest_scan(text, text, text)
+	IS 'read a table named by an Iceberg REST catalog at its current snapshot; supply a column definition list, as for iceberg_scan; the metadata location is resolved through the catalog and read like any other Iceberg table (#388)';
+
+CREATE FUNCTION pgcolumnar.iceberg_rest_namespaces(catalog_uri text)
+	RETURNS SETOF text
+	LANGUAGE C STRICT
+	AS 'MODULE_PATHNAME', 'pgcolumnar_iceberg_rest_namespaces';
+
+COMMENT ON FUNCTION pgcolumnar.iceberg_rest_namespaces(text)
+	IS 'list the namespaces of an Iceberg REST catalog, one per row, multi-level namespaces dot-joined (#388)';
+
+CREATE FUNCTION pgcolumnar.iceberg_rest_tables(catalog_uri text, namespace text)
+	RETURNS SETOF text
+	LANGUAGE C STRICT
+	AS 'MODULE_PATHNAME', 'pgcolumnar_iceberg_rest_tables';
+
+COMMENT ON FUNCTION pgcolumnar.iceberg_rest_tables(text, text)
+	IS 'list the table names in a namespace of an Iceberg REST catalog, one per row (#388)';
+
 /* ---------------------------------------------------------------------------
  * Parquet foreign-data wrapper (Phase G)
  *

--- a/src/columnar_iceberg.c
+++ b/src/columnar_iceberg.c
@@ -45,6 +45,7 @@
 
 #include "columnar_avro.h"
 #include "columnar_puffin.h"
+#include "columnar_iceberg.h"
 #include "columnar_objstore.h"
 #include "columnar_parquet_reader.h"
 
@@ -2046,47 +2047,16 @@ ice_eq_probe(IceScanCtx *c, IceEntry *d, List *elig,
 	return (int64) ord;
 }
 
-PG_FUNCTION_INFO_V1(pgcolumnar_iceberg_scan);
-
 /*
- * pgcolumnar.iceberg_scan(metadata_path text) returns setof record
- *
- * Read an Apache Iceberg table at its current snapshot. The caller supplies a
- * column definition list; each output column name is resolved to a field id via
- * the table's current schema, and every live data file is read projected by
- * those ids -- so a data file written before a column rename still reads, since
- * Iceberg selects columns by id, not name or position.
- *
- * Row-level deletes are applied, each kind under its own spec rule:
- *
- * - Position deletes drop the listed row ordinals of the data file they name,
- *   when the data file's data sequence number is less than OR EQUAL TO the
- *   delete's (a position delete applies to data written in the same commit or
- *   earlier, so the same-sequence upsert case counts).
- * - v3 deletion vectors (Puffin files) are position deletes in bitmap form:
- *   the same <= sequence rule, scoped to their referenced_data_file. An
- *   applicable DV SUPERSEDES position-delete files for its data file (the
- *   spec's scope rule; the writer folded their deletes into it). At most one
- *   DV may reference a data file; deletion vectors are refused below
- *   format-version 3.
- * - Equality deletes drop every data row whose equality_ids column values match
- *   a delete row (all columns equal; null matches null), when the data file's
- *   sequence number is STRICTLY LESS THAN the delete's (an equality delete
- *   never touches same-commit data). An unpartitioned-spec equality delete is
- *   global; a partition-scoped one applies only to a data file whose partition
- *   (spec id and tuple) equals the delete's, comparing the stored transformed
- *   partition tuples (phase 5). A partition-scoped delete matching no data
- *   file's spec, or carrying an uncomparable partition value, is refused.
- *
- * Only PARQUET files are read. Superuser / pg_read_server_files;
- * materialize-mode SRF.
+ * The body of iceberg_scan, factored (#388 phase 7) so the REST catalog client
+ * reads a table it resolved by name through the very same path. `path` is a
+ * metadata.json location (local or remote), `tupdesc` the caller's column
+ * definition list; the rows land in a materialize-mode tuplestore on `rsinfo`.
  */
-Datum
-pgcolumnar_iceberg_scan(PG_FUNCTION_ARGS)
+void
+PgColumnarIcebergScanInto(const char *path, TupleDesc tupdesc,
+						  ReturnSetInfo *rsinfo)
 {
-	char	   *path = text_to_cstring(PG_GETARG_TEXT_PP(0));
-	ReturnSetInfo *rsinfo = (ReturnSetInfo *) fcinfo->resultinfo;
-	TupleDesc	tupdesc;
 	MemoryContext oldcxt;
 	IceScanCtx	ctx;
 	char	   *json;
@@ -2097,21 +2067,6 @@ pgcolumnar_iceberg_scan(PG_FUNCTION_ARGS)
 	List	   *dvdels;
 	List	   *eqdels;
 	ListCell   *lc;
-
-	if (!has_privs_of_role(GetUserId(), ROLE_PG_READ_SERVER_FILES))
-		ereport(ERROR,
-				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-				 errmsg("must be superuser or a member of the pg_read_server_files role to read a server file")));
-	if (rsinfo == NULL || !IsA(rsinfo, ReturnSetInfo) ||
-		(rsinfo->allowedModes & SFRM_Materialize) == 0)
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("set-valued function called in a context that cannot accept a set")));
-	if (get_call_result_type(fcinfo, NULL, &tupdesc) != TYPEFUNC_COMPOSITE)
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("pgcolumnar.iceberg_scan requires a column definition list"),
-				 errhint("Call it as SELECT * FROM pgcolumnar.iceberg_scan(path) AS t(col1 type1, ...).")));
 
 	/* map output column names -> field ids via the table's current schema */
 	json = ice_slurp_text(path);
@@ -2341,5 +2296,65 @@ pgcolumnar_iceberg_scan(PG_FUNCTION_ARGS)
 
 	MemoryContextDelete(ctx.filectx);
 	ExecDropSingleTupleTableSlot(ctx.slot);
+}
+
+PG_FUNCTION_INFO_V1(pgcolumnar_iceberg_scan);
+
+/*
+ * pgcolumnar.iceberg_scan(metadata_path text) returns setof record
+ *
+ * Read an Apache Iceberg table at its current snapshot. The caller supplies a
+ * column definition list; each output column name is resolved to a field id via
+ * the table's current schema, and every live data file is read projected by
+ * those ids -- so a data file written before a column rename still reads, since
+ * Iceberg selects columns by id, not name or position.
+ *
+ * Row-level deletes are applied, each kind under its own spec rule:
+ *
+ * - Position deletes drop the listed row ordinals of the data file they name,
+ *   when the data file's data sequence number is less than OR EQUAL TO the
+ *   delete's (a position delete applies to data written in the same commit or
+ *   earlier, so the same-sequence upsert case counts).
+ * - v3 deletion vectors (Puffin files) are position deletes in bitmap form:
+ *   the same <= sequence rule, scoped to their referenced_data_file. An
+ *   applicable DV SUPERSEDES position-delete files for its data file (the
+ *   spec's scope rule; the writer folded their deletes into it). At most one
+ *   DV may reference a data file; deletion vectors are refused below
+ *   format-version 3.
+ * - Equality deletes drop every data row whose equality_ids column values match
+ *   a delete row (all columns equal; null matches null), when the data file's
+ *   sequence number is STRICTLY LESS THAN the delete's (an equality delete
+ *   never touches same-commit data). An unpartitioned-spec equality delete is
+ *   global; a partition-scoped one applies only to a data file whose partition
+ *   (spec id and tuple) equals the delete's, comparing the stored transformed
+ *   partition tuples (phase 5). A partition-scoped delete matching no data
+ *   file's spec, or carrying an uncomparable partition value, is refused.
+ *
+ * Only PARQUET files are read. Superuser / pg_read_server_files;
+ * materialize-mode SRF.
+ */
+Datum
+pgcolumnar_iceberg_scan(PG_FUNCTION_ARGS)
+{
+	char	   *path = text_to_cstring(PG_GETARG_TEXT_PP(0));
+	ReturnSetInfo *rsinfo = (ReturnSetInfo *) fcinfo->resultinfo;
+	TupleDesc	tupdesc;
+
+	if (!has_privs_of_role(GetUserId(), ROLE_PG_READ_SERVER_FILES))
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 errmsg("must be superuser or a member of the pg_read_server_files role to read a server file")));
+	if (rsinfo == NULL || !IsA(rsinfo, ReturnSetInfo) ||
+		(rsinfo->allowedModes & SFRM_Materialize) == 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("set-valued function called in a context that cannot accept a set")));
+	if (get_call_result_type(fcinfo, NULL, &tupdesc) != TYPEFUNC_COMPOSITE)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("pgcolumnar.iceberg_scan requires a column definition list"),
+				 errhint("Call it as SELECT * FROM pgcolumnar.iceberg_scan(path) AS t(col1 type1, ...).")));
+
+	PgColumnarIcebergScanInto(path, tupdesc, rsinfo);
 	return (Datum) 0;
 }

--- a/src/columnar_iceberg.h
+++ b/src/columnar_iceberg.h
@@ -1,0 +1,22 @@
+/*-------------------------------------------------------------------------
+ * columnar_iceberg.h
+ *		Internal interface to the Iceberg reader (#388).
+ *-------------------------------------------------------------------------
+ */
+#ifndef COLUMNAR_ICEBERG_H
+#define COLUMNAR_ICEBERG_H
+
+#include "funcapi.h"
+#include "access/tupdesc.h"
+
+/*
+ * Read the Iceberg table whose current metadata.json is at `path` (a local or
+ * remote URI) into a materialize-mode tuplestore on `rsinfo`, projecting the
+ * columns named by `tupdesc`. This is the body of iceberg_scan, shared with the
+ * REST catalog client, which resolves a table by name into a metadata location
+ * and reads it through the same path. Raises on any failure.
+ */
+extern void PgColumnarIcebergScanInto(const char *path, TupleDesc tupdesc,
+									  ReturnSetInfo *rsinfo);
+
+#endif							/* COLUMNAR_ICEBERG_H */

--- a/src/columnar_iceberg_rest.c
+++ b/src/columnar_iceberg_rest.c
@@ -22,15 +22,49 @@
 #include "postgres.h"
 
 #include "catalog/pg_authid_d.h"
+#include "catalog/pg_type_d.h"
 #include "fmgr.h"
 #include "lib/stringinfo.h"
 #include "miscadmin.h"
 #include "utils/acl.h"
 #include "utils/builtins.h"
 #include "utils/jsonb.h"
+#include "utils/tuplestore.h"
 
+#include "funcapi.h"
+#include "columnar_iceberg.h"
 #include "columnar_objstore.h"
 #include "columnar_iceberg_rest.h"
+
+/*
+ * Set up a materialize-mode SRF returning a single text column, and return its
+ * tuplestore. Used by the listing functions, which return SETOF text (a scalar
+ * return type InitMaterializedSRF does not build a tupdesc for).
+ */
+static Tuplestorestate *
+rest_text_srf_setup(ReturnSetInfo *rsinfo, TupleDesc *tdout)
+{
+	Tuplestorestate *ts;
+	TupleDesc	td;
+	MemoryContext oldcxt;
+
+	if (rsinfo == NULL || !IsA(rsinfo, ReturnSetInfo) ||
+		(rsinfo->allowedModes & SFRM_Materialize) == 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("set-valued function called in a context that cannot accept a set")));
+
+	oldcxt = MemoryContextSwitchTo(rsinfo->econtext->ecxt_per_query_memory);
+	td = CreateTemplateTupleDesc(1);
+	TupleDescInitEntry(td, 1, "name", TEXTOID, -1, 0);
+	ts = tuplestore_begin_heap(false, false, work_mem);
+	rsinfo->returnMode = SFRM_Materialize;
+	rsinfo->setResult = ts;
+	rsinfo->setDesc = td;
+	MemoryContextSwitchTo(oldcxt);
+	*tdout = td;
+	return ts;
+}
 
 /*
  * A catalog reply is small (a metadata-location plus, for now, an ignored inline
@@ -288,4 +322,181 @@ pgcolumnar_iceberg_rest_table_location(PG_FUNCTION_ARGS)
 
 	loc = PgColumnarIcebergRestLoadTableLocation(catalog_uri, ns, table);
 	PG_RETURN_TEXT_P(cstring_to_text(loc));
+}
+
+PG_FUNCTION_INFO_V1(pgcolumnar_iceberg_rest_scan);
+
+/*
+ * SQL: iceberg_rest_scan(catalog_uri, namespace, table_name) RETURNS SETOF
+ * record. Resolve the table's current metadata-location through the catalog,
+ * then read it through the very same path as iceberg_scan (a resolved remote
+ * location reads because the reader is remote-capable). Superuser /
+ * pg_read_server_files, materialize-mode SRF, column definition list required.
+ */
+Datum
+pgcolumnar_iceberg_rest_scan(PG_FUNCTION_ARGS)
+{
+	char	   *catalog_uri = text_to_cstring(PG_GETARG_TEXT_PP(0));
+	char	   *ns = text_to_cstring(PG_GETARG_TEXT_PP(1));
+	char	   *table = text_to_cstring(PG_GETARG_TEXT_PP(2));
+	ReturnSetInfo *rsinfo = (ReturnSetInfo *) fcinfo->resultinfo;
+	TupleDesc	tupdesc;
+	char	   *loc;
+
+	if (!has_privs_of_role(GetUserId(), ROLE_PG_READ_SERVER_FILES))
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 errmsg("must be superuser or a member of the pg_read_server_files role to read a REST catalog")));
+	if (rsinfo == NULL || !IsA(rsinfo, ReturnSetInfo) ||
+		(rsinfo->allowedModes & SFRM_Materialize) == 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("set-valued function called in a context that cannot accept a set")));
+	if (get_call_result_type(fcinfo, NULL, &tupdesc) != TYPEFUNC_COMPOSITE)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("pgcolumnar.iceberg_rest_scan requires a column definition list"),
+				 errhint("Call it as SELECT * FROM pgcolumnar.iceberg_rest_scan(uri, ns, tbl) AS t(col1 type1, ...).")));
+
+	loc = PgColumnarIcebergRestLoadTableLocation(catalog_uri, ns, table);
+	/*
+	 * A metadata-location is a URI. The reader's remote path handles s3:// and
+	 * http(s)://; a file:// location is a local path, and the local read path
+	 * opens a bare filename, so strip the scheme here.
+	 */
+	if (pg_strncasecmp(loc, "file://", 7) == 0)
+		loc += 7;
+	PgColumnarIcebergScanInto(loc, tupdesc, rsinfo);
+	return (Datum) 0;
+}
+
+PG_FUNCTION_INFO_V1(pgcolumnar_iceberg_rest_namespaces);
+
+/*
+ * SQL: iceberg_rest_namespaces(catalog_uri) RETURNS SETOF text. One row per
+ * namespace; a multi-level namespace is dot-joined.
+ */
+Datum
+pgcolumnar_iceberg_rest_namespaces(PG_FUNCTION_ARGS)
+{
+	char	   *catalog_uri = text_to_cstring(PG_GETARG_TEXT_PP(0));
+	ReturnSetInfo *rsinfo = (ReturnSetInfo *) fcinfo->resultinfo;
+	Tuplestorestate *ts;
+	TupleDesc	td;
+	Jsonb	   *doc;
+	JsonbValue	vbuf;
+	JsonbValue *nsv;
+	uint32		n;
+	uint32		i;
+
+	if (!has_privs_of_role(GetUserId(), ROLE_PG_READ_SERVER_FILES))
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 errmsg("must be superuser or a member of the pg_read_server_files role to read a REST catalog")));
+	ts = rest_text_srf_setup(rsinfo, &td);
+
+	doc = rest_get_json(catalog_uri, "/v1/namespaces", "namespaces");
+	if (!JsonContainerIsObject(&doc->root))
+		ereport(ERROR,
+				(errcode(ERRCODE_DATA_CORRUPTED),
+				 errmsg("iceberg: the REST catalog namespaces response is not a JSON object")));
+	nsv = getKeyJsonValueFromContainer(&doc->root, "namespaces", 10, &vbuf);
+	if (nsv == NULL || nsv->type != jbvBinary ||
+		!JsonContainerIsArray(nsv->val.binary.data))
+		return (Datum) 0;		/* no namespaces */
+
+	/* each element is itself an array of level strings; dot-join them */
+	n = JsonContainerSize(nsv->val.binary.data);
+	for (i = 0; i < n; i++)
+	{
+		JsonbValue *lv = getIthJsonbValueFromContainer(nsv->val.binary.data, i);
+		StringInfoData name;
+		uint32		nlev;
+		uint32		j;
+		Datum		values[1];
+		bool		nulls[1] = {false};
+
+		if (lv == NULL || lv->type != jbvBinary ||
+			!JsonContainerIsArray(lv->val.binary.data))
+			continue;
+		initStringInfo(&name);
+		nlev = JsonContainerSize(lv->val.binary.data);
+		for (j = 0; j < nlev; j++)
+		{
+			JsonbValue *pv = getIthJsonbValueFromContainer(lv->val.binary.data, j);
+
+			if (pv == NULL || pv->type != jbvString)
+				continue;
+			if (name.len > 0)
+				appendStringInfoChar(&name, '.');
+			appendBinaryStringInfo(&name, pv->val.string.val, pv->val.string.len);
+		}
+		values[0] = PointerGetDatum(cstring_to_text_with_len(name.data, name.len));
+		tuplestore_putvalues(ts, td, values, nulls);
+		pfree(name.data);
+	}
+	return (Datum) 0;
+}
+
+PG_FUNCTION_INFO_V1(pgcolumnar_iceberg_rest_tables);
+
+/*
+ * SQL: iceberg_rest_tables(catalog_uri, namespace) RETURNS SETOF text. One row
+ * per table name in the namespace.
+ */
+Datum
+pgcolumnar_iceberg_rest_tables(PG_FUNCTION_ARGS)
+{
+	char	   *catalog_uri = text_to_cstring(PG_GETARG_TEXT_PP(0));
+	char	   *ns = text_to_cstring(PG_GETARG_TEXT_PP(1));
+	ReturnSetInfo *rsinfo = (ReturnSetInfo *) fcinfo->resultinfo;
+	Tuplestorestate *ts;
+	TupleDesc	td;
+	StringInfoData rp;
+	Jsonb	   *doc;
+	JsonbValue	vbuf;
+	JsonbValue *idv;
+	uint32		n;
+	uint32		i;
+
+	if (!has_privs_of_role(GetUserId(), ROLE_PG_READ_SERVER_FILES))
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 errmsg("must be superuser or a member of the pg_read_server_files role to read a REST catalog")));
+	ts = rest_text_srf_setup(rsinfo, &td);
+
+	initStringInfo(&rp);
+	appendStringInfoString(&rp, "/v1/namespaces/");
+	rest_append_namespace(&rp, ns);
+	appendStringInfoString(&rp, "/tables");
+	doc = rest_get_json(catalog_uri, rp.data, "table list");
+	if (!JsonContainerIsObject(&doc->root))
+		ereport(ERROR,
+				(errcode(ERRCODE_DATA_CORRUPTED),
+				 errmsg("iceberg: the REST catalog table-list response is not a JSON object")));
+	idv = getKeyJsonValueFromContainer(&doc->root, "identifiers", 11, &vbuf);
+	if (idv == NULL || idv->type != jbvBinary ||
+		!JsonContainerIsArray(idv->val.binary.data))
+		return (Datum) 0;		/* no tables */
+
+	n = JsonContainerSize(idv->val.binary.data);
+	for (i = 0; i < n; i++)
+	{
+		JsonbValue *e = getIthJsonbValueFromContainer(idv->val.binary.data, i);
+		JsonbValue	nbuf;
+		JsonbValue *nm;
+		Datum		values[1];
+		bool		nulls[1] = {false};
+
+		if (e == NULL || e->type != jbvBinary ||
+			!JsonContainerIsObject(e->val.binary.data))
+			continue;
+		nm = getKeyJsonValueFromContainer(e->val.binary.data, "name", 4, &nbuf);
+		if (nm == NULL || nm->type != jbvString)
+			continue;
+		values[0] = PointerGetDatum(cstring_to_text_with_len(nm->val.string.val,
+															 nm->val.string.len));
+		tuplestore_putvalues(ts, td, values, nulls);
+	}
+	return (Datum) 0;
 }

--- a/test/entry_point_privilege.sh
+++ b/test/entry_point_privilege.sh
@@ -56,6 +56,8 @@ SQLFILE="$(dirname "${BASH_SOURCE[0]}")/../pgcolumnar--1.0-alpha.sql"
 #   iceberg_scan           reads an Iceberg table's FILES, server-file role (#388)
 #   read_avro_manifest     reads an Avro FILE, gated by the server-file role (#388)
 #   iceberg_rest_table_location  reads an external REST catalog, server-file role (#388 phase 7)
+#   iceberg_rest_scan      reads a REST-cataloged table's FILES, server-file role (#388 phase 7)
+#   iceberg_rest_namespaces / iceberg_rest_tables  list a REST catalog, server-file role (#388 phase 7)
 #   read_manifest_list     reads an Avro FILE, gated by the server-file role (#388)
 #
 # Kept on ONE line and matched after whitespace normalisation. A multi-line list
@@ -63,7 +65,7 @@ SQLFILE="$(dirname "${BASH_SOURCE[0]}")/../pgcolumnar--1.0-alpha.sql"
 # line end is followed by a newline rather than a space, so it silently fails to
 # match and reads as an unbucketed function. That is not hypothetical: it is what
 # the first run of this suite reported for parquet_fdw_validator.
-EXEMPT="columnar_handler parquet_fdw_handler parquet_fdw_validator parquet_schema read_parquet file_split_offsets iceberg_current_snapshot iceberg_data_files iceberg_scan iceberg_rest_table_location read_avro_manifest read_manifest_list"
+EXEMPT="columnar_handler parquet_fdw_handler parquet_fdw_validator parquet_schema read_parquet file_split_offsets iceberg_current_snapshot iceberg_data_files iceberg_scan iceberg_rest_table_location iceberg_rest_scan iceberg_rest_namespaces iceberg_rest_tables read_avro_manifest read_manifest_list"
 EXEMPT="$(echo $EXEMPT)"
 
 # Relation-taking entry points with NO privilege check of any kind on main.

--- a/test/iceberg_rest_scan.sh
+++ b/test/iceberg_rest_scan.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+# pgColumnar Iceberg REST catalog read + listing, 7b (#388 phase 7). 7a resolved
+# a table named by a REST catalog to its metadata-location; 7b reads it. The
+# proof is the SAME ORACLE: iceberg_rest_scan(catalog, ns, table) must return the
+# identical rows as iceberg_scan(the metadata path the catalog reports), so the
+# REST layer is proven correct by returning identical rows -- the catalog changes
+# how the table is NAMED, never the rows. Plus namespace/table listing.
+#
+# The hermetic fixture (test/iceberg_rest_server.py) points loadTable at the
+# committed warehouse, relocated into the work dir and served as a file:// URI,
+# and verifies the Authorization: Bearer header. The token is read from the
+# server environment (PGCOLUMNAR_ICEBERG_REST_TOKEN), never a SQL argument.
+#
+# Usage:  test/iceberg_rest_scan.sh [PG_CONFIG]
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+python3 -c 'import json' 2>/dev/null || pgc_skip python "python3 is needed"
+MODDIR="$("$PGC_PG_CONFIG" --pkglibdir)"
+[ -f "$MODDIR/pgcolumnar_objstore.so" ] \
+	|| pgc_skip objstore "the object-store module is not installed"
+
+FX="$(dirname "${BASH_SOURCE[0]}")/fixtures/iceberg"
+WH="$FX/warehouse"
+[ -f "$(ls "$WH"/db/events/data/*/*.parquet 2>/dev/null | head -1)" ] \
+	|| pgc_skip fixture "iceberg warehouse data files are missing"
+
+# relocate the warehouse into the work dir; that metadata.json is what the
+# catalog will report as the table's current metadata-location.
+DEST="$PGC_WORKDIR/wh"
+rm -rf "$DEST"; mkdir -p "$DEST"
+cp -r "$WH/db" "$DEST/db"
+chmod -R u+rwX "$DEST"
+MD="$(ls "$DEST"/db/events/metadata/*.metadata.json | sort | tail -1)"
+MDLOC="file://$MD"
+
+TOKEN="rest-scan-token-shh"
+REST_PORT="$(pgc_pick_free_port "$PGC_AUX_PORT_LO" "$PGC_AUX_PORT_HI")"
+REST_LOG="$PGC_WORKDIR/rest.log"
+SRV_PID=""
+
+rest_teardown() {
+	[ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null
+	pgc_teardown
+}
+trap rest_teardown EXIT INT TERM
+
+pg_restart_env() {
+	pgc_pg "pg_ctl -D '$PGC_PGDATA' stop -m fast -w" >/dev/null 2>&1
+	pgc_pg "$* pg_ctl -D '$PGC_PGDATA' -l '$PGC_LOGFILE' start -w" >/dev/null 2>&1
+	for _ in $(seq 1 30); do [ -n "$(q 'SELECT 1')" ] && return 0; sleep 0.5; done
+	echo "FATAL: cluster did not come back after env restart"; exit 1
+}
+
+python3 "$(dirname "${BASH_SOURCE[0]}")/iceberg_rest_server.py" \
+	--port "$REST_PORT" --log "$REST_LOG" --token "$TOKEN" \
+	--namespace db --table events \
+	--metadata-location "$MDLOC" \
+	> "$PGC_WORKDIR/rest_server.out" 2>&1 &
+SRV_PID=$!
+for _ in $(seq 1 50); do grep -q READY "$PGC_WORKDIR/rest_server.out" 2>/dev/null && break; sleep 0.1; done
+check "premise: rest fixture server is up" \
+	"$(grep -c READY "$PGC_WORKDIR/rest_server.out" 2>/dev/null)" "1"
+
+CAT="http://127.0.0.1:$REST_PORT"
+pg_restart_env "PGCOLUMNAR_ICEBERG_REST_TOKEN='$TOKEN'"
+q "ALTER SYSTEM SET pgcolumnar.objstore_allowed_endpoints = '127.0.0.1'" >/dev/null
+q "SELECT pg_reload_conf()" >/dev/null
+
+# ---- premise: the location the catalog reports is the relocated metadata -----
+check "the catalog reports the relocated metadata location" \
+	"$(q "SELECT pgcolumnar.iceberg_rest_table_location('$CAT','db','events')")" \
+	"$MDLOC"
+
+# ---- SAME ORACLE: REST read == direct iceberg_scan of that metadata ----------
+DIRECT="$(q "SELECT id || '|' || region || '|' || amount
+             FROM pgcolumnar.iceberg_scan('$MD') AS t(id bigint, region text, amount int)
+             ORDER BY id")"
+VIA_REST="$(q "SELECT id || '|' || region || '|' || amount
+               FROM pgcolumnar.iceberg_rest_scan('$CAT','db','events') AS t(id bigint, region text, amount int)
+               ORDER BY id")"
+check "iceberg_rest_scan returns the five current-snapshot rows" \
+	"$VIA_REST" "$(printf '1|eu|10\n2|eu|20\n3|us|30\n4|us|40\n5|us|50')"
+check_text "iceberg_rest_scan matches iceberg_scan of the same table (same oracle)" \
+	"$VIA_REST" "$DIRECT"
+
+# ---- projection by field id flows through the REST path ----------------------
+check "iceberg_rest_scan projects and reorders by field id (amount, id)" \
+	"$(q "SELECT amount || '|' || id
+	      FROM pgcolumnar.iceberg_rest_scan('$CAT','db','events') AS t(amount int, id bigint)
+	      ORDER BY id")" \
+	"$(printf '10|1\n20|2\n30|3\n40|4\n50|5')"
+
+# ---- listing ----------------------------------------------------------------
+check "iceberg_rest_namespaces lists the catalog's namespaces" \
+	"$(q "SELECT string_agg(ns, ',' ORDER BY ns) FROM pgcolumnar.iceberg_rest_namespaces('$CAT') AS ns")" \
+	"db"
+check "iceberg_rest_tables lists a namespace's tables" \
+	"$(q "SELECT string_agg(t, ',' ORDER BY t) FROM pgcolumnar.iceberg_rest_tables('$CAT','db') AS t")" \
+	"events"
+
+# ---- an unknown table surfaces the catalog 404 cleanly through the read ------
+sqlstate_of() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -qtA 2>&1 <<SQLEOF | sed -n 's/^ERROR:  \([0-9A-Z]\{5\}\).*/\1/p' | head -1
+\\set VERBOSITY sqlstate
+$1;
+SQLEOF
+}
+check "iceberg_rest_scan of an unknown table is a clean not-found (42P01)" \
+	"$(sqlstate_of "SELECT * FROM pgcolumnar.iceberg_rest_scan('$CAT','db','nosuch') AS t(id bigint)")" \
+	"42P01"
+
+check "backend still up after the REST read" "$(q 'SELECT 1')" "1"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -91,6 +91,7 @@ SUITES=(
 	iceberg_name_mapping
 	iceberg_objstore
 	iceberg_rest
+	iceberg_rest_scan
 	iceberg_scan
 	import_deferred
 	import_exclusion


### PR DESCRIPTION
Phase 7 (Iceberg REST catalog), second increment, on top of the merged 7a. Design: `design/ISSUE_388_PHASE7_REST_CATALOG.md`.

## What this adds
7a resolved a table named by a REST catalog to its metadata-location. 7b reads it and lists the catalog.

- **`iceberg_rest_scan(catalog_uri, namespace, table_name) RETURNS SETOF record`** — resolves the table through the catalog, then reads its metadata-location through the **same path as `iceberg_scan`** (a resolved remote location reads because the reader has been remote-capable since phase 6). Takes a column definition list exactly like `iceberg_scan`; every field-id projection and delete rule applies unchanged.
- **`iceberg_rest_namespaces(catalog_uri)`** / **`iceberg_rest_tables(catalog_uri, namespace)`** `RETURNS SETOF text` — list a catalog.

## Factoring
The body of `iceberg_scan` is extracted into `PgColumnarIcebergScanInto` (new `src/columnar_iceberg.h`) so the filesystem SRF and the REST scan read through one path; the SRF is now a thin privilege/tupdesc wrapper. `iceberg_scan` is behaviorally unchanged — its suite passes 7/7.

## Notes for review
- A `file://` metadata-location is stripped to a bare path before the local read (the local read path opens a filename; `s3://` and `http(s)://` go through the reader’s remote path unchanged). Real catalogs return `s3://`.
- The listing functions build a one-column text tuplestore by hand (`InitMaterializedSRF` does not build a tupdesc for a `SETOF` scalar) and walk the catalog JSON with an **object/array guard at every step** — applying the 7a lesson (the #644 array-vs-object class) to every new jsonb access.
- All three new entry points are added to `entry_point_privilege.sh` EXEMPT (external-catalog reads, `pg_read_server_files`, no path-text arg) — the coverage class you flagged on 7a. I ran it this time.

## Proof
`test/iceberg_rest_scan.sh` (9 checks) — the **same oracle**: `iceberg_rest_scan` returns the identical rows as `iceberg_scan` of the metadata path the catalog reports (`check_text`, which refuses an empty side), plus field-id projection, namespace/table listing, and a 404-as-42P01 read.

- **Removal proof**: dropping the `file://` strip reds the read arms, and `check_text` catches the empty side — proving the same-oracle instrument is fair.
- **Gates**: 9/9 (`iceberg_rest_scan`) + 7/7 (`iceberg_scan` regression) + 31/31 (`entry_point_privilege`) on PG17, PG18, PG19, clean under `pg18_san` ASAN+UBSAN, `docs_style`/STE clean, `harness_selftest` green.

## Follow-up
Foreign-server credentials, vended storage creds, and OAuth2 exchange remain in **#656**. This is the last planned read-side increment for the REST catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)