### PR TITLE
docs: audit pass for professionalism, how-tos, and currency

### DIFF
--- a/docs/administration.md
+++ b/docs/administration.md
@@ -11,11 +11,11 @@ tables. pgColumnar puts data in this order:
 
 - A **row group** is the unit of write. Each write transaction appends one or
   more row groups of up to `pgcolumnar.stripe_row_limit` rows.
-- In a row group, pgColumnar keeps each column as a chunk and compresses each
-  chunk separately. pgColumnar encodes the values of a chunk in **vectors**. A vector
-  holds a maximum of `pgcolumnar.chunk_group_row_limit` rows. The vector is the
-  unit of the encoding cascade. It is also the unit of minimum and maximum
-  skipping.
+- pgColumnar divides each row group into **chunk groups** of up to
+  `pgcolumnar.chunk_group_row_limit` rows. Within a chunk group each column is a
+  **chunk**, compressed on its own and encoded in fixed 1024-value **vectors**. A
+  zone map holds the minimum and maximum of each chunk group. A scan skips a whole
+  chunk group when its filter cannot match that range.
 - Each chunk records its minimum and maximum and an optional bloom filter, and a
   per-vector zone map records the finer minimum and maximum ranges.
 
@@ -43,8 +43,8 @@ data, rewrite the table with [`pgcolumnar.vacuum`](sql-reference.md#pgcolumnarva
 ## Row-group sizing
 
 `pgcolumnar.chunk_group_row_limit` (default 10000) sets how many rows share one
-minimum and maximum in a vector. Smaller vectors skip more precisely on selective
-range filters but hold less data per vector. `pgcolumnar.stripe_row_limit` (default
+minimum and maximum in a chunk group. Smaller chunk groups skip more precisely on
+selective range filters but hold less data per group. `pgcolumnar.stripe_row_limit` (default
 150000) sets the write unit. The defaults suit most workloads. Change them for a
 table with `pgcolumnar.set_options` when a specific access pattern
 calls for it, and measure the result.
@@ -305,7 +305,7 @@ A columnar table is an ordinary WAL-logged relation.
 - **Physical backup** (`pg_basebackup`, file-system snapshots) and **physical
   replication** include columnar tables and their WAL.
 - **Logical backup** (`pg_dump`) writes the table definition, including `USING
-  columnar`, and its data with `COPY`. Restore requires the `pgcolumnar` extension
+  pgcolumnar`, and its data with `COPY`. Restore requires the `pgcolumnar` extension
   installed and present in `shared_preload_libraries` on the target server.
 
 Install and preload the extension on any server that restores or replicates a

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -126,8 +126,8 @@ block.
 ## Make queries fast
 
 - **Project only the columns you need.** Column pruning decodes only the columns a
-  narrow `SELECT` names. `SELECT *` decodes everything. This is the largest and
-  cheapest single win on a wide table.
+  narrow `SELECT` names. `SELECT *` decodes everything. On a wide table this is
+  the single biggest reduction in decode cost.
 - **Late materialization is on by default** (`pgcolumnar.enable_late_materialization`).
   A row the filter rejects does not have its other columns built. Decode cost then
   scales with rows emitted. Leave it on.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,7 +20,7 @@ pgColumnar has two kinds of settings:
 | Setting | Type | Default | Description |
 | --- | --- | --- | --- |
 | `pgcolumnar.stripe_row_limit` | integer | `150000` | Maximum rows per row group. The row group is the unit of write and the granularity at which whole segments are appended. Range 1000 to INT_MAX. |
-| `pgcolumnar.chunk_group_row_limit` | integer | `10000` | Maximum rows per vector. The vector is the unit of encoding and of min/max skipping. Range 100 to INT_MAX. |
+| `pgcolumnar.chunk_group_row_limit` | integer | `10000` | Maximum rows per chunk group. The chunk group is the band a scan skips as a unit when a filter cannot match its minimum and maximum. Within a chunk group each column is encoded in fixed 1024-value vectors. Range 100 to INT_MAX. |
 | `pgcolumnar.encoding_sample_rows` | integer | `2048` | The number of rows that the writer samples to select the value encoding of a vector. The writer estimates each candidate on a sample of windows. The windows contain consecutive values and have an equal distance between them. Thus the sample shows the global shape and also the local runs. The writer then applies only the two best candidates to the full vector. A value of `0` applies each candidate to each vector. This is the behaviour of earlier versions. The writer changes a value below 128 to `0`, because a smaller sample cannot put the candidates in order. This setting changes the write speed. It can also change the compression ratio. It does not change correctness. |
 
 ### Compression
@@ -100,12 +100,14 @@ schemes and the credential model.
 | `pgcolumnar.objstore_buffered` | boolean | `on` | Coalesce remote Parquet reads to one request per column chunk instead of many small ranged reads. |
 | `pgcolumnar.objstore_part_size` | integer | `0` | Multipart part size in bytes for a remote export. `0` uses the module default of 8 MiB. Raise it for a fast link. Range 0 to INT_MAX. |
 
-### Concurrent unique inserts
+### Concurrent writes
 
 | Setting | Type | Default | Description |
 | --- | --- | --- | --- |
 | `pgcolumnar.enable_unique_insert_lock` | boolean | `on` | Serialize concurrent inserts of the same unique-index key with a transaction-scoped advisory lock, so overlapping same-key inserts conflict correctly. |
 | `pgcolumnar.unique_lock_buckets` | integer | `128` | Advisory-lock buckets per unique index. Bounds how many advisory locks a transaction holds per unique index. Equal keys always share a bucket; unrelated keys may share one, which only over-serializes. Range 1 to 1048576. Settable only at server start: the bucket is part of the lock tag, so backends that disagree on this value would not serialize against each other. |
+| `pgcolumnar.enable_row_update_lock` | boolean | `on` | Serialize a concurrent `UPDATE` or `DELETE` of the same row on the row identity, so the losing writer gets a retryable `serialization_failure` instead of duplicating the row and losing an update. Off restores the prior behavior. |
+| `pgcolumnar.row_lock_buckets` | integer | `1024` | Advisory-lock buckets per storage for same-row `UPDATE`/`DELETE` serialization. Bounds the row locks a transaction holds, so a bulk update cannot exhaust the lock table. Unrelated rows may share a bucket, which only over-serializes. Range 1 to 1048576. Settable only at server start: the bucket is part of the lock tag. |
 
 ### Internal settings
 

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -112,6 +112,65 @@ SELECT pgcolumnar.recluster('events', 'customer_id', 'amount');   -- online
 SELECT * FROM pgcolumnar.sort_status('events');
 ```
 
+## Skip more chunk groups on equality filters
+
+A bloom filter skips a chunk group when an equality filter names a value the group
+does not hold. It complements the minimum and maximum, which skip range filters
+only. Bloom filtering is on by default (`pgcolumnar.enable_bloom_filter`).
+
+```sql
+EXPLAIN (ANALYZE) SELECT * FROM events WHERE customer_id = 42;
+```
+
+**Tuning.** It works best on a clustered or sorted column, because equal values
+then sit in few chunk groups. Read `Columnar Chunk Groups Removed by Filter` to
+confirm the skip. A scattered high-cardinality column gains little. Turn the
+feature off with `SET pgcolumnar.enable_bloom_filter = off` to compare.
+
+## Add a projection for a second sort order
+
+A table has one physical sort order. A projection stores a column subset a second
+time under a different sort key, so a second access pattern also prunes well. The
+planner reads the projection instead of the base table when the projection covers
+every column the query needs and gives a lower cost.
+
+```sql
+SELECT pgcolumnar.add_projection(
+    'events', 'events_by_customer',
+    columns  => ARRAY['customer_id', 'amount', 'ts'],
+    sort_key => ARRAY['customer_id']);
+
+EXPLAIN SELECT sum(amount) FROM events WHERE customer_id = 42;
+```
+
+Adding a projection fills it from the existing rows. Later inserts write to the
+base table and to every projection, so each projection adds write cost. Drop one
+with `pgcolumnar.drop_projection('events', 'events_by_customer')`.
+
+**Tuning.** Add a projection only for a hot access pattern the base sort order
+serves poorly. Confirm the plan shows `Columnar Projection`. Keep the column list
+minimal, because a projection that misses one queried column is never used. See
+Projections in the administration guide for detail.
+
+## Add indexes and use index-only scans
+
+A columnar table supports B-tree and other index types. An index helps a highly
+selective point lookup that no chunk-group skip can serve. An index-only scan
+answers a query from the index alone when the chunk groups it reads are all
+visible.
+
+```sql
+CREATE INDEX ON events (order_id);
+VACUUM events;
+EXPLAIN (ANALYZE) SELECT order_id FROM events WHERE order_id = 9001;
+```
+
+**Tuning.** Keep `VACUUM` current, because any write clears the all-visible mark
+and forces a fetch from the row data. `pgcolumnar.enable_index_only_scan` and
+`pgcolumnar.enable_index_fetch_penalty` shape when the planner prefers an index
+over a scan. Prefer a sort key or a projection for a range query. Reserve an index
+for a selective point lookup.
+
 ## Reclaim space after deletes and updates
 
 A delete or update marks rows dead. Space returns when you compact.
@@ -310,12 +369,60 @@ transforms. It prunes `year`, `month`, `day`, and `hour` on a timestamp or
 timestamptz column, and `year`, `month`, and `day` on a date column. Metrics
 pruning covers integer and boolean columns by their stored minimum and maximum.
 Pruning never changes the rows returned. A predicate the wrapper cannot decide
-simply reads the file.
+reads the file and returns the same rows.
 
 **Tuning.** Filter on a partition column to remove whole files. Filter on an
 integer or boolean column to prune by metrics. Confirm the effect with
 `EXPLAIN (ANALYZE)`, which reports `Files Pruned`. A predicate on an unsupported
 type still returns correct rows, only without the pruning.
+
+## Tune concurrent writes
+
+pgColumnar serializes two conflicting writes so neither is lost. A concurrent
+insert of the same unique key, and a concurrent `UPDATE` or `DELETE` of the same
+row, each take a transaction-scoped advisory lock. The losing writer gets a
+retryable error, which the application repeats.
+
+```conf
+# postgresql.conf (both bucket counts are read at server start only)
+pgcolumnar.row_lock_buckets = 4096
+pgcolumnar.unique_lock_buckets = 512
+```
+
+**Tuning.** `pgcolumnar.enable_row_update_lock` and
+`pgcolumnar.enable_unique_insert_lock` are on by default and should stay on for
+correctness. Raise `row_lock_buckets` or `unique_lock_buckets` for a workload with
+many concurrent single-row writes, so fewer unrelated rows share a bucket. Retry a
+`serialization_failure` (SQLSTATE 40001) in the application. See Concurrency in the
+limitations guide.
+
+## Vectorize a GROUP BY aggregate
+
+The vectorized aggregate path computes an ungrouped aggregate over decoded
+vectors. An opt-in setting extends it to `GROUP BY`.
+
+```sql
+SET pgcolumnar.enable_group_vectorization = on;
+EXPLAIN (ANALYZE) SELECT region, sum(amount) FROM events GROUP BY region;
+```
+
+**Tuning.** Turn it on for a `GROUP BY` with a bounded number of distinct groups.
+The plan then shows `Columnar Vectorized Group Keys`. A query that exceeds
+`pgcolumnar.groupagg_max_groups` (default 1000000) raises an error, so leave the
+setting off for high-cardinality grouping.
+
+## Count rows quickly
+
+An unfiltered `count(*)` reads the per-chunk-group row counts from metadata and
+decodes no column data.
+
+```sql
+EXPLAIN (ANALYZE) SELECT count(*) FROM events;
+```
+
+**Tuning.** A filter, or a table with deleted rows, forces a fold over the
+surviving rows and decodes the filtered columns. Keep the filter on a sorted or
+bloomed column so chunk-group skipping removes most groups first.
 
 ## Measure and introspect
 
@@ -334,3 +441,19 @@ EXPLAIN (ANALYZE) SELECT sum(amount) FROM events WHERE region = 'eu';
 **Tuning.** Read `Columnar Chunk Groups Removed by Filter` to confirm a filter
 skips data. A low removal count on a selective filter means the sort key does not
 match the query. Re-sort on the filtered column, then check the count again.
+
+## Benchmark your own workload
+
+Reference numbers live in the benchmarks guide. Measure your own tables the same
+way.
+
+```sql
+\timing on
+EXPLAIN (ANALYZE, BUFFERS) SELECT sum(amount) FROM events WHERE region = 'eu';
+```
+
+**Tuning.** Warm the cache with one run and time the next. Read the `Columnar`
+counters in the plan to confirm the query took the path you measure, on both the
+columnar table and any row-store baseline. Compare a columnar table against a heap
+table of the same rows, not against a different query. Load enough rows to fill the
+row groups, because a small table hides the skipping and decode effects.

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,9 +64,9 @@ figures below are theirs.
 | table size | 2604 MB | 2051 MB | 1.27x smaller |
 | narrow `GROUP BY` aggregate | 266 ms | 115 ms | **2.3x faster** |
 
-Read the last two rows with the others. Columnar storage still wins the narrow
-aggregate, which is what it is for. It wins little on size, because only about a
-quarter of the bytes are the kind that compress. Every row-wise operation loses.
+Read the last two rows with the others. Columnar storage still favors the narrow
+aggregate, its intended case. It gains little on size, because only about a
+quarter of the bytes are the kind that compress. Every row-wise operation is slower.
 
 Use heap when most of your bytes are one large value per row. Use heap when point
 lookups are the main access pattern. Use pgColumnar when queries read a few

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -708,3 +708,22 @@ correct rows; these are the conditions under which it can skip at all:
 
 The `Row Groups Skipped` counter in `EXPLAIN ANALYZE` reports what was actually
 skipped.
+
+## Reading Apache Iceberg
+
+The Iceberg read surface (`iceberg_scan`, `iceberg_data_files`, the
+`pgcolumnar_iceberg` foreign-data wrapper, and the REST catalog client) reads a
+table at its current snapshot. It has these limits:
+
+- The metadata, manifests, and manifest lists are written by whoever authored the
+  table. They are input without trust, parsed by code this project wrote. An
+  honest caller names only the trusted `metadata.json`. Refer to Security in the
+  administration guide for the trust boundary.
+- The reader refuses malformed or hostile metadata rather than crashing or
+  returning wrong rows. It rejects a non-regular file, such as a FIFO, named as a
+  path. It also rejects a null manifest sequence number, a null or negative
+  position-delete position, and a `current-schema-id` that names no schema.
+- Reads apply position deletes, equality deletes, and format-version-3 deletion
+  vectors. The data files must be Parquet.
+- The reader does not write or commit to an Iceberg table, and it reads only the
+  current snapshot. Time travel to an older snapshot is not supported.

--- a/docs/sql-reference.md
+++ b/docs/sql-reference.md
@@ -680,10 +680,9 @@ to a new directory therefore still reads. A recorded path that points outside
 the table location is refused, not read.
 
 Delete files are refused, not ignored. A snapshot that carries any delete
-manifest or delete entry raises an error. It does not return rows the table says
-are gone. Reading Iceberg tables that use deletes is a later step (#388
-phase 4). This lists data files from the manifests; opening each Parquet file
-and projecting its columns by field id is the following step (#388 phase 3c).
+manifest or delete entry raises an error here. It does not return rows the table
+says are gone. To read a table that uses deletes, use `iceberg_scan`, which
+applies position, equality, and deletion-vector deletes.
 
 ```sql
 SELECT file_path, record_count, partition

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -18,8 +18,9 @@ CREATE TABLE events (
 ) USING pgcolumnar;
 ```
 
-The table behaves like any PostgreSQL table for SQL purposes. It supports
-transactions, constraints, indexes, `COPY`, and `pg_dump`.
+The table behaves like an ordinary PostgreSQL table for most SQL. It supports
+transactions, constraints, indexes, `COPY`, and `pg_dump`. See
+[Limitations](limitations.md) for the exceptions.
 
 ## Convert an existing table
 


### PR DESCRIPTION
Audit of the user-facing docs against all recently merged work, done in three read-only passes and then fixed. `docs_style.sh` passes.

## Professionalism / correctness
- **`administration.md` factual fix**: `USING columnar` → `USING pgcolumnar` (the token as written would fail on a stock install).
- **Terminology contradiction resolved**: a *vector* is the fixed 1024-value encode unit (`COLUMNAR_NATIVE_VECTOR_LENGTH`); the *chunk group* (`chunk_group_row_limit`, default 10000) is the skip unit. `configuration.md` and `administration.md` were calling the chunk group a "vector" and attaching the 10000-row limit to it, contradicting `features.md`/`benchmarks.md`. Aligned both to the correct model.
- **Overstatement qualified**: `user-guide.md` "behaves like any PostgreSQL table" now says "most SQL" and links Limitations (which documents the `FOR UPDATE`, FK-referenced-side, `ON CONFLICT DO UPDATE`, `UNLOGGED` exceptions).
- Neutralized editorializing prose in `index.md` ("wins/loses"), `best-practices.md` ("largest and cheapest win"), `how-to.md` ("simply reads the file").

## Currency (docs updated for all merged work)
- **`configuration.md`**: added the two shipped concurrency GUCs `pgcolumnar.enable_row_update_lock` (on) and `pgcolumnar.row_lock_buckets` (1024) from issue #5 — their siblings were listed but these were missing.
- **`sql-reference.md`**: replaced stale "later step (#388 phase 4/3c)" prose on `iceberg_data_files` with a cross-reference to `iceberg_scan` (both steps shipped).
- **`limitations.md`**: added a *Reading Apache Iceberg* section (there was none), covering the #644 read-path hardening (malformed/hostile metadata refused, not crashed) and the read-only / current-snapshot non-goals.
- Verified current and left as-is: #656 REST catalog credentials (CREATE SERVER + USER MAPPING, OAuth2, vended creds), #388 Iceberg read (signatures match the SQL), #394 object-storage export writes.

## How-to coverage (the user asked for a guide per feature, incl. optimization)
Added seven task recipes to `how-to.md`, each with a Tuning note and verified EXPLAIN counters: bloom-filter equality skipping, projections (`add_projection`), indexes and index-only scans, tuning concurrent writes (the lock GUCs), GROUP BY vectorization, fast `count(*)`, and benchmarking your own workload. These were the gaps a coverage audit found against the shipping function/GUC set.

Every GUC name, default, function signature, and EXPLAIN label in the additions was checked against `src/` and `pgcolumnar--1.0-alpha.sql`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
