### PR TITLE
docs: cover the Iceberg, object-storage, and online-maintenance epics

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -143,9 +143,11 @@ Lightweight, type-aware value-stream encodings, applied per chunk before the
 block codec and reversed after decompression, as reversible transforms of the
 raw value-stream bytes (so all downstream decode is unchanged). Encodings: RLE,
 frame-of-reference with bit-packing, delta and delta-of-delta (integer family),
-Gorilla XOR (float4/float8), and a dictionary (any fixed-width or varlena type,
-for low cardinality). `ColumnarEncodeChunk` measures each applicable encoding and
-keeps the smallest; `ColumnarDecodeChunk` reverses it. This file also holds the
+Gorilla XOR (float4/float8), a dictionary (any fixed-width or varlena type, for
+low cardinality), and FSST substring coding for text and other varlena values.
+`ColumnarEncodeChunk` measures each applicable encoding and keeps the smallest;
+`ColumnarDecodeChunk` reverses it. The `pgcolumnar.fsst_verdict_reuse` setting
+caps how often the FSST keep-or-drop decision is recomputed across row groups. This file also holds the
 compression-block run iterator (`ColumnarBlockReader`) that exposes a chunk as
 (value, run-length) pairs so an aggregate can fold a run at a time.
 
@@ -217,9 +219,27 @@ back into full stripes, and rebuilds the indexes so their item pointers address
 the renumbered rows. This combines small stripes and physically reclaims
 deleted-row space. `pgcolumnar.vacuum_sorted` runs the same rewrite but feeds the
 live rows through a tuplesort keyed on the chosen columns first, so the table is
-stored physically sorted (a one-time reorder; see gap 26). `pgcolumnar.stats`
-reports the per-stripe layout, and a storage-id lookup resolves a relation to its
-storage id.
+stored physically sorted (a one-time reorder; see gap 26). `pgcolumnar.cluster`
+reorders by a Z-order curve on several columns, and holds `AccessExclusiveLock`
+like the rewrite verbs above.
+
+This file also holds the online reclaim verbs. They run under
+`ShareUpdateExclusiveLock`, so reads and writes continue. `pgcolumnar.compact`
+retires fully-deleted row groups, and `pgcolumnar.compact_rewrite` rewrites
+partially-deleted groups. `pgcolumnar.recluster` re-establishes a Z-order online,
+and `pgcolumnar.truncate` returns reclaimed end blocks to the operating system.
+`pgcolumnar.stats` and `pgcolumnar.sort_status` report the per-stripe layout and
+the remaining sort order. `pgcolumnar.maintenance_due` reports the compact and
+recluster thresholds. A storage-id lookup resolves a relation to its storage id.
+
+### columnar_autovacuum.c
+The maintenance daemon (`pgcolumnar.autovacuum`). A background-worker launcher
+starts one short-lived worker per database on a schedule. Each worker consults
+`pgcolumnar.maintenance_due` for the tables that have crossed the compact or
+recluster thresholds, then runs the online reclaim verbs on them through SPI, each
+in its own transaction. It runs only the `ShareUpdateExclusiveLock` verbs, and it
+registers as an autovacuum-kind process so it yields to a stronger lock a session
+requests.
 
 ### columnar_unique.c
 Concurrent unique-key insert serialization (issue #5). Before a freshly inserted
@@ -380,6 +400,33 @@ Object storage reads **exact object keys**. A glob metacharacter in a remote pat
 is refused rather than expanded. Expanding one needs a LIST call, and its paged
 response would be a third parser written here for input an outside party
 controls.
+
+### columnar_iceberg.c and columnar_avro.c
+The Apache Iceberg read path (#388). `columnar_avro.c` reads the Avro manifest and
+manifest-list files. `columnar_iceberg.c` walks a table's current snapshot, reads
+each Parquet data file through the same reader as the Parquet FDW, and applies the
+three delete kinds: position deletes, equality deletes (including partition-scoped),
+and format-version 3 deletion vectors, whose Puffin roaring bitmap is decoded in
+`columnar_puffin.c` and `columnar_delete_vector.c`. It resolves each requested
+column to a schema field id, or to a name mapping for a file with no field ids.
+`pgcolumnar.iceberg_scan`, `iceberg_current_snapshot`, and `iceberg_data_files`
+are its SQL surface.
+
+### columnar_iceberg_rest.c
+The Iceberg REST catalog client. It calls `/v1/config` and `loadTable` over the
+object-store transport, resolves a table to its metadata location, and lists
+namespaces and tables. It obtains the bearer token from the environment, or from a
+foreign server and user mapping, and can mint one by an OAuth2 client-credentials
+exchange. It reads vended storage credentials from a `loadTable` reply.
+
+### columnar_iceberg_fdw.c
+The `pgcolumnar_iceberg` foreign-data wrapper. It gives the Iceberg read path the
+query predicate, which the bare `iceberg_scan` function does not receive, and
+prunes whole data files before they open. Partition pruning covers identity,
+`bucket[N]` (a murmur3 hash), `truncate[W]`, and the year, month, day, and hour
+temporal transforms on date, timestamp, and timestamptz columns. Metrics pruning
+reads a data file's stored minimum and maximum. `EXPLAIN (ANALYZE)` reports
+`Files Pruned`.
 
 ### columnar_visibilitymap.c
 Index-only-scan support (gap 28). A columnar visibility-map fork records which

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -223,23 +223,25 @@ stored physically sorted (a one-time reorder; see gap 26). `pgcolumnar.cluster`
 reorders by a Z-order curve on several columns, and holds `AccessExclusiveLock`
 like the rewrite verbs above.
 
-This file also holds the online reclaim verbs. They run under
-`ShareUpdateExclusiveLock`, so reads and writes continue. `pgcolumnar.compact`
+This file also holds the online reclaim verbs, which run under
+`ShareUpdateExclusiveLock` so reads and writes continue. `pgcolumnar.compact`
 retires fully-deleted row groups, and `pgcolumnar.compact_rewrite` rewrites
-partially-deleted groups. `pgcolumnar.recluster` re-establishes a Z-order online,
-and `pgcolumnar.truncate` returns reclaimed end blocks to the operating system.
-`pgcolumnar.stats` and `pgcolumnar.sort_status` report the per-stripe layout and
-the remaining sort order. `pgcolumnar.maintenance_due` reports the compact and
-recluster thresholds. A storage-id lookup resolves a relation to its storage id.
+partially-deleted groups. `pgcolumnar.recluster` re-establishes a Z-order online.
+`pgcolumnar.truncate` returns reclaimed end blocks to the operating system. It
+takes a brief conditional `AccessExclusiveLock` for the physical shrink, and skips
+that step when the table is busy. `pgcolumnar.stats` and `pgcolumnar.sort_status` report the
+per-stripe layout and the remaining sort order. `pgcolumnar.maintenance_due`
+reports the compact-rewrite and recluster thresholds. A storage-id lookup resolves
+a relation to its storage id.
 
 ### columnar_autovacuum.c
 The maintenance daemon (`pgcolumnar.autovacuum`). A background-worker launcher
 starts one short-lived worker per database on a schedule. Each worker consults
-`pgcolumnar.maintenance_due` for the tables that have crossed the compact or
-recluster thresholds, then runs the online reclaim verbs on them through SPI, each
-in its own transaction. It runs only the `ShareUpdateExclusiveLock` verbs, and it
-registers as an autovacuum-kind process so it yields to a stronger lock a session
-requests.
+`pgcolumnar.maintenance_due` for the tables that have crossed the compact-rewrite
+or recluster thresholds, then runs `pgcolumnar.compact_rewrite` and
+`pgcolumnar.recluster` on them through SPI, each in its own transaction. It calls
+only those two `ShareUpdateExclusiveLock` verbs, and it registers as an
+autovacuum-kind process so it yields to a stronger lock a session requests.
 
 ### columnar_unique.c
 Concurrent unique-key insert serialization (issue #5). Before a freshly inserted
@@ -423,10 +425,10 @@ exchange. It reads vended storage credentials from a `loadTable` reply.
 The `pgcolumnar_iceberg` foreign-data wrapper. It gives the Iceberg read path the
 query predicate, which the bare `iceberg_scan` function does not receive, and
 prunes whole data files before they open. Partition pruning covers identity,
-`bucket[N]` (a murmur3 hash), `truncate[W]`, and the year, month, day, and hour
-temporal transforms on date, timestamp, and timestamptz columns. Metrics pruning
-reads a data file's stored minimum and maximum. `EXPLAIN (ANALYZE)` reports
-`Files Pruned`.
+`bucket[N]` (a murmur3 hash), `truncate[W]`, and the temporal transforms. It
+prunes year, month, day, and hour on a timestamp or timestamptz column, and year,
+month, and day on a date column. Metrics pruning reads a data file's stored minimum
+and maximum. `EXPLAIN (ANALYZE)` reports `Files Pruned`.
 
 ### columnar_visibilitymap.c
 Index-only-scan support (gap 28). A columnar visibility-map fork records which

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -319,6 +319,55 @@ no more restricted than the rest of the cluster. An independent validation on
 Both of those are little-endian. A move to a big-endian host is not supported and
 is not tested.
 
+## Object storage
+
+The Parquet functions, the Iceberg reader, and both foreign-data wrappers reach
+object storage. They accept an `s3://`, `http://`, or `https://` URL where they
+accept a local path. The support lives in a separate module,
+`pgcolumnar_objstore`, loaded on the first remote use.
+
+Remote access is default-deny. `pgcolumnar.objstore_allowed_endpoints` lists the
+hosts the module may reach, as `host` or `host:port`, comma-separated. It is empty
+by default, so no remote host is reachable until an administrator lists it. It is a
+superuser-only setting, so a role cannot widen its own reach. A link-local or
+instance-metadata address, including `169.254.169.254`, is refused even when it is
+listed, so the setting cannot open a path to cloud credentials.
+
+```ini
+# postgresql.conf
+pgcolumnar.objstore_allowed_endpoints = 's3.amazonaws.com, minio.internal:9000'
+```
+
+Credentials for the function API come from the server process environment:
+`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_REGION` or
+`AWS_DEFAULT_REGION`, and `AWS_ENDPOINT_URL`. The `pgcolumnar_parquet` foreign-data
+wrapper can take `access_key_id`, `secret_access_key`, `session_token`, and
+`credentials_required` from its server and user mapping instead, so each role uses
+its own credentials. An `s3://` request is signed with AWS Signature Version 4.
+
+`pgcolumnar.objstore_s3_addressing` selects path-style or virtual-host addressing,
+and `pgcolumnar.objstore_part_size` sets the multipart part size for an export. See
+the [Configuration reference](configuration.md#object-storage).
+
+## Apache Iceberg
+
+The Iceberg reader and the `pgcolumnar_iceberg` foreign-data wrapper read data,
+metadata, and delete files over the same object-storage transport. They are
+governed by the same `pgcolumnar.objstore_allowed_endpoints` allow-list and the
+same link-local refusal as every other remote access.
+
+A REST catalog needs a bearer token. It is read from the
+`PGCOLUMNAR_ICEBERG_REST_TOKEN` server environment variable, or per role from a
+foreign server and user mapping of the `pgcolumnar_iceberg_catalog` wrapper. The
+per-role token lives in `pg_user_mapping`, which is not world-readable, so one
+role's token is private from another. A token is never a function argument, so it
+does not appear in the statement log or in `pg_stat_activity`. A user mapping may
+carry OAuth2 client credentials instead, and the client secret travels only in the
+token-request body.
+
+The Iceberg functions require the `pg_read_server_files` role, like the other read
+functions.
+
 ## Security
 
 ### Server-side file access
@@ -345,6 +394,10 @@ A superuser holds both roles, so a superuser reaches every function. A read
 function needs `pg_read_server_files`. A write function needs
 `pg_write_server_files`. A role without the matching role is refused in C at the
 point of use.
+
+The same functions reach an object-storage URL where they reach a local path. A
+remote path is gated by a second control, the endpoint allow-list, in addition to
+the server-file role. See [Object storage](#object-storage) below.
 
 Two layers keep an unprivileged role out. The `pgcolumnar` schema does not grant
 `USAGE` to `PUBLIC`, so a role without schema access cannot reach the functions. A

--- a/docs/features.md
+++ b/docs/features.md
@@ -133,8 +133,36 @@ coverage.
   do not overlap. Range predicates and ordered scans therefore skip more chunk
   groups. The sort key also compresses better under the RLE and delta encodings. It is a one-time reorder, like `CLUSTER`: rows inserted afterward
   append in insert order until the next call.
+- `pgcolumnar.cluster(table, col [, col ...])` orders the rows by a Z-order
+  (Morton) curve on several numeric columns at once. Point and range filters on
+  more than one clustered column then skip more groups. It holds
+  `AccessExclusiveLock`, like core `CLUSTER`, so it is an eager bulk operation.
+
+### Online reclaim and clustering
+
+These verbs run against a live table under `ShareUpdateExclusiveLock`, so reads
+and writes continue.
+
+- `pgcolumnar.compact(table)` retires row groups that are fully deleted and drops
+  their metadata, so scans skip them.
+- `pgcolumnar.compact_rewrite(table, min_deleted_fraction, max_groups)` rewrites
+  partially deleted row groups to drop their dead rows and reclaim the space.
+  `max_groups` bounds how many one call rewrites.
+- `pgcolumnar.recluster(table, col [, col ...])` re-establishes the same Z-order
+  as `cluster` online. It is a fast no-op when the recorded key is intact.
+- `pgcolumnar.truncate(table)` returns the reclaimed end blocks to the operating
+  system, taking a brief `AccessExclusiveLock` only when it is free.
+
+### Reporting and the maintenance daemon
+
 - `pgcolumnar.stats(table)` reports per-row-group row counts, deleted-row counts,
-  chunk counts, and byte sizes.
+  chunk counts, and byte sizes. `pgcolumnar.sort_status(table)` reports how much of
+  the declared sort order remains. `pgcolumnar.maintenance_due(table, ...)` reports
+  whether a table has crossed the compact and recluster thresholds.
+- `pgcolumnar.autovacuum` is a background maintenance daemon. When on, a per-database
+  worker runs the online verbs above on a schedule for tables that
+  `maintenance_due` reports as due. It runs only the online operations, so it never
+  takes an exclusive lock, and it yields to a stronger lock a session requests.
 
 ## Parallel bulk ingest
 
@@ -211,3 +239,67 @@ coverage.
   not. A row group that
   predicate pushdown excludes is never read from disk at all, and
   `parquet_schema` reads only the footer.
+
+## Object storage
+
+- Every path that reads or writes a Parquet or Arrow file also accepts an
+  `s3://`, `http://`, or `https://` URL. This covers `read_parquet`,
+  `export_parquet`, `import_parquet`, `parquet_schema`, the `pgcolumnar_parquet`
+  foreign-data wrapper, and the Iceberg reader. The support lives in a separate
+  module, `pgcolumnar_objstore`, loaded on the first remote use.
+- `s3://` requests are signed with AWS Signature Version 4. An `https://` request
+  verifies the server certificate when the module is built with OpenSSL. An export
+  writes a small object in one request, and a large object as a multipart upload
+  that is visible only when it completes.
+- Credentials come from the server process environment: `AWS_ACCESS_KEY_ID`,
+  `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_REGION`, and
+  `AWS_ENDPOINT_URL`. The foreign-data wrapper can read them from its server and
+  user mapping instead.
+- `pgcolumnar.objstore_allowed_endpoints` gates every remote scheme. It is empty
+  by default, so no host is reachable until an administrator lists it. A
+  link-local or instance-metadata address is refused even when it is listed.
+
+## Apache Iceberg
+
+Read-only support for Apache Iceberg tables at their current snapshot.
+
+- `pgcolumnar.iceberg_scan(metadata_path) AS t(...)` reads a table given a column
+  definition list. It resolves each output column to a schema field id, so a data
+  file written before a column rename still reads. The metadata path may be local
+  or an object-storage URL.
+- It applies row-level deletes of all three kinds. A position delete drops named
+  row ordinals. An equality delete drops rows matching on its `equality_ids`,
+  including a partition-scoped delete. A format-version 3 deletion vector applies a
+  Puffin roaring bitmap. Each kind follows its own sequence rule.
+- A data file written outside Iceberg, with no field ids, is read through the
+  table's `schema.name-mapping.default` property. A file with neither field ids nor
+  such a mapping is refused rather than guessed.
+- `pgcolumnar.iceberg_current_snapshot` and `pgcolumnar.iceberg_data_files`
+  introspect a table. `pgcolumnar.read_avro_manifest` and
+  `pgcolumnar.read_manifest_list` read the Avro building blocks.
+
+### REST catalog
+
+- `pgcolumnar.iceberg_rest_scan(catalog_uri, namespace, table)` reads a table named
+  by a catalog rather than a metadata path. `iceberg_rest_table_location`,
+  `iceberg_rest_namespaces`, and `iceberg_rest_tables` resolve and list a catalog.
+- A bearer token comes from the `PGCOLUMNAR_ICEBERG_REST_TOKEN` environment
+  variable. It can instead come per role from a foreign server and user mapping of
+  the `pgcolumnar_iceberg_catalog` wrapper. The mapping holds the token in
+  `pg_user_mapping`, where it is not world-readable.
+- A user mapping may carry OAuth2 client credentials instead of a static token.
+  The catalog then mints a short-lived bearer by the client-credentials grant.
+- A catalog can vend short-lived storage credentials in its reply. The reader then
+  reads the table files with those credentials, not the server environment.
+
+### Foreign-data wrapper and file pruning
+
+- The `pgcolumnar_iceberg` foreign-data wrapper exposes an Iceberg table as a
+  foreign table with a `metadata_path` option. Unlike `iceberg_scan`, it receives
+  the query predicate, so it prunes whole data files before it opens them.
+- Partition pruning covers identity, `bucket[N]` (murmur3), `truncate[W]`, and the
+  temporal transforms `year`, `month`, `day`, and `hour` on date, timestamp, and
+  timestamptz columns. Metrics pruning covers integer and boolean columns by their
+  stored minimum and maximum.
+- Pruning is only an optimization. A predicate the wrapper cannot decide reads the
+  file and returns the same rows. `EXPLAIN (ANALYZE)` reports `Files Pruned`.

--- a/docs/features.md
+++ b/docs/features.md
@@ -16,20 +16,22 @@ settings see the [configuration reference](configuration.md); for constraints se
   apply each candidate to the whole vector. On a load of 6,000,000 rows this
   removes approximately one third of the write time, with no measured cost to the
   ratio. `pgcolumnar.encoding_sample_rows = 0` restores the
-  exhaustive behaviour.
-- The writer puts the rows into row groups, which are the unit of the write. In a
-  row group, it keeps each column as its own chunk and compresses each chunk
-  separately. It encodes the values of a chunk in vectors of a fixed size. Zone maps hold each chunk's and each vector's
-  minimum and maximum for skipping.
+  exhaustive behavior.
+- The writer puts the rows into row groups, the unit of the write. It divides each
+  row group into chunk groups, a band of up to `pgcolumnar.chunk_group_row_limit`
+  rows. Within a chunk group, each column is a chunk, compressed on its own and
+  encoded in fixed-size vectors. A zone map holds the minimum and maximum of each
+  chunk and each vector. A scan skips a whole chunk group when its filter cannot
+  match that range.
 
 ## Encodings and compression
 
-- Value encodings that know the type, applied to each chunk before compression.
-  These are run-length (RLE), frame-of-reference
-  with bit-packing (FOR), delta, delta-of-delta, and Gorilla XOR for floats.
-  There is also a dictionary for columns with a low cardinality, which includes
-  text. Each chunk takes the encoding that makes it
-  smallest. The block codec then runs on the encoded stream.
+- Type-aware value encodings, applied to each chunk before compression. These are
+  run-length (RLE), frame-of-reference with bit-packing (FOR), delta,
+  delta-of-delta, and Gorilla XOR for floats. A dictionary encoding also covers
+  low-cardinality columns, including text, and FSST covers longer text values.
+  Each chunk takes the encoding that makes it smallest. The block codec then runs
+  on the encoded stream.
 - Block compression with four codecs: `none`, `pglz`, `lz4`, and `zstd` with a
   level. The writer compresses each column chunk separately. It stores a chunk
   without compression if the compression makes it no smaller.
@@ -37,16 +39,15 @@ settings see the [configuration reference](configuration.md); for constraints se
 ## Scan and execution
 
 - Column projection: a scan decodes only the columns the query references.
-- Chunk-group skipping: a per-chunk minimum and maximum skip list lets a filtered
-  scan skip chunk groups that cannot match a pushed-down `column op const`
-  qualifier. A per-chunk bloom filter additionally skips groups on an equality
-  probe whose value is provably absent, for hashable columns whose collation is
-  deterministic. This covers the types that have no collation,
-  such as ids and uuids. It also covers text under an ordinary deterministic
-  collation. It does not cover a nondeterministic collation, because two equal
-  values there do not have to share a hash. The
-  executor always re-applies the full qualifier, so skipping never changes
-  results.
+- Chunk-group skipping: the per-chunk zone map lets a filtered scan skip chunk
+  groups that cannot match a pushed-down `column op const` qualifier. A per-chunk
+  bloom filter additionally skips groups on an equality probe whose value is
+  provably absent, for hashable columns whose collation is deterministic. This
+  covers the types that have no collation, such as IDs and UUIDs. It also covers
+  text under an ordinary deterministic collation. It does not cover a
+  nondeterministic collation, because two equal values there need not share a
+  hash. The executor always re-applies the full qualifier, so skipping never
+  changes results.
 - Vectorized aggregate. The zone-map metadata answers an ungrouped `count`,
   `sum`, `avg`, `min` or `max` on a supported column type. If the group has
   deletes, a fold over the decoded values answers it, one column at a time.
@@ -58,8 +59,9 @@ settings see the [configuration reference](configuration.md); for constraints se
   pass over the reader. It is off by default.
 - Column statistics. `ANALYZE` samples rows from across the row groups. It stores
   the null fraction, the distinct counts, the most-common values, the histograms
-  and the correlation. The planner then estimates the predicates from the data. Correlation is what lets the planner
-  see the locality `pgcolumnar.vacuum_sorted` and Z-order clustering create.
+  and the correlation. The planner then estimates predicate selectivity from that
+  data. Correlation lets the planner detect the locality that
+  `pgcolumnar.vacuum_sorted` and Z-order clustering create.
 - A fetch by row number decodes only the columns that the executor asks for. It
   keeps the decoded row group for the rest of the statement. An index-driven read
   of a wide table therefore does not decode the columns that it will not return.
@@ -77,17 +79,16 @@ coverage.
   assigned a stable row number and synthetic item pointer at insert time, so
   ordinary index scans fetch rows by item pointer.
 - Index-only scans: a columnar visibility-map fork records which chunk groups are
-  all-visible. Lazy `VACUUM` sets the bit for a group when two conditions
-  are true. The inserting transaction of the group must come before the oldest
-  snapshot horizon. The group must also have no deletes. Any write clears the bit. WAL
-  records both operations. For an all-visible group, a covering index query
-  answers from the index tuple. For any other group, it uses the row fetch that
-  checks the snapshot. An index-only answer therefore never returns a row that
-  the snapshot cannot see. On by default (`pgcolumnar.enable_index_only_scan`).
+  all-visible. Lazy `VACUUM` sets a chunk group's bit only when the group has no
+  deletes and was inserted before the oldest snapshot horizon. Any write clears the
+  bit, and WAL records both operations. A covering index query answers an
+  all-visible chunk group from the index tuple. For any other group it uses the row
+  fetch that checks the snapshot. An index-only answer therefore never returns a
+  row the snapshot cannot see. On by default (`pgcolumnar.enable_index_only_scan`).
 
 ## Projections
 
-- Multiple projections, which follow the C-Store model.
+- pgColumnar supports multiple projections, following the C-Store model.
   `pgcolumnar.add_projection(table, name, columns, sort_key)` declares an extra
   physical copy of a subset of the columns. That copy has its own sort order. It
   shares the row identity of the table. Every insert fans
@@ -116,9 +117,9 @@ coverage.
 
 - `ALTER TABLE ... ADD COLUMN` on a table that holds rows, with no rewrite. A row
   group that the writer wrote before the column existed carries no chunk for that
-  column. The reader then gives the missing value of the column. That value is
-  NULL, or the constant default that you gave with the column. This matches the
-  fast-default behaviour of a heap table.
+  column. The reader then supplies the missing value of the column. That value is
+  NULL, or the constant default declared with the column. This matches the
+  fast-default behavior of a heap table.
 - `pgcolumnar.alter_table_set_access_method(table, method)` converts a table to or
   from columnar storage. See [limitations](limitations.md) for the PostgreSQL 13
   and 14 behavior.
@@ -160,16 +161,17 @@ and writes continue.
   the declared sort order remains. `pgcolumnar.maintenance_due(table, ...)` reports
   whether a table has crossed the compact and recluster thresholds.
 - `pgcolumnar.autovacuum` is a background maintenance daemon. When on, a per-database
-  worker runs the online verbs above on a schedule for tables that
-  `maintenance_due` reports as due. It runs only the online operations, so it never
-  takes an exclusive lock, and it yields to a stronger lock a session requests.
+  worker runs `compact_rewrite` and `recluster` on a schedule for tables that
+  `maintenance_due` reports as due. It runs only those two online operations, so it
+  never takes an exclusive lock, and it yields to a stronger lock a session
+  requests.
 
 ## Parallel bulk ingest
 
 - `pgcolumnar.parallel_copy(target, path [, workers])` loads a COPY text file with
   several background workers at once, as one atomic operation. It returns the row
-  count. The columnar encode step is CPU bound, so more workers give a large load
-  speedup up to the physical core count.
+  count. The columnar encode step is CPU bound, so more workers speed up a large
+  load, up to the physical core count.
 - Each worker runs core `COPY` over a byte range of the file, so parse and write
   behavior match `COPY FROM` exactly. There is no second parser to keep correct.
 - The load is atomic. Each worker prepares its transaction, and a coordinator
@@ -196,9 +198,9 @@ and writes continue.
   import maintains each index on the target. It also applies the unique
   constraints and the exclusion constraints. It therefore cannot leave the table
   in a state that ordinary DML would refuse. The Parquet reader parses the Thrift
-  metadata. It decompresses uncompressed, Snappy, GZIP, ZSTD and LZ4_RAW pages.
-  It decodes the PLAIN encoding and the dictionary encoding, from data-page
-  version 1 and version 2.
+  metadata. It reads uncompressed pages and pages compressed with Snappy, GZIP,
+  ZSTD, or LZ4_RAW. It decodes the PLAIN encoding and the dictionary encoding, from
+  data-page version 1 and version 2.
 - Both directions cover scalar types, one-dimensional arrays, and composite types
   (Arrow List and Struct, Parquet LIST and group), with nulls at every level. The
   functions require a server-file role, `pg_read_server_files` to read or
@@ -219,10 +221,10 @@ and writes continue.
   sorted order that does not change between runs.
 - The foreign-table scan streams one row group at a time. It holds one row group
   rather than the whole file, and a `LIMIT` the plan meets early leaves the rest
-  undecoded. It pushes work down. It skips a row group when the
-  minimum and maximum statistics exclude the predicate of the query. It decodes
-  only the columns that the query refers to. `EXPLAIN ANALYZE` reports the row
-  groups read, skipped, and decoded, the columns read, and the number of files.
+  undecoded. It also pushes work down. It skips a row group when the minimum and
+  maximum statistics exclude the query predicate, and it decodes only the columns
+  the query refers to. `EXPLAIN ANALYZE` reports the row groups read, skipped, and
+  decoded, the columns read, and the number of files.
   Skipping applies to `column op constant` clauses over integer and
   floating-point columns; see [limitations.md](limitations.md) for the exact
   conditions.
@@ -231,13 +233,12 @@ and writes continue.
   removes complete files before the reader opens them. A file that pruning
   removes therefore costs no I/O.
   `EXPLAIN ANALYZE` reports `Files Pruned`.
-- uuid and numeric columns are read from their Parquet representations, and the
+- UUID and numeric columns are read from their Parquet representations, and the
   reader handles millisecond, microsecond, and nanosecond time units.
-- Files are read on demand rather than loaded whole. The reader reads the footer first. It then
-  reads each page when the scan reaches it. Memory use therefore does not increase
-  with the size of the file. The available disk limits a file, and memory does
-  not. A row group that
-  predicate pushdown excludes is never read from disk at all, and
+- Files are read on demand rather than loaded whole. The reader reads the footer
+  first, then reads each page only when the scan reaches it. Memory use therefore
+  stays flat regardless of file size, so disk, not memory, bounds the file. A row
+  group that predicate pushdown excludes is never read from disk at all, and
   `parquet_schema` reads only the footer.
 
 ## Object storage
@@ -298,8 +299,8 @@ Read-only support for Apache Iceberg tables at their current snapshot.
   foreign table with a `metadata_path` option. Unlike `iceberg_scan`, it receives
   the query predicate, so it prunes whole data files before it opens them.
 - Partition pruning covers identity, `bucket[N]` (murmur3), `truncate[W]`, and the
-  temporal transforms `year`, `month`, `day`, and `hour` on date, timestamp, and
-  timestamptz columns. Metrics pruning covers integer and boolean columns by their
-  stored minimum and maximum.
+  temporal transforms. It prunes `year`, `month`, `day`, and `hour` on a timestamp
+  or timestamptz column, and `year`, `month`, and `day` on a date column. Metrics
+  pruning covers integer and boolean columns by their stored minimum and maximum.
 - Pruning is only an optimization. A predicate the wrapper cannot decide reads the
   file and returns the same rows. `EXPLAIN (ANALYZE)` reports `Files Pruned`.

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -1,10 +1,11 @@
 # How-to guides
 
-Task-focused recipes for each pgColumnar feature. Every recipe ends with a short
-tuning note. For full signatures see the [SQL reference](sql-reference.md); for
-every server setting see the [Configuration reference](configuration.md).
+Task-focused recipes for each pgColumnar feature. Each recipe ends with a short
+tuning note, and a permissions note where one applies. For full function
+signatures see the [SQL reference](sql-reference.md). For every server setting see
+the [Configuration reference](configuration.md).
 
-Load `pgcolumnar` in `shared_preload_libraries` before you begin. It installs
+Load `pgcolumnar` in `shared_preload_libraries` before you begin. It installs the
 planner and executor hooks that every backend needs.
 
 ## Create a columnar table
@@ -25,7 +26,7 @@ METHOD` in place and keeps the table identity and dependents. On 13 and 14 it
 copies through a new table and swaps the names, so the original OID and its
 dependent objects are not preserved.
 
-**Tune it.** Columnar storage rewards wide scans over a few columns. Keep small,
+**Tuning.** Columnar storage rewards wide scans over a few columns. Keep small,
 highly selective point-lookup tables as heap. Put analytic and append-heavy
 tables on `pgcolumnar`.
 
@@ -45,10 +46,11 @@ SELECT pgcolumnar.parallel_copy('events', '/data/events.csv');   -- workers auto
 SELECT pgcolumnar.parallel_copy('events', '/data/events.csv', 8);
 ```
 
-**Tune it.** Prefer few large transactions over many small ones. Many small
-commits produce many small row groups, which read less efficiently. Run
-`pgcolumnar.vacuum` after a trickle load to combine them. The caller of
-`parallel_copy` needs the `pg_read_server_files` role.
+**Tuning.** Many small commits produce many small row groups, which read less
+efficiently. Run `pgcolumnar.vacuum` after a trickle load to combine them.
+
+**Permissions.** The caller of `parallel_copy` needs the `pg_read_server_files`
+role.
 
 ## Choose compression and encoding
 
@@ -69,15 +71,16 @@ The codec is one of `none`, `pglz`, `lz4`, or `zstd`. `compression_level`
 applies to `zstd` and ranges from 1 to 22, default 3. `encode_effort` is `full`
 by default, or `fast` to skip the costly FSST search on a text-heavy load.
 
-**Tune it.** Use `zstd` for the best ratio and `lz4` for the fastest
-decompression. Raise `compression_level` for cold, archival data. Set
-`encode_effort` to `fast` when a text load is CPU-bound and the ratio matters
-less. Re-run `pgcolumnar.vacuum` to re-encode existing data under new options.
+**Tuning.** Use `zstd` for the best ratio and `lz4` for the fastest
+decompression. Raise `compression_level` toward its maximum of 22 for cold data
+that is written once and read rarely. Set `encode_effort` to `fast` when a text
+load is CPU-bound and the ratio matters less. Re-run `pgcolumnar.vacuum` to
+re-encode existing data under new options.
 
-## Make queries skip data with a sort key
+## Sort a table to skip more chunk groups
 
-pgColumnar keeps a per-chunk minimum and maximum for every column. A query skips
-a chunk group when its filter cannot match that range. Sorting the table on the
+pgColumnar records a per-chunk minimum and maximum in a zone map. A scan skips a
+chunk group when its filter cannot match that range. Sorting the table on the
 columns you filter tightens those ranges, so more groups are skipped.
 
 ```sql
@@ -96,11 +99,11 @@ SELECT pgcolumnar.cluster('events', 'customer_id', 'amount');
 uses a Z-order curve, so filters on more than one of its columns all skip more
 groups. `cluster` takes numeric columns only.
 
-**Tune it.** Sort on the column your selective queries filter on. A sort is a
-trade. It groups one dimension tightly and spreads the others. For a live table
-use `pgcolumnar.recluster`, which re-establishes the same Z-order under a weaker
-lock so reads and writes continue. Read `pgcolumnar.sort_status` to see how much
-order remains, and re-sort when it decays.
+**Tuning.** Sort on the column your selective queries filter on. A sort is a
+trade-off: it groups one dimension tightly while spreading the others. For a live
+table use `pgcolumnar.recluster`, which re-establishes the same Z-order under a
+weaker lock so reads and writes continue. Read `pgcolumnar.sort_status` to see how
+much order remains, and re-sort when it decays.
 
 ```sql
 SELECT pgcolumnar.recluster('events', 'customer_id', 'amount');   -- online
@@ -123,23 +126,24 @@ against a live table. `compact_rewrite` rewrites groups whose dead fraction is a
 least `min_deleted_fraction` (default 0.2), and `max_groups` caps how many one
 call rewrites (0 means no cap). `vacuum` rewrites the whole relation.
 
-**Tune it.** Prefer `compact` and `compact_rewrite` for online reclaim. Reserve
-`vacuum` for a full reorganisation window. Cap `compact_rewrite` with `max_groups`
+**Tuning.** Prefer `compact` and `compact_rewrite` for online reclaim. Reserve
+`vacuum` for a full reorganization window. Cap `compact_rewrite` with `max_groups`
 to bound each call and keep it incremental.
 
 ## Keep tables optimized automatically
 
-A background daemon can compact and recluster tables on a schedule.
+A background daemon can compact and recluster tables on a schedule. The threshold
+values below are examples, not the defaults.
 
 ```sql
 -- postgresql.conf
 pgcolumnar.autovacuum = on
 pgcolumnar.autovacuum_naptime = '60s'
 pgcolumnar.autovacuum_compact_threshold = 0.2
-pgcolumnar.autovacuum_recluster_threshold = 0.2
+pgcolumnar.autovacuum_recluster_threshold = 0.1
 ```
 
-**Tune it.** Lower the thresholds to keep tables tighter at the cost of more
+**Tuning.** Lower the thresholds to keep tables tighter at the cost of more
 background work. The daemon calls the online operations only, so it does not take
 an exclusive lock. A table whose clustering is already intact reclusters as a
 fast no-op, so the daemon does not churn storage.
@@ -155,11 +159,11 @@ SELECT * FROM pgcolumnar.parquet_schema('/data/events.parquet');
 SELECT pgcolumnar.import_parquet('events', '/data/events.parquet');
 ```
 
-Export a table, in one call or in parallel.
+Export a table to one file, or in parallel to a directory of files.
 
 ```sql
-SELECT pgcolumnar.export_parquet('events', '/data/out.parquet');
-SELECT pgcolumnar.parallel_export_parquet('events', '/data/out.parquet', 8);
+SELECT pgcolumnar.export_parquet('events', '/data/events.parquet');
+SELECT pgcolumnar.parallel_export_parquet('events', '/data/events_out', 8);
 ```
 
 Expose a Parquet file, directory, or Hive layout as a foreign table.
@@ -170,10 +174,16 @@ CREATE FOREIGN TABLE events_parquet (id bigint, ts timestamptz, region text)
   SERVER pq OPTIONS (path '/data/events', partition_columns 'region');
 ```
 
-**Tune it.** Project only the columns you need, because the reader reads only
-those columns. A predicate on a `partition_columns` column removes whole files
-before they open. `EXPLAIN (ANALYZE)` reports `Files Pruned` and the row groups
-read and skipped. Reading needs the `pg_read_server_files` role, and
+`parallel_export_parquet` writes one `part-NNNN.parquet` file per worker into the
+directory, and `read_parquet` or the foreign table reads the directory back as one
+relation.
+
+**Tuning.** Project only the columns you need, because the reader reads only those
+columns. A predicate on a `partition_columns` column removes whole files before
+they open. `EXPLAIN (ANALYZE)` reports `Files Pruned` and the row groups read and
+skipped.
+
+**Permissions.** Reading needs the `pg_read_server_files` role, and
 `parallel_export_parquet` needs `pg_write_server_files`.
 
 ## Import and export Arrow
@@ -182,11 +192,11 @@ The Arrow IPC file format works the same way as Parquet.
 
 ```sql
 SELECT pgcolumnar.import_arrow('events', '/data/events.arrow');
-SELECT pgcolumnar.export_arrow('events', '/data/out.arrow');
+SELECT pgcolumnar.export_arrow('events', '/data/events.arrow');
 ```
 
-**Tune it.** Use Arrow to exchange data with an in-process analytic engine
-without a Parquet encode step. Use Parquet for durable, compressed files.
+**Tuning.** Use Arrow to exchange data with an in-process analytic engine without
+a Parquet encode step. Use Parquet for durable, compressed files.
 
 ## Use object storage
 
@@ -196,10 +206,10 @@ Every path that accepts a local path also accepts an `s3://`, `http://`, or
 ```sql
 SELECT * FROM pgcolumnar.read_parquet('s3://bucket/events.parquet')
   AS t(id bigint, region text);
-SELECT pgcolumnar.export_parquet('events', 's3://bucket/out.parquet');
+SELECT pgcolumnar.export_parquet('events', 's3://bucket/events.parquet');
 ```
 
-Set the endpoint allow-list first. It gates every remote scheme.
+Set the endpoint allow-list first, because it gates every remote scheme.
 
 ```sql
 -- postgresql.conf (a superuser setting)
@@ -210,9 +220,10 @@ The environment supplies `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,
 `AWS_SESSION_TOKEN`, `AWS_REGION`, and `AWS_ENDPOINT_URL`. A host that resolves to
 a link-local or instance-metadata address is refused even when it is listed.
 
-**Tune it.** Raise `pgcolumnar.objstore_part_size` to use larger multipart chunks
-on a fast link. Choose `pgcolumnar.objstore_s3_addressing` to match your provider
-path or virtual-host style. Keep the allow-list as small as your buckets require.
+**Tuning.** Raise `pgcolumnar.objstore_part_size` to use larger multipart parts
+over a high-latency network. Choose `pgcolumnar.objstore_s3_addressing` to match
+your provider's path or virtual-host style. Keep the allow-list as small as your
+buckets require.
 
 ## Query an Apache Iceberg table
 
@@ -233,9 +244,10 @@ before a column rename still reads. It applies position deletes, equality
 deletes, and format-version 3 deletion vectors. The metadata path may be a local
 path or an `s3://`, `http://`, or `https://` URL.
 
-**Tune it.** Select only the columns you need. Read from object storage under the
-same allow-list as every other remote access. The function requires the
-`pg_read_server_files` role.
+**Tuning.** Select only the columns you need. Read from object storage under the
+same allow-list as every other remote access.
+
+**Permissions.** The function requires the `pg_read_server_files` role.
 
 ## Query an Iceberg REST catalog
 
@@ -271,15 +283,16 @@ CREATE USER MAPPING FOR analyst SERVER cat OPTIONS (
   oauth_client_id 'app', oauth_client_secret 's3cr3t', oauth_scope 'catalog');
 ```
 
-**Tune it.** A catalog can vend short-lived storage credentials in its reply.
+**Tuning.** A catalog can vend short-lived storage credentials in its reply.
 `iceberg_rest_scan` then reads the table files with those credentials, not the
 server environment. The client secret travels in the request body, never a URL or
 a log line.
 
 ## Prune Iceberg data files with the foreign-data wrapper
 
-`iceberg_scan` gets no query predicate, so it cannot skip files. The foreign-data
-wrapper gives Iceberg a predicate-bearing scan that prunes whole files.
+`iceberg_scan` receives no query predicate, so it cannot skip files. The
+foreign-data wrapper gives Iceberg a predicate-bearing scan that prunes whole
+files.
 
 ```sql
 CREATE SERVER ice FOREIGN DATA WRAPPER pgcolumnar_iceberg;
@@ -291,12 +304,13 @@ SELECT sum(amount) FROM events WHERE region = 'eu';
 ```
 
 Partition pruning covers identity, `bucket[N]`, `truncate[W]`, and the temporal
-transforms `year`, `month`, `day`, and `hour` on date, timestamp, and timestamptz
-columns. Metrics pruning covers integer and boolean columns by their stored
-minimum and maximum. Pruning never changes the rows returned. A predicate the
-wrapper cannot decide simply reads the file.
+transforms. It prunes `year`, `month`, `day`, and `hour` on a timestamp or
+timestamptz column, and `year`, `month`, and `day` on a date column. Metrics
+pruning covers integer and boolean columns by their stored minimum and maximum.
+Pruning never changes the rows returned. A predicate the wrapper cannot decide
+simply reads the file.
 
-**Tune it.** Filter on a partition column to remove whole files. Filter on an
+**Tuning.** Filter on a partition column to remove whole files. Filter on an
 integer or boolean column to prune by metrics. Confirm the effect with
 `EXPLAIN (ANALYZE)`, which reports `Files Pruned`. A predicate on an unsupported
 type still returns correct rows, only without the pruning.
@@ -306,7 +320,7 @@ type still returns correct rows, only without the pruning.
 Inspect physical layout, sort quality, and query plans.
 
 ```sql
-SELECT * FROM pgcolumnar.stats('events');          -- per-stripe rows, dead rows, size
+SELECT * FROM pgcolumnar.stats('events');          -- per-row-group rows, dead rows, size
 SELECT * FROM pgcolumnar.sort_status('events');    -- sorted vs appended groups
 SELECT pgcolumnar.analyze('events');               -- refresh planner statistics
 EXPLAIN (ANALYZE) SELECT sum(amount) FROM events WHERE region = 'eu';
@@ -315,6 +329,6 @@ EXPLAIN (ANALYZE) SELECT sum(amount) FROM events WHERE region = 'eu';
 `EXPLAIN (ANALYZE)` on a columnar scan reports `Columnar Pushed-Down Filters`,
 `Columnar Usable Skip Predicates`, and `Columnar Chunk Groups Removed by Filter`.
 
-**Tune it.** Read `Columnar Chunk Groups Removed by Filter` to confirm a filter
+**Tuning.** Read `Columnar Chunk Groups Removed by Filter` to confirm a filter
 skips data. A low removal count on a selective filter means the sort key does not
 match the query. Re-sort on the filtered column, then check the count again.

--- a/docs/index.md
+++ b/docs/index.md
@@ -85,7 +85,8 @@ WAL, replication, indexes, `COPY`, and `pg_dump`. The extension adds:
   tables. They read a local path or object storage (`s3://`, `http://`,
   `https://`), gated by `pgcolumnar.objstore_allowed_endpoints`.
 - Online maintenance that runs against a live table (`compact`, `compact_rewrite`,
-  `recluster`), and an optional `pgcolumnar.autovacuum` daemon that schedules it.
+  `recluster`), and an optional `pgcolumnar.autovacuum` daemon that schedules
+  `compact_rewrite` and `recluster`.
 
 ## Design and internals
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,8 @@ pgColumnar is a column-oriented storage extension for PostgreSQL, implemented as
 a table access method. A table created `USING pgcolumnar` stores its data by
 column, with per-column compression, chunk-group skipping, and a vectorized
 aggregate path. It targets analytic workloads: large scans, aggregates, and
-column projections over append-mostly data.
+column projections over append-mostly data. It also reads external Parquet and
+Apache Iceberg tables, from a local path or from object storage.
 
 pgColumnar builds from one source tree on PostgreSQL 15 through 18, with 19
 validated against 19beta2. It is
@@ -17,6 +18,8 @@ licensed under the MIT License.
 | See what pgColumnar provides | [Features](features.md) |
 | Install the extension and load it into a server | [Installation](installation.md) |
 | Create columnar tables, load data, and query them | [User guide](user-guide.md) |
+| Follow a recipe for one feature, with a tuning note | [How-to guides](how-to.md) |
+| Read Parquet or Apache Iceberg data in place | [User guide](user-guide.md) and [SQL reference](sql-reference.md) |
 | Operate columnar tables in production | [Administration](administration.md) |
 | Look up a setting and its default | [Configuration reference](configuration.md) |
 | Look up a `pgcolumnar.*` function | [SQL reference](sql-reference.md) |
@@ -78,6 +81,11 @@ WAL, replication, indexes, `COPY`, and `pg_dump`. The extension adds:
 - A set of catalog tables and functions in the `pgcolumnar` schema.
 - Planner and executor paths for columnar scans, aggregates, index-only scans,
   and projections, controlled by settings under the `pgcolumnar.` prefix.
+- Readers and foreign-data wrappers for external Parquet and Apache Iceberg
+  tables. They read a local path or object storage (`s3://`, `http://`,
+  `https://`), gated by `pgcolumnar.objstore_allowed_endpoints`.
+- Online maintenance that runs against a live table (`compact`, `compact_rewrite`,
+  `recluster`), and an optional `pgcolumnar.autovacuum` daemon that schedules it.
 
 ## Design and internals
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -269,13 +269,26 @@ SELECT region, sum(amount) FROM pgcolumnar.iceberg_scan(
   GROUP BY region;
 ```
 
-Name a table by a REST catalog instead of a metadata path. For per-role
-credentials, name a foreign server that holds the catalog URI, with the bearer
-token in the role's user mapping.
+Name a table by a REST catalog instead of a metadata path. The catalog URI form
+takes its bearer token from the `PGCOLUMNAR_ICEBERG_REST_TOKEN` server
+environment variable.
 
 ```sql
 SELECT * FROM pgcolumnar.iceberg_rest_scan(
   'https://catalog.example.com', 'analytics', 'events')
+  AS t(id bigint, region text, amount int);
+```
+
+For per-role credentials, pass a foreign server name as the first argument. The
+server holds the catalog URI, and the current role's user mapping supplies the
+token.
+
+```sql
+CREATE SERVER cat FOREIGN DATA WRAPPER pgcolumnar_iceberg_catalog
+  OPTIONS (catalog_uri 'https://catalog.example.com');
+CREATE USER MAPPING FOR analyst SERVER cat OPTIONS (token 's3cr3t');
+
+SELECT * FROM pgcolumnar.iceberg_rest_scan('cat', 'analytics', 'events')
   AS t(id bigint, region text, amount int);
 ```
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -202,8 +202,8 @@ INSERT INTO people VALUES (1, ARRAY['a','b'], ROW('Portland','97201')::addr);
 
 ## Read Parquet files in place
 
-You can query a server-side Parquet file without importing it, either as a
-set-returning function or as a foreign table. Both require the
+You can query a Parquet file without importing it, either as a set-returning
+function or as a foreign table. Reading a local server file requires the
 `pg_read_server_files` role, which superusers hold.
 
 ```sql
@@ -240,6 +240,61 @@ EXPLAIN (ANALYZE, COSTS OFF) SELECT id FROM events_parquet WHERE ts >= '2026-01-
 --     Columns Total: 3
 --     Files: 4
 ```
+
+The `path` may also be an object-storage URL. Every read and export function, and
+both foreign-data wrappers, accept an `s3://`, `http://`, or `https://` URL where
+they accept a local path.
+
+```sql
+SELECT count(*) FROM pgcolumnar.read_parquet('s3://bucket/events.parquet')
+  AS t(id int, ts timestamp);
+```
+
+Credentials come from the server process environment (`AWS_ACCESS_KEY_ID`,
+`AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_REGION`, `AWS_ENDPOINT_URL`).
+An administrator must first list the endpoint in the superuser-only
+`pgcolumnar.objstore_allowed_endpoints`, which is empty by default and refuses
+every host until then. See [Administration](administration.md#object-storage).
+
+## Read an Apache Iceberg table
+
+Read an Iceberg table at its current snapshot. Give a metadata path and a column
+definition list. The reader applies the table's delete files and resolves each
+column by schema field id.
+
+```sql
+SELECT region, sum(amount) FROM pgcolumnar.iceberg_scan(
+  '/warehouse/db/events/metadata/00042.metadata.json')
+  AS t(id bigint, region text, amount int)
+  GROUP BY region;
+```
+
+Name a table by a REST catalog instead of a metadata path. For per-role
+credentials, name a foreign server that holds the catalog URI, with the bearer
+token in the role's user mapping.
+
+```sql
+SELECT * FROM pgcolumnar.iceberg_rest_scan(
+  'https://catalog.example.com', 'analytics', 'events')
+  AS t(id bigint, region text, amount int);
+```
+
+For file pruning, use the `pgcolumnar_iceberg` foreign-data wrapper. It receives
+the query predicate, which `iceberg_scan` does not, so it removes whole data
+files before it opens them.
+
+```sql
+CREATE SERVER ice FOREIGN DATA WRAPPER pgcolumnar_iceberg;
+CREATE FOREIGN TABLE events_iceberg (id bigint, region text, amount int)
+  SERVER ice OPTIONS (metadata_path '/warehouse/db/events/metadata/v3.metadata.json');
+
+-- EXPLAIN (ANALYZE) reports "Files Pruned"
+SELECT sum(amount) FROM events_iceberg WHERE region = 'eu';
+```
+
+The wrapper prunes by partition (identity, `bucket[N]`, `truncate[W]`, and the
+year, month, day, and hour transforms) and by integer and boolean metrics. See
+the [SQL reference](sql-reference.md) and the [how-to guides](how-to.md#query-an-apache-iceberg-table).
 
 ## Capture changes for replication or CDC
 
@@ -329,3 +384,8 @@ decoded unless the consumer filters them.
   [`pgcolumnar.vacuum_sorted`](sql-reference.md#pgcolumnarvacuum_sortedtablename-regclass-variadic-sort_columns-name).
 - Move data in and out of the Arrow and Parquet ecosystem:
   [import and export](sql-reference.md#import-and-export).
+- Reclaim space and re-sort a live table without an exclusive lock:
+  [`compact`, `compact_rewrite`, and `recluster`](administration.md#online-maintenance-and-disk-reclaim),
+  or schedule them with the [`pgcolumnar.autovacuum` daemon](administration.md#the-maintenance-daemon-pgcolumnarautovacuum).
+- Follow a task-focused recipe for any feature, each with a tuning note:
+  [how-to guides](how-to.md).


### PR DESCRIPTION
## Why

The previous docs PR (#670) verified that what was *written* was accurate. This
one addresses the other half: **whole shipped epics were never documented**. A
completeness/staleness audit found that `features.md` and several other docs
predate the Iceberg (#388), object-storage (#393/#394), and online-maintenance
work and do not mention them at all.

Docs only — no behavior changes. Every claim was checked against `CHANGELOG.md`,
the install SQL, and `src/`.

## What was missing, now added

**features.md** (the worst — it predated two epics):
- New **Object storage** section (s3/http(s) URLs, the `pgcolumnar_objstore`
  module, AWS_* credentials, the `objstore_allowed_endpoints` allow-list).
- New **Apache Iceberg** section (`iceberg_scan` + the three delete kinds + name
  mapping; the REST catalog with per-role server/user-mapping tokens, OAuth2, and
  vended credentials; the `pgcolumnar_iceberg` FDW with partition + metrics
  pruning).
- Expanded **Maintenance** (the online verbs `compact`/`compact_rewrite`/
  `recluster`, plus `cluster`, `truncate`, `sort_status`, `maintenance_due`, and
  the `autovacuum` daemon).

**index.md** — external Parquet/Iceberg reading and object storage named in the
intro, "How it fits together", and "Where to start".

**user-guide.md** — a new **Read an Apache Iceberg table** section; object-storage
URLs + the allow-list added to the Parquet examples; the local-only access note
corrected; a Next-steps pointer to online maintenance.

**administration.md** — new **Object storage** and **Apache Iceberg** operational/
security sections (default-deny + superuser-only + link-local refusal, AWS_* and
FDW user-mapping credentials, REST token handling kept out of the log); the
server-file security table annotated for remote endpoints.

**ARCHITECTURE.md** — module-map entries for `columnar_autovacuum.c` and the
Iceberg subsystem; the `columnar_vacuum.c` entry extended with the online reclaim
verbs; FSST added to the encoding list.

## Gate

`docs_style.sh` (STE + nav + version-consistency) green across all 14 documents;
cross-doc anchors verified to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)