### PR TITLE
bench: pin the external comparison-engine builds (TimescaleDB 2.29.0, Citus v14.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ## [Unreleased]
 
+### Added
+
+- The cross-engine benchmark arms are now reproducible from the repository.
+  `bench/build_timescaledb.sh` pins TimescaleDB 2.29.0 with the exact cmake
+  options recovered from the original benchmark build, and `bench/build_citus.sh`
+  pins Citus v14.1.0, each built against one explicit `pg_config` and refusing an
+  assert build. `bench/provision.sh check` continues to report their presence;
+  installing them is now a scripted, pinned step instead of a manual one (#702).
+
 ## [1.0-alpha2] - 2026-08-18
 
 ### Added

--- a/bench/build_citus.sh
+++ b/bench/build_citus.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Build the benchmark's Citus arm from source, pinned to the version that
+# produced the numbers in docs/benchmarks.md. Citus v14.1.0 is the first
+# release line that supports PostgreSQL 18. Comparison target only — no Citus
+# source enters pgColumnar (see PROVENANCE.md).
+#
+# Recovered from the benchmark machine's loose tooling before it was
+# decommissioned (issue #702); Citus uses plain autoconf + PGXS, so unlike
+# TimescaleDB there is no cmake cache to mirror — the pin is the tag and the
+# one configure flag.
+#
+# Usage:
+#   bench/build_citus.sh [PG_CONFIG] [TAG]
+#     defaults: /usr/local/pg18n/bin/pg_config  v14.1.0
+#
+# The default pg_config is the benchmark convention (a NON-assert PostgreSQL;
+# see docs/benchmarks.md). Set CITUS_SRC to reuse a source checkout.
+# Requires a C toolchain, git, and sudo for `make install`.
+set -euo pipefail
+
+PG_CONFIG="${1:-/usr/local/pg18n/bin/pg_config}"
+TAG="${2:-v14.1.0}"
+SRC="${CITUS_SRC:-/tmp/citus-$TAG}"
+
+command -v "$PG_CONFIG" >/dev/null || { echo "no pg_config at $PG_CONFIG" >&2; exit 1; }
+echo "== building Citus $TAG against $("$PG_CONFIG" --version) ($PG_CONFIG)"
+
+# Benchmark arms must run on a non-assert PostgreSQL. An assert build's numbers
+# are invalid, so refuse one the way the rest of the bench tooling does.
+if "$PG_CONFIG" --configure | grep -q -- '--enable-cassert'; then
+	echo "REFUSING: $PG_CONFIG is an assert build; benchmark numbers from it are invalid" >&2
+	exit 1
+fi
+
+[ -d "$SRC" ] || git clone --depth 1 --branch "$TAG" \
+	https://github.com/citusdata/citus.git "$SRC"
+cd "$SRC"
+
+# --without-libcurl: the bench arm needs the columnar AM, not telemetry.
+PATH="$("$PG_CONFIG" --bindir):$PATH" ./configure \
+	--with-pg-config="$PG_CONFIG" --without-libcurl
+make -s -j"$(nproc)"
+sudo make -s install
+
+# Verify the artifact, not the exit status.
+PKGLIB="$("$PG_CONFIG" --pkglibdir)"
+ls -1 "$PKGLIB"/citus*.so || { echo "FAILED: no citus .so in $PKGLIB" >&2; exit 1; }
+echo "== installed:"
+ls -1 "$PKGLIB"/citus*.so
+echo
+echo "Citus must be preloaded to be used:"
+echo "  shared_preload_libraries = 'citus'   (or 'pgcolumnar,citus')"
+echo "  then: CREATE EXTENSION citus;"
+echo "        SELECT extversion FROM pg_extension WHERE extname = 'citus';"

--- a/bench/build_timescaledb.sh
+++ b/bench/build_timescaledb.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Build the benchmark's TimescaleDB arm from source, pinned to the exact
+# version and cmake options that produced the numbers in docs/benchmarks.md.
+#
+# The flags below are not a guess: they were read back from the CMakeCache.txt
+# of the original build tree on the benchmark machine before it was
+# decommissioned (issue #702). TimescaleDB builds with cmake via its
+# ./bootstrap wrapper, not PGXS. APACHE_ONLY=OFF selects the community (TSL)
+# edition — that is why an install yields both timescaledb-<v>.so and
+# timescaledb-tsl-<v>.so.
+#
+# Usage:
+#   bench/build_timescaledb.sh [PG_CONFIG] [VERSION]
+#     defaults: /usr/local/pg18n/bin/pg_config  2.29.0
+#
+# The default pg_config is the benchmark convention (a NON-assert PostgreSQL;
+# see docs/benchmarks.md). Set TS_SRC to reuse a source checkout.
+# Requires cmake, a C toolchain, git, and sudo for `make install`.
+set -euo pipefail
+
+PG_CONFIG="${1:-/usr/local/pg18n/bin/pg_config}"
+VERSION="${2:-2.29.0}"
+SRC="${TS_SRC:-/tmp/timescaledb-$VERSION}"
+
+command -v "$PG_CONFIG" >/dev/null || { echo "no pg_config at $PG_CONFIG" >&2; exit 1; }
+echo "== building TimescaleDB $VERSION against $("$PG_CONFIG" --version) ($PG_CONFIG)"
+
+# Benchmark arms must run on a non-assert PostgreSQL. An assert build's numbers
+# are invalid, so refuse one the way the rest of the bench tooling does.
+if "$PG_CONFIG" --configure | grep -q -- '--enable-cassert'; then
+	echo "REFUSING: $PG_CONFIG is an assert build; benchmark numbers from it are invalid" >&2
+	exit 1
+fi
+
+[ -d "$SRC" ] || git clone --depth 1 --branch "$VERSION" \
+	https://github.com/timescale/timescaledb.git "$SRC"
+cd "$SRC"
+
+# Exact options from the original build's CMakeCache.txt:
+./bootstrap \
+	-DPG_CONFIG="$PG_CONFIG" \
+	-DCMAKE_BUILD_TYPE=Release \
+	-DAPACHE_ONLY=OFF \
+	-DUSE_OPENSSL=0 \
+	-DREGRESS_CHECKS=OFF \
+	-DWARNINGS_AS_ERRORS=OFF \
+	-DTAP_CHECKS=OFF \
+	-DLINTER=OFF
+cd build
+make -j"$(nproc)"
+sudo make install
+
+# Verify the artifact, not the exit status: a cmake picking up a stray prefix
+# installs elsewhere and still returns 0.
+PKGLIB="$("$PG_CONFIG" --pkglibdir)"
+ls -1 "$PKGLIB"/timescaledb*.so || { echo "FAILED: no timescaledb .so in $PKGLIB" >&2; exit 1; }
+echo "== installed:"
+ls -1 "$PKGLIB"/timescaledb*.so
+echo
+echo "TimescaleDB must be preloaded to be used:"
+echo "  shared_preload_libraries = 'timescaledb'   (or 'pgcolumnar,timescaledb')"
+echo "  then: CREATE EXTENSION timescaledb;"
+echo "        SELECT extversion FROM pg_extension WHERE extname = 'timescaledb';"

--- a/bench/provision.sh
+++ b/bench/provision.sh
@@ -22,7 +22,8 @@
 #   * It does not install Citus or TimescaleDB. Both must be built against one
 #     exact PostgreSQL, and picking that version silently is how a comparison
 #     ends up measuring the wrong engine. `check` reports whether they are
-#     present; installing them is still manual and issue #505 says so.
+#     present; building them is a deliberate separate step, pinned by
+#     bench/build_citus.sh and bench/build_timescaledb.sh (issue #702).
 #   * It does not download the ClickBench dataset (~70 GB unpacked). `check`
 #     reports whether it is there.
 #   * It does not install DuckDB. `check` reports whether `duckdb` is on PATH;
@@ -139,7 +140,7 @@ do_check() {
 		fi
 	done
 
-	echo "== comparison engines (this script does not install these)"
+	echo "== comparison engines (installed by bench/build_citus.sh and bench/build_timescaledb.sh, not here)"
 	local n18="$PREFIX_ROOT/$WANT_PG_BENCH/lib/postgresql"
 	for m in citus timescaledb; do
 		if ls "$n18"/${m}*.so >/dev/null 2>&1; then

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -428,8 +428,10 @@ suite. This section is a separate, larger run. It compares pgColumnar with heap,
 TimescaleDB, and Citus on the TSBS `cpu` workload, at 100,000,000 rows across 21
 columns. The data is loaded byte for byte the same way into each engine.
 
-The bench host has 16 vCPU and 62 GB. Each engine uses the configuration its own
-users would choose:
+The bench host has 16 vCPU and 62 GB. The comparison engines are built from
+source against the same non-assert PostgreSQL. The exact versions and build
+flags are pinned by `bench/build_timescaledb.sh` and `bench/build_citus.sh`.
+Each engine uses the configuration its own users would choose:
 
 - pgColumnar: columnar scan, storage in load order. One btree on
   `(hostname, time DESC)`. The load order is not globally sorted on either key. It is


### PR DESCRIPTION
Closes #702.

The bench that produced every number in `docs/benchmarks.md` is gone, and documenting its rebuild surfaced the gap #702 records: the TimescaleDB arm was never scripted, and the Citus build script lived only as loose tooling on the decommissioned host. This makes both external comparison engines reproducible from the repository.

## What this is

- **`bench/build_timescaledb.sh`** — pins **2.29.0** with the exact cmake options recovered from the original build tree's `CMakeCache.txt` before the host was decommissioned (recorded in #702): `CMAKE_BUILD_TYPE=Release`, `APACHE_ONLY=OFF` (community/TSL edition — the box had both `timescaledb-2.29.0.so` and `timescaledb-tsl-2.29.0.so`), `USE_OPENSSL=0`, checks/linters off. Not a guess — a read-back.
- **`bench/build_citus.sh`** — pins **v14.1.0** (first PG18-supporting line) with its one configure flag (`--without-libcurl`), from the recovered loose script. Comparison target only; no Citus source enters pgColumnar.
- Both take one explicit `pg_config` argument (default: the bench's non-assert convention), **refuse an assert build** the way the rest of the bench tooling does, and **verify the installed `.so`** instead of trusting the exit status.
- `bench/provision.sh` keeps its deliberate design (`check` reports presence, does not install); its "not installed here" comments now point at the two scripts instead of calling the step manual.
- Docs carried in-PR: `docs/benchmarks.md` cross-engine section now names the pinned scripts; CHANGELOG entry under Unreleased.

## Verification

- `shellcheck` clean on both new scripts (0 findings; the 3 info-level notes in `provision.sh` are pre-existing lines this PR does not touch).
- `test/docs_style.sh` PASSED, 9/9 checks, with the docs/CHANGELOG edits.
- The TimescaleDB flag set is provenance-verified against the original `CMakeCache.txt` (table in #702); the Citus script is the archived one that built the published `cpu_citus` arm, parameterized.
- Not run end-to-end here: neither engine was rebuilt on a live bench (there is none); the scripts' build steps are unchanged from the recovered originals beyond parameterization and the assert-build refusal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
