### PR TITLE
feat: Iceberg REST catalog warehouse server option (#656)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ which was true until that script existed.
 
 ## [Unreleased]
 
+### Added
+
+- The Iceberg REST catalog `FOREIGN SERVER` now accepts a `warehouse` option
+  alongside `catalog_uri`. It selects a warehouse on a multi-warehouse catalog
+  and is sent as the `?warehouse=` query parameter on the `GET /v1/config`
+  request. This completes the per-catalog credential model (issue #656).
+  Regression test: iceberg_rest_server.
+
 ### Fixed
 
 - The Iceberg read path now refuses four classes of malformed or hostile table

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -325,11 +325,12 @@ SELECT * FROM pgcolumnar.iceberg_rest_tables('https://catalog.example.com', 'ana
 
 For per-role credentials, name a foreign server instead of a URI. The server
 holds the catalog URI. The current role's user mapping holds the bearer token,
-kept in `pg_user_mapping` where it is not world-readable.
+kept in `pg_user_mapping` where it is not world-readable. On a multi-warehouse
+catalog, add a `warehouse` server option; it is sent on the config request.
 
 ```sql
 CREATE SERVER cat FOREIGN DATA WRAPPER pgcolumnar_iceberg_catalog
-  OPTIONS (catalog_uri 'https://catalog.example.com');
+  OPTIONS (catalog_uri 'https://catalog.example.com', warehouse 'analytics_wh');
 CREATE USER MAPPING FOR analyst SERVER cat OPTIONS (token 's3cr3t');
 
 SELECT * FROM pgcolumnar.iceberg_rest_scan('cat', 'analytics', 'events')

--- a/docs/sql-reference.md
+++ b/docs/sql-reference.md
@@ -832,8 +832,10 @@ SELECT count(*) FROM pgcolumnar.iceberg_scan(
 ```
 
 The `pgcolumnar_iceberg_catalog` wrapper has a validator but no handler, so its
-servers cannot be selected from as tables. It accepts only `catalog_uri` on a
-server. On a user mapping it accepts `token`, the OAuth2 options
+servers cannot be selected from as tables. It accepts `catalog_uri` and an
+optional `warehouse` on a server. The `warehouse` selects a warehouse on a
+multi-warehouse catalog and is sent as the `?warehouse=` parameter on the
+`GET /v1/config` request. On a user mapping it accepts `token`, the OAuth2 options
 (`oauth_client_id`, `oauth_client_secret`, `oauth_scope`, `oauth_token_uri`), and
 `credentials_required`. A secret on a server, where options are world-readable,
 is rejected. Setting `credentials_required 'false'` is restricted to a superuser.

--- a/src/columnar_iceberg_rest.c
+++ b/src/columnar_iceberg_rest.c
@@ -14,7 +14,8 @@
  * ENVIRONMENT (PGCOLUMNAR_ICEBERG_REST_TOKEN), never a SQL argument: a token in
  * a function argument would land in pg_stat_activity and the statement log. The
  * per-catalog FOREIGN SERVER + USER MAPPING credential model, vended storage
- * credentials, and OAuth2 token exchange are tracked as #656.
+ * credentials, OAuth2 token exchange, and the warehouse server option are
+ * implemented (issue #656); secrets live only on the USER MAPPING.
  *
  * See design/ISSUE_388_PHASE7_REST_CATALOG.md.
  *-------------------------------------------------------------------------
@@ -110,11 +111,13 @@ static char *rest_oauth_token(const char *catalog_uri, const char *token_uri,
 							  const char *scope);
 
 static void
-rest_resolve_server(const char *name, char **out_uri, char **out_token)
+rest_resolve_server(const char *name, char **out_uri, char **out_token,
+					char **out_warehouse)
 {
 	ForeignServer *srv = GetForeignServerByName(name, false);
 	ListCell   *lc;
 	char	   *uri = NULL;
+	char	   *warehouse = NULL;
 	char	   *token = NULL;
 	char	   *oauthId = NULL;
 	char	   *oauthSecret = NULL;
@@ -129,6 +132,8 @@ rest_resolve_server(const char *name, char **out_uri, char **out_token)
 
 		if (strcmp(d->defname, "catalog_uri") == 0)
 			uri = defGetString(d);
+		else if (strcmp(d->defname, "warehouse") == 0)
+			warehouse = defGetString(d);
 	}
 	if (uri == NULL)
 		ereport(ERROR,
@@ -212,6 +217,8 @@ rest_resolve_server(const char *name, char **out_uri, char **out_token)
 
 	*out_uri = pstrdup(uri);
 	*out_token = token;
+	if (out_warehouse != NULL)
+		*out_warehouse = (warehouse != NULL) ? pstrdup(warehouse) : NULL;
 }
 
 /*
@@ -221,7 +228,8 @@ rest_resolve_server(const char *name, char **out_uri, char **out_token)
  * URL, so the two are unambiguous.
  */
 static void
-rest_resolve(const char *arg0, char **out_uri, char **out_token)
+rest_resolve(const char *arg0, char **out_uri, char **out_token,
+			 char **out_warehouse)
 {
 	if (pg_strncasecmp(arg0, "http://", 7) == 0 ||
 		pg_strncasecmp(arg0, "https://", 8) == 0)
@@ -230,9 +238,11 @@ rest_resolve(const char *arg0, char **out_uri, char **out_token)
 
 		*out_uri = pstrdup(arg0);
 		*out_token = (env != NULL && env[0] != '\0') ? pstrdup(env) : NULL;
+		if (out_warehouse != NULL)
+			*out_warehouse = NULL;	/* a bare URI carries no warehouse */
 	}
 	else
-		rest_resolve_server(arg0, out_uri, out_token);
+		rest_resolve_server(arg0, out_uri, out_token, out_warehouse);
 }
 
 /* Append `s` percent-encoded (RFC 3986 unreserved kept), for one path segment. */
@@ -479,12 +489,13 @@ rest_oauth_token(const char *catalog_uri, const char *token_uri,
  */
 static Jsonb *
 rest_load_table_doc(const char *catalog_uri, const char *ns, const char *table,
-					const char *token, char **out_location)
+					const char *token, const char *warehouse, char **out_location)
 {
 	Jsonb	   *cfg;
 	char	   *prefix;
 	Jsonb	   *lt;
 	StringInfoData rp;
+	StringInfoData cfgpath;
 
 	if (pg_strncasecmp(catalog_uri, "http://", 7) != 0 &&
 		pg_strncasecmp(catalog_uri, "https://", 8) != 0)
@@ -492,8 +503,17 @@ rest_load_table_doc(const char *catalog_uri, const char *ns, const char *table,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("iceberg: a REST catalog URI must be http:// or https://")));
 
-	/* config: {overrides, defaults}; a prefix, if any, is spliced after /v1/ */
-	cfg = rest_get_json(catalog_uri, "/v1/config", "config", token);
+	/* config: {overrides, defaults}; a prefix, if any, is spliced after /v1/.
+	 * A warehouse option selects a warehouse on a multi-warehouse catalog and is
+	 * sent as the ?warehouse= query parameter (Iceberg REST spec). */
+	initStringInfo(&cfgpath);
+	appendStringInfoString(&cfgpath, "/v1/config");
+	if (warehouse != NULL && warehouse[0] != '\0')
+	{
+		appendStringInfoString(&cfgpath, "?warehouse=");
+		rest_pct_encode(&cfgpath, warehouse);
+	}
+	cfg = rest_get_json(catalog_uri, cfgpath.data, "config", token);
 	/*
 	 * The config body is untrusted (a compromised or hostile allow-listed
 	 * catalog). getKeyJsonValueFromContainer Asserts object-ness before its
@@ -627,11 +647,11 @@ rest_vended_cfg(JsonbContainer *lt, const char *metadata_location)
 char *
 PgColumnarIcebergRestLoadTableLocation(const char *catalog_uri,
 									   const char *ns, const char *table,
-									   const char *token)
+									   const char *token, const char *warehouse)
 {
 	char	   *loc;
 
-	(void) rest_load_table_doc(catalog_uri, ns, table, token, &loc);
+	(void) rest_load_table_doc(catalog_uri, ns, table, token, warehouse, &loc);
 	return loc;
 }
 
@@ -650,6 +670,7 @@ pgcolumnar_iceberg_rest_table_location(PG_FUNCTION_ARGS)
 	char	   *table = text_to_cstring(PG_GETARG_TEXT_PP(2));
 	char	   *catalog_uri;
 	char	   *token;
+	char	   *warehouse;
 	char	   *loc;
 
 	if (!has_privs_of_role(GetUserId(), ROLE_PG_READ_SERVER_FILES))
@@ -657,8 +678,9 @@ pgcolumnar_iceberg_rest_table_location(PG_FUNCTION_ARGS)
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 				 errmsg("must be superuser or a member of the pg_read_server_files role to read a REST catalog")));
 
-	rest_resolve(arg0, &catalog_uri, &token);
-	loc = PgColumnarIcebergRestLoadTableLocation(catalog_uri, ns, table, token);
+	rest_resolve(arg0, &catalog_uri, &token, &warehouse);
+	loc = PgColumnarIcebergRestLoadTableLocation(catalog_uri, ns, table, token,
+												 warehouse);
 	PG_RETURN_TEXT_P(cstring_to_text(loc));
 }
 
@@ -681,6 +703,7 @@ pgcolumnar_iceberg_rest_scan(PG_FUNCTION_ARGS)
 	TupleDesc	tupdesc;
 	char	   *catalog_uri;
 	char	   *token;
+	char	   *warehouse;
 	Jsonb	   *lt;
 	char	   *loc;
 	PgColumnarObjStoreConfig *cfg;
@@ -700,9 +723,9 @@ pgcolumnar_iceberg_rest_scan(PG_FUNCTION_ARGS)
 				 errmsg("pgcolumnar.iceberg_rest_scan requires a column definition list"),
 				 errhint("Call it as SELECT * FROM pgcolumnar.iceberg_rest_scan(uri, ns, tbl) AS t(col1 type1, ...).")));
 
-	rest_resolve(arg0, &catalog_uri, &token);
+	rest_resolve(arg0, &catalog_uri, &token, &warehouse);
 	/* one loadTable: the metadata-location AND the vended storage creds (if any) */
-	lt = rest_load_table_doc(catalog_uri, ns, table, token, &loc);
+	lt = rest_load_table_doc(catalog_uri, ns, table, token, warehouse, &loc);
 	cfg = rest_vended_cfg(&lt->root, loc);
 	/*
 	 * A metadata-location is a URI. The reader's remote path handles s3:// and
@@ -742,7 +765,7 @@ pgcolumnar_iceberg_rest_namespaces(PG_FUNCTION_ARGS)
 				 errmsg("must be superuser or a member of the pg_read_server_files role to read a REST catalog")));
 	ts = rest_text_srf_setup(rsinfo, &td);
 
-	rest_resolve(arg0, &catalog_uri, &token);
+	rest_resolve(arg0, &catalog_uri, &token, NULL);
 	doc = rest_get_json(catalog_uri, "/v1/namespaces", "namespaces", token);
 	if (!JsonContainerIsObject(&doc->root))
 		ereport(ERROR,
@@ -815,7 +838,7 @@ pgcolumnar_iceberg_rest_tables(PG_FUNCTION_ARGS)
 				 errmsg("must be superuser or a member of the pg_read_server_files role to read a REST catalog")));
 	ts = rest_text_srf_setup(rsinfo, &td);
 
-	rest_resolve(arg0, &catalog_uri, &token);
+	rest_resolve(arg0, &catalog_uri, &token, NULL);
 	initStringInfo(&rp);
 	appendStringInfoString(&rp, "/v1/namespaces/");
 	rest_append_namespace(&rp, ns);
@@ -875,13 +898,16 @@ pgcolumnar_iceberg_catalog_validator(PG_FUNCTION_ARGS)
 
 		if (catalog == ForeignServerRelationId)
 		{
-			/* srvoptions is world-readable: only the non-secret URI belongs here */
-			if (strcmp(def->defname, "catalog_uri") != 0)
+			/* srvoptions is world-readable: only non-secret options belong here.
+			 * catalog_uri is the endpoint; warehouse selects a warehouse on a
+			 * multi-warehouse catalog and is sent on GET /v1/config. */
+			if (strcmp(def->defname, "catalog_uri") != 0 &&
+				strcmp(def->defname, "warehouse") != 0)
 				ereport(ERROR,
 						(errcode(ERRCODE_FDW_INVALID_OPTION_NAME),
 						 errmsg("invalid option \"%s\" for a pgcolumnar_iceberg_catalog server",
 								def->defname),
-						 errhint("Valid server option: catalog_uri. Secrets go on a USER MAPPING.")));
+						 errhint("Valid server options: catalog_uri, warehouse. Secrets go on a USER MAPPING.")));
 		}
 		else if (catalog == UserMappingRelationId)
 		{

--- a/src/columnar_iceberg_rest.h
+++ b/src/columnar_iceberg_rest.h
@@ -14,6 +14,7 @@
 extern char *PgColumnarIcebergRestLoadTableLocation(const char *catalog_uri,
 													const char *ns,
 													const char *table,
-													const char *token);
+													const char *token,
+													const char *warehouse);
 
 #endif							/* COLUMNAR_ICEBERG_REST_H */

--- a/test/iceberg_rest_server.py
+++ b/test/iceberg_rest_server.py
@@ -84,7 +84,9 @@ class Handler(BaseHTTPRequestHandler):
     def do_GET(self):
         parsed = urllib.parse.urlparse(self.path)
         path = parsed.path
-        self._logline("GET", path)
+        # log the full request target (path + any query) so a test can assert a
+        # query parameter such as ?warehouse=; routing still uses the bare path.
+        self._logline("GET", self.path)
 
         if not path.startswith("/v1/"):
             self._not_found("no such path")

--- a/test/iceberg_rest_server.sh
+++ b/test/iceberg_rest_server.sh
@@ -98,6 +98,21 @@ check "a catalog_uri option on the USER MAPPING is rejected (HV00D)" \
 	"$(sqlstate_of "ALTER USER MAPPING FOR postgres SERVER cat OPTIONS (ADD catalog_uri 'x')")" \
 	"HV00D"
 
+# ---- #656: a warehouse SERVER option is accepted and sent on GET /v1/config --
+# On current main the validator rejects any server option but catalog_uri, so
+# CREATE SERVER ... OPTIONS (warehouse ...) fails HV00D. It must be accepted and
+# forwarded to GET /v1/config as ?warehouse=, to select a warehouse on a
+# multi-warehouse catalog.
+check "a warehouse option on the SERVER is accepted (not HV00D)" \
+	"$(sqlstate_of "CREATE SERVER whcat FOREIGN DATA WRAPPER pgcolumnar_iceberg_catalog OPTIONS (catalog_uri '$CAT', warehouse 'wh1')")" \
+	""
+q "CREATE USER MAPPING FOR postgres SERVER whcat OPTIONS (token '$TOKEN')" >/dev/null
+check "a warehouse-configured server resolves a table location" \
+	"$(q "SELECT pgcolumnar.iceberg_rest_table_location('whcat','db','events')")" \
+	"$MDLOC"
+check "the warehouse was sent on GET /v1/config (?warehouse=wh1)" \
+	"$(grep -c 'GET /v1/config?warehouse=wh1 ' "$REST_LOG" 2>/dev/null)" "1"
+
 # ---- OAuth2 client-credentials: mint a bearer, then use it -------------------
 # A second fixture requires a client id/secret at POST /v1/oauth/tokens and, on a
 # match, mints OATOKEN -- which loadTable then requires. So a green read proves


### PR DESCRIPTION
Closes #656 — the last open item of the Iceberg REST catalog credential model: the `warehouse` `CREATE SERVER` option, which was not just missing but actively rejected by the validator.

## What it does
- The `pgcolumnar_iceberg_catalog` validator now accepts an optional `warehouse` server option alongside `catalog_uri` (secrets still only on the USER MAPPING; the errhint lists it).
- `warehouse` is resolved from the server options and sent as the `?warehouse=` query parameter on `GET /v1/config` (Iceberg REST spec), percent-encoded, so a multi-warehouse catalog returns the config and prefix for that warehouse. `iceberg_rest_scan` and `iceberg_rest_table_location` send it; the listing endpoints (which never call `/v1/config`) pass NULL. A bare `http(s)://` catalog URI carries no warehouse.

## TDD evidence
Three new arms in `iceberg_rest_server`, proven RED on unfixed source and GREEN after the fix:
- `a warehouse option on the SERVER is accepted (not HV00D)` — RED: `got [HV00D]` (validator rejects); GREEN: accepted.
- `a warehouse-configured server resolves a table location` — RED: `got []` (no such server); GREEN: the metadata location.
- `the warehouse was sent on GET /v1/config (?warehouse=wh1)` — RED: `got [0]`; GREEN: `1`. The mock REST server now logs the GET query string so the parameter can be asserted.

Neighbor REST suites pass unchanged (`iceberg_rest`, `iceberg_rest_scan`, `iceberg_rest_vended`) — the resolve/loadTable signature threading did not regress them.

With this merged, #656 has nothing left; the credential model (FOREIGN SERVER + USER MAPPING, OAuth2 client-credentials, vended storage credentials) was already shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
