### PR TITLE
fix: index-fetch cost ignores per-table stripe_row_limit (#7/#11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ which was true until that script existed.
 
 ## [Unreleased]
 
+### Fixed
+
+- The index-fetch cost penalty now sizes row groups by a relation's effective
+  `stripe_row_limit` (the per-table option when set, else the GUC), matching the
+  writer and the zone-map survival estimate. It read only the GUC, so it
+  mis-priced the row-group decode for a table that set the option, and could steer
+  the planner toward or away from an index scan on that table. The effective-limit
+  lookup is now one shared helper. Regression test: native_index_fetch_stripe_cost.
+
 ### Security
 
 - Fixed an uninitialized-memory read in the native DICT decode path. A chunk

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -458,6 +458,7 @@ extern void PgColumnarDeleteMetadata(uint64 storageId);
 
 /* per-table options catalog (spec 7.4) */
 extern bool PgColumnarReadOptions(Oid relid, PgColumnarOptions *opts);
+extern int pgcolumnar_effective_stripe_row_limit(Oid relid);
 
 /* declared physical sort key (#288); List of pstrdup'd column names, NIL if
  * none is declared. Names (not attnums) so the value survives dump/restore. */

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -833,10 +833,10 @@ pgcolumnar_scan_decode_shape(RelOptInfo *rel, Index rti, Oid relid,
  * decode of R rows across the columns the scan needs.
  */
 static Cost
-pgcolumnar_index_fetch_penalty(RelOptInfo *rel, double rows, double rho,
+pgcolumnar_index_fetch_penalty(RelOptInfo *rel, Oid relid, double rows, double rho,
 							 int nproj, double decodedWidth, bool tid_ordered)
 {
-	double		R = (double) pgcolumnar_stripe_row_limit;
+	double		R = (double) pgcolumnar_effective_stripe_row_limit(relid);
 	double		N = (rel->tuples > 0) ? rel->tuples : rows;
 	double		n_groups,
 				pages_per_stripe,
@@ -1111,12 +1111,8 @@ pgcolumnar_zonemap_survival(RelOptInfo *rel, Oid heapRelid)
 	 * cost model that is otherwise wrong by an order of magnitude.
 	 */
 	{
-		PgColumnarOptions opts;
-		int			limit = pgcolumnar_stripe_row_limit;
+		int			limit = pgcolumnar_effective_stripe_row_limit(heapRelid);
 
-		if (PgColumnarReadOptions(heapRelid, &opts) &&
-			opts.stripeRowLimitSet && opts.stripeRowLimit > 0)
-			limit = opts.stripeRowLimit;
 		if (limit <= 0)
 			return 1.0;
 		groups = ceil(rel->tuples / (double) limit);
@@ -1296,13 +1292,13 @@ pgcolumnar_penalize_index_fetches(RelOptInfo *rel, Index rti, Oid relid,
 			IndexPath  *ip = castNode(IndexPath, p);
 			double		rho = pgcolumnar_index_correlation(ip->indexinfo, relid);
 
-			add = pgcolumnar_index_fetch_penalty(rel, p->rows, rho, nproj,
+			add = pgcolumnar_index_fetch_penalty(rel, relid, p->rows, rho, nproj,
 											   decodedWidth, false);
 		}
 		else if (p->pathtype == T_BitmapHeapScan)
 		{
 			/* a bitmap heap scan fetches in TID (row-number) order */
-			add = pgcolumnar_index_fetch_penalty(rel, p->rows, 1.0, nproj,
+			add = pgcolumnar_index_fetch_penalty(rel, relid, p->rows, 1.0, nproj,
 											   decodedWidth, true);
 		}
 		/* T_IndexOnlyScan and the custom scans do no heap fetch */

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -2676,6 +2676,25 @@ PgColumnarReadOptions(Oid relid, PgColumnarOptions *opts)
 	return found;
 }
 
+/*
+ * The stripe (row group) row limit in force for a relation: the per-table
+ * `stripe_row_limit` option when set, else the GUC default. The writer honors
+ * the per-table override, so every consumer that reasons about how many row
+ * groups a table has (the writer, the zone-map survival estimate, the index-
+ * fetch cost penalty) must read the same effective value. Reading only the GUC
+ * mis-sizes the group count for a table that set the option (#7 / #11).
+ */
+int
+pgcolumnar_effective_stripe_row_limit(Oid relid)
+{
+	PgColumnarOptions opts;
+
+	if (PgColumnarReadOptions(relid, &opts) &&
+		opts.stripeRowLimitSet && opts.stripeRowLimit > 0)
+		return opts.stripeRowLimit;
+	return pgcolumnar_stripe_row_limit;
+}
+
 
 /*
  * PgColumnarReadSortBy

--- a/src/columnar_write_state.c
+++ b/src/columnar_write_state.c
@@ -662,11 +662,7 @@ void
 PgColumnarEnsureStorageRow(Relation rel)
 {
 	NativeStorageMetadata s;
-	PgColumnarOptions opts;
-	int			stripeRowLimit = pgcolumnar_stripe_row_limit;
-
-	if (PgColumnarReadOptions(RelationGetRelid(rel), &opts) && opts.stripeRowLimitSet)
-		stripeRowLimit = opts.stripeRowLimit;
+	int			stripeRowLimit = pgcolumnar_effective_stripe_row_limit(RelationGetRelid(rel));
 
 	s.storageId = PgColumnarStorageId(rel);
 	s.relationOid = RelationGetRelid(rel);

--- a/test/native_index_fetch_stripe_cost.sh
+++ b/test/native_index_fetch_stripe_cost.sh
@@ -28,7 +28,7 @@ c2="$(topcost)"
 echo "-- index-scan total cost: stripe_row_limit=2000 -> $c1 ; =150000 -> $c2"
 
 check "the index-fetch cost responds to the per-table stripe_row_limit (c1 is a number)" \
-	"$(echo "$c1" | grep -qE '^[0-9.]+$' && echo num)" "num"
+	"$(case "$c1" in ''|*[!0-9.]*) ;; *) echo num ;; esac)" "num"
 check "changing the per-table stripe_row_limit changes the estimated cost" \
 	"$([ -n "$c1" ] && [ -n "$c2" ] && [ "$c1" != "$c2" ] && echo differ)" "differ"
 check "backend alive" "$(q 'SELECT 1')" "1"

--- a/test/native_index_fetch_stripe_cost.sh
+++ b/test/native_index_fetch_stripe_cost.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Regression: the index-fetch cost penalty must size row groups by the table's
+# effective stripe_row_limit (the per-table option when set), not the GUC. The
+# penalty exists to price the row-group decode a columnar index fetch forces, and
+# that decode's size is the effective limit. Reading only the GUC mis-prices a
+# table that set the option. Here, changing the per-table option must change the
+# estimated index-scan cost; on the unfixed build it did not.
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+q "CREATE TABLE ct (id int, v int) USING pgcolumnar" >/dev/null
+q "INSERT INTO ct SELECT g, g FROM generate_series(1, 200000) g" >/dev/null
+q "CREATE INDEX ct_id ON ct (id)" >/dev/null
+q "ANALYZE ct" >/dev/null
+
+topcost() {  # total cost of the top plan node for an index-forced range scan
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" -qtA \
+		-c "SET enable_seqscan=off" \
+		-c "EXPLAIN (COSTS on, FORMAT text) SELECT * FROM ct WHERE id BETWEEN 1 AND 100000" 2>/dev/null \
+		| grep -oiE 'cost=[0-9.]+\.\.[0-9.]+' | head -1 | sed 's/.*\.\.//'
+}
+
+q "SELECT pgcolumnar.set_options('ct', stripe_row_limit => 2000)" >/dev/null
+c1="$(topcost)"
+q "SELECT pgcolumnar.set_options('ct', stripe_row_limit => 150000)" >/dev/null
+c2="$(topcost)"
+echo "-- index-scan total cost: stripe_row_limit=2000 -> $c1 ; =150000 -> $c2"
+
+check "the index-fetch cost responds to the per-table stripe_row_limit (c1 is a number)" \
+	"$(echo "$c1" | grep -qE '^[0-9.]+$' && echo num)" "num"
+check "changing the per-table stripe_row_limit changes the estimated cost" \
+	"$([ -n "$c1" ] && [ -n "$c2" ] && [ "$c1" != "$c2" ] && echo differ)" "differ"
+check "backend alive" "$(q 'SELECT 1')" "1"
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -130,6 +130,7 @@ SUITES=(
 	native_gap
 	native_groupagg
 	native_index
+	native_index_fetch_stripe_cost
 	native_index_projection
 	native_ios
 	native_late_materialization


### PR DESCRIPTION
## Size the index-fetch cost penalty by the effective stripe_row_limit

Audit findings #7 (optimization, HIGH) and #11 (modularity, HIGH) — one root cause.

`pgcolumnar_index_fetch_penalty` sized row groups from the GUC:

```c
double R = (double) pgcolumnar_stripe_row_limit;   /* ignores the per-table option */
```

But a table's group count follows its **effective** `stripe_row_limit` — the per-table option when set, else the GUC — which is what the writer actually honors and what `pgcolumnar_zonemap_survival` already reads. So on a table created `WITH (stripe_row_limit = ...)`, the penalty computed the wrong number of groups and mis-priced the decode a columnar index fetch forces, steering the planner toward or away from an index scan.

The effective-limit lookup was duplicated across four sites; the index-fetch penalty was the one copy that got it wrong (#11).

### Fix
`pgcolumnar_effective_stripe_row_limit(relid)` is the single resolver. The three single-field consumers use it: `index_fetch_penalty` (with `relid` threaded in from `penalize_index_fetches`), `zonemap_survival`, and the flush writer. The two multi-field readers keep their one read-all-options call.

### Proof (bench, PG 18.4)
`test/native_index_fetch_stripe_cost.sh`: on one table, change `stripe_row_limit` via `set_options` and read the index-scan cost.
- **Unfixed:** cost is `3880.70` for both `stripe_row_limit = 2000` and `150000` — invariant, because it read the GUC.
- **Fixed:** `2000 -> 3640.34`, `150000 -> 3845.34` — the cost now responds to the per-table limit.

`scan_decode_cost`, `native_index_projection`, `native_skip`, `native_recluster` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjdBLCRm7YmYai1FPgpsQn
