### PR TITLE
feat: Iceberg FDW data-file min/max metrics pruning (#388, phase 5b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,12 +81,14 @@ which was true until that script existed.
   foreign table over an Iceberg table gets the query's predicate, which
   `iceberg_scan` cannot, and prunes: a predicate on an identity-partitioned
   column removes whole data files before they are opened, reading each file's
-  partition value from the manifest. Pruning is only an optimization, so a
+  partition value from the manifest. A predicate on an integer or boolean column
+  removes whole files whose stored minimum and maximum exclude it, so an
+  unpartitioned column prunes too. Pruning is only an optimization, so a
   predicate the wrapper cannot decide never changes the rows returned, and every
   projection and delete rule matches `iceberg_scan`. The table option is
-  `metadata_path`; `EXPLAIN (ANALYZE)` reports `Files Pruned`. Only identity
-  partitioning prunes in this release; other partition transforms read in full.
-  See
+  `metadata_path`; `EXPLAIN (ANALYZE)` reports `Files Pruned`. Partition pruning
+  covers identity partitioning and metrics pruning covers integer and boolean
+  columns; other transforms and types read in full. See
   [Iceberg FDW](docs/sql-reference.md#the-pgcolumnar_iceberg-foreign-data-wrapper).
 
 - The Parquet read and export functions and the foreign-data wrapper read from

--- a/docs/sql-reference.md
+++ b/docs/sql-reference.md
@@ -896,20 +896,22 @@ EXPLAIN (ANALYZE, COSTS OFF) SELECT id FROM events WHERE ts >= '2026-01-01';
 
 Exposes an Apache Iceberg table as a foreign table. Unlike `iceberg_scan`, which
 is a set-returning function that receives no predicate, the foreign table gets
-the query's quals and prunes. A predicate on an identity-partitioned column
-removes whole data files before they are opened. The partition value is read
-from the manifest, so a file is skipped without a read. Pruning is only an
-optimization. A file that is not pruned is read normally, so a predicate the
-wrapper cannot decide never changes the rows returned. Field-id projection and
-every delete rule are those of `iceberg_scan`.
+the query's quals and prunes data files two ways. A predicate on an
+identity-partitioned column removes whole files by their partition value. A
+predicate on an integer or boolean column removes whole files whose stored
+minimum and maximum exclude it. An unpartitioned column can prune this way. Both
+read the value from the manifest, so a file is skipped without a read. Pruning is only an optimization. A file that is not pruned is read
+normally, so a predicate the wrapper cannot decide never changes the rows
+returned. Field-id projection and every delete rule are those of `iceberg_scan`.
 
 The one table option is `metadata_path`, the table's current `metadata.json`
 (a local path or an object-storage URL). The wrapper requires the
 `pg_read_server_files` role. `EXPLAIN (ANALYZE)` reports `Files Pruned`.
 
-Only identity partitioning prunes in this release. A table partitioned by a
+Partition pruning covers identity partitioning only. A table partitioned by a
 transform such as `bucket`, `truncate`, or a temporal function is read in full,
-which is correct but not yet optimized.
+which is correct but not yet optimized. Metrics pruning covers integer and
+boolean columns; other column types are read in full.
 
 ```sql
 CREATE SERVER ice FOREIGN DATA WRAPPER pgcolumnar_iceberg;

--- a/src/columnar_avro.c
+++ b/src/columnar_avro.c
@@ -669,6 +669,148 @@ av_read_int_array(AvReader *r, AvSchema *s, int32 **out, int *nout)
 	*nout = n;
 }
 
+#define AV_MAX_BOUNDS 8192
+#define AV_MAX_BOUND_LEN 65536
+
+/*
+ * Decode a lower_bounds / upper_bounds field: Iceberg's map<int,bytes> is an
+ * Avro array of {key:int, value:bytes} records (Avro maps need string keys), so
+ * read it as a block array of key/value records, keeping the field id and a copy
+ * of the single-value binary. Absent, null, or mistyped decodes as empty.
+ */
+static void
+av_read_bound_map(AvReader *r, AvSchema *s,
+				  PgColumnarAvroBound **out, int *nout)
+{
+	bool		isnull;
+	AvSchema   *t = av_unwrap_union(r, s, &isnull);
+	AvSchema   *rec;
+	PgColumnarAvroBound *b = NULL;
+	int			n = 0;
+	int			cap = 0;
+
+	*out = NULL;
+	*nout = 0;
+	if (r->error || isnull)
+		return;
+	if (t->kind != AV_ARRAY || t->items->kind != AV_RECORD)
+	{
+		av_skip(r, t);
+		return;
+	}
+	rec = t->items;
+
+	while (!r->error)
+	{
+		int64		cnt;
+		int64		i;
+
+		CHECK_FOR_INTERRUPTS();
+		cnt = av_long(r);
+		if (cnt == 0)
+			break;
+		if (cnt < 0)
+		{
+			if (cnt < -AV_MAX_BOUNDS)
+			{
+				r->error = true;
+				break;
+			}
+			cnt = -cnt;
+			(void) av_long(r);	/* block byte size, unused */
+		}
+		if (cnt > AV_MAX_BOUNDS || n + cnt > AV_MAX_BOUNDS)
+		{
+			r->error = true;
+			break;
+		}
+		for (i = 0; i < cnt && !r->error; i++)
+		{
+			int32		key = 0;
+			char	   *val = NULL;
+			int			vlen = 0;
+			bool		haskey = false;
+			bool		hasval = false;
+			int			j;
+
+			for (j = 0; j < rec->n && !r->error; j++)
+			{
+				const char *fn = rec->fields[j].name;
+				AvSchema   *fty = rec->fields[j].type;
+
+				if (strcmp(fn, "key") == 0)
+				{
+					bool		have;
+					int64		k = av_read_long(r, fty, &have);
+
+					if (r->error || k < PG_INT32_MIN || k > PG_INT32_MAX)
+					{
+						r->error = true;
+						break;
+					}
+					key = (int32) k;
+					haskey = true;
+				}
+				else if (strcmp(fn, "value") == 0)
+				{
+					bool		vnull;
+					AvSchema   *vt = av_unwrap_union(r, fty, &vnull);
+
+					if (r->error)
+						break;
+					if (vnull)
+						continue;
+					if (vt->kind != AV_BYTES && vt->kind != AV_STRING)
+					{
+						av_skip(r, vt);
+						continue;
+					}
+					{
+						int64		len = av_long(r);
+						const uint8 *p;
+
+						if (r->error || len < 0 || len > AV_MAX_BOUND_LEN)
+						{
+							r->error = true;
+							break;
+						}
+						p = av_take(r, len);
+						if (r->error)
+							break;
+						val = (char *) palloc(Max(len, 1));
+						if (len > 0)
+							memcpy(val, p, len);
+						vlen = (int) len;
+						hasval = true;
+					}
+				}
+				else
+					av_skip(r, fty);
+			}
+			if (r->error)
+				break;
+			if (haskey && hasval)
+			{
+				if (n == cap)
+				{
+					cap = cap ? cap * 2 : 8;
+					b = (b == NULL)
+						? (PgColumnarAvroBound *) palloc(cap * sizeof(*b))
+						: (PgColumnarAvroBound *) repalloc(b, cap * sizeof(*b));
+				}
+				b[n].field_id = key;
+				b[n].bytes = val;
+				b[n].blen = vlen;
+				n++;
+			}
+		}
+	}
+	if (r->error)
+		return;
+	*out = b;
+	*nout = n;
+}
+
 /* decode one data_file record into the projected fields */
 static void
 av_decode_data_file(AvReader *r, AvSchema *s, PgColumnarAvroManifestEntry *e)
@@ -706,6 +848,10 @@ av_decode_data_file(AvReader *r, AvSchema *s, PgColumnarAvroManifestEntry *e)
 		}
 		else if (strcmp(nm, "equality_ids") == 0)
 			av_read_int_array(r, ft, &e->equality_ids, &e->nequality_ids);
+		else if (strcmp(nm, "lower_bounds") == 0)
+			av_read_bound_map(r, ft, &e->lower_bounds, &e->nlower);
+		else if (strcmp(nm, "upper_bounds") == 0)
+			av_read_bound_map(r, ft, &e->upper_bounds, &e->nupper);
 		else if (strcmp(nm, "referenced_data_file") == 0)
 			e->referenced_data_file = av_read_string(r, ft);
 		else if (strcmp(nm, "content_offset") == 0)

--- a/src/columnar_avro.h
+++ b/src/columnar_avro.h
@@ -60,7 +60,22 @@ typedef struct PgColumnarAvroManifestEntry
 	bool		has_content_size;	/* false when the field is null or absent */
 	PgColumnarAvroPartCell *part_cells; /* the partition tuple, typed, or NULL */
 	int			npart_cells;	/* 0 when there is no partition struct */
+	struct PgColumnarAvroBound *lower_bounds;	/* per field id, single-value bin */
+	int			nlower;
+	struct PgColumnarAvroBound *upper_bounds;
+	int			nupper;
 } PgColumnarAvroManifestEntry;
+
+/*
+ * One data-file column bound (lower_bounds / upper_bounds map entry): a field id
+ * and the column value in Iceberg single-value binary form.
+ */
+typedef struct PgColumnarAvroBound
+{
+	int32		field_id;
+	char	   *bytes;
+	int			blen;
+} PgColumnarAvroBound;
 
 /*
  * One decoded manifest_file entry from a snapshot's manifest list: which

--- a/src/columnar_iceberg.c
+++ b/src/columnar_iceberg.c
@@ -1177,6 +1177,38 @@ PgColumnarIcebergIdentityPartMap(const char *path,
 	*out_npos = (int) nspec;
 }
 
+/*
+ * Return, for each column of `tupdesc`, the current-schema field id of the
+ * column with that name (0 when the table has no such column), for FDW metrics
+ * pruning that keys a data file's bounds by field id. palloc'd, length natts.
+ */
+int *
+PgColumnarIcebergColumnFieldIds(const char *path,
+								const PgColumnarObjStoreConfig *cfg,
+								TupleDesc tupdesc)
+{
+	char	   *json = ice_slurp_text(path, cfg);
+	Jsonb	   *jb = DatumGetJsonbP(DirectFunctionCall1(jsonb_in,
+													   CStringGetDatum(json)));
+	JsonbContainer *fieldsc = ice_current_schema_fields(&jb->root, path);
+	uint32		nf = JsonContainerSize(fieldsc);
+	int		   *out = (int *) palloc0(sizeof(int) * Max(tupdesc->natts, 1));
+	int			a;
+
+	for (a = 0; a < tupdesc->natts; a++)
+	{
+		Form_pg_attribute att = TupleDescAttr(tupdesc, a);
+		int64		fid;
+
+		if (att->attisdropped)
+			continue;
+		fid = ice_field_id_by_name(fieldsc, nf, NameStr(att->attname));
+		if (fid > 0 && fid <= PG_INT32_MAX)
+			out[a] = (int) fid;
+	}
+	return out;
+}
+
 /* A name mapping has one entry per top-level column plus a few aliases; a real
  * schema is well under this. The metadata.json is capped at 64 MB, so without a
  * bound a crafted mapping could carry millions of names -- refuse rather than
@@ -1342,7 +1374,36 @@ typedef struct IceEntry
 	int64		record_count;	/* for a DV, its cardinality per the spec */
 	PgColumnarAvroPartCell *part_cells; /* typed partition tuple, or NULL */
 	int			npart_cells;
+	PgColumnarAvroBound *lower_bounds;	/* per-field-id column bounds, or NULL */
+	int			nlower;
+	PgColumnarAvroBound *upper_bounds;
+	int			nupper;
 }			IceEntry;
+
+/* deep-copy a bound map into the current memory context */
+static void
+ice_copy_bounds(const PgColumnarAvroBound *src, int nsrc,
+				PgColumnarAvroBound **out, int *nout)
+{
+	int			i;
+
+	*out = NULL;
+	*nout = 0;
+	if (nsrc <= 0)
+		return;
+	*out = (PgColumnarAvroBound *) palloc0(sizeof(PgColumnarAvroBound) * nsrc);
+	*nout = nsrc;
+	for (i = 0; i < nsrc; i++)
+	{
+		(*out)[i] = src[i];
+		if (src[i].bytes != NULL)
+		{
+			(*out)[i].bytes = (char *) palloc(Max(src[i].blen, 1));
+			if (src[i].blen > 0)
+				memcpy((*out)[i].bytes, src[i].bytes, src[i].blen);
+		}
+	}
+}
 
 /* deep-copy a partition tuple into the current memory context */
 static void
@@ -1475,6 +1536,8 @@ ice_scan_cb(void *ctx, PgColumnarAvroManifestEntry *e,
 	ie->record_count = e->record_count;
 	ice_copy_part_cells(e->part_cells, e->npart_cells,
 						&ie->part_cells, &ie->npart_cells);
+	ice_copy_bounds(e->lower_bounds, e->nlower, &ie->lower_bounds, &ie->nlower);
+	ice_copy_bounds(e->upper_bounds, e->nupper, &ie->upper_bounds, &ie->nupper);
 	if (e->nequality_ids > 0)
 	{
 		ie->eq_ids = (int32 *) palloc(e->nequality_ids * sizeof(int32));
@@ -2277,15 +2340,26 @@ PgColumnarIcebergScanCore(const char *path, TupleDesc tupdesc,
 		ListCell   *lc2;
 
 		/* pruning: a caller-supplied filter may skip a whole data file whose
-		 * partition value cannot match the scan's predicate (the FDW). Skipping
-		 * a file never changes correctness -- a false-negative just reads a file
-		 * that would have returned no rows -- so the filter is only ever an
-		 * optimization, never a source of wrong results. */
-		if (filter != NULL && filter(filterarg, d->part_cells, d->npart_cells,
-									 d->spec_id))
+		 * partition value or column bounds cannot match the scan's predicate
+		 * (the FDW). Skipping a file never changes correctness -- a false-negative
+		 * just reads a file that would have returned no rows -- so the filter is
+		 * only ever an optimization, never a source of wrong results. */
+		if (filter != NULL)
 		{
-			pruned++;
-			continue;
+			PgColumnarIceFileMeta meta;
+
+			meta.cells = d->part_cells;
+			meta.ncells = d->npart_cells;
+			meta.spec_id = d->spec_id;
+			meta.lower = d->lower_bounds;
+			meta.nlower = d->nlower;
+			meta.upper = d->upper_bounds;
+			meta.nupper = d->nupper;
+			if (filter(filterarg, &meta))
+			{
+				pruned++;
+				continue;
+			}
 		}
 
 		if (d->file_format != NULL && strcmp(d->file_format, "PARQUET") != 0)

--- a/src/columnar_iceberg.h
+++ b/src/columnar_iceberg.h
@@ -13,16 +13,30 @@
 #include "columnar_objstore.h"	/* PgColumnarObjStoreConfig */
 
 struct PgColumnarAvroPartCell;
+struct PgColumnarAvroBound;
 
 /*
- * A per-data-file filter for a filtered Iceberg scan (the FDW's pruning): return
- * true to SKIP (prune) the file, false to read it. `cells`/`ncells` is the
- * file's typed partition tuple (as stored in the manifest, already transformed),
- * `spec_id` its partition spec id.
+ * What a per-data-file filter (the FDW's pruning) sees about one data file: its
+ * typed partition tuple (already transformed) and spec id, and its column
+ * lower/upper bounds (Iceberg single-value binary, keyed by field id).
+ */
+typedef struct PgColumnarIceFileMeta
+{
+	const struct PgColumnarAvroPartCell *cells;
+	int			ncells;
+	int32		spec_id;
+	const struct PgColumnarAvroBound *lower;
+	int			nlower;
+	const struct PgColumnarAvroBound *upper;
+	int			nupper;
+} PgColumnarIceFileMeta;
+
+/*
+ * A per-data-file filter for a filtered Iceberg scan: return true to SKIP
+ * (prune) the file, false to read it.
  */
 typedef bool (*PgColumnarIceFileFilter) (void *arg,
-										 const struct PgColumnarAvroPartCell *cells,
-										 int ncells, int32 spec_id);
+										 const PgColumnarIceFileMeta *meta);
 
 /*
  * Read the Iceberg table whose current metadata.json is at `path` (a local or
@@ -63,5 +77,13 @@ extern void PgColumnarIcebergIdentityPartMap(const char *path,
 											 TupleDesc tupdesc,
 											 int **out_attno, int *out_npos,
 											 int32 *out_specid);
+
+/*
+ * Per-column current-schema field ids (0 when absent), length tupdesc->natts,
+ * for FDW metrics pruning keyed by field id. palloc'd in the current context.
+ */
+extern int *PgColumnarIcebergColumnFieldIds(const char *path,
+											const PgColumnarObjStoreConfig *cfg,
+											TupleDesc tupdesc);
 
 #endif							/* COLUMNAR_ICEBERG_H */

--- a/src/columnar_iceberg_fdw.c
+++ b/src/columnar_iceberg_fdw.c
@@ -22,6 +22,7 @@
 #include <sys/stat.h>
 
 #include "access/reloptions.h"
+#include "access/stratnum.h"
 #include "catalog/pg_authid_d.h"
 #include "catalog/pg_foreign_table.h"
 #include "catalog/pg_type_d.h"
@@ -65,8 +66,21 @@ typedef struct IceFdwState
 	int32		specid;			/* current spec; a file with another spec is read */
 	List	   *partQuals;		/* compiled quals over identity-partition columns */
 	TupleTableSlot *partSlot;
+	List	   *metricQuals;	/* IceMetricQual*, min/max prune on int/bool cols */
 	int64		filesPruned;
 }			IceFdwState;
+
+/*
+ * A predicate a data file's column bounds can decide: "column <op> constant" on
+ * an integer/boolean column, reduced to a btree strategy (normalized so the
+ * column is on the left) and the constant as int64.
+ */
+typedef struct IceMetricQual
+{
+	int32		fieldid;		/* the column's Iceberg field id */
+	int			strategy;		/* BTLess..BTGreater, column-on-left normalized */
+	int64		constval;
+}			IceMetricQual;
 
 /* a named option of a foreign table, or NULL */
 static char *
@@ -228,26 +242,239 @@ ice_fdw_cell_datum(const PgColumnarAvroPartCell *c, Oid typid, bool *ok)
 	return (Datum) 0;
 }
 
+/* the lower/upper bound bytes for `fieldid` in a bound map, or NULL */
+static const PgColumnarAvroBound *
+ice_fdw_find_bound(const PgColumnarAvroBound *b, int n, int32 fieldid)
+{
+	int			i;
+
+	for (i = 0; i < n; i++)
+		if (b[i].field_id == fieldid)
+			return &b[i];
+	return NULL;
+}
+
+/* Decode an Iceberg single-value binary integer/boolean bound to int64 by its
+ * byte width (bool 1, int 4, long 8, all little-endian). Returns false for any
+ * other width, so an unexpected encoding never prunes. */
+static bool
+ice_fdw_bound_int(const PgColumnarAvroBound *b, int64 *out)
+{
+	const unsigned char *p = (const unsigned char *) b->bytes;
+
+	if (b->bytes == NULL)
+		return false;
+	if (b->blen == 1)
+		*out = (int64) p[0];
+	else if (b->blen == 4)
+		*out = (int64) (int32) ((uint32) p[0] | ((uint32) p[1] << 8) |
+								((uint32) p[2] << 16) | ((uint32) p[3] << 24));
+	else if (b->blen == 8)
+		*out = (int64) ((uint64) p[0] | ((uint64) p[1] << 8) |
+						((uint64) p[2] << 16) | ((uint64) p[3] << 24) |
+						((uint64) p[4] << 32) | ((uint64) p[5] << 40) |
+						((uint64) p[6] << 48) | ((uint64) p[7] << 56));
+	else
+		return false;
+	return true;
+}
+
+/* Does "column <strategy> const" have no satisfying value in [lo, hi]? Sound and
+ * conservative: only returns true when the file provably yields no matching row. */
+static bool
+ice_fdw_metric_excludes(int strategy, int64 c, int64 lo, int64 hi)
+{
+	switch (strategy)
+	{
+		case BTEqualStrategyNumber:
+			return (c < lo || c > hi);
+		case BTLessStrategyNumber:	/* col < c : possible iff lo < c */
+			return (lo >= c);
+		case BTLessEqualStrategyNumber:	/* col <= c : possible iff lo <= c */
+			return (lo > c);
+		case BTGreaterStrategyNumber:	/* col > c : possible iff hi > c */
+			return (hi <= c);
+		case BTGreaterEqualStrategyNumber:	/* col >= c : possible iff hi >= c */
+			return (hi < c);
+		default:
+			return false;
+	}
+}
+
+/* Extract an int2/int4/int8/bool Const as int64; false for any other type. */
+static bool
+ice_fdw_const_int(Const *c, int64 *out)
+{
+	if (c->constisnull)
+		return false;
+	switch (c->consttype)
+	{
+		case BOOLOID:
+			*out = DatumGetBool(c->constvalue) ? 1 : 0;
+			return true;
+		case INT2OID:
+			*out = (int64) DatumGetInt16(c->constvalue);
+			return true;
+		case INT4OID:
+			*out = (int64) DatumGetInt32(c->constvalue);
+			return true;
+		case INT8OID:
+			*out = DatumGetInt64(c->constvalue);
+			return true;
+		default:
+			return false;
+	}
+}
+
+/*
+ * Compile the scan's "column <op> const" predicates over integer/boolean columns
+ * into IceMetricQuals a data file's min/max bounds can decide. Any column with a
+ * field id and a supported type qualifies (not only partition columns), so a
+ * predicate on an unpartitioned column can still prune whole files by metrics.
+ */
+static List *
+ice_fdw_metric_quals(ForeignScanState *node, TupleDesc tupdesc,
+					 const int *attFieldId)
+{
+	ForeignScan *fs = (ForeignScan *) node->ss.ps.plan;
+	List	   *out = NIL;
+	ListCell   *lc;
+
+	foreach(lc, fs->scan.plan.qual)
+	{
+		OpExpr	   *op = (OpExpr *) lfirst(lc);
+		Node	   *larg;
+		Node	   *rarg;
+		Var		   *var;
+		Const	   *con;
+		bool		varLeft;
+		int			strategy = 0;
+		int64		cval;
+		Oid			ctype;
+		ListCell   *ic;
+		List	   *interp;
+		IceMetricQual *mq;
+
+		if (!IsA(op, OpExpr) || list_length(op->args) != 2)
+			continue;
+		larg = (Node *) linitial(op->args);
+		rarg = (Node *) lsecond(op->args);
+		if (IsA(larg, Var) && IsA(rarg, Const))
+		{
+			var = (Var *) larg;
+			con = (Const *) rarg;
+			varLeft = true;
+		}
+		else if (IsA(larg, Const) && IsA(rarg, Var))
+		{
+			var = (Var *) rarg;
+			con = (Const *) larg;
+			varLeft = false;
+		}
+		else
+			continue;
+		if (var->varattno < 1 || var->varattno > tupdesc->natts ||
+			attFieldId[var->varattno - 1] == 0)
+			continue;
+		ctype = TupleDescAttr(tupdesc, var->varattno - 1)->atttypid;
+		if (ctype != INT2OID && ctype != INT4OID && ctype != INT8OID &&
+			ctype != BOOLOID)
+			continue;
+		if (contain_volatile_functions((Node *) op))
+			continue;
+		if (!ice_fdw_const_int(con, &cval))
+			continue;
+
+		interp = PgColumnarGetOpInterpretation(op->opno);
+		foreach(ic, interp)
+		{
+			PgColumnarOpInterpretation *o = (PgColumnarOpInterpretation *) lfirst(ic);
+			int			s = PgColumnarOpInterpStrategy(o);
+
+			if (s >= BTLessStrategyNumber && s <= BTGreaterStrategyNumber)
+			{
+				strategy = s;
+				break;
+			}
+		}
+		if (strategy == 0)
+			continue;
+		/* normalize so the column is on the left: "c op var" -> "var flip(op) c" */
+		if (!varLeft)
+		{
+			switch (strategy)
+			{
+				case BTLessStrategyNumber:
+					strategy = BTGreaterStrategyNumber;
+					break;
+				case BTLessEqualStrategyNumber:
+					strategy = BTGreaterEqualStrategyNumber;
+					break;
+				case BTGreaterStrategyNumber:
+					strategy = BTLessStrategyNumber;
+					break;
+				case BTGreaterEqualStrategyNumber:
+					strategy = BTLessEqualStrategyNumber;
+					break;
+				default:
+					break;		/* BTEqual is symmetric */
+			}
+		}
+
+		mq = (IceMetricQual *) palloc(sizeof(IceMetricQual));
+		mq->fieldid = attFieldId[var->varattno - 1];
+		mq->strategy = strategy;
+		mq->constval = cval;
+		out = lappend(out, mq);
+	}
+	return out;
+}
+
 /*
  * The per-file filter passed to PgColumnarIcebergScanCore: return true to prune
- * (skip) a data file whose identity-partition values make every candidate qual
- * false. A file written under a different partition spec than the current one,
- * or with an incomparable/unsupported partition cell, is never pruned.
+ * (skip) a data file that provably yields no matching row -- because its column
+ * min/max bounds exclude a predicate, or its identity-partition value does. A
+ * file written under a different partition spec, or with a missing bound or an
+ * incomparable/unsupported partition cell, is never pruned (it is read and its
+ * rows are re-filtered by the recheckable qual).
  */
 static bool
-ice_fdw_file_excludes(void *arg, const PgColumnarAvroPartCell *cells,
-					  int ncells, int32 spec_id)
+ice_fdw_file_excludes(void *arg, const PgColumnarIceFileMeta *meta)
 {
 	IceFdwState *st = (IceFdwState *) arg;
-	ExprContext *econtext = st->node->ss.ps.ps_ExprContext;
+	ExprContext *econtext;
 	TupleDesc	tupdesc = st->tupdesc;
 	ListCell   *lc;
 	int			i;
 	int			k;
 
-	if (st->partQuals == NIL || spec_id != st->specid || ncells != st->npart)
+	/* metrics pruning: a data file whose [lower, upper] for a column excludes
+	 * the predicate over it yields no matching row (bounds present for both). */
+	foreach(lc, st->metricQuals)
+	{
+		IceMetricQual *mq = (IceMetricQual *) lfirst(lc);
+		const PgColumnarAvroBound *lb = ice_fdw_find_bound(meta->lower, meta->nlower,
+														   mq->fieldid);
+		const PgColumnarAvroBound *ub = ice_fdw_find_bound(meta->upper, meta->nupper,
+														   mq->fieldid);
+		int64		lo;
+		int64		hi;
+
+		if (lb == NULL || ub == NULL)
+			continue;			/* no bounds for this column: cannot decide */
+		if (!ice_fdw_bound_int(lb, &lo) || !ice_fdw_bound_int(ub, &hi))
+			continue;			/* unexpected width: do not prune */
+		if (lo > hi)
+			continue;			/* a nonsense bound: never prune on it */
+		if (ice_fdw_metric_excludes(mq->strategy, mq->constval, lo, hi))
+			return true;
+	}
+
+	if (st->partQuals == NIL || meta->spec_id != st->specid ||
+		meta->ncells != st->npart)
 		return false;
 
+	econtext = st->node->ss.ps.ps_ExprContext;
 	ExecClearTuple(st->partSlot);
 	for (i = 0; i < tupdesc->natts; i++)
 	{
@@ -263,13 +490,13 @@ ice_fdw_file_excludes(void *arg, const PgColumnarAvroPartCell *cells,
 
 		if (a <= 0 || a > tupdesc->natts)
 			continue;
-		if (cells[k].isnull)
+		if (meta->cells[k].isnull)
 		{
 			st->partSlot->tts_isnull[a - 1] = true;	/* a real NULL: prunable */
 			continue;
 		}
 		typid = TupleDescAttr(tupdesc, a - 1)->atttypid;
-		d = ice_fdw_cell_datum(&cells[k], typid, &ok);
+		d = ice_fdw_cell_datum(&meta->cells[k], typid, &ok);
 		if (!ok)
 		{
 			/*
@@ -358,6 +585,14 @@ icefdwBeginForeignScan(ForeignScanState *node, int eflags)
 		st->partSlot = MakeSingleTupleTableSlot(tupdesc, &TTSOpsVirtual);
 	}
 
+	/* metrics pruning: min/max over int/bool columns, keyed by field id */
+	{
+		int		   *attFieldId = PgColumnarIcebergColumnFieldIds(st->metadata_path,
+																 NULL, tupdesc);
+
+		st->metricQuals = ice_fdw_metric_quals(node, tupdesc, attFieldId);
+	}
+
 	st->tupstore = tuplestore_begin_heap(false, false, work_mem);
 	st->readslot = MakeSingleTupleTableSlot(tupdesc, &TTSOpsMinimalTuple);
 	st->started = false;
@@ -378,10 +613,11 @@ icefdwIterateForeignScan(ForeignScanState *node)
 	if (!st->started)
 	{
 		/* read the surviving files (pruned by the filter) into the tuplestore */
+		bool		prune = (st->partQuals != NIL || st->metricQuals != NIL);
+
 		st->filesPruned = PgColumnarIcebergScanCore(st->metadata_path, st->tupdesc,
 													NULL, st->tupstore,
-													st->partQuals != NIL ?
-													ice_fdw_file_excludes : NULL,
+													prune ? ice_fdw_file_excludes : NULL,
 													st);
 		st->started = true;
 	}

--- a/test/iceberg_fdw.sh
+++ b/test/iceberg_fdw.sh
@@ -72,12 +72,30 @@ check "region='zz' prunes both files (Files Pruned: 2)" \
 check "region='zz' returns no rows" \
 	"$(q "SELECT count(*) FROM ev WHERE region='zz'")" "0"
 
-# ---- a predicate on a NON-partition column prunes nothing, stays correct -----
-check "a non-partition predicate prunes no files (Files Pruned: 0)" \
-	"$(fp "SELECT * FROM ev WHERE amount > 25")" "0"
-check "the non-partition predicate still returns the right rows" \
+# ---- metrics pruning: a NON-partition int column prunes by file min/max ------
+# amount bounds: region=eu file [10,20], region=us file [30,50].
+check "amount > 25 prunes the eu file by metrics (Files Pruned: 1)" \
+	"$(fp "SELECT * FROM ev WHERE amount > 25")" "1"
+check "amount > 25 still returns the right rows" \
 	"$(q "SELECT string_agg(id::text, ',' ORDER BY id) FROM ev WHERE amount > 25")" \
 	"3,4,5"
+check "amount < 15 prunes the us file by metrics (Files Pruned: 1)" \
+	"$(fp "SELECT * FROM ev WHERE amount < 15")" "1"
+check "amount < 15 returns only id 1" \
+	"$(q "SELECT string_agg(id::text, ',' ORDER BY id) FROM ev WHERE amount < 15")" "1"
+check "amount = 30 prunes the eu file, keeps us (Files Pruned: 1)" \
+	"$(fp "SELECT * FROM ev WHERE amount = 30")" "1"
+check "amount = 30 returns id 3" \
+	"$(q "SELECT string_agg(id::text, ',' ORDER BY id) FROM ev WHERE amount = 30")" "3"
+check "amount = 100 prunes both files by metrics (Files Pruned: 2)" \
+	"$(fp "SELECT * FROM ev WHERE amount = 100")" "2"
+check "amount = 100 returns no rows" \
+	"$(q "SELECT count(*) FROM ev WHERE amount = 100")" "0"
+check_text "a metrics-pruned query matches iceberg_scan (same oracle)" \
+	"$(q "SELECT string_agg(id::text, ',' ORDER BY id) FROM ev WHERE amount >= 30")" \
+	"$(q "SELECT string_agg(id::text, ',' ORDER BY id)
+	      FROM pgcolumnar.iceberg_scan('$MD') AS t(id bigint, region text, amount int)
+	      WHERE amount >= 30")"
 
 # ---- a DATE identity partition must NOT over-prune (the #660 bug) ------------
 # the FDW cannot convert a date partition cell, so it must read the file in full


### PR DESCRIPTION
Second pruning increment (phase 5b), on top of 5a's identity-partition pruning. Design: `design/ISSUE_388_PRUNING.md`.

## What this adds
The Iceberg FDW now also prunes a whole data file whose stored column **min/max** exclude a predicate — so a predicate on an **unpartitioned** column prunes too, not only partition columns. Scoped to **integer and boolean** columns, whose Iceberg single-value binary bounds are exact (no string-truncation complexity); other types read in full.

```sql
-- amount is not a partition column; pruned by the file min/max in the manifest
SELECT * FROM ev WHERE amount > 25;   -- EXPLAIN ANALYZE: Files Pruned: 1
```

## How
- **Avro** (`av_read_bound_map`): decodes `lower_bounds`/`upper_bounds` (Iceberg's `map<int,bytes>` is an Avro array of `{key:int,value:bytes}` records) onto the manifest entry, carried onto `IceEntry` and deep-copied like the partition tuple.
- **Filter meta**: the per-file callback now takes a `PgColumnarIceFileMeta` (partition cells + spec id + the bound maps), doing both partition and metrics pruning.
- **Metric quals**: `ice_fdw_metric_quals` compiles the scan's `column <op> const` btree predicates over int/bool columns into `(field id, strategy normalized column-on-left, int64 const)`. At read time each file's lower/upper for that field id is decoded little-endian by width (bool 1, int 4, long 8), and the file is pruned **only when `[lower, upper]` provably yields no matching row**.

## Sound
Metrics pruning drops whole files only; clauses stay recheckable, so rows never change. A missing bound, an unexpected byte width, or an inverted bound never prunes. Nulls never satisfy a comparison, and a file with no bound for the column is read.

## Proof
`iceberg_fdw.sh` grows metrics arms on the region warehouse (amount bounds: eu `[10,20]`, us `[30,50]`): `amount>25` prunes eu, `amount<15` prunes us, `amount=30` prunes eu, `amount=100` prunes both (0 rows) — each with the correct rows and a **same-oracle** check vs `iceberg_scan`.

- **Removal proof**: neutering `ice_fdw_metric_excludes` reds *exactly* the Files-Pruned arms (`got 0`) while **every row arm stays green** — load-bearing and correctness-independent.
- **Gates**: 23/23 + full iceberg family + `avro_manifest` on PG17/18/19, clean under `pg18_san` ASAN+UBSAN, `docs_style`/STE clean.

## Next
5c — the partition transform library (truncate/temporal for range pruning, then bucket/murmur3 for equality).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
