### PR TITLE
fix: parallel_copy no longer hangs the backend on a FIFO path (#686)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ which was true until that script existed.
 
 ### Fixed
 
+- `pgcolumnar.parallel_copy` no longer hangs the backend when its path names a
+  FIFO. `pcopy_open_regular_file` opened the path `O_RDONLY` and then checked for
+  a regular file, but a FIFO blocks inside that `open(2)` and the block survives a
+  cancel or `statement_timeout`, a denial of service. It now opens with
+  `O_NONBLOCK`, rejects a non-regular file, then clears the flag, which also
+  closes the stat-before-open race. Regression test: parallel_copy (#686).
+
 - The Iceberg read path now refuses four classes of malformed or hostile table
   metadata that an adversarial re-audit (#644) found it mishandled. A non-regular
   file (for example a FIFO) named as a metadata, manifest, or data path is

--- a/src/columnar_parallel_copy.c
+++ b/src/columnar_parallel_copy.c
@@ -113,7 +113,16 @@ pcopy_open_regular_file(const char *path, off_t *size_out)
 	int			fd;
 	struct stat st;
 
-	fd = OpenTransientFile(path, O_RDONLY | PG_BINARY);
+	/*
+	 * Open with O_NONBLOCK so a FIFO open(2) returns immediately instead of
+	 * blocking until a writer appears. A blocking open on a FIFO is uninterruptible
+	 * across a cancel or statement_timeout (SA_RESTART), a denial of service. We
+	 * then fstat the fd we hold and reject anything that is not a regular file, so
+	 * there is no stat-before-open race: the file we checked is the file we opened.
+	 * A regular file has O_NONBLOCK cleared below; it is a no-op on regular reads,
+	 * but leaving it set on some platforms is untidy.
+	 */
+	fd = OpenTransientFile(path, O_RDONLY | O_NONBLOCK | PG_BINARY);
 	if (fd < 0)
 		ereport(ERROR,
 				(errcode_for_file_access(),
@@ -134,6 +143,20 @@ pcopy_open_regular_file(const char *path, off_t *size_out)
 		ereport(ERROR,
 				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
 				 errmsg("\"%s\" is not a regular file", path)));
+	}
+	{
+		int			flags = fcntl(fd, F_GETFL);
+
+		if (flags == -1 || fcntl(fd, F_SETFL, flags & ~O_NONBLOCK) == -1)
+		{
+			int			save_errno = errno;
+
+			CloseTransientFile(fd);
+			errno = save_errno;
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not clear nonblocking mode on file \"%s\": %m", path)));
+		}
 	}
 	if (size_out != NULL)
 		*size_out = st.st_size;

--- a/test/parallel_copy.sh
+++ b/test/parallel_copy.sh
@@ -433,4 +433,29 @@ check "single table: a bad row fails the whole load" \
 check "single table: failed load leaves the target empty" "$(q "SELECT count(*) FROM t_single")" 0
 check "single table: no prepared-transaction leak after failure" "$(q "SELECT count(*) FROM pg_prepared_xacts")" 0
 
+# --- #686: parallel_copy must refuse a FIFO, not hang the backend -------------
+# pcopy_open_regular_file opened O_RDONLY then fstat, so a FIFO blocked in open(2)
+# (cancel-resistant, its own S_ISREG check unreachable). It must open O_NONBLOCK,
+# reject the non-regular file (42809), and never block. RED (unguarded) is a
+# wall-clock HANG; GREEN is 42809.
+sqlstate_or_hang() {
+	local out rc
+	out="$(timeout -s KILL 5 env PATH="$PGC_BINDIR:$PATH" psql \
+		-h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" -qtA 2>&1 <<SQLEOF
+\\set VERBOSITY sqlstate
+$1;
+SQLEOF
+)"
+	rc=$?
+	if [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then echo HANG; return; fi
+	printf '%s\n' "$out" | sed -n 's/^ERROR:  \([0-9A-Z]\{5\}\).*/\1/p' | head -1
+}
+psql_run "DROP TABLE IF EXISTS t_fifo; CREATE TABLE t_fifo (id int, txt text) USING pgcolumnar;" >/dev/null
+PCFIFO="$PGC_WORKDIR/pc.fifo"; mkfifo "$PCFIFO"
+check "parallel_copy on a FIFO is refused, not a hang (42809)" \
+	"$(sqlstate_or_hang "SELECT pgcolumnar.parallel_copy('t_fifo'::regclass, '$PCFIFO', 2)")" \
+	"42809"
+exec 9<>"$PCFIFO" 2>/dev/null; exec 9>&- 2>/dev/null    # release any blocked opener
+check "backend still up after the parallel_copy FIFO refusal" "$(q 'SELECT 1')" "1"
+
 pgc_summary


### PR DESCRIPTION
Closes #686. Scoped to the `parallel_copy` FIFO denial of service (the substantive half). The `min_sequence_number` cosmetic that was also in #686 is **deferred to #691** — adding a field to `PgColumnarAvroManifestFile` crashes `iceberg_scan` on an assert build (a latent memory bug that must be understood first), so the cosmetic is not worth shipping under it.

## The fix (medium-severity DoS)
`pcopy_open_regular_file` opened the path `O_RDONLY` and *then* `fstat`'d it, so a FIFO blocked inside `open(2)` before the `S_ISREG` check could run — and the block is cancel-resistant (`SA_RESTART` survives a cancel and `statement_timeout`). Its own comment claimed it "avoids an uninterruptible open() on a FIFO"; it did not.

It now opens `O_RDONLY | O_NONBLOCK` (a FIFO `open(2)` returns immediately), rejects a non-regular file with `WRONG_OBJECT_TYPE` (42809), then clears `O_NONBLOCK`. Because it `fstat`s the fd it holds, this also closes the stat-before-open TOCTOU: the file checked is the file opened.

## TDD evidence
New arm in `parallel_copy`: RED `got [HANG]` (blocked open), GREEN `42809`; reverting the O_NONBLOCK fix reproduces the hang. Full `parallel_copy` suite and `iceberg_malformed` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
