### PR TITLE
perf: read only the predicate columns' zone maps for skipping (O-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ which was true until that script existed.
 
 ### Fixed
 
+- Group and per-vector skipping now read only the predicate columns' zone maps.
+  `pgcolumnar_native_group_can_match` and the per-vector skip builder read the
+  whole group's zone maps (every attribute's min/max) up front and used only the
+  columns carrying predicates, so on a wide table a scan that consults one or two
+  columns paid min/max buffer traffic proportional to the table width. Both now
+  probe per column via `zone_map_pkey`'s `column_index`, exactly as the per-column
+  bloom fetch already did; the per-vector spans (identical across columns) come
+  from a predicate column, falling back to the whole-group read only when no
+  predicate column has per-vector rows. On a 30-column table a one-predicate scan
+  went from about 1200 zone-map row fetches to 30, matching the 2-column table.
+  Regression test: native_zonemap_narrow.
 - `pgcolumnar.read_manifest_list` now reports a null manifest-list
   `min_sequence_number` as SQL NULL instead of 0, matching `sequence_number`. The
   value is not used by the delete-application rules, so this is a display fix.

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -454,6 +454,9 @@ extern void PgColumnarCheckNativeFormatVersion(uint64 storageId, const char *rel
 extern List *PgColumnarReadRowGroupList(uint64 storageId, Snapshot snapshot);
 extern List *PgColumnarReadZoneMapList(uint64 storageId, uint64 groupNumber,
 									 Snapshot snapshot);
+extern NativeZoneMapMetadata *PgColumnarReadZoneMapForColumn(uint64 storageId,
+									 uint64 groupNumber, int columnIndex,
+									 Snapshot snapshot);
 extern void PgColumnarDeleteMetadata(uint64 storageId);
 
 /* per-table options catalog (spec 7.4) */

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -2262,6 +2262,10 @@ PgColumnarReadBloomForColumn(uint64 storageId, uint64 groupNumber,
 	return b;
 }
 
+static NativeZoneMapMetadata *zonemap_from_tuple(HeapTuple tuple,
+					TupleDesc tupdesc, uint64 storageId,
+					uint64 groupNumber, int32 vecIndex);
+
 /*
  * PgColumnarReadZoneMapVectors
  *		The per-vector zone maps (vector_index >= 0) of one row group, for
@@ -2289,48 +2293,63 @@ PgColumnarReadZoneMapVectors(uint64 storageId, uint64 groupNumber, Snapshot snap
 							  2, key);
 	while (HeapTupleIsValid(tuple = systable_getnext(scan)))
 	{
-		NativeZoneMapMetadata *z;
 		bool		isnull;
-		int32		vecIndex;
-		Datum		d;
-
-		vecIndex = DatumGetInt32(
+		int32		vecIndex = DatumGetInt32(
 			heap_getattr(tuple, Anum_zone_map_vector_index, tupdesc, &isnull));
+
 		if (vecIndex < 0)
 			continue;			/* per-vector rows only */
 
-		z = palloc0(sizeof(NativeZoneMapMetadata));
-		z->storageId = storageId;
-		z->groupNumber = groupNumber;
-		z->columnIndex = DatumGetInt16(
-			heap_getattr(tuple, Anum_zone_map_column_index, tupdesc, &isnull));
-		z->vectorIndex = vecIndex;
+		result = lappend(result,
+						 zonemap_from_tuple(tuple, tupdesc, storageId,
+											groupNumber, vecIndex));
+	}
+	systable_endscan(scan);
+	table_close(rel, AccessShareLock);
 
-		d = heap_getattr(tuple, Anum_zone_map_minimum, tupdesc, &isnull);
-		if (!isnull)
-		{
-			bytea	   *bmin = DatumGetByteaPP(d);
-			Datum		dmax = heap_getattr(tuple, Anum_zone_map_maximum,
-											tupdesc, &isnull);
+	return result;
+}
 
-			if (!isnull)
-			{
-				bytea	   *bmax = DatumGetByteaPP(dmax);
+/*
+ * PgColumnarReadZoneMapVectorsForColumn
+ *		The per-vector zone maps of ONE column of a row group. Mirrors
+ *		PgColumnarReadZoneMapForColumn: per-vector skipping consults only the
+ *		predicate columns, and every column's per-vector rows carry the same
+ *		value/null counts, so a scan reads the predicate columns' rows plus one
+ *		column's for the vector spans, not every attribute's. Probes zone_map_pkey
+ *		on (storage_id, group_number, column_index).
+ */
+List *
+PgColumnarReadZoneMapVectorsForColumn(uint64 storageId, uint64 groupNumber,
+									  int columnIndex, Snapshot snapshot)
+{
+	Relation	rel = open_columnar_table("zone_map", AccessShareLock);
+	TupleDesc	tupdesc = RelationGetDescr(rel);
+	ScanKeyData key[3];
+	SysScanDesc scan;
+	Oid			idxOid;
+	HeapTuple	tuple;
+	List	   *result = NIL;
 
-				z->minimumLen = VARSIZE_ANY_EXHDR(bmin);
-				z->minimum = (const char *) memcpy(palloc(z->minimumLen + 1),
-												   VARDATA_ANY(bmin), z->minimumLen);
-				z->maximumLen = VARSIZE_ANY_EXHDR(bmax);
-				z->maximum = (const char *) memcpy(palloc(z->maximumLen + 1),
-												   VARDATA_ANY(bmax), z->maximumLen);
-				z->hasMinMax = true;
-			}
-		}
-		z->valueCount = (uint64) DatumGetInt64(
-			heap_getattr(tuple, Anum_zone_map_value_count, tupdesc, &isnull));
-		z->nullCount = (uint64) DatumGetInt64(
-			heap_getattr(tuple, Anum_zone_map_null_count, tupdesc, &isnull));
-		result = lappend(result, z);
+	ScanKeyInit(&key[0], Anum_zone_map_storage_id, BTEqualStrategyNumber,
+				F_INT8EQ, Int64GetDatum((int64) storageId));
+	ScanKeyInit(&key[1], Anum_zone_map_group_number, BTEqualStrategyNumber,
+				F_INT8EQ, Int64GetDatum((int64) groupNumber));
+	ScanKeyInit(&key[2], Anum_zone_map_column_index, BTEqualStrategyNumber,
+				F_INT2EQ, Int16GetDatum((int16) columnIndex));
+	idxOid = pgcolumnar_index_oid("zone_map_pkey");
+	scan = systable_beginscan(rel, idxOid, OidIsValid(idxOid), snapshot, 3, key);
+	while (HeapTupleIsValid(tuple = systable_getnext(scan)))
+	{
+		bool		isnull;
+		int32		vecIndex = DatumGetInt32(
+			heap_getattr(tuple, Anum_zone_map_vector_index, tupdesc, &isnull));
+
+		if (vecIndex < 0)
+			continue;			/* per-vector rows only */
+		result = lappend(result,
+						 zonemap_from_tuple(tuple, tupdesc, storageId,
+											groupNumber, vecIndex));
 	}
 	systable_endscan(scan);
 	table_close(rel, AccessShareLock);
@@ -2471,6 +2490,61 @@ PgColumnarReadColumnChunkList(uint64 storageId, uint64 groupNumber, Snapshot sna
 }
 
 /*
+ * zonemap_from_tuple
+ *		Build a NativeZoneMapMetadata from one whole-chunk zone_map tuple. Shared
+ *		by the whole-group reader and the per-column probe; the caller has
+ *		confirmed vector_index == -1 and holds the relation open. min/max/sum are
+ *		copied into the current memory context.
+ */
+static NativeZoneMapMetadata *
+zonemap_from_tuple(HeapTuple tuple, TupleDesc tupdesc,
+				   uint64 storageId, uint64 groupNumber, int32 vecIndex)
+{
+	NativeZoneMapMetadata *z = palloc0(sizeof(NativeZoneMapMetadata));
+	bool		isnull;
+	Datum		d;
+
+	z->storageId = storageId;
+	z->groupNumber = groupNumber;
+	z->columnIndex = DatumGetInt16(
+		heap_getattr(tuple, Anum_zone_map_column_index, tupdesc, &isnull));
+	z->vectorIndex = vecIndex;
+
+	d = heap_getattr(tuple, Anum_zone_map_minimum, tupdesc, &isnull);
+	if (!isnull)
+	{
+		bytea	   *bmin = DatumGetByteaPP(d);
+		Datum		dmax = heap_getattr(tuple, Anum_zone_map_maximum, tupdesc, &isnull);
+
+		if (!isnull)
+		{
+			bytea	   *bmax = DatumGetByteaPP(dmax);
+
+			z->minimumLen = VARSIZE_ANY_EXHDR(bmin);
+			z->minimum = (const char *) memcpy(palloc(z->minimumLen + 1),
+											   VARDATA_ANY(bmin), z->minimumLen);
+			z->maximumLen = VARSIZE_ANY_EXHDR(bmax);
+			z->maximum = (const char *) memcpy(palloc(z->maximumLen + 1),
+											   VARDATA_ANY(bmax), z->maximumLen);
+			z->hasMinMax = true;
+		}
+	}
+
+	d = heap_getattr(tuple, Anum_zone_map_sum, tupdesc, &isnull);
+	if (!isnull)
+	{
+		z->sum = datumCopy(d, false, -1);	/* numeric is varlena */
+		z->hasSum = true;
+	}
+
+	z->valueCount = (uint64) DatumGetInt64(
+		heap_getattr(tuple, Anum_zone_map_value_count, tupdesc, &isnull));
+	z->nullCount = (uint64) DatumGetInt64(
+		heap_getattr(tuple, Anum_zone_map_null_count, tupdesc, &isnull));
+	return z;
+}
+
+/*
  * PgColumnarReadZoneMapList
  *		The whole-chunk zone maps (vector_index -1) of one row group, for group
  *		skipping (native spec 7.1, Phase D5b). The caller indexes the result by
@@ -2497,56 +2571,61 @@ PgColumnarReadZoneMapList(uint64 storageId, uint64 groupNumber, Snapshot snapsho
 							  2, key);
 	while (HeapTupleIsValid(tuple = systable_getnext(scan)))
 	{
-		NativeZoneMapMetadata *z;
 		bool		isnull;
-		int32		vecIndex;
-		Datum		d;
-
-		vecIndex = DatumGetInt32(
+		int32		vecIndex = DatumGetInt32(
 			heap_getattr(tuple, Anum_zone_map_vector_index, tupdesc, &isnull));
+
 		if (vecIndex != -1)
 			continue;			/* whole-chunk rows only, for group skipping */
 
-		z = palloc0(sizeof(NativeZoneMapMetadata));
-		z->storageId = storageId;
-		z->groupNumber = groupNumber;
-		z->columnIndex = DatumGetInt16(
-			heap_getattr(tuple, Anum_zone_map_column_index, tupdesc, &isnull));
-		z->vectorIndex = vecIndex;
+		result = lappend(result,
+						 zonemap_from_tuple(tuple, tupdesc, storageId, groupNumber, -1));
+	}
+	systable_endscan(scan);
+	table_close(rel, AccessShareLock);
 
-		d = heap_getattr(tuple, Anum_zone_map_minimum, tupdesc, &isnull);
-		if (!isnull)
-		{
-			bytea	   *bmin = DatumGetByteaPP(d);
-			Datum		dmax = heap_getattr(tuple, Anum_zone_map_maximum,
-											tupdesc, &isnull);
+	return result;
+}
 
-			if (!isnull)
-			{
-				bytea	   *bmax = DatumGetByteaPP(dmax);
+/*
+ * PgColumnarReadZoneMapForColumn
+ *		The whole-chunk zone map of ONE column of a row group, for group skipping.
+ *		Mirrors PgColumnarReadBloomForColumn: a scan wants the zone maps of only
+ *		the columns carrying predicates, so reading a whole group's worth (all
+ *		attributes) is wasted work and buffer traffic on a wide table. zone_map_pkey
+ *		is (storage_id, group_number, column_index, vector_index), so this probes
+ *		the exact column. Returns NULL when the column has no whole-chunk zone map.
+ */
+NativeZoneMapMetadata *
+PgColumnarReadZoneMapForColumn(uint64 storageId, uint64 groupNumber,
+							   int columnIndex, Snapshot snapshot)
+{
+	Relation	rel = open_columnar_table("zone_map", AccessShareLock);
+	TupleDesc	tupdesc = RelationGetDescr(rel);
+	ScanKeyData key[3];
+	SysScanDesc scan;
+	Oid			idxOid;
+	HeapTuple	tuple;
+	NativeZoneMapMetadata *result = NULL;
 
-				z->minimumLen = VARSIZE_ANY_EXHDR(bmin);
-				z->minimum = (const char *) memcpy(palloc(z->minimumLen + 1),
-												   VARDATA_ANY(bmin), z->minimumLen);
-				z->maximumLen = VARSIZE_ANY_EXHDR(bmax);
-				z->maximum = (const char *) memcpy(palloc(z->maximumLen + 1),
-												   VARDATA_ANY(bmax), z->maximumLen);
-				z->hasMinMax = true;
-			}
-		}
+	ScanKeyInit(&key[0], Anum_zone_map_storage_id, BTEqualStrategyNumber,
+				F_INT8EQ, Int64GetDatum((int64) storageId));
+	ScanKeyInit(&key[1], Anum_zone_map_group_number, BTEqualStrategyNumber,
+				F_INT8EQ, Int64GetDatum((int64) groupNumber));
+	ScanKeyInit(&key[2], Anum_zone_map_column_index, BTEqualStrategyNumber,
+				F_INT2EQ, Int16GetDatum((int16) columnIndex));
+	idxOid = pgcolumnar_index_oid("zone_map_pkey");
+	scan = systable_beginscan(rel, idxOid, OidIsValid(idxOid), snapshot, 3, key);
+	while (HeapTupleIsValid(tuple = systable_getnext(scan)))
+	{
+		bool		isnull;
+		int32		vecIndex = DatumGetInt32(
+			heap_getattr(tuple, Anum_zone_map_vector_index, tupdesc, &isnull));
 
-		d = heap_getattr(tuple, Anum_zone_map_sum, tupdesc, &isnull);
-		if (!isnull)
-		{
-			z->sum = datumCopy(d, false, -1);	/* numeric is varlena */
-			z->hasSum = true;
-		}
-
-		z->valueCount = (uint64) DatumGetInt64(
-			heap_getattr(tuple, Anum_zone_map_value_count, tupdesc, &isnull));
-		z->nullCount = (uint64) DatumGetInt64(
-			heap_getattr(tuple, Anum_zone_map_null_count, tupdesc, &isnull));
-		result = lappend(result, z);
+		if (vecIndex != -1)
+			continue;			/* whole-chunk row only */
+		result = zonemap_from_tuple(tuple, tupdesc, storageId, groupNumber, -1);
+		break;
 	}
 	systable_endscan(scan);
 	table_close(rel, AccessShareLock);

--- a/src/columnar_metadata.h
+++ b/src/columnar_metadata.h
@@ -69,6 +69,9 @@ extern List *PgColumnarReadColumnChunkList(uint64 storageId, uint64 groupNumber,
 
 extern List *PgColumnarReadZoneMapVectors(uint64 storageId, uint64 groupNumber,
 										Snapshot snapshot);
+extern List *PgColumnarReadZoneMapVectorsForColumn(uint64 storageId,
+										uint64 groupNumber, int columnIndex,
+										Snapshot snapshot);
 
 extern NativeBloomMetadata *PgColumnarReadBloomForColumn(uint64 storageId,
 													   uint64 groupNumber,

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -1273,32 +1273,43 @@ native_zone_excludes(SkipPredicate *pred, Form_pg_attribute att,
 static bool
 pgcolumnar_native_group_can_match(PgColumnarReadState *rs, uint64 groupNumber)
 {
-	List	   *zones;
-	NativeZoneMapMetadata **byCol;
+	NativeZoneMapMetadata **byColZone = NULL;
+	bool	   *zoneLookedUp = NULL;
 	NativeBloomMetadata **byColBloom = NULL;
 	bool	   *bloomLookedUp = NULL;
-	ListCell   *lc;
 	int			p;
 
 	if (rs->numPredicates == 0)
 		return true;
-
-	zones = PgColumnarReadZoneMapList(rs->storageId, groupNumber, rs->metaSnapshot);
-	byCol = palloc0(sizeof(NativeZoneMapMetadata *) * rs->natts);
-	foreach(lc, zones)
-	{
-		NativeZoneMapMetadata *z = (NativeZoneMapMetadata *) lfirst(lc);
-
-		if (z->columnIndex >= 0 && z->columnIndex < rs->natts)
-			byCol[z->columnIndex] = z;
-	}
 
 	for (p = 0; p < rs->numPredicates; p++)
 	{
 		SkipPredicate *pred = &rs->predicates[p];
 		Form_pg_attribute att = TupleDescAttr(rs->tupdesc, pred->attidx);
 
-		if (native_zone_excludes(pred, att, byCol[pred->attidx], rs->skipContext))
+		/*
+		 * Fetch this column's zone map on first use, not the whole group's. A
+		 * predicate probes one column, so a scan needs the zone maps of the
+		 * columns carrying predicates and no others; reading every attribute's
+		 * min/max is buffer traffic proportional to the table width (#314, the
+		 * same saving the per-column bloom fetch below already makes).
+		 * zoneLookedUp records the fetch, not the result, so a column with no
+		 * zone map is looked up once rather than on every predicate.
+		 */
+		if (byColZone == NULL)
+		{
+			byColZone = palloc0(sizeof(NativeZoneMapMetadata *) * rs->natts);
+			zoneLookedUp = palloc0(sizeof(bool) * rs->natts);
+		}
+		if (!zoneLookedUp[pred->attidx])
+		{
+			byColZone[pred->attidx] =
+				PgColumnarReadZoneMapForColumn(rs->storageId, groupNumber,
+											   pred->attidx, rs->metaSnapshot);
+			zoneLookedUp[pred->attidx] = true;
+		}
+
+		if (native_zone_excludes(pred, att, byColZone[pred->attidx], rs->skipContext))
 			return false;
 
 		/*
@@ -1528,7 +1539,7 @@ PgColumnarEstimatePruneSurvival(uint64 storageId, TupleDesc tupdesc, List *qual,
 static void
 pgcolumnar_native_build_skipvec(PgColumnarReadState *rs, uint64 groupNumber, int vecCount)
 {
-	List	   *zones;
+	List	   *spanZones;
 	NativeZoneMapMetadata ***byColVec;
 	uint32	   *span;
 	bool	   *skip;
@@ -1557,33 +1568,59 @@ pgcolumnar_native_build_skipvec(PgColumnarReadState *rs, uint64 groupNumber, int
 	if (rs->numPredicates == 0 && rs->nativeQualFilter == NULL)
 		return;
 
-	zones = PgColumnarReadZoneMapVectors(rs->storageId, groupNumber, rs->metaSnapshot);
-	if (zones == NIL)
-		return;					/* legacy: no per-vector zone maps */
-
 	/* per-predicate-column lookup [column][vector] */
 	byColVec = (NativeZoneMapMetadata ***)
 		palloc0(sizeof(NativeZoneMapMetadata **) * rs->natts);
+
+	/*
+	 * Read only the predicate columns' per-vector zone maps, plus one column's
+	 * for the vector spans. Reading every attribute's per-vector rows up front is
+	 * buffer traffic proportional to the table width, for a scan that consults
+	 * one or two columns (#314, the per-column bloom fetch makes the same saving).
+	 */
+	spanZones = NIL;
 	for (p = 0; p < rs->numPredicates; p++)
 	{
 		int			col = rs->predicates[p].attidx;
+		List	   *cz;
 
-		if (col >= 0 && col < rs->natts && byColVec[col] == NULL)
-			byColVec[col] = (NativeZoneMapMetadata **)
-				palloc0(sizeof(NativeZoneMapMetadata *) * vecCount);
+		if (col < 0 || col >= rs->natts || byColVec[col] != NULL)
+			continue;
+		cz = PgColumnarReadZoneMapVectorsForColumn(rs->storageId, groupNumber,
+												   col, rs->metaSnapshot);
+		byColVec[col] = (NativeZoneMapMetadata **)
+			palloc0(sizeof(NativeZoneMapMetadata *) * vecCount);
+		foreach(lc, cz)
+		{
+			NativeZoneMapMetadata *z = (NativeZoneMapMetadata *) lfirst(lc);
+
+			if (z->vectorIndex >= 0 && z->vectorIndex < vecCount)
+				byColVec[col][z->vectorIndex] = z;
+		}
+		if (spanZones == NIL && cz != NIL)
+			spanZones = cz;
 	}
 
+	/*
+	 * The spans are the same for every column, so a predicate column's rows
+	 * supply them. When no predicate column has per-vector rows (a phase-2
+	 * qual-only scan, or legacy predicate columns), fall back to the whole-group
+	 * read purely to size the spans; correctness never depends on which column
+	 * supplied them.
+	 */
+	if (spanZones == NIL)
+		spanZones = PgColumnarReadZoneMapVectors(rs->storageId, groupNumber,
+												 rs->metaSnapshot);
+	if (spanZones == NIL)
+		return;					/* legacy: no per-vector zone maps */
+
 	span = (uint32 *) palloc0(sizeof(uint32) * vecCount);
-	foreach(lc, zones)
+	foreach(lc, spanZones)
 	{
 		NativeZoneMapMetadata *z = (NativeZoneMapMetadata *) lfirst(lc);
 
-		if (z->vectorIndex < 0 || z->vectorIndex >= vecCount)
-			continue;
-		span[z->vectorIndex] = (uint32) (z->valueCount + z->nullCount);
-		if (z->columnIndex >= 0 && z->columnIndex < rs->natts &&
-			byColVec[z->columnIndex] != NULL)
-			byColVec[z->columnIndex][z->vectorIndex] = z;
+		if (z->vectorIndex >= 0 && z->vectorIndex < vecCount)
+			span[z->vectorIndex] = (uint32) (z->valueCount + z->nullCount);
 	}
 
 	MemoryContextReset(rs->skipContext);

--- a/test/native_zonemap_narrow.sh
+++ b/test/native_zonemap_narrow.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# pgColumnar group-skipping reads only the predicate columns' zone maps.
+#
+# pgcolumnar_native_group_can_match read the WHOLE group's zone maps up front
+# (PgColumnarReadZoneMapList, all attributes) and used only the columns carrying
+# predicates. On a wide table that is min/max buffer traffic proportional to the
+# table width, for a scan that consults one or two columns. The per-column bloom
+# fetch already avoids exactly this; the zone map now does too, via a per-column
+# probe (PgColumnarReadZoneMapForColumn) keyed on zone_map_pkey's column_index.
+#
+# The measurement is width-independent: a one-predicate scan reads the same number
+# of zone_map tuples whether the table has 2 columns or 30, because it fetches only
+# the predicate column's zone map. Before the change the wide table read about
+# width-times more. The instrument is pg_stat_all_tables.idx_tup_fetch for
+# pgcolumnar.zone_map, made readable with pg_stat_force_next_flush.
+#
+# Removal proof: reverting to the whole-group read makes the wide table's zone_map
+# fetches scale with its column count, so the wide-vs-narrow check fails.
+#
+# Usage:  test/native_zonemap_narrow.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+q "CREATE EXTENSION IF NOT EXISTS pgcolumnar;" >/dev/null
+
+wcols=""; wvals=""
+for i in $(seq 1 30); do
+	wcols="$wcols${wcols:+, }c$i int"
+	wvals="$wvals${wvals:+, }g"
+done
+q "SET pgcolumnar.stripe_row_limit=2000;
+   CREATE TABLE w ($wcols) USING pgcolumnar;
+   INSERT INTO w SELECT $wvals FROM generate_series(1,20000) g;
+   CREATE TABLE n (c1 int, c2 int) USING pgcolumnar;
+   INSERT INTO n SELECT g, g FROM generate_series(1,20000) g;" >/dev/null
+
+# zone_map tuples fetched by a one-predicate scan of TABLE, examining every group.
+zm_fetch() {
+	q "SELECT pg_stat_reset();" >/dev/null
+	q "SELECT count(*) FROM $1 WHERE c1 >= 0;" >/dev/null
+	q "SELECT pg_stat_force_next_flush();" >/dev/null
+	q "SELECT coalesce(idx_tup_fetch,0) FROM pg_stat_all_tables WHERE relname='zone_map' AND schemaname='pgcolumnar';"
+}
+
+WF="$(zm_fetch w)"
+NF="$(zm_fetch n)"
+echo "-- zone_map idx_tup_fetch: wide(30 col)=$WF narrow(2 col)=$NF"
+
+# Per-column: the 30-column table reads essentially the same zone_map tuples as
+# the 2-column table (only c1's). Allow a small margin. Before the fix WF was
+# about 15x NF (30 columns vs 2), so this fails on the whole-group read.
+check "zone_map reads scale with predicates, not table width (wide ~= narrow)" \
+	"$([ "$WF" -le $((NF * 2)) ] && echo yes || echo no)" "yes"
+
+# Correctness: skipping unread columns' zone maps must not change results.
+check "wide scan result is correct" "$(q 'SELECT count(*) FROM w WHERE c1 >= 0;')" "20000"
+check "narrow scan result is correct" "$(q 'SELECT count(*) FROM n WHERE c1 >= 0;')" "20000"
+# A pruning scan still prunes: c1 has values 1..20000 across 10 groups; c1 > 19000
+# lives in the last group only.
+check "a pruning predicate still prunes on the wide table" \
+	"$(q 'SELECT count(*) FROM w WHERE c1 > 19000;')" "1000"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -175,6 +175,7 @@ SUITES=(
 	native_vecskip
 	native_writer
 	native_zonemap
+	native_zonemap_narrow
 	objstore_addressing
 	objstore_allowlist
 	objstore_credentials


### PR DESCRIPTION
From the optimization audit (two agents flagged it independently). `pgcolumnar_native_group_can_match` and the per-vector skip builder read the **whole group's zone maps** — every attribute's min/max — and used only the columns carrying predicates. On a wide table that's min/max read+copy traffic **proportional to the table width**, for a scan that consults one or two columns. The per-column bloom fetch already avoids exactly this (#314); the zone map now does too.

## Fix
`zone_map_pkey` is `(storage_id, group_number, column_index, vector_index)`, so a per-column probe is a 3-key index scan. New `PgColumnarReadZoneMapForColumn` / `PgColumnarReadZoneMapVectorsForColumn` read one column's maps. `can_match` fetches each predicate column lazily (mirroring the bloom `byCol`/`lookedUp` pattern). `build_skipvec` reads each predicate column's per-vector maps; **the vector spans are identical across columns**, so they come from a predicate column, falling back to the whole-group read only when no predicate column has per-vector rows (phase-2 qual-only, or legacy). The four zone-map readers now share one tuple→struct builder.

## Measured
A 30-column table, one predicate, examining every group: **~1200 → 30** zone_map row fetches — matching a 2-column table (width-independent, ~40× on the wide table).

**Removal proof:** the whole-group read makes wide ≈ 15× narrow (test fails). Correctness — the spans drive vector positioning — held across native_zonemap, native_vecskip, native_skip, native_exact_selection, native_fetch_position, native_groupagg, **differential** on pg18_nc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
