### PR TITLE
docs: document the concurrent-UPDATE duplication limitation (audit #5)

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -399,6 +399,13 @@ same way as a `CREATE INDEX` that is not concurrent. Turn projection scans off w
   commit. It then reads the committed mask again and merges its own bits. Thus
   both sets of delete marks survive. Writes to different row groups continue at
   the same time.
+- A concurrent `UPDATE` of the same row is a delete of the old version plus an
+  insert of the new one. The two writers do not serialize on the row itself.
+  Without a covering unique index, two sessions that update the same row can each
+  keep their own new version. The row is then duplicated and one update is lost.
+  A unique index on the updated key makes the writers go in sequence, and the
+  conflict is found. This is a known limitation. Add a unique index, or serialize
+  the updates in your application, where correctness needs it.
 - Concurrent inserts of the same unique key go in sequence. The server therefore
   always finds the conflict. Before a new row reaches the uniqueness check, the
   access method takes an advisory lock with the scope of the transaction. The key

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -404,8 +404,11 @@ same way as a `CREATE INDEX` that is not concurrent. Turn projection scans off w
   Without a covering unique index, two sessions that update the same row can each
   keep their own new version. The row is then duplicated and one update is lost.
   A unique index on the updated key makes the writers go in sequence, and the
-  conflict is found. This is a known limitation. Add a unique index, or serialize
-  the updates in your application, where correctness needs it.
+  conflict is found. The second writer then gets a unique-violation error, which
+  the application retries. This is not the transparent serialization a heap gives,
+  where both updates apply. This is a known limitation. Add a unique index and
+  retry on conflict, or serialize the updates in your application, where
+  correctness needs it.
 - Concurrent inserts of the same unique key go in sequence. The server therefore
   always finds the conflict. Before a new row reaches the uniqueness check, the
   access method takes an advisory lock with the scope of the transaction. The key


### PR DESCRIPTION
## Document the concurrent-UPDATE duplication limitation

Audit finding #5 (data-integrity). Two sessions that `UPDATE` the same row on a columnar table with **no covering unique index** each append their own new version, so the row is duplicated and one update is lost. Heap serializes on the tuple (tuple lock + EvalPlanQual) and yields one row with both updates.

### Reproduced (bench, PG 18.4)
Session A holds an open transaction with `UPDATE cu SET v=v+1 WHERE id=1`; session B runs the same update. After both commit:
- **Columnar:** `count(*) WHERE id=1` = **2**, values `[101,101]` (duplicated row, lost update).
- **Heap:** one row, `v=102`.

Root cause: `pgcolumnar_tuple_update` always returns `TM_Ok` and takes no tuple lock, so the executor never runs EvalPlanQual to re-read the concurrent winner. The existing Concurrency docs describe the delete-mark serialization ("both delete marks survive") but do not note that for UPDATE this duplicates the row.

### Why this is a doc, not a code fix (for now)
The proper fix is a deep MVCC change to the access method (detect the concurrently-modified old row and return `TM_Updated` so EvalPlanQual runs); the delete vector does not even track a deleting xid. That is a maintainer-level design decision with real correctness risk (a wrong fix can corrupt data or deadlock), so per the audit it is documented now and the reproduction handed off for a designed fix. The repro harness is available (`repro_concurrent_update.sh`).

This documents the current behavior and the workaround (a unique index, or application-level serialization) so it is an informed choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjdBLCRm7YmYai1FPgpsQn
