### PR TITLE
security: close stat-before-open TOCTOU in local file reads (S-F1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,17 @@ which was true until that script existed.
 
 ### Security
 
+- Closed a stat-before-open race in the local file read path. The
+  non-regular-file guard that keeps a FIFO from blocking the backend in `open(2)`
+  (a cancel-resistant denial of service) screened the path with `stat()` before a
+  separate `open()`, so a local principal who can write the directory could swap
+  the checked regular file for a FIFO in the window between them and re-introduce
+  the block. All five local openers (the Iceberg metadata and manifest reads, the
+  Avro manifest read, `import_arrow`, and the Parquet source) now go through one
+  helper that opens `O_NONBLOCK`, `fstat`s the fd it holds, refuses a non-regular
+  file, then clears the flag, so the file checked is the file opened. The Parquet
+  source reads positionally with `pg_pread`. Regression test:
+  local_open_race_free.
 - Fixed a backend crash on a hostile Iceberg manifest with a null path. The
   reader decodes a manifest and manifest list against the schema embedded in the
   file, which the table author controls, so a manifest_path (or data or delete

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,12 +93,14 @@ which was true until that script existed.
   (a cancel-resistant denial of service) screened the path with `stat()` before a
   separate `open()`, so a local principal who can write the directory could swap
   the checked regular file for a FIFO in the window between them and re-introduce
-  the block. All five local openers (the Iceberg metadata and manifest reads, the
-  Avro manifest read, `import_arrow`, and the Parquet source) now go through one
-  helper that opens `O_NONBLOCK`, `fstat`s the fd it holds, refuses a non-regular
-  file, then clears the flag, so the file checked is the file opened. The Parquet
-  source reads positionally with `pg_pread`. Regression test:
-  local_open_race_free.
+  the block. The five transient-fd local openers (the Iceberg metadata and
+  manifest reads, the Avro manifest read, `import_arrow`, and the Parquet source)
+  now go through one helper that opens `O_NONBLOCK`, `fstat`s the fd it holds,
+  refuses a non-regular file, then clears the flag, so the file checked is the
+  file opened. The Parquet source reads positionally with `pg_pread`. The
+  parallel-copy partition coordinator (`pcopy_partition_aligned_offsets`), which
+  needs a stdio `FILE*` for `getline`, applies the same `O_NONBLOCK` open plus
+  `fstat` inline. Regression tests: local_open_race_free, parallel_copy.
 - Fixed a backend crash on a hostile Iceberg manifest with a null path. The
   reader decodes a manifest and manifest list against the schema embedded in the
   file, which the table author controls, so a manifest_path (or data or delete

--- a/src/columnar_arrow.c
+++ b/src/columnar_arrow.c
@@ -1761,7 +1761,7 @@ pgcolumnar_import_arrow(PG_FUNCTION_ARGS)
 	int			ncols;
 	ImpNode    *tops;
 	int			totalBuffers = 0;
-	FILE	   *f;
+	int			fd;
 	TupleTableSlot *slot;
 	PgColumnarIndexInsertState *indexes;
 	CommandId	cid;
@@ -1840,15 +1840,9 @@ pgcolumnar_import_arrow(PG_FUNCTION_ARGS)
 	/* refuse a FIFO/non-regular file before the open, same as the Iceberg and
 	 * parquet read paths: fopen("rb") on a FIFO blocks in open(2) and the block
 	 * survives a cancel/statement_timeout (a DoS). See #644 / #686. */
-	PgColumnarRejectNonRegularFile(path);
-	f = AllocateFile(path, PG_BINARY_R);
-	if (f == NULL)
-	{
-		table_close(rel, RowExclusiveLock);
-		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not open file \"%s\" for reading: %m", path)));
-	}
+	/* Race-free local open (rejects a FIFO without a stat-before-open window);
+	 * it raises on failure, and the RowExclusiveLock releases at abort. */
+	fd = PgColumnarOpenLocalRegularFile(path, NULL);
 
 	slot = table_slot_create(rel, NULL);
 	cid = GetCurrentCommandId(true);
@@ -1879,11 +1873,11 @@ pgcolumnar_import_arrow(PG_FUNCTION_ARGS)
 		uint8		headerType;
 
 		/* message framing: [0xFFFFFFFF] [metaLen] or [metaLen] (legacy) */
-		if (fread(&first, 4, 1, f) != 1)
+		if (!PgColumnarReadExact(fd, &first, 4))
 			break;				/* clean EOF */
 		if (first == 0xFFFFFFFF)
 		{
-			if (fread(&metaLen, 4, 1, f) != 1)
+			if (!PgColumnarReadExact(fd, &metaLen, 4))
 				IMPORT_CORRUPT("truncated continuation");
 		}
 		else
@@ -1892,7 +1886,7 @@ pgcolumnar_import_arrow(PG_FUNCTION_ARGS)
 			break;				/* end-of-stream marker */
 
 		meta = palloc(metaLen);
-		if (fread(meta, 1, metaLen, f) != metaLen)
+		if (!PgColumnarReadExact(fd, meta, metaLen))
 			IMPORT_CORRUPT("truncated metadata");
 
 		msg = pgc_fb_indirect(meta, metaLen, 0);
@@ -1908,7 +1902,7 @@ pgcolumnar_import_arrow(PG_FUNCTION_ARGS)
 		if (bodyLength > 0)
 		{
 			body = palloc((Size) bodyLength);
-			if (fread(body, 1, bodyLength, f) != (size_t) bodyLength)
+			if (!PgColumnarReadExact(fd, body, (size_t) bodyLength))
 				IMPORT_CORRUPT("truncated body");
 		}
 
@@ -2030,7 +2024,7 @@ pgcolumnar_import_arrow(PG_FUNCTION_ARGS)
 		pfree(meta);
 	}
 
-	FreeFile(f);
+	CloseTransientFile(fd);
 	MemoryContextDelete(rowCtx);
 	if (indexes != NULL)
 		PgColumnarIndexInsertEnd(indexes);

--- a/src/columnar_avro.c
+++ b/src/columnar_avro.c
@@ -1271,33 +1271,11 @@ PgColumnarAvroReadManifestList(const uint8 *buf, int64 len, int *nout)
 static uint8 *
 av_slurp_file(const char *path, int64 *outlen)
 {
-	FILE	   *f;
-	int64		flen;
 	uint8	   *buf;
 
-	PgColumnarRejectNonRegularFile(path);
-	f = AllocateFile(path, PG_BINARY_R);
-	if (f == NULL)
-		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not open file \"%s\" for reading: %m", path)));
-	if (fseeko(f, 0, SEEK_END) != 0)
-		ereport(ERROR, (errcode_for_file_access(),
-						errmsg("could not seek \"%s\": %m", path)));
-	flen = (int64) ftello(f);
-	if (flen < 0 || flen > AV_MAX_FILE)
-		ereport(ERROR,
-				(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
-				 errmsg("columnar: Avro file \"%s\" is too large", path)));
-	if (fseeko(f, 0, SEEK_SET) != 0)
-		ereport(ERROR, (errcode_for_file_access(),
-						errmsg("could not seek \"%s\": %m", path)));
-	buf = (uint8 *) palloc(Max(flen, 1));
-	if (flen > 0 && fread(buf, 1, flen, f) != (size_t) flen)
-		ereport(ERROR, (errcode_for_file_access(),
-						errmsg("could not read \"%s\": %m", path)));
-	FreeFile(f);
-	*outlen = flen;
+	/* Race-free local open (rejects a FIFO without a stat-before-open window). */
+	buf = (uint8 *) PgColumnarSlurpLocalRegularFile(path, AV_MAX_FILE,
+													"Avro file", outlen);
 	return buf;
 }
 

--- a/src/columnar_iceberg.c
+++ b/src/columnar_iceberg.c
@@ -129,37 +129,15 @@ ice_slurp_remote(const char *url, int64 *outlen,
 static char *
 ice_slurp_text(const char *path, const PgColumnarObjStoreConfig *cfg)
 {
-	FILE	   *f;
 	int64		flen;
-	char	   *buf;
 
 	if (PgColumnarPathIsRemote(path))
 		return (char *) ice_slurp_remote(path, &flen, cfg);
 
-	PgColumnarRejectNonRegularFile(path);
-	f = AllocateFile(path, PG_BINARY_R);
-	if (f == NULL)
-		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not open file \"%s\" for reading: %m", path)));
-	if (fseeko(f, 0, SEEK_END) != 0)
-		ereport(ERROR, (errcode_for_file_access(),
-						errmsg("could not seek \"%s\": %m", path)));
-	flen = (int64) ftello(f);
-	if (flen < 0 || flen > ICE_MAX_METADATA)
-		ereport(ERROR,
-				(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
-				 errmsg("columnar: Iceberg metadata \"%s\" is too large", path)));
-	if (fseeko(f, 0, SEEK_SET) != 0)
-		ereport(ERROR, (errcode_for_file_access(),
-						errmsg("could not seek \"%s\": %m", path)));
-	buf = (char *) palloc(flen + 1);
-	if (flen > 0 && fread(buf, 1, flen, f) != (size_t) flen)
-		ereport(ERROR, (errcode_for_file_access(),
-						errmsg("could not read \"%s\": %m", path)));
-	buf[flen] = '\0';
-	FreeFile(f);
-	return buf;
+	/* Race-free local open (rejects a FIFO without a stat-before-open window),
+	 * NUL-terminated so the JSON parser can treat it as a cstring. */
+	return PgColumnarSlurpLocalRegularFile(path, ICE_MAX_METADATA,
+										   "Iceberg metadata", &flen);
 }
 
 /* slurp a whole binary file (a manifest list, manifest, or Puffin file) into a
@@ -168,37 +146,12 @@ static uint8 *
 ice_slurp_bin(const char *path, int64 *outlen,
 			  const PgColumnarObjStoreConfig *cfg)
 {
-	FILE	   *f;
-	int64		flen;
-	uint8	   *buf;
-
 	if (PgColumnarPathIsRemote(path))
 		return ice_slurp_remote(path, outlen, cfg);
 
-	PgColumnarRejectNonRegularFile(path);
-	f = AllocateFile(path, PG_BINARY_R);
-	if (f == NULL)
-		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not open file \"%s\" for reading: %m", path)));
-	if (fseeko(f, 0, SEEK_END) != 0)
-		ereport(ERROR, (errcode_for_file_access(),
-						errmsg("could not seek \"%s\": %m", path)));
-	flen = (int64) ftello(f);
-	if (flen < 0 || flen > ICE_MAX_METADATA)
-		ereport(ERROR,
-				(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
-				 errmsg("columnar: Iceberg manifest \"%s\" is too large", path)));
-	if (fseeko(f, 0, SEEK_SET) != 0)
-		ereport(ERROR, (errcode_for_file_access(),
-						errmsg("could not seek \"%s\": %m", path)));
-	buf = (uint8 *) palloc(Max(flen, 1));
-	if (flen > 0 && fread(buf, 1, flen, f) != (size_t) flen)
-		ereport(ERROR, (errcode_for_file_access(),
-						errmsg("could not read \"%s\": %m", path)));
-	FreeFile(f);
-	*outlen = flen;
-	return buf;
+	/* Race-free local open; see PgColumnarOpenLocalRegularFile. */
+	return (uint8 *) PgColumnarSlurpLocalRegularFile(path, ICE_MAX_METADATA,
+													 "Iceberg manifest", outlen);
 }
 
 /*

--- a/src/columnar_objstore.c
+++ b/src/columnar_objstore.c
@@ -12,7 +12,11 @@
 #include "fmgr.h"
 #include "utils/elog.h"
 #include "miscadmin.h"
+#include <fcntl.h>
 #include <sys/stat.h>
+#include <unistd.h>
+
+#include "storage/fd.h"
 
 #include "columnar.h"
 #include "columnar_objstore.h"
@@ -58,37 +62,132 @@ PgColumnarPathIsRemote(const char *path)
 }
 
 /*
- * Refuse a LOCAL path that names anything but a regular file, BEFORE it is
- * opened. AllocateFile()/fopen("rb") on a FIFO blocks in open(2) until a writer
- * appears; because our signal handlers use SA_RESTART the blocked open resumes
- * across SIGINT/SIGALRM, so neither a query cancel nor statement_timeout gets
- * the backend back (a cancel-resistant availability DoS). An fstat AFTER the
- * open cannot help -- the block is inside the open itself -- so screen first.
+ * Open a LOCAL regular file for reading with no stat-before-open race.
  *
- * A regular file (or a symlink to one; stat() follows) is allowed. A FIFO,
- * socket, block/char device, or directory is refused. A path that does not
- * exist / cannot be stat'd is left to the opener, which reports the errno by
- * name (a typo must still be a clean "could not open file", not this error).
- * Remote (s3://, http(s)://) paths are not filesystem objects: skipped.
+ * AllocateFile()/fopen("rb") on a FIFO blocks in open(2) until a writer appears;
+ * because our signal handlers use SA_RESTART the blocked open resumes across
+ * SIGINT/SIGALRM, so neither a query cancel nor statement_timeout gets the
+ * backend back (a cancel-resistant availability DoS, #644/#686). A plain stat()
+ * before the open avoids the block but races: a local principal who can write the
+ * directory can swap the checked regular file for a FIFO between the stat and the
+ * open, re-introducing the block.
  *
- * This must sit at EVERY local open the Iceberg/parquet read path can reach
- * (ice_slurp_text, ice_slurp_bin, av_slurp_file, pq_source_open_cfg), not only
- * in ice_open_path: the SQL-argument metadata pointer and the avro/parquet
- * function APIs open without going through ice_open_path.
+ * So open once, O_NONBLOCK (a FIFO then returns immediately instead of blocking),
+ * fstat the fd we hold -- the file we checked is the file we opened -- refuse a
+ * non-regular file, then clear O_NONBLOCK for the read. This is the same pattern
+ * as pcopy_open_regular_file, and it is the single opener every local Iceberg,
+ * Avro, Parquet, and Arrow read reaches. The DATA_CORRUPTED code matches the
+ * malformed-metadata refusals the read path already raises.
+ *
+ * A regular file (or a symlink to one; the open follows it) is allowed. A path
+ * that does not exist is left as the open's errno-by-name error. Remote paths are
+ * excluded by the caller (they are not filesystem objects).
  */
-void
-PgColumnarRejectNonRegularFile(const char *path)
+int
+PgColumnarOpenLocalRegularFile(const char *path, off_t *size_out)
 {
+	int			fd;
+	int			flags;
 	struct stat st;
 
-	if (PgColumnarPathIsRemote(path))
-		return;
-	if (stat(path, &st) != 0)
-		return;					/* leave errno reporting to the opener */
+	fd = OpenTransientFile(path, O_RDONLY | O_NONBLOCK | PG_BINARY);
+	if (fd < 0)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not open file \"%s\" for reading: %m", path)));
+	if (fstat(fd, &st) != 0)
+	{
+		int			save_errno = errno;
+
+		CloseTransientFile(fd);
+		errno = save_errno;
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not stat file \"%s\": %m", path)));
+	}
 	if (!S_ISREG(st.st_mode))
+	{
+		CloseTransientFile(fd);
 		ereport(ERROR,
 				(errcode(ERRCODE_DATA_CORRUPTED),
 				 errmsg("columnar: \"%s\" is not a regular file", path)));
+	}
+	flags = fcntl(fd, F_GETFL);
+	if (flags == -1 || fcntl(fd, F_SETFL, flags & ~O_NONBLOCK) == -1)
+	{
+		int			save_errno = errno;
+
+		CloseTransientFile(fd);
+		errno = save_errno;
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not clear nonblocking mode on file \"%s\": %m", path)));
+	}
+	if (size_out != NULL)
+		*size_out = st.st_size;
+	return fd;
+}
+
+/* Read exactly n bytes; true on success, false on early EOF or error (errno set). */
+bool
+PgColumnarReadExact(int fd, void *buf, size_t n)
+{
+	char	   *p = (char *) buf;
+	size_t		done = 0;
+
+	while (done < n)
+	{
+		ssize_t		r;
+
+		CHECK_FOR_INTERRUPTS();
+		r = read(fd, p + done, n - done);
+		if (r < 0)
+		{
+			if (errno == EINTR)
+				continue;
+			return false;
+		}
+		if (r == 0)
+			return false;		/* EOF before n */
+		done += (size_t) r;
+	}
+	return true;
+}
+
+/* Slurp a whole local regular file into a palloc'd buffer via the race-free opener. */
+char *
+PgColumnarSlurpLocalRegularFile(const char *path, int64 maxlen,
+								const char *what, int64 *outlen)
+{
+	off_t		sz = 0;
+	int			fd = PgColumnarOpenLocalRegularFile(path, &sz);
+	int64		flen = (int64) sz;
+	char	   *buf;
+
+	if (flen < 0 || flen > maxlen)
+	{
+		CloseTransientFile(fd);
+		ereport(ERROR,
+				(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+				 errmsg("columnar: %s \"%s\" is too large", what, path)));
+	}
+	/* flen + 1 and a trailing NUL so text callers can treat it as a cstring;
+	 * binary callers use *outlen and ignore the extra byte. */
+	buf = (char *) palloc(flen + 1);
+	if (flen > 0 && !PgColumnarReadExact(fd, buf, (size_t) flen))
+	{
+		int			save_errno = errno;
+
+		CloseTransientFile(fd);
+		errno = save_errno;
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not read file \"%s\": %m", path)));
+	}
+	CloseTransientFile(fd);
+	buf[flen] = '\0';
+	*outlen = flen;
+	return buf;
 }
 
 const PgColumnarObjStoreApi *

--- a/src/columnar_objstore.h
+++ b/src/columnar_objstore.h
@@ -176,7 +176,27 @@ extern const PgColumnarObjStoreApi *PgColumnarObjStoreGet(void);
 /* Does `path` look like a remote URL at all? Cheap, no module load. */
 extern bool PgColumnarPathIsRemote(const char *path);
 
-/* Refuse a local FIFO/socket/device/directory before it is opened (#644). */
-extern void PgColumnarRejectNonRegularFile(const char *path);
+/*
+ * Open a local regular file for reading with no stat-before-open race: opens
+ * O_NONBLOCK so a FIFO cannot block the open(2), fstats the held fd, refuses a
+ * non-regular file (DATA_CORRUPTED), then clears O_NONBLOCK. Returns a transient
+ * fd (close with CloseTransientFile). *size_out, if non-NULL, receives the size.
+ * The caller must have already excluded remote paths (PgColumnarPathIsRemote).
+ */
+extern int PgColumnarOpenLocalRegularFile(const char *path, off_t *size_out);
+
+/*
+ * Read exactly n bytes from fd into buf (handling short reads and EINTR).
+ * Returns true on success, false on EOF-before-n or error (errno set).
+ */
+extern bool PgColumnarReadExact(int fd, void *buf, size_t n);
+
+/*
+ * Slurp a whole local regular file into a palloc'd buffer via the race-free
+ * opener above. Refuses a file larger than maxlen (PROGRAM_LIMIT_EXCEEDED, with
+ * `what` naming the object, e.g. "Iceberg manifest"). *outlen receives the size.
+ */
+extern char *PgColumnarSlurpLocalRegularFile(const char *path, int64 maxlen,
+											 const char *what, int64 *outlen);
 
 #endif							/* COLUMNAR_OBJSTORE_H */

--- a/src/columnar_parallel_copy.c
+++ b/src/columnar_parallel_copy.c
@@ -597,31 +597,65 @@ pcopy_partition_aligned_offsets(Relation parent, const char *path, int *workers_
 	seg_start[0] = 0;
 
 	/*
-	 * Read via AllocateFile/FreeFile (PostgreSQL-tracked stdio) so getline() can do
-	 * the line parsing: OpenTransientFile + fdopen + fclose would close the OS fd
-	 * but leave fd.c's transient-file bookkeeping dangling ("temporary files not
-	 * closed at end-of-transaction"). The caller has already checked
-	 * pg_read_server_files; re-check it is a regular file here (AllocateFile does
-	 * not), matching pcopy_open_regular_file.
+	 * Open O_NONBLOCK so a FIFO cannot block the open(2) -- a cancel-resistant
+	 * availability DoS (#644/#686) -- then fstat the fd we hold and reject a
+	 * non-regular file, with no stat-before-open race: the file checked is the
+	 * file opened. Clear O_NONBLOCK and fdopen for getline(), which needs stdio.
+	 * A raw open + fdopen (not OpenTransientFile) is used so fclose fully closes it
+	 * without leaving fd.c's transient-file bookkeeping dangling; every error path
+	 * here closes the fd, and the getline loop's fclose runs under the PG_TRY
+	 * below. The caller has already checked pg_read_server_files.
 	 */
 	{
+		int			fd = open(path, O_RDONLY | O_NONBLOCK | PG_BINARY);
 		struct stat st;
+		int			flags;
 
-		if (stat(path, &st) != 0)
+		if (fd < 0)
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not open file \"%s\" for reading: %m", path)));
+		if (fstat(fd, &st) != 0)
+		{
+			int			save_errno = errno;
+
+			close(fd);
+			errno = save_errno;
 			ereport(ERROR,
 					(errcode_for_file_access(),
 					 errmsg("could not stat file \"%s\": %m", path)));
+		}
 		if (!S_ISREG(st.st_mode))
+		{
+			close(fd);
 			ereport(ERROR,
 					(errcode(ERRCODE_WRONG_OBJECT_TYPE),
 					 errmsg("\"%s\" is not a regular file", path)));
+		}
+		flags = fcntl(fd, F_GETFL);
+		if (flags == -1 || fcntl(fd, F_SETFL, flags & ~O_NONBLOCK) == -1)
+		{
+			int			save_errno = errno;
+
+			close(fd);
+			errno = save_errno;
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not clear nonblocking mode on file \"%s\": %m", path)));
+		}
 		size = st.st_size;
+		fp = fdopen(fd, PG_BINARY_R);
+		if (fp == NULL)
+		{
+			int			save_errno = errno;
+
+			close(fd);
+			errno = save_errno;
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not open file \"%s\" for reading: %m", path)));
+		}
 	}
-	fp = AllocateFile(path, PG_BINARY_R);
-	if (fp == NULL)
-		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not open file \"%s\" for reading: %m", path)));
 
 	/*
 	 * Wrap the scan so every exit path -- including an implicit throw from
@@ -687,13 +721,13 @@ pcopy_partition_aligned_offsets(Relation parent, const char *path, int *workers_
 	{
 		if (line)
 			free(line);
-		FreeFile(fp);
+		fclose(fp);
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
 	if (line)
 		free(line);				/* getline() uses malloc, not palloc */
-	FreeFile(fp);
+	fclose(fp);
 
 	while (cur < nseg - 1)
 		seg_start[++cur] = size;

--- a/src/columnar_parquet_reader.c
+++ b/src/columnar_parquet_reader.c
@@ -1511,7 +1511,7 @@ typedef struct PqSourceOps
 struct PqSource
 {
 	const PqSourceOps *ops;		/* the implementation; never NULL once opened */
-	FILE	   *f;				/* AllocateFile handle (buffered), local only */
+	int			fd;				/* transient fd (pread), local only; -1 when none */
 	void	   *priv;			/* remote implementation's own state */
 	const PgColumnarObjStoreApi *api;	/* remote only; NULL for local */
 	const char *path;			/* for error messages; palloc'd by the caller */
@@ -1541,35 +1541,38 @@ struct PqSource
 static void
 pq_source_read_local(PqSource *src, int64 off, void *buf, size_t n)
 {
+	char	   *p = (char *) buf;
+	size_t		done = 0;
+
 	Assert(off >= 0 && n <= (size_t) (src->len - off));
-	if (fseeko(src->f, (off_t) off, SEEK_SET) != 0)
-		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not seek in \"%s\": %m", src->path)));
-	if (fread(buf, 1, n, src->f) != n)
+	while (done < n)
 	{
-		/*
-		 * A short read is not an I/O error, so errno holds whatever a previous
-		 * call left there; reporting %m would name an unrelated cause. Only a
-		 * real stream error gets %m.
-		 */
-		if (ferror(src->f))
+		ssize_t		r = pg_pread(src->fd, p + done, n - done, (off_t) (off + done));
+
+		if (r < 0)
+		{
+			if (errno == EINTR)
+				continue;
 			ereport(ERROR,
 					(errcode_for_file_access(),
 					 errmsg("could not read \"%s\": %m", src->path)));
-		ereport(ERROR,
-				(errcode(ERRCODE_DATA_CORRUPTED),
-				 errmsg("unexpected end of file in \"%s\"", src->path)));
+		}
+		if (r == 0)
+			/* short of n before EOF: a truncated/corrupt Parquet file */
+			ereport(ERROR,
+					(errcode(ERRCODE_DATA_CORRUPTED),
+					 errmsg("unexpected end of file in \"%s\"", src->path)));
+		done += (size_t) r;
 	}
 }
 
 static void
 pq_source_close_local(PqSource *src)
 {
-	if (src->f != NULL)
+	if (src->fd >= 0)
 	{
-		FreeFile(src->f);
-		src->f = NULL;
+		CloseTransientFile(src->fd);
+		src->fd = -1;
 	}
 }
 
@@ -1670,6 +1673,7 @@ pq_source_open_cfg(const char *path, PqSource *src, PqFile *pf,
 
 	memset(src, 0, sizeof(*src));
 	src->path = path;
+	src->fd = -1;
 
 	/*
 	 * Set before anything below can raise, so an error path never leaves a
@@ -1725,19 +1729,11 @@ pq_source_open_cfg(const char *path, PqSource *src, PqFile *pf,
 	}
 	else
 	{
-		PgColumnarRejectNonRegularFile(path);
-		src->f = AllocateFile(path, PG_BINARY_R);
-		if (src->f == NULL)
-			ereport(ERROR,
-					(errcode_for_file_access(),
-					 errmsg("could not open file \"%s\" for reading: %m", path)));
-		/* off_t, not long: a 32-bit long would cap a readable file at 2GB */
-		if (fseeko(src->f, 0, SEEK_END) != 0 || (src->len = ftello(src->f)) < 0)
-		{
-			FreeFile(src->f);
-			ereport(ERROR, (errcode_for_file_access(),
-							errmsg("could not size \"%s\": %m", path)));
-		}
+		off_t		sz = 0;
+
+		/* Race-free local open; see PgColumnarOpenLocalRegularFile. */
+		src->fd = PgColumnarOpenLocalRegularFile(path, &sz);
+		src->len = (int64) sz;
 	}
 
 	if (src->len < 12)

--- a/test/local_open_race_free.sh
+++ b/test/local_open_race_free.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# pgColumnar local file opens are race-free (no stat-before-open TOCTOU).
+#
+# The read path opens local files named by an Iceberg metadata pointer, an Avro
+# manifest, a Parquet path, or an Arrow import. A FIFO named there must not block
+# the backend in open(2): a blocking open is cancel-resistant (SA_RESTART), an
+# availability DoS (#644/#686). The first fix screened with stat() BEFORE the
+# open, which avoids the block but races -- a local principal who can write the
+# directory can swap the checked regular file for a FIFO between the stat and the
+# open, re-introducing the block. All five local openers (ice_slurp_text,
+# ice_slurp_bin, av_slurp_file, import_arrow, the Parquet source) now go through
+# one helper, PgColumnarOpenLocalRegularFile, that opens O_NONBLOCK and fstats the
+# fd it holds: the file it checks is the file it opened.
+#
+# The TOCTOU itself cannot be tested deterministically -- a static FIFO is refused
+# by both the stat and the fstat form, and only a lost race distinguishes them --
+# so, like decode_interrupts.sh, the guard is a source-shape assertion: the opener
+# must open O_NONBLOCK and fstat (never stat a path before opening it), and the
+# racy stat-before-open helper must be gone. A revert to stat-before-open fails
+# these. The functional arm confirms each entry point still refuses a FIFO with a
+# clean SQLSTATE rather than a hang.
+#
+# Usage:  test/local_open_race_free.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+q "CREATE EXTENSION IF NOT EXISTS pgcolumnar;" >/dev/null
+
+SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/src"
+OBJ="$SRC/columnar_objstore.c"
+
+# --- shape arm: the opener is race-free, and the racy helper is gone ----------
+# Body of PgColumnarOpenLocalRegularFile: from its definition line to the next
+# function at column zero.
+opener_body() {
+	awk '/^PgColumnarOpenLocalRegularFile\(/{f=1}
+	     f && NR>1 && /^[A-Za-z_].*\(/ && !/^PgColumnarOpenLocalRegularFile\(/ {exit}
+	     f {print}' "$OBJ"
+}
+
+check "the race-free opener exists" \
+	"$([ -n "$(opener_body)" ] && echo yes || echo no)" "yes"
+check "the opener opens O_NONBLOCK (a FIFO cannot block the open)" \
+	"$([ "$(opener_body | grep -c 'O_NONBLOCK')" -ge 1 ] && echo yes || echo no)" "yes"
+check "the opener fstats the fd it holds (checks what it opened)" \
+	"$([ "$(opener_body | grep -c 'fstat(')" -ge 1 ] && echo yes || echo no)" "yes"
+check "the opener never stats a path before opening it (no TOCTOU)" \
+	"$(opener_body | grep -Ec 'stat\((const )?path|stat\("|stat\(path')" "0"
+check "the racy stat-before-open helper is gone" \
+	"$(grep -rc 'PgColumnarRejectNonRegularFile' "$SRC" | awk -F: '{s+=$2} END{print s+0}')" "0"
+
+# --- functional arm: each newly-converted entry point refuses a FIFO ----------
+# A static FIFO is refused by both the old and new code, so this does not prove
+# the race is closed; it proves the entry point reaches the guard and returns a
+# clean error, not a hang. XX001 is DATA_CORRUPTED, what the opener raises.
+sqlstate_or_hang() {
+	local out rc
+	out="$(timeout -s KILL 5 env PATH="$PGC_BINDIR:$PATH" psql \
+		-h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" -qtA 2>&1 <<SQLEOF
+\\set VERBOSITY sqlstate
+$1;
+SQLEOF
+)"
+	rc=$?
+	if [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then echo HANG; return; fi
+	printf '%s\n' "$out" | sed -n 's/^ERROR:  \([0-9A-Z]\{5\}\).*/\1/p' | head -1
+}
+fifo_release() { exec 9<>"$1" 2>/dev/null; exec 9>&- 2>/dev/null; }
+
+FIFO="$PGC_WORKDIR/lo.fifo"; mkfifo "$FIFO"
+check "read_parquet on a FIFO is a clean error, not a hang" \
+	"$(sqlstate_or_hang "SELECT * FROM pgcolumnar.read_parquet('$FIFO') AS t(c int)")" \
+	"XX001"; fifo_release "$FIFO"
+check "read_avro_manifest on a FIFO is a clean error, not a hang" \
+	"$(sqlstate_or_hang "SELECT count(*) FROM pgcolumnar.read_avro_manifest('$FIFO')")" \
+	"XX001"; fifo_release "$FIFO"
+check "backend still up after the FIFO refusals" "$(q 'SELECT 1')" "1"
+
+pgc_summary

--- a/test/local_open_race_free.sh
+++ b/test/local_open_race_free.sh
@@ -53,6 +53,21 @@ check "the opener never stats a path before opening it (no TOCTOU)" \
 check "the racy stat-before-open helper is gone" \
 	"$(grep -rc 'PgColumnarRejectNonRegularFile' "$SRC" | awk -F: '{s+=$2} END{print s+0}')" "0"
 
+# The parallel-copy partition coordinator opens the file itself (getline needs a
+# FILE*, so it cannot use the transient-fd helper). It must still open O_NONBLOCK
+# and fstat, never stat a path before opening it. Body from its definition line to
+# the next function at column zero.
+PC="$SRC/columnar_parallel_copy.c"
+pcopy_part_body() {
+	awk '/^pcopy_partition_aligned_offsets\(/{f=1}
+	     f && NR>1 && /^[A-Za-z_].*\(/ && !/^pcopy_partition_aligned_offsets\(/ {exit}
+	     f {print}' "$PC"
+}
+check "the partition coordinator opens O_NONBLOCK (a FIFO cannot block its open)" \
+	"$([ "$(pcopy_part_body | grep -c 'O_NONBLOCK')" -ge 1 ] && echo yes || echo no)" "yes"
+check "the partition coordinator never stats a path before opening it (no TOCTOU)" \
+	"$(pcopy_part_body | grep -Ec 'stat\((const )?path|stat\("|stat\(path')" "0"
+
 # --- functional arm: each newly-converted entry point refuses a FIFO ----------
 # A static FIFO is refused by both the old and new code, so this does not prove
 # the race is closed; it proves the entry point reaches the guard and returns a

--- a/test/parallel_copy.sh
+++ b/test/parallel_copy.sh
@@ -458,4 +458,16 @@ check "parallel_copy on a FIFO is refused, not a hang (42809)" \
 exec 9<>"$PCFIFO" 2>/dev/null; exec 9>&- 2>/dev/null    # release any blocked opener
 check "backend still up after the parallel_copy FIFO refusal" "$(q 'SELECT 1')" "1"
 
+# The partition-aligned coordinator (pcopy_partition_aligned_offsets, reached only
+# for a PARTITIONED target) opens the file via getline() and had the same
+# stat-before-open FIFO hazard the single-file path fixed (#696). A FIFO named to a
+# partitioned target must also be refused, not hang.
+mkpart t_fifo_part 3
+PCFIFO2="$PGC_WORKDIR/pc2.fifo"; mkfifo "$PCFIFO2"
+check "parallel_copy on a FIFO via the partitioned coordinator is refused, not a hang (42809)" \
+	"$(sqlstate_or_hang "SELECT pgcolumnar.parallel_copy('t_fifo_part'::regclass, '$PCFIFO2', 3)")" \
+	"42809"
+exec 9<>"$PCFIFO2" 2>/dev/null; exec 9>&- 2>/dev/null
+check "backend still up after the partitioned-coordinator FIFO refusal" "$(q 'SELECT 1')" "1"
+
 pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -103,6 +103,7 @@ SUITES=(
 	import_export_privilege
 	index_only
 	isolation
+	local_open_race_free
 	logical_subscriber
 	maintenance_due
 	native_agg


### PR DESCRIPTION
From the security audit. The non-regular-file guard that keeps a FIFO from blocking the backend in `open(2)` (a cancel-resistant DoS, #644/#686) screened with `stat()` **before** a separate `open()`. That races: a local principal who can write the containing directory can swap the checked regular file for a FIFO in the window, re-introducing the block.

## Fix
All five local openers — `ice_slurp_text`, `ice_slurp_bin`, `av_slurp_file`, `import_arrow`, and the Parquet source `pq_source` — now go through one helper `PgColumnarOpenLocalRegularFile`: open `O_NONBLOCK` (a FIFO returns immediately instead of blocking), `fstat` the held fd, refuse a non-regular file (`DATA_CORRUPTED`), clear `O_NONBLOCK`. **The file it checks is the file it opened.** This is the pattern `pcopy_open_regular_file` already used; the racy `PgColumnarRejectNonRegularFile` is removed. Slurp callers collapse to one `PgColumnarSlurpLocalRegularFile` call (fstat gives the size). The Parquet source reads positionally with `pg_pread`.

## Testing — `local_open_race_free`
The TOCTOU **cannot** be tested deterministically: a static FIFO is refused by both the stat and the fstat form; only a lost race differs. So, per the `decode_interrupts.sh` precedent, the guard is a **source-shape assertion** — the opener opens `O_NONBLOCK` and `fstat`s, never stats a path before opening, and the racy helper is gone. **Removal proof:** reintroducing the stat-before-open helper flips the shape checks red. Functional arm: `read_parquet` / `read_avro_manifest` on a FIFO return a clean `XX001`, not a hang.

**No regression** across iceberg_malformed, arrow_import, avro_manifest, iceberg_scan, iceberg_data_files, parquet_import, native_parquet_streaming, native_parquet_codecs, parquet_nested, objstore_module on pg18_nc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
