### PR TITLE
docs: per-feature how-to guides + full doc verification pass

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -117,7 +117,7 @@ answer.
 | --- | --- | --- | --- |
 | `pgcolumnar.bulk_parallel_writer` | boolean | `off` | Internal. Set by `pgcolumnar.parallel_copy` loader workers so they skip the storage-row creation lock when the row already exists committed, which is what lets several atomic writers load one table at once. Marked `GUC_NOT_IN_SAMPLE`; leave it alone. Setting it by hand is safe but pointless: the skip only fires when the storage row is already committed, which is exactly when the lock guards nothing. |
 | `pgcolumnar.maintenance_hold_ms` | integer | `0` | Internal, for tests. A maintenance verb holds `ShareUpdateExclusiveLock` this many milliseconds, interruptibly, so a test can observe the daemon yield to a stronger lock. `0` disables it. Range 0 to 600000. Leave it at `0`. |
-| `pgcolumnar.sink_fail_after` | integer | `-1` | Internal, for tests. A fault-injection point that fails a write sink after this many rows. `-1` disables it. Range -1 to INT_MAX. Leave it at `-1`. |
+| `pgcolumnar.sink_fail_after` | integer | `-1` | Internal, for tests. A fault-injection point that fails an export write after this many bytes, by the path a full disk takes. `-1` disables it. Range -1 to INT_MAX. Leave it at `-1`. |
 
 ## Per-table storage options
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,6 +30,7 @@ pgColumnar has two kinds of settings:
 | `pgcolumnar.compression` | enum | `zstd` | Default codec for new chunks. One of `none`, `pglz`, `lz4`, `zstd`. `lz4` and `zstd` are available only when the extension was built with those libraries. |
 | `pgcolumnar.compression_level` | integer | `3` | Level for the `zstd` codec. Range 1 to 22. Higher levels compress more and write more slowly. |
 | `pgcolumnar.fsst_min_gain_percent` | integer | `5` | Minimum size reduction, in percent, for FSST string encoding to be kept for a column chunk. Range 0 to 99. See below. |
+| `pgcolumnar.fsst_verdict_reuse` | integer | `16` | How many later row groups may reuse a column's FSST keep-or-drop verdict before it is decided again. Range 0 to INT_MAX. |
 | `pgcolumnar.parallel_flush` | boolean | `off` | Opt-in. When on, a stripe flush of two or more columns fans the per-column encode and compress work out to background workers. The stored bytes match the serial path. It helps one large flush of many numeric columns by up to 14 percent. A wide text-heavy flush regresses, because it copies the buffered bytes through shared memory. Frequent small flushes regress too, so it is off by default. Enable it for a wide numeric bulk load in the session that runs it. |
 
 To build the FSST codes for each vector is one of the larger costs of a load of
@@ -65,6 +66,8 @@ disk. It never changes the values that a table returns.
 | `pgcolumnar.enable_parallel_vector_agg` | boolean | `off` | Let the ungrouped batch fold run as a parallel partial aggregate under `Gather`, each worker folding its own row groups. Requires `pgcolumnar.enable_ungrouped_vector_agg`. Off by default. |
 | `pgcolumnar.enable_column_projection` | boolean | `on` | Read only the columns a query references rather than every column of the row group. |
 | `pgcolumnar.enable_index_fetch_penalty` | boolean | `on` | Charge a columnar index scan for the row-group decode its per-row heap fetches force, so the planner does not treat a columnar fetch as if it were a heap page read. Set to `off` to restore the pre-1.0-alpha planner behaviour. |
+| `pgcolumnar.enable_late_materialization` | boolean | `on` | Evaluate the scan qualifier before building the columns it does not read, so decode cost scales with rows emitted rather than rows scanned. |
+| `pgcolumnar.qual_skipvec_min_payload_cols` | integer | `20` | Minimum projected non-qual columns before per-vector qual gating skips a no-match 1024-row vector's payload decode. Range 0 to 100000. |
 
 ### Index-only scan and projections
 
@@ -94,6 +97,8 @@ schemes and the credential model.
 | --- | --- | --- | --- |
 | `pgcolumnar.objstore_allowed_endpoints` | string | `''` (empty) | The endpoints the module may connect to, comma-separated as `host` or `host:port`. Empty refuses every remote endpoint, so a role that can read or write server files cannot reach an arbitrary host through the extension. Link-local addresses, including `169.254.169.254`, are refused whether or not they are listed. Superuser-only, so a role cannot widen its own reach. |
 | `pgcolumnar.objstore_s3_addressing` | string | `path` | The S3 request addressing style. `path` sends `s3://bucket/key` to `endpoint/bucket/key`; `virtual` sends it to `bucket.endpoint/key`, which is what AWS now prefers. Under virtual-host addressing the allow-list still authorizes the endpoint, not the per-bucket hostname. |
+| `pgcolumnar.objstore_buffered` | boolean | `on` | Coalesce remote Parquet reads to one request per column chunk instead of many small ranged reads. |
+| `pgcolumnar.objstore_part_size` | integer | `0` | Multipart part size in bytes for a remote export. `0` uses the module default of 8 MiB. Raise it for a fast link. Range 0 to INT_MAX. |
 
 ### Concurrent unique inserts
 
@@ -104,13 +109,15 @@ schemes and the credential model.
 
 ### Internal settings
 
-One setting is registered but is not a tuning knob. It is listed here because it
-appears in `pg_settings` and a reader who finds it there deserves an answer.
+These settings are registered but are not tuning knobs. They are listed here
+because they appear in `pg_settings` and a reader who finds one there deserves an
+answer.
 
 | Setting | Type | Default | Description |
 | --- | --- | --- | --- |
 | `pgcolumnar.bulk_parallel_writer` | boolean | `off` | Internal. Set by `pgcolumnar.parallel_copy` loader workers so they skip the storage-row creation lock when the row already exists committed, which is what lets several atomic writers load one table at once. Marked `GUC_NOT_IN_SAMPLE`; leave it alone. Setting it by hand is safe but pointless: the skip only fires when the storage row is already committed, which is exactly when the lock guards nothing. |
 | `pgcolumnar.maintenance_hold_ms` | integer | `0` | Internal, for tests. A maintenance verb holds `ShareUpdateExclusiveLock` this many milliseconds, interruptibly, so a test can observe the daemon yield to a stronger lock. `0` disables it. Range 0 to 600000. Leave it at `0`. |
+| `pgcolumnar.sink_fail_after` | integer | `-1` | Internal, for tests. A fault-injection point that fails a write sink after this many rows. `-1` disables it. Range -1 to INT_MAX. Leave it at `-1`. |
 
 ## Per-table storage options
 

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -1,0 +1,320 @@
+# How-to guides
+
+Task-focused recipes for each pgColumnar feature. Every recipe ends with a short
+tuning note. For full signatures see the [SQL reference](sql-reference.md); for
+every server setting see the [Configuration reference](configuration.md).
+
+Load `pgcolumnar` in `shared_preload_libraries` before you begin. It installs
+planner and executor hooks that every backend needs.
+
+## Create a columnar table
+
+Create a new table with the access method, or convert an existing heap table.
+
+```sql
+-- new table
+CREATE TABLE events (id bigint, ts timestamptz, region text, amount numeric)
+  USING pgcolumnar;
+
+-- convert an existing table (heap to columnar, or back)
+SELECT pgcolumnar.alter_table_set_access_method('events', 'pgcolumnar');
+```
+
+On PostgreSQL 15 and later the conversion runs `ALTER TABLE ... SET ACCESS
+METHOD` in place and keeps the table identity and dependents. On 13 and 14 it
+copies through a new table and swaps the names, so the original OID and its
+dependent objects are not preserved.
+
+**Tune it.** Columnar storage rewards wide scans over a few columns. Keep small,
+highly selective point-lookup tables as heap. Put analytic and append-heavy
+tables on `pgcolumnar`.
+
+## Load data efficiently
+
+`COPY` and multi-row `INSERT` both work. A bulk load writes best in large
+transactions, because each transaction seals its own row groups.
+
+```sql
+COPY events FROM '/data/events.csv' WITH (FORMAT csv, HEADER true);
+```
+
+Load a local file in parallel with a pool of background writers.
+
+```sql
+SELECT pgcolumnar.parallel_copy('events', '/data/events.csv');   -- workers auto
+SELECT pgcolumnar.parallel_copy('events', '/data/events.csv', 8);
+```
+
+**Tune it.** Prefer few large transactions over many small ones. Many small
+commits produce many small row groups, which read less efficiently. Run
+`pgcolumnar.vacuum` after a trickle load to combine them. The caller of
+`parallel_copy` needs the `pg_read_server_files` role.
+
+## Choose compression and encoding
+
+Each column is encoded automatically (run-length, frame-of-reference,
+bit-packing, delta, delta-of-delta, Gorilla XOR, dictionary, and FSST for text).
+A block codec then compresses the encoded chunk. The codec is `zstd` by default.
+
+```sql
+-- per table
+SELECT pgcolumnar.set_options('events', compression => 'zstd', compression_level => 6);
+SELECT pgcolumnar.set_options('events', encode_effort => 'fast');
+
+-- session default for new chunks
+SET pgcolumnar.compression = 'lz4';
+```
+
+The codec is one of `none`, `pglz`, `lz4`, or `zstd`. `compression_level`
+applies to `zstd` and ranges from 1 to 22, default 3. `encode_effort` is `full`
+by default, or `fast` to skip the costly FSST search on a text-heavy load.
+
+**Tune it.** Use `zstd` for the best ratio and `lz4` for the fastest
+decompression. Raise `compression_level` for cold, archival data. Set
+`encode_effort` to `fast` when a text load is CPU-bound and the ratio matters
+less. Re-run `pgcolumnar.vacuum` to re-encode existing data under new options.
+
+## Make queries skip data with a sort key
+
+pgColumnar keeps a per-chunk minimum and maximum for every column. A query skips
+a chunk group when its filter cannot match that range. Sorting the table on the
+columns you filter tightens those ranges, so more groups are skipped.
+
+```sql
+-- one-shot ascending sort on a key
+SELECT pgcolumnar.vacuum_sorted('events', 'region', 'ts');
+
+-- declare a key, then re-apply it later with no arguments
+SELECT pgcolumnar.set_options('events', sort_by => ARRAY['region','ts']);
+SELECT pgcolumnar.vacuum_sorted('events');
+
+-- Z-order (Morton) clustering over several numeric columns at once
+SELECT pgcolumnar.cluster('events', 'customer_id', 'amount');
+```
+
+`vacuum_sorted` sorts ascending and tightens the first column most. `cluster`
+uses a Z-order curve, so filters on more than one of its columns all skip more
+groups. `cluster` takes numeric columns only.
+
+**Tune it.** Sort on the column your selective queries filter on. A sort is a
+trade. It groups one dimension tightly and spreads the others. For a live table
+use `pgcolumnar.recluster`, which re-establishes the same Z-order under a weaker
+lock so reads and writes continue. Read `pgcolumnar.sort_status` to see how much
+order remains, and re-sort when it decays.
+
+```sql
+SELECT pgcolumnar.recluster('events', 'customer_id', 'amount');   -- online
+SELECT * FROM pgcolumnar.sort_status('events');
+```
+
+## Reclaim space after deletes and updates
+
+A delete or update marks rows dead. Space returns when you compact.
+
+```sql
+SELECT pgcolumnar.compact('events');                    -- retire fully-dead groups
+SELECT pgcolumnar.compact_rewrite('events', 0.3);       -- rewrite groups >= 30% dead
+SELECT pgcolumnar.vacuum('events');                     -- combine small groups + reclaim
+SELECT pgcolumnar.truncate('events');                   -- return end blocks to the OS
+```
+
+`compact` and `compact_rewrite` hold only `ShareUpdateExclusiveLock`, so they run
+against a live table. `compact_rewrite` rewrites groups whose dead fraction is at
+least `min_deleted_fraction` (default 0.2), and `max_groups` caps how many one
+call rewrites (0 means no cap). `vacuum` rewrites the whole relation.
+
+**Tune it.** Prefer `compact` and `compact_rewrite` for online reclaim. Reserve
+`vacuum` for a full reorganisation window. Cap `compact_rewrite` with `max_groups`
+to bound each call and keep it incremental.
+
+## Keep tables optimized automatically
+
+A background daemon can compact and recluster tables on a schedule.
+
+```sql
+-- postgresql.conf
+pgcolumnar.autovacuum = on
+pgcolumnar.autovacuum_naptime = '60s'
+pgcolumnar.autovacuum_compact_threshold = 0.2
+pgcolumnar.autovacuum_recluster_threshold = 0.2
+```
+
+**Tune it.** Lower the thresholds to keep tables tighter at the cost of more
+background work. The daemon calls the online operations only, so it does not take
+an exclusive lock. A table whose clustering is already intact reclusters as a
+fast no-op, so the daemon does not churn storage.
+
+## Read and write Parquet
+
+Read a Parquet file directly, inspect its schema, or load it into a table.
+
+```sql
+SELECT * FROM pgcolumnar.read_parquet('/data/events.parquet')
+  AS t(id bigint, ts timestamptz, region text);
+SELECT * FROM pgcolumnar.parquet_schema('/data/events.parquet');
+SELECT pgcolumnar.import_parquet('events', '/data/events.parquet');
+```
+
+Export a table, in one call or in parallel.
+
+```sql
+SELECT pgcolumnar.export_parquet('events', '/data/out.parquet');
+SELECT pgcolumnar.parallel_export_parquet('events', '/data/out.parquet', 8);
+```
+
+Expose a Parquet file, directory, or Hive layout as a foreign table.
+
+```sql
+CREATE SERVER pq FOREIGN DATA WRAPPER pgcolumnar_parquet;
+CREATE FOREIGN TABLE events_parquet (id bigint, ts timestamptz, region text)
+  SERVER pq OPTIONS (path '/data/events', partition_columns 'region');
+```
+
+**Tune it.** Project only the columns you need, because the reader reads only
+those columns. A predicate on a `partition_columns` column removes whole files
+before they open. `EXPLAIN (ANALYZE)` reports `Files Pruned` and the row groups
+read and skipped. Reading needs the `pg_read_server_files` role, and
+`parallel_export_parquet` needs `pg_write_server_files`.
+
+## Import and export Arrow
+
+The Arrow IPC file format works the same way as Parquet.
+
+```sql
+SELECT pgcolumnar.import_arrow('events', '/data/events.arrow');
+SELECT pgcolumnar.export_arrow('events', '/data/out.arrow');
+```
+
+**Tune it.** Use Arrow to exchange data with an in-process analytic engine
+without a Parquet encode step. Use Parquet for durable, compressed files.
+
+## Use object storage
+
+Every path that accepts a local path also accepts an `s3://`, `http://`, or
+`https://` URL. Credentials come from the server process environment.
+
+```sql
+SELECT * FROM pgcolumnar.read_parquet('s3://bucket/events.parquet')
+  AS t(id bigint, region text);
+SELECT pgcolumnar.export_parquet('events', 's3://bucket/out.parquet');
+```
+
+Set the endpoint allow-list first. It gates every remote scheme.
+
+```sql
+-- postgresql.conf (a superuser setting)
+pgcolumnar.objstore_allowed_endpoints = 's3.amazonaws.com, minio.internal'
+```
+
+The environment supplies `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,
+`AWS_SESSION_TOKEN`, `AWS_REGION`, and `AWS_ENDPOINT_URL`. A host that resolves to
+a link-local or instance-metadata address is refused even when it is listed.
+
+**Tune it.** Raise `pgcolumnar.objstore_part_size` to use larger multipart chunks
+on a fast link. Choose `pgcolumnar.objstore_s3_addressing` to match your provider
+path or virtual-host style. Keep the allow-list as small as your buckets require.
+
+## Query an Apache Iceberg table
+
+Read an Iceberg table at its current snapshot from a metadata path.
+
+```sql
+SELECT region, sum(amount) FROM pgcolumnar.iceberg_scan(
+  '/warehouse/db/events/metadata/00042.metadata.json')
+  AS t(id bigint, region text, amount int)
+  GROUP BY region;
+
+SELECT * FROM pgcolumnar.iceberg_current_snapshot('.../00042.metadata.json');
+SELECT * FROM pgcolumnar.iceberg_data_files('.../00042.metadata.json');
+```
+
+The reader resolves each output column to a schema field id, so a file written
+before a column rename still reads. It applies position deletes, equality
+deletes, and format-version 3 deletion vectors. The metadata path may be a local
+path or an `s3://`, `http://`, or `https://` URL.
+
+**Tune it.** Select only the columns you need. Read from object storage under the
+same allow-list as every other remote access. The function requires the
+`pg_read_server_files` role.
+
+## Query an Iceberg REST catalog
+
+Name a table by catalog, namespace, and table instead of a metadata path.
+
+```sql
+SELECT * FROM pgcolumnar.iceberg_rest_scan(
+  'https://catalog.example.com', 'analytics', 'events')
+  AS t(id bigint, region text, amount int);
+
+SELECT * FROM pgcolumnar.iceberg_rest_namespaces('https://catalog.example.com');
+SELECT * FROM pgcolumnar.iceberg_rest_tables('https://catalog.example.com', 'analytics');
+```
+
+For per-role credentials, name a foreign server instead of a URI. The server
+holds the catalog URI. The current role's user mapping holds the bearer token,
+kept in `pg_user_mapping` where it is not world-readable.
+
+```sql
+CREATE SERVER cat FOREIGN DATA WRAPPER pgcolumnar_iceberg_catalog
+  OPTIONS (catalog_uri 'https://catalog.example.com');
+CREATE USER MAPPING FOR analyst SERVER cat OPTIONS (token 's3cr3t');
+
+SELECT * FROM pgcolumnar.iceberg_rest_scan('cat', 'analytics', 'events')
+  AS t(id bigint, region text, amount int);
+```
+
+A user mapping may carry OAuth2 client credentials rather than a static token.
+The catalog then mints a short-lived bearer.
+
+```sql
+CREATE USER MAPPING FOR analyst SERVER cat OPTIONS (
+  oauth_client_id 'app', oauth_client_secret 's3cr3t', oauth_scope 'catalog');
+```
+
+**Tune it.** A catalog can vend short-lived storage credentials in its reply.
+`iceberg_rest_scan` then reads the table files with those credentials, not the
+server environment. The client secret travels in the request body, never a URL or
+a log line.
+
+## Prune Iceberg data files with the foreign-data wrapper
+
+`iceberg_scan` gets no query predicate, so it cannot skip files. The foreign-data
+wrapper gives Iceberg a predicate-bearing scan that prunes whole files.
+
+```sql
+CREATE SERVER ice FOREIGN DATA WRAPPER pgcolumnar_iceberg;
+CREATE FOREIGN TABLE events (id bigint, region text, amount int)
+  SERVER ice OPTIONS (metadata_path '/warehouse/db/events/metadata/v3.metadata.json');
+
+-- reads only the matching files; EXPLAIN ANALYZE shows "Files Pruned"
+SELECT sum(amount) FROM events WHERE region = 'eu';
+```
+
+Partition pruning covers identity, `bucket[N]`, `truncate[W]`, and the temporal
+transforms `year`, `month`, `day`, and `hour` on date, timestamp, and timestamptz
+columns. Metrics pruning covers integer and boolean columns by their stored
+minimum and maximum. Pruning never changes the rows returned. A predicate the
+wrapper cannot decide simply reads the file.
+
+**Tune it.** Filter on a partition column to remove whole files. Filter on an
+integer or boolean column to prune by metrics. Confirm the effect with
+`EXPLAIN (ANALYZE)`, which reports `Files Pruned`. A predicate on an unsupported
+type still returns correct rows, only without the pruning.
+
+## Measure and introspect
+
+Inspect physical layout, sort quality, and query plans.
+
+```sql
+SELECT * FROM pgcolumnar.stats('events');          -- per-stripe rows, dead rows, size
+SELECT * FROM pgcolumnar.sort_status('events');    -- sorted vs appended groups
+SELECT pgcolumnar.analyze('events');               -- refresh planner statistics
+EXPLAIN (ANALYZE) SELECT sum(amount) FROM events WHERE region = 'eu';
+```
+
+`EXPLAIN (ANALYZE)` on a columnar scan reports `Columnar Pushed-Down Filters`,
+`Columnar Usable Skip Predicates`, and `Columnar Chunk Groups Removed by Filter`.
+
+**Tune it.** Read `Columnar Chunk Groups Removed by Filter` to confirm a filter
+skips data. A low removal count on a selective filter means the sort key does not
+match the query. Re-sort on the filtered column, then check the count again.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,8 @@ column, with per-column compression, chunk-group skipping, and a vectorized
 aggregate path. It targets analytic workloads: large scans, aggregates, and
 column projections over append-mostly data.
 
-pgColumnar builds from one source tree on PostgreSQL 15 through 19. It is
+pgColumnar builds from one source tree on PostgreSQL 15 through 18, with 19
+validated against 19beta2. It is
 licensed under the MIT License.
 
 ## Where to start

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -29,7 +29,8 @@ On PostgreSQL 15 and later:
 ALTER TABLE events SET ACCESS METHOD pgcolumnar;
 ```
 
-On any supported major, including 13 and 14, the extension provides a helper:
+On any supported major, and on 13 and 14 which build but are outside the tested
+matrix, the extension provides a helper:
 
 ```sql
 SELECT pgcolumnar.alter_table_set_access_method('events', 'pgcolumnar');
@@ -231,8 +232,8 @@ depth), or a
 glob pattern. `EXPLAIN (ANALYZE)` shows how much the scan skipped:
 
 ```sql
-EXPLAIN (ANALYZE, COSTS OFF) SELECT id FROM events WHERE ts >= '2026-01-01';
---   Foreign Scan on events
+EXPLAIN (ANALYZE, COSTS OFF) SELECT id FROM events_parquet WHERE ts >= '2026-01-01';
+--   Foreign Scan on events_parquet
 --     Row Groups: 12
 --     Row Groups Skipped: 9
 --     Columns Read: 2

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,6 +99,7 @@ nav:
   - Getting started:
       - Installation: installation.md
       - User guide: user-guide.md
+      - How-to guides: how-to.md
   - Concepts:
       - Features: features.md
       - Architecture: ARCHITECTURE.md

--- a/pgcolumnar--1.0-alpha.sql
+++ b/pgcolumnar--1.0-alpha.sql
@@ -956,7 +956,7 @@ CREATE FUNCTION pgcolumnar.iceberg_scan(metadata_path text)
 	AS 'MODULE_PATHNAME', 'pgcolumnar_iceberg_scan';
 
 COMMENT ON FUNCTION pgcolumnar.iceberg_scan(text)
-	IS 'read an Apache Iceberg table at its current snapshot; supply a column definition list, whose names resolve to the table schema field ids, e.g. SELECT * FROM pgcolumnar.iceberg_scan(path) AS t(id bigint, region text); refuses tables with delete files (#388)';
+	IS 'read an Apache Iceberg table at its current snapshot; supply a column definition list, whose names resolve to the table schema field ids, e.g. SELECT * FROM pgcolumnar.iceberg_scan(path) AS t(id bigint, region text); applies position, equality, and deletion-vector deletes (#388)';
 
 CREATE FUNCTION pgcolumnar.iceberg_rest_table_location(catalog_uri text,
 													   namespace text,


### PR DESCRIPTION
## What

Two things the request asked for: **verify every doc against the code**, and **add
how-to guides for each feature including optimization**.

### New: `docs/how-to.md`

A task-focused recipe per feature, each ending with a **Tune it** note, linked
into the nav under *Getting started*. Sections: create/convert tables, load
(`COPY` and `parallel_copy`), compression and encoding, sort keys and clustering
for chunk-group skipping, space reclaim, the maintenance daemon, Parquet + Arrow
read/write and the Parquet FDW, object storage, the Iceberg reader, the Iceberg
REST catalog (server/user-mapping + OAuth2), Iceberg FDW file pruning, and
introspection. Passes the STE doc gate.

### Verification pass

Audited every doc against the code — function signatures vs `pgcolumnar--1.0-alpha.sql`,
GUC names/defaults/bounds/context vs the `DefineCustom*Variable` calls, lock
levels vs `columnar_vacuum.c`, and behavior vs the C. **The docs were already
highly accurate** (sql-reference, features, administration, limitations: zero
discrepancies). Gaps found and fixed:

- **configuration.md** — document six settings that exist and appear in
  `pg_settings` but were undocumented (`enable_late_materialization`,
  `qual_skipvec_min_payload_cols`, `fsst_verdict_reuse`, `objstore_buffered`,
  `objstore_part_size`, and the test-only `sink_fail_after`); fix an "Internal
  settings" miscount.
- **index.md** — match installation.md's support ceiling (15–18, 19 validated
  against 19beta2) instead of "15 through 19".
- **user-guide.md** — clarify 13/14 build but are outside the tested matrix; fix
  an EXPLAIN example that named the native table instead of the foreign table.
- **pgcolumnar--1.0-alpha.sql** — correct a stale `COMMENT` on `iceberg_scan`
  that still claimed it refuses delete files (it applies position, equality, and
  deletion-vector deletes).

## Gate

`docs_style.sh` (STE + nav + version-consistency) green across all 14 documents.
All function/GUC/lock claims cross-checked against `src/` and the install SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)