### PR TITLE
feat: Iceberg REST catalog credentials via FOREIGN SERVER + USER MAPPING (#656)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,13 @@ which was true until that script existed.
   second TLS stack enters the server process. A bearer token, when the catalog
   requires one, is read from the `PGCOLUMNAR_ICEBERG_REST_TOKEN` server
   environment variable, never a function argument, so it does not appear in the
-  statement log. When the catalog vends short-lived storage credentials in its
+  statement log. The first argument may instead name a foreign server of the new
+  validator-only `pgcolumnar_iceberg_catalog` wrapper (#656). The server holds
+  `catalog_uri`, and the current role's user mapping holds the bearer `token` in
+  `pg_user_mapping`, which is not world-readable, so one role's token is private
+  from another. A role with neither a mapping token nor superuser rights is
+  refused, and the validator keeps secrets off the world-readable server options.
+  When the catalog vends short-lived storage credentials in its
   `loadTable` reply (the flat `config` keys or the `storage-credentials` array,
   longest prefix selected), `iceberg_rest_scan` reads the table's files with
   those credentials rather than the server environment (#656). Vended

--- a/design/ISSUE_656_CATALOG_CREDENTIALS.md
+++ b/design/ISSUE_656_CATALOG_CREDENTIALS.md
@@ -1,0 +1,124 @@
+# Issue #656 (part 2) — Iceberg REST catalog per-catalog credentials + OAuth2
+
+Status: DESIGN. Extends #388 phase 7 (REST catalog) and #656 part 1 (vended
+storage credentials, merged #659). This part gives the REST catalog a
+`FOREIGN SERVER` + `USER MAPPING` credential model, so a catalog's URI and a
+per-role bearer token live in the catalog rather than a single server-wide
+environment variable, and adds OAuth2 client-credentials token exchange.
+
+## Why
+
+Phase 7 authenticates with one static bearer token from the server environment
+(`PGCOLUMNAR_ICEBERG_REST_TOKEN`) -- process-global, one token per server, no
+per-role scoping. The idiomatic PostgreSQL model, which the objstore FDW already
+uses for S3, is a `FOREIGN SERVER` per catalog (non-secret options) and a
+`USER MAPPING` per role (the secret, stored in `pg_user_mapping`, visible only to
+that role or a superuser). This brings that to the REST catalog and adds OAuth2
+so a mapping can hold a client id/secret instead of a long-lived token.
+
+## The credential template (objstore FDW, verbatim shape)
+
+`pqfdw_objstore_config` (columnar_parquet_reader.c) is the pattern: get the
+server, read non-secret options from `server->options`, probe the current role's
+user mapping in the syscache (`SearchSysCache2(USERMAPPINGUSERSERVER, GetUserId(),
+serverid)`, falling back to the `InvalidOid` PUBLIC mapping, without erroring when
+absent), read the secret options from the mapping, enforce a credential-pairing
+rule (half a credential is `28000`, never a silent fallback), and gate ambient
+fallback on `superuser() || !credentials_required`. The REST bearer follows this
+exactly.
+
+## API: content-sniff, no new function names
+
+The four REST functions keep their signatures. Their first `text` argument is
+sniffed:
+
+- Starts with `http://` or `https://` -> a catalog URI (the phase-7 form): token
+  from `PGCOLUMNAR_ICEBERG_REST_TOKEN`.
+- Otherwise -> a `FOREIGN SERVER` name: resolve `catalog_uri` (server option) and
+  the current role's `token` (user-mapping option) from the catalog.
+
+Two `(text, text, text)` overloads cannot coexist, so content-sniffing keeps one
+function per operation and both forms working. A server name can never look like
+`http(s)://` (server names are identifiers), so there is no ambiguity; a
+non-URI that is not a server errors cleanly ("server does not exist").
+
+## The FDW: `pgcolumnar_iceberg_catalog` (validator-only)
+
+A new FDW distinct from `pgcolumnar_iceberg` (whose table holds `metadata_path`)
+and `pgcolumnar_parquet`. It creates no foreign tables -- a catalog is a service
+endpoint plus a per-role token -- so the wrapper needs only a `VALIDATOR`, no
+`HANDLER`. `CREATE SERVER ... FOREIGN DATA WRAPPER pgcolumnar_iceberg_catalog`
+gives the server OID the syscache lookup needs.
+
+Validator arms (mirroring the parquet validator's security split):
+- `ForeignServerRelationId`: accept only `catalog_uri` (srvoptions are
+  world-readable, so nothing secret here).
+- `UserMappingRelationId`: accept `token`, and (part 5c-2) `oauth_client_id`,
+  `oauth_client_secret`, `oauth_scope`, `oauth_token_uri`, and
+  `credentials_required`. Secrets live only here (`pg_user_mapping` is
+  role-protected).
+- Only a superuser may set `credentials_required 'false'`.
+
+## Security invariants (unchanged from phase 7)
+
+- The token and `oauth_client_secret` are USER MAPPING options, never SERVER
+  options. The SQL call passes only a server NAME; the secret is fetched inside C
+  and never becomes a SQL argument, so it does not reach `log_statement` or
+  `pg_stat_activity`.
+- No error message ever prints a token/secret value (the existing 401 errhint
+  names the env variable, not its value; keep that).
+- The OAuth2 `client_secret` goes in the POST body, never a URL query string.
+- Pairing + ambient gate: `oauth_client_id` without `oauth_client_secret` (or a
+  half credential) -> `28000`; ambient fallback to the env token only when
+  `superuser() || !credentials_required`.
+- The transport's allow-list, link-local refusal, and header CR/LF guard apply
+  to every request, including the OAuth POST, unchanged.
+- The `pg_read_server_files` function gate is kept for both forms in 5c-1 (every
+  external read in this extension is gated on it); relaxing it for the
+  server-name form (a role with its own mapping) is a documented later option,
+  not silently dropped.
+
+## OAuth2 exchange (5c-2)
+
+Selected purely by which user-mapping options are present: if `oauth_client_id`
+is set, the resolver mints a bearer via `POST {catalog}/v1/oauth/tokens` with a
+form body `grant_type=client_credentials&client_id=...&client_secret=...&scope=...`
+(each value percent-encoded via the existing `rest_pct_encode`), `Content-Type:
+application/x-www-form-urlencoded`, parsing `{access_token, expires_in}`. This
+reuses the ABI v5 `http_request` (POST + body + custom Content-Type already
+supported -- no ABI bump) and `rest_json_string`. No new SQL surface. Optional:
+cache the minted token per (server OID, role) honoring `expires_in`.
+
+## Threading
+
+`rest_get_json` and `rest_load_table_doc` gain a `const char *token` parameter
+(NULL = no Authorization header) instead of reading `getenv` internally. Each SQL
+function's C entry resolves `(uri, token)` up front -- from the env for the URI
+form, or from `rest_resolve_server(name, &uri, &token, &allow_ambient)` for the
+server form (mapping token, else OAuth mint, else gated ambient env) -- and
+threads the token into the core. `rest_vended_cfg` and `PgColumnarIcebergScanInto`
+are untouched (vended storage creds stay orthogonal).
+
+## Increment split
+
+- **5c-1** — SERVER/USER-MAPPING static bearer: the `pgcolumnar_iceberg_catalog`
+  FDW (validator + wrapper), the C validator, `rest_resolve_server`, the
+  content-sniff in the four functions, and the `token` parameter on
+  `rest_get_json`/`rest_load_table_doc`. Static token in the mapping.
+- **5c-2** — OAuth2 client-credentials exchange: validator acceptance of the
+  `oauth_*` mapping options, `rest_post_form` + `rest_oauth_token`, and the
+  resolver's mint branch. No new SQL.
+
+## Proof plan
+
+Hermetic REST fixture extended: it already verifies `Authorization: Bearer`.
+5c-1: `CREATE SERVER` + `CREATE USER MAPPING` with the fixture's token; a
+server-name `iceberg_rest_scan('srv', ns, tbl)` reads with the mapping token and
+**no `PGCOLUMNAR_ICEBERG_REST_TOKEN` in the environment** -- proving the mapping
+token, not ambient, authenticated. Arms: wrong mapping token -> 28000; a role
+with no mapping and `credentials_required` -> 28000 (no ambient); the URI form
+still works; the token never appears in the PG log. 5c-2: the fixture serves
+`POST /v1/oauth/tokens` for a client id/secret, returns a bearer, and loadTable
+then requires exactly that bearer; a wrong client secret -> 28000; the secret
+never in the PG log nor the catalog request log. Removal proofs, PG17/18/19 +
+ASAN, docs. STE clean.

--- a/docs/sql-reference.md
+++ b/docs/sql-reference.md
@@ -789,29 +789,46 @@ The request is carried by the `pgcolumnar_objstore` module, so no additional TLS
 library is loaded into the server process. HTTPS requires the module to be built
 with OpenSSL, as for object storage.
 
-When the catalog requires authentication, the bearer token is read from the
-`PGCOLUMNAR_ICEBERG_REST_TOKEN` variable in the server process environment. It is
-never a function argument, so it does not appear in the statement log or in
+The first argument is either a catalog URI or the name of a foreign server. A
+value beginning with `http://` or `https://` is a URI. Any other value names a
+server. A server name can never look like a URI, so the two forms never collide.
+
+When the first argument is a URI, the token comes from the environment. It is
+read from the `PGCOLUMNAR_ICEBERG_REST_TOKEN` variable in the server process. It
+is never a function argument, so it does not appear in the statement log or in
 `pg_stat_activity`. A catalog that needs no token is queried without one.
+
+When the first argument names a server, the catalog URI comes from the server
+and the token comes from the current role's user mapping. The token lives in
+`pg_user_mapping`, which is not world-readable, so one role's token is not
+visible to another. A role with no mapping and no token is refused. A superuser,
+or a mapping that sets `credentials_required 'false'`, uses the environment token
+instead.
 
 Multi-level namespaces are given dot-separated, and the function requires the
 `pg_read_server_files` role, like the other Iceberg functions.
 
 ```sql
--- token, if any, comes from the server environment, not the query
+-- URI form: the token, if any, comes from the server environment, not the query
 SELECT pgcolumnar.iceberg_rest_table_location(
          'https://catalog.example.com', 'analytics', 'events');
 --> s3://warehouse/analytics/events/metadata/00042-....metadata.json
 
+-- server form: the token is per-role and stays in pg_user_mapping
+CREATE SERVER cat FOREIGN DATA WRAPPER pgcolumnar_iceberg_catalog
+  OPTIONS (catalog_uri 'https://catalog.example.com');
+CREATE USER MAPPING FOR analyst SERVER cat OPTIONS (token 's3cr3t');
+
 SELECT count(*) FROM pgcolumnar.iceberg_scan(
-  pgcolumnar.iceberg_rest_table_location('https://catalog.example.com',
-                                         'analytics', 'events'))
+  pgcolumnar.iceberg_rest_table_location('cat', 'analytics', 'events'))
   AS t(id bigint, region text, amount int);
 ```
 
-Per-catalog credentials can move to a foreign server and user mapping. The
-catalog can issue temporary storage credentials. See issue #656 and the later
-phase 7 work.
+The `pgcolumnar_iceberg_catalog` wrapper has a validator but no handler, so its
+servers cannot be selected from as tables. It accepts only `catalog_uri` on a
+server, and only `token` and `credentials_required` on a user mapping. A secret
+on a server, where options are world-readable, is rejected. Setting
+`credentials_required 'false'` is restricted to a superuser.
 
 ### pgcolumnar.iceberg_rest_scan(catalog_uri text, namespace text, table_name text) returns setof record
 

--- a/pgcolumnar--1.0-alpha.sql
+++ b/pgcolumnar--1.0-alpha.sql
@@ -1039,6 +1039,19 @@ CREATE FOREIGN DATA WRAPPER pgcolumnar_iceberg
 COMMENT ON FOREIGN DATA WRAPPER pgcolumnar_iceberg
 	IS 'read an Apache Iceberg table as a foreign table, pruning data files by a predicate on an identity-partition column; table option: metadata_path (#388)';
 
+CREATE FUNCTION pgcolumnar.iceberg_catalog_fdw_validator(text[], oid)
+	RETURNS void
+	LANGUAGE C
+	AS 'MODULE_PATHNAME', 'pgcolumnar_iceberg_catalog_validator';
+
+-- Validator-only wrapper (no HANDLER): a REST catalog creates no foreign tables.
+-- A SERVER under it holds catalog_uri; a USER MAPPING holds the per-role token.
+CREATE FOREIGN DATA WRAPPER pgcolumnar_iceberg_catalog
+	VALIDATOR pgcolumnar.iceberg_catalog_fdw_validator;
+
+COMMENT ON FOREIGN DATA WRAPPER pgcolumnar_iceberg_catalog
+	IS 'name an Iceberg REST catalog: a SERVER holds catalog_uri, a USER MAPPING holds the bearer token; the iceberg_rest_* functions accept a server name in place of a catalog URI (#656)';
+
 CREATE FUNCTION pgcolumnar.vm_selftest(rel regclass, blk int)
 	RETURNS boolean
 	LANGUAGE C

--- a/src/columnar_iceberg_rest.c
+++ b/src/columnar_iceberg_rest.c
@@ -21,14 +21,20 @@
  */
 #include "postgres.h"
 
+#include "access/reloptions.h"
 #include "catalog/pg_authid_d.h"
+#include "catalog/pg_foreign_server.h"
 #include "catalog/pg_type_d.h"
+#include "catalog/pg_user_mapping.h"
+#include "commands/defrem.h"
 #include "fmgr.h"
+#include "foreign/foreign.h"
 #include "lib/stringinfo.h"
 #include "miscadmin.h"
 #include "utils/acl.h"
 #include "utils/builtins.h"
 #include "utils/jsonb.h"
+#include "utils/syscache.h"
 #include "utils/tuplestore.h"
 
 #include "funcapi.h"
@@ -88,6 +94,115 @@ rest_objstore(void)
 				 errmsg("iceberg: the object-store module is required for a REST catalog"),
 				 errhint("Install the pgcolumnar_objstore module.")));
 	return api;
+}
+
+/*
+ * Resolve a FOREIGN SERVER (pgcolumnar_iceberg_catalog) into its catalog_uri and
+ * the current role's bearer token. The token comes from the role's USER MAPPING
+ * (or the PUBLIC mapping), which lives in pg_user_mapping and is not
+ * world-readable. When the mapping carries no token, fall back to the
+ * environment token only if ambient use is allowed (a superuser, or a mapping
+ * that set credentials_required 'false'); otherwise refuse (28000). *out_token
+ * may be NULL for an anonymous catalog.
+ */
+static void
+rest_resolve_server(const char *name, char **out_uri, char **out_token)
+{
+	ForeignServer *srv = GetForeignServerByName(name, false);
+	ListCell   *lc;
+	char	   *uri = NULL;
+	char	   *token = NULL;
+	bool		credRequired = true;
+	HeapTuple	tp;
+
+	foreach(lc, srv->options)
+	{
+		DefElem    *d = (DefElem *) lfirst(lc);
+
+		if (strcmp(d->defname, "catalog_uri") == 0)
+			uri = defGetString(d);
+	}
+	if (uri == NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_FDW_OPTION_NAME_NOT_FOUND),
+				 errmsg("iceberg: server \"%s\" has no \"catalog_uri\" option", name)));
+
+	/* the current role's mapping, else the PUBLIC (InvalidOid) mapping */
+	tp = SearchSysCache2(USERMAPPINGUSERSERVER,
+						 ObjectIdGetDatum(GetUserId()),
+						 ObjectIdGetDatum(srv->serverid));
+	if (!HeapTupleIsValid(tp))
+		tp = SearchSysCache2(USERMAPPINGUSERSERVER,
+							 ObjectIdGetDatum(InvalidOid),
+							 ObjectIdGetDatum(srv->serverid));
+	if (HeapTupleIsValid(tp))
+	{
+		Datum		datum;
+		bool		isnull;
+
+		datum = SysCacheGetAttr(USERMAPPINGUSERSERVER, tp,
+								Anum_pg_user_mapping_umoptions, &isnull);
+		if (!isnull)
+		{
+			List	   *umopts = untransformRelOptions(datum);
+			ListCell   *l2;
+
+			foreach(l2, umopts)
+			{
+				DefElem    *d = (DefElem *) lfirst(l2);
+
+				if (strcmp(d->defname, "token") == 0)
+					token = pstrdup(defGetString(d));
+				else if (strcmp(d->defname, "credentials_required") == 0)
+					credRequired = defGetBoolean(d);
+			}
+		}
+		ReleaseSysCache(tp);
+	}
+
+	if (token == NULL)
+	{
+		bool		ambientOk = superuser() || !credRequired;
+
+		if (ambientOk)
+		{
+			const char *env = getenv(REST_TOKEN_ENV);
+
+			if (env != NULL && env[0] != '\0')
+				token = pstrdup(env);
+		}
+		else
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION),
+					 errmsg("iceberg: no bearer token for REST catalog server \"%s\"",
+							name),
+					 errhint("Create a USER MAPPING with a token option for this role, "
+							 "or set credentials_required 'false' on it.")));
+	}
+
+	*out_uri = pstrdup(uri);
+	*out_token = token;
+}
+
+/*
+ * Resolve the first function argument, which is EITHER a catalog URI (http(s)://,
+ * with the token from the environment, the phase-7 form) OR a FOREIGN SERVER name
+ * (with the URI and token from the catalog). A server name can never look like a
+ * URL, so the two are unambiguous.
+ */
+static void
+rest_resolve(const char *arg0, char **out_uri, char **out_token)
+{
+	if (pg_strncasecmp(arg0, "http://", 7) == 0 ||
+		pg_strncasecmp(arg0, "https://", 8) == 0)
+	{
+		const char *env = getenv(REST_TOKEN_ENV);
+
+		*out_uri = pstrdup(arg0);
+		*out_token = (env != NULL && env[0] != '\0') ? pstrdup(env) : NULL;
+	}
+	else
+		rest_resolve_server(arg0, out_uri, out_token);
 }
 
 /* Append `s` percent-encoded (RFC 3986 unreserved kept), for one path segment. */
@@ -184,10 +299,9 @@ rest_json_string_opt(JsonbContainer *c, const char *key)
  */
 static Jsonb *
 rest_get_json(const char *catalog_uri, const char *resource_path,
-			  const char *what)
+			  const char *what, const char *token)
 {
 	const PgColumnarObjStoreApi *api = rest_objstore();
-	const char *token = getenv(REST_TOKEN_ENV);
 	StringInfoData url;
 	const char *headers[2];
 	int			nheaders = 0;
@@ -219,8 +333,8 @@ rest_get_json(const char *catalog_uri, const char *resource_path,
 				(errcode(ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION),
 				 errmsg("iceberg: the REST catalog refused the request (HTTP %d)",
 						r.status),
-				 errhint("Set %s in the server environment, or check its value.",
-						 REST_TOKEN_ENV)));
+				 errhint("Provide the catalog's bearer token via a USER MAPPING "
+						 "or the %s server environment variable.", REST_TOKEN_ENV)));
 	if (r.status == 404)
 		ereport(ERROR,
 				(errcode(ERRCODE_UNDEFINED_TABLE),
@@ -245,7 +359,7 @@ rest_get_json(const char *catalog_uri, const char *resource_path,
  */
 static Jsonb *
 rest_load_table_doc(const char *catalog_uri, const char *ns, const char *table,
-					char **out_location)
+					const char *token, char **out_location)
 {
 	Jsonb	   *cfg;
 	char	   *prefix;
@@ -259,7 +373,7 @@ rest_load_table_doc(const char *catalog_uri, const char *ns, const char *table,
 				 errmsg("iceberg: a REST catalog URI must be http:// or https://")));
 
 	/* config: {overrides, defaults}; a prefix, if any, is spliced after /v1/ */
-	cfg = rest_get_json(catalog_uri, "/v1/config", "config");
+	cfg = rest_get_json(catalog_uri, "/v1/config", "config", token);
 	/*
 	 * The config body is untrusted (a compromised or hostile allow-listed
 	 * catalog). getKeyJsonValueFromContainer Asserts object-ness before its
@@ -294,7 +408,7 @@ rest_load_table_doc(const char *catalog_uri, const char *ns, const char *table,
 	appendStringInfoString(&rp, "/tables/");
 	rest_pct_encode(&rp, table);
 
-	lt = rest_get_json(catalog_uri, rp.data, "table");
+	lt = rest_get_json(catalog_uri, rp.data, "table", token);
 	if (out_location != NULL)
 		*out_location = rest_json_string(&lt->root, "metadata-location",
 										 "loadTable response");
@@ -392,11 +506,12 @@ rest_vended_cfg(JsonbContainer *lt, const char *metadata_location)
  */
 char *
 PgColumnarIcebergRestLoadTableLocation(const char *catalog_uri,
-									   const char *ns, const char *table)
+									   const char *ns, const char *table,
+									   const char *token)
 {
 	char	   *loc;
 
-	(void) rest_load_table_doc(catalog_uri, ns, table, &loc);
+	(void) rest_load_table_doc(catalog_uri, ns, table, token, &loc);
 	return loc;
 }
 
@@ -410,9 +525,11 @@ PG_FUNCTION_INFO_V1(pgcolumnar_iceberg_rest_table_location);
 Datum
 pgcolumnar_iceberg_rest_table_location(PG_FUNCTION_ARGS)
 {
-	char	   *catalog_uri = text_to_cstring(PG_GETARG_TEXT_PP(0));
+	char	   *arg0 = text_to_cstring(PG_GETARG_TEXT_PP(0));
 	char	   *ns = text_to_cstring(PG_GETARG_TEXT_PP(1));
 	char	   *table = text_to_cstring(PG_GETARG_TEXT_PP(2));
+	char	   *catalog_uri;
+	char	   *token;
 	char	   *loc;
 
 	if (!has_privs_of_role(GetUserId(), ROLE_PG_READ_SERVER_FILES))
@@ -420,7 +537,8 @@ pgcolumnar_iceberg_rest_table_location(PG_FUNCTION_ARGS)
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 				 errmsg("must be superuser or a member of the pg_read_server_files role to read a REST catalog")));
 
