### PR TITLE
fix: estimate Iceberg FDW rows from manifests (not a constant 1000)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ which was true until that script existed.
 
 ## [Unreleased]
 
+### Fixed
+
+- The Iceberg foreign-data wrapper now estimates a scan's row count from the
+  manifests (the sum of the live data files' record counts) instead of a constant
+  1000. The constant mis-sized every scan and corrupted join planning above a
+  large Iceberg table. Regression test: iceberg_fdw_estimate.
+
 ### Security
 
 - Fixed an uninitialized-memory read in the native DICT decode path. A chunk

--- a/src/columnar_iceberg.c
+++ b/src/columnar_iceberg.c
@@ -927,6 +927,43 @@ pgcolumnar_iceberg_data_files(PG_FUNCTION_ARGS)
 	return (Datum) 0;
 }
 
+/* Sum the live data files' record counts for a row estimate. Delete files are
+ * ignored, so the count is a slight overestimate on a table with deletes, which
+ * is the safe direction for a planner cardinality. collect_deletes is true so a
+ * table that carries deletes is estimated rather than refused. */
+static void
+ice_estimate_cb(void *ctx, PgColumnarAvroManifestEntry *e,
+				const PgColumnarAvroManifestFile *mf,
+				const char *recorded_root, const char *actual_root,
+				const char *mdpath, int64 snapshot_id)
+{
+	(void) mf;
+	(void) recorded_root;
+	(void) actual_root;
+	(void) mdpath;
+	(void) snapshot_id;
+	if (e->content == 0)		/* a data file; deletes do not add rows */
+		*(int64 *) ctx += e->record_count;
+}
+
+/*
+ * A planner row estimate for the current snapshot: the sum of the live data
+ * files' record counts, read from the manifests. Zero for a table with no
+ * current snapshot. Used by the foreign-data wrapper's GetForeignRelSize in
+ * place of a constant guess.
+ */
+int64
+PgColumnarIcebergEstimateRows(const char *path)
+{
+	Jsonb	   *jb;
+	int64		total = 0;
+
+	jb = DatumGetJsonbP(DirectFunctionCall1(jsonb_in,
+											CStringGetDatum(ice_slurp_text(path, NULL))));
+	ice_walk_data_files(path, &jb->root, true, ice_estimate_cb, &total, NULL);
+	return total;
+}
+
 /*
  * Locate the "fields" array of the table's current schema in a parsed
  * metadata.json: the entry of "schemas" whose "schema-id" equals

--- a/src/columnar_iceberg.h
+++ b/src/columnar_iceberg.h
@@ -58,6 +58,7 @@ extern void PgColumnarIcebergScanInto(const char *path, TupleDesc tupdesc,
  * vehicle for the Iceberg FDW: it obtains the file list, prunes by the filter,
  * and reads the survivors (with their deletes applied) into the tuplestore.
  */
+extern int64 PgColumnarIcebergEstimateRows(const char *path);
 extern int64 PgColumnarIcebergScanCore(const char *path, TupleDesc tupdesc,
 									   const PgColumnarObjStoreConfig *cfg,
 									   Tuplestorestate *tupstore,

--- a/src/columnar_iceberg_fdw.c
+++ b/src/columnar_iceberg_fdw.c
@@ -283,7 +283,18 @@ static void
 icefdwGetForeignRelSize(PlannerInfo *root, RelOptInfo *baserel,
 						Oid foreigntableid)
 {
-	baserel->rows = 1000.0;		/* a planning ballpark; the scan reads real rows */
+	char	   *mdpath = ice_fdw_get_option(foreigntableid, "metadata_path");
+	int64		est = 0;
+
+	/*
+	 * Estimate from the manifests the scan reads anyway: the sum of the live
+	 * data files' record counts. A constant guess (the old 1000) mis-sizes a
+	 * large table and corrupts every join decision above the scan. The metadata
+	 * is small, and the scan opens it regardless, so reading it here is cheap.
+	 */
+	if (mdpath != NULL)
+		est = PgColumnarIcebergEstimateRows(mdpath);
+	baserel->rows = (est > 0) ? (double) est : 1.0;
 }
 
 static void

--- a/src/columnar_iceberg_fdw.c
+++ b/src/columnar_iceberg_fdw.c
@@ -38,6 +38,7 @@
 #include "foreign/foreign.h"
 #include "miscadmin.h"
 #include "nodes/makefuncs.h"
+#include "optimizer/cost.h"
 #include "optimizer/optimizer.h"
 #include "optimizer/pathnode.h"
 #include "optimizer/planmain.h"
@@ -291,10 +292,16 @@ icefdwGetForeignRelSize(PlannerInfo *root, RelOptInfo *baserel,
 	 * data files' record counts. A constant guess (the old 1000) mis-sizes a
 	 * large table and corrupts every join decision above the scan. The metadata
 	 * is small, and the scan opens it regardless, so reading it here is cheap.
+	 *
+	 * The sum is the base-table cardinality (baserel->tuples), not the output
+	 * row count. Set it and let set_baserel_size_estimates apply the scan's
+	 * restriction clauses (baserestrictinfo is populated by now), so a filtered
+	 * scan estimates its filtered rows rather than the whole table.
 	 */
 	if (mdpath != NULL)
 		est = PgColumnarIcebergEstimateRows(mdpath);
-	baserel->rows = (est > 0) ? (double) est : 1.0;
+	baserel->tuples = (est > 0) ? (double) est : 1.0;
+	set_baserel_size_estimates(root, baserel);
 }
 
 static void

--- a/test/iceberg_fdw_estimate.sh
+++ b/test/iceberg_fdw_estimate.sh
@@ -27,5 +27,14 @@ echo "-- planner estimate=$est  actual=$actual"
 check "the FDW estimates a positive row count from the manifests" \
 	"$([ -n "$est" ] && [ "$est" -gt 0 ] && echo yes)" "yes"
 check "the estimate is the real record count, not the old constant 1000" "$est" "$actual"
+
+# The sum is the base cardinality, so selectivity still applies: a filtered scan
+# must estimate fewer rows than the whole table (the old code set rows directly
+# and ignored the WHERE, estimating the full count under a filter too).
+filt="$(q "EXPLAIN (FORMAT text) SELECT * FROM ev WHERE region = 'eu'" | grep -oiE 'rows=[0-9]+' | head -1 | cut -d= -f2)"
+echo "-- filtered (region='eu') estimate=$filt of $actual"
+check "a filtered scan estimates fewer rows than the whole table (selectivity applied)" \
+	"$([ -n "$filt" ] && [ "$filt" -lt "$actual" ] && echo yes)" "yes"
+
 check "backend alive" "$(q 'SELECT 1')" "1"
 pgc_summary

--- a/test/iceberg_fdw_estimate.sh
+++ b/test/iceberg_fdw_estimate.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Regression: the Iceberg FDW must estimate baserel->rows from the manifests, not
+# hand the planner a constant. The old code set rows = 1000 for every table, which
+# mis-sizes a scan and corrupts join planning above it. Post-fix the estimate
+# equals the live record count summed from the manifests.
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+python3 -c 'import json' 2>/dev/null || pgc_skip python "python3 is needed"
+FX="$(dirname "${BASH_SOURCE[0]}")/fixtures/iceberg"
+WH="$FX/warehouse"
+[ -f "$(ls "$WH"/db/events/data/*/*.parquet 2>/dev/null | head -1)" ] \
+	|| pgc_skip fixture "iceberg warehouse data files are missing"
+
+DEST="$PGC_WORKDIR/wh"; rm -rf "$DEST"; mkdir -p "$DEST"
+cp -r "$WH/db" "$DEST/db"; chmod -R u+rwX "$DEST"
+MD="$(ls "$DEST"/db/events/metadata/*.metadata.json | sort | tail -1)"
+
+q "CREATE SERVER ice FOREIGN DATA WRAPPER pgcolumnar_iceberg" >/dev/null
+q "CREATE FOREIGN TABLE ev (id bigint, region text, amount int)
+   SERVER ice OPTIONS (metadata_path '$MD')" >/dev/null
+
+actual="$(q "SELECT count(*) FROM ev")"
+est="$(q "EXPLAIN (FORMAT text) SELECT * FROM ev" | grep -oiE 'rows=[0-9]+' | head -1 | cut -d= -f2)"
+echo "-- planner estimate=$est  actual=$actual"
+check "the FDW estimates a positive row count from the manifests" \
+	"$([ -n "$est" ] && [ "$est" -gt 0 ] && echo yes)" "yes"
+check "the estimate is the real record count, not the old constant 1000" "$est" "$actual"
+check "backend alive" "$(q 'SELECT 1')" "1"
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -88,6 +88,7 @@ SUITES=(
 	iceberg_deletes
 	iceberg_dv
 	iceberg_fdw
+	iceberg_fdw_estimate
 	iceberg_malformed
 	iceberg_name_mapping
 	iceberg_objstore


### PR DESCRIPTION
## Estimate the Iceberg FDW's row count from the manifests

Audit finding #8 (optimization, HIGH).

`icefdwGetForeignRelSize` set `baserel->rows = 1000.0` for **every** Iceberg foreign table, ignoring the `record_count` the manifests carry. A large table is then planned as 1000 rows, which corrupts every join decision above the scan (the huge table lands on a nested-loop inner side; an unbounded tuplestore holds the whole thing).

### Fix
`PgColumnarIcebergEstimateRows(metadata_path)` walks the manifests (the scan reads them anyway) and sums the live data files' `record_count`. `collect_deletes = true` so a table that carries deletes is estimated rather than refused; delete files are not subtracted, so the estimate is a slight overestimate, which is the safe direction for a planner cardinality. The wrapper uses it in place of the constant.

### Proof (bench, PG 18.4)
`test/iceberg_fdw_estimate.sh` on the committed `events` warehouse (5 rows):
- **Before:** `EXPLAIN` reports `rows=1000`.
- **After:** `rows=5`, equal to the real `count(*)`.

Existing `iceberg_fdw`, `iceberg_scan`, and `iceberg_deletes` still pass. Registered in `run_all_versions.sh`.

First of the optimization/modularity audit findings. More to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjdBLCRm7YmYai1FPgpsQn
