### PR TITLE
security: bound a varlena value's stored length against its buffer (D-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,19 @@ which was true until that script existed.
 
 ### Security
 
+- The native varlena decoder now bounds a value's stored length against its
+  buffer. A varying-length value in a column chunk (and a zone map's min/max)
+  carries its own length prefix, which `PgColumnarDecodeValue`,
+  `pgcolumnar_skip_value`, and `pgcolumnar_build_val_offsets` read and `memcpy`d
+  with no check that the value fit; a corrupt chunk or catalog row could then
+  declare a value running past the buffer (an out-of-bounds read), and a prefix
+  carrying the external-TOAST tag would be detoasted through a bogus pointer. The
+  decode sites now pass the value stream's end and read through a bounded reader
+  that refuses an over-long length or an external tag with `DATA_CORRUPTED`. This
+  is the trusted-storage boundary (bit rot, a hand-written stripe), not a
+  file-author-reachable one, but a clean error beats a crash. Regression test:
+  native_varlena_bound (a min/max whose header claims ~1 GB now errors instead of
+  crashing the backend; a mutation removing the bound reddens it).
 - Closed a stat-before-open race in the local file read path. The
   non-regular-file guard that keeps a FIFO from blocking the backend in `open(2)`
   (a cancel-resistant denial of service) screened the path with `stat()` before a

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -680,7 +680,7 @@ typedef struct PgColumnarVector
 extern void PgColumnarEncodeValue(StringInfo buf, Form_pg_attribute att,
 								Datum value);
 extern Datum PgColumnarDecodeValue(Form_pg_attribute att, char **cursor,
-								 MemoryContext targetContext);
+								 const char *end, MemoryContext targetContext);
 
 /* -------------------------------------------------------------------------
  * lightweight value-stream encodings (pgcolumnar_encoding.c, I1)
@@ -981,6 +981,43 @@ PgColumnarVarSizeAnyUnaligned(const char *p)
 #else
 	return (hdr >> 2) & 0x3FFFFFFF;
 #endif
+}
+
+/*
+ * Bounded variant, for a varlena decoded from native storage. The value's length
+ * prefix is stored, not computed, so a corrupt native chunk (bit rot, or a
+ * hand-written stripe) can declare a value that runs past its decoded buffer --
+ * an out-of-bounds read -- and if the prefix carries the external-TOAST tag, the
+ * value is later detoasted through a pointer that points at nothing. `end` is one
+ * past the last valid byte of the value stream. This refuses a value that starts
+ * at or past `end`, a 4-byte header whose bytes are not all in range, an external
+ * TOAST tag (native storage stores only inline, detoasted values), or a length
+ * that would read past `end`. A valid inline value is unaffected: its stored
+ * length always fits. Returns the value's total size in bytes.
+ */
+static inline uint32
+PgColumnarVarSizeAnyUnalignedBounded(const char *p, const char *end)
+{
+	uint32		len;
+
+	if (p >= end)
+		ereport(ERROR,
+				(errcode(ERRCODE_DATA_CORRUPTED),
+				 errmsg("pgcolumnar: varlena value starts at or past the value stream end")));
+	if (VARATT_IS_EXTERNAL(p))
+		ereport(ERROR,
+				(errcode(ERRCODE_DATA_CORRUPTED),
+				 errmsg("pgcolumnar: external TOAST pointer in a native value stream")));
+	if (!VARATT_IS_1B(p) && (Size) (end - p) < sizeof(uint32))
+		ereport(ERROR,
+				(errcode(ERRCODE_DATA_CORRUPTED),
+				 errmsg("pgcolumnar: varlena header runs past the value stream end")));
+	len = PgColumnarVarSizeAnyUnaligned(p);
+	if (len < 1 || (Size) (end - p) < (Size) len)
+		ereport(ERROR,
+				(errcode(ERRCODE_DATA_CORRUPTED),
+				 errmsg("pgcolumnar: varlena value length runs past the value stream end")));
+	return len;
 }
 
 #endif							/* PGCOLUMNAR_H */

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -137,6 +137,7 @@ struct PgColumnarReadState
 	char	   *nativeBuffer;		/* whole current row group, in groupContext */
 	char	  **nativeValidity;		/* [natts]; NULL if the column is absent */
 	char	  **nativeValueCursor;	/* [natts]; advancing values cursor */
+	char	  **nativeValueEnd;		/* [natts]; one past the last value byte, for bounds */
 
 	/*
 	 * Per-vector (1024-row) skipping within a loaded group (Phase D5b). When any
@@ -298,7 +299,7 @@ PgColumnarEncodeValue(StringInfo buf, Form_pg_attribute att, Datum value)
  *		stripe buffer's next reset.
  */
 Datum
-PgColumnarDecodeValue(Form_pg_attribute att, char **cursor,
+PgColumnarDecodeValue(Form_pg_attribute att, char **cursor, const char *end,
 					MemoryContext targetContext)
 {
 	char	   *p = *cursor;
@@ -306,20 +307,29 @@ PgColumnarDecodeValue(Form_pg_attribute att, char **cursor,
 
 	if (att->attbyval)
 	{
+		if (p + att->attlen > end)
+			ereport(ERROR,
+					(errcode(ERRCODE_DATA_CORRUPTED),
+					 errmsg("pgcolumnar: fixed-length value runs past the value stream end")));
 		result = fetch_att(p, true, att->attlen);
 		*cursor = p + att->attlen;
 	}
 	else if (att->attlen > 0)
 	{
-		char	   *copy = MemoryContextAlloc(targetContext, att->attlen);
+		char	   *copy;
 
+		if (p + att->attlen > end)
+			ereport(ERROR,
+					(errcode(ERRCODE_DATA_CORRUPTED),
+					 errmsg("pgcolumnar: fixed-length value runs past the value stream end")));
+		copy = MemoryContextAlloc(targetContext, att->attlen);
 		memcpy(copy, p, att->attlen);
 		result = PointerGetDatum(copy);
 		*cursor = p + att->attlen;
 	}
 	else
 	{
-		Size		len = PgColumnarVarSizeAnyUnaligned(p);
+		Size		len = PgColumnarVarSizeAnyUnalignedBounded(p, end);
 		char	   *copy = MemoryContextAlloc(targetContext, len);
 
 		memcpy(copy, p, len);
@@ -345,14 +355,20 @@ PgColumnarDecodeValue(Form_pg_attribute att, char **cursor,
  * and sits next to it so a change to that cursor arithmetic cannot miss this.
  */
 static inline void
-pgcolumnar_skip_value(Form_pg_attribute att, char **cursor)
+pgcolumnar_skip_value(Form_pg_attribute att, char **cursor, const char *end)
 {
 	char	   *p = *cursor;
 
 	if (att->attbyval || att->attlen > 0)
+	{
+		if (p + att->attlen > end)
+			ereport(ERROR,
+					(errcode(ERRCODE_DATA_CORRUPTED),
+					 errmsg("pgcolumnar: fixed-length value runs past the value stream end")));
 		*cursor = p + att->attlen;
+	}
 	else
-		*cursor = p + PgColumnarVarSizeAnyUnaligned(p);
+		*cursor = p + PgColumnarVarSizeAnyUnalignedBounded(p, end);
 }
 
 /*
@@ -400,7 +416,7 @@ pgcolumnar_row_read_column(PgColumnarReadState *rs, int c, Datum *values, bool *
 		}
 		else
 			values[c] = PgColumnarDecodeValue(att, &rs->nativeValueCursor[c],
-											rs->rowContext);
+											rs->nativeValueEnd[c], rs->rowContext);
 		nulls[c] = false;
 	}
 	else
@@ -429,7 +445,7 @@ pgcolumnar_row_skip_column(PgColumnarReadState *rs, int c, Datum *values, bool *
 		return;
 
 	if ((vbits[rs->rowInGroup >> 3] >> (rs->rowInGroup & 7)) & 1)
-		pgcolumnar_skip_value(att, &rs->nativeValueCursor[c]);
+		pgcolumnar_skip_value(att, &rs->nativeValueCursor[c], rs->nativeValueEnd[c]);
 }
 
 /* -------------------------------------------------------------------------
@@ -804,7 +820,8 @@ pgcolumnar_native_decode_chunk(MemoryContext cx, Form_pg_attribute att,
 							 char *values, uint32 valuesLen,
 							 const char *desc, uint32 descLen, int blockCodec,
 							 uint32 **outVecRawLen, int *outVecCount,
-							 const bool *skipVec, int *outVecDecoded)
+							 const bool *skipVec, int *outVecDecoded,
+							 Size *outRawTotal)
 {
 	int			decodedCount = 0;
 	uint32		vectorCount;
@@ -982,6 +999,8 @@ pgcolumnar_native_decode_chunk(MemoryContext cx, Form_pg_attribute att,
 		*outVecRawLen = vecRawLen;
 	if (outVecCount != NULL)
 		*outVecCount = (int) vectorCount;
+	if (outRawTotal != NULL)
+		*outRawTotal = (Size) rawTotal;
 	/*
 	 * Reported from the loop that did the work, never derived from the mask the
 	 * caller passed in. Deriving it is the first thing anyone writes here and it
@@ -1163,7 +1182,8 @@ pgcolumnar_native_refine_skipvec(PgColumnarReadState *rs, int vecCount)
 				if (!((rs->nativeValidity[col][r >> 3] >> (r & 7)) & 1))
 					continue;	/* NULL: satisfies no btree comparison */
 
-				val = PgColumnarDecodeValue(att, &vecCur, scratch);
+				val = PgColumnarDecodeValue(att, &vecCur,
+											rs->nativeValueEnd[col], scratch);
 
 				/* every predicate on THIS column, conjunctively */
 				ok = true;
@@ -1218,9 +1238,9 @@ native_zone_excludes(SkipPredicate *pred, Form_pg_attribute att,
 		return false;
 
 	cur = (char *) z->minimum;
-	minv = PgColumnarDecodeValue(att, &cur, cx);
+	minv = PgColumnarDecodeValue(att, &cur, z->minimum + z->minimumLen, cx);
 	cur = (char *) z->maximum;
-	maxv = PgColumnarDecodeValue(att, &cur, cx);
+	maxv = PgColumnarDecodeValue(att, &cur, z->maximum + z->maximumLen, cx);
 
 	switch (pred->strategy)
 	{
@@ -2121,6 +2141,7 @@ pgcolumnar_native_load_group(PgColumnarReadState *rs)
 
 	rs->nativeValidity = palloc0(sizeof(char *) * rs->natts);
 	rs->nativeValueCursor = palloc0(sizeof(char *) * rs->natts);
+	rs->nativeValueEnd = palloc0(sizeof(char *) * rs->natts);
 	rs->nativeVecRawLen = (uint32 **) palloc0(sizeof(uint32 *) * rs->natts);
 	validityBytes = (int) ((rg->rowCount + 7) / 8);
 	maxVecCount = 0;
@@ -2249,8 +2270,10 @@ pgcolumnar_native_load_group(PgColumnarReadState *rs)
 			(uint8) cc->encodingDescriptor[0] == COLUMNAR_NATIVE_ENCDESC_BASELINE)
 		{
 			/* D2b baseline: raw present values follow the validity bitmap; no
-			 * per-vector structure, so per-vector skipping is disabled below */
+			 * per-vector structure, so per-vector skipping is disabled below. The
+			 * value region runs from the bitmap end to the chunk end. */
 			rs->nativeValueCursor[cc->columnIndex] = base + validityBytes;
+			rs->nativeValueEnd[cc->columnIndex] = base + cc->pageLength;
 			allDescriptor = false;
 		}
 		else
@@ -2259,6 +2282,7 @@ pgcolumnar_native_load_group(PgColumnarReadState *rs)
 			uint32	   *vraw = NULL;
 			int			vcount = 0;
 			int			vdecoded = 0;
+			Size		rawTotal = 0;
 
 			/* D4: reconstruct the raw present-value stream from the descriptor */
 			rs->nativeValueCursor[cc->columnIndex] =
@@ -2267,7 +2291,9 @@ pgcolumnar_native_load_group(PgColumnarReadState *rs)
 											 cc->encodingDescriptor,
 											 cc->encodingDescriptorLen,
 											 cc->blockCodec, &vraw, &vcount,
-											 rs->nativeSkipVec, &vdecoded);
+											 rs->nativeSkipVec, &vdecoded, &rawTotal);
+			rs->nativeValueEnd[cc->columnIndex] =
+				rs->nativeValueCursor[cc->columnIndex] + rawTotal;
 			rs->nativeVecRawLen[cc->columnIndex] = vraw;
 			if (vcount > maxVecCount)
 				maxVecCount = vcount;
@@ -3053,6 +3079,7 @@ typedef struct PgColumnarFetchGroup
 
 	NativeColumnChunkMetadata **ccForCol;	/* [natts] */
 	char	  **rawBuf;			/* [natts]; NULL until that column is decoded */
+	uint32	   *rawBufLen;		/* [natts]; byte length of rawBuf[c], for bounds */
 
 	/*
 	 * Position indexes, built with rawBuf and holding for as long as it does
@@ -3188,7 +3215,8 @@ pgcolumnar_rank_before(const char *vbits, const uint32 *prefix, uint64 row)
  *		their k-th value is at k * attlen and needs no table.
  */
 static uint32 *
-pgcolumnar_build_val_offsets(Form_pg_attribute att, char *rawBuf, uint32 nvalues)
+pgcolumnar_build_val_offsets(Form_pg_attribute att, char *rawBuf,
+							 const char *rawEnd, uint32 nvalues)
 {
 	uint32	   *offsets = (uint32 *) palloc(sizeof(uint32) * (nvalues + 1));
 	char	   *cursor = rawBuf;
@@ -3197,7 +3225,7 @@ pgcolumnar_build_val_offsets(Form_pg_attribute att, char *rawBuf, uint32 nvalues
 	for (k = 0; k < nvalues; k++)
 	{
 		offsets[k] = (uint32) (cursor - rawBuf);
-		cursor += PgColumnarVarSizeAnyUnaligned(cursor);
+		cursor += PgColumnarVarSizeAnyUnalignedBounded(cursor, rawEnd);
 
 		/*
 		 * A chunk holds as many values as chunk_group_row_limit allows, which is
@@ -3494,6 +3522,7 @@ pgcolumnar_fetch_row(Relation rel, Snapshot snapshot, uint64 rowNumber,
 		entry->vbits = palloc0(sizeof(char *) * natts);
 		entry->ccForCol = palloc0(sizeof(NativeColumnChunkMetadata *) * natts);
 		entry->rawBuf = palloc0(sizeof(char *) * natts);
+		entry->rawBufLen = palloc0(sizeof(uint32) * natts);
 		entry->rankPrefix = palloc0(sizeof(uint32 *) * natts);
 		entry->valOffset = palloc0(sizeof(uint32 *) * natts);
 		entry->colCx = palloc0(sizeof(MemoryContext) * natts);
@@ -3555,6 +3584,7 @@ pgcolumnar_fetch_row(Relation rel, Snapshot snapshot, uint64 rowNumber,
 		NativeColumnChunkMetadata *cc = entry->ccForCol[c];
 		char	   *vbits;
 		char	   *rawBuf;
+		uint32		rawBufLen = 0;	/* byte length of rawBuf, for bounds checks */
 		char	   *cursor;
 		uint64		present;
 		bool		justDecoded;	/* this fetch decoded it; may not fit */
@@ -3604,6 +3634,7 @@ pgcolumnar_fetch_row(Relation rel, Snapshot snapshot, uint64 rowNumber,
 		if (entry->rawBuf[c] != NULL)
 		{
 			rawBuf = entry->rawBuf[c];
+			rawBufLen = entry->rawBufLen[c];
 			justDecoded = false;
 		}
 		else
@@ -3647,15 +3678,23 @@ pgcolumnar_fetch_row(Relation rel, Snapshot snapshot, uint64 rowNumber,
 
 			decOld = MemoryContextSwitchTo(decCx);
 			if (baseline)
+			{
 				rawBuf = vstream;
+				rawBufLen = vlen;
+			}
 			else
+			{
+				Size		rawTotal = 0;
+
 				rawBuf =
 					pgcolumnar_native_decode_chunk(decCx, att,
 												 vstream, vlen,
 												 cc->encodingDescriptor,
 												 cc->encodingDescriptorLen,
 												 cc->blockCodec, NULL, NULL,
-												 NULL, NULL);
+												 NULL, NULL, &rawTotal);
+				rawBufLen = (uint32) rawTotal;
+			}
 			MemoryContextSwitchTo(decOld);
 
 			/*
@@ -3684,7 +3723,7 @@ pgcolumnar_fetch_row(Relation rel, Snapshot snapshot, uint64 rowNumber,
 						COLUMNAR_RANK_BLOCK_ROWS;
 
 					entry->valOffset[c] =
-						pgcolumnar_build_val_offsets(att, rawBuf,
+						pgcolumnar_build_val_offsets(att, rawBuf, rawBuf + rawBufLen,
 												   entry->rankPrefix[c][nblocks]);
 				}
 				MemoryContextSwitchTo(idxOld);
@@ -3693,6 +3732,7 @@ pgcolumnar_fetch_row(Relation rel, Snapshot snapshot, uint64 rowNumber,
 			if (decCx != tmp)
 			{
 				entry->rawBuf[c] = rawBuf;
+				entry->rawBufLen[c] = rawBufLen;
 				/*
 				 * Baseline columns get a context too, now that their stream is
 				 * their own allocation rather than an interior pointer into a
@@ -3719,7 +3759,7 @@ pgcolumnar_fetch_row(Relation rel, Snapshot snapshot, uint64 rowNumber,
 		else
 			cursor = rawBuf + entry->valOffset[c][present];
 
-		values[c] = PgColumnarDecodeValue(att, &cursor, target);
+		values[c] = PgColumnarDecodeValue(att, &cursor, rawBuf + rawBufLen, target);
 		nulls[c] = false;
 
 		/*

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -2868,7 +2868,9 @@ pgcolumnar_fill_native_metadata_agg(PgColumnarAggScanState *state, int *ndirty)
 							MemoryContextSwitchTo(state->resultContext);
 						char	   *cur = (spec->kind == COLUMNAR_AGG_MIN)
 							? (char *) z->minimum : (char *) z->maximum;
-						Datum		v = PgColumnarDecodeValue(att, &cur,
+						const char *curEnd = (spec->kind == COLUMNAR_AGG_MIN)
+							? z->minimum + z->minimumLen : z->maximum + z->maximumLen;
+						Datum		v = PgColumnarDecodeValue(att, &cur, curEnd,
 														state->resultContext);
 
 						if (!spec->sawValue)

--- a/src/columnar_write_state.c
+++ b/src/columnar_write_state.c
@@ -741,7 +741,9 @@ buffered_build_offsets(ColumnChunkBuffer *col, Form_pg_attribute att,
 			(uint32) (cursor - col->valueStream.data);
 
 		if (col->existsStream.data[i])
-			(void) PgColumnarDecodeValue(att, &cursor, scratch);
+			(void) PgColumnarDecodeValue(att, &cursor,
+										 col->valueStream.data + col->valueStream.len,
+										 scratch);
 	}
 
 	MemoryContextDelete(scratch);
@@ -1040,7 +1042,9 @@ PgColumnarBufferedRowByNumber(Relation rel, uint64 rowNumber,
 
 				if (existsBytes[posInGroup])
 				{
-					values[c] = PgColumnarDecodeValue(att, &cursor, target);
+					values[c] = PgColumnarDecodeValue(att, &cursor,
+													  col->valueStream.data + col->valueStream.len,
+													  target);
 					nulls[c] = false;
 				}
 				else

--- a/test/native_varlena_bound.sh
+++ b/test/native_varlena_bound.sh
@@ -26,6 +26,15 @@
 # fetch, the vector aggregate) share the one bounded reader, so they are bounded
 # by the same fix; the min/max path is the one a catalog UPDATE can reach.
 #
+# Reproducing the removal proof (two traps that both come back falsely GREEN):
+#   - Do a fresh (make clean) build, NOT PGC_SKIP_BUILD=1. The bounded reader is a
+#     header inline; PGXS does not track header deps, so a skip build tests the
+#     old .so and the gutted guard never takes effect (gate-environment stale-.so).
+#   - Poison column_index=1 (txt), not 0. Column 0 is the int id and has no varlena
+#     min/max, so corrupting its zone map does not reach the varlena decoder.
+# With a clean build and column 1 poisoned, the ungutted bound gives XX001; the
+# gutted one turns the ~1 GB claim into a memcpy that SIGSEGVs the backend.
+#
 # Usage:  test/native_varlena_bound.sh [PG_CONFIG]
 # Written fresh for pgColumnar.
 

--- a/test/native_varlena_bound.sh
+++ b/test/native_varlena_bound.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# pgColumnar bounds a varlena value's stored length against its buffer.
+#
+# A varying-length value in a native chunk (and in a zone map's min/max) carries
+# its own length prefix, which the decoder trusted: PgColumnarDecodeValue,
+# pgcolumnar_skip_value, and pgcolumnar_build_val_offsets read
+# PgColumnarVarSizeAnyUnaligned and memcpy that many bytes with no check that the
+# value fits its buffer. A corrupt chunk or catalog row (bit rot, a hand-written
+# stripe) can then declare a value that runs past the buffer -- an out-of-bounds
+# read -- and a header carrying the external-TOAST tag is later detoasted through
+# a pointer to nothing. This is the trusted-storage boundary core PostgreSQL does
+# not defend for a heap page either, but the reader aspires to (see corruption.sh
+# / hardening.sh), and a clean error beats a crash.
+#
+# Every decode site now passes the value stream's end and reads through
+# PgColumnarVarSizeAnyUnalignedBounded, which refuses a length (or an external
+# tag) that would read past it. The zone map's min/max is a catalog bytea, so it
+# is corruptible with a plain UPDATE (unlike the relation-file value stream),
+# which makes this reachable and testable: point a min at a 5-byte value whose
+# 4-byte header claims ~1 GB, then a predicate that consults it.
+#
+# RED (unbounded) is a ~1 GB memcpy from a 5-byte buffer -- a SIGSEGV that takes
+# the backend (and the cluster) down. GREEN is a clean DATA_CORRUPTED (XX001) and
+# a surviving backend. The other decode sites (the sequential scan, the per-row
+# fetch, the vector aggregate) share the one bounded reader, so they are bounded
+# by the same fix; the min/max path is the one a catalog UPDATE can reach.
+#
+# Usage:  test/native_varlena_bound.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+q "CREATE EXTENSION IF NOT EXISTS pgcolumnar;" >/dev/null
+q "CREATE TABLE t (id int, txt text) USING pgcolumnar;
+   INSERT INTO t SELECT g, 'v'||g FROM generate_series(1,2000) g;" >/dev/null
+SID="$(q "SELECT pgcolumnar.get_storage_id('t');")"
+
+check "the txt column has a whole-chunk zone map to corrupt" \
+	"$(q "SELECT count(*) FROM pgcolumnar.zone_map WHERE storage_id=$SID AND column_index=1 AND vector_index=-1;")" \
+	"1"
+
+# 0xfcffffff is a 4-byte varlena header claiming (0x3fffffff) ~1 GB; the value is
+# only 5 bytes. errors() runs the query; SQLSTATE / survival are asserted below.
+errcode() { # SQL -> the 5-char SQLSTATE it raises, or NOERR
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" \
+		-qtA -v VERBOSITY=sqlstate -c "$1" 2>&1 \
+		| sed -n 's/^ERROR:  \([0-9A-Z]\{5\}\).*/\1/p' | head -1
+}
+alive() { [ "$(q 'SELECT 1;')" = "1" ] && echo yes || echo no; }
+
+# --- corrupt the MINIMUM ------------------------------------------------------
+q "UPDATE pgcolumnar.zone_map SET minimum = E'\\\\xfcffffff00'::bytea
+   WHERE storage_id=$SID AND column_index=1 AND vector_index=-1;" >/dev/null
+check "a min with an over-long varlena length is refused, not an OOB read (XX001)" \
+	"$(errcode "SELECT count(*) FROM t WHERE txt > 'a';")" "XX001"
+check "backend survived the corrupt minimum" "$(alive)" "yes"
+
+# --- restore, then corrupt the MAXIMUM ---------------------------------------
+q "UPDATE pgcolumnar.zone_map SET maximum = E'\\\\xfcffffff00'::bytea
+   WHERE storage_id=$SID AND column_index=1 AND vector_index=-1;" >/dev/null
+check "a max with an over-long varlena length is refused, not an OOB read (XX001)" \
+	"$(errcode "SELECT count(*) FROM t WHERE txt < 'zzz';")" "XX001"
+check "backend survived the corrupt maximum" "$(alive)" "yes"
+
+# --- an external-TOAST tag in the raw value stream is refused -----------------
+# 0x01 is the 1-byte external-TOAST tag; native storage never holds one, and
+# detoasting it would deref a bogus pointer. VARSIZE alone would accept it.
+q "UPDATE pgcolumnar.zone_map SET minimum = E'\\\\x0102030405060708090a0b0c0d0e0f1011'::bytea
+   WHERE storage_id=$SID AND column_index=1 AND vector_index=-1;" >/dev/null
+check "an external-TOAST-tagged min value is refused (XX001)" \
+	"$(errcode "SELECT count(*) FROM t WHERE txt > 'a';")" "XX001"
+check "backend survived the external-tagged minimum" "$(alive)" "yes"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -176,6 +176,7 @@ SUITES=(
 	native_toasted_write
 	native_truncate
 	native_vacuum_race
+	native_varlena_bound
 	native_vecdecode
 	native_vecskip
 	native_writer


### PR DESCRIPTION
The one real Class-B defect from the audit. A varlena value in a native chunk (and a zone map's min/max) carries its own length prefix, which `PgColumnarDecodeValue` / `pgcolumnar_skip_value` / `pgcolumnar_build_val_offsets` read and `memcpy`d with **no bound check**. A corrupt chunk or catalog row can declare a value that runs past its buffer (OOB read), and an external-TOAST-tagged prefix is later detoasted through a bogus pointer. Trusted-storage boundary (bit rot / hand-written stripe), not file-author-reachable — but a clean error beats a crash.

## Fix
New `PgColumnarVarSizeAnyUnalignedBounded(p, end)` refuses a start at/past `end`, a truncated 4-byte header, an external-TOAST tag, or an over-long length. The three decoders take the value stream's `end`; callers supply it — the scan and per-vector eval from a new `rs->nativeValueEnd[]` (via `native_decode_chunk` now reporting the raw total), the per-row fetch from a new cache `rawBufLen`, min/max from the stored length, and the write-path re-read + vector aggregate from their own buffers. A valid inline value always fits, so nothing correct is refused.

## Test — `native_varlena_bound` (with a RED repro, as you asked)
The zone map's min/max is a **catalog bytea**, so a plain `UPDATE` corrupts it (the relation-file value stream can't be). A min whose 4-byte header claims **~1 GB** against a 5-byte value, and an external-TOAST-tagged min, now raise `DATA_CORRUPTED` and the backend **survives**.

**Removal proof:** gutting the bounded reader turns each into a ~1 GB `memcpy` from a 5-byte buffer — the backend **SIGSEGVs**, so every "survived" check reddens. No regression across native_roundtrip, native_fetch_position/cache, native_zonemap, native_vecdecode, native_groupagg, native_writer, native_index, native_agg, **corruption, hardening**, differential on pg18_nc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
