### PR TITLE
fix: all-null Parquet column (empty dictionary page) still reads (regression from #673)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@ which was true until that script existed.
   bit_width 32) passed a signed bounds check that sign-extended it to a negative
   int, and the dictionary was then read far out of bounds, crashing the backend
   from a single crafted file. The bounds check is now unsigned and the index is
-  rejected. Regression test: native_parquet_dict_oob.
+  rejected. The index decode runs only when the page has coded values, so an
+  all-null column with an empty dictionary page still reads. Regression tests:
+  native_parquet_dict_oob and native_parquet_streaming.
 
 ### Added
 

--- a/src/columnar_parquet_reader.c
+++ b/src/columnar_parquet_reader.c
@@ -2116,14 +2116,24 @@ decode_leaf_entries(PqSource *src, PqChunk *ch,
 				uint32	   *idx;
 				int			bw;
 
-				if (dict == NULL || vallen < 1 || dictCount < 1)
-					return false;
-				bw = valbuf[0];
-				idx = palloc(sizeof(uint32) * Max(nnn, 1));
-				if (!rle_bitpack_decode(valbuf + 1, vallen - 1, bw, nnn, idx))
-					return false;
-				for (i = 0; i < nnn; i++)
+				/*
+				 * Decode indices only when the page has coded values. An
+				 * all-null page (nnn == 0) has zero indices and, for a column
+				 * that is entirely null, an empty dictionary (dictCount == 0);
+				 * the guards below would wrongly reject that valid case, so they
+				 * apply only when nnn > 0. When nnn > 0 a dictCount >= 1 is
+				 * required, which keeps (uint32) dictCount a valid bound.
+				 */
+				if (nnn > 0)
 				{
+					if (dict == NULL || vallen < 1 || dictCount < 1)
+						return false;
+					bw = valbuf[0];
+					idx = palloc(sizeof(uint32) * nnn);
+					if (!rle_bitpack_decode(valbuf + 1, vallen - 1, bw, nnn, idx))
+						return false;
+					for (i = 0; i < nnn; i++)
+					{
 					/*
 					 * idx[i] is file-controlled and unsigned. The bounds test must
 					 * be unsigned too: a signed comparison sign-extends any index
@@ -2132,9 +2142,10 @@ decode_leaf_entries(PqSource *src, PqChunk *ch,
 					 * then reads far out of bounds. Compare as uint32 against a
 					 * dictCount already proven >= 1 above.
 					 */
-					if (idx[i] >= (uint32) dictCount)
-						return false;
-					pv[i] = dict[idx[i]];
+						if (idx[i] >= (uint32) dictCount)
+							return false;
+						pv[i] = dict[idx[i]];
+					}
 				}
 			}
 			else if (h.encoding == PQE_PLAIN)


### PR DESCRIPTION
## Urgent: fixes a regression on `main`

`main` currently returns **empty results** for an all-null Parquet column and for
an Iceberg null-delete read. This restores them.

### Cause
The Parquet dictionary OOB fix (#673) added a pre-decode guard:

```c
if (dict == NULL || vallen < 1 || dictCount < 1)
    return false;
```

That `dictCount < 1` also rejects a **legitimate** all-null page: a column that is
entirely null has zero coded values (`nnn == 0`) and an empty dictionary
(`dictCount == 0`), which is valid, not corrupt. So the guard turned a valid page
into a decode error. It regressed two suites on `main`:
- `native_parquet_streaming` — "all-null column (empty dictionary page) still reads" returns `[]`.
- `iceberg_deletes` — "a null delete value matches only null data values" returns `[]` (it reads such a column).

### Fix
Decode the dictionary indices only when the page has coded values (`nnn > 0`). An
all-null page then reads. When there **are** values, the same `dictCount >= 1`
requirement holds, so the unsigned bound `(uint32) dictCount` that closes the
out-of-bounds read is fully preserved.

### Verified (PG 18.4 bench)
- `native_parquet_streaming`, `iceberg_deletes`, `native_parquet_dict_oob` all pass.
- `native_parquet_dict_oob` still reproduces the OOB rejection, so #673's security fix is intact.
- Strict PG19 build clean.

Regression tests already in tree cover it (`native_parquet_streaming` all-null,
`iceberg_deletes` null-delete). CHANGELOG amends #673's Security bullet rather
than adding a new one (the regression never shipped; both are in Unreleased).

🤖 Generated with [Claude Code](https://claude.com/claude-code)