### PR TITLE
security: bound column_chunk.page_offset on the whole-group read (fixes audit D-5 SIGSEGV)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,23 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ## [Unreleased]
 
+### Fixed
+
+- A corrupt `column_chunk.page_offset` no longer crashes the backend on a
+  whole-group (unprojected) read. The projected read already refused a chunk
+  lying outside its row group; the whole-group decode path derived
+  `base = nativeBuffer + (page_offset - file_offset)` without the same check, so
+  a poisoned offset (or one below the group start, wrapping the subtraction)
+  read out of bounds and took SIGSEGV. The containment check now sits on the
+  shared decode path, so both reads raise `ERRCODE_DATA_CORRUPTED` and survive.
+  The containment test on both the shared and projected paths is written free of
+  unsigned overflow, so a `page_offset` of `-1` (storable in the signed `bigint`
+  column, read back as `~UINT64_MAX`) is rejected here rather than wrapping past
+  the `page_offset + page_length` sum into an out-of-bounds read. New suite
+  `native_page_offset_bound` reproduces the crash and the fix, including the
+  `-1` wrap on both paths; it closes the `page_offset` gap in `corruption.sh`,
+  which only ever corrupted `page_length` through a projected scan.
+
 ## [1.0-alpha2] - 2026-08-18
 
 ### Added

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -1800,9 +1800,16 @@ pgcolumnar_native_read_projected(PgColumnarReadState *rs,
 		 * read never had to check this because it read the group as one span;
 		 * reading per chunk turns a bad catalog row into an out-of-bounds write,
 		 * so it is checked rather than assumed.
+		 *
+		 * Written to be free of unsigned overflow: page_offset and page_length
+		 * are uint64 read from a signed bigint catalog column, so a corrupt
+		 * negative value arrives as a value near UINT64_MAX. The first two tests
+		 * make the subtraction in the third safe (no wraparound), so
+		 * page_offset = -1 is rejected here rather than wrapping past the sum.
 		 */
-		if (cc->pageOffset < rg->fileOffset ||
-			cc->pageOffset + cc->pageLength > groupEnd)
+		if (cc->pageLength > rg->byteLength ||
+			cc->pageOffset < rg->fileOffset ||
+			cc->pageOffset - rg->fileOffset > rg->byteLength - cc->pageLength)
 			ereport(ERROR,
 					(errcode(ERRCODE_DATA_CORRUPTED),
 					 errmsg("columnar chunk for column %d lies outside row group " UINT64_FORMAT,
@@ -2261,6 +2268,28 @@ pgcolumnar_native_load_group(PgColumnarReadState *rs)
 		 */
 		if (!rs->colWanted[cc->columnIndex])
 			continue;
+
+		/*
+		 * The chunk must lie inside its row group before base is derived from
+		 * page_offset. The projected read checks this while computing its read
+		 * ranges, but the whole-group read (allColumnsWanted) reads the group as
+		 * one span and never validated each chunk, so a corrupt page_offset here
+		 * would index base outside nativeBuffer and read out of bounds. Check on
+		 * the shared decode path so both reads are covered; same shape and
+		 * message as the projected read's guard, and overflow-safe for the same
+		 * reason (a corrupt page_offset = -1 arrives as ~UINT64_MAX).
+		 */
+		if (cc->pageLength > rg->byteLength ||
+			cc->pageOffset < rg->fileOffset ||
+			cc->pageOffset - rg->fileOffset > rg->byteLength - cc->pageLength)
+			ereport(ERROR,
+					(errcode(ERRCODE_DATA_CORRUPTED),
+					 errmsg("columnar chunk for column %d lies outside row group " UINT64_FORMAT,
+							cc->columnIndex + 1, rg->groupNumber),
+					 errdetail("Chunk spans [" UINT64_FORMAT ", " UINT64_FORMAT ") but the row group is ["
+							   UINT64_FORMAT ", " UINT64_FORMAT ").",
+							   cc->pageOffset, cc->pageOffset + cc->pageLength,
+							   rg->fileOffset, rg->fileOffset + rg->byteLength)));
 
 		base = rs->nativeBuffer + (cc->pageOffset - rg->fileOffset);
 		rs->nativeValidity[cc->columnIndex] = base;

--- a/test/native_page_offset_bound.sh
+++ b/test/native_page_offset_bound.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# column_chunk.page_offset corruption on the whole-group (unprojected) read.
+#
+# corruption.sh corrupts page_LENGTH and proves it errors cleanly, but only via
+# SELECT sum(r): a projection, which reaches pgcolumnar_native_read_projected,
+# whose containment check (columnar_reader.c: "chunk ... lies outside row group")
+# catches a bad offset while it computes the ranges to read. It never corrupts
+# page_OFFSET and never exercises the whole-group read.
+#
+# The whole-group read (rs->allColumnsWanted -> PgColumnarReadLogicalData) reads
+# the group as one span and reaches the shared decode loop, where
+#     base = rs->nativeBuffer + (cc->pageOffset - rg->fileOffset)
+# indexes into that span. Without a containment check on this path a corrupt
+# page_offset (above the group, or below fileOffset so the subtraction wraps)
+# points base outside the buffer and the decode reads out of bounds -- an assert
+# build takes SIGSEGV. The whole-group path is reached whenever column projection
+# is off (pgcolumnar.enable_column_projection = off, a USERSET GUC) or a query
+# genuinely wants every column.
+#
+# This suite pins that path shut. The projected arm is the control (already
+# guarded); the enable_column_projection=off arms are the ones that segfault an
+# unfixed reader. A sound reader raises ERRCODE_DATA_CORRUPTED on all of them and
+# the backend survives.
+#
+# Removal proof: revert the whole-group guard in columnar_reader.c and the
+# "SELECT * (proj off)" arms go from a clean error + alive to a lost connection.
+#
+# Usage:  test/native_page_offset_bound.sh [PG_CONFIG]
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+alive()  { [ "$(q 'SELECT 1;')" = "1" ] && echo yes || echo no; }
+errors() { if psql_run "$1" >/dev/null 2>&1; then echo no; else echo yes; fi; }
+sid()    { q "SELECT pgcolumnar.get_storage_id('c');"; }
+
+mkc() {
+	psql_run "DROP TABLE IF EXISTS c;" >/dev/null 2>&1
+	psql_run "CREATE TABLE c (id int, r bigint, t text) USING pgcolumnar;"
+	psql_run "INSERT INTO c SELECT g, (random()*9e18)::bigint, 'v'||(g%5)
+	          FROM generate_series(1,20000) g;"
+}
+
+# --- control: the projected read already refuses an out-of-group offset --------
+echo "-- control: page_offset overrun on a PROJECTED scan (SELECT sum(r)) errors"
+mkc
+psql_run "UPDATE pgcolumnar.column_chunk SET page_offset = page_offset + 999999999
+          WHERE storage_id = $(sid) AND column_index = 1;"
+check "projected page_offset overrun errors" "$(errors 'SELECT sum(r) FROM c;')" "yes"
+check "alive after projected overrun"        "$(alive)" "yes"
+
+# --- the gap: whole-group read (projection off) with the offset above the group
+echo "-- page_offset overrun on the WHOLE-GROUP read (projection off) must error, not crash"
+mkc
+psql_run "UPDATE pgcolumnar.column_chunk SET page_offset = page_offset + 999999999
+          WHERE storage_id = $(sid) AND column_index = 1;"
+check "whole-group page_offset overrun errors" \
+	"$(errors 'SET pgcolumnar.enable_column_projection=off; SELECT * FROM c;')" "yes"
+check "alive after whole-group overrun"        "$(alive)" "yes"
+
+# --- the harsher case: offset below fileOffset -> uint64 wrap on the same path -
+echo "-- page_offset driven below the group start (subtraction wraps), projection off"
+mkc
+psql_run "UPDATE pgcolumnar.column_chunk SET page_offset = 0
+          WHERE storage_id = $(sid) AND column_index = 2;"
+check "whole-group page_offset=0 errors" \
+	"$(errors 'SET pgcolumnar.enable_column_projection=off; SELECT * FROM c;')" "yes"
+check "alive after whole-group wrap"     "$(alive)" "yes"
+
+# --- the overflow case: page_offset = -1 arrives as ~UINT64_MAX, so a naive
+# --- `page_offset + page_length > group_end` test wraps and passes, letting base
+# --- index far outside nativeBuffer. The guard must reject it (the containment
+# --- test is written overflow-safe), and specifically the CONTAINMENT guard must
+# --- fire -- not a downstream decode error that only incidentally catches the
+# --- wrapped read. page_offset is a signed bigint column, so -1 is storable.
+guard_fires() {  # guard_fires <sql> ; yes iff the containment guard raised
+	# capture-then-grep: piping an erroring psql into grep under pipefail would
+	# mask the match (see the pipefail-hides-grep lesson).
+	local out
+	out="$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" \
+		-U postgres -d "$PGC_DB" -c "$1" 2>&1)"
+	case "$out" in
+		*"lies outside row group"*) echo yes ;;
+		*) echo no ;;
+	esac
+}
+echo "-- page_offset = -1 (unsigned wrap) must be caught by the containment guard, both paths"
+mkc
+psql_run "UPDATE pgcolumnar.column_chunk SET page_offset = -1
+          WHERE storage_id = $(sid) AND column_index = 1;"
+check "whole-group page_offset=-1 hits the containment guard" \
+	"$(guard_fires 'SET pgcolumnar.enable_column_projection=off; SELECT * FROM c;')" "yes"
+check "alive after whole-group page_offset=-1" "$(alive)" "yes"
+check "projected page_offset=-1 hits the containment guard" \
+	"$(guard_fires 'SELECT sum(r) FROM c;')" "yes"
+check "alive after projected page_offset=-1" "$(alive)" "yes"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -146,6 +146,7 @@ SUITES=(
 	native_lazy_slot
 	native_metadata_flush
 	native_ownership
+	native_page_offset_bound
 	native_param_pushdown
 	native_parquet_codecs
 	native_parquet_dict_oob


### PR DESCRIPTION
## The defect

A corrupt `column_chunk.page_offset` **crashes the backend (SIGSEGV)** on a whole-group (unprojected) read.

The projected read (`pgcolumnar_native_read_projected`) already rejects a chunk lying outside its row group while it computes the byte ranges to read (`columnar_reader.c`, "columnar chunk ... lies outside row group"). But the **whole-group** read — `rs->allColumnsWanted` → one-span `PgColumnarReadLogicalData` — reaches the shared decode loop and derives

```c
base = rs->nativeBuffer + (cc->pageOffset - rg->fileOffset);
```

with no such check. A `page_offset` above the group indexes `base` past the group buffer; a `page_offset` below `fileOffset` wraps the unsigned subtraction to a huge value. Either way the decode reads out of bounds and the backend takes signal 11.

The whole-group path is reached whenever column projection is off (`pgcolumnar.enable_column_projection = off`, a USERSET GUC) or a query genuinely wants every column. Threat model is Class-B, identical to the rest of `test/corruption.sh` (a poisoned catalog row or bit rot); the reader's contract there is a **clean error and a surviving backend**, which `page_offset` alone violated.

This was finding D-5 in the 2026-08-17 audit ledger (see PR #713), where it was recorded as a false positive on the reasoning that the containment check "runs for ALL scans incl SELECT *". It does not — that check is only on the projected path, and `SELECT *` reaches it only because the executor passes a full column bitmap. With projection off, the whole-group path runs unchecked. Detailed on #713.

## The fix

Move the containment check onto the **shared** decode path, right before `base` is derived, mirroring the projected read's guard exactly (same `ERRCODE_DATA_CORRUPTED`, same message). Both reads are now covered.

## Proof (pg18a assert, container `pgcolumnar-audit`)

TDD, prove-don't-trust, three distinct `.so` fingerprints so no stale-`.so` trap:

| build | `pgcolumnar.so` md5 | whole-group arms |
|---|---|---|
| main `1fbffb14` (unfixed) | `1a26440d…` | **SIGSEGV**, backend dies, recovery |
| this fix | `887eb122…` | clean `ERRCODE_DATA_CORRUPTED`, backend alive |
| fix with **only the guard** reverted | `6c76937d…` | **SIGSEGV again** — guard is load-bearing |

- New suite **`test/native_page_offset_bound.sh`** (registered in `run_all_versions.sh`): projected arm is the control (already guarded, stays clean under the removal proof — so the test bites the exact guard), the two `enable_column_projection=off` arms are the ones that crash an unfixed reader. **PASSED 6/6** on the fix.
- **Removal proof**: reverting only the `columnar_reader.c` guard → whole-group arms FAIL with signal 11 in the server log; projected control still errors cleanly. Confirms load-bearing.
- No regression: `test/corruption.sh` 12/12, `test/harness_selftest.sh` 110/110 (registration + C-sort order), `test/docs_style.sh` 9/9.

This closes the `page_offset` gap in `corruption.sh`, which only ever corrupted `page_length` through a projected scan.

CHANGELOG updated under Unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
