### PR TITLE
perf: batch fold iterates needed columns, not all natts (#10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ which was true until that script existed.
 
 ### Fixed
 
+- The ungrouped batch fold's per-row gather now steps over the columns a query
+  references rather than all of a table's columns. On a wide table a scan that
+  reads a few columns walked every column per row (twice on a deferred group),
+  which is loop overhead proportional to the table width. It now iterates compact
+  key/payload lists; a 46-column single-aggregate fold measured about 23% faster
+  with no change in results. Regression test: native_batch_fold_projection.
 - The Iceberg foreign-data wrapper now pushes projection down: it decodes only
   the columns a query references (from the output list and the recheck quals),
   not every column of every surviving file. A narrow projection over a wide table

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -3139,6 +3139,21 @@ pgcolumnar_native_batch_fold(PgColumnarAggScanState *state, Relation rel,
 	bool	   *ciskey = (bool *) palloc0(sizeof(bool) * natts);
 	Datum	   *cval = (Datum *) palloc0(sizeof(Datum) * natts);
 	bool	   *cisnull = (bool *) palloc0(sizeof(bool) * natts);
+	/*
+	 * Compact needed-column lists, so the per-row loops step over the columns a
+	 * query actually reads rather than all natts (a count(x) on a 100-column
+	 * table needs one). keyCols and payloadCols split the needed set the way
+	 * ciskey does; phase1Cols is what phase 1 gathers (keys always, payload too
+	 * unless the group defers). Order is column order, and each column's state is
+	 * independent, so iterating the list is equivalent to the masked full range.
+	 */
+	int		   *keyCols = (int *) palloc(sizeof(int) * Max(natts, 1));
+	int		   *payloadCols = (int *) palloc(sizeof(int) * Max(natts, 1));
+	int		   *phase1Cols = (int *) palloc(sizeof(int) * Max(natts, 1));
+	int			nKeyCols = 0;
+	int			nPayCols = 0;
+	int			nPhase1 = 0;
+	int			ci;
 	int			npayload = 0;
 	int64		candRows = 0;	/* rows that reached the key check */
 	int64		survRows = 0;	/* rows that passed it */
@@ -3169,8 +3184,14 @@ pgcolumnar_native_batch_fold(PgColumnarAggScanState *state, Relation rel,
 				ciskey[ka] = true;
 		}
 		for (col = 0; col < natts; col++)
-			if (cneeded[col] && !ciskey[col])
-				npayload++;
+			if (cneeded[col])
+			{
+				if (ciskey[col])
+					keyCols[nKeyCols++] = col;
+				else
+					payloadCols[nPayCols++] = col;
+			}
+		npayload = nPayCols;
 	}
 
 	/*
@@ -3233,6 +3254,17 @@ pgcolumnar_native_batch_fold(PgColumnarAggScanState *state, Relation rel,
 		state->foldGroupsTotal++;
 		if (deferOn)
 			state->foldGroupsDeferred++;
+
+		/*
+		 * Phase 1 gathers the key columns always, and the payload too unless this
+		 * group defers it. deferOn is per group, so this list is rebuilt here.
+		 */
+		nPhase1 = 0;
+		for (ci = 0; ci < nKeyCols; ci++)
+			phase1Cols[nPhase1++] = keyCols[ci];
+		if (!deferOn)
+			for (ci = 0; ci < nPayCols; ci++)
+				phase1Cols[nPhase1++] = payloadCols[ci];
 
 		/*
 		 * This loop now honours skipVec, and it has to (#512, #452 phase 1b-i).
@@ -3330,10 +3362,9 @@ pgcolumnar_native_batch_fold(PgColumnarAggScanState *state, Relation rel,
 			 * here at all -- not even their cursors -- so the failing-row
 			 * path below can consume their slots without a fetch (#405).
 			 */
-			for (col = 0; col < natts; col++)
+			for (ci = 0; ci < nPhase1; ci++)
 			{
-				if (!cneeded[col] || (deferOn && !ciskey[col]))
-					continue;
+				col = phase1Cols[ci];
 				if ((cvalidity[col][r >> 3] >> (r & 7)) & 1)
 				{
 					/*
@@ -3358,10 +3389,12 @@ pgcolumnar_native_batch_fold(PgColumnarAggScanState *state, Relation rel,
 			{
 				/* consume deferred payload slots; never read them (#405) */
 				if (deferOn)
-					for (col = 0; col < natts; col++)
-						if (cneeded[col] && !ciskey[col] &&
-							((cvalidity[col][r >> 3] >> (r & 7)) & 1))
+					for (ci = 0; ci < nPayCols; ci++)
+					{
+						col = payloadCols[ci];
+						if ((cvalidity[col][r >> 3] >> (r & 7)) & 1)
 							cpresent[col]++;
+					}
 				continue;
 			}
 
@@ -3370,10 +3403,12 @@ pgcolumnar_native_batch_fold(PgColumnarAggScanState *state, Relation rel,
 			if (del)
 			{
 				if (deferOn)
-					for (col = 0; col < natts; col++)
-						if (cneeded[col] && !ciskey[col] &&
-							((cvalidity[col][r >> 3] >> (r & 7)) & 1))
+					for (ci = 0; ci < nPayCols; ci++)
+					{
+						col = payloadCols[ci];
+						if ((cvalidity[col][r >> 3] >> (r & 7)) & 1)
 							cpresent[col]++;
+					}
 				continue;
 			}
 			candRows++;
@@ -3395,10 +3430,12 @@ pgcolumnar_native_batch_fold(PgColumnarAggScanState *state, Relation rel,
 			if (!pass)
 			{
 				if (deferOn)
-					for (col = 0; col < natts; col++)
-						if (cneeded[col] && !ciskey[col] &&
-							((cvalidity[col][r >> 3] >> (r & 7)) & 1))
+					for (ci = 0; ci < nPayCols; ci++)
+					{
+						col = payloadCols[ci];
+						if ((cvalidity[col][r >> 3] >> (r & 7)) & 1)
 							cpresent[col]++;
+					}
 				continue;
 			}
 			survRows++;
@@ -3410,10 +3447,9 @@ pgcolumnar_native_batch_fold(PgColumnarAggScanState *state, Relation rel,
 			 * rows times fetched payload values, never candidates.
 			 */
 			if (deferOn)
-				for (col = 0; col < natts; col++)
+				for (ci = 0; ci < nPayCols; ci++)
 				{
-					if (!cneeded[col] || ciskey[col])
-						continue;
+					col = payloadCols[ci];
 					if ((cvalidity[col][r >> 3] >> (r & 7)) & 1)
 					{
 						cval[col] = fetch_att(cpacked[col] + cpresent[col] * cattlen[col],

--- a/test/native_batch_fold_projection.sh
+++ b/test/native_batch_fold_projection.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Regression for #10: the ungrouped batch fold's per-row loops now step over
+# compact needed-column lists (keyCols/payloadCols) instead of masking 0..natts.
+# A bug there would silently return a wrong aggregate, so this proves the loops
+# still gather exactly the right columns on a WIDE table (many columns, few
+# referenced). Built on parallel_vector_agg.sh's recipe (which fires the fold),
+# widened with filler columns and summing a high-index one, with a selective key
+# so the deferred-payload path (phase 2) runs.
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+# wide table: 44 filler bigints, then the aggregated column v LAST, so the fold's
+# one payload column sits at a high index -- an under-built payload list would
+# drop it and change sum(v). (Summing a second column flips the plan off the fold
+# on a wide table, so the fold fires with a single aggregated column.)
+FILL=""; for i in $(seq 0 43); do FILL="$FILL, f$i bigint"; done
+q "CREATE TABLE t (id int, k int$FILL, v float8) USING pgcolumnar" >/dev/null
+q "SELECT pgcolumnar.set_options('t'::regclass, stripe_row_limit => 40000)" >/dev/null
+FVALS=""; for i in $(seq 0 43); do FVALS="$FVALS, g*$((i + 2))"; done
+q "INSERT INTO t SELECT g, g % 1000 $FVALS,
+       CASE WHEN g % 50 = 0 THEN NULL ELSE ((g % 13) - 6)::float8 END
+   FROM generate_series(1, 400000) g" >/dev/null
+q "ANALYZE t" >/dev/null
+
+# k < 400 is a pushable, selective key so the fold defers the (high-index) payload.
+INNER="SELECT count(*) n, sum(v) sv FROM t WHERE k < 400"
+
+PAR="SET max_parallel_workers_per_gather=4; SET parallel_setup_cost=0; SET parallel_tuple_cost=0; SET min_parallel_table_scan_size=0; SET min_parallel_index_scan_size=0;"
+FOLDOFF="$PAR SET pgcolumnar.enable_ungrouped_vector_agg=off; SET pgcolumnar.enable_group_vectorization=off;"
+FOLDON="$PAR SET pgcolumnar.enable_ungrouped_vector_agg=on; SET pgcolumnar.enable_parallel_vector_agg=on;"
+
+ref="$(q "$FOLDOFF $INNER" | tail -1)"
+got="$(q "$FOLDON $INNER" | tail -1)"
+echo "-- ref=[$ref]"
+echo "-- got=[$got]"
+
+plan="$(env PATH="$PGC_BINDIR:$PATH" psql -h "127.0.0.1" -p "$PGC_PORT" -U postgres -d "$PGC_DB" -qtA \
+	-c "$FOLDON" -c "EXPLAIN (COSTS OFF, VERBOSE) $INNER" 2>/dev/null)"
+foldcnt="$(printf '%s' "$plan" | grep -ciE 'Batch Fold: yes')"
+
+check "the ungrouped batch fold actually ran (Batch Fold: yes)" \
+	"$([ "$foldcnt" -gt 0 ] && echo yes)" "yes"
+check "ref is a non-empty result (not a vacuous empty compare)" \
+	"$(case "$ref" in ''|'<none>') echo no ;; *) echo yes ;; esac)" "yes"
+check "the folded aggregate equals the non-fold aggregate (payload columns correct)" "$got" "$ref"
+check "backend alive" "$(q 'SELECT 1')" "1"
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -108,6 +108,7 @@ SUITES=(
 	native_agg
 	native_agg_addcolumn
 	native_agg_deletes
+	native_batch_fold_projection
 	native_backend_crash
 	native_bloom
 	native_cancel


### PR DESCRIPTION
## Iterate the needed columns in the batch fold, not all of them

Audit finding #10 (optimization).

`pgcolumnar_native_batch_fold`'s per-row loops walked `0..natts` and tested a per-column `cneeded` mask: the phase-1 gather, the three deferred-payload consume paths, and the phase-2 payload materialize. On a wide table a fold that reads a few columns paid loop-and-branch cost proportional to the whole table width, per row, and twice on a deferred group.

### Fix
Build compact `keyCols` / `payloadCols` lists once (and `phase1Cols` per group, since `deferOn` is per group) and iterate those. Each column's fold state is independent, so column order is unchanged and the transformation is behavior-identical.

### Correctness (bench, PG 18.4)
`test/native_batch_fold_projection.sh` forces the fold on a wide table and asserts its result equals a plain aggregate. It is **load-bearing**: I verified that dropping one column from the payload list makes `sum(v)` return `0` instead of `-32`, and the test catches it (RED). The existing fold suites all still pass: `parallel_vector_agg` (fires `Batch Fold: yes`), `native_agg`, `native_groupagg`, `native_agg_deletes`, `native_agg_addcolumn`, `native_vecdecode`, `rewrite_group_scan`.

### Performance (A/B, same query, fixed vs unfixed, interleaved)
A 46-column, 400k-row table, `SELECT count(*), sum(v) WHERE k < 400` (one column referenced): **~17ms unfixed -> ~13ms fixed, about 23% faster**, results identical. The win scales with the table's column count.

This is the last of the six optimization/modularity audit findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjdBLCRm7YmYai1FPgpsQn
