### PR TITLE
refactor: single-source the native encoding-descriptor wire layout (M-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,18 @@ which was true until that script existed.
 
 ### Changed
 
+- The native encoding-descriptor wire layout is single-sourced. The descriptor
+  is a column chunk's writer-to-reader contract for its per-vector encoding; its
+  byte layout was hand-packed in `columnar_write_state.c` and hand-parsed in three
+  passes in `columnar_reader.c`, so a field change had to be made in five disjoint
+  places or a reader stride would land mid-field. Because the version byte does
+  not move on a field change, the version guard would pass and the mismatch would
+  surface as `DATA_CORRUPTED` or wrong values, not a clean rejection. A new
+  `columnar_encdesc.h` owns the layout (`PgColumnarEncdescPut*` / `ReadEntry`), and
+  a `StaticAssert` ties the entry length to the field widths. The on-disk bytes are
+  unchanged (verified byte-identical to the hand-packed form). Regression test:
+  native_encdesc_golden (pins the layout; catches a field-order change that the
+  self-consistent round-trip suites cannot).
 - The delete-vector visibility logic is single-sourced. The fold that ORs a row
   group's delete bitmaps into one mask was duplicated in the sequential scan and
   the index-fetch liveness cache, and the per-row bit test was open-coded in five

--- a/src/columnar_encdesc.h
+++ b/src/columnar_encdesc.h
@@ -1,0 +1,94 @@
+/*-------------------------------------------------------------------------
+ *
+ * columnar_encdesc.h
+ *		Wire codec for the native encoding descriptor (PGCN v1, descriptor
+ *		version 2). The descriptor is the writer -> reader contract for a column
+ *		chunk's per-vector encoding, and its byte layout was hand-packed in
+ *		columnar_write_state.c and hand-parsed in three passes in
+ *		columnar_reader.c. Add or reorder a field there and every one of those
+ *		disjoint sites had to change in step, or a reader stride would land
+ *		mid-field -- and because the version byte does not move on a field change,
+ *		the version guard would pass and the mismatch would surface as
+ *		DATA_CORRUPTED or wrong values in production.
+ *
+ * This puts the field offsets and widths in ONE place. The writer appends
+ * through PgColumnarEncdescPut*, the readers advance through
+ * PgColumnarEncdescReadEntry, and COLUMNAR_NATIVE_ENCDESC_ENTRY_LEN is tied to
+ * the field widths by a StaticAssert (columnar_encdesc.c), so a field change is
+ * one edit here that cannot silently desync the two sides.
+ *
+ * The on-disk bytes are unchanged from the hand-packed form: the Put helpers make
+ * the identical appendBinaryStringInfo sequence, and the Read helpers read the
+ * identical offsets. Proven byte-identical (native_encdesc_golden).
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef COLUMNAR_ENCDESC_H
+#define COLUMNAR_ENCDESC_H
+
+#include "lib/stringinfo.h"
+
+#include "columnar.h"			/* COLUMNAR_NATIVE_ENCDESC_* constants */
+
+/* header: version u8, reserved u8, vectorCount u32 (COLUMNAR_NATIVE_ENCDESC_HEADER_LEN) */
+#define COLUMNAR_ENCDESC_HDR_OFF_VECCOUNT 2
+
+/* per-vector entry: type u8, valueCount u32, rawLen u32, encLen u32 (…ENTRY_LEN) */
+#define COLUMNAR_ENCDESC_OFF_VALUECOUNT 1
+#define COLUMNAR_ENCDESC_OFF_RAWLEN		(1 + (int) sizeof(uint32))
+#define COLUMNAR_ENCDESC_OFF_ENCLEN		(1 + 2 * (int) sizeof(uint32))
+
+/* one decoded per-vector entry */
+typedef struct PgColumnarEncdescEntry
+{
+	uint8		type;
+	uint32		valueCount;
+	uint32		rawLen;
+	uint32		encLen;
+} PgColumnarEncdescEntry;
+
+/* append the descriptor header (version + reserved + vectorCount) */
+static inline void
+PgColumnarEncdescPutHeader(StringInfo desc, uint32 vectorCount)
+{
+	uint8		version = COLUMNAR_NATIVE_ENCDESC_VERSION;
+	uint8		reserved = 0;
+
+	appendBinaryStringInfo(desc, (char *) &version, 1);
+	appendBinaryStringInfo(desc, (char *) &reserved, 1);
+	appendBinaryStringInfo(desc, (char *) &vectorCount, sizeof(uint32));
+}
+
+/* append one per-vector entry */
+static inline void
+PgColumnarEncdescPutEntry(StringInfo desc, uint8 type, uint32 valueCount,
+						  uint32 rawLen, uint32 encLen)
+{
+	appendBinaryStringInfo(desc, (char *) &type, 1);
+	appendBinaryStringInfo(desc, (char *) &valueCount, sizeof(uint32));
+	appendBinaryStringInfo(desc, (char *) &rawLen, sizeof(uint32));
+	appendBinaryStringInfo(desc, (char *) &encLen, sizeof(uint32));
+}
+
+/* read vectorCount from a header; caller has already checked descLen and version */
+static inline uint32
+PgColumnarEncdescReadVectorCount(const char *desc)
+{
+	uint32		vectorCount;
+
+	memcpy(&vectorCount, desc + COLUMNAR_ENCDESC_HDR_OFF_VECCOUNT, sizeof(uint32));
+	return vectorCount;
+}
+
+/* read one per-vector entry at dp into *e; returns the cursor past it */
+static inline const char *
+PgColumnarEncdescReadEntry(const char *dp, PgColumnarEncdescEntry *e)
+{
+	e->type = (uint8) dp[0];
+	memcpy(&e->valueCount, dp + COLUMNAR_ENCDESC_OFF_VALUECOUNT, sizeof(uint32));
+	memcpy(&e->rawLen, dp + COLUMNAR_ENCDESC_OFF_RAWLEN, sizeof(uint32));
+	memcpy(&e->encLen, dp + COLUMNAR_ENCDESC_OFF_ENCLEN, sizeof(uint32));
+	return dp + COLUMNAR_NATIVE_ENCDESC_ENTRY_LEN;
+}
+
+#endif							/* COLUMNAR_ENCDESC_H */

--- a/src/columnar_encdesc.h
+++ b/src/columnar_encdesc.h
@@ -14,7 +14,7 @@
  * This puts the field offsets and widths in ONE place. The writer appends
  * through PgColumnarEncdescPut*, the readers advance through
  * PgColumnarEncdescReadEntry, and COLUMNAR_NATIVE_ENCDESC_ENTRY_LEN is tied to
- * the field widths by a StaticAssert (columnar_encdesc.c), so a field change is
+ * the field widths by a StaticAssert (in columnar_write_state.c), so a field change is
  * one edit here that cannot silently desync the two sides.
  *
  * The on-disk bytes are unchanged from the hand-packed form: the Put helpers make

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -13,6 +13,7 @@
  *-------------------------------------------------------------------------
  */
 #include "columnar.h"
+#include "columnar_encdesc.h"
 
 #include "columnar_delete_vector.h"
 #include "columnar_metadata.h"
@@ -827,7 +828,7 @@ pgcolumnar_native_decode_chunk(MemoryContext cx, Form_pg_attribute att,
 		ereport(ERROR,
 				(errcode(ERRCODE_DATA_CORRUPTED),
 				 errmsg("pgcolumnar: unrecognized native encoding descriptor")));
-	memcpy(&vectorCount, desc + 2, sizeof(uint32));
+	vectorCount = PgColumnarEncdescReadVectorCount(desc);
 
 	/*
 	 * Version 2 (E3b) appends a trailing region { uint32 sharedTableLen, bytes }
@@ -853,14 +854,11 @@ pgcolumnar_native_decode_chunk(MemoryContext cx, Form_pg_attribute att,
 	dp = desc + COLUMNAR_NATIVE_ENCDESC_HEADER_LEN;
 	for (v = 0; v < vectorCount; v++)
 	{
-		uint32		rawLen;
-		uint32		encLen;
+		PgColumnarEncdescEntry e;
 
-		memcpy(&rawLen, dp + 1 + sizeof(uint32), sizeof(uint32));
-		memcpy(&encLen, dp + 1 + 2 * sizeof(uint32), sizeof(uint32));
-		encTotal += encLen;
-		rawTotal += rawLen;
-		dp += COLUMNAR_NATIVE_ENCDESC_ENTRY_LEN;
+		dp = PgColumnarEncdescReadEntry(dp, &e);
+		encTotal += e.encLen;
+		rawTotal += e.rawLen;
 	}
 
 	/*
@@ -904,12 +902,13 @@ pgcolumnar_native_decode_chunk(MemoryContext cx, Form_pg_attribute att,
 		uint32		valueCount;
 		uint32		rawLen;
 		uint32		encLen;
+		PgColumnarEncdescEntry e;
 
-		encType = (uint8) dp[0];
-		memcpy(&valueCount, dp + 1, sizeof(uint32));
-		memcpy(&rawLen, dp + 1 + sizeof(uint32), sizeof(uint32));
-		memcpy(&encLen, dp + 1 + 2 * sizeof(uint32), sizeof(uint32));
-		dp += COLUMNAR_NATIVE_ENCDESC_ENTRY_LEN;
+		dp = PgColumnarEncdescReadEntry(dp, &e);
+		encType = e.type;
+		valueCount = e.valueCount;
+		rawLen = e.rawLen;
+		encLen = e.encLen;
 
 		vecRawLen[v] = rawLen;
 		if (rawLen > 0)
@@ -2174,7 +2173,7 @@ pgcolumnar_native_load_group(PgColumnarReadState *rs)
 				continue;
 			}
 
-			memcpy(&vc, cc->encodingDescriptor + 2, sizeof(uint32));
+			vc = PgColumnarEncdescReadVectorCount(cc->encodingDescriptor);
 			if ((int) vc > maxVecCount)
 				maxVecCount = (int) vc;
 		}

--- a/src/columnar_write_state.c
+++ b/src/columnar_write_state.c
@@ -12,6 +12,7 @@
  *-------------------------------------------------------------------------
  */
 #include "columnar.h"
+#include "columnar_encdesc.h"
 
 #include "columnar_metadata.h"
 #include "columnar_storage.h"
@@ -42,6 +43,17 @@
 #include "utils/rel.h"
 #include "utils/snapmgr.h"
 #include "utils/typcache.h"
+
+/*
+ * The encoding-descriptor entry and header lengths must equal the field widths
+ * columnar_encdesc.h packs and columnar_reader.c parses. If a field is added or
+ * a width changed without updating these, a reader stride lands mid-field; pin it
+ * at compile time so the mismatch is a build error, not a DATA_CORRUPTED at read.
+ */
+StaticAssertDecl(COLUMNAR_NATIVE_ENCDESC_ENTRY_LEN == 1 + 3 * (int) sizeof(uint32),
+				 "encdesc entry length drifted from its field widths");
+StaticAssertDecl(COLUMNAR_NATIVE_ENCDESC_HEADER_LEN == 2 + (int) sizeof(uint32),
+				 "encdesc header length drifted from its field widths");
 
 #ifndef DSM_HANDLE_INVALID
 #define DSM_HANDLE_INVALID 0
@@ -1090,8 +1102,6 @@ flush_one_column(Form_pg_attribute att, List *chunkGroups,
 	uint64		rowIdx = 0;
 	StringInfo	encoded = makeStringInfo();
 	StringInfo	desc = makeStringInfo();
-	uint8		descVersion = COLUMNAR_NATIVE_ENCDESC_VERSION;
-	uint8		descReserved = 0;
 	uint32		vectorCount = (uint32) list_length(chunkGroups);
 	char	   *fsstTable = NULL;	/* chunk-shared FSST table (E3b), or NULL */
 	uint32		fsstTableLen = 0;
@@ -1139,10 +1149,8 @@ flush_one_column(Form_pg_attribute att, List *chunkGroups,
 	}
 	appendBinaryStringInfo(chunk, (char *) validity, validityBytes);
 
-	/* descriptor header */
-	appendBinaryStringInfo(desc, (char *) &descVersion, 1);
-	appendBinaryStringInfo(desc, (char *) &descReserved, 1);
-	appendBinaryStringInfo(desc, (char *) &vectorCount, sizeof(uint32));
+	/* descriptor header (columnar_encdesc.h owns the wire layout) */
+	PgColumnarEncdescPutHeader(desc, vectorCount);
 
 	/*
 	 * E3b: build one FSST symbol table for the whole column chunk from a
@@ -1307,10 +1315,8 @@ flush_one_column(Form_pg_attribute att, List *chunkGroups,
 		entryType = (uint8) encType;
 		entryValueCount = (uint32) col->valueCount;
 		entryRawLen = (uint32) col->valueStream.len;
-		appendBinaryStringInfo(desc, (char *) &entryType, 1);
-		appendBinaryStringInfo(desc, (char *) &entryValueCount, sizeof(uint32));
-		appendBinaryStringInfo(desc, (char *) &entryRawLen, sizeof(uint32));
-		appendBinaryStringInfo(desc, (char *) &encLen, sizeof(uint32));
+		PgColumnarEncdescPutEntry(desc, entryType, entryValueCount,
+								  entryRawLen, encLen);
 
 		/* per-vector zone map (native spec 7.1, D5) */
 		{

--- a/test/native_encdesc_golden.sh
+++ b/test/native_encdesc_golden.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# pgColumnar native encoding-descriptor wire layout is stable.
+#
+# The descriptor is the writer->reader contract for a column chunk's per-vector
+# encoding. Its byte layout was hand-packed in columnar_write_state.c and
+# hand-parsed in three passes in columnar_reader.c; columnar_encdesc.h now owns it
+# (PgColumnarEncdescPut*/ReadEntry), and a StaticAssert ties ENTRY_LEN to the
+# field widths. The codec was verified to emit byte-identical descriptors to the
+# hand-packed form (captured from both and compared).
+#
+# This pins the LAYOUT, not the encoder's choice: it decodes the on-disk
+# descriptor of a deterministic table and asserts the version byte, the
+# vectorCount, the per-entry valueCount and rawLen at their fixed offsets, and a
+# self-consistent total length. A codec that reorders a field or changes a width
+# reads these back wrong (or the StaticAssert fails the build first), so a layout
+# drift fails here rather than surfacing as DATA_CORRUPTED or wrong values in
+# production. It does NOT pin which encoding was chosen, so encoder tuning does
+# not spuriously break it.
+#
+# Layout (descriptor version 2):
+#   header:  version u8 @0, reserved u8 @1, vectorCount u32 @2   (HEADER_LEN 6)
+#   entry:   type u8 @0, valueCount u32 @1, rawLen u32 @5, encLen u32 @9  (ENTRY_LEN 13)
+#   trailer: sharedTableLen u32, then that many bytes
+#
+# Usage:  test/native_encdesc_golden.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+q "CREATE EXTENSION IF NOT EXISTS pgcolumnar;" >/dev/null
+
+# 300 rows (< the sample size), so encoding choice is deterministic and the whole
+# table is one row group (300 < stripe_row_limit) with one vector per chunk.
+q "CREATE TABLE d (a int, b bigint, c text) USING pgcolumnar;
+   INSERT INTO d SELECT g, g*1000000::bigint, 'val'||(g%4) FROM generate_series(1,300) g;" >/dev/null
+SID="$(q "SELECT pgcolumnar.get_storage_id('d');")"
+
+# a single byte of column COL's descriptor at 0-based offset OFF
+b() { q "SELECT get_byte(encoding_descriptor, $2) FROM pgcolumnar.column_chunk
+         WHERE storage_id=$SID AND column_index=$1;"; }
+# a little-endian uint32 of column COL's descriptor at 0-based offset OFF (inlined:
+# each q is a fresh session, so no session-local helper function survives)
+le32() { q "SELECT get_byte(d,$2)+get_byte(d,$2+1)*256+get_byte(d,$2+2)*65536
+                   +get_byte(d,$2+3)*16777216
+            FROM (SELECT encoding_descriptor d FROM pgcolumnar.column_chunk
+                  WHERE storage_id=$SID AND column_index=$1) x;"; }
+olen() { q "SELECT octet_length(encoding_descriptor) FROM pgcolumnar.column_chunk
+            WHERE storage_id=$SID AND column_index=$1;"; }
+
+# version byte is 2 on every column's descriptor
+for col in 0 1 2; do
+	check "column $col descriptor version byte is 2" "$(b $col 0)" "2"
+done
+
+# vectorCount (u32 @2) is 1 (one chunk group, one vector)
+check "vectorCount parses as 1 (at offset 2)" "$(le32 0 2)" "1"
+
+# self-consistent length: 6 (header) + vectorCount*13 (entries) + 4 (sharedLen) +
+# sharedTableLen. For these columns the FSST shared table is empty (0).
+check "descriptor length is header + 1 entry + empty trailer (23)" "$(olen 0)" "23"
+check "trailing sharedTableLen is 0 (u32 at offset 6+13=19)" "$(le32 0 19)" "0"
+
+# per-entry valueCount (u32 @ 6+1=7) is the row count on every column
+for col in 0 1 2; do
+	check "column $col entry valueCount parses as 300 (at offset 7)" \
+		"$(le32 $col 7)" "300"
+done
+
+# per-entry rawLen (u32 @ 6+5=11) is value_count * attlen for the fixed-width cols:
+# int a = 300*4 = 1200, bigint b = 300*8 = 2400. A field-offset drift reads these
+# back wrong.
+check "int column a rawLen parses as 1200 (300*4, at offset 11)" "$(le32 0 11)" "1200"
+check "bigint column b rawLen parses as 2400 (300*8, at offset 11)" "$(le32 1 11)" "2400"
+
+# the whole table still reads back correctly under this descriptor
+check "the table reads back all rows" "$(q 'SELECT count(*) FROM d;')" "300"
+check "a full-column read is correct" "$(q 'SELECT sum(a) FROM d;')" "45150"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -123,6 +123,7 @@ SUITES=(
 	native_delete_visibility_paths
 	native_dict_underfill
 	native_dml
+	native_encdesc_golden
 	native_encoding
 	native_exact_selection
 	native_fastdecode


### PR DESCRIPTION
From the modularity audit. The encoding descriptor is a column chunk's writer→reader contract. Its byte layout was **hand-packed** in `columnar_write_state.c` and **hand-parsed in three passes** in `columnar_reader.c`, so a field change meant editing five disjoint sites; and because the version byte doesn't move on a field change, a missed site surfaces as `DATA_CORRUPTED` or wrong values, not a clean rejection.

## Fix
New `columnar_encdesc.h` owns the layout (`PgColumnarEncdescPut*` / `ReadEntry`); the field offsets live only there. A `StaticAssert` ties `ENTRY_LEN`/`HEADER_LEN` to the field widths, so a width change is a **build error**, not a silent stride mismatch.

## Byte-identical (verified, not assumed)
Captured the `encoding_descriptor` bytea of a deterministic table from **both this branch and main** — all three column descriptors matched exactly (`020001000000052c010000b00400001200000000000000`, …). The Put helpers make the identical `appendBinaryStringInfo` sequence.

## Test — `native_encdesc_golden`
Decodes the descriptor and pins the version byte, vectorCount, per-entry valueCount/rawLen at their fixed offsets, and a self-consistent length.

**Removal proof (the interesting part):** swapping valueCount↔rawLen in the codec *consistently* (read/write still agree) leaves `native_roundtrip` **GREEN** — the format is self-consistent — but reddens `native_encdesc_golden`, because the on-disk offsets moved. That's exactly the silent-format-drift the round-trip suites **cannot** see and this codec prevents.

No regression across native_encoding, native_format, native_roundtrip, native_vecdecode, write_fsst_compressed, native_fastdecode, **differential** on pg18_nc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
