### PR TITLE
feat: Iceberg REST catalog vended storage credentials (#656)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,12 @@ which was true until that script existed.
   second TLS stack enters the server process. A bearer token, when the catalog
   requires one, is read from the `PGCOLUMNAR_ICEBERG_REST_TOKEN` server
   environment variable, never a function argument, so it does not appear in the
-  statement log. See
+  statement log. When the catalog vends short-lived storage credentials in its
+  `loadTable` reply (the flat `config` keys or the `storage-credentials` array,
+  longest prefix selected), `iceberg_rest_scan` reads the table's files with
+  those credentials rather than the server environment (#656). Vended
+  credentials do not bypass the endpoint allow-list. A table that vends none
+  reads with the ambient environment as before. See
   [Iceberg REST catalog](docs/sql-reference.md#pgcolumnariceberg_rest_scancatalog_uri-text-namespace-text-table_name-text-returns-setof-record).
 
 - The Parquet read and export functions and the foreign-data wrapper read from

--- a/design/ISSUE_656_VENDED_CREDENTIALS.md
+++ b/design/ISSUE_656_VENDED_CREDENTIALS.md
@@ -1,0 +1,142 @@
+# Issue #656 (part 1) — Iceberg REST catalog vended storage credentials
+
+Status: DESIGN. Extends #388 phase 7 (REST catalog read, merged #657/#658).
+Tracked under #656 (the credential-model follow-up). This part delivers **vended
+credentials**: reading a REST-cataloged table's data with the short-lived,
+scoped storage credentials the catalog issues, instead of the ambient
+server-environment credentials phase 7 falls back to.
+
+## Why this is the next increment
+
+Phase 7 reads a REST-cataloged table's data files with the **ambient** objstore
+credentials (`AWS_*` in the server environment), documented as a deliberate
+first-cut limitation. That works for a single-tenant server whose environment
+holds credentials for the bucket, but it is exactly what a real REST catalog
+exists to avoid: the catalog issues **per-table, short-lived, least-privilege**
+credentials at `loadTable` time, so a reader never needs standing bucket
+credentials in its environment. Without vended credentials, the REST catalog
+support cannot read a table in a cloud account the server has no ambient
+credentials for, which is the common deployment.
+
+## The Iceberg REST vended-credential shapes
+
+`loadTable` (and `loadCredentials`) responses can carry storage credentials two
+ways (both in the OpenAPI spec):
+
+1. **Flat `config` map** (Tabular/Polaris style), keys the client reads:
+   - `s3.access-key-id`, `s3.secret-access-key`, `s3.session-token`
+   - `s3.region` (or `client.region`), `s3.endpoint`
+   These are the SigV4 credential triple plus endpoint/region. The client signs
+   its own S3 requests with them (vended credentials do NOT remove SigV4; only
+   the separate remote-signing mode does, which is out of scope).
+
+2. **`storage-credentials` array** (newer spec): `[{ "prefix": "s3://bucket/db/t",
+   "config": { "s3.access-key-id": ..., ... } }]` — per-prefix credentials, so a
+   table spanning locations can carry more than one. The client picks the entry
+   whose `prefix` is the longest match for the file being read.
+
+Scope for this increment: support **both**, preferring `storage-credentials`
+(longest-prefix match) and falling back to the flat `config` keys. A location
+matched by neither, on a table that vended any credentials, is read with the
+matched/flat vended set; a table that vended nothing keeps the phase-7 ambient
+behavior.
+
+## Credential model and security
+
+- Build a `PgColumnarObjStoreConfig` from the vended keys:
+  `endpoint = s3.endpoint`, `region = s3.region|client.region`,
+  `akid = s3.access-key-id`, `secret = s3.secret-access-key`,
+  `token = s3.session-token`, **`allow_ambient = false`**.
+- `allow_ambient = false` is deliberate: once a catalog vends credentials, a
+  data read must use them, never silently fall back to the server's ambient
+  identity (that would broaden access beyond what the catalog scoped, and hide a
+  misconfiguration). A table that vends **no** credentials passes `cfg = NULL`,
+  which is the existing ambient path.
+- The vended secret lives only in backend memory for the duration of the scan,
+  is never logged (the objstore module already keeps `cfg->secret` out of every
+  error message), and never crosses into the catalog request log. It arrives
+  over the already-authenticated, allow-listed catalog connection.
+- The **endpoint the vended creds point at is still subject to the allow-list**:
+  the objstore `open()` runs `os_check_endpoint_allowed` + the link-local
+  refusal regardless of `cfg`, so a catalog cannot vend credentials for an
+  internal host and have the reader connect to it. Vended creds change *who* the
+  request is signed as, never *whether the endpoint is allowed*.
+
+## The threading problem (crux — finalize against the seam investigation)
+
+Today `PgColumnarIcebergScanInto` and `ice_slurp_remote` reach the objstore
+`open()` with `cfg = NULL`. Vended credentials require a caller-supplied
+`const PgColumnarObjStoreConfig *` to flow from the REST scan down to every
+objstore `open()` for that table's metadata, manifests, data, and delete files.
+
+Seam investigation result: the objstore `open()`/`list_objects()` already take a
+`cfg`; the two internal helpers `pq_source_open_cfg` and `pq_resolve_paths`
+already thread it, and the FDW already passes a non-NULL `st->oscfg` through
+them. But the **public parquet entries and the iceberg slurp helpers have no
+`cfg` parameter at all** — every iceberg remote read is hardwired to NULL. So the
+change is purely additive threading:
+
+- Carry one `const PgColumnarObjStoreConfig *cfg` on **`IceScanCtx`**, set once in
+  `PgColumnarIcebergScanInto`. It already reaches every delete/data reader via
+  `ctx`/`c`, so only the leaf calls change.
+- Add a trailing `cfg` param to: `PgColumnarReadParquetByFieldId` and
+  `...NM` (down through `pq_read_file_into` to `pq_source_open_cfg`, replacing the
+  hardwired-NULL `pq_source_open`); and to `ice_slurp_remote` / `ice_slurp_text` /
+  `ice_slurp_bin` / `ice_walk_data_files` (down to `ice_slurp_remote`'s
+  `api->open`).
+- Add a trailing `cfg` param to `PgColumnarIcebergScanInto`.
+- **Every existing caller passes `NULL`**: the filesystem `iceberg_scan`,
+  `iceberg_current_snapshot`, `iceberg_data_files`, `read_parquet`, and any native
+  reader — byte-identical ambient behavior, proven by the existing suites. The
+  FDW is untouched (separate route). Only `iceberg_rest_scan` passes a real cfg.
+
+Header note: `columnar_parquet_reader.h` includes `columnar_objstore.h` for the
+`PgColumnarObjStoreConfig` type.
+
+**Single table-wide cfg (this increment).** The cfg is resolved once from the
+`loadTable` reply: prefer the `storage-credentials` entry whose `prefix` is the
+longest match for the table's metadata-location, else the flat `config` keys.
+Per-file multiple-credential resolution (a table whose files span locations with
+different vended sets) is rare and deferred; the best-matching single set is used
+table-wide and the limitation is documented.
+
+## SQL surface
+
+No new SQL functions. `iceberg_rest_scan` transparently uses vended credentials
+when the catalog issues them; the behavior change is that a table the ambient
+environment could not read now reads when the catalog vends credentials for it.
+
+## Proof plan (TDD, prove-don't-trust)
+
+- **Hermetic S3 + REST fixtures together**: the REST fixture's `loadTable`
+  returns a metadata-location on the **S3 fixture** (`objstore_http_server.py`
+  with SigV4 verification) AND a `config`/`storage-credentials` block naming the
+  fixture's key id / secret / region. The postmaster environment holds **no**
+  `AWS_*` credentials (or wrong ones), so a green read PROVES the data was
+  signed with the **vended** credentials, not ambient — the SigV4 fixture
+  verifies every signature against the vended secret.
+- **Removal proof**: with the vended-cred threading neutered (pass `cfg = NULL`),
+  the read must fail (the ambient environment has no/creds-wrong), reddening the
+  arm — proving the vended path is load-bearing, not masked by ambient.
+- **Negative arm**: a table that vends a WRONG secret -> the S3 fixture 403s ->
+  a clean error (not a crash, not an ambient fallback). Establishes that a
+  present-but-wrong vended credential is used and refused, not bypassed.
+- **Ambient-still-works arm**: a table that vends nothing, with ambient creds in
+  the environment, still reads (phase-7 behavior preserved, `cfg = NULL`).
+- **`storage-credentials` longest-prefix** arm: two entries, the more specific
+  one selected for the data file's prefix.
+- **Allow-list still applies**: vended creds for an endpoint off
+  `objstore_allowed_endpoints` -> 42501 (the boundary is independent of cfg).
+- Gates: PG17/18/19 + `pg18_san` ASAN (new untrusted-JSON parse of the config +
+  a credential-lifetime path). Docs: sql-reference note + CHANGELOG. STE clean.
+
+## Non-goals (still deferred, tracked in #656)
+
+- OAuth2 client-credentials token exchange (`POST /v1/oauth/tokens`) + refresh.
+- Per-catalog `FOREIGN SERVER` + `USER MAPPING` credential storage (this
+  increment keeps the env-var bearer for the *catalog* auth; it vends *storage*
+  creds from the catalog reply).
+- Remote request signing (`s3.remote-signing-enabled`) — the catalog signs each
+  request; a distinct mechanism from vended creds.
+- Refresh of an expired vended credential mid-scan (a scan is short; re-issue on
+  the next call). Documented, not handled.

--- a/docs/sql-reference.md
+++ b/docs/sql-reference.md
@@ -822,6 +822,13 @@ field-id projection and every delete rule apply unchanged. The catalog and
 authentication rules are those of `iceberg_rest_table_location` above, including
 the allow-list, the link-local refusal, and the environment bearer token.
 
+A catalog can vend storage credentials in its `loadTable` reply. The data,
+metadata, and delete files are then read with those credentials, not the server
+environment. Both the flat `config` keys and the `storage-credentials` array are
+read, and the longest-prefix match is used. Vended credentials do not bypass the
+allow-list. The endpoint is still checked. A table that vends no credentials is
+read with the ambient environment, as before.
+
 ```sql
 SELECT region, sum(amount)
   FROM pgcolumnar.iceberg_rest_scan('https://catalog.example.com',

--- a/src/columnar_iceberg.c
+++ b/src/columnar_iceberg.c
@@ -71,7 +71,8 @@
  * module). The metadata cap bounds the object as for a local file.
  */
 static uint8 *
-ice_slurp_remote(const char *url, int64 *outlen)
+ice_slurp_remote(const char *url, int64 *outlen,
+				 const PgColumnarObjStoreConfig *cfg)
 {
 	const PgColumnarObjStoreApi *api = PgColumnarObjStoreGet();
 	PgColumnarObjHandle *h;
@@ -93,7 +94,7 @@ ice_slurp_remote(const char *url, int64 *outlen)
 				 errmsg("iceberg: reading \"%s\" is not supported", url),
 				 errdetail("The installed object-store module handles no such URL scheme.")));
 
-	h = api->open(url, NULL, &len);	/* raises on failure; len is required */
+	h = api->open(url, cfg, &len);	/* raises on failure; len is required */
 	/* the handle is module-owned and not freed on transaction abort (the module
 	 * uses explicit caller cleanup, like its sink API), so close it on any raise
 	 * between open and the normal close -- a too-large check, palloc, or a
@@ -126,14 +127,14 @@ ice_slurp_remote(const char *url, int64 *outlen)
  * http(s)://) through the object-store module.
  */
 static char *
-ice_slurp_text(const char *path)
+ice_slurp_text(const char *path, const PgColumnarObjStoreConfig *cfg)
 {
 	FILE	   *f;
 	int64		flen;
 	char	   *buf;
 
 	if (PgColumnarPathIsRemote(path))
-		return (char *) ice_slurp_remote(path, &flen);
+		return (char *) ice_slurp_remote(path, &flen, cfg);
 
 	f = AllocateFile(path, PG_BINARY_R);
 	if (f == NULL)
@@ -163,14 +164,15 @@ ice_slurp_text(const char *path)
 /* slurp a whole binary file (a manifest list, manifest, or Puffin file) into a
  * palloc'd buffer. Local via AllocateFile; remote via the object-store module. */
 static uint8 *
-ice_slurp_bin(const char *path, int64 *outlen)
+ice_slurp_bin(const char *path, int64 *outlen,
+			  const PgColumnarObjStoreConfig *cfg)
 {
 	FILE	   *f;
 	int64		flen;
 	uint8	   *buf;
 
 	if (PgColumnarPathIsRemote(path))
-		return ice_slurp_remote(path, outlen);
+		return ice_slurp_remote(path, outlen, cfg);
 
 	f = AllocateFile(path, PG_BINARY_R);
 	if (f == NULL)
@@ -641,7 +643,7 @@ pgcolumnar_iceberg_current_snapshot(PG_FUNCTION_ARGS)
 
 	tupstore = ice_srf_begin(fcinfo, &tupdesc);
 
-	json = ice_slurp_text(path);
+	json = ice_slurp_text(path, NULL);	/* introspection: ambient creds */
 	/* jsonb_in raises a clean 22P02 on malformed JSON */
 	jb = DatumGetJsonbP(DirectFunctionCall1(jsonb_in, CStringGetDatum(json)));
 
@@ -714,7 +716,8 @@ typedef void (*IceDataFileCb) (void *ctx, PgColumnarAvroManifestEntry *e,
  */
 static void
 ice_walk_data_files(const char *path, JsonbContainer *root,
-					bool collect_deletes, IceDataFileCb cb, void *ctx)
+					bool collect_deletes, IceDataFileCb cb, void *ctx,
+					const PgColumnarObjStoreConfig *cfg)
 {
 	JsonbContainer *sc;
 	int64		cur;
@@ -757,7 +760,7 @@ ice_walk_data_files(const char *path, JsonbContainer *root,
 	ml_path = ice_open_path(recorded_root, actual_root,
 							ice_str_required(sc, "manifest-list", path),
 							"manifest-list", path);
-	mlbuf = ice_slurp_bin(ml_path, &mllen);
+	mlbuf = ice_slurp_bin(ml_path, &mllen, cfg);
 	mfs = PgColumnarAvroReadManifestList(mlbuf, mllen, &nmf);
 
 	for (mi = 0; mi < nmf; mi++)
@@ -782,7 +785,7 @@ ice_walk_data_files(const char *path, JsonbContainer *root,
 
 		m_path = ice_open_path(recorded_root, actual_root, mfs[mi].manifest_path,
 							   "manifest", path);
-		mbuf = ice_slurp_bin(m_path, &mlen);
+		mbuf = ice_slurp_bin(m_path, &mlen, cfg);
 		entries = PgColumnarAvroReadManifest(mbuf, mlen, &ne);
 
 		for (ei = 0; ei < ne; ei++)
@@ -919,8 +922,8 @@ pgcolumnar_iceberg_data_files(PG_FUNCTION_ARGS)
 
 	ctx.tupstore = ice_srf_begin(fcinfo, &ctx.tupdesc);
 	jb = DatumGetJsonbP(DirectFunctionCall1(jsonb_in,
-											CStringGetDatum(ice_slurp_text(path))));
-	ice_walk_data_files(path, &jb->root, false, ice_list_cb, &ctx);
+											CStringGetDatum(ice_slurp_text(path, NULL))));
+	ice_walk_data_files(path, &jb->root, false, ice_list_cb, &ctx, NULL);
 	return (Datum) 0;
 }
 
@@ -1301,6 +1304,7 @@ typedef struct IceScanCtx
 	char	   *recorded_root;
 	char	   *actual_root;
 	char	   *mdpath;
+	const PgColumnarObjStoreConfig *cfg;	/* vended storage creds, or NULL */
 	List	   *data;			/* IceEntry* content 0 */
 	List	   *posdel;			/* IceEntry* content 1 */
 	List	   *eqdel;			/* IceEntry* content 2 */
@@ -1415,7 +1419,8 @@ ice_read_pos_deletes(IceScanCtx *c)
 		safe = ice_open_path(c->recorded_root, c->actual_root,
 							 pd->file_path, "position-delete", c->mdpath);
 		ts = tuplestore_begin_heap(false, false, work_mem);
-		(void) PgColumnarReadParquetByFieldId(safe, dtd, fids, 2, ts, wslot, NULL, 0);
+		(void) PgColumnarReadParquetByFieldId(safe, dtd, fids, 2, ts, wslot, NULL, 0,
+											  c->cfg);
 		while (tuplestore_gettupleslot(ts, true, false, rslot))
 		{
 			bool		n1,
@@ -1536,7 +1541,7 @@ ice_read_dvs(IceScanCtx *c, int64 format_version)
 		old = MemoryContextSwitchTo(filectx);
 		safe = ice_open_path(c->recorded_root, c->actual_root,
 							 pd->file_path, "deletion-vector", c->mdpath);
-		buf = ice_slurp_bin(safe, &len);
+		buf = ice_slurp_bin(safe, &len, c->cfg);
 		{
 			uint64	   *scratch_pos;
 			int64		scratch_n;
@@ -1825,7 +1830,7 @@ ice_read_eq_deletes(IceScanCtx *c, JsonbContainer *root, const char *path,
 							 ed->file_path, "equality-delete", c->mdpath);
 		ts = tuplestore_begin_heap(false, false, work_mem);
 		(void) PgColumnarReadParquetByFieldId(safe, dtd, (const int *) E->ids,
-											  E->nids, ts, wslot, NULL, 0);
+											  E->nids, ts, wslot, NULL, 0, c->cfg);
 		while (tuplestore_gettupleslot(ts, true, false, rslot))
 		{
 			IceEqRow   *row;
@@ -2003,7 +2008,7 @@ ice_eq_probe(IceScanCtx *c, IceEntry *d, List *elig,
 						 "data-file", c->mdpath);
 	ts = tuplestore_begin_heap(false, false, work_mem);
 	(void) PgColumnarReadParquetByFieldId(safe, ptd, uids, nuni, ts, wslot,
-										  NULL, 0);
+										  NULL, 0, c->cfg);
 	dv = (Datum *) palloc(nuni * sizeof(Datum));
 	dn = (bool *) palloc(nuni * sizeof(bool));
 	while (tuplestore_gettupleslot(ts, true, false, rslot))
@@ -2055,7 +2060,8 @@ ice_eq_probe(IceScanCtx *c, IceEntry *d, List *elig,
  */
 void
 PgColumnarIcebergScanInto(const char *path, TupleDesc tupdesc,
-						  ReturnSetInfo *rsinfo)
+						  ReturnSetInfo *rsinfo,
+						  const PgColumnarObjStoreConfig *cfg)
 {
 	MemoryContext oldcxt;
 	IceScanCtx	ctx;
@@ -2068,8 +2074,10 @@ PgColumnarIcebergScanInto(const char *path, TupleDesc tupdesc,
 	List	   *eqdels;
 	ListCell   *lc;
 
+	ctx.cfg = cfg;				/* vended storage creds for every file, or NULL */
+
 	/* map output column names -> field ids via the table's current schema */
-	json = ice_slurp_text(path);
+	json = ice_slurp_text(path, cfg);
 	jb = DatumGetJsonbP(DirectFunctionCall1(jsonb_in, CStringGetDatum(json)));
 	field_ids = ice_field_ids_for_columns(&jb->root, tupdesc, path, &nfield);
 	ice_name_mapping(&jb->root, path, &ctx.nm_names, &ctx.nm_ids, &ctx.nm_count);
@@ -2098,7 +2106,7 @@ PgColumnarIcebergScanInto(const char *path, TupleDesc tupdesc,
 
 	/* pass 1: collect the snapshot's data and delete entries (reuse the
 	 * metadata already parsed for the schema, so the file is read once) */
-	ice_walk_data_files(path, &jb->root, true, ice_scan_cb, &ctx);
+	ice_walk_data_files(path, &jb->root, true, ice_scan_cb, &ctx, cfg);
 
 	/* read the position-delete files once into (dpath, pos, seq) rows, and the
 	 * applicable equality-delete files once into per-file delete-row sets
@@ -2268,7 +2276,7 @@ PgColumnarIcebergScanInto(const char *path, TupleDesc tupdesc,
 													(const char *const *) ctx.nm_names,
 													ctx.nm_ids, ctx.nm_count,
 													ctx.tupstore, ctx.slot,
-													skip, nskip);
+													skip, nskip, ctx.cfg);
 		MemoryContextSwitchTo(old);
 		MemoryContextReset(ctx.filectx);
 
@@ -2355,6 +2363,6 @@ pgcolumnar_iceberg_scan(PG_FUNCTION_ARGS)
 				 errmsg("pgcolumnar.iceberg_scan requires a column definition list"),
 				 errhint("Call it as SELECT * FROM pgcolumnar.iceberg_scan(path) AS t(col1 type1, ...).")));
 
-	PgColumnarIcebergScanInto(path, tupdesc, rsinfo);
+	PgColumnarIcebergScanInto(path, tupdesc, rsinfo, NULL);
 	return (Datum) 0;
 }

--- a/src/columnar_iceberg.h
+++ b/src/columnar_iceberg.h
@@ -9,14 +9,19 @@
 #include "funcapi.h"
 #include "access/tupdesc.h"
 
+#include "columnar_objstore.h"	/* PgColumnarObjStoreConfig */
+
 /*
  * Read the Iceberg table whose current metadata.json is at `path` (a local or
  * remote URI) into a materialize-mode tuplestore on `rsinfo`, projecting the
  * columns named by `tupdesc`. This is the body of iceberg_scan, shared with the
  * REST catalog client, which resolves a table by name into a metadata location
- * and reads it through the same path. Raises on any failure.
+ * and reads it through the same path. `cfg` is the object-store config for every
+ * remote file of the table (catalog-vended storage credentials), or NULL to use
+ * the ambient environment. Raises on any failure.
  */
 extern void PgColumnarIcebergScanInto(const char *path, TupleDesc tupdesc,
-									  ReturnSetInfo *rsinfo);
+									  ReturnSetInfo *rsinfo,
+									  const PgColumnarObjStoreConfig *cfg);
 
 #endif							/* COLUMNAR_ICEBERG_H */

--- a/src/columnar_iceberg_rest.c
+++ b/src/columnar_iceberg_rest.c
@@ -240,18 +240,17 @@ rest_get_json(const char *catalog_uri, const char *resource_path,
 }
 
 /*
- * Resolve the current metadata-location of catalog_uri's ns.table. Calls
- * GET /v1/config to learn any path prefix, then loadTable.
+ * Call GET /v1/config (to learn any path prefix) then loadTable, and return the
+ * whole loadTable JSON document. *out_location is set to its metadata-location.
  */
-char *
-PgColumnarIcebergRestLoadTableLocation(const char *catalog_uri,
-									   const char *ns, const char *table)
+static Jsonb *
+rest_load_table_doc(const char *catalog_uri, const char *ns, const char *table,
+					char **out_location)
 {
 	Jsonb	   *cfg;
 	char	   *prefix;
 	Jsonb	   *lt;
 	StringInfoData rp;
-	char	   *loc;
 
 	if (pg_strncasecmp(catalog_uri, "http://", 7) != 0 &&
 		pg_strncasecmp(catalog_uri, "https://", 8) != 0)
@@ -296,7 +295,108 @@ PgColumnarIcebergRestLoadTableLocation(const char *catalog_uri,
 	rest_pct_encode(&rp, table);
 
 	lt = rest_get_json(catalog_uri, rp.data, "table");
-	loc = rest_json_string(&lt->root, "metadata-location", "loadTable response");
+	if (out_location != NULL)
+		*out_location = rest_json_string(&lt->root, "metadata-location",
+										 "loadTable response");
+	return lt;
+}
+
+/*
+ * Build an object-store config from the storage credentials a loadTable reply
+ * vends, or NULL when it vends none (the caller then falls back to ambient). A
+ * `storage-credentials` array is preferred, choosing the entry whose `prefix` is
+ * the longest match for `metadata_location`; otherwise the flat `config` object.
+ * allow_ambient is false: once a catalog vends credentials a read must use them,
+ * never silently the server's ambient identity.
+ */
+static PgColumnarObjStoreConfig *
+rest_vended_cfg(JsonbContainer *lt, const char *metadata_location)
+{
+	JsonbContainer *chosen = NULL;
+	int			bestlen = -1;
+	JsonbValue	vbuf;
+	JsonbValue *sc;
+	char	   *akid;
+	char	   *secret;
+	PgColumnarObjStoreConfig *cfg;
+
+	if (lt == NULL || !JsonContainerIsObject(lt))
+		return NULL;
+
+	sc = getKeyJsonValueFromContainer(lt, "storage-credentials", 19, &vbuf);
+	if (sc != NULL && sc->type == jbvBinary &&
+		JsonContainerIsArray(sc->val.binary.data))
+	{
+		uint32		n = JsonContainerSize(sc->val.binary.data);
+		uint32		i;
+		int			mloclen = (int) strlen(metadata_location);
+
+		for (i = 0; i < n; i++)
+		{
+			JsonbValue *e = getIthJsonbValueFromContainer(sc->val.binary.data, i);
+			JsonbValue	pbuf,
+						cbuf;
+			JsonbValue *pv;
+			JsonbValue *cv;
+
+			if (e == NULL || e->type != jbvBinary ||
+				!JsonContainerIsObject(e->val.binary.data))
+				continue;
+			pv = getKeyJsonValueFromContainer(e->val.binary.data, "prefix", 6, &pbuf);
+			cv = getKeyJsonValueFromContainer(e->val.binary.data, "config", 6, &cbuf);
+			if (pv == NULL || pv->type != jbvString ||
+				cv == NULL || cv->type != jbvBinary ||
+				!JsonContainerIsObject(cv->val.binary.data))
+				continue;
+			if (pv->val.string.len <= mloclen &&
+				strncmp(metadata_location, pv->val.string.val,
+						pv->val.string.len) == 0 &&
+				pv->val.string.len > bestlen)
+			{
+				bestlen = pv->val.string.len;
+				chosen = cv->val.binary.data;
+			}
+		}
+	}
+
+	if (chosen == NULL)
+	{
+		JsonbValue *cv = getKeyJsonValueFromContainer(lt, "config", 6, &vbuf);
+
+		if (cv != NULL && cv->type == jbvBinary &&
+			JsonContainerIsObject(cv->val.binary.data))
+			chosen = cv->val.binary.data;
+	}
+	if (chosen == NULL)
+		return NULL;
+
+	akid = rest_json_string_opt(chosen, "s3.access-key-id");
+	secret = rest_json_string_opt(chosen, "s3.secret-access-key");
+	if (akid == NULL || secret == NULL)
+		return NULL;			/* no usable vended creds -> ambient fallback */
+
+	cfg = (PgColumnarObjStoreConfig *) palloc0(sizeof(PgColumnarObjStoreConfig));
+	cfg->akid = akid;
+	cfg->secret = secret;
+	cfg->token = rest_json_string_opt(chosen, "s3.session-token");
+	cfg->region = rest_json_string_opt(chosen, "s3.region");
+	if (cfg->region == NULL)
+		cfg->region = rest_json_string_opt(chosen, "client.region");
+	cfg->endpoint = rest_json_string_opt(chosen, "s3.endpoint");
+	cfg->allow_ambient = false;
+	return cfg;
+}
+
+/*
+ * Resolve the current metadata-location of catalog_uri's ns.table.
+ */
+char *
+PgColumnarIcebergRestLoadTableLocation(const char *catalog_uri,
+									   const char *ns, const char *table)
+{
+	char	   *loc;
+
+	(void) rest_load_table_doc(catalog_uri, ns, table, &loc);
 	return loc;
 }
 
@@ -341,7 +441,9 @@ pgcolumnar_iceberg_rest_scan(PG_FUNCTION_ARGS)
 	char	   *table = text_to_cstring(PG_GETARG_TEXT_PP(2));
 	ReturnSetInfo *rsinfo = (ReturnSetInfo *) fcinfo->resultinfo;
 	TupleDesc	tupdesc;
+	Jsonb	   *lt;
 	char	   *loc;
+	PgColumnarObjStoreConfig *cfg;
 
 	if (!has_privs_of_role(GetUserId(), ROLE_PG_READ_SERVER_FILES))
 		ereport(ERROR,
@@ -358,7 +460,9 @@ pgcolumnar_iceberg_rest_scan(PG_FUNCTION_ARGS)
 				 errmsg("pgcolumnar.iceberg_rest_scan requires a column definition list"),
 				 errhint("Call it as SELECT * FROM pgcolumnar.iceberg_rest_scan(uri, ns, tbl) AS t(col1 type1, ...).")));
 
-	loc = PgColumnarIcebergRestLoadTableLocation(catalog_uri, ns, table);
+	/* one loadTable: the metadata-location AND the vended storage creds (if any) */
+	lt = rest_load_table_doc(catalog_uri, ns, table, &loc);
+	cfg = rest_vended_cfg(&lt->root, loc);
 	/*
 	 * A metadata-location is a URI. The reader's remote path handles s3:// and
 	 * http(s)://; a file:// location is a local path, and the local read path
@@ -366,7 +470,7 @@ pgcolumnar_iceberg_rest_scan(PG_FUNCTION_ARGS)
 	 */
 	if (pg_strncasecmp(loc, "file://", 7) == 0)
 		loc += 7;
-	PgColumnarIcebergScanInto(loc, tupdesc, rsinfo);
+	PgColumnarIcebergScanInto(loc, tupdesc, rsinfo, cfg);
 	return (Datum) 0;
 }
 

--- a/src/columnar_parquet_reader.c
+++ b/src/columnar_parquet_reader.c
@@ -3528,7 +3528,8 @@ pq_read_file_into(const char *path, TupleDesc tupdesc, TupleTableSlot *slot,
 				  const int *field_ids, int nfield,
 				  const char *const *nm_names, const int *nm_ids, int nm_count,
 				  bool missing_as_null,
-				  const uint64 *skipPos, int nSkipPos)
+				  const uint64 *skipPos, int nSkipPos,
+				  const PgColumnarObjStoreConfig *cfg)
 {
 	PqSource	src;
 	PqFile		pf;
@@ -3537,7 +3538,7 @@ pq_read_file_into(const char *path, TupleDesc tupdesc, TupleTableSlot *slot,
 	int			ntops;
 	int64		n;
 
-	pq_source_open(path, &src, &pf);
+	pq_source_open_cfg(path, &src, &pf, cfg);
 	pq_check_row_groups(&pf, path);
 	if (field_ids != NULL)
 		tops = build_imp_targets_by_field_id(tupdesc, &pf, field_ids, nfield,
@@ -3563,11 +3564,12 @@ int64
 PgColumnarReadParquetByFieldId(const char *path, TupleDesc tupdesc,
 							   const int *field_ids, int nfield,
 							   Tuplestorestate *tupstore, TupleTableSlot *slot,
-							   const uint64 *skipPos, int nSkipPos)
+							   const uint64 *skipPos, int nSkipPos,
+							   const PgColumnarObjStoreConfig *cfg)
 {
 	return pq_read_file_into(path, tupdesc, slot, pq_tuplestore_sink, tupstore,
 							 field_ids, nfield, NULL, NULL, 0, false,
-							 skipPos, nSkipPos);
+							 skipPos, nSkipPos, cfg);
 }
 
 /*
@@ -3586,11 +3588,12 @@ PgColumnarReadParquetByFieldIdNM(const char *path, TupleDesc tupdesc,
 								 const char *const *nm_names, const int *nm_ids,
 								 int nm_count,
 								 Tuplestorestate *tupstore, TupleTableSlot *slot,
-								 const uint64 *skipPos, int nSkipPos)
+								 const uint64 *skipPos, int nSkipPos,
+								 const PgColumnarObjStoreConfig *cfg)
 {
 	return pq_read_file_into(path, tupdesc, slot, pq_tuplestore_sink, tupstore,
 							 field_ids, nfield, nm_names, nm_ids, nm_count,
-							 true, skipPos, nSkipPos);
+							 true, skipPos, nSkipPos, cfg);
 }
 
 /*
@@ -3657,7 +3660,7 @@ pgcolumnar_import_parquet(PG_FUNCTION_ARGS)
 
 		total += pq_read_file_into((char *) lfirst(lc), tupdesc, slot,
 								   pq_insert_sink, &sinkarg, NULL, 0,
-								   NULL, NULL, 0, false, NULL, 0);
+								   NULL, NULL, 0, false, NULL, 0, NULL);
 		MemoryContextSwitchTo(old);
 		MemoryContextReset(fileCtx);
 	}
@@ -3777,7 +3780,7 @@ pgcolumnar_read_parquet(PG_FUNCTION_ARGS)
 
 		(void) pq_read_file_into((char *) lfirst(lc), retdesc, slot,
 								 pq_tuplestore_sink, tupstore, field_ids, nfield,
-								 NULL, NULL, 0, false, NULL, 0);
+								 NULL, NULL, 0, false, NULL, 0, NULL);
 		MemoryContextSwitchTo(old);
 		MemoryContextReset(fileCtx);
 	}

--- a/src/columnar_parquet_reader.h
+++ b/src/columnar_parquet_reader.h
@@ -17,6 +17,8 @@
 #include "executor/tuptable.h"
 #include "utils/tuplestore.h"
 
+#include "columnar_objstore.h"	/* PgColumnarObjStoreConfig */
+
 /*
  * Read one Parquet file's rows into `tupstore`, binding output column i (of
  * `tupdesc`) to the file column whose Parquet field id equals field_ids[i], and
@@ -30,7 +32,8 @@ extern int64 PgColumnarReadParquetByFieldId(const char *path, TupleDesc tupdesc,
 											 const int *field_ids, int nfield,
 											 Tuplestorestate *tupstore,
 											 TupleTableSlot *slot,
-											 const uint64 *skipPos, int nSkipPos);
+											 const uint64 *skipPos, int nSkipPos,
+											 const PgColumnarObjStoreConfig *cfg);
 
 /*
  * As above, plus an Iceberg name mapping (schema.name-mapping.default): for a
@@ -45,6 +48,7 @@ extern int64 PgColumnarReadParquetByFieldIdNM(const char *path, TupleDesc tupdes
 											   Tuplestorestate *tupstore,
 											   TupleTableSlot *slot,
 											   const uint64 *skipPos,
-											   int nSkipPos);
+											   int nSkipPos,
+											   const PgColumnarObjStoreConfig *cfg);
 
 #endif							/* COLUMNAR_PARQUET_READER_H */

--- a/test/iceberg_rest_server.py
+++ b/test/iceberg_rest_server.py
@@ -145,11 +145,36 @@ class Handler(BaseHTTPRequestHandler):
         if ns_norm != ARGS.namespace or table != ARGS.table:
             self._not_found("no such table %s.%s" % (ns, table))
             return
-        self._send_json(200, {
+        config = {}
+        # vended storage credentials: the client must sign its S3 reads with
+        # these, not with any ambient environment credential.
+        if ARGS.vend_key:
+            config["s3.access-key-id"] = ARGS.vend_key
+            config["s3.secret-access-key"] = ARGS.vend_secret
+            config["s3.region"] = ARGS.vend_region
+            if ARGS.vend_endpoint:
+                config["s3.endpoint"] = ARGS.vend_endpoint
+            if ARGS.vend_token:
+                config["s3.session-token"] = ARGS.vend_token
+        resp = {
             "metadata-location": ARGS.metadata_location,
             "metadata": {"format-version": 2, "location": ARGS.table_location},
-            "config": {},
-        })
+            "config": config,
+        }
+        # storage-credentials array form (newer spec), longest-prefix selected by
+        # the client. When --storage-cred-prefix is given, offer TWO entries: a
+        # deliberately wrong catch-all and the correct, more specific one, so a
+        # green read proves longest-prefix selection.
+        if ARGS.storage_cred_prefix and ARGS.vend_key:
+            resp["storage-credentials"] = [
+                {"prefix": "s3://", "config": {
+                    "s3.access-key-id": "WRONGKEY",
+                    "s3.secret-access-key": "wrong-secret",
+                    "s3.region": ARGS.vend_region,
+                    "s3.endpoint": ARGS.vend_endpoint}},
+                {"prefix": ARGS.storage_cred_prefix, "config": config},
+            ]
+        self._send_json(200, resp)
 
 
 def main():
@@ -164,6 +189,12 @@ def main():
     ap.add_argument("--metadata-location", required=True)
     ap.add_argument("--table-location", default="")
     ap.add_argument("--bad-config", action="store_true")
+    ap.add_argument("--vend-key", default="")
+    ap.add_argument("--vend-secret", default="")
+    ap.add_argument("--vend-token", default="")
+    ap.add_argument("--vend-region", default="")
+    ap.add_argument("--vend-endpoint", default="")
+    ap.add_argument("--storage-cred-prefix", default="")
     ARGS = ap.parse_args()
     open(ARGS.log, "w").close()
     httpd = ThreadingHTTPServer(("127.0.0.1", ARGS.port), Handler)

--- a/test/iceberg_rest_vended.sh
+++ b/test/iceberg_rest_vended.sh
@@ -95,6 +95,21 @@ check "iceberg_rest_scan reads via vended credentials (no ambient creds set)" \
 	      ORDER BY id")" \
 	"$(printf '1|eu|10\n3|us|30\n5|us|50')"
 
+# ---- the vended secret never appears in any log --------------------------
+# the secret comes from the catalog response, is used only as the SigV4 signing
+# seed (never sent on the wire), and is never a SQL argument, so log_statement
+# cannot capture it. Pin that: read under log_statement='all', then grep.
+q "ALTER SYSTEM SET log_statement='all'" >/dev/null
+q "SELECT pg_reload_conf()" >/dev/null
+q "SELECT count(*) FROM pgcolumnar.iceberg_rest_scan('$CAT','db','t')
+   AS t(id bigint, region text, amount int)" >/dev/null
+q "ALTER SYSTEM SET log_statement='none'" >/dev/null
+q "SELECT pg_reload_conf()" >/dev/null
+check "the vended secret never appears in the PG server log" \
+	"$(grep -c "$SECRET" "$PGC_LOGFILE" 2>/dev/null)" "0"
+check "the vended secret never appears in the S3 request log" \
+	"$(grep -c "$SECRET" "$PGC_WORKDIR/s3.log" 2>/dev/null)" "0"
+
 # ---- a WRONG vended secret is used and refused (403 -> 28000), not bypassed --
 start_rest --token "$RESTTOK" \
 	--vend-key "$AKID" --vend-secret "wrong-vended-secret" --vend-region "$REGION" --vend-endpoint "$S3EP"

--- a/test/iceberg_rest_vended.sh
+++ b/test/iceberg_rest_vended.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+#
+# pgColumnar Iceberg REST catalog VENDED credentials (#656). A REST catalog
+# returns, in its loadTable reply, short-lived scoped storage credentials; the
+# reader must sign its S3 data/metadata/delete reads with THOSE, not with any
+# ambient environment credential. The proof: the postmaster environment holds NO
+# AWS_* credentials, the warehouse is served over the SigV4-verifying S3 fixture,
+# and a green read can only happen if the request was signed with the vended
+# credentials the SigV4 fixture is configured to accept.
+#
+# Two hermetic servers: the S3 fixture (test/objstore_http_server.py, SigV4) and
+# the REST catalog (test/iceberg_rest_server.py) whose loadTable points at an
+# s3:// metadata-location and vends the S3 fixture's key/secret/region/endpoint.
+#
+# Usage:  test/iceberg_rest_vended.sh [PG_CONFIG]
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+python3 -c 'import json' 2>/dev/null || pgc_skip python "python3 is needed"
+MODDIR="$("$PGC_PG_CONFIG" --pkglibdir)"
+[ -f "$MODDIR/pgcolumnar_objstore.so" ] \
+	|| pgc_skip objstore "the object-store module is not installed"
+
+FX="$(dirname "${BASH_SOURCE[0]}")/fixtures/iceberg"
+[ -f "$FX/warehouse_del/db/t/metadata/apply.metadata.json" ] \
+	|| pgc_skip fixture "iceberg fixtures are missing"
+
+AKID="VENDEDKEYID"; SECRET="vended-secret-shh"; REGION="pgc-test-1"; BUCKET="pgc-bucket"
+RESTTOK="rest-token-vend"
+# One free port is picked per server only AFTER the previous one binds:
+# pgc_pick_free_port does not hold the port, so picking six up front returns the
+# same number six times (nothing is bound between the picks).
+S3_PORT="$(pgc_pick_free_port "$PGC_AUX_PORT_LO" "$PGC_AUX_PORT_HI")"
+PIDS=""
+LAST_PORT=""
+
+vend_teardown() { for p in $PIDS; do kill "$p" 2>/dev/null; done; pgc_teardown; }
+trap vend_teardown EXIT INT TERM
+
+sqlstate_of() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -qtA 2>&1 <<SQLEOF | sed -n 's/^ERROR:  \([0-9A-Z]\{5\}\).*/\1/p' | head -1
+\\set VERBOSITY sqlstate
+$1;
+SQLEOF
+}
+pg_restart_env() {
+	pgc_pg "pg_ctl -D '$PGC_PGDATA' stop -m fast -w" >/dev/null 2>&1
+	pgc_pg "$* pg_ctl -D '$PGC_PGDATA' -l '$PGC_LOGFILE' start -w" >/dev/null 2>&1
+	for _ in $(seq 1 30); do [ -n "$(q 'SELECT 1')" ] && return 0; sleep 0.5; done
+	echo "FATAL: cluster did not come back after env restart"; exit 1
+}
+start_rest() {  # $@=extra args; picks a fresh free port into LAST_PORT
+	LAST_PORT="$(pgc_pick_free_port "$PGC_AUX_PORT_LO" "$PGC_AUX_PORT_HI")"
+	python3 "$(dirname "${BASH_SOURCE[0]}")/iceberg_rest_server.py" \
+		--port "$LAST_PORT" --log "$PGC_WORKDIR/rest_$LAST_PORT.log" \
+		--namespace db --table t \
+		--metadata-location "s3://$BUCKET/db/t/metadata/apply.metadata.json" \
+		"$@" > "$PGC_WORKDIR/rest_$LAST_PORT.out" 2>&1 &
+	PIDS="$PIDS $!"
+	for _ in $(seq 1 50); do grep -q READY "$PGC_WORKDIR/rest_$LAST_PORT.out" 2>/dev/null && break; sleep 0.1; done
+}
+
+# ---- serve the warehouse over the SigV4 S3 fixture ---------------------------
+mkdir -p "$PGC_WORKDIR/$BUCKET"
+cp -r "$FX/warehouse_del/db" "$PGC_WORKDIR/$BUCKET/db"
+chmod -R u+rwX "$PGC_WORKDIR/$BUCKET"
+python3 "$(dirname "${BASH_SOURCE[0]}")/objstore_http_server.py" \
+	--dir "$PGC_WORKDIR" --port "$S3_PORT" --log "$PGC_WORKDIR/s3.log" \
+	--sigv4-key "$AKID" --sigv4-secret "$SECRET" --sigv4-region "$REGION" \
+	> "$PGC_WORKDIR/s3.out" 2>&1 &
+PIDS="$PIDS $!"
+for _ in $(seq 1 50); do grep -q READY "$PGC_WORKDIR/s3.out" 2>/dev/null && break; sleep 0.1; done
+check "premise: the SigV4 S3 fixture is up" \
+	"$(grep -c READY "$PGC_WORKDIR/s3.out" 2>/dev/null)" "1"
+
+S3EP="http://127.0.0.1:$S3_PORT"
+# the catalog that vends the correct S3 creds + endpoint
+start_rest --token "$RESTTOK" \
+	--vend-key "$AKID" --vend-secret "$SECRET" --vend-region "$REGION" --vend-endpoint "$S3EP"
+CAT="http://127.0.0.1:$LAST_PORT"
+
+# NO AWS_* credentials in the environment: a read can only work with vended ones.
+pg_restart_env "PGCOLUMNAR_ICEBERG_REST_TOKEN='$RESTTOK'"
+q "ALTER SYSTEM SET pgcolumnar.objstore_allowed_endpoints = '127.0.0.1'" >/dev/null
+q "SELECT pg_reload_conf()" >/dev/null
+
+# ---- CORE: vended creds sign the S3 reads (no ambient creds exist) -----------
+# apply.metadata.json drops ordinals 1,3 (id 2, id 4); survivors 1,3,5.
+check "iceberg_rest_scan reads via vended credentials (no ambient creds set)" \
+	"$(q "SELECT id || '|' || region || '|' || amount
+	      FROM pgcolumnar.iceberg_rest_scan('$CAT','db','t') AS t(id bigint, region text, amount int)
+	      ORDER BY id")" \
+	"$(printf '1|eu|10\n3|us|30\n5|us|50')"
+
+# ---- a WRONG vended secret is used and refused (403 -> 28000), not bypassed --
+start_rest --token "$RESTTOK" \
+	--vend-key "$AKID" --vend-secret "wrong-vended-secret" --vend-region "$REGION" --vend-endpoint "$S3EP"
+BAD_PORT="$LAST_PORT"
+check "a wrong vended secret is refused by S3, not bypassed (28000)" \
+	"$(sqlstate_of "SELECT * FROM pgcolumnar.iceberg_rest_scan('http://127.0.0.1:$BAD_PORT','db','t')
+	                AS t(id bigint, region text, amount int)")" \
+	"28000"
+
+# ---- storage-credentials: longest-prefix entry (correct) beats catch-all ----
+start_rest --token "$RESTTOK" \
+	--vend-key "$AKID" --vend-secret "$SECRET" --vend-region "$REGION" --vend-endpoint "$S3EP" \
+	--storage-cred-prefix "s3://$BUCKET/db/t"
+SC_PORT="$LAST_PORT"
+check "storage-credentials longest-prefix match selects the right creds" \
+	"$(q "SELECT count(*) FROM pgcolumnar.iceberg_rest_scan('http://127.0.0.1:$SC_PORT','db','t')
+	      AS t(id bigint, region text, amount int)")" \
+	"3"
+
+# ---- vended creds do NOT bypass the allow-list ------------------------------
+# a catalog that vends an endpoint off the allow-list is refused at the read.
+start_rest --token "$RESTTOK" \
+	--vend-key "$AKID" --vend-secret "$SECRET" --vend-region "$REGION" \
+	--vend-endpoint "http://127.0.0.2:$S3_PORT"
+LL_PORT="$LAST_PORT"
+check "vended creds for an off-allow-list endpoint are refused (42501)" \
+	"$(sqlstate_of "SET pgcolumnar.objstore_allowed_endpoints='127.0.0.1';
+	                SELECT * FROM pgcolumnar.iceberg_rest_scan('http://127.0.0.1:$LL_PORT','db','t')
+	                AS t(id bigint, region text, amount int)")" \
+	"42501"
+
+# ---- ambient still works when the catalog vends nothing ---------------------
+start_rest --token "$RESTTOK"   # no --vend-key: config is empty
+AMB_PORT="$LAST_PORT"
+pg_restart_env "PGCOLUMNAR_ICEBERG_REST_TOKEN='$RESTTOK'" \
+	"AWS_ENDPOINT_URL='$S3EP'" "AWS_ACCESS_KEY_ID='$AKID'" \
+	"AWS_SECRET_ACCESS_KEY='$SECRET'" "AWS_REGION='$REGION'"
+q "ALTER SYSTEM SET pgcolumnar.objstore_allowed_endpoints = '127.0.0.1'" >/dev/null
+q "SELECT pg_reload_conf()" >/dev/null
+check "a table vending no creds still reads with ambient (cfg NULL path)" \
+	"$(q "SELECT count(*) FROM pgcolumnar.iceberg_rest_scan('http://127.0.0.1:$AMB_PORT','db','t')
+	      AS t(id bigint, region text, amount int)")" \
+	"3"
+
+check "backend still up after the vended-credential arms" "$(q 'SELECT 1')" "1"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -92,6 +92,7 @@ SUITES=(
 	iceberg_objstore
 	iceberg_rest
 	iceberg_rest_scan
+	iceberg_rest_vended
 	iceberg_scan
 	import_deferred
 	import_exclusion


### PR DESCRIPTION
First part of #656 (the REST credential model), on top of the merged phase-7 read side. Design: `design/ISSUE_656_VENDED_CREDENTIALS.md`.

## What this does
Reads a REST-cataloged table with the **short-lived scoped storage credentials the catalog vends** in its `loadTable` reply, instead of the ambient server-environment credentials phase 7 fell back to. This makes a table in a cloud account the server has no standing credentials for readable, which is the common REST deployment.

No new SQL surface: `iceberg_rest_scan` transparently uses vended credentials when the catalog issues them.

## Threading (the crux, reviewer focus)
Every objstore `open()` in the Iceberg read path was hardwired to `cfg=NULL` (ambient). This adds one `const PgColumnarObjStoreConfig *cfg`:
- carried on `IceScanCtx`, set once in `PgColumnarIcebergScanInto`;
- a trailing **NULL-default** `cfg` param on the two public parquet entries (`PgColumnarReadParquetByFieldId{,NM}` -> `pq_read_file_into` -> the already-cfg-aware `pq_source_open_cfg`) and the four iceberg slurp helpers (`ice_slurp_remote`/`text`/`bin`, `ice_walk_data_files`).

**Every existing caller passes `NULL`**: filesystem `iceberg_scan`, `iceberg_current_snapshot`, `iceberg_data_files`, `read_parquet`, `import`, so behavior off the REST path is byte-identical (the existing suites prove it: `iceberg_scan` 7/7, `iceberg_deletes`, `iceberg_objstore`, `native_read_parquet` all green). The FDW is untouched (separate route). Only `iceberg_rest_scan` builds and passes a real cfg.

## Vended credentials and security
- One `loadTable` yields both the metadata-location and the vended creds. `rest_vended_cfg` reads a `storage-credentials` array (**longest-prefix** match against the metadata-location) or the flat `config` keys (`s3.access-key-id`/`secret-access-key`/`session-token`/`region`/`endpoint`).
- **`allow_ambient=false`**: once a catalog vends credentials, a read uses them and never silently the ambient identity of the server. A table that vends nothing passes `cfg=NULL` (the phase-7 ambient path).
- The **allow-list and link-local refusal apply independent of cfg**, so a catalog cannot vend credentials for an internal host and be reached.
- The vended config body is walked with an object/array guard at every step (the 7a #644 lesson).

## Proof (prove, do not trust)
`test/iceberg_rest_vended.sh` (7 checks) runs the **SigV4-verifying S3 fixture AND the REST fixture together, with NO `AWS_*` in the postmaster environment**, so a green read can only happen if the request was signed with the **vended** credentials the S3 fixture accepts.

- Core read; a **wrong vended secret** is used and refused by S3 (403 -> 28000), not bypassed; **storage-credentials longest-prefix** selects the right creds over a wrong catch-all; a **vended off-allow-list endpoint** -> 42501; a table **vending nothing** still reads with ambient.
- **Removal proof**: neutering `rest_vended_cfg` reds exactly the vended arms (`got []`, no ambient fallback) while the ambient arm stays green.
- **Gates**: 7/7 plus regression on PG17/18/19, clean under `pg18_san` ASAN+UBSAN, `docs_style`/STE clean, `harness_selftest` green.

## Remaining in #656
OAuth2 token exchange, and the `FOREIGN SERVER` + `USER MAPPING` per-catalog credential model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
