### PR TITLE
perf: index delete_vector catalog reads instead of seq-scanning (O-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ which was true until that script existed.
 
 ### Fixed
 
+- Reads of the `delete_vector` catalog now use its `delete_vector_pkey` index
+  instead of a sequential scan. `PgColumnarReadDeleteVectorList` (called once per
+  row group while a scan builds its liveness cache), the reclaim deleted-count
+  sum, and `PgColumnarStorageHasDeleteVector` each passed `InvalidOid` to
+  `systable_beginscan`, so every call sequentially scanned the whole
+  `delete_vector` catalog filtered by scan key. On a table with deletes the cost
+  was `O(row_groups * delete_vector_rows)`. The sibling metadata tables already
+  index their reads this way; `delete_vector` now matches. Regression test:
+  native_delete_vector_index (asserts the reads take the index, seq_scan = 0).
 - `pgcolumnar.read_manifest_list` now reports a null manifest-list
   `min_sequence_number` as SQL NULL instead of 0, matching `sequence_number`. The
   value is not used by the delete-application rules, so this is a display fix.

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -509,6 +509,7 @@ PgColumnarComputeFullyDeletedGroups(uint64 storageId, TransactionId oldestXmin)
 	HeapTuple	gtuple;
 	Snapshot	snap;
 	List	   *groups = NIL;
+	Oid			dvIdx = pgcolumnar_index_oid("delete_vector_pkey");
 
 	snap = RegisterSnapshot(GetLatestSnapshot());
 
@@ -548,7 +549,7 @@ PgColumnarComputeFullyDeletedGroups(uint64 storageId, TransactionId oldestXmin)
 					F_INT8EQ, Int64GetDatum((int64) storageId));
 		ScanKeyInit(&mkey[1], Anum_delete_vector_group_number, BTEqualStrategyNumber,
 					F_INT8EQ, Int64GetDatum((int64) groupNumber));
-		mscan = systable_beginscan(mrel, InvalidOid, false, snap, 2, mkey);
+		mscan = systable_beginscan(mrel, dvIdx, OidIsValid(dvIdx), snap, 2, mkey);
 		while (HeapTupleIsValid(mtuple = systable_getnext(mscan)))
 		{
 			TransactionId mxmin = HeapTupleHeaderGetXmin(mtuple->t_data);
@@ -1296,13 +1297,14 @@ PgColumnarReadDeleteVectorList(uint64 storageId, uint64 stripeId, Snapshot snaps
 	SysScanDesc scan;
 	HeapTuple	tuple;
 	List	   *result = NIL;
+	Oid			dvIdx = pgcolumnar_index_oid("delete_vector_pkey");
 
 	ScanKeyInit(&key[0], Anum_delete_vector_storage_id, BTEqualStrategyNumber,
 				F_INT8EQ, Int64GetDatum((int64) storageId));
 	ScanKeyInit(&key[1], Anum_delete_vector_group_number, BTEqualStrategyNumber,
 				F_INT8EQ, Int64GetDatum((int64) stripeId));
 
-	scan = systable_beginscan(rel, InvalidOid, false, snapshot, 2, key);
+	scan = systable_beginscan(rel, dvIdx, OidIsValid(dvIdx), snapshot, 2, key);
 	while (HeapTupleIsValid(tuple = systable_getnext(scan)))
 	{
 		DeleteVectorMetadata *rm = palloc0(sizeof(DeleteVectorMetadata));
@@ -1351,10 +1353,11 @@ PgColumnarStorageHasDeleteVector(uint64 storageId, Snapshot snapshot)
 	ScanKeyData key[1];
 	SysScanDesc scan;
 	bool		found;
+	Oid			dvIdx = pgcolumnar_index_oid("delete_vector_pkey");
 
 	ScanKeyInit(&key[0], Anum_delete_vector_storage_id, BTEqualStrategyNumber,
 				F_INT8EQ, Int64GetDatum((int64) storageId));
-	scan = systable_beginscan(rel, InvalidOid, false, snapshot, 1, key);
+	scan = systable_beginscan(rel, dvIdx, OidIsValid(dvIdx), snapshot, 1, key);
 	found = HeapTupleIsValid(systable_getnext(scan));
 	systable_endscan(scan);
 	table_close(rel, AccessShareLock);

--- a/test/native_delete_vector_index.sh
+++ b/test/native_delete_vector_index.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# pgColumnar delete_vector reads use delete_vector_pkey, not a seq scan.
+#
+# The delete_vector catalog has a unique index on (storage_id, group_number), and
+# the sibling metadata tables (row_group, zone_map, bloom, column_chunk) all pass
+# their _pkey to systable_beginscan. delete_vector did not: PgColumnarReadDeleteVectorList,
+# the reclaim deleted-count sum, and PgColumnarStorageHasDeleteVector each passed
+# InvalidOid / indexOK=false, so every call sequentially scanned the whole
+# delete_vector catalog filtered by scan key. ReadDeleteVectorList runs once per
+# row group while a scan builds its liveness cache, so on a table with deletes the
+# cost was O(groups * delete_vector_rows) -- an unused index turning a per-group
+# index probe into a full catalog scan.
+#
+# This asserts the reads now take the index. The instrument is behavioural and
+# size-independent: after a scan of a table with deletes across many groups,
+# pg_stat_all_tables for pgcolumnar.delete_vector must show idx_scan > 0 and
+# seq_scan = 0. On the pre-fix code every one of those reads was a seq scan
+# (idx_scan = 0, seq_scan = groups), so the check flips red when the index is
+# removed. pg_stat_force_next_flush makes the counters readable without racing the
+# stats collector. A correctness arm pins the delete result so the index switch is
+# proven not to change visibility.
+#
+# Usage:  test/native_delete_vector_index.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+q "CREATE EXTENSION IF NOT EXISTS pgcolumnar;" >/dev/null
+
+# One session, so stripe_row_limit applies to the INSERT: 40000 rows / 2000 = 20
+# row groups. Delete id % 500 = 0 (80 rows) so every group gets a delete_vector row.
+q "SET pgcolumnar.stripe_row_limit=2000;
+   CREATE TABLE t (id int, v bigint) USING pgcolumnar;
+   INSERT INTO t SELECT g, g FROM generate_series(1,40000) g;
+   DELETE FROM t WHERE id % 500 = 0;" >/dev/null
+
+check "the delete produced one delete_vector row per group" \
+	"$(q "SELECT count(*) FROM pgcolumnar.delete_vector;")" "20"
+
+# Reset, run a full scan that builds the liveness cache (reads delete_vector per
+# group), then force the stats out and read them.
+q "SELECT pg_stat_reset();" >/dev/null
+q "SELECT sum(v) FROM t;" >/dev/null
+q "SELECT pg_stat_force_next_flush();" >/dev/null
+
+check "delete_vector reads used the index (idx_scan > 0)" \
+	"$(q "SELECT idx_scan > 0 FROM pg_stat_all_tables WHERE relname='delete_vector' AND schemaname='pgcolumnar';")" \
+	"t"
+check "delete_vector reads did NOT sequentially scan the catalog (seq_scan = 0)" \
+	"$(q "SELECT coalesce(seq_scan,0) FROM pg_stat_all_tables WHERE relname='delete_vector' AND schemaname='pgcolumnar';")" \
+	"0"
+
+# Correctness: the index switch must not change which rows are visible. Live sum =
+# sum(1..40000) - sum(deleted) = 800020000 - 1620000.
+check "the deletes are still applied (visibility unchanged by the index switch)" \
+	"$(q "SELECT sum(v) FROM t;")" "798400000"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -117,6 +117,7 @@ SUITES=(
 	native_ctas
 	native_decode_gate_width
 	native_decode_gating
+	native_delete_vector_index
 	native_dict_underfill
 	native_dml
 	native_encoding


### PR DESCRIPTION
From the aggressive optimization audit. Reads of `pgcolumnar.delete_vector` passed `InvalidOid` / `indexOK=false` to `systable_beginscan`, so each **sequentially scanned the whole delete_vector catalog** filtered by scan key, despite the unique `delete_vector_pkey (storage_id, group_number)`.

`PgColumnarReadDeleteVectorList` runs **once per row group** while a scan builds its liveness cache, so on a table with deletes the cost was **O(row_groups × delete_vector_rows)**. Two more sites had the same gap (the reclaim deleted-count sum, `PgColumnarStorageHasDeleteVector`).

The sibling metadata tables (row_group, zone_map, bloom, column_chunk) already resolve their `_pkey` via `pgcolumnar_index_oid` and pass it to `systable_beginscan`; delete_vector now matches, using the exact in-file idiom.

## Why it is cost-only, not semantic
Index and seq scans run the same per-tuple visibility check in the heap fetch, so the `SnapshotDirty` caller is unaffected. Proven by the delete/reclaim/concurrency suites staying green: native_agg_deletes, iceberg_deletes, native_dml, native_reclaim, native_reclaim_reconcile, update_conc, native_vacuum_race.

## Measurement — `native_delete_vector_index`
Behavioural, size-independent, lag-free (`pg_stat_force_next_flush`): after a `sum(v)` scan of a 20-group table with a delete in every group, `pg_stat_all_tables` for `delete_vector` shows `idx_scan > 0`, `seq_scan = 0`.

**Removal proof:** reverting the index makes `seq_scan = 20` (one full-catalog scan per group — the O(G²) laid bare) and `idx_scan = 0`; both checks flip red. A correctness arm pins the delete result (`sum = 798400000`) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