-	loc = PgColumnarIcebergRestLoadTableLocation(catalog_uri, ns, table);
+	rest_resolve(arg0, &catalog_uri, &token);
+	loc = PgColumnarIcebergRestLoadTableLocation(catalog_uri, ns, table, token);
 	PG_RETURN_TEXT_P(cstring_to_text(loc));
 }
 
@@ -436,11 +554,13 @@ PG_FUNCTION_INFO_V1(pgcolumnar_iceberg_rest_scan);
 Datum
 pgcolumnar_iceberg_rest_scan(PG_FUNCTION_ARGS)
 {
-	char	   *catalog_uri = text_to_cstring(PG_GETARG_TEXT_PP(0));
+	char	   *arg0 = text_to_cstring(PG_GETARG_TEXT_PP(0));
 	char	   *ns = text_to_cstring(PG_GETARG_TEXT_PP(1));
 	char	   *table = text_to_cstring(PG_GETARG_TEXT_PP(2));
 	ReturnSetInfo *rsinfo = (ReturnSetInfo *) fcinfo->resultinfo;
 	TupleDesc	tupdesc;
+	char	   *catalog_uri;
+	char	   *token;
 	Jsonb	   *lt;
 	char	   *loc;
 	PgColumnarObjStoreConfig *cfg;
@@ -460,8 +580,9 @@ pgcolumnar_iceberg_rest_scan(PG_FUNCTION_ARGS)
 				 errmsg("pgcolumnar.iceberg_rest_scan requires a column definition list"),
 				 errhint("Call it as SELECT * FROM pgcolumnar.iceberg_rest_scan(uri, ns, tbl) AS t(col1 type1, ...).")));
 
