### PR TITLE
refactor: single-source the delete-vector visibility logic (M-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,19 @@ which was true until that script existed.
   request. This completes the per-catalog credential model (issue #656).
   Regression test: iceberg_rest_server.
 
+### Changed
+
+- The delete-vector visibility logic is single-sourced. The fold that ORs a row
+  group's delete bitmaps into one mask was duplicated in the sequential scan and
+  the index-fetch liveness cache, and the per-row bit test was open-coded in five
+  places across the sequential scan, the index-only scan, the per-row fetch, and
+  the buffered read-your-writes path. A change to one (a new bitmap encoding, a
+  bound) could silently diverge the others, invisible until one access path hit
+  the changed row. The fold is now `pgcolumnar_merge_delete_vectors` and the bit
+  test `dv_row_deleted`; every path routes through them. Behavior is unchanged.
+  Regression test: native_delete_visibility_paths (asserts all paths agree on the
+  deleted set; a mutation of the shared bit test fails every path).
+
 ### Fixed
 
 - `pgcolumnar.read_manifest_list` now reports a null manifest-list

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -333,6 +333,22 @@ typedef struct DeleteVectorMetadata
 } DeleteVectorMetadata;
 
 /*
+ * Is `row` (a 0-based index within a chunk group) marked deleted in a delete
+ * vector bitmap of maskLen bytes? The single source of the delete-vector bit
+ * test: the seqscan, index fetch, index-only scan, per-row fetch, and buffered
+ * delete-vector paths all consult it, so the bounds check and the bit math stay
+ * in one place. A NULL or too-short mask means "not deleted" (the row is beyond
+ * what the mask covers), which is the conservative, correct answer.
+ */
+static inline bool
+dv_row_deleted(const char *mask, uint32 maskLen, uint64 row)
+{
+	return mask != NULL &&
+		(row >> 3) < maskLen &&
+		(mask[row >> 3] & (1 << (row & 7))) != 0;
+}
+
+/*
  * One columnar.projection row (gap 26, format 2.2). A projection is a named,
  * ordered column subset stored as its own columnar storage (projStorageId),
  * sorted on sortKey, sharing the table's row-number identity space.

--- a/src/columnar_delete_vector.c
+++ b/src/columnar_delete_vector.c
@@ -300,8 +300,7 @@ PgColumnarDeleteVectorBufferedDeleted(Relation rel, uint64 rowNumber)
 				rowNumber > chunk->endRowNumber)
 				continue;
 			bitIndex = rowNumber - chunk->startRowNumber;
-			if ((bitIndex >> 3) < chunk->maskLen &&
-				(chunk->mask[bitIndex >> 3] & (1 << (bitIndex & 7))) != 0)
+			if (dv_row_deleted(chunk->mask, chunk->maskLen, bitIndex))
 				return true;
 		}
 	}

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -1262,6 +1262,40 @@ native_zone_excludes(SkipPredicate *pred, Form_pg_attribute att,
 }
 
 /*
+ * pgcolumnar_merge_delete_vectors
+ *		OR a group's delete_vector bitmaps into one mask of `want` bytes, in the
+ *		current memory context. The single source of the fold: the seqscan
+ *		(native_load_group) and the index-fetch liveness cache both build the
+ *		group's combined delete mask this way, so a change to the encoding or the
+ *		bounding stays in one place. *outMask is NULL and *outLen 0 when the group
+ *		has no non-empty delete vector (allocated lazily on the first one).
+ */
+static void
+pgcolumnar_merge_delete_vectors(List *maskList, uint32 want,
+								char **outMask, uint32 *outLen)
+{
+	ListCell   *mlc;
+
+	*outMask = NULL;
+	*outLen = 0;
+	foreach(mlc, maskList)
+	{
+		DeleteVectorMetadata *rm = (DeleteVectorMetadata *) lfirst(mlc);
+		uint32		i;
+
+		if (rm->bitmap == NULL || rm->bitmapLen == 0)
+			continue;
+		if (*outMask == NULL)
+		{
+			*outMask = palloc0(want > 0 ? want : 1);
+			*outLen = want;
+		}
+		for (i = 0; i < rm->bitmapLen && i < want; i++)
+			(*outMask)[i] |= rm->bitmap[i];
+	}
+}
+
+/*
  * pgcolumnar_native_group_can_match
  *		Decide whether a native row group could hold a row satisfying every
  *		pushed-down predicate, using its whole-chunk zone maps (native spec 7.1,
@@ -1877,9 +1911,8 @@ pgcolumnar_native_qual_skipvec(PgColumnarReadState *rs, int vecCount)
 
 			rs->rowInGroup = r;
 
-			deleted = (rs->nativeDeleteMask != NULL &&
-					   (r >> 3) < rs->nativeDeleteMaskLen &&
-					   (rs->nativeDeleteMask[r >> 3] & (1 << (r & 7))) != 0);
+			deleted = dv_row_deleted(rs->nativeDeleteMask,
+									 rs->nativeDeleteMaskLen, r);
 
 			MemoryContextReset(rs->rowContext);
 			oldContext = MemoryContextSwitchTo(rs->rowContext);
@@ -2017,24 +2050,11 @@ pgcolumnar_native_load_group(PgColumnarReadState *rs)
 		List	   *maskList = PgColumnarReadDeleteVectorList(rs->storageId,
 													   rg->groupNumber,
 													   rs->metaSnapshot);
-		ListCell   *mlc;
 		uint32		want = (uint32) ((rg->rowCount + 7) / 8);
 
-		foreach(mlc, maskList)
-		{
-			DeleteVectorMetadata *rm = (DeleteVectorMetadata *) lfirst(mlc);
-			uint32		i;
-
-			if (rm->bitmap == NULL || rm->bitmapLen == 0)
-				continue;
-			if (rs->nativeDeleteMask == NULL)
-			{
-				rs->nativeDeleteMask = palloc0(want > 0 ? want : 1);
-				rs->nativeDeleteMaskLen = want;
-			}
-			for (i = 0; i < rm->bitmapLen && i < want; i++)
-				rs->nativeDeleteMask[i] |= rm->bitmap[i];
-		}
+		pgcolumnar_merge_delete_vectors(maskList, want,
+										&rs->nativeDeleteMask,
+										&rs->nativeDeleteMaskLen);
 	}
 
 	/*
@@ -2414,10 +2434,8 @@ pgcolumnar_native_next_row(PgColumnarReadState *rs, Datum *values, bool *nulls,
 		 * even for a deleted row so the cursors stay aligned for the next row; a
 		 * deleted row is simply not emitted (D6b).
 		 */
-		deleted = (rs->nativeDeleteMask != NULL &&
-				   (rs->rowInGroup >> 3) < rs->nativeDeleteMaskLen &&
-				   (rs->nativeDeleteMask[rs->rowInGroup >> 3] &
-					(1 << (rs->rowInGroup & 7))) != 0);
+		deleted = dv_row_deleted(rs->nativeDeleteMask, rs->nativeDeleteMaskLen,
+								 rs->rowInGroup);
 
 		MemoryContextReset(rs->rowContext);
 		oldContext = MemoryContextSwitchTo(rs->rowContext);
@@ -2840,7 +2858,6 @@ PgColumnarBuildLivenessCache(Relation rel, Snapshot snapshot)
 		NativeRowGroupMetadata *rg = (NativeRowGroupMetadata *) lfirst(lc);
 		LiveStripeEntry *e = &cache->stripes[i++];
 		List	   *rml;
-		ListCell   *mc;
 		uint32		want = (uint32) ((rg->rowCount + 7) / 8);
 
 		e->firstRowNumber = rg->firstRowNumber;
@@ -2851,21 +2868,7 @@ PgColumnarBuildLivenessCache(Relation rel, Snapshot snapshot)
 		e->maskLens = palloc0(sizeof(uint32) * 1);
 
 		rml = PgColumnarReadDeleteVectorList(storageId, rg->groupNumber, metaSnapshot);
-		foreach(mc, rml)
-		{
-			DeleteVectorMetadata *rm = (DeleteVectorMetadata *) lfirst(mc);
-			uint32		b;
-
-			if (rm->bitmap == NULL || rm->bitmapLen == 0)
-				continue;
-			if (e->masks[0] == NULL)
-			{
-				e->masks[0] = palloc0(want > 0 ? want : 1);
-				e->maskLens[0] = want;
-			}
-			for (b = 0; b < rm->bitmapLen && b < want; b++)
-				e->masks[0][b] |= rm->bitmap[b];
-		}
+		pgcolumnar_merge_delete_vectors(rml, want, &e->masks[0], &e->maskLens[0]);
 	}
 
 	if (cache->nstripes > 1)
@@ -2899,9 +2902,7 @@ PgColumnarLivenessCacheIsLive(PgColumnarLivenessCache *cache, uint64 rowNumber)
 			uint64		inGroup = off - (uint64) chunkId * (uint64) e->chunkRowCount;
 
 			if (chunkId >= 0 && chunkId < e->chunkGroupCount &&
-				e->masks[chunkId] != NULL &&
-				(inGroup >> 3) < e->maskLens[chunkId] &&
-				(e->masks[chunkId][inGroup >> 3] & (1 << (inGroup & 7))) != 0)
+				dv_row_deleted(e->masks[chunkId], e->maskLens[chunkId], inGroup))
 				return false;	/* deleted */
 			return true;		/* covered and not deleted */
 		}
@@ -3392,8 +3393,7 @@ pgcolumnar_fetch_row(Relation rel, Snapshot snapshot, uint64 rowNumber,
 		{
 			DeleteVectorMetadata *rm = (DeleteVectorMetadata *) lfirst(mlc);
 
-			if (rm->bitmap != NULL && (rowInGrp >> 3) < rm->bitmapLen &&
-				(rm->bitmap[rowInGrp >> 3] & (1 << (rowInGrp & 7))) != 0)
+			if (dv_row_deleted(rm->bitmap, rm->bitmapLen, rowInGrp))
 				deleted = true;
 		}
 		if (deleted)

--- a/test/native_delete_visibility_paths.sh
+++ b/test/native_delete_visibility_paths.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# pgColumnar delete visibility agrees across every access path.
+#
+# The delete-vector fold (OR the group's bitmaps into one mask) and the per-row
+# bit test are consulted by four independent paths: the sequential scan, the
+# index fetch, the index-only scan, and the buffered (read-your-writes) path. The
+# fold is single-sourced in pgcolumnar_merge_delete_vectors and the bit test in
+# dv_row_deleted, so a deleted row is invisible through all of them identically.
+#
+# This is the characterization test for that seam: it deletes a known set and
+# asserts every path returns the same live set. It does not go red when the seam
+# is un-refactored (the paths behaved the same before), which is the point -- it
+# guards the INVARIANT the shared helpers protect, so a future change that breaks
+# one path's fold or bit test fails here rather than only under one plan shape.
+#
+# Usage:  test/native_delete_visibility_paths.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+q "CREATE EXTENSION IF NOT EXISTS pgcolumnar;" >/dev/null
+# Small stripes so the 5000 rows span five groups (each builds its own mask).
+q "SET pgcolumnar.stripe_row_limit=1000;
+   CREATE TABLE t (id int, v int) USING pgcolumnar;
+   INSERT INTO t SELECT g, g FROM generate_series(1,5000) g;
+   CREATE UNIQUE INDEX t_id ON t (id);
+   DELETE FROM t WHERE id % 7 = 0;" >/dev/null
+
+# Live count = 5000 - floor(5000/7) = 5000 - 714 = 4286. Five row groups.
+LIVE=4286
+
+# The last line of each probe is the count; SET/BEGIN precede it under a
+# multi-statement send.
+last() { q "$1" | tail -1; }
+
+# A qual on the non-indexed column forces a real row-emitting sequential scan
+# (which applies the delete mask per row), not the unqualified count(*) metadata
+# fast-path (which subtracts delete counts and never reaches the bit test).
+check "sequential scan sees the live set (row-emitting path)" \
+	"$(last 'SET enable_indexscan=off; SET enable_bitmapscan=off; SET enable_indexonlyscan=off; SELECT count(*) FROM t WHERE v >= 0;')" "$LIVE"
+check "index / bitmap scan sees the live set" \
+	"$(last 'SET enable_seqscan=off; SET enable_indexonlyscan=off; SELECT count(*) FROM t WHERE id >= 0;')" "$LIVE"
+check "index-only scan sees the live set" \
+	"$(last 'SET enable_seqscan=off; SET enable_indexonlyscan=on; SELECT count(id) FROM t WHERE id >= 0;')" "$LIVE"
+check "aggregate over the whole table sees the live set" \
+	"$(q 'SELECT count(*) FROM t;')" "$LIVE"
+
+# A specific deleted row is invisible, and its live neighbour visible, via the
+# index fetch (which reaches the same bit test through a different path).
+check "a deleted row is invisible via the index" \
+	"$(last 'SET enable_seqscan=off; SELECT count(*) FROM t WHERE id = 700;')" "0"
+check "a live row is visible via the index" \
+	"$(last 'SET enable_seqscan=off; SELECT count(*) FROM t WHERE id = 701;')" "1"
+# The buffered (same-transaction) path: delete more inside a txn, then read it back.
+check "a row deleted in-transaction is invisible in the same transaction" \
+	"$(q 'BEGIN; DELETE FROM t WHERE id = 8; SELECT count(*) FROM t WHERE id = 8; ROLLBACK;' | grep -E '^[0-9]+$' | head -1)" "0"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -117,6 +117,7 @@ SUITES=(
 	native_ctas
 	native_decode_gate_width
 	native_decode_gating
+	native_delete_visibility_paths
 	native_dict_underfill
 	native_dml
 	native_encoding


### PR DESCRIPTION
From the modularity audit. The delete-vector fold was copy-pasted in the seqscan and index-fetch liveness cache, and the per-row bit test open-coded in five places (seqscan x2, index-only scan, per-row fetch, buffered read-your-writes). Delete visibility that must be identical across every access path was hand-maintained in each -- the #644/#692 guard-in-one-twin shape, on the MVCC path.

Fix: the fold is now pgcolumnar_merge_delete_vectors; the bit test the inline dv_row_deleted (columnar.h, shared with columnar_delete_vector.c). Every site routes through them. Verified identical before consolidating.

Test native_delete_visibility_paths: deletes a known set, asserts the seqscan (row-emitting), index/bitmap, index-only, per-row index-fetch, and buffered same-transaction paths all return the same live set. Mutation proof: forcing dv_row_deleted false fails every path; the count(*) metadata fast-path is correctly unaffected. No regression across iceberg_deletes, native_agg_deletes, iceberg_dv, native_dml, update_conc, index_only, native_fetch_position, native_index, native_reclaim, differential on pg18_nc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)