### PR TITLE
Serialize concurrent same-row UPDATE/DELETE (issue #5, UPDATE facet)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ which was true until that script existed.
 
 ### Fixed
 
+- Concurrent `UPDATE` or `DELETE` of the same columnar row now serializes on the
+  row identity, so the losing writer gets a retryable `serialization_failure`
+  instead of duplicating the row and losing an update (issue #5, the UPDATE facet).
+  Two sessions updating one row without a covering unique index each kept their own
+  new version. The fix takes a transaction-scoped advisory lock on the row, then
+  re-reads the committed delete vector under a fresh snapshot before writing. New
+  GUCs `pgcolumnar.enable_row_update_lock` (default on) and
+  `pgcolumnar.row_lock_buckets` (default 1024). Regression test: update_conc.
 - The ungrouped batch fold's per-row gather now steps over the columns a query
   references rather than all of a table's columns. On a wide table a scan that
   reads a few columns walked every column per row (twice on a deferred group),

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ OBJS = \
 	src/columnar_vector.o \
 	src/columnar_vacuum.o \
 	src/columnar_unique.o \
+	src/columnar_row_lock.o \
 	src/columnar_arrow.o \
 	src/columnar_flatbuffers.o \
 	src/columnar_thrift.o \

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -409,7 +409,10 @@ same way as a `CREATE INDEX` that is not concurrent. Turn projection scans off w
   `pgcolumnar.enable_row_update_lock` (default on) controls this serialization.
   The GUC `pgcolumnar.row_lock_buckets` (default 1024) bounds the held locks per
   storage, so a bulk update cannot exhaust the lock table. Unrelated rows may
-  share a bucket, which only makes them wait when they need not.
+  share a bucket, which only makes them wait when they need not. For the same
+  reason, two multi-statement transactions can rarely deadlock, even on disjoint
+  rows. This happens when their bucketed locks collide in opposite statement order.
+  Retry resolves it, as with any serialization failure.
 - Concurrent inserts of the same unique key go in sequence. The server therefore
   always finds the conflict. Before a new row reaches the uniqueness check, the
   access method takes an advisory lock with the scope of the transaction. The key

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -399,16 +399,17 @@ same way as a `CREATE INDEX` that is not concurrent. Turn projection scans off w
   commit. It then reads the committed mask again and merges its own bits. Thus
   both sets of delete marks survive. Writes to different row groups continue at
   the same time.
-- A concurrent `UPDATE` of the same row is a delete of the old version plus an
-  insert of the new one. The two writers do not serialize on the row itself.
-  Without a covering unique index, two sessions that update the same row can each
-  keep their own new version. The row is then duplicated and one update is lost.
-  A unique index on the updated key makes the writers go in sequence, and the
-  conflict is found. The second writer then gets a unique-violation error, which
-  the application retries. This is not the transparent serialization a heap gives,
-  where both updates apply. This is a known limitation. Add a unique index and
-  retry on conflict, or serialize the updates in your application, where
-  correctness needs it.
+- A concurrent `UPDATE` or `DELETE` of the same row serializes on the row
+  identity. The second writer waits for the first to commit. It then gets a
+  retryable `serialization_failure`, so the row is never duplicated and no update
+  is lost. This holds at every isolation level and needs no unique index. Retry
+  the transaction on this error, as you retry one at `REPEATABLE READ`. The
+  behavior is stricter than a heap at `READ COMMITTED`. A heap re-applies both
+  updates transparently there; pgColumnar makes the loser retry. The GUC
+  `pgcolumnar.enable_row_update_lock` (default on) controls this serialization.
+  The GUC `pgcolumnar.row_lock_buckets` (default 1024) bounds the held locks per
+  storage, so a bulk update cannot exhaust the lock table. Unrelated rows may
+  share a bucket, which only makes them wait when they need not.
 - Concurrent inserts of the same unique key go in sequence. The server therefore
   always finds the conflict. Before a new row reaches the uniqueness check, the
   access method takes an advisory lock with the scope of the transaction. The key

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -790,6 +790,7 @@ extern char *PgColumnarDecompressValueStream(const char *comp, uint32 compLen,
 #define PGCOLUMNAR_LOCKCLASS_DELETE_VECTOR	101
 #define PGCOLUMNAR_LOCKCLASS_STORAGE_ROW	102
 #define PGCOLUMNAR_LOCKCLASS_UNIQUE_KEY		103
+#define PGCOLUMNAR_LOCKCLASS_ROW_IDENTITY	104
 
 /* -------------------------------------------------------------------------
  * concurrent unique-key insert serialization (pgcolumnar_unique.c, issue #5)
@@ -803,6 +804,20 @@ extern char *PgColumnarDecompressValueStream(const char *comp, uint32 compLen,
  * ------------------------------------------------------------------------- */
 extern void PgColumnarLockUniqueKeys(Relation rel, TupleTableSlot *slot);
 extern void PgColumnarUniqueInit(void);
+
+/* -------------------------------------------------------------------------
+ * concurrent same-row UPDATE/DELETE serialization (pgcolumnar_row_lock.c,
+ * issue #5, the UPDATE facet). The write paths call PgColumnarRowWriteConflict
+ * before marking the old row deleted, to serialize on the row identity and turn
+ * a lost update into a retryable serialization_failure. See columnar_row_lock.c.
+ * ------------------------------------------------------------------------- */
+extern bool pgcolumnar_enable_row_update_lock;
+extern int	pgcolumnar_row_lock_buckets;
+extern bool PgColumnarLockRowIdentity(Relation rel, uint64 rowNumber, bool wait);
+extern bool PgColumnarRowCommittedDeleted(Relation rel, uint64 rowNumber);
+extern bool PgColumnarRowWriteConflict(Relation rel, ItemPointer otid,
+									   CommandId cid, bool wait,
+									   TM_FailureData *tmfd, TM_Result *result);
 
 /* -------------------------------------------------------------------------
  * planner integration (pgcolumnar_customscan.c, spec 8.3, 9)

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -813,11 +813,11 @@ extern void PgColumnarUniqueInit(void);
  * ------------------------------------------------------------------------- */
 extern bool pgcolumnar_enable_row_update_lock;
 extern int	pgcolumnar_row_lock_buckets;
-extern bool PgColumnarLockRowIdentity(Relation rel, uint64 rowNumber, bool wait);
-extern bool PgColumnarRowCommittedDeleted(Relation rel, uint64 rowNumber);
 extern bool PgColumnarRowWriteConflict(Relation rel, ItemPointer otid,
 									   CommandId cid, bool wait,
 									   TM_FailureData *tmfd, TM_Result *result);
+extern void PgColumnarSerializeFlushRows(uint64 storageId, const uint64 *rows,
+										 int nrows);
 
 /* -------------------------------------------------------------------------
  * planner integration (pgcolumnar_customscan.c, spec 8.3, 9)

--- a/src/columnar_delete_vector.c
+++ b/src/columnar_delete_vector.c
@@ -333,6 +333,50 @@ delete_vector_flush_buffer(DeleteVectorBuffer *buf)
 		pushedSnapshot = true;
 	}
 
+	/*
+	 * issue #5: before writing the delete marks, serialize the rows being flushed
+	 * as deleted against concurrent writers of the same rows, taking their
+	 * row-identity locks in one sorted batch (deadlock-free) and raising a
+	 * serialization_failure on a committed conflict. Collect the row numbers from
+	 * the sorted chunks first, so the batch is ordered the same way for every
+	 * transaction, exactly like the chunk-group locks below.
+	 */
+	{
+		uint64		nrows = 0;
+		uint64	   *rows;
+		uint64		ri = 0;
+		ListCell   *cc;
+
+		foreach(cc, buf->chunks)
+		{
+			DeleteVectorChunkBuffer *chunk = (DeleteVectorChunkBuffer *) lfirst(cc);
+			uint32		i;
+			int			bit;
+
+			for (i = 0; i < chunk->maskLen; i++)
+				for (bit = 0; bit < 8; bit++)
+					if (chunk->mask[i] & (1 << bit))
+						nrows++;
+		}
+		if (nrows > 0)
+		{
+			rows = (uint64 *) palloc(sizeof(uint64) * nrows);
+			foreach(cc, buf->chunks)
+			{
+				DeleteVectorChunkBuffer *chunk = (DeleteVectorChunkBuffer *) lfirst(cc);
+				uint32		i;
+				int			bit;
+
+				for (i = 0; i < chunk->maskLen; i++)
+					for (bit = 0; bit < 8; bit++)
+						if (chunk->mask[i] & (1 << bit))
+							rows[ri++] = chunk->startRowNumber + (uint64) (i * 8 + bit);
+			}
+			PgColumnarSerializeFlushRows(buf->storageId, rows, (int) nrows);
+			pfree(rows);
+		}
+	}
+
 	foreach(lc, buf->chunks)
 	{
 		DeleteVectorChunkBuffer *chunk = (DeleteVectorChunkBuffer *) lfirst(lc);

--- a/src/columnar_row_lock.c
+++ b/src/columnar_row_lock.c
@@ -1,0 +1,213 @@
+/*-------------------------------------------------------------------------
+ *
+ * columnar_row_lock.c
+ *		Serialize concurrent writers of the SAME columnar row (issue #5, the
+ *		UPDATE facet).
+ *
+ * A columnar UPDATE is delete-old plus insert-new, and a DELETE marks a bit in
+ * the delete vector. Neither takes a lock on the row identity, and
+ * pgcolumnar_tuple_lock does not implement row locking, so core never runs
+ * EvalPlanQual. Two transactions updating the same row therefore each keep their
+ * own new version: the old row is deleted once and both new rows survive, so the
+ * row is duplicated and one update is lost. A heap serializes this transparently.
+ *
+ * This module gives the write paths a row-identity guard, modeled on the
+ * concurrent unique-key insert serialization in columnar_unique.c and the
+ * chunk-group advisory lock in columnar_metadata.c (issue #4). Before a write
+ * marks the old row deleted it:
+ *
+ *   1. If the row is already marked deleted in THIS command's own buffer, the
+ *      same command is modifying it twice (a self-join UPDATE ... FROM). Return
+ *      TM_SelfModified so core resolves it exactly as it does for a heap.
+ *   2. Take a transaction-scoped advisory lock on the row identity
+ *      (storage id, row number). A concurrent writer of the same row waits here
+ *      until this transaction commits. A no-wait caller that would block gets
+ *      TM_BeingModified.
+ *   3. Re-read the row's liveness in the LATEST committed state (not the caller
+ *      snapshot, which PgColumnarCatalogSnapshot only copies). If a concurrent
+ *      transaction has committed a delete of this row, raise a retryable
+ *      serialization_failure. The lock is the authority for waiting out the
+ *      competitor; this fresh-snapshot re-read is the authority for whether a
+ *      conflict actually happened, so a hash-bucket collision can only add
+ *      waiting, never a false failure.
+ *
+ * The net contract at every isolation level is one retryable serialization
+ * failure for the losing writer of a same-row race, matching what a heap gives
+ * at REPEATABLE READ and what columnar already gives at SERIALIZABLE. READ
+ * COMMITTED becomes stricter than a heap (the loser retries rather than
+ * re-applying transparently via EvalPlanQual); see docs/limitations.md.
+ *
+ * Written fresh for pgColumnar. It reuses no upstream source; it derives from the
+ * issue #5 design analysis and the public PostgreSQL API. See PROVENANCE.md.
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "columnar.h"
+
+#include "access/tableam.h"
+#include "access/xact.h"
+#include "miscadmin.h"
+#include "storage/lock.h"
+#include "utils/snapmgr.h"
+
+#include "columnar_delete_vector.h"
+
+/*
+ * GUCs. enable_row_update_lock is USERSET so it can be turned off for a session
+ * that wants the old behavior. row_lock_buckets is POSTMASTER because the bucket
+ * count is part of the advisory lock tag: two backends racing the same row must
+ * compute the same bucket, which they only do when they agree on this value
+ * (identical to unique_lock_buckets).
+ */
+bool		pgcolumnar_enable_row_update_lock = true;
+int			pgcolumnar_row_lock_buckets = 1024;
+
+/*
+ * row_identity_lock_key
+ *		Mix (storage id, row number) into a 64-bit advisory-lock key, with the
+ *		same FNV-1a plus splitmix64 finalizer as delete_vector_chunk_lock_key and
+ *		the unique-key hash, so the avalanche spreads the bits. A collision only
+ *		makes two unrelated rows serialize needlessly; it never affects
+ *		correctness, because the exact-row committed re-read below is what decides
+ *		a real conflict.
+ */
+static uint64
+row_identity_lock_key(uint64 storageId, uint64 rowNumber)
+{
+	uint64		h = UINT64CONST(1469598103934665603);	/* FNV-1a offset basis */
+
+	h = (h ^ storageId) * UINT64CONST(1099511628211);
+	h = (h ^ rowNumber) * UINT64CONST(1099511628211);
+
+	h ^= h >> 33;
+	h *= UINT64CONST(0xff51afd7ed558ccd);
+	h ^= h >> 33;
+	h *= UINT64CONST(0xc4ceb9fe1a85ec53);
+	h ^= h >> 33;
+
+	return h;
+}
+
+/*
+ * PgColumnarLockRowIdentity
+ *		Take the transaction-scoped exclusive advisory lock for one row identity.
+ *		Returns true when the lock is held. With wait == false it returns false
+ *		instead of blocking when another transaction holds the row. The lock is
+ *		held until this transaction ends (the concurrent writer must not run its
+ *		committed re-read until our delete is committed and visible to it), which
+ *		is why it is a transaction lock, exactly like the delete-vector and
+ *		unique-key locks.
+ *
+ *		The bucket bounds the transaction's distinct held row locks to at most
+ *		row_lock_buckets per storage, so a bulk UPDATE cannot exhaust the lock
+ *		table; unrelated rows sharing a bucket only over-serialize.
+ */
+bool
+PgColumnarLockRowIdentity(Relation rel, uint64 rowNumber, bool wait)
+{
+	uint64		storageId = PgColumnarStorageId(rel);
+	uint32		numBuckets = (uint32) Max(1, pgcolumnar_row_lock_buckets);
+	uint64		key = row_identity_lock_key(storageId, rowNumber);
+	uint32		bucket = (uint32) (key % numBuckets);
+	LOCKTAG		tag;
+	LockAcquireResult res;
+
+	SET_LOCKTAG_ADVISORY(tag, MyDatabaseId,
+						 (uint32) storageId, bucket,
+						 PGCOLUMNAR_LOCKCLASS_ROW_IDENTITY);
+
+	res = LockAcquire(&tag, ExclusiveLock, false /* transaction lock */ ,
+					  !wait /* dontWait */ );
+	return res != LOCKACQUIRE_NOT_AVAIL;
+}
+
+/*
+ * PgColumnarRowCommittedDeleted
+ *		Is the row deleted in the LATEST committed state? Used only after the
+ *		row-identity lock is held, so any concurrent writer has already committed
+ *		or aborted. GetLatestSnapshot (pushed active for the catalog scan, as PG18
+ *		asserts) sees a delete a concurrent transaction committed after our own
+ *		snapshot, which PgColumnarCatalogSnapshot(caller) would not. The caller
+ *		must check the in-memory buffer (PgColumnarDeleteVectorBufferedDeleted)
+ *		first, so this only runs when the row is not our own buffered delete; a
+ *		row with no covering committed group (concurrently compacted) reads as
+ *		deleted, which is the correct conflict verdict.
+ */
+bool
+PgColumnarRowCommittedDeleted(Relation rel, uint64 rowNumber)
+{
+	bool		live;
+
+	PushActiveSnapshot(GetLatestSnapshot());
+	live = PgColumnarRowIsLive(rel, GetActiveSnapshot(), rowNumber);
+	PopActiveSnapshot();
+
+	return !live;
+}
+
+/*
+ * PgColumnarRowWriteConflict
+ *		The shared row-identity guard for pgcolumnar_tuple_update and
+ *		pgcolumnar_tuple_delete, run BEFORE the write marks the old row deleted.
+ *
+ *		Returns true when the write must not proceed; then *result holds the
+ *		TM_Result to return and tmfd is filled for the self-modified and
+ *		being-modified cases. Raises a serialization_failure (does not return) on
+ *		a committed concurrent delete. Returns false when the write may proceed.
+ *		Does not set *lockmode; the update callback sets it when this returns a
+ *		blocking result, since tuple_delete has no lockmode.
+ */
+bool
+PgColumnarRowWriteConflict(Relation rel, ItemPointer otid, CommandId cid,
+						   bool wait, TM_FailureData *tmfd, TM_Result *result)
+{
+	uint64		rowNumber = PgColumnarItemPointerToRowNumber(otid);
+
+	/*
+	 * Same command modifying the same row twice (a self-join UPDATE ... FROM):
+	 * the old row is already marked deleted in this command's own buffer. Report
+	 * it as self-modified so core resolves it as it does for a heap, rather than
+	 * writing a second new version. cmax == the current command id makes core
+	 * treat it as already handled by this command. This is a deterministic
+	 * correctness fix independent of concurrency, so it runs even when the
+	 * row-lock GUC is off.
+	 */
+	if (PgColumnarDeleteVectorBufferedDeleted(rel, rowNumber))
+	{
+		ItemPointerCopy(otid, &tmfd->ctid);
+		tmfd->xmax = GetCurrentTransactionId();
+		tmfd->cmax = cid;
+		*result = TM_SelfModified;
+		return true;
+	}
+
+	if (!pgcolumnar_enable_row_update_lock)
+		return false;
+
+	/*
+	 * Serialize against any concurrent writer of this exact row. With wait the
+	 * loser blocks here until the winner commits; a no-wait caller that would
+	 * block is told so.
+	 */
+	if (!PgColumnarLockRowIdentity(rel, rowNumber, wait))
+	{
+		ItemPointerCopy(otid, &tmfd->ctid);
+		tmfd->xmax = InvalidTransactionId;
+		tmfd->cmax = InvalidCommandId;
+		*result = TM_BeingModified;
+		return true;
+	}
+
+	/*
+	 * The lock is now ours, so any competitor has resolved. If it committed a
+	 * delete of this row, our write would duplicate the row and lose an update;
+	 * fail with a retryable serialization error instead. The application retries.
+	 */
+	if (PgColumnarRowCommittedDeleted(rel, rowNumber))
+		ereport(ERROR,
+				(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
+				 errmsg("columnar: could not serialize access due to concurrent update or delete of the same row"),
+				 errhint("Retry the transaction.")));
+
+	return false;
+}

--- a/src/columnar_row_lock.c
+++ b/src/columnar_row_lock.c
@@ -11,31 +11,41 @@
  * own new version: the old row is deleted once and both new rows survive, so the
  * row is duplicated and one update is lost. A heap serializes this transparently.
  *
- * This module gives the write paths a row-identity guard, modeled on the
- * concurrent unique-key insert serialization in columnar_unique.c and the
- * chunk-group advisory lock in columnar_metadata.c (issue #4). Before a write
- * marks the old row deleted it:
+ * The serialization happens at delete-vector FLUSH time, not per row in the
+ * table-AM callbacks, so the row-identity locks can be acquired in a single
+ * sorted batch. This mirrors the issue #4 discipline in delete_vector_flush_buffer
+ * (list_sort before taking the chunk-group locks): every transaction acquires in
+ * the same order, so no AB-BA cycle forms. Acquiring incrementally per row (in
+ * scan order) would take the bucketed locks in a transaction-dependent order and
+ * deadlock two transactions touching unrelated rows that share a bucket.
  *
- *   1. If the row is already marked deleted in THIS command's own buffer, the
- *      same command is modifying it twice (a self-join UPDATE ... FROM). Return
- *      TM_SelfModified so core resolves it exactly as it does for a heap.
- *   2. Take a transaction-scoped advisory lock on the row identity
- *      (storage id, row number). A concurrent writer of the same row waits here
- *      until this transaction commits. A no-wait caller that would block gets
- *      TM_BeingModified.
- *   3. Re-read the row's liveness in the LATEST committed state (not the caller
- *      snapshot, which PgColumnarCatalogSnapshot only copies). If a concurrent
- *      transaction has committed a delete of this row, raise a retryable
- *      serialization_failure. The lock is the authority for waiting out the
- *      competitor; this fresh-snapshot re-read is the authority for whether a
- *      conflict actually happened, so a hash-bucket collision can only add
- *      waiting, never a false failure.
+ * The flow, gated by pgcolumnar.enable_row_update_lock:
+ *   1. PgColumnarRowWriteConflict, called by pgcolumnar_tuple_update and
+ *      pgcolumnar_tuple_delete BEFORE marking the old row deleted, reports a
+ *      same-command self-modify (the row is already in this command's own buffer)
+ *      as TM_SelfModified, so a self-join UPDATE ... FROM resolves as it does for
+ *      a heap. This runs even with the GUC off; it is a deterministic correctness
+ *      fix independent of concurrency.
+ *   2. PgColumnarSerializeFlushRows, called from delete_vector_flush_buffer before
+ *      the delete-vector upsert, sorts the flushed rows by lock key, takes a
+ *      transaction-scoped advisory lock on each (all held to commit), then re-reads
+ *      the LATEST committed state (GetLatestSnapshot, not the caller snapshot,
+ *      which PgColumnarCatalogSnapshot only copies) and raises a retryable
+ *      serialization_failure if any of these rows was committed-deleted by a
+ *      concurrent transaction. The lock waits out the competitor; the committed
+ *      re-read decides whether a conflict actually happened, so a hash-bucket
+ *      collision can only add waiting, never a false failure.
  *
- * The net contract at every isolation level is one retryable serialization
- * failure for the losing writer of a same-row race, matching what a heap gives
- * at REPEATABLE READ and what columnar already gives at SERIALIZABLE. READ
- * COMMITTED becomes stricter than a heap (the loser retries rather than
- * re-applying transparently via EvalPlanQual); see docs/limitations.md.
+ * A conflict is a row whose COMMITTED group still EXISTS and whose bit is set. A
+ * row whose group is gone (retired by a concurrent rewrite) is left to the
+ * flush-time Phase F3b check in PgColumnarUpsertDeleteVector, which raises its own
+ * "row group was compacted concurrently" error; it is also the read-your-writes
+ * case for a row this transaction just inserted, which is not a conflict.
+ *
+ * The loser gets one retryable serialization_failure at every isolation level,
+ * matching a heap at REPEATABLE READ and what columnar already gave at
+ * SERIALIZABLE. READ COMMITTED is stricter than a heap: the loser retries rather
+ * than re-applying via EvalPlanQual. See docs/limitations.md.
  *
  * Written fresh for pgColumnar. It reuses no upstream source; it derives from the
  * issue #5 design analysis and the public PostgreSQL API. See PROVENANCE.md.
@@ -48,16 +58,16 @@
 #include "access/xact.h"
 #include "miscadmin.h"
 #include "storage/lock.h"
+#include "utils/memutils.h"
 #include "utils/snapmgr.h"
 
 #include "columnar_delete_vector.h"
 
 /*
- * GUCs. enable_row_update_lock is USERSET so it can be turned off for a session
- * that wants the old behavior. row_lock_buckets is POSTMASTER because the bucket
- * count is part of the advisory lock tag: two backends racing the same row must
- * compute the same bucket, which they only do when they agree on this value
- * (identical to unique_lock_buckets).
+ * GUCs. enable_row_update_lock is USERSET so a session can turn the serialization
+ * off. row_lock_buckets is POSTMASTER because the bucket count is part of the
+ * advisory lock tag: two backends racing the same row must compute the same
+ * bucket, which they only do when they agree on this value (as unique_lock_buckets).
  */
 bool		pgcolumnar_enable_row_update_lock = true;
 int			pgcolumnar_row_lock_buckets = 1024;
@@ -66,10 +76,8 @@ int			pgcolumnar_row_lock_buckets = 1024;
  * row_identity_lock_key
  *		Mix (storage id, row number) into a 64-bit advisory-lock key, with the
  *		same FNV-1a plus splitmix64 finalizer as delete_vector_chunk_lock_key and
- *		the unique-key hash, so the avalanche spreads the bits. A collision only
- *		makes two unrelated rows serialize needlessly; it never affects
- *		correctness, because the exact-row committed re-read below is what decides
- *		a real conflict.
+ *		the unique-key hash. A collision only makes two unrelated rows serialize
+ *		needlessly; the exact-row committed re-read is what decides a real conflict.
  */
 static uint64
 row_identity_lock_key(uint64 storageId, uint64 rowNumber)
@@ -89,73 +97,13 @@ row_identity_lock_key(uint64 storageId, uint64 rowNumber)
 }
 
 /*
- * PgColumnarLockRowIdentity
- *		Take the transaction-scoped exclusive advisory lock for one row identity.
- *		Returns true when the lock is held. With wait == false it returns false
- *		instead of blocking when another transaction holds the row. The lock is
- *		held until this transaction ends (the concurrent writer must not run its
- *		committed re-read until our delete is committed and visible to it), which
- *		is why it is a transaction lock, exactly like the delete-vector and
- *		unique-key locks.
- *
- *		The bucket bounds the transaction's distinct held row locks to at most
- *		row_lock_buckets per storage, so a bulk UPDATE cannot exhaust the lock
- *		table; unrelated rows sharing a bucket only over-serialize.
- */
-bool
-PgColumnarLockRowIdentity(Relation rel, uint64 rowNumber, bool wait)
-{
-	uint64		storageId = PgColumnarStorageId(rel);
-	uint32		numBuckets = (uint32) Max(1, pgcolumnar_row_lock_buckets);
-	uint64		key = row_identity_lock_key(storageId, rowNumber);
-	uint32		bucket = (uint32) (key % numBuckets);
-	LOCKTAG		tag;
-	LockAcquireResult res;
-
-	SET_LOCKTAG_ADVISORY(tag, MyDatabaseId,
-						 (uint32) storageId, bucket,
-						 PGCOLUMNAR_LOCKCLASS_ROW_IDENTITY);
-
-	res = LockAcquire(&tag, ExclusiveLock, false /* transaction lock */ ,
-					  !wait /* dontWait */ );
-	return res != LOCKACQUIRE_NOT_AVAIL;
-}
-
-/*
- * PgColumnarRowCommittedDeleted
- *		Is the row deleted in the LATEST committed state? Used only after the
- *		row-identity lock is held, so any concurrent writer has already committed
- *		or aborted. GetLatestSnapshot (pushed active for the catalog scan, as PG18
- *		asserts) sees a delete a concurrent transaction committed after our own
- *		snapshot, which PgColumnarCatalogSnapshot(caller) would not. The caller
- *		must check the in-memory buffer (PgColumnarDeleteVectorBufferedDeleted)
- *		first, so this only runs when the row is not our own buffered delete; a
- *		row with no covering committed group (concurrently compacted) reads as
- *		deleted, which is the correct conflict verdict.
- */
-bool
-PgColumnarRowCommittedDeleted(Relation rel, uint64 rowNumber)
-{
-	bool		live;
-
-	PushActiveSnapshot(GetLatestSnapshot());
-	live = PgColumnarRowIsLive(rel, GetActiveSnapshot(), rowNumber);
-	PopActiveSnapshot();
-
-	return !live;
-}
-
-/*
  * PgColumnarRowWriteConflict
- *		The shared row-identity guard for pgcolumnar_tuple_update and
- *		pgcolumnar_tuple_delete, run BEFORE the write marks the old row deleted.
- *
- *		Returns true when the write must not proceed; then *result holds the
- *		TM_Result to return and tmfd is filled for the self-modified and
- *		being-modified cases. Raises a serialization_failure (does not return) on
- *		a committed concurrent delete. Returns false when the write may proceed.
- *		Does not set *lockmode; the update callback sets it when this returns a
- *		blocking result, since tuple_delete has no lockmode.
+ *		Self-modify guard for pgcolumnar_tuple_update and pgcolumnar_tuple_delete,
+ *		run before the write marks the old row deleted. Returns true when the write
+ *		must not proceed; then *result is TM_SelfModified and tmfd is filled.
+ *		Returns false when the write may proceed. The row-identity locking and the
+ *		committed-conflict check happen later, in PgColumnarSerializeFlushRows at
+ *		flush time, so they can be taken in one sorted batch.
  */
 bool
 PgColumnarRowWriteConflict(Relation rel, ItemPointer otid, CommandId cid,
@@ -163,14 +111,14 @@ PgColumnarRowWriteConflict(Relation rel, ItemPointer otid, CommandId cid,
 {
 	uint64		rowNumber = PgColumnarItemPointerToRowNumber(otid);
 
+	(void) wait;
+
 	/*
-	 * Same command modifying the same row twice (a self-join UPDATE ... FROM):
-	 * the old row is already marked deleted in this command's own buffer. Report
-	 * it as self-modified so core resolves it as it does for a heap, rather than
-	 * writing a second new version. cmax == the current command id makes core
-	 * treat it as already handled by this command. This is a deterministic
-	 * correctness fix independent of concurrency, so it runs even when the
-	 * row-lock GUC is off.
+	 * Same command modifying the same row twice (a self-join UPDATE ... FROM): the
+	 * old row is already marked deleted in this command's own buffer. Report it as
+	 * self-modified so core resolves it as it does for a heap, rather than writing
+	 * a second new version. cmax == the current command id makes core treat it as
+	 * already handled by this command. This runs even when the row-lock GUC is off.
 	 */
 	if (PgColumnarDeleteVectorBufferedDeleted(rel, rowNumber))
 	{
@@ -181,33 +129,205 @@ PgColumnarRowWriteConflict(Relation rel, ItemPointer otid, CommandId cid,
 		return true;
 	}
 
-	if (!pgcolumnar_enable_row_update_lock)
-		return false;
+	return false;
+}
 
-	/*
-	 * Serialize against any concurrent writer of this exact row. With wait the
-	 * loser blocks here until the winner commits; a no-wait caller that would
-	 * block is told so.
-	 */
-	if (!PgColumnarLockRowIdentity(rel, rowNumber, wait))
+/* one { lock key, row number } pair, sorted by key for ordered acquisition */
+typedef struct RowLockEntry
+{
+	uint64		key;
+	uint64		rowNumber;
+} RowLockEntry;
+
+static int
+rowlockentry_cmp(const void *a, const void *b)
+{
+	const RowLockEntry *ra = (const RowLockEntry *) a;
+	const RowLockEntry *rb = (const RowLockEntry *) b;
+
+	if (ra->key < rb->key)
+		return -1;
+	if (ra->key > rb->key)
+		return 1;
+	if (ra->rowNumber < rb->rowNumber)
+		return -1;
+	if (ra->rowNumber > rb->rowNumber)
+		return 1;
+	return 0;
+}
+
+/* a committed row group plus its merged delete mask, for the batch conflict check */
+typedef struct CommittedGroup
+{
+	uint64		firstRowNumber;
+	uint64		rowCount;
+	char	   *mask;
+	uint32		maskLen;
+} CommittedGroup;
+
+/*
+ * committed_deleted_in
+ *		Is rowNumber deleted in the committed groups array (sorted by
+ *		firstRowNumber)? True only when a covering group EXISTS and the bit is set;
+ *		a missing group is not a conflict (left to Phase F3b / read-your-writes).
+ */
+static bool
+committed_deleted_in(CommittedGroup *groups, int ngroups, uint64 rowNumber)
+{
+	int			lo = 0;
+	int			hi = ngroups - 1;
+
+	while (lo <= hi)
 	{
-		ItemPointerCopy(otid, &tmfd->ctid);
-		tmfd->xmax = InvalidTransactionId;
-		tmfd->cmax = InvalidCommandId;
-		*result = TM_BeingModified;
-		return true;
+		int			mid = (lo + hi) / 2;
+		CommittedGroup *g = &groups[mid];
+
+		if (rowNumber < g->firstRowNumber)
+			hi = mid - 1;
+		else if (rowNumber >= g->firstRowNumber + g->rowCount)
+			lo = mid + 1;
+		else
+		{
+			uint64		bit = rowNumber - g->firstRowNumber;
+
+			return (g->mask != NULL && (bit >> 3) < g->maskLen &&
+					(g->mask[bit >> 3] & (1 << (bit & 7))) != 0);
+		}
+	}
+	return false;				/* no committed group covers it: not our conflict */
+}
+
+static int
+committedgroup_cmp(const void *a, const void *b)
+{
+	const CommittedGroup *ga = (const CommittedGroup *) a;
+	const CommittedGroup *gb = (const CommittedGroup *) b;
+
+	if (ga->firstRowNumber < gb->firstRowNumber)
+		return -1;
+	if (ga->firstRowNumber > gb->firstRowNumber)
+		return 1;
+	return 0;
+}
+
+/*
+ * PgColumnarSerializeFlushRows
+ *		Serialize the rows about to be flushed as deleted (the delete half of every
+ *		UPDATE and every DELETE in this flush) against concurrent writers of the
+ *		same rows. Acquire a transaction-scoped advisory lock on each row IN SORTED
+ *		KEY ORDER (deadlock-free, as every transaction acquires in the same order),
+ *		then raise a retryable serialization_failure if any of these rows was
+ *		committed-deleted by another transaction. Called from
+ *		delete_vector_flush_buffer before the delete-vector upsert, so it runs
+ *		inside the same flush that already serializes the chunk-group writes.
+ */
+void
+PgColumnarSerializeFlushRows(uint64 storageId, const uint64 *rows, int nrows)
+{
+	MemoryContext tmp;
+	MemoryContext old;
+	RowLockEntry *ents;
+	uint32		numBuckets;
+	Snapshot	meta;
+	List	   *rgList;
+	CommittedGroup *groups;
+	int			ngroups;
+	int			i;
+	ListCell   *lc;
+	bool		conflict = false;
+
+	if (!pgcolumnar_enable_row_update_lock || nrows <= 0)
+		return;
+
+	tmp = AllocSetContextCreate(CurrentMemoryContext,
+								"columnar row serialize",
+								ALLOCSET_SMALL_SIZES);
+	old = MemoryContextSwitchTo(tmp);
+
+	/* sort the rows by lock key so the whole batch is acquired in one order */
+	ents = (RowLockEntry *) palloc(sizeof(RowLockEntry) * nrows);
+	for (i = 0; i < nrows; i++)
+	{
+		ents[i].key = row_identity_lock_key(storageId, rows[i]);
+		ents[i].rowNumber = rows[i];
+	}
+	qsort(ents, nrows, sizeof(RowLockEntry), rowlockentry_cmp);
+
+	numBuckets = (uint32) Max(1, pgcolumnar_row_lock_buckets);
+	for (i = 0; i < nrows; i++)
+	{
+		uint32		bucket = (uint32) (ents[i].key % numBuckets);
+		LOCKTAG		tag;
+
+		/* a repeated bucket is already held; LockAcquire makes it a no-op */
+		SET_LOCKTAG_ADVISORY(tag, MyDatabaseId,
+							 (uint32) storageId, bucket,
+							 PGCOLUMNAR_LOCKCLASS_ROW_IDENTITY);
+		(void) LockAcquire(&tag, ExclusiveLock, false /* transaction lock */ ,
+						   false /* wait */ );
 	}
 
 	/*
-	 * The lock is now ours, so any competitor has resolved. If it committed a
-	 * delete of this row, our write would duplicate the row and lose an update;
-	 * fail with a retryable serialization error instead. The application retries.
+	 * With the locks held, read the latest committed groups and delete masks once,
+	 * then classify every flushed row against them. GetLatestSnapshot (pushed
+	 * active, as PG18 asserts for a catalog scan) sees a delete a concurrent
+	 * transaction committed after our own snapshot; our own not-yet-flushed deletes
+	 * are in the buffer, not this committed view, so they are not self-conflicts.
 	 */
-	if (PgColumnarRowCommittedDeleted(rel, rowNumber))
+	PushActiveSnapshot(GetLatestSnapshot());
+	meta = PgColumnarCatalogSnapshot(GetActiveSnapshot());
+	rgList = PgColumnarReadRowGroupList(storageId, meta);
+	ngroups = list_length(rgList);
+	groups = (CommittedGroup *) palloc0(sizeof(CommittedGroup) * Max(ngroups, 1));
+
+	i = 0;
+	foreach(lc, rgList)
+	{
+		NativeRowGroupMetadata *rg = (NativeRowGroupMetadata *) lfirst(lc);
+		List	   *maskList = PgColumnarReadDeleteVectorList(storageId,
+															  rg->groupNumber,
+															  meta);
+		uint32		want = (uint32) ((rg->rowCount + 7) / 8);
+		ListCell   *mc;
+
+		groups[i].firstRowNumber = rg->firstRowNumber;
+		groups[i].rowCount = rg->rowCount;
+		foreach(mc, maskList)
+		{
+			DeleteVectorMetadata *rm = (DeleteVectorMetadata *) lfirst(mc);
+			uint32		b;
+
+			if (rm->bitmap == NULL || rm->bitmapLen == 0)
+				continue;
+			if (groups[i].mask == NULL)
+			{
+				groups[i].mask = (char *) palloc0(want > 0 ? want : 1);
+				groups[i].maskLen = want;
+			}
+			for (b = 0; b < rm->bitmapLen && b < want; b++)
+				groups[i].mask[b] |= rm->bitmap[b];
+		}
+		i++;
+	}
+	if (ngroups > 1)
+		qsort(groups, ngroups, sizeof(CommittedGroup), committedgroup_cmp);
+
+	for (i = 0; i < nrows; i++)
+	{
+		if (committed_deleted_in(groups, ngroups, ents[i].rowNumber))
+		{
+			conflict = true;
+			break;
+		}
+	}
+
+	PopActiveSnapshot();
+	MemoryContextSwitchTo(old);
+	MemoryContextDelete(tmp);
+
+	if (conflict)
 		ereport(ERROR,
 				(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
 				 errmsg("columnar: could not serialize access due to concurrent update or delete of the same row"),
 				 errhint("Retry the transaction.")));
-
-	return false;
 }

--- a/src/columnar_row_lock.c
+++ b/src/columnar_row_lock.c
@@ -132,10 +132,17 @@ PgColumnarRowWriteConflict(Relation rel, ItemPointer otid, CommandId cid,
 	return false;
 }
 
-/* one { lock key, row number } pair, sorted by key for ordered acquisition */
+/*
+ * one { lock bucket, row number } pair. Sorted by BUCKET, which is the actual
+ * lock resource (SET_LOCKTAG_ADVISORY takes the bucket, not the raw key). Sorting
+ * by the raw key would not order the buckets consistently, because bucket =
+ * key % numBuckets and modulo is not order-preserving, so two transactions could
+ * take the same two buckets in opposite order and deadlock. Ordering by the bucket
+ * makes every transaction acquire shared buckets ascending, so no cycle forms.
+ */
 typedef struct RowLockEntry
 {
-	uint64		key;
+	uint32		bucket;
 	uint64		rowNumber;
 } RowLockEntry;
 
@@ -145,9 +152,9 @@ rowlockentry_cmp(const void *a, const void *b)
 	const RowLockEntry *ra = (const RowLockEntry *) a;
 	const RowLockEntry *rb = (const RowLockEntry *) b;
 
-	if (ra->key < rb->key)
+	if (ra->bucket < rb->bucket)
 		return -1;
-	if (ra->key > rb->key)
+	if (ra->bucket > rb->bucket)
 		return 1;
 	if (ra->rowNumber < rb->rowNumber)
 		return -1;
@@ -244,24 +251,29 @@ PgColumnarSerializeFlushRows(uint64 storageId, const uint64 *rows, int nrows)
 								ALLOCSET_SMALL_SIZES);
 	old = MemoryContextSwitchTo(tmp);
 
-	/* sort the rows by lock key so the whole batch is acquired in one order */
+	/*
+	 * Compute each row's bucket (the actual lock resource) and sort by it, so the
+	 * whole batch, and every other transaction's batch, acquires shared buckets in
+	 * the same ascending order.
+	 */
+	numBuckets = (uint32) Max(1, pgcolumnar_row_lock_buckets);
 	ents = (RowLockEntry *) palloc(sizeof(RowLockEntry) * nrows);
 	for (i = 0; i < nrows; i++)
 	{
-		ents[i].key = row_identity_lock_key(storageId, rows[i]);
+		uint64		key = row_identity_lock_key(storageId, rows[i]);
+
+		ents[i].bucket = (uint32) (key % numBuckets);
 		ents[i].rowNumber = rows[i];
 	}
 	qsort(ents, nrows, sizeof(RowLockEntry), rowlockentry_cmp);
 
-	numBuckets = (uint32) Max(1, pgcolumnar_row_lock_buckets);
 	for (i = 0; i < nrows; i++)
 	{
-		uint32		bucket = (uint32) (ents[i].key % numBuckets);
 		LOCKTAG		tag;
 
 		/* a repeated bucket is already held; LockAcquire makes it a no-op */
 		SET_LOCKTAG_ADVISORY(tag, MyDatabaseId,
-							 (uint32) storageId, bucket,
+							 (uint32) storageId, ents[i].bucket,
 							 PGCOLUMNAR_LOCKCLASS_ROW_IDENTITY);
 		(void) LockAcquire(&tag, ExclusiveLock, false /* transaction lock */ ,
 						   false /* wait */ );

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -1445,6 +1445,11 @@ static TM_Result
 pgcolumnar_tuple_delete(COLUMNAR_TUPLE_DELETE_ARGS)
 {
 	uint64		rowNumber = PgColumnarItemPointerToRowNumber(tid);
+	TM_Result	conflict;
+
+	/* issue #5: serialize on the row identity before marking it deleted */
+	if (PgColumnarRowWriteConflict(rel, tid, cid, wait, tmfd, &conflict))
+		return conflict;
 
 	PgColumnarMarkRowDeleted(rel, rowNumber);
 	return TM_Ok;
@@ -1465,6 +1470,20 @@ pgcolumnar_tuple_update(COLUMNAR_TUPLE_UPDATE_ARGS)
 	uint64		oldRowNumber = PgColumnarItemPointerToRowNumber(otid);
 	PgColumnarWriteState *writeState;
 	uint64		rowNumber;
+	TM_Result	conflict;
+
+	/*
+	 * issue #5: serialize on the row identity before marking the old row
+	 * deleted, so two transactions updating the same row do not each keep their
+	 * own new version. The loser gets a retryable serialization_failure (or
+	 * TM_SelfModified for a same-command self-join). lockmode is set for the
+	 * non-Ok returns as core expects.
+	 */
+	if (PgColumnarRowWriteConflict(rel, otid, cid, wait, tmfd, &conflict))
+	{
+		*lockmode = LockTupleExclusive;
+		return conflict;
+	}
 
 	PgColumnarMarkRowDeleted(rel, oldRowNumber);
 
@@ -2846,6 +2865,39 @@ _PG_init(void)
 							"this value.",
 							&pgcolumnar_unique_lock_buckets,
 							128,
+							1, 1048576,
+							PGC_POSTMASTER,
+							0,
+							NULL, NULL, NULL);
+
+	DefineCustomBoolVariable("pgcolumnar.enable_row_update_lock",
+							 "Serialize concurrent UPDATE/DELETE of the same "
+							 "columnar row so the losing writer gets a retryable "
+							 "serialization_failure instead of duplicating the "
+							 "row and losing an update (issue #5).",
+							 "On by default. Off restores the prior behavior, "
+							 "where two transactions updating the same row can "
+							 "each keep their own version.",
+							 &pgcolumnar_enable_row_update_lock,
+							 true,
+							 PGC_USERSET,
+							 0,
+							 NULL, NULL, NULL);
+
+	DefineCustomIntVariable("pgcolumnar.row_lock_buckets",
+							"Advisory-lock buckets per storage for same-row "
+							"UPDATE/DELETE serialization.",
+							"Bounds the transaction's held row locks to at most "
+							"this many per storage, so a bulk UPDATE cannot "
+							"exhaust the lock table. The same row always hashes to "
+							"the same bucket; unrelated rows may share one, which "
+							"only over-serializes. Fixed at server start because "
+							"the bucket is part of the advisory lock tag: two "
+							"backends racing the same row must compute the same "
+							"bucket, which they only do when they agree on this "
+							"value.",
+							&pgcolumnar_row_lock_buckets,
+							1024,
 							1, 1048576,
 							PGC_POSTMASTER,
 							0,

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -226,6 +226,7 @@ SUITES=(
 	temporal
 	ungrouped_vector_agg
 	unique_conc
+	update_conc
 	vacuum_lock_privilege
 	vacuum_stripe_count
 	vm_privilege

--- a/test/update_conc.sh
+++ b/test/update_conc.sh
@@ -426,6 +426,24 @@ check "unique/RC heap composes with no error (sqlstate 00000)" "$H_SS" "00000"
 check "unique/RC columnar loser errors where heap composes (not transparent)" \
 	"$([ "$C_SS" != "00000" ] && echo errored)" "errored"
 
+# ---------------------------------------------------------------------------
+# savepoint: a subtransaction that updates a row then rolls back must discard both
+# the delete mark and the appended new version, and must not wedge on the
+# transaction-scoped row lock. Single session, deterministic. Final state must
+# match the heap oracle: the pre-savepoint value survives, the rolled-back one does
+# not, and the row is not duplicated.
+# ---------------------------------------------------------------------------
+sp_arm() {  # tbl -> "count/values" for id=1 after a savepoint rollback
+	seed1 "$1"
+	ctl_q "BEGIN; UPDATE $1 SET v=10 WHERE id=1; SAVEPOINT sp; UPDATE $1 SET v=99 WHERE id=1; ROLLBACK TO sp; COMMIT;" >/dev/null 2>&1
+	ctl_q "SELECT count(*)||'/'||coalesce(string_agg(v::text, ',' ORDER BY v),'') FROM $1 WHERE id=1;"
+}
+echo; echo "### savepoint: subxact rollback discards the update, no wedge"
+H_SP="$(sp_arm t_heap)"; C_SP="$(sp_arm t_col)"
+echo "-- heap=$H_SP ; col=$C_SP"
+check "savepoint columnar final state matches heap oracle" "$C_SP" "$H_SP"
+check "savepoint columnar kept the pre-savepoint value, no duplicate (1/10)" "$C_SP" "1/10"
+
 send s1 "\\q"
 send s2 "\\q"
 

--- a/test/update_conc.sh
+++ b/test/update_conc.sh
@@ -1,0 +1,438 @@
+#!/usr/bin/env bash
+#
+# pgColumnar concurrent same-row UPDATE test (tracking issue #5, the UPDATE half).
+#
+# A columnar UPDATE is delete-old + insert-new (src/columnar_tableam.c
+# pgcolumnar_tuple_update): it marks the old row deleted in the delete vector and
+# appends a fresh row with a new row number. It always returns TM_Ok and takes no
+# lock on the row identity, and pgcolumnar_tuple_lock raises COLUMNAR_UNSUPPORTED,
+# so core never runs EvalPlanQual. Two sessions updating the SAME row therefore
+# each keep their own new version. The old row is deleted once (idempotent) and
+# both new rows survive, so the row is DUPLICATED and one update is LOST. A heap
+# serializes transparently: at READ COMMITTED EvalPlanQual re-applies the second
+# update to the first's new version, at REPEATABLE READ the second gets a
+# serialization_failure. Columnar does neither. This is the known limitation
+# documented in docs/limitations.md (Concurrency section).
+#
+# THE OBSERVED MECHANISM (probed on the bench, not assumed):
+# The second writer DOES block, but on the wrong lock. A columnar UPDATE flushes
+# its delete mark at the statement's executor-end and holds the chunk-group
+# advisory lock (issue #4) until commit. So s2's UPDATE of the same row blocks on
+# that chunk-group lock (wait_event_type='Lock', wait_event='advisory'), exactly
+# as a heap s2 blocks on the row lock. The chunk-group lock serializes the
+# delete-vector read-modify-write; it does NOT serialize the row identity, so both
+# appends still happen and the duplicate survives after s2 unblocks and commits.
+# Both engines therefore reach wait_event_type='Lock', so ONE wait_blocked barrier
+# forces the overlap on both arms. The engines diverge only in the final state and
+# in whether the losing writer errors, which is exactly what the heap oracle
+# measures.
+#
+# This suite is RED-first: the checks encode the CORRECT (post-fix) behavior, so
+# every columnar arm FAILS on today's code and PASSES once same-row writes
+# serialize. A heap table runs the byte-identical interleaving as the oracle, and
+# a non-overlapping serial columnar arm is the removal-proof control: it stays
+# GREEN today, proving the RED is caused by the forced OVERLAP and not a broken
+# update. Barriers are pg_stat_activity polls for a real lock wait, never sleeps;
+# lock_timeout caps any genuine hang so a wedge cannot masquerade as a pass.
+#
+# The minimal fix makes READ COMMITTED STRICTER than a heap: the loser gets a
+# retryable serialization_failure instead of a transparent EvalPlanQual re-apply.
+# So at RC the columnar final VALUE is not compared to the heap oracle (only the
+# no-duplicate row count and the loser's SQLSTATE are). At REPEATABLE READ the
+# fix makes the two engines match fully. Whether retryable-40001-at-RC is an
+# acceptable close of #5, or #5 stays open until a heap-transparent EvalPlanQual
+# path exists, is a maintainer decision this suite does not prejudge.
+#
+# SCOPE OF THE DEFECT, as MEASURED here (not assumed): the lost update reproduces
+# at READ COMMITTED and REPEATABLE READ. SERIALIZABLE is ALREADY safe on today's
+# code -- the losing writer gets a 40001 with no fix, because the delete-vector
+# read-modify-write conflict (or SSI) fires at that level. So the SERIALIZABLE arm
+# is a REGRESSION guard, GREEN today and expected to stay GREEN, not part of the
+# RED. The fix's job is to bring RC and RR up to the safety SERIALIZABLE already
+# has.
+#
+# Written fresh for pgColumnar; it reuses no upstream test file or expected
+# output. Derived from the format/interface spec, the issue #5 design analysis,
+# and the public PostgreSQL API.
+#
+# Usage:
+#   test/update_conc.sh [PG_CONFIG]
+#
+# PG_CONFIG defaults to /usr/local/pg17/bin/pg_config. Run as a user that may
+# "runuser -u postgres" (e.g. root) when the current user is not postgres.
+
+
+# Own harness rather than lib.sh; portlib carries the port band.
+. "$(dirname "${BASH_SOURCE[0]}")/portlib.sh"
+
+set -uo pipefail
+
+PG_CONFIG="${1:-/usr/local/pg17/bin/pg_config}"
+BINDIR="$("$PG_CONFIG" --bindir)"
+SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+WORKDIR="$(mktemp -d /tmp/pgcolumnar-upconc.XXXXXX)"
+PGDATA="$WORKDIR/data"
+LOGFILE="$WORKDIR/server.log"
+
+port_is_free() {
+	if command -v ss >/dev/null 2>&1; then
+		! ss -Htln "sport = :$1" 2>/dev/null | grep -q ":$1"
+	else
+		! (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null
+	fi
+}
+# The cluster listens on a unix socket only (listen_addresses='' below), so the
+# number never binds a TCP port; it is really just the socket-file name. Drawn
+# from portlib's band regardless, so the choice is safe by intent, not accident.
+pick_port() {
+	local p i
+	for i in $(seq 1 100); do
+		p=$(( PGC_PORT_LO + RANDOM % (PGC_PORT_HI - PGC_PORT_LO) ))
+		if port_is_free "$p"; then echo "$p"; return 0; fi
+	done
+	echo $(( PGC_PORT_LO + RANDOM % (PGC_PORT_HI - PGC_PORT_LO) ))
+}
+PORT="${PGC_PORT:-$(pick_port)}"
+
+echo "== pgColumnar concurrent same-row UPDATE test (issue #5) =="
+echo "PG_CONFIG=$PG_CONFIG"
+echo "workdir=$WORKDIR"
+echo "port=$PORT (private unix socket in workdir; TCP disabled)"
+
+# The matrix runner installs the extension once per version and sets
+# PGC_SKIP_BUILD; skip the redundant per-suite build+install then, which also
+# avoids racing a concurrent suite's install into the same lib dir.
+if [ -z "${PGC_SKIP_BUILD:-}" ]; then
+	echo "-- building"
+	make -C "$SRCDIR" PG_CONFIG="$PG_CONFIG" >/dev/null
+	echo "-- installing"
+	make -C "$SRCDIR" install PG_CONFIG="$PG_CONFIG" >/dev/null
+fi
+
+if [ "$(id -u)" = "0" ]; then
+	RUNPG=(runuser -u postgres --)
+	chown -R postgres "$WORKDIR"
+else
+	RUNPG=(env)
+fi
+run_pg() { "${RUNPG[@]}" env PATH="$BINDIR:$PATH" bash -lc "$1"; }
+
+SESS_PIDS=()
+cleanup() {
+	for p in "${SESS_PIDS[@]:-}"; do kill "$p" >/dev/null 2>&1 || true; done
+	run_pg "pg_ctl -D '$PGDATA' stop -m immediate -w" >/dev/null 2>&1 || true
+	if [ -f "$PGDATA/postmaster.pid" ]; then
+		pmpid="$(head -n1 "$PGDATA/postmaster.pid" 2>/dev/null)"
+		if [ -n "${pmpid:-}" ] && [ "$pmpid" -gt 1 ] 2>/dev/null; then
+			kill -9 "$pmpid" >/dev/null 2>&1 || true
+		fi
+	fi
+	if command -v pkill >/dev/null 2>&1; then
+		pkill -9 -f "$WORKDIR" >/dev/null 2>&1 || true
+	fi
+	rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+echo "-- initdb"
+run_pg "initdb -D '$PGDATA' -A trust" >/dev/null 2>&1
+run_pg "echo \"port=$PORT\" >> '$PGDATA/postgresql.conf'"
+run_pg "echo \"shared_preload_libraries='pgcolumnar'\" >> '$PGDATA/postgresql.conf'"
+run_pg "echo \"listen_addresses=''\" >> '$PGDATA/postgresql.conf'"
+run_pg "echo \"unix_socket_directories='$WORKDIR'\" >> '$PGDATA/postgresql.conf'"
+# Cap any real hang so a bug cannot masquerade as a pass by blocking forever.
+run_pg "echo \"lock_timeout=30000\" >> '$PGDATA/postgresql.conf'"
+echo "-- start"
+run_pg "pg_ctl -D '$PGDATA' -l '$LOGFILE' start -w" >/dev/null
+run_pg "createdb -h '$WORKDIR' -p $PORT upconc"
+
+PSQL="psql -h '$WORKDIR' -p $PORT -d upconc -qAtX -v ON_ERROR_STOP=1"
+SPSQL="psql -h '$WORKDIR' -p $PORT -d upconc -qAtX"
+ctl_q() { run_pg "$PSQL -c \"$1\""; }
+
+fail=0
+check() {  # name got want
+	if [ "$2" = "$3" ]; then
+		echo "PASS  $1: $2"
+	else
+		echo "FAIL  $1: got [$2] want [$3]"
+		fail=1
+	fi
+}
+
+# --- persistent interactive sessions over FIFOs (as in test/concurrency.sh) ---
+start_session() {  # name
+	local name="$1"
+	local infile="$WORKDIR/$name.in"
+	local outfile="$WORKDIR/$name.out"
+	run_pg "mkfifo '$infile'; touch '$outfile'"
+	run_pg "$SPSQL >'$outfile' 2>&1 <'$infile'" &
+	SESS_PIDS+=("$!")
+	exec {fd}<>"$infile"
+	eval "FD_$name=$fd"
+}
+send() {  # name sql...
+	local name="$1"; shift
+	local fd; eval "fd=\$FD_$name"
+	printf '%s\n' "$*" >&"$fd"
+}
+send_wait() {  # name label sql...
+	local name="$1" label="$2"; shift 2
+	local fd outfile="$WORKDIR/$name.out" i=0
+	eval "fd=\$FD_$name"
+	printf '%s\n' "$*" >&"$fd"
+	printf '\\echo <<%s>>\n' "$label" >&"$fd"
+	while ! grep -q "<<$label>>" "$outfile" 2>/dev/null; do
+		sleep 0.05; i=$((i + 1))
+		if [ "$i" -ge 1200 ]; then
+			echo "FAIL  timeout waiting for $name/$label"; fail=1; return 1
+		fi
+	done
+	return 0
+}
+wait_sentinel() {  # name label
+	local name="$1" label="$2" outfile i=0
+	outfile="$WORKDIR/$name.out"
+	while ! grep -q "<<$label>>" "$outfile" 2>/dev/null; do
+		sleep 0.05; i=$((i + 1))
+		if [ "$i" -ge 1200 ]; then
+			echo "FAIL  timeout waiting for $name/$label sentinel"; fail=1; return 1
+		fi
+	done
+	return 0
+}
+wait_blocked() {  # application_name
+	local app="$1" i=0 n
+	while :; do
+		n="$(ctl_q "SELECT count(*) FROM pg_stat_activity WHERE application_name='$app' AND wait_event_type='Lock';")"
+		[ "$n" = "1" ] && return 0
+		sleep 0.05; i=$((i + 1))
+		if [ "$i" -ge 1200 ]; then
+			echo "FAIL  timeout waiting for $app to block"; fail=1; return 1
+		fi
+	done
+}
+
+# psql sets :SQLSTATE after each command. We echo a per-arm-unique marker
+# followed by that variable, so each arm's outcome is read from its OWN marker
+# (the session out file accumulates every arm). '00000' is success.
+ss_of() {  # session marker -> the 5-char SQLSTATE of that arm's last command
+	grep -oE "$2 [0-9A-Z]{5}" "$WORKDIR/$1.out" | tail -1 | sed "s/^$2 //"
+}
+
+ctl_q "CREATE EXTENSION pgcolumnar;" >/dev/null
+ctl_q "CREATE TABLE t_heap (id int, v int);" >/dev/null
+ctl_q "CREATE TABLE t_col  (id int, v int) USING pgcolumnar;" >/dev/null
+
+seed1() { ctl_q "TRUNCATE $1;" >/dev/null; ctl_q "INSERT INTO $1 VALUES (1,0);" >/dev/null; }
+seedN() { ctl_q "TRUNCATE $1;" >/dev/null; ctl_q "INSERT INTO $1 SELECT g,0 FROM generate_series(1,$2) g;" >/dev/null; }
+cnt()  { ctl_q "SELECT count(*) FROM $1 WHERE id=1;"; }
+vals() { ctl_q "SELECT coalesce(string_agg(v::text, ',' ORDER BY v),'') FROM $1 WHERE id=1;"; }
+
+start_session s1
+start_session s2
+send s1 "SET application_name='cc_s1';"
+send s2 "SET application_name='cc_s2';"
+
+# ---------------------------------------------------------------------------
+# uu <tbl> <iso> <marker> : update-vs-update. s1 sets v=10, s2 sets v=20, both
+# on id=1 under isolation <iso>, forced to overlap. Distinct constants (10/20,
+# never v+1) keep count, value-set and SQLSTATE from coinciding across the
+# duplicated and the composed states. Leaves RES_CNT/RES_VALS/RES_SS set.
+# ---------------------------------------------------------------------------
+uu() {  # tbl iso marker
+	local tbl="$1" iso="$2" m="$3"
+	seed1 "$tbl"
+	send_wait s1 "${m}b1" "BEGIN ISOLATION LEVEL $iso;"
+	send_wait s2 "${m}b2" "BEGIN ISOLATION LEVEL $iso;"
+	send_wait s1 "${m}u1" "UPDATE $tbl SET v=10 WHERE id=1;"
+	send s2 "UPDATE $tbl SET v=20 WHERE id=1;"
+	send s2 "\\echo ${m}SS :SQLSTATE"
+	send s2 "\\echo <<${m}u2>>"
+	wait_blocked cc_s2 || true
+	send_wait s1 "${m}c1" "COMMIT;"
+	wait_sentinel s2 "${m}u2"
+	send_wait s2 "${m}c2" "COMMIT;"
+	RES_CNT="$(cnt "$tbl")"; RES_VALS="$(vals "$tbl")"; RES_SS="$(ss_of s2 "${m}SS")"
+}
+
+echo; echo "### update-vs-update, READ COMMITTED"
+uu t_heap "READ COMMITTED" uurc_h; H_CNT=$RES_CNT; H_VALS=$RES_VALS; H_SS=$RES_SS
+uu t_col  "READ COMMITTED" uurc_c; C_CNT=$RES_CNT; C_VALS=$RES_VALS; C_SS=$RES_SS
+echo "-- heap: count=$H_CNT vals={$H_VALS} sqlstate=$H_SS ; col: count=$C_CNT vals={$C_VALS} sqlstate=$C_SS"
+check "uu/RC heap oracle composes both updates (one row)" "$H_CNT" "1"
+check "uu/RC columnar keeps a single row (no duplicate)"  "$C_CNT" "1"
+check "uu/RC columnar loser gets serialization_failure"  "$C_SS"  "40001"
+# RC value is intentionally NOT compared to heap: the minimal fix makes the loser
+# retry (col ends {10}) where a heap re-applies transparently (heap ends {20}).
+
+echo; echo "### update-vs-update, REPEATABLE READ"
+uu t_heap "REPEATABLE READ" uurr_h; H_CNT=$RES_CNT; H_VALS=$RES_VALS; H_SS=$RES_SS
+uu t_col  "REPEATABLE READ" uurr_c; C_CNT=$RES_CNT; C_VALS=$RES_VALS; C_SS=$RES_SS
+echo "-- heap: count=$H_CNT vals={$H_VALS} sqlstate=$H_SS ; col: count=$C_CNT vals={$C_VALS} sqlstate=$C_SS"
+check "uu/RR heap oracle: loser serialization_failure"   "$H_SS"  "40001"
+check "uu/RR columnar count matches heap oracle"         "$C_CNT" "$H_CNT"
+check "uu/RR columnar value-set matches heap oracle"     "$C_VALS" "$H_VALS"
+check "uu/RR columnar loser gets serialization_failure"  "$C_SS"  "40001"
+
+echo; echo "### update-vs-update, SERIALIZABLE"
+uu t_heap "SERIALIZABLE" uus_h; H_CNT=$RES_CNT; H_VALS=$RES_VALS; H_SS=$RES_SS
+uu t_col  "SERIALIZABLE" uus_c; C_CNT=$RES_CNT; C_VALS=$RES_VALS; C_SS=$RES_SS
+echo "-- heap: count=$H_CNT vals={$H_VALS} sqlstate=$H_SS ; col: count=$C_CNT vals={$C_VALS} sqlstate=$C_SS"
+check "uu/SER columnar count matches heap oracle"        "$C_CNT" "$H_CNT"
+check "uu/SER columnar loser gets serialization_failure" "$C_SS"  "40001"
+
+# ---------------------------------------------------------------------------
+# update-vs-delete, RC: s1 UPDATEs id=1, s2 DELETEs id=1. A heap deletes the live
+# (updated) version -> count(id=1)=0. Columnar today: s2 sees the pre-update row,
+# marks it deleted (idempotent), s1's new appended version survives -> count=1,
+# the DELETE is lost. Post-fix the loser gets 40001. The distinguishing signal at
+# RC is the SQLSTATE (count stays 1 whether the delete is lost or the loser
+# aborts), so the crisp assertion is on SQLSTATE.
+# ---------------------------------------------------------------------------
+ud() {  # tbl marker
+	local tbl="$1" m="$2"
+	seed1 "$tbl"
+	send_wait s1 "${m}b1" "BEGIN ISOLATION LEVEL READ COMMITTED;"
+	send_wait s2 "${m}b2" "BEGIN ISOLATION LEVEL READ COMMITTED;"
+	send_wait s1 "${m}u1" "UPDATE $tbl SET v=10 WHERE id=1;"
+	send s2 "DELETE FROM $tbl WHERE id=1;"
+	send s2 "\\echo ${m}SS :SQLSTATE"
+	send s2 "\\echo <<${m}d2>>"
+	wait_blocked cc_s2 || true
+	send_wait s1 "${m}c1" "COMMIT;"
+	wait_sentinel s2 "${m}d2"
+	send_wait s2 "${m}c2" "COMMIT;"
+	RES_CNT="$(cnt "$tbl")"; RES_SS="$(ss_of s2 "${m}SS")"
+}
+echo; echo "### update-vs-delete, READ COMMITTED"
+ud t_heap udrc_h; H_CNT=$RES_CNT; H_SS=$RES_SS
+ud t_col  udrc_c; C_CNT=$RES_CNT; C_SS=$RES_SS
+echo "-- heap: count=$H_CNT sqlstate=$H_SS ; col: count=$C_CNT sqlstate=$C_SS"
+check "ud/RC heap oracle: delete applies to the live row (count 0)" "$H_CNT" "0"
+check "ud/RC columnar loser gets serialization_failure"             "$C_SS"  "40001"
+
+# ---------------------------------------------------------------------------
+# delete-vs-update, RC: s1 DELETEs id=1, s2 UPDATEs id=1. Heap: the row is gone,
+# s2 updates nothing -> count 0. Columnar today: s2 re-inserts a successor to a
+# row s1 committed-deleted -> count 1, a committed DELETE silently undone. Here
+# the fix ALSO restores final-state equality: the loser aborts (40001), the delete
+# stays, count 0 == heap. So both count and SQLSTATE are asserted.
+# ---------------------------------------------------------------------------
+du() {  # tbl marker
+	local tbl="$1" m="$2"
+	seed1 "$tbl"
+	send_wait s1 "${m}b1" "BEGIN ISOLATION LEVEL READ COMMITTED;"
+	send_wait s2 "${m}b2" "BEGIN ISOLATION LEVEL READ COMMITTED;"
+	send_wait s1 "${m}d1" "DELETE FROM $tbl WHERE id=1;"
+	send s2 "UPDATE $tbl SET v=20 WHERE id=1;"
+	send s2 "\\echo ${m}SS :SQLSTATE"
+	send s2 "\\echo <<${m}u2>>"
+	wait_blocked cc_s2 || true
+	send_wait s1 "${m}c1" "COMMIT;"
+	wait_sentinel s2 "${m}u2"
+	send_wait s2 "${m}c2" "COMMIT;"
+	RES_CNT="$(cnt "$tbl")"; RES_SS="$(ss_of s2 "${m}SS")"
+}
+echo; echo "### delete-vs-update, READ COMMITTED"
+du t_heap durc_h; H_CNT=$RES_CNT; H_SS=$RES_SS
+du t_col  durc_c; C_CNT=$RES_CNT; C_SS=$RES_SS
+echo "-- heap: count=$H_CNT sqlstate=$H_SS ; col: count=$C_CNT sqlstate=$C_SS"
+check "du/RC heap oracle: committed delete stands (count 0)" "$H_CNT" "0"
+check "du/RC columnar count matches heap oracle"             "$C_CNT" "$H_CNT"
+check "du/RC columnar loser gets serialization_failure"      "$C_SS"  "40001"
+
+# ---------------------------------------------------------------------------
+# self-update in ONE statement (no concurrency, fully deterministic): UPDATE .. FROM
+# (VALUES(1),(1)) matches id=1 twice. A heap raises "tuple to be updated was
+# already modified by an operation triggered by the current command" and leaves
+# one row. Columnar today applies both -> two rows. Post-fix the AM returns
+# TM_SelfModified and core raises the same error. The crisp RED is the row count.
+# ---------------------------------------------------------------------------
+self_update() {  # tbl
+	local tbl="$1"
+	seed1 "$tbl"
+	ctl_q "UPDATE $tbl t SET v=v+1 FROM (VALUES (1),(1)) s(id) WHERE t.id=s.id;" >/dev/null 2>&1 || true
+	echo "$(cnt "$tbl")"
+}
+echo; echo "### self-update in one statement"
+H_CNT="$(self_update t_heap)"; C_CNT="$(self_update t_col)"
+echo "-- heap: count=$H_CNT ; col: count=$C_CNT"
+check "self-update heap oracle keeps one row" "$H_CNT" "1"
+check "self-update columnar keeps one row (no self-duplicate)" "$C_CNT" "1"
+
+# ---------------------------------------------------------------------------
+# multi-row overlapping ranges, RC: s1 updates id 1..120, s2 updates id 80..200
+# (overlap 80..120 = 41 rows). Heap total stays 200. Columnar today appends 41
+# duplicates -> 241. Post-fix the loser aborts (40001), leaving 200. Both the
+# total row count and the SQLSTATE are asserted.
+# ---------------------------------------------------------------------------
+multirow() {  # tbl marker
+	local tbl="$1" m="$2"
+	seedN "$tbl" 200
+	send_wait s1 "${m}b1" "BEGIN ISOLATION LEVEL READ COMMITTED;"
+	send_wait s2 "${m}b2" "BEGIN ISOLATION LEVEL READ COMMITTED;"
+	send_wait s1 "${m}u1" "UPDATE $tbl SET v=v+1 WHERE id BETWEEN 1 AND 120;"
+	send s2 "UPDATE $tbl SET v=v+1 WHERE id BETWEEN 80 AND 200;"
+	send s2 "\\echo ${m}SS :SQLSTATE"
+	send s2 "\\echo <<${m}u2>>"
+	wait_blocked cc_s2 || true
+	send_wait s1 "${m}c1" "COMMIT;"
+	wait_sentinel s2 "${m}u2"
+	send_wait s2 "${m}c2" "COMMIT;"
+	RES_TOT="$(ctl_q "SELECT count(*) FROM $tbl;")"; RES_SS="$(ss_of s2 "${m}SS")"
+}
+echo; echo "### multi-row overlapping updates, READ COMMITTED"
+multirow t_heap mrrc_h; H_TOT=$RES_TOT; H_SS=$RES_SS
+multirow t_col  mrrc_c; C_TOT=$RES_TOT; C_SS=$RES_SS
+echo "-- heap: total=$H_TOT sqlstate=$H_SS ; col: total=$C_TOT sqlstate=$C_SS"
+check "multirow heap oracle total unchanged (200)" "$H_TOT" "200"
+check "multirow columnar total matches heap (no per-row duplicates)" "$C_TOT" "$H_TOT"
+check "multirow columnar loser gets serialization_failure" "$C_SS" "40001"
+
+# ---------------------------------------------------------------------------
+# CONTROL (removal proof): the SAME two columnar updates run NON-overlapping in
+# time -- s1 commits fully before s2 begins. No barrier. This MUST stay a single
+# row on today's code, proving the columnar update mechanism is itself correct and
+# the RED above is caused specifically by the forced overlap. If this showed 2 the
+# suite would be measuring an always-broken update, not a concurrency bug.
+# ---------------------------------------------------------------------------
+echo; echo "### CONTROL: serial (non-overlapping) columnar updates"
+seed1 t_col
+send_wait s1 ser_b1 "BEGIN;"; send_wait s1 ser_u1 "UPDATE t_col SET v=10 WHERE id=1;"; send_wait s1 ser_c1 "COMMIT;"
+send_wait s2 ser_b2 "BEGIN;"; send_wait s2 ser_u2 "UPDATE t_col SET v=20 WHERE id=1;"; send_wait s2 ser_c2 "COMMIT;"
+echo "-- col serial: count=$(cnt t_col) vals={$(vals t_col)}"
+check "CONTROL serial columnar keeps one row (GREEN today; proves the RED is the overlap)" "$(cnt t_col)" "1"
+check "CONTROL serial columnar keeps the last writer's value" "$(vals t_col)" "20"
+
+# ---------------------------------------------------------------------------
+# CHARACTERIZATION: a covering UNIQUE(id) index makes the shipped unique-key
+# advisory lock (columnar_unique.c) serialize the two NEW rows, so the loser gets
+# a unique_violation (23505) instead of duplicating -- but a heap COMPOSES with no
+# error. This documents why the primary RED fixture above has NO unique index (an
+# index would mask the lost update) and that the unique path is a partial
+# mitigation, not heap-transparent serialization. Stable before and after the fix.
+# ---------------------------------------------------------------------------
+echo; echo "### CHARACTERIZATION: covering UNIQUE(id) is only a partial mitigation"
+ctl_q "CREATE TABLE t_colu (id int, v int) USING pgcolumnar;" >/dev/null
+ctl_q "CREATE UNIQUE INDEX t_colu_uidx ON t_colu (id);" >/dev/null
+ctl_q "CREATE TABLE t_heapu (id int, v int);" >/dev/null
+ctl_q "CREATE UNIQUE INDEX t_heapu_uidx ON t_heapu (id);" >/dev/null
+uu t_heapu "READ COMMITTED" uxh_; H_CNT=$RES_CNT; H_SS=$RES_SS
+uu t_colu  "READ COMMITTED" uxc_; C_CNT=$RES_CNT; C_SS=$RES_SS
+echo "-- heap+uniq: count=$H_CNT sqlstate=$H_SS ; col+uniq: count=$C_CNT sqlstate=$C_SS"
+check "unique/RC heap composes with no error (sqlstate 00000)" "$H_SS" "00000"
+check "unique/RC columnar loser errors where heap composes (not transparent)" \
+	"$([ "$C_SS" != "00000" ] && echo errored)" "errored"
+
+send s1 "\\q"
+send s2 "\\q"
+
+echo
+if [ "$fail" = 0 ]; then
+	echo "UPDATE CONCURRENCY TEST PASSED"
+else
+	echo "UPDATE CONCURRENCY TEST FAILED"
+fi
+exit "$fail"


### PR DESCRIPTION
## Serialize concurrent same-row UPDATE/DELETE (issue #5, the UPDATE facet)

Closes the lost-update / row-duplication limitation documented in
`docs/limitations.md`, and opened for a contract decision in #683. The maintainer
call in #683 is the READ COMMITTED contract; this PR implements the minimal option
(Option A) that #683 recommended.

### The defect

A columnar UPDATE is delete-old plus insert-new and takes no lock on the row
identity; `pgcolumnar_tuple_lock` is unimplemented, so core never runs
EvalPlanQual. Two transactions updating the same row each kept their own new
version, so the row was duplicated and one update was lost. A DELETE racing an
UPDATE was lost the same way, and a self-join `UPDATE ... FROM` duplicated the row
with no concurrency at all.

### The fix

New module `src/columnar_row_lock.c` gives the write paths a row-identity guard,
modeled on the concurrent unique-key insert lock (`columnar_unique.c`) and the
issue #4 chunk-group lock. Before marking the old row deleted,
`pgcolumnar_tuple_update` and `pgcolumnar_tuple_delete`:

1. report a same-command self-modify (buffered-deleted row) as `TM_SelfModified`,
   so a self-join resolves as it does for a heap (this runs even with the GUC off);
2. take a transaction-scoped advisory lock on `(storage, row)`; a no-wait caller
   that would block gets `TM_BeingModified`;
3. re-read the row's liveness in the LATEST committed state (`GetLatestSnapshot`,
   not the caller snapshot, which `PgColumnarCatalogSnapshot` only copies) and, if a
   concurrent transaction committed a delete, raise a retryable
   `serialization_failure`.

The loser of a same-row race now gets one retryable `serialization_failure` at
every isolation level, matching a heap at REPEATABLE READ and what columnar already
gave at SERIALIZABLE. READ COMMITTED is intentionally stricter than a heap: the
loser retries rather than re-applying via EvalPlanQual. Transparent RC re-apply
would need a per-row version chain and an eager per-row catalog write, measured at a
permanent ~40% UPDATE penalty plus a new vacuum reaper; see #683. No on-disk, WAL,
or catalog format change here.

New GUCs: `pgcolumnar.enable_row_update_lock` (USERSET, default on) and
`pgcolumnar.row_lock_buckets` (POSTMASTER, default 1024, bounds held locks per
storage so a bulk UPDATE cannot exhaust the lock table).

### Proof (pg18a, assert)

- New suite `test/update_conc.sh` drives two psql sessions over FIFOs, forces the
  overlap with a `pg_stat_activity` lock-wait barrier (no sleeps), and diffs a
  columnar table against a heap oracle running the byte-identical interleaving. It
  is RED on `main` and GREEN with this fix across update/update (RC, RR, SER),
  update/delete, delete/update, self-update in one statement, and multi-row overlap.
  A serial non-overlapping control and a covering-unique-index contrast bound it.
- Removal proof: on the fixed binary, `enable_row_update_lock=off` brings the
  duplicate back (count 2), `on` keeps it fixed (count 1).
- No regression: `concurrent_diff`, `phase3`, `concurrency`, and `unique_conc` all
  pass with the fix, so disjoint concurrent DML, insert-then-update read-your-writes,
  savepoints, same-group deletes, and unique-key serialization are unaffected.
- `harness_selftest` is clean (suite registered, SUITES C-sorted, no lint).

Two behaviors were measured on the bench, not assumed: the second writer blocks on
the issue #4 chunk-group advisory lock (not a row lock), and SERIALIZABLE was
already safe on `main`, so the defect was scoped to READ COMMITTED and REPEATABLE
READ.

`update_conc` is registered in `run_all_versions.sh`; docs and CHANGELOG are updated
and the limitation is removed. Full-matrix (18 and 19, preflight on all five majors)
runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjdBLCRm7YmYai1FPgpsQn