+	rest_resolve(arg0, &catalog_uri, &token);
 	/* one loadTable: the metadata-location AND the vended storage creds (if any) */
-	lt = rest_load_table_doc(catalog_uri, ns, table, &loc);
+	lt = rest_load_table_doc(catalog_uri, ns, table, token, &loc);
 	cfg = rest_vended_cfg(&lt->root, loc);
 	/*
 	 * A metadata-location is a URI. The reader's remote path handles s3:// and
@@ -483,10 +604,12 @@ PG_FUNCTION_INFO_V1(pgcolumnar_iceberg_rest_namespaces);
 Datum
 pgcolumnar_iceberg_rest_namespaces(PG_FUNCTION_ARGS)
 {
-	char	   *catalog_uri = text_to_cstring(PG_GETARG_TEXT_PP(0));
+	char	   *arg0 = text_to_cstring(PG_GETARG_TEXT_PP(0));
 	ReturnSetInfo *rsinfo = (ReturnSetInfo *) fcinfo->resultinfo;
 	Tuplestorestate *ts;
 	TupleDesc	td;
+	char	   *catalog_uri;
+	char	   *token;
 	Jsonb	   *doc;
 	JsonbValue	vbuf;
 	JsonbValue *nsv;
@@ -499,7 +622,8 @@ pgcolumnar_iceberg_rest_namespaces(PG_FUNCTION_ARGS)
 				 errmsg("must be superuser or a member of the pg_read_server_files role to read a REST catalog")));
 	ts = rest_text_srf_setup(rsinfo, &td);
 
-	doc = rest_get_json(catalog_uri, "/v1/namespaces", "namespaces");
+	rest_resolve(arg0, &catalog_uri, &token);
+	doc = rest_get_json(catalog_uri, "/v1/namespaces", "namespaces", token);
 	if (!JsonContainerIsObject(&doc->root))
 		ereport(ERROR,
 				(errcode(ERRCODE_DATA_CORRUPTED),
@@ -551,11 +675,13 @@ PG_FUNCTION_INFO_V1(pgcolumnar_iceberg_rest_tables);
 Datum
 pgcolumnar_iceberg_rest_tables(PG_FUNCTION_ARGS)
 {
-	char	   *catalog_uri = text_to_cstring(PG_GETARG_TEXT_PP(0));
+	char	   *arg0 = text_to_cstring(PG_GETARG_TEXT_PP(0));
 	char	   *ns = text_to_cstring(PG_GETARG_TEXT_PP(1));
 	ReturnSetInfo *rsinfo = (ReturnSetInfo *) fcinfo->resultinfo;
 	Tuplestorestate *ts;
 	TupleDesc	td;
+	char	   *catalog_uri;
+	char	   *token;
 	StringInfoData rp;
 	Jsonb	   *doc;
 	JsonbValue	vbuf;
@@ -569,11 +695,12 @@ pgcolumnar_iceberg_rest_tables(PG_FUNCTION_ARGS)
 				 errmsg("must be superuser or a member of the pg_read_server_files role to read a REST catalog")));
 	ts = rest_text_srf_setup(rsinfo, &td);
 
+	rest_resolve(arg0, &catalog_uri, &token);
 	initStringInfo(&rp);
 	appendStringInfoString(&rp, "/v1/namespaces/");
 	rest_append_namespace(&rp, ns);
 	appendStringInfoString(&rp, "/tables");
-	doc = rest_get_json(catalog_uri, rp.data, "table list");
+	doc = rest_get_json(catalog_uri, rp.data, "table list", token);
 	if (!JsonContainerIsObject(&doc->root))
 		ereport(ERROR,
 				(errcode(ERRCODE_DATA_CORRUPTED),
@@ -603,4 +730,64 @@ pgcolumnar_iceberg_rest_tables(PG_FUNCTION_ARGS)
 		tuplestore_putvalues(ts, td, values, nulls);
 	}
 	return (Datum) 0;
+}
+
+/* -------------------------------------------------------------------------
+ * The pgcolumnar_iceberg_catalog foreign-data wrapper (#656). It creates no
+ * foreign tables -- a catalog is a service endpoint plus a per-role token -- so
+ * the wrapper is validator-only. A CREATE SERVER under it holds catalog_uri (a
+ * non-secret, world-readable option); a CREATE USER MAPPING holds the bearer
+ * token (a secret, which pg_user_mapping keeps role-private).
+ * ------------------------------------------------------------------------- */
+
+PG_FUNCTION_INFO_V1(pgcolumnar_iceberg_catalog_validator);
+
+Datum
+pgcolumnar_iceberg_catalog_validator(PG_FUNCTION_ARGS)
+{
+	List	   *options = untransformRelOptions(PG_GETARG_DATUM(0));
+	Oid			catalog = PG_GETARG_OID(1);
+	ListCell   *lc;
+
+	foreach(lc, options)
+	{
+		DefElem    *def = (DefElem *) lfirst(lc);
+
+		if (catalog == ForeignServerRelationId)
+		{
+			/* srvoptions is world-readable: only the non-secret URI belongs here */
+			if (strcmp(def->defname, "catalog_uri") != 0)
+				ereport(ERROR,
+						(errcode(ERRCODE_FDW_INVALID_OPTION_NAME),
+						 errmsg("invalid option \"%s\" for a pgcolumnar_iceberg_catalog server",
+								def->defname),
+						 errhint("Valid server option: catalog_uri. Secrets go on a USER MAPPING.")));
+		}
+		else if (catalog == UserMappingRelationId)
+		{
+			/* secrets live only here (pg_user_mapping is role-protected) */
+			if (strcmp(def->defname, "token") == 0)
+				 /* the bearer token */ ;
+			else if (strcmp(def->defname, "credentials_required") == 0)
+			{
+				(void) defGetBoolean(def);
+				if (!defGetBoolean(def) && !superuser())
+					ereport(ERROR,
+							(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+							 errmsg("only a superuser may set credentials_required 'false'")));
+			}
+			else
+				ereport(ERROR,
+						(errcode(ERRCODE_FDW_INVALID_OPTION_NAME),
+						 errmsg("invalid option \"%s\" for a pgcolumnar_iceberg_catalog user mapping",
+								def->defname),
+						 errhint("Valid user-mapping options: token, credentials_required.")));
+		}
+		else if (def->defname != NULL)
+			ereport(ERROR,
+					(errcode(ERRCODE_FDW_INVALID_OPTION_NAME),
+					 errmsg("invalid option \"%s\" for pgcolumnar_iceberg_catalog",
+							def->defname)));
+	}
+	PG_RETURN_VOID();
 }

--- a/src/columnar_iceberg_rest.h
+++ b/src/columnar_iceberg_rest.h
@@ -13,6 +13,7 @@
  */
 extern char *PgColumnarIcebergRestLoadTableLocation(const char *catalog_uri,
 													const char *ns,
-													const char *table);
+													const char *table,
+													const char *token);
 
 #endif							/* COLUMNAR_ICEBERG_REST_H */

--- a/test/entry_point_privilege.sh
+++ b/test/entry_point_privilege.sh
@@ -65,7 +65,7 @@ SQLFILE="$(dirname "${BASH_SOURCE[0]}")/../pgcolumnar--1.0-alpha.sql"
 # line end is followed by a newline rather than a space, so it silently fails to
 # match and reads as an unbucketed function. That is not hypothetical: it is what
 # the first run of this suite reported for parquet_fdw_validator.
-EXEMPT="columnar_handler parquet_fdw_handler parquet_fdw_validator iceberg_fdw_handler iceberg_fdw_validator parquet_schema read_parquet file_split_offsets iceberg_current_snapshot iceberg_data_files iceberg_scan iceberg_rest_table_location iceberg_rest_scan iceberg_rest_namespaces iceberg_rest_tables read_avro_manifest read_manifest_list"
+EXEMPT="columnar_handler parquet_fdw_handler parquet_fdw_validator iceberg_fdw_handler iceberg_fdw_validator iceberg_catalog_fdw_validator parquet_schema read_parquet file_split_offsets iceberg_current_snapshot iceberg_data_files iceberg_scan iceberg_rest_table_location iceberg_rest_scan iceberg_rest_namespaces iceberg_rest_tables read_avro_manifest read_manifest_list"
 EXEMPT="$(echo $EXEMPT)"
 
 # Relation-taking entry points with NO privilege check of any kind on main.

--- a/test/iceberg_rest_server.sh
+++ b/test/iceberg_rest_server.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# pgColumnar Iceberg REST catalog FOREIGN SERVER + USER MAPPING credentials
+# (#656). The iceberg_rest_* functions accept a FOREIGN SERVER name in place of a
+# catalog URI: the server holds catalog_uri, and the current role's USER MAPPING
+# holds the bearer token (kept role-private in pg_user_mapping, never a SQL
+# argument or a log line). The proof: with NO PGCOLUMNAR_ICEBERG_REST_TOKEN in
+# the environment, a server-name call still authenticates -- so the mapping
+# token, not ambient, is what signed the request (the hermetic fixture 401s a
+# wrong/absent token).
+#
+# Usage:  test/iceberg_rest_server.sh [PG_CONFIG]
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+python3 -c 'import json' 2>/dev/null || pgc_skip python "python3 is needed"
+MODDIR="$("$PGC_PG_CONFIG" --pkglibdir)"
+[ -f "$MODDIR/pgcolumnar_objstore.so" ] \
+	|| pgc_skip objstore "the object-store module is not installed"
+
+TOKEN="s3cr3t-mapping-token-xyz"
+REST_PORT="$(pgc_pick_free_port "$PGC_AUX_PORT_LO" "$PGC_AUX_PORT_HI")"
+REST_LOG="$PGC_WORKDIR/rest.log"
+MDLOC="file:///tmp/pgc_rest/db/events/metadata/00001.metadata.json"
+SRV_PID=""
+
+st_teardown() { [ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null; pgc_teardown; }
+trap st_teardown EXIT INT TERM
+
+sqlstate_of() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -qtA 2>&1 <<SQLEOF | sed -n 's/^ERROR:  \([0-9A-Z]\{5\}\).*/\1/p' | head -1
+\\set VERBOSITY sqlstate
+$1;
+SQLEOF
+}
+pg_restart_env() {
+	pgc_pg "pg_ctl -D '$PGC_PGDATA' stop -m fast -w" >/dev/null 2>&1
+	pgc_pg "$* pg_ctl -D '$PGC_PGDATA' -l '$PGC_LOGFILE' start -w" >/dev/null 2>&1
+	for _ in $(seq 1 30); do [ -n "$(q 'SELECT 1')" ] && return 0; sleep 0.5; done
+	echo "FATAL: cluster did not come back after env restart"; exit 1
+}
+
+python3 "$(dirname "${BASH_SOURCE[0]}")/iceberg_rest_server.py" \
+	--port "$REST_PORT" --log "$REST_LOG" --token "$TOKEN" \
+	--namespace db --table events --metadata-location "$MDLOC" \
+	> "$PGC_WORKDIR/rest.out" 2>&1 &
+SRV_PID=$!
+for _ in $(seq 1 50); do grep -q READY "$PGC_WORKDIR/rest.out" 2>/dev/null && break; sleep 0.1; done
+check "premise: rest fixture up" "$(grep -c READY "$PGC_WORKDIR/rest.out" 2>/dev/null)" "1"
+
+CAT="http://127.0.0.1:$REST_PORT"
+# NO token in the environment: only a USER MAPPING can authenticate.
+pg_restart_env ""
+q "ALTER SYSTEM SET pgcolumnar.objstore_allowed_endpoints = '127.0.0.1'" >/dev/null
+q "SELECT pg_reload_conf()" >/dev/null
+
+q "CREATE SERVER cat FOREIGN DATA WRAPPER pgcolumnar_iceberg_catalog
+   OPTIONS (catalog_uri '$CAT')" >/dev/null
+q "CREATE USER MAPPING FOR postgres SERVER cat OPTIONS (token '$TOKEN')" >/dev/null
+
+# ---- a server-name call authenticates with the mapping token -----------------
+check "iceberg_rest_table_location('cat',...) reads via the mapping token" \
+	"$(q "SELECT pgcolumnar.iceberg_rest_table_location('cat','db','events')")" \
+	"$MDLOC"
+check "the request carried an Authorization header" \
+	"$(grep -c 'GET /v1/namespaces/db/tables/events AUTH=yes' "$REST_LOG" 2>/dev/null)" "1"
+
+# ---- the mapping token never appears in the PG log ---------------------------
+q "ALTER SYSTEM SET log_statement='all'" >/dev/null
+q "SELECT pg_reload_conf()" >/dev/null
+q "SELECT pgcolumnar.iceberg_rest_table_location('cat','db','events')" >/dev/null
+q "ALTER SYSTEM SET log_statement='none'" >/dev/null
+q "SELECT pg_reload_conf()" >/dev/null
+check "the mapping token never appears in the PG server log" \
+	"$(grep -c "$TOKEN" "$PGC_LOGFILE" 2>/dev/null)" "0"
+
+# ---- a wrong mapping token is refused by the catalog (28000) -----------------
+q "ALTER USER MAPPING FOR postgres SERVER cat OPTIONS (SET token 'wrong-token')" >/dev/null
+check "a wrong mapping token is refused (28000)" \
+	"$(sqlstate_of "SELECT pgcolumnar.iceberg_rest_table_location('cat','db','events')")" \
+	"28000"
+
+# ---- no credential at all (no mapping, no env token) is refused --------------
+q "DROP USER MAPPING FOR postgres SERVER cat" >/dev/null
+check "no mapping and no env token is refused, not bypassed (28000)" \
+	"$(sqlstate_of "SELECT pgcolumnar.iceberg_rest_table_location('cat','db','events')")" \
+	"28000"
+q "CREATE USER MAPPING FOR postgres SERVER cat OPTIONS (token '$TOKEN')" >/dev/null
+
+# ---- validator: secrets only on a user mapping, uri only on a server ---------
+check "a token option on the SERVER is rejected (HV00D)" \
+	"$(sqlstate_of "CREATE SERVER bad1 FOREIGN DATA WRAPPER pgcolumnar_iceberg_catalog OPTIONS (catalog_uri '$CAT', token 'x')")" \
+	"HV00D"
+check "a catalog_uri option on the USER MAPPING is rejected (HV00D)" \
+	"$(sqlstate_of "ALTER USER MAPPING FOR postgres SERVER cat OPTIONS (ADD catalog_uri 'x')")" \
+	"HV00D"
+
+# ---- the URI form still works when the env token is present ------------------
+pg_restart_env "PGCOLUMNAR_ICEBERG_REST_TOKEN='$TOKEN'"
+q "ALTER SYSTEM SET pgcolumnar.objstore_allowed_endpoints='127.0.0.1'" >/dev/null
+q "SELECT pg_reload_conf()" >/dev/null
+check "the catalog-URI form still works with the env token" \
+	"$(q "SELECT pgcolumnar.iceberg_rest_table_location('$CAT','db','events')")" \
+	"$MDLOC"
+
+check "backend still up" "$(q 'SELECT 1')" "1"
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -93,6 +93,7 @@ SUITES=(
 	iceberg_objstore
 	iceberg_rest
 	iceberg_rest_scan
+	iceberg_rest_server
 	iceberg_rest_vended
 	iceberg_scan
 	import_deferred


### PR DESCRIPTION
## What

The `iceberg_rest_*` functions now accept a **foreign server name** in place of a
catalog URI. This is #656 part 2 (the FOREIGN SERVER model the phase-7 env-token
work deferred), and completes per-role catalog credentials.

- A new **validator-only** foreign-data wrapper `pgcolumnar_iceberg_catalog` (no
  HANDLER: a REST catalog creates no foreign tables).
- A **SERVER** under it holds `catalog_uri` (world-readable, non-secret).
- The current role's **USER MAPPING** holds the bearer `token` in
  `pg_user_mapping`, which is not world-readable, so one role's token is private
  from another. This is the durable improvement over the single process-wide
  `PGCOLUMNAR_ICEBERG_REST_TOKEN` env var, which still serves the URI form.

The first argument is **content-sniffed**: `http(s)://` is a URI (env token); any
other value names a server (mapping token). A server name can never look like a
URI, so the two forms never collide and all four function signatures are
unchanged.

## Security model

- Resolution reads `catalog_uri` from the server and the token from the role's
  mapping, falling to the PUBLIC mapping.
- A role with neither a mapping token nor superuser rights is **refused (28000)**,
  unless its mapping sets `credentials_required 'false'`.
- The **validator** keeps secrets off the world-readable server options: only
  `catalog_uri` on a server, only `token`/`credentials_required` on a mapping, and
  `credentials_required 'false'` is superuser-only.

## Proof (test/iceberg_rest_server.sh, 10 checks)

With **NO** env token in the environment:
- a server-name call authenticates against the hermetic REST fixture, so the
  **mapping token, not ambient**, signed the request (fixture 401s a bad/absent token);
- the request carried an `Authorization` header;
- the token never appears in the PG server log;
- a wrong mapping token, and no-mapping-no-env, are both refused **28000**;
- the validator rejects a `token` on a SERVER and a `catalog_uri` on a USER
  MAPPING (**HV00D**);
- the URI form still works with the env token.

**Removal proofs**: neutering the mapping-token read reds only the "reads via
mapping token" arm; short-circuiting the validator body reds only the two HV00D
arms.

## Gates

- PG17 / PG18 / PG19 (this suite + `entry_point_privilege`), full iceberg suite
  regression sweep on PG18: all green.
- Strict PG19 build `-Wimplicit-fallthrough=5 -Werror`: clean.
- ASAN run of the resolver path (`untransformRelOptions` / `SysCacheGetAttr` /
  `pstrdup` / `ReleaseSysCache` / http): backend sanitizer scan clean; good token
  returns the metadata location, wrong token returns 28000.

## Docs

`docs/sql-reference.md` and `CHANGELOG.md` updated; `docs_style` (STE) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)