### PR TITLE
perf: push parameterized predicates down for chunk-group skipping (O-4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,16 @@ which was true until that script existed.
 
 ### Fixed
 
+- Chunk-group skipping now applies to parameterized predicates. A qual like
+  `col >= $1` from a prepared statement, PL/pgSQL, or the extended protocol kept a
+  `Param` operand, and the scan-key builder accepted only a `Const`, so on a
+  generic plan the scan built no key and read every chunk group. Begin now freezes
+  execution-stable operands (a `PARAM_EXTERN`, or a subexpression with no `Var`,
+  no `PARAM_EXEC`, and no volatile function) into `Const`s before building the
+  keys. A correlated `PARAM_EXEC` changes per rescan and is deliberately not
+  frozen, so results stay correct; the executor still re-applies the original qual
+  to every surviving row. On a 20-group test a `>= $1` generic-plan scan went from
+  reading all 20 groups to reading 1. Regression test: native_param_pushdown.
 - `pgcolumnar.read_manifest_list` now reports a null manifest-list
   `min_sequence_number` as SQL NULL instead of 0, matching `sequence_number`. The
   value is not used by the delete-application rules, so this is a display fix.

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -63,6 +63,7 @@
 #include "statistics/statistics.h"
 #include "catalog/pg_statistic_ext.h"
 #include "utils/builtins.h"
+#include "utils/datum.h"
 #include "utils/lsyscache.h"
 #include "utils/pg_locale.h"
 #include "utils/rel.h"
@@ -534,6 +535,136 @@ PgColumnarBuildScanKeys(List *qual, Index scanrelid, TupleDesc tupdesc,
 
 	*nkeys = n;
 	return keys;
+}
+
+/*
+ * True if the node contains a Var or a PARAM_EXEC parameter: a value that can
+ * differ per row, or per rescan of a correlated (nestloop) inner scan. Such an
+ * operand is not safe to freeze into a scan key, because the keys are built once
+ * at Begin and are not rebuilt on rescan.
+ */
+static bool
+pgcolumnar_operand_unstable_walker(Node *node, void *ctx)
+{
+	if (node == NULL)
+		return false;
+	if (IsA(node, Var))
+		return true;
+	if (IsA(node, Param) && ((Param *) node)->paramkind == PARAM_EXEC)
+		return true;
+	return expression_tree_walker(node, pgcolumnar_operand_unstable_walker, ctx);
+}
+
+/*
+ * Evaluate a scan-key operand to a Const, guarded. Returns NULL if evaluation
+ * raises (e.g. a stable function that errors, or a param not yet bound under a
+ * plain EXPLAIN), so the caller leaves the clause as-is rather than turning a
+ * scan that might otherwise prune the operand away into an error.
+ */
+static Node *
+pgcolumnar_try_eval_const(Node *expr, PlanState *ps, ExprContext *econtext)
+{
+	Node	   *result = NULL;
+	MemoryContext oldcxt = CurrentMemoryContext;
+
+	PG_TRY();
+	{
+		ExprState  *es = ExecInitExpr((Expr *) expr, ps);
+		bool		isnull;
+		Datum		d = ExecEvalExprSwitchContext(es, econtext, &isnull);
+		Oid			typ = exprType(expr);
+		int16		typlen;
+		bool		typbyval;
+
+		get_typlenbyval(typ, &typlen, &typbyval);
+		if (!isnull && !typbyval)
+			d = datumCopy(d, typbyval, typlen);
+		result = (Node *) makeConst(typ, exprTypmod(expr), exprCollation(expr),
+									(int) typlen, isnull ? (Datum) 0 : d,
+									isnull, typbyval);
+	}
+	PG_CATCH();
+	{
+		MemoryContextSwitchTo(oldcxt);
+		FlushErrorState();
+		result = NULL;
+	}
+	PG_END_TRY();
+	return result;
+}
+
+/*
+ * Freeze execution-stable non-Const operands of a scan qual into Consts, so a
+ * predicate like "col >= $1" (a PARAM_EXTERN from a prepared statement or
+ * PL/pgSQL, or a stable subexpression) can drive chunk-group skipping.
+ * pgcolumnar_clause_to_scankey only accepts a Const operand, so without this a
+ * parameterized scan disables pruning entirely and reads every chunk group.
+ *
+ * Only operands that cannot change within this execution are frozen: no Var, no
+ * PARAM_EXEC, and no volatile function. Freezing an unstable operand would be a
+ * wrong-results bug (a group wrongly skipped is never rechecked); freezing a
+ * stable one is exact, and the executor still re-applies the original qual to
+ * every surviving row. Returns the qual unchanged when no expression context is
+ * available yet.
+ */
+static List *
+pgcolumnar_stabilize_quals(List *qual, PlanState *ps)
+{
+	ExprContext *econtext;
+	List	   *out = NIL;
+	ListCell   *lc;
+
+	if (qual == NIL || ps == NULL || ps->ps_ExprContext == NULL)
+		return qual;
+	econtext = ps->ps_ExprContext;
+
+	foreach(lc, qual)
+	{
+		Node	   *clause = (Node *) lfirst(lc);
+		OpExpr	   *op;
+		List	   *newargs = NIL;
+		ListCell   *alc;
+		bool		changed = false;
+
+		if (!IsA(clause, OpExpr) || list_length(((OpExpr *) clause)->args) != 2)
+		{
+			out = lappend(out, clause);
+			continue;
+		}
+		op = (OpExpr *) clause;
+		foreach(alc, op->args)
+		{
+			Node	   *arg = (Node *) lfirst(alc);
+			Node	   *bare = arg;
+
+			if (IsA(bare, RelabelType))
+				bare = (Node *) ((RelabelType *) bare)->arg;
+			if (!IsA(bare, Const) &&
+				!pgcolumnar_operand_unstable_walker(arg, NULL) &&
+				!contain_volatile_functions(arg))
+			{
+				Node	   *c = pgcolumnar_try_eval_const(arg, ps, econtext);
+
+				if (c != NULL)
+				{
+					newargs = lappend(newargs, c);
+					changed = true;
+					continue;
+				}
+			}
+			newargs = lappend(newargs, arg);
+		}
+		if (changed)
+		{
+			OpExpr	   *nop = copyObject(op);
+
+			nop->args = newargs;
+			out = lappend(out, (Node *) nop);
+		}
+		else
+			out = lappend(out, clause);
+	}
+	return out;
 }
 
 /*
@@ -2100,8 +2231,14 @@ PgColumnarBeginCustomScan(CustomScanState *node, EState *estate, int eflags)
 	 */
 	cstate->projectedColumns =
 		pgcolumnar_projected_columns(cscan, tupdesc->natts, &cstate->nProjected);
+	/*
+	 * Freeze stable parameters (e.g. "col >= $1" from a prepared statement) into
+	 * Consts so they drive chunk-group skipping; a plain Const qual is unchanged.
+	 */
 	cstate->scanKeys =
-		PgColumnarBuildScanKeys(cscan->scan.plan.qual, cscan->scan.scanrelid,
+		PgColumnarBuildScanKeys(pgcolumnar_stabilize_quals(cscan->scan.plan.qual,
+														   &node->ss.ps),
+							  cscan->scan.scanrelid,
 							  tupdesc, &cstate->nScanKeys);
 
 	/* the projection the planner chose (gap 26); reported by EXPLAIN */

--- a/test/native_param_pushdown.sh
+++ b/test/native_param_pushdown.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# pgColumnar chunk-group skipping works for parameterized predicates.
+#
+# The scan-key builder (pgcolumnar_clause_to_scankey) only accepted a Const
+# operand, so a predicate like "col >= $1" -- a PARAM_EXTERN from a prepared
+# statement, PL/pgSQL, or the extended protocol -- built no scan key and disabled
+# chunk-group skipping entirely. On a generic plan the scan then read every group.
+#
+# Begin now freezes execution-stable operands (a PARAM_EXTERN, or any subexpression
+# with no Var, no PARAM_EXEC, and no volatile function) into Consts before building
+# the keys. This is exact: such an operand cannot change within the execution, and
+# the executor still re-applies the original qual to every surviving row.
+#
+# The correctness hazard is a correlated PARAM_EXEC (a nestloop inner scan whose
+# qual references the outer row): it changes per rescan, and the keys are built
+# once, so freezing it would silently skip groups that in fact match. That param
+# is deliberately NOT frozen; the correlated arm below proves results stay correct.
+#
+# Usage:  test/native_param_pushdown.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+q "CREATE EXTENSION IF NOT EXISTS pgcolumnar;" >/dev/null
+# 40000 rows / 2000 = 20 monotonic groups; ts >= 39000 lives in the last group.
+q "SET pgcolumnar.stripe_row_limit=2000;
+   CREATE TABLE t (id int, ts int) USING pgcolumnar;
+   INSERT INTO t SELECT g, g FROM generate_series(1,40000) g;
+   CREATE TABLE thr (lo int); INSERT INTO thr VALUES (39000),(38000);" >/dev/null
+
+psql_c() { env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" -At -c "$1" 2>&1; }
+
+# Groups read by a generic-plan parameterized scan. Under the fix the last group
+# is the only one read; without it, all 20 are.
+groups_removed() {
+	psql_c "SET plan_cache_mode=force_generic_plan;
+		DEALLOCATE ALL;
+		PREPARE p(int) AS SELECT count(*) FROM t WHERE ts >= \$1;
+		EXPLAIN (ANALYZE, TIMING off, SUMMARY off) EXECUTE p(39000);" \
+		| sed -n 's/.*Chunk Groups Removed by Filter: \([0-9]*\).*/\1/p' | head -1
+}
+
+check "a generic-plan parameterized qual prunes chunk groups (19 of 20 removed)" \
+	"$(groups_removed)" "19"
+
+# Correctness: the pruned count equals the literal count (ids 39000..40000).
+prep_count() {
+	psql_c "SET plan_cache_mode=force_generic_plan;
+		DEALLOCATE ALL;
+		PREPARE c(int) AS SELECT count(*) FROM t WHERE ts >= \$1;
+		EXECUTE c(39000);" | tail -1
+}
+check "parameterized count matches the literal count" "$(prep_count)" "1001"
+check "literal count is the expected value" \
+	"$(q 'SELECT count(*) FROM t WHERE ts >= 39000;')" "1001"
+
+# Safety: a correlated PARAM_EXEC (nestloop inner scan) must NOT be frozen, or it
+# would mis-prune per outer row. sum over thr(39000, 38000) = 1001 + 2001 = 3002.
+check "a correlated PARAM_EXEC is not mis-pruned (results stay correct)" \
+	"$(q 'SELECT sum(c) FROM thr, LATERAL (SELECT count(*) c FROM t WHERE t.ts >= thr.lo) s;')" \
+	"3002"
+
+check "backend alive" "$(q 'SELECT 1;')" "1"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -141,6 +141,7 @@ SUITES=(
 	native_lazy_slot
 	native_metadata_flush
 	native_ownership
+	native_param_pushdown
 	native_parquet_codecs
 	native_parquet_dict_oob
 	native_parquet_fdw


### PR DESCRIPTION
From the optimization audit. A qual like `col >= $1` (a `PARAM_EXTERN` from a prepared statement, PL/pgSQL, or the extended protocol) kept a `Param` operand, and the scan-key builder accepted only a `Const`, so **on a generic plan the scan built no key and read every chunk group**.

**Measured:** a 20 row-group table, `WHERE ts >= 39000` removed 19/20 groups as a literal but **0/20** as a generic-plan `$1`.

## Fix
Begin freezes **execution-stable** operands into `Const`s before building the keys: a `PARAM_EXTERN`, or any subexpression with no `Var`, no `PARAM_EXEC`, and no volatile function. Such an operand can't change within the execution, and the executor still re-applies the original qual to every surviving row, so the skip is exact.

### The correctness hazard, handled
A **correlated `PARAM_EXEC`** (nestloop inner scan whose qual references the outer row) changes per rescan, and the keys are built once and not rebuilt — freezing it would silently skip matching groups. It is deliberately **not** frozen. Evaluation is `PG_TRY`-guarded so a stable operand that raises leaves the clause unchanged.

## Test — `native_param_pushdown`
- Generic-plan `$1` now removes 19/20 groups.
- Parameterized count equals literal (1001).
- **Correlated `PARAM_EXEC`** over `thr(39000,38000)` stays correct (3002).
- **Removal proof:** bypassing the freeze reads 0 removed while correctness stays green (pruning is a pure optimization; the executor re-filters).

**No regression** across pushdown_report, native_skip, native_zonemap, planner_choice_quality, native_late_materialization, **differential**, parallel_vector_agg, native_parquet_pushdown on pg18_nc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
