### PR TITLE
feat: OAuth2 client-credentials for the Iceberg REST catalog (#656)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,12 @@ which was true until that script existed.
   `pg_user_mapping`, which is not world-readable, so one role's token is private
   from another. A role with neither a mapping token nor superuser rights is
   refused, and the validator keeps secrets off the world-readable server options.
-  When the catalog vends short-lived storage credentials in its
+  A user mapping may instead carry OAuth2 client credentials (`oauth_client_id`,
+  `oauth_client_secret`, and optionally `oauth_scope` and `oauth_token_uri`)
+  (#656). The catalog then mints a bearer by the client-credentials grant; the
+  secret travels in the request body, never a URL or a log line, and a half
+  credential is refused before any request. When the catalog vends short-lived
+  storage credentials in its
   `loadTable` reply (the flat `config` keys or the `storage-credentials` array,
   longest prefix selected), `iceberg_rest_scan` reads the table's files with
   those credentials rather than the server environment (#656). Vended

--- a/docs/sql-reference.md
+++ b/docs/sql-reference.md
@@ -805,6 +805,14 @@ visible to another. A role with no mapping and no token is refused. A superuser,
 or a mapping that sets `credentials_required 'false'`, uses the environment token
 instead.
 
+A user mapping may carry OAuth2 client credentials rather than a static token.
+When it sets `oauth_client_id` and `oauth_client_secret`, the catalog is asked to
+mint a bearer by the client-credentials grant. The request goes to
+`oauth_token_uri` when set, otherwise to `{catalog_uri}/v1/oauth/tokens`, with an
+optional `oauth_scope`. The client secret travels in the request body, never a
+URL or a log line. A mapping that sets only one of the pair is refused before any
+request is made.
+
 Multi-level namespaces are given dot-separated, and the function requires the
 `pg_read_server_files` role, like the other Iceberg functions.
 
@@ -826,9 +834,10 @@ SELECT count(*) FROM pgcolumnar.iceberg_scan(
 
 The `pgcolumnar_iceberg_catalog` wrapper has a validator but no handler, so its
 servers cannot be selected from as tables. It accepts only `catalog_uri` on a
-server, and only `token` and `credentials_required` on a user mapping. A secret
-on a server, where options are world-readable, is rejected. Setting
-`credentials_required 'false'` is restricted to a superuser.
+server. On a user mapping it accepts `token`, the OAuth2 options
+(`oauth_client_id`, `oauth_client_secret`, `oauth_scope`, `oauth_token_uri`), and
+`credentials_required`. A secret on a server, where options are world-readable,
+is rejected. Setting `credentials_required 'false'` is restricted to a superuser.
 
 ### pgcolumnar.iceberg_rest_scan(catalog_uri text, namespace text, table_name text) returns setof record
 

--- a/src/columnar_iceberg_rest.c
+++ b/src/columnar_iceberg_rest.c
@@ -105,6 +105,10 @@ rest_objstore(void)
  * that set credentials_required 'false'); otherwise refuse (28000). *out_token
  * may be NULL for an anonymous catalog.
  */
+static char *rest_oauth_token(const char *catalog_uri, const char *token_uri,
+							  const char *client_id, const char *client_secret,
+							  const char *scope);
+
 static void
 rest_resolve_server(const char *name, char **out_uri, char **out_token)
 {
@@ -112,6 +116,10 @@ rest_resolve_server(const char *name, char **out_uri, char **out_token)
 	ListCell   *lc;
 	char	   *uri = NULL;
 	char	   *token = NULL;
+	char	   *oauthId = NULL;
+	char	   *oauthSecret = NULL;
+	char	   *oauthScope = NULL;
+	char	   *oauthUri = NULL;
 	bool		credRequired = true;
 	HeapTuple	tp;
 
@@ -153,11 +161,33 @@ rest_resolve_server(const char *name, char **out_uri, char **out_token)
 
 				if (strcmp(d->defname, "token") == 0)
 					token = pstrdup(defGetString(d));
+				else if (strcmp(d->defname, "oauth_client_id") == 0)
+					oauthId = pstrdup(defGetString(d));
+				else if (strcmp(d->defname, "oauth_client_secret") == 0)
+					oauthSecret = pstrdup(defGetString(d));
+				else if (strcmp(d->defname, "oauth_scope") == 0)
+					oauthScope = pstrdup(defGetString(d));
+				else if (strcmp(d->defname, "oauth_token_uri") == 0)
+					oauthUri = pstrdup(defGetString(d));
 				else if (strcmp(d->defname, "credentials_required") == 0)
 					credRequired = defGetBoolean(d);
 			}
 		}
 		ReleaseSysCache(tp);
+	}
+
+	/* OAuth2 client-credentials: a half credential (one of id/secret) is refused
+	 * before any request; a complete pair mints the bearer when no static token. */
+	if (token == NULL && (oauthId != NULL || oauthSecret != NULL))
+	{
+		if (oauthId == NULL || oauthSecret == NULL)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION),
+					 errmsg("iceberg: incomplete OAuth2 credential for REST catalog server \"%s\"",
+							name),
+					 errhint("Set both oauth_client_id and oauth_client_secret on the "
+							 "USER MAPPING.")));
+		token = rest_oauth_token(uri, oauthUri, oauthId, oauthSecret, oauthScope);
 	}
 
 	if (token == NULL)
@@ -351,6 +381,96 @@ rest_get_json(const char *catalog_uri, const char *resource_path,
 
 	jd = DirectFunctionCall1(jsonb_in, CStringGetDatum(r.body));
 	return DatumGetJsonbP(jd);
+}
+
+/*
+ * POST a form body to an absolute URL and return the parsed JSON reply. Used for
+ * the OAuth2 token endpoint. No Authorization header is sent (this call obtains
+ * the bearer). The allow-list, link-local refusal, and header guards of the
+ * transport apply as for any request. A 401/403 is the catalog rejecting the
+ * client credentials, mapped to 28000 with no secret in the message.
+ */
+static Jsonb *
+rest_post_form(const char *url, const char *body, const char *what)
+{
+	const PgColumnarObjStoreApi *api = rest_objstore();
+	const char *headers[2];
+	int			nheaders = 0;
+	PgColumnarHttpResult r;
+	Datum		jd;
+
+	headers[nheaders++] = "Accept: application/json";
+	headers[nheaders++] = "Content-Type: application/x-www-form-urlencoded";
+
+	r = api->http_request(url, "POST", headers, nheaders,
+						  body, (int) strlen(body), REST_MAX_RESPONSE);
+
+	if (r.status == 400 || r.status == 401 || r.status == 403)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION),
+				 errmsg("iceberg: the REST catalog refused the OAuth2 %s (HTTP %d)",
+						what, r.status),
+				 errhint("Check oauth_client_id and oauth_client_secret on the "
+						 "USER MAPPING.")));
+	if (r.status != 200)
+		ereport(ERROR,
+				(errcode(ERRCODE_PROTOCOL_VIOLATION),
+				 errmsg("iceberg: the REST catalog returned HTTP %d for the OAuth2 %s",
+						r.status, what)));
+	if (r.body == NULL || r.body_len == 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_DATA_CORRUPTED),
+				 errmsg("iceberg: the REST catalog returned an empty OAuth2 %s", what)));
+
+	jd = DirectFunctionCall1(jsonb_in, CStringGetDatum(r.body));
+	return DatumGetJsonbP(jd);
+}
+
+/*
+ * Mint a bearer token by the OAuth2 client-credentials grant. POSTs
+ * grant_type=client_credentials with the client id/secret (and optional scope),
+ * each percent-encoded, to the token endpoint: `token_uri` when given, else
+ * {catalog}/v1/oauth/tokens. The secret travels in the body, never a query
+ * string, and is not logged. Returns the palloc'd access_token.
+ */
+static char *
+rest_oauth_token(const char *catalog_uri, const char *token_uri,
+				 const char *client_id, const char *client_secret,
+				 const char *scope)
+{
+	StringInfoData url;
+	StringInfoData body;
+	Jsonb	   *reply;
+
+	initStringInfo(&url);
+	if (token_uri != NULL && token_uri[0] != '\0')
+		appendStringInfoString(&url, token_uri);
+	else
+	{
+		appendStringInfoString(&url, catalog_uri);
+		while (url.len > 0 && url.data[url.len - 1] == '/')
+			url.data[--url.len] = '\0';
+		appendStringInfoString(&url, "/v1/oauth/tokens");
+	}
+
+	initStringInfo(&body);
+	appendStringInfoString(&body, "grant_type=client_credentials");
+	appendStringInfoString(&body, "&client_id=");
+	rest_pct_encode(&body, client_id);
+	appendStringInfoString(&body, "&client_secret=");
+	rest_pct_encode(&body, client_secret);
+	if (scope != NULL && scope[0] != '\0')
+	{
+		appendStringInfoString(&body, "&scope=");
+		rest_pct_encode(&body, scope);
+	}
+
+	reply = rest_post_form(url.data, body.data, "token exchange");
+	if (!JsonContainerIsObject(&reply->root))
+		ereport(ERROR,
+				(errcode(ERRCODE_DATA_CORRUPTED),
+				 errmsg("iceberg: the OAuth2 token response is not a JSON object")));
+	return rest_json_string(&reply->root, "access_token", "OAuth2 token response");
 }
 
 /*
@@ -765,9 +885,14 @@ pgcolumnar_iceberg_catalog_validator(PG_FUNCTION_ARGS)
 		}
 		else if (catalog == UserMappingRelationId)
 		{
-			/* secrets live only here (pg_user_mapping is role-protected) */
-			if (strcmp(def->defname, "token") == 0)
-				 /* the bearer token */ ;
+			/* secrets live only here (pg_user_mapping is role-protected):
+			 * the static bearer token, or the OAuth2 client-credentials inputs */
+			if (strcmp(def->defname, "token") == 0 ||
+				strcmp(def->defname, "oauth_client_id") == 0 ||
+				strcmp(def->defname, "oauth_client_secret") == 0 ||
+				strcmp(def->defname, "oauth_scope") == 0 ||
+				strcmp(def->defname, "oauth_token_uri") == 0)
+				 /* a credential input */ ;
 			else if (strcmp(def->defname, "credentials_required") == 0)
 			{
 				(void) defGetBoolean(def);
@@ -781,7 +906,9 @@ pgcolumnar_iceberg_catalog_validator(PG_FUNCTION_ARGS)
 						(errcode(ERRCODE_FDW_INVALID_OPTION_NAME),
 						 errmsg("invalid option \"%s\" for a pgcolumnar_iceberg_catalog user mapping",
 								def->defname),
-						 errhint("Valid user-mapping options: token, credentials_required.")));
+						 errhint("Valid user-mapping options: token, oauth_client_id, "
+								 "oauth_client_secret, oauth_scope, oauth_token_uri, "
+								 "credentials_required.")));
 		}
 		else if (def->defname != NULL)
 			ereport(ERROR,

--- a/test/iceberg_rest_server.py
+++ b/test/iceberg_rest_server.py
@@ -130,6 +130,30 @@ class Handler(BaseHTTPRequestHandler):
 
         self._not_found("no such resource")
 
+    def do_POST(self):
+        parsed = urllib.parse.urlparse(self.path)
+        path = parsed.path
+        self._logline("POST", path)     # never logs the body, so no secret leaks
+        if path != "/v1/oauth/tokens" or not ARGS.oauth_client_id:
+            self._not_found("no such path")
+            return
+        n = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(n).decode() if n > 0 else ""
+        form = urllib.parse.parse_qs(body)
+
+        def one(k):
+            v = form.get(k, [""])
+            return v[0] if v else ""
+        # client-credentials grant: the id and secret must match exactly. A wrong
+        # secret is 401, which the client maps to 28000 with no secret in the log.
+        if (one("grant_type") == "client_credentials"
+                and one("client_id") == ARGS.oauth_client_id
+                and one("client_secret") == ARGS.oauth_client_secret):
+            self._send_json(200, {"access_token": ARGS.token,
+                                  "token_type": "bearer", "expires_in": 3600})
+        else:
+            self._unauthorized()
+
     def _load_table(self, ns, table):
         if table == "toobig":
             # advertise a body far larger than any sane response cap, send none:
@@ -195,6 +219,8 @@ def main():
     ap.add_argument("--vend-region", default="")
     ap.add_argument("--vend-endpoint", default="")
     ap.add_argument("--storage-cred-prefix", default="")
+    ap.add_argument("--oauth-client-id", default="")
+    ap.add_argument("--oauth-client-secret", default="")
     ARGS = ap.parse_args()
     open(ARGS.log, "w").close()
     httpd = ThreadingHTTPServer(("127.0.0.1", ARGS.port), Handler)

--- a/test/iceberg_rest_server.sh
+++ b/test/iceberg_rest_server.sh
@@ -98,6 +98,60 @@ check "a catalog_uri option on the USER MAPPING is rejected (HV00D)" \
 	"$(sqlstate_of "ALTER USER MAPPING FOR postgres SERVER cat OPTIONS (ADD catalog_uri 'x')")" \
 	"HV00D"
 
+# ---- OAuth2 client-credentials: mint a bearer, then use it -------------------
+# A second fixture requires a client id/secret at POST /v1/oauth/tokens and, on a
+# match, mints OATOKEN -- which loadTable then requires. So a green read proves
+# the full mint->use flow, with NO env token and NO static mapping token. The
+# secret travels only in the POST body; it must appear in neither log.
+OCID="client-abc"; OCSEC="s3cr3t-oauth-secret"; OATOKEN="minted-bearer-777"
+OPORT="$(pgc_pick_free_port "$PGC_AUX_PORT_LO" "$PGC_AUX_PORT_HI")"
+OLOG="$PGC_WORKDIR/orest.log"
+python3 "$(dirname "${BASH_SOURCE[0]}")/iceberg_rest_server.py" \
+	--port "$OPORT" --log "$OLOG" --token "$OATOKEN" \
+	--oauth-client-id "$OCID" --oauth-client-secret "$OCSEC" \
+	--namespace db --table events --metadata-location "$MDLOC" \
+	> "$PGC_WORKDIR/orest.out" 2>&1 &
+OSRV_PID=$!
+for _ in $(seq 1 50); do grep -q READY "$PGC_WORKDIR/orest.out" 2>/dev/null && break; sleep 0.1; done
+OCAT="http://127.0.0.1:$OPORT"
+q "CREATE SERVER ocat FOREIGN DATA WRAPPER pgcolumnar_iceberg_catalog
+   OPTIONS (catalog_uri '$OCAT')" >/dev/null
+q "CREATE USER MAPPING FOR postgres SERVER ocat
+   OPTIONS (oauth_client_id '$OCID', oauth_client_secret '$OCSEC')" >/dev/null
+
+check "a server with an OAuth2 mapping reads by a minted bearer" \
+	"$(q "SELECT pgcolumnar.iceberg_rest_table_location('ocat','db','events')")" \
+	"$MDLOC"
+check "the OAuth2 token endpoint was called (POST /v1/oauth/tokens)" \
+	"$(grep -c 'POST /v1/oauth/tokens' "$OLOG" 2>/dev/null)" "1"
+check "loadTable then carried the minted bearer (Authorization present)" \
+	"$(grep -c 'GET /v1/namespaces/db/tables/events AUTH=yes' "$OLOG" 2>/dev/null)" "1"
+check "the client secret never appears in the fixture request log" \
+	"$(grep -c "$OCSEC" "$OLOG" 2>/dev/null)" "0"
+q "ALTER SYSTEM SET log_statement='all'" >/dev/null
+q "SELECT pg_reload_conf()" >/dev/null
+q "SELECT pgcolumnar.iceberg_rest_table_location('ocat','db','events')" >/dev/null
+q "ALTER SYSTEM SET log_statement='none'" >/dev/null
+q "SELECT pg_reload_conf()" >/dev/null
+check "the client secret never appears in the PG server log" \
+	"$(grep -c "$OCSEC" "$PGC_LOGFILE" 2>/dev/null)" "0"
+
+q "ALTER USER MAPPING FOR postgres SERVER ocat OPTIONS (SET oauth_client_secret 'wrong-secret')" >/dev/null
+check "a wrong OAuth2 client secret is refused (28000)" \
+	"$(sqlstate_of "SELECT pgcolumnar.iceberg_rest_table_location('ocat','db','events')")" \
+	"28000"
+q "ALTER USER MAPPING FOR postgres SERVER ocat OPTIONS (DROP oauth_client_secret)" >/dev/null
+check "a half OAuth2 credential (id, no secret) is refused before any request (28000)" \
+	"$(sqlstate_of "SELECT pgcolumnar.iceberg_rest_table_location('ocat','db','events')")" \
+	"28000"
+check "oauth options are accepted on a USER MAPPING (no error)" \
+	"$(sqlstate_of "ALTER USER MAPPING FOR postgres SERVER ocat OPTIONS (ADD oauth_scope 'catalog')")" \
+	""
+check "an oauth option on the SERVER is rejected (HV00D)" \
+	"$(sqlstate_of "CREATE SERVER bad2 FOREIGN DATA WRAPPER pgcolumnar_iceberg_catalog OPTIONS (catalog_uri '$OCAT', oauth_client_secret 'x')")" \
+	"HV00D"
+kill "$OSRV_PID" 2>/dev/null
+
 # ---- the URI form still works when the env token is present ------------------
 pg_restart_env "PGCOLUMNAR_ICEBERG_REST_TOKEN='$TOKEN'"
 q "ALTER SYSTEM SET pgcolumnar.objstore_allowed_endpoints='127.0.0.1'" >/dev/null


### PR DESCRIPTION
## What

Extends the REST-catalog `USER MAPPING` (from #665) with the **OAuth2
client-credentials grant**, the last identified piece of #388's REST catalog
support. A role can now authenticate to a catalog that mints short-lived bearers
instead of issuing a static token.

A user mapping sets `oauth_client_id` and `oauth_client_secret` (and optionally
`oauth_scope`, `oauth_token_uri`). When it does and has no static `token`, the
resolver mints a bearer by `POST grant_type=client_credentials` to the token
endpoint (`oauth_token_uri` if set, else `{catalog_uri}/v1/oauth/tokens`) and
uses the returned `access_token`. Selection is purely by which options are
present; **no new SQL surface**.

## Security (design/ISSUE_656_CATALOG_CREDENTIALS.md)

- The client secret is a `USER MAPPING` option (`pg_user_mapping` is
  role-protected), never a server option, never a SQL argument. It travels in the
  **POST body**, never a URL query string; no error prints it.
- A **half credential** (only one of id/secret) is refused **28000** before any
  request is made.
- The validator accepts `oauth_*` only on a user mapping and rejects them on a
  server (**HV00D**). `credentials_required 'false'` stays superuser-only.
- The OAuth POST rides the same objstore transport: allow-list, link-local
  refusal, and header CR/LF guard apply unchanged. `rest_post_form` reuses the ABI
  v5 `http_request` POST+body+Content-Type (no ABI bump).

## Proof (`test/iceberg_rest_server.sh`, now 19 checks)

The fixture serves `POST /v1/oauth/tokens` for a client id/secret and mints the
bearer that `loadTable` then requires. With **no env token and no static mapping
token**:

- a server with an OAuth2 mapping reads by the minted bearer — so the mint, not
  ambient, authenticated;
- the token endpoint was called; `loadTable` carried the minted bearer;
- the secret appears in **neither** the PG log **nor** the catalog request log;
- a wrong secret → **28000**; a half credential → **28000**;
- the validator rejects an `oauth_client_secret` on a server (**HV00D**).

**Removal proof**: neutering the mint call reds only the minted-read arm (the POST
is never made); the 28000 arms stay green for their own reasons.

## Gates

PG17 / PG18 / PG19, strict PG19 `-Wimplicit-fallthrough=5 -Werror` clean, and an
ASAN run of the resolver + mint path (backend sanitizer-clean). Docs + CHANGELOG
updated; `docs_style` (STE) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)