### PR TITLE
fix: reject CR/LF in object-store request path/host (request-splitting)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ which was true until that script existed.
 
 ### Security
 
+- Fixed an HTTP request-line injection in the object-store client. A URL path or
+  host containing CR or LF was written verbatim into the request line, so a
+  crafted path could split the request and smuggle a second line to an
+  allow-listed endpoint. The request path and host are now rejected if they carry
+  CR or LF, as the caller-supplied header lines already were. Regression test:
+  objstore_crlf.
+
+### Security
+
 - Fixed an out-of-bounds read in the Parquet dictionary decode path. A file whose
   RLE_DICTIONARY data page carried an index with the high bit set (reachable at
   bit_width 32) passed a signed bounds check that sign-extended it to a negative

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,6 @@ which was true until that script existed.
   CR or LF, as the caller-supplied header lines already were. Regression test:
   objstore_crlf.
 
-### Security
-
 - Fixed an out-of-bounds read in the Parquet dictionary decode path. A file whose
   RLE_DICTIONARY data page carried an index with the high bit set (reachable at
   bit_width 32) passed a signed bounds check that sign-extended it to a negative

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -95,7 +95,7 @@ schemes and the credential model.
 
 | Setting | Type | Default | Description |
 | --- | --- | --- | --- |
-| `pgcolumnar.objstore_allowed_endpoints` | string | `''` (empty) | The endpoints the module may connect to, comma-separated as `host` or `host:port`. Empty refuses every remote endpoint, so a role that can read or write server files cannot reach an arbitrary host through the extension. Link-local addresses, including `169.254.169.254`, are refused whether or not they are listed. Superuser-only, so a role cannot widen its own reach. |
+| `pgcolumnar.objstore_allowed_endpoints` | string | `''` (empty) | The endpoints the module may connect to, comma-separated as `host` or `host:port`. An entry with no port matches any port on that host; add a port to restrict it. Empty refuses every remote endpoint, so a role that can read or write server files cannot reach an arbitrary host through the extension. Link-local addresses, including `169.254.169.254`, are refused whether or not they are listed. Superuser-only, so a role cannot widen its own reach. |
 | `pgcolumnar.objstore_s3_addressing` | string | `path` | The S3 request addressing style. `path` sends `s3://bucket/key` to `endpoint/bucket/key`; `virtual` sends it to `bucket.endpoint/key`, which is what AWS now prefers. Under virtual-host addressing the allow-list still authorizes the endpoint, not the per-bucket hostname. |
 | `pgcolumnar.objstore_buffered` | boolean | `on` | Coalesce remote Parquet reads to one request per column chunk instead of many small ranged reads. |
 | `pgcolumnar.objstore_part_size` | integer | `0` | Multipart part size in bytes for a remote export. `0` uses the module default of 8 MiB. Raise it for a fast link. Range 0 to INT_MAX. |

--- a/objstore/columnar_objstore_module.c
+++ b/objstore/columnar_objstore_module.c
@@ -1147,6 +1147,26 @@ os_sign_request(PgColumnarObjHandle *h, const char *method,
 /* ---------------------------------------------------------------- request */
 
 /*
+ * Request-line splitting guard. The request-target and host go verbatim into
+ * "%s %s HTTP/1.1\r\nHost: %s:%d\r\n", so a CR or LF in either would inject a
+ * second request line or header onto the connection. This is the same defense
+ * the caller-supplied header lines already carry; the request-target and host,
+ * which can come from a user-controlled URL / catalog_uri, need it too.
+ */
+static void
+os_reject_target_ctl(PgColumnarObjHandle *h)
+{
+	if (h->abspath != NULL && strpbrk(h->abspath, "\r\n") != NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_DATA_EXCEPTION),
+				 errmsg("columnar: an HTTP request path may not contain CR or LF")));
+	if (h->host != NULL && strpbrk(h->host, "\r\n") != NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_DATA_EXCEPTION),
+				 errmsg("columnar: an HTTP request host may not contain CR or LF")));
+}
+
+/*
  * One request/response cycle with a single reconnect on a stale keep-alive
  * connection. `off`/`n` describe the Range for GET; HEAD sends no Range.
  */
@@ -1158,6 +1178,7 @@ os_request(PgColumnarObjHandle *h, const char *method,
 	bool		isGet = (strcmp(method, "GET") == 0);
 	int			attempt;
 
+	os_reject_target_ctl(h);
 	initStringInfo(&req);
 	appendStringInfo(&req, "%s %s HTTP/1.1\r\nHost: %s:%d\r\n",
 					 method, h->abspath, h->host, h->port);
@@ -1795,6 +1816,7 @@ os_write_request(PgColumnarObjHandle *h, const char *method, const char *rawQuer
 	char		payloadHex[PG_SHA256_DIGEST_LENGTH * 2 + 1];
 	int			attempt;
 
+	os_reject_target_ctl(h);
 	os_sha256(body, (size_t) bodylen, phash);
 	os_hex(phash, sizeof(phash), payloadHex);
 

--- a/objstore/columnar_objstore_module.c
+++ b/objstore/columnar_objstore_module.c
@@ -366,6 +366,28 @@ os_addr_is_linklocal(const struct addrinfo *ai)
 	return false;
 }
 
+/*
+ * Request-line splitting guard. The request-target and host go verbatim into
+ * "%s %s HTTP/1.1\r\nHost: %s:%d\r\n" in every request builder, so a CR or LF in
+ * either (from a user-controlled URL or catalog_uri) would inject a second
+ * request line or header onto the connection. This is the same defense the
+ * caller-supplied header lines already carry. It lives in os_connect, the one
+ * path every request builder (GET, write, list, and the ABI http_request) goes
+ * through, so no emit site can be missed.
+ */
+static void
+os_reject_target_ctl(PgColumnarObjHandle *h)
+{
+	if (h->abspath != NULL && strpbrk(h->abspath, "\r\n") != NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_DATA_EXCEPTION),
+				 errmsg("columnar: an HTTP request path may not contain CR or LF")));
+	if (h->host != NULL && strpbrk(h->host, "\r\n") != NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_DATA_EXCEPTION),
+				 errmsg("columnar: an HTTP request host may not contain CR or LF")));
+}
+
 static void
 os_connect(PgColumnarObjHandle *h)
 {
@@ -379,6 +401,7 @@ os_connect(PgColumnarObjHandle *h)
 	Assert(h->fd < 0);
 
 	os_check_endpoint_allowed(h);
+	os_reject_target_ctl(h);
 
 	if (!h->fd_reserved)
 	{
@@ -1147,26 +1170,6 @@ os_sign_request(PgColumnarObjHandle *h, const char *method,
 /* ---------------------------------------------------------------- request */
 
 /*
- * Request-line splitting guard. The request-target and host go verbatim into
- * "%s %s HTTP/1.1\r\nHost: %s:%d\r\n", so a CR or LF in either would inject a
- * second request line or header onto the connection. This is the same defense
- * the caller-supplied header lines already carry; the request-target and host,
- * which can come from a user-controlled URL / catalog_uri, need it too.
- */
-static void
-os_reject_target_ctl(PgColumnarObjHandle *h)
-{
-	if (h->abspath != NULL && strpbrk(h->abspath, "\r\n") != NULL)
-		ereport(ERROR,
-				(errcode(ERRCODE_DATA_EXCEPTION),
-				 errmsg("columnar: an HTTP request path may not contain CR or LF")));
-	if (h->host != NULL && strpbrk(h->host, "\r\n") != NULL)
-		ereport(ERROR,
-				(errcode(ERRCODE_DATA_EXCEPTION),
-				 errmsg("columnar: an HTTP request host may not contain CR or LF")));
-}
-
-/*
  * One request/response cycle with a single reconnect on a stale keep-alive
  * connection. `off`/`n` describe the Range for GET; HEAD sends no Range.
  */
@@ -1178,7 +1181,6 @@ os_request(PgColumnarObjHandle *h, const char *method,
 	bool		isGet = (strcmp(method, "GET") == 0);
 	int			attempt;
 
-	os_reject_target_ctl(h);
 	initStringInfo(&req);
 	appendStringInfo(&req, "%s %s HTTP/1.1\r\nHost: %s:%d\r\n",
 					 method, h->abspath, h->host, h->port);
@@ -1816,7 +1818,6 @@ os_write_request(PgColumnarObjHandle *h, const char *method, const char *rawQuer
 	char		payloadHex[PG_SHA256_DIGEST_LENGTH * 2 + 1];
 	int			attempt;
 
-	os_reject_target_ctl(h);
 	os_sha256(body, (size_t) bodylen, phash);
 	os_hex(phash, sizeof(phash), payloadHex);
 

--- a/test/crlf_listener.py
+++ b/test/crlf_listener.py
@@ -1,0 +1,27 @@
+import socket, sys
+# Minimal capture listener: accept one connection, record the raw request bytes,
+# return a short 200 so the client does not hang, then exit.
+port = int(sys.argv[1]); outf = sys.argv[2]
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(("127.0.0.1", port)); s.listen(1)
+sys.stderr.write("LISTENING\n"); sys.stderr.flush()
+s.settimeout(20)
+try:
+    conn, _ = s.accept()
+    conn.settimeout(2)
+    data = b""
+    try:
+        while len(data) < 4096:
+            chunk = conn.recv(1024)
+            if not chunk: break
+            data += chunk
+    except socket.timeout:
+        pass
+    open(outf, "wb").write(data)
+    body = b"hi"
+    conn.sendall(b"HTTP/1.1 200 OK\r\nContent-Length: %d\r\n\r\n%s" % (len(body), body))
+    conn.close()
+except socket.timeout:
+    open(outf, "wb").write(b"")   # no connection arrived
+s.close()

--- a/test/objstore_crlf.sh
+++ b/test/objstore_crlf.sh
@@ -31,4 +31,19 @@ check "a CR/LF in the URL path is rejected before the request is sent" "$rej" "1
 inj="$(grep -ciE 'X-Injected' "$CAP" 2>/dev/null | head -1)"
 check "no injected line reached the listener (no request splitting)" "$inj" "0"
 check "backend alive" "$(q 'SELECT 1')" "1"
+
+# ---- the REST catalog path is guarded too (objstore_http_request) ------------
+# The guard lives in os_connect, the single connect path, so the ABI http_request
+# the REST client uses is covered as well. A catalog_uri whose path carries CR/LF
+# must be rejected before the request is sent, not just the read_parquet path.
+CATURL="http://127.0.0.1:$PORT/x"$'\r'$'\n'"X-Injected: yes"
+q "CREATE SERVER cat FOREIGN DATA WRAPPER pgcolumnar_iceberg_catalog OPTIONS (catalog_uri '$CATURL')" >/dev/null
+q "CREATE USER MAPPING FOR postgres SERVER cat OPTIONS (token 'x')" >/dev/null
+env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" \
+	-c "SELECT pgcolumnar.iceberg_rest_table_location('cat', 'db', 'events')" \
+	>/dev/null 2>"$PGC_WORKDIR/rest.err"
+rej2="$(grep -ciE 'CR or LF' "$PGC_WORKDIR/rest.err" 2>/dev/null | head -1)"
+echo "-- REST path error:"; grep -iE 'ERROR' "$PGC_WORKDIR/rest.err" | head -1 | sed 's/^/     /'
+check "a CR/LF in a REST catalog_uri is rejected too (objstore_http_request path)" "$rej2" "1"
+check "backend alive after the REST attempt" "$(q 'SELECT 1')" "1"
 pgc_summary

--- a/test/objstore_crlf.sh
+++ b/test/objstore_crlf.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Repro for HTTP request-line splitting via CR/LF in an object-store URL path.
+# A URL path containing \r\n is emitted verbatim into "GET <path> HTTP/1.1", so
+# an unfixed build sends a split request (the injected line reaches the server as
+# its own header/request). Post-fix the request is rejected before it is sent.
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+PORT="$(pgc_pick_free_port "$PGC_AUX_PORT_LO" "$PGC_AUX_PORT_HI")"
+CAP="$PGC_WORKDIR/req_capture.txt"
+python3 "$(dirname "${BASH_SOURCE[0]}")/crlf_listener.py" "$PORT" "$CAP" 2>"$PGC_WORKDIR/lst.log" &
+LPID=$!
+for _ in $(seq 1 50); do grep -q LISTENING "$PGC_WORKDIR/lst.log" 2>/dev/null && break; sleep 0.1; done
+
+q "ALTER SYSTEM SET pgcolumnar.objstore_allowed_endpoints='127.0.0.1'" >/dev/null
+q "SELECT pg_reload_conf()" >/dev/null
+
+# URL whose path smuggles a second line: /x<CR><LF>X-Injected: yes
+URL="http://127.0.0.1:$PORT/x"$'\r'$'\n'"X-Injected: yes"
+env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" \
+	-c "SELECT * FROM pgcolumnar.read_parquet('$URL') AS t(v int)" >/dev/null 2>"$PGC_WORKDIR/crlf.err"
+wait "$LPID" 2>/dev/null || true
+
+echo "-- psql error:"; grep -iE 'ERROR' "$PGC_WORKDIR/crlf.err" | head -1 | sed 's/^/     /'
+echo "-- captured request bytes:"; sed 's/^/     /' "$CAP" 2>/dev/null | head -4
+
+# Post-fix: the query is rejected with a CR/LF error and nothing is smuggled.
+rej="$(grep -ciE 'CR or LF' "$PGC_WORKDIR/crlf.err" 2>/dev/null | head -1)"
+check "a CR/LF in the URL path is rejected before the request is sent" "$rej" "1"
+inj="$(grep -ciE 'X-Injected' "$CAP" 2>/dev/null | head -1)"
+check "no injected line reached the listener (no request splitting)" "$inj" "0"
+check "backend alive" "$(q 'SELECT 1')" "1"
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -172,6 +172,7 @@ SUITES=(
 	objstore_addressing
 	objstore_allowlist
 	objstore_credentials
+	objstore_crlf
 	objstore_http_read
 	objstore_listing
 	objstore_module


### PR DESCRIPTION
## Fix HTTP request-line injection (CR/LF) in the object-store client

### The bug
`os_request` and `os_write_request` (`objstore/columnar_objstore_module.c`) write the request-target and host verbatim into the request line:

```c
appendStringInfo(&req, "%s %s HTTP/1.1\r\nHost: %s:%d\r\n",
                 method, h->abspath, h->host, h->port);
```

`h->abspath` / `h->host` come from a user-controlled URL (or `catalog_uri`). A path containing `\r\n` splits the request line and smuggles a second request/header onto the connection to an allow-listed endpoint. The caller-supplied header lines already rejected CR/LF (line ~2582); the request-target and host did not.

### Proof (reproduced on the bench, PG 18.4)
`test/objstore_crlf.sh` runs a capture listener and points `read_parquet` at `http://127.0.0.1:PORT/x\r\nX-Injected: yes`:
- **Unfixed:** the listener captures `X-Injected: yes HTTP/1.1` as its own line, i.e. the request was split.
- **Fixed:** `ERROR: columnar: an HTTP request path may not contain CR or LF`, and nothing is smuggled.

### The fix
Both emit paths call `os_reject_target_ctl(h)`, which raises on CR or LF in the path or host before the request is built. This mirrors the defense the header lines already carry.

### Also
Documents that a port-less allow-list entry matches any port on that host (a separate low-severity finding). That behavior is relied upon (the suites allow-list `127.0.0.1` and reach stubs on random ports), so rather than break it, the config reference now states it, so an operator who wants a port restriction adds one.

Findings #3 (HIGH) and #4 (low) of the audit. #673 (CRITICAL) merged; #674 (HIGH) is approved and mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjdBLCRm7YmYai1FPgpsQn
