### PR TITLE
fix: make Thrift and Avro field-skip loops interruptible (DoS hardening)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,18 @@ which was true until that script existed.
 
 ### Fixed
 
+- The Thrift and Avro field-skip loops are now interruptible. A Parquet footer
+  whose unknown field is a `list<bool>` with a file-declared count up to
+  `0xFFFFFFFF` (or a struct holding many such lists) drove billions of zero-byte
+  skips through `PgColumnarThriftSkip`, which checked stack depth but not
+  interrupts, so the backend spun uncancellably on a sub-2 KB file reached through
+  `parquet_schema()` / `read_parquet()`. `av_skip` had the same gap on an
+  `array<null>` manifest block, where its interrupt check ran once per block
+  rather than per element. Both now call `CHECK_FOR_INTERRUPTS` on the per-value
+  skip path, so `statement_timeout` and cancel apply. This is a denial-of-service
+  hardening in the same class as the parallel_copy FIFO fix. Regression test:
+  decode_skip_interrupts (functional cancel for Thrift; per-element placement
+  shape for both).
 - `pgcolumnar.read_manifest_list` now reports a null manifest-list
   `min_sequence_number` as SQL NULL instead of 0, matching `sequence_number`. The
   value is not used by the delete-application rules, so this is a display fix.

--- a/src/columnar_avro.c
+++ b/src/columnar_avro.c
@@ -330,6 +330,17 @@ av_skip(AvReader *r, AvSchema *s)
 	int64		cnt;
 
 	check_stack_depth();
+
+	/*
+	 * Per-element interrupt check. The AV_ARRAY/AV_MAP arms below check once per
+	 * block, before the count is read, but a single block declares a count up to
+	 * AV_MAX_OBJECTS (50,000,000) and AV_NULL consumes zero bytes, so the inner
+	 * element loop can run 50M no-op skips with nothing to yield on. Because every
+	 * element (and every record field) is one av_skip call, a check here bounds all
+	 * of them uniformly. av_skip only ever skips unconsumed metadata fields, never
+	 * the row data, so this is off the hot path.
+	 */
+	CHECK_FOR_INTERRUPTS();
 	if (r->error)
 		return;
 	switch (s->kind)

--- a/src/columnar_thrift.c
+++ b/src/columnar_thrift.c
@@ -125,6 +125,19 @@ PgColumnarThriftSkip(TCReader *r, int ftype)
 	 */
 	check_stack_depth();
 
+	/*
+	 * check_stack_depth bounds recursion depth but not width, and it does not
+	 * process interrupts. TC_BOOL_TRUE, TC_BOOL_FALSE and the default arm consume
+	 * zero bytes and never set r->error, so a TC_LIST of bool with a file-declared
+	 * size up to 0xFFFFFFFF (or a struct holding many such lists) spins billions of
+	 * no-op iterations that touch neither the cursor nor the error flag. Without
+	 * this check that loop ignores SIGINT and statement_timeout -- an
+	 * uninterruptible backend hang from a sub-2 KB footer. It fires once per
+	 * skipped value (each list element is one Skip call) and Skip is off the hot
+	 * data path, so it is free in the honest case and bounds the hostile one.
+	 */
+	CHECK_FOR_INTERRUPTS();
+
 	switch (ftype)
 	{
 		case TC_BOOL_TRUE:

--- a/test/decode_skip_interrupts.sh
+++ b/test/decode_skip_interrupts.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+#
+# pgColumnar skip-path interrupt discipline (Thrift + Avro).
+#
+# The decode_interrupts.sh suite covers the native column decoders. This covers
+# the two *skip* loops that walk unconsumed fields of an attacker-authored file:
+#
+#   1. PgColumnarThriftSkip (columnar_thrift.c) skips every unrecognised field of
+#      a Parquet footer. Its TC_LIST/TC_SET arm loops `size` times, and `size` is
+#      a file-controlled varint up to 0xFFFFFFFF; TC_BOOL_TRUE/TC_BOOL_FALSE and
+#      the default arm consume ZERO bytes and never set r->error. So a footer with
+#      one list<bool> of 0xFFFFFFFF drives ~4.3 billion no-op iterations, and a
+#      struct holding K such lists multiplies that without bound -- all from a
+#      sub-2 KB file. The function had check_stack_depth() (recursion) but no
+#      CHECK_FOR_INTERRUPTS, so the loop ignored SIGINT and statement_timeout: an
+#      uninterruptible backend hang, the #686 FIFO-hang class on the footer path.
+#
+#   2. av_skip (columnar_avro.c) skips unconsumed Avro manifest fields. Its
+#      interrupt check sat at block granularity; an array<null> block declares a
+#      count up to AV_MAX_OBJECTS (50,000,000) and AV_NULL consumes zero bytes, so
+#      one block ran 50M no-op skips with no per-element check. The AV_RECORD
+#      field loop had none at all.
+#
+# Both are reachable today by an honest caller who names a hostile file:
+# parquet_schema()/read_parquet() for (1), read_manifest/iceberg_scan for (2).
+#
+# This suite asserts the fix two ways. The functional arm crafts the bomb and
+# proves a 2 s statement_timeout now aborts it (SQLSTATE 57014) instead of the
+# backend spinning until a KILL: a genuine cancellation test, resolvable here --
+# unlike the in-memory decoders (see decode_interrupts.sh) -- precisely because
+# the unfixed loop is effectively unbounded, so there is no sub-100 ms window to
+# race. The shape arm (like decode_interrupts.sh / wal_envelope.sh) pins the
+# CHECK_FOR_INTERRUPTS into the skip bodies so a future edit that drops it fails
+# here in the matrix without depending on timing.
+#
+# Removal proof: revert either fix and the matching functional check goes from
+# 57014 to HANG (the KILL fires), and the matching shape check goes to 0.
+#
+# Usage:  test/decode_skip_interrupts.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+W="$PGC_WORKDIR"
+SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/src"
+
+# --- craft the Thrift skip-bomb footer ----------------------------------------
+# A Parquet file is PAR1 + FileMetaData + <uint32 metalen> + PAR1; the crafted
+# metadata is what parse_file_metadata walks. No writer produces this, so it is
+# built by hand (as native_parquet_stack.sh does).
+python3 - "$W" <<'PY'
+import struct, sys
+W = sys.argv[1]
+
+def uleb(n):
+    out = bytearray()
+    while True:
+        b = n & 0x7f
+        n >>= 7
+        if n:
+            out.append(b | 0x80)
+        else:
+            out.append(b); break
+    return bytes(out)
+
+def wrap(meta):
+    return b'PAR1' + meta + struct.pack('<I', len(meta)) + b'PAR1'
+
+# 0x1c  : top-level field header (delta 1, type TC_STRUCT=12) -> the else-arm of
+#         parse_file_metadata routes it to PgColumnarThriftSkip(TC_STRUCT), which
+#         loops reading inner fields.
+# per inner field:
+#   0x19 : field header (delta 1, type TC_LIST=9)
+#   0xf1 : list header -- size nibble 0x0f (long form) | element type
+#          TC_BOOL_TRUE=1; a bool element consumes ZERO bytes when skipped.
+#   uleb(0xFFFFFFFF) : the long-form element count, ~4.3e9.
+# K such lists inside the struct => K * 4.3e9 zero-byte skips before the struct
+# STOP is ever reached. K=256 is an effectively unbounded (hour-scale) loop from
+# ~1.8 KB, so on unfixed code the KILL fires long before it could finish.
+BOMB = 0xFFFFFFFF
+K = 256
+meta = bytearray(b'\x1c')
+meta += (b'\x19\xf1' + uleb(BOMB)) * K
+meta += b'\x00'   # struct STOP
+meta += b'\x00'   # FileMetaData STOP
+open(f"{W}/skip_bomb.parquet", "wb").write(wrap(bytes(meta)))
+PY
+
+# probe FILE -> the SQLSTATE it raises, NOERR, or HANG (backend never yielded and
+# the KILL wrapper terminated the client). statement_timeout is small; the KILL
+# cap is far larger, so on fixed code the cancel lands well inside it.
+probe() {
+	local out rc
+	# query_canceled (57014) must be caught by name: PL/pgSQL's WHEN OTHERS
+	# deliberately does NOT trap QUERY_CANCELED, so a WHEN OTHERS handler would let
+	# the timeout propagate uncaught and print nothing to match here.
+	out="$(timeout -s KILL 30 env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 \
+		-p "$PGC_PORT" -U postgres -d "$PGC_DB" -At -c "SET statement_timeout='2s';
+		DO \$\$ BEGIN PERFORM count(*) FROM pgcolumnar.parquet_schema('$1');
+		RAISE NOTICE 'NOERR';
+		EXCEPTION WHEN query_canceled THEN RAISE NOTICE 'SQLSTATE=%', SQLSTATE;
+		WHEN OTHERS THEN RAISE NOTICE 'SQLSTATE=%', SQLSTATE; END \$\$;" 2>&1)"
+	rc=$?
+	# coreutils timeout reports 124 when the command times out (128+9=137 only
+	# with --preserve-status); either means the client was killed because the
+	# backend never yielded -- an uninterruptible hang.
+	if [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then echo "HANG"; return; fi
+	echo "$out" | grep -m1 -oE 'SQLSTATE=[0-9A-Z]+|NOERR' | sed 's/SQLSTATE=//'
+}
+
+# 57014 is query_canceled -- what statement_timeout raises once the loop yields.
+# Before the fix this input did not raise 57014; it spun uninterruptibly until the
+# KILL (HANG). Pinning 57014 means an unrelated failure cannot pass this.
+check "Thrift skip-bomb footer is cancellable, not an uninterruptible hang" \
+	"$(probe "$W/skip_bomb.parquet")" "57014"
+check "backend survived the Thrift skip-bomb footer" "$(q 'SELECT 1;')" "1"
+
+# --- shape arm: the interrupt check must be present in the skip body ----------
+TF="$SRC/columnar_thrift.c"
+AF="$SRC/columnar_avro.c"
+
+check "PgColumnarThriftSkip checks for interrupts" \
+	"$(awk '/^PgColumnarThriftSkip\(/{f=1} f&&/CHECK_FOR_INTERRUPTS/{n++} f&&/^}/{exit} END{print n+0}' "$TF")" \
+	"1"
+
+# av_skip is guarded by shape rather than a live cancel, deliberately. Its unbounded
+# arm is one array<null> block, capped at AV_MAX_OBJECTS (50M) zero-byte skips ~ a
+# low-seconds window; a statement_timeout test on a window that small is unreliable
+# (the same reason decode_interrupts.sh is a shape test). The reachable-now behaviour
+# of this whole skip-loop class is proven functionally above via the Thrift bomb.
+#
+# Placement matters: av_skip already had a CHECK_FOR_INTERRUPTS in the AV_ARRAY and
+# AV_MAP arms, but per BLOCK (before the count), not per element -- the inner element
+# loop ran uninterrupted. So counting checks anywhere in av_skip would pass on the
+# unguarded code. Instead assert a check exists BEFORE the switch, i.e. on the
+# per-call path every element and record field takes. That reads 0 on the old code
+# (its checks are inside the switch arms) and 1 once the per-element check is added.
+check "av_skip checks for interrupts per element (before the switch, not just per block)" \
+	"$(awk '/^av_skip\(/{f=1} f&&/switch \(s->kind\)/{print n+0; exit} f&&/CHECK_FOR_INTERRUPTS/{n++}' "$AF")" \
+	"1"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -64,6 +64,7 @@ SUITES=(
 	concurrent_diff
 	corruption
 	decode_interrupts
+	decode_skip_interrupts
 	dependency_estimate
 	differential
 	docs_style


### PR DESCRIPTION
An aggressive decode-path security audit (prove-don't-trust + TDD) surfaced two uninterruptible-hang DoS defects of the same class, both reachable today by an honest caller who names a hostile file. Same class as the parallel_copy FIFO hang (#686).

## D-1 (HIGH) — Thrift footer skip
`PgColumnarThriftSkip` checked stack depth but not interrupts. TC_BOOL_TRUE/TC_BOOL_FALSE/default consume zero bytes and never set r->error, so a Parquet footer with an unknown `list<bool>` of count up to 0xFFFFFFFF (or a struct of many such lists) spins billions of no-op iterations ignoring SIGINT/statement_timeout. Reachable via parquet_schema()/read_parquet(). Reproduced: ~1.8 KB footer spun uninterruptibly, killed by wrapper at 25s while a 2s statement_timeout never fired; fixed = clean cancel (57014).

## D-2 (MEDIUM) — Avro manifest skip
`av_skip` checked interrupts per block, not per element; an array<null> block runs up to AV_MAX_OBJECTS (50M) zero-byte skips uninterrupted. Reachable via read_manifest/iceberg_scan.

## Fix
Both call CHECK_FOR_INTERRUPTS on the per-value skip path (off the hot data path).

## Test decode_skip_interrupts
Functional Thrift cancel (unfixed HANG, fixed 57014) + placement-sensitive shape (check must precede the switch; reads 0 on pre-fix av_skip despite its 2 per-block checks). Removal proof verified for both. No regression: native_parquet_stack, avro_manifest, decode_interrupts, native_read_parquet, docs_style, harness_selftest on pg18_nc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
