### PR TITLE
opt: IN-list / ANY(array) predicates drive zone-map chunk-group skipping (#704)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ## [Unreleased]
 
+### Added
+
+- `IN (...)` and `= ANY(array)` predicates now drive chunk-group skipping.
+  The scan-key builder derives a conservative `[min, max]` range over the
+  array's non-NULL elements. A single-valued list becomes an equality key,
+  which keeps the bloom-filter probe. A parameterized array on a generic
+  plan is frozen at executor start, like scalar parameters. That includes a
+  mixed list such as `IN (1, $1)`. A correlated array is not frozen and
+  stays correct. A new suite, `native_saop_pushdown`, proves the pruning,
+  the conservativeness, and both freeze rules. (#704)
+
 ## [1.0-alpha2] - 2026-08-18
 
 ### Added

--- a/design/SAOP_ZONEMAP_PLAN.md
+++ b/design/SAOP_ZONEMAP_PLAN.md
@@ -1,0 +1,142 @@
+# IN-list / ANY(array) zone-map pushdown (#704)
+
+## Problem
+
+`pgcolumnar_clause_to_scankey` (src/columnar_customscan.c) accepts only
+`OpExpr`, so an `IN (...)` / `= ANY(array)` qual (`ScalarArrayOpExpr`) builds
+no scan key and the scan reads every row group. Every comparable predicate
+shape (equality, range, anchored LIKE, parameterized scalar) already prunes.
+
+## Design
+
+Add a `ScalarArrayOpExpr` branch that derives a conservative `[min, max]`
+range over the array elements and emits two range scan keys. The executor
+still rechecks exact membership on every surviving row, so the keys only
+need to be conservative (never skip a group that could match), not exact.
+
+Acceptance conditions, mirroring the OpExpr path:
+
+1. `saop->useOr` is true (`= ANY`; `ALL` semantics are different and out of
+   scope), left arg (RelabelType-stripped) is a `Var` of the scanned rel with
+   a valid attno, right arg is a non-null array `Const`.
+2. `saop->inputcollid == attcollation` (same collation rule, same reason:
+   the stored min/max are ordered under the column collation).
+3. `get_op_opfamily_strategy(saop->opno, <column btree opfamily>)` is
+   `BTEqualStrategyNumber`. This admits cross-type equality (e.g.
+   `int4col = ANY(bigint[])`); the reader already resolves cross-type
+   comparison procs per #477/#483.
+4. Detoast the array, deconstruct, ignore NULL elements (under `useOr`
+   equality a NULL element can never make the qual true). Zero non-null
+   elements: no keys.
+5. Order elements with the btree ordering proc for `(elemtype, elemtype)`
+   from the SAME opfamily (`get_opfamily_proc(..., BTORDER_PROC)`), compared
+   under `saop->inputcollid`; missing proc: no keys.
+6. Emit `col >= min` (BTGreaterEqual) and `col <= max` (BTLessEqual), with
+   `sk_subtype = elemtype`. `PgColumnarBuildScanKeys` already allocates two
+   `ScanKeyData` slots per clause (the anchored-LIKE precedent), so the
+   allocation is unchanged. Exception: a list with ONE distinct value
+   (`= ANY('{7}')`, `= ANY('{7,7}')`) emits a single BTEqual key instead,
+   which is exact for that clause and keeps the reader's bloom probe -- so
+   `x IN (7)` prunes like `x = 7` even where every group's range contains 7.
+
+Multi-value lists get range keys, not per-element equality keys: predicates
+conjoin ANDwise in `pgcolumnar_group_can_match`, so N equality keys would be
+wrong (a group must satisfy all keys), and the SkipPredicate list has no OR
+structure. The range is the correct conservative projection of the
+disjunction onto that AND-only structure. Consequence for multi-value lists:
+no bloom-filter probe (that requires an equality key); a gappy IN-list over
+a wide range prunes little. That is the same trade the LIKE-prefix pushdown
+makes. Note for the #715 exactness-marker design: the single-distinct-value
+key IS exact and IS an equality key; only the multi-value range keys are
+weaker than their clause.
+
+Parameterized arrays (`col = ANY($1)`): extend `pgcolumnar_stabilize_quals`
+(#697) to freeze a stable non-Const array argument of a `ScalarArrayOpExpr`
+the same way it freezes scalar OpExpr operands (no Var, no PARAM_EXEC, no
+volatile function; guarded evaluation). A correlated PARAM_EXEC array is
+deliberately not frozen, same as #697.
+
+## Hazard analysis (outcome)
+
+An adversarial six-dimension hazard workflow ran alongside implementation
+(NULL/empty semantics, collation incl. nondeterministic, cross-type and
+domains, memory lifetime across Begin/rescan/planner callers, the freeze
+extension, planner/executor consistency and sibling paths). Disposition of
+its six must-address findings:
+
+- H1 detoast + lifetime: handled. `DatumGetArrayTypeP` before any header
+  access; the detoasted copy and the deconstructed element datums are never
+  freed, so the reader's by-pointer retention (`compareValue`) stays valid
+  across rescans, matching the LIKE precedent.
+- H2 batch-fold eligibility admits quals that build no key: REAL,
+  pre-existing, reproduced empirically (`count(*) WHERE x <> 5` counts the
+  excluded row with `pgcolumnar.enable_ungrouped_vector_agg=on`). Filed as
+  #715 with the repro; not fixed here (its own TDD PR).
+- H3 conservative keys must never enter the batch fold: guarded three ways.
+  A load-bearing comment at the eligibility gate (columnar_vector.c), a
+  matching warning in the builder's header comment, and a live test arm
+  (vector-agg count over an IN-list with the GUC on must stay exact).
+- H4 vector-agg paths rebuild keys per rescan without freeing: pre-existing
+  growth, made larger by arrays. Filed as a follow-up issue; not widened
+  into this change.
+- H5 domain element types: VERIFIED UNREACHABLE, no code. Probed with the
+  domain resolution removed: literal `::intdom[]` cast, ArrayExpr cast, and
+  a domain-array parameter under a generic plan all arrive with base-type
+  OIDs in the array header and all prune. Shipping `getBaseType` there
+  would be a guard that fails "can I delete this and stay green"; the
+  domain arms stay in the suite as characterization locks. (Also caught in
+  review: `deconstruct_array` asserts the header's own OID, so the naive
+  resolution would have tripped assert builds.)
+- H6 mixed lists (`IN (1, $1)` on a generic plan arrive as an unfolded
+  ArrayExpr): handled by construction — the freeze evaluates the whole
+  array argument, not bare Params — and pinned by its own test arm.
+
+Nondeterministic-collation ordering was rated already-handled (the
+`inputcollid == attcollation` gate plus zone maps written under the column
+collation make the range conservative under the same ordering); the ICU
+removal-proof fixture is impossible on this build farm (`--without-icu`),
+so the argument lives here rather than in a test.
+
+## Test plan (TDD)
+
+New suite `test/native_saop_pushdown.sh`, modeled on
+`native_param_pushdown.sh` (same 40000-row / 20-group fixture, same
+`Chunk Groups Removed by Filter` instrument, which counts groups actually
+removed, i.e. work done, not keys built).
+
+RED first against an unmodified build; each pruning arm's expected value
+failed pre-fix (all read 0). The shipped suite's arms:
+
+- `ts IN (39100, 39200)` removes 19 of 20 groups, with the full instrument
+  asserted separately: Pushed-Down Filters = 2 (intent), Usable Skip
+  Predicates = 2 (accepted), Removed = 19 (work done); count matches the
+  literal-OR equivalent.
+- NULL element: `ts = ANY(ARRAY[39100, NULL]::int[])` removes 19, count 1.
+- Cross-type: `ts = ANY('{...}'::bigint[])` removes 19, count correct.
+- Domain-element arrays: characterization locks (base OIDs in the header;
+  see the hazard section) -- prune 19, count correct.
+- Single-distinct-value refinement: on a column where every group's range
+  contains the probe (premise pinned by a range-only arm removing 0 and an
+  equality arm removing 20), `= ANY('{25,25}')` removes 20 via the bloom
+  probe.
+- Wide list spanning the range removes 0 but counts correctly.
+- `NOT IN` with a list confined to ONE group: removes 0 and counts exactly
+  (a spanning list could not detect a wrongly derived positive range).
+- Empty array and all-NULL array: correct result, backend alive.
+- Parameterized: generic-plan `PREPARE p(int[])` removes 19; mixed
+  `IN (literal, $1)` (an unfolded ArrayExpr on a generic plan) removes 19;
+  a correlated PARAM_EXEC array (LATERAL, per-rescan lists landing in
+  different groups with different cardinalities) sums exactly.
+- Vector-agg guard: with `enable_ungrouped_vector_agg=on`, the plan shows
+  `Batch Fold: no` for the IN-list and `Batch Fold: yes` for the equivalent
+  exact range quals (the fold is reachable, only the SAOP is refused), and
+  the count stays exact.
+- Text column IN-list prunes and counts correctly under the column
+  collation.
+
+Removal proofs, each run against the built suite: severing the scankey
+dispatch reddens every literal pruning arm (and the parameterized ones,
+which need keys too); severing only the freeze extension reddens exactly
+the two generic-plan parameterized arms; severing only the
+single-distinct-value equality branch reddens exactly the `'{25,25}'`
+bloom arm.

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -31,6 +31,7 @@
 #include <math.h>
 
 #include "access/htup_details.h"
+#include "access/nbtree.h"
 #include "access/parallel.h"
 #include "access/relation.h"
 #include "access/relscan.h"
@@ -62,6 +63,7 @@
 #include "optimizer/restrictinfo.h"
 #include "statistics/statistics.h"
 #include "catalog/pg_statistic_ext.h"
+#include "utils/array.h"
 #include "utils/builtins.h"
 #include "utils/datum.h"
 #include "utils/lsyscache.h"
@@ -405,6 +407,181 @@ pgcolumnar_like_prefix_scankey(OpExpr *op, Var *var, Const *con,
 	return 1;
 }
 
+/*
+ * pgcolumnar_saop_range_scankey
+ *		Turn `col = ANY(array)` -- the planner's form of `col IN (...)` -- into
+ *		the [min, max] range it implies, so zone maps can skip groups whose
+ *		range cannot intersect any listed value (#704).
+ *
+ * Range keys rather than per-element equality keys, because the skip
+ * predicates conjoin: pgcolumnar_group_can_match requires a group to satisfy
+ * EVERY predicate, and a list has no group satisfying `= a AND = b`. The range
+ * is the disjunction's projection onto that AND-only structure, and it is
+ * conservative by construction: the executor still rechecks exact membership
+ * on every surviving row, so a group inside the range holding none of the
+ * listed values is read and filtered, never skipped wrongly. The cost of that
+ * shape is no bloom probe (equality-only, columnar_reader.c) and little
+ * pruning from a list that spans the column's range. Because these keys are
+ * WEAKER than their clause, they must never serve as an exact row filter:
+ * the batch-fold eligibility gate in columnar_vector.c is what keeps them
+ * out of the vectorized fold, and its comment names this function.
+ *
+ * Only `useOr` equality: `= ALL (list)` is a conjunction already and is
+ * satisfiable only for a single-valued list, and a negated operator admits
+ * everything outside the list, so neither yields this range. NULL elements
+ * cannot make `= ANY` true (each yields NULL, and OR ignores NULL beside a
+ * true), so they are ignored for the range; a list with no non-NULL element
+ * matches nothing and builds no keys rather than a degenerate range.
+ *
+ * The element ordering proc comes from the COLUMN type's btree opfamily, for
+ * the element type pair -- the same family that supplied the equality
+ * operator's strategy, so "min of the list" and "compares below the group's
+ * max" agree on one ordering. A cross-type list (int column, bigint elements)
+ * therefore orders its elements with the element type's own proc from that
+ * family, and the reader resolves the (column, element) comparison the same
+ * way it does for any cross-type range key (#477).
+ *
+ * Same collation rule as the OpExpr path, same reason (spec 9): the stored
+ * min/max are ordered under the column's collation, so only a comparison
+ * under that collation may drive skipping. That rule, not a determinism
+ * check, is what text needs here: under a nondeterministic collation a value
+ * equal to a listed element sorts equal to it, so it lies inside the range.
+ */
+static int
+pgcolumnar_saop_range_scankey(ScalarArrayOpExpr *saop, Index scanrelid,
+							  TupleDesc tupdesc, ScanKey key)
+{
+	Node	   *leftop;
+	Node	   *rightop;
+	Var		   *var;
+	Const	   *con;
+	TypeCacheEntry *tce;
+	Oid			cmpProc;
+	FmgrInfo	cmpFn;
+	ArrayType  *arr;
+	Oid			elemtype;
+	int16		elmlen;
+	bool		elmbyval;
+	char		elmalign;
+	Datum	   *elems;
+	bool	   *nulls;
+	int			nelems;
+	int			i;
+	Datum		minVal = (Datum) 0;
+	Datum		maxVal = (Datum) 0;
+	bool		have = false;
+
+	if (!saop->useOr)
+		return 0;
+	if (list_length(saop->args) != 2)
+		return 0;
+
+	leftop = (Node *) linitial(saop->args);
+	rightop = (Node *) lsecond(saop->args);
+	if (IsA(leftop, RelabelType))
+		leftop = (Node *) ((RelabelType *) leftop)->arg;
+	if (!IsA(leftop, Var) || !IsA(rightop, Const))
+		return 0;
+	var = (Var *) leftop;
+	con = (Const *) rightop;
+
+	if (var->varno != scanrelid)
+		return 0;
+	if (var->varattno < 1 || var->varattno > tupdesc->natts)
+		return 0;
+	if (con->constisnull)
+		return 0;
+	if (saop->inputcollid !=
+		TupleDescAttr(tupdesc, var->varattno - 1)->attcollation)
+		return 0;
+
+	tce = lookup_type_cache(var->vartype, TYPECACHE_BTREE_OPFAMILY);
+	if (!OidIsValid(tce->btree_opf))
+		return 0;
+	if (get_op_opfamily_strategy(saop->opno, tce->btree_opf) !=
+		BTEqualStrategyNumber)
+		return 0;
+
+	arr = DatumGetArrayTypeP(con->constvalue);
+
+	/*
+	 * No getBaseType on the element type, deliberately. Every reachable
+	 * domain-array shape (`'{...}'::intdom[]` literal, an ArrayExpr cast,
+	 * and a prepared `$1::intdom[]` under a generic plan) arrives with the
+	 * BASE type's OID in the array header, so a domain resolution here can
+	 * never fire -- probed by removing it and watching the domain arms of
+	 * native_saop_pushdown.sh stay green. An element type the opfamily
+	 * cannot order (below) bails to "no keys", which is conservative.
+	 */
+	elemtype = ARR_ELEMTYPE(arr);
+	cmpProc = get_opfamily_proc(tce->btree_opf, elemtype, elemtype,
+								BTORDER_PROC);
+	if (!OidIsValid(cmpProc))
+		return 0;
+	fmgr_info(cmpProc, &cmpFn);
+
+	get_typlenbyvalalign(elemtype, &elmlen, &elmbyval, &elmalign);
+	deconstruct_array(arr, elemtype, elmlen, elmbyval, elmalign,
+					  &elems, &nulls, &nelems);
+
+	for (i = 0; i < nelems; i++)
+	{
+		if (nulls[i])
+			continue;
+		if (!have)
+		{
+			minVal = maxVal = elems[i];
+			have = true;
+			continue;
+		}
+		if (DatumGetInt32(FunctionCall2Coll(&cmpFn, saop->inputcollid,
+											elems[i], minVal)) < 0)
+			minVal = elems[i];
+		if (DatumGetInt32(FunctionCall2Coll(&cmpFn, saop->inputcollid,
+											elems[i], maxVal)) > 0)
+			maxVal = elems[i];
+	}
+	if (!have)
+		return 0;
+
+	/*
+	 * A list with one distinct value is an equality, and emitting it as one
+	 * beats [v, v]: the reader's bloom probe fires only for an equality key
+	 * (columnar_reader.c), so `x IN (7)` keeps the pruning power of `x = 7`
+	 * on a column whose per-group ranges all contain 7.
+	 */
+	if (DatumGetInt32(FunctionCall2Coll(&cmpFn, saop->inputcollid,
+										minVal, maxVal)) == 0)
+	{
+		MemSet(&key[0], 0, sizeof(ScanKeyData));
+		key[0].sk_flags = 0;
+		key[0].sk_attno = var->varattno;
+		key[0].sk_strategy = BTEqualStrategyNumber;
+		key[0].sk_subtype = elemtype;
+		key[0].sk_collation = saop->inputcollid;
+		key[0].sk_argument = minVal;
+		return 1;
+	}
+
+	MemSet(&key[0], 0, sizeof(ScanKeyData));
+	key[0].sk_flags = 0;
+	key[0].sk_attno = var->varattno;
+	key[0].sk_strategy = BTGreaterEqualStrategyNumber;
+	key[0].sk_subtype = elemtype;
+	key[0].sk_collation = saop->inputcollid;
+	key[0].sk_argument = minVal;
+
+	MemSet(&key[1], 0, sizeof(ScanKeyData));
+	key[1].sk_flags = 0;
+	key[1].sk_attno = var->varattno;
+	key[1].sk_strategy = BTLessEqualStrategyNumber;
+	key[1].sk_subtype = elemtype;
+	key[1].sk_collation = saop->inputcollid;
+	key[1].sk_argument = maxVal;
+
+	return 2;
+}
+
 static int
 pgcolumnar_clause_to_scankey(Node *clause, Index scanrelid, TupleDesc tupdesc,
 						   ScanKey key)
@@ -417,6 +594,11 @@ pgcolumnar_clause_to_scankey(Node *clause, Index scanrelid, TupleDesc tupdesc,
 	bool		varOnLeft;
 	TypeCacheEntry *tce;
 	StrategyNumber strat;
+
+	/* `col IN (...)` / `col = ANY(array)` becomes a [min, max] range (#704) */
+	if (IsA(clause, ScalarArrayOpExpr))
+		return pgcolumnar_saop_range_scankey((ScalarArrayOpExpr *) clause,
+											 scanrelid, tupdesc, key);
 
 	if (!IsA(clause, OpExpr))
 		return 0;
@@ -525,8 +707,9 @@ PgColumnarBuildScanKeys(List *qual, Index scanrelid, TupleDesc tupdesc,
 		return NULL;
 
 	/*
-	 * Two slots per clause: an anchored LIKE yields a lower and an upper bound
-	 * from one clause (#426), and everything else yields at most one.
+	 * Two slots per clause: an anchored LIKE (#426) and an IN-list range
+	 * (#704) each yield a lower and an upper bound from one clause, and
+	 * everything else yields at most one.
 	 */
 	keys = (ScanKey) palloc0(sizeof(ScanKeyData) * 2 * list_length(qual));
 	foreach(lc, qual)
@@ -621,18 +804,30 @@ pgcolumnar_stabilize_quals(List *qual, PlanState *ps)
 	foreach(lc, qual)
 	{
 		Node	   *clause = (Node *) lfirst(lc);
-		OpExpr	   *op;
+		List	   *args;
 		List	   *newargs = NIL;
 		ListCell   *alc;
 		bool		changed = false;
 
-		if (!IsA(clause, OpExpr) || list_length(((OpExpr *) clause)->args) != 2)
+		/*
+		 * The same freeze serves `col = ANY($1)` (#704): the array argument of
+		 * a ScalarArrayOpExpr is one operand like any other, judged by the
+		 * same stability rule below. The Var side is never frozen (the walker
+		 * sees it), and a correlated PARAM_EXEC array is refused exactly as a
+		 * scalar one is.
+		 */
+		if (IsA(clause, OpExpr) &&
+			list_length(((OpExpr *) clause)->args) == 2)
+			args = ((OpExpr *) clause)->args;
+		else if (IsA(clause, ScalarArrayOpExpr) &&
+				 list_length(((ScalarArrayOpExpr *) clause)->args) == 2)
+			args = ((ScalarArrayOpExpr *) clause)->args;
+		else
 		{
 			out = lappend(out, clause);
 			continue;
 		}
-		op = (OpExpr *) clause;
-		foreach(alc, op->args)
+		foreach(alc, args)
 		{
 			Node	   *arg = (Node *) lfirst(alc);
 			Node	   *bare = arg;
@@ -656,10 +851,13 @@ pgcolumnar_stabilize_quals(List *qual, PlanState *ps)
 		}
 		if (changed)
 		{
-			OpExpr	   *nop = copyObject(op);
+			Node	   *nclause = (Node *) copyObject(clause);
 
-			nop->args = newargs;
-			out = lappend(out, (Node *) nop);
+			if (IsA(nclause, OpExpr))
+				((OpExpr *) nclause)->args = newargs;
+			else
+				((ScalarArrayOpExpr *) nclause)->args = newargs;
+			out = lappend(out, nclause);
 		}
 		else
 			out = lappend(out, clause);

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -3028,6 +3028,22 @@ pgcolumnar_batch_shape_eligible(PgColumnarAggScanState *state, TupleDesc tupdesc
 		return false;
 
 	/*
+	 * LOAD-BEARING: this gate is what keeps an IN-list's CONSERVATIVE scan
+	 * keys out of the fold. PgColumnarBuildScanKeys emits keys weaker than
+	 * their clause for a ScalarArrayOpExpr (a [min, max] range, #704), and
+	 * the fold's only per-row filter is the key loop, so such a key used
+	 * here counts rows the clause rejects. The SAOP is excluded only
+	 * because pgcolumnar_clause_to_predicate accepts nothing but OpExpr --
+	 * if you teach it about ScalarArrayOpExpr, you must first give keys an
+	 * exactness marker and gate the fold on it (#715 is the same hole from
+	 * the other side: a convertible clause that builds NO key, and an
+	 * anchored LIKE (#426), whose keys are also conservative, is a strict
+	 * OpExpr that PASSES this gate and is kept out of the fold only by the
+	 * byval gather guard below). native_saop_pushdown.sh's vector-agg arms
+	 * go red if this regresses.
+	 */
+
+	/*
 	 * Every column the fold will GATHER must be passed BY VALUE (#423).
 	 *
 	 * The gather does pointer arithmetic on attlen and hardcodes attbyval:
@@ -3051,8 +3067,9 @@ pgcolumnar_batch_shape_eligible(PgColumnarAggScanState *state, TupleDesc tupdesc
 	 * The type check below is not this check and cannot stand in for it. It walks
 	 * the SCAN KEYS and asks whether each type is comparable, while the gather
 	 * walks state->projected and needs to know whether each type is fixed width.
-	 * A text column filtered with LIKE is in projected and not in the keys, since
-	 * LIKE is not a pushable scan key, so it reached the gather unchecked. That is
+	 * A text column filtered with an unanchored LIKE is in projected and not in
+	 * the keys (an anchored LIKE builds only conservative range keys, #426; an
+	 * unanchored one builds none), so it reached the gather unchecked. That is
 	 * exactly ClickBench q21, SELECT COUNT(*) FROM hits WHERE URL LIKE '%google%'.
 	 *
 	 * Falling back to the row path is what the ADD COLUMN case already does.

--- a/test/native_saop_pushdown.sh
+++ b/test/native_saop_pushdown.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+#
+# pgColumnar chunk-group skipping works for IN-list / = ANY(array) predicates.
+#
+# The scan-key builder (pgcolumnar_clause_to_scankey) accepted only OpExpr, so a
+# ScalarArrayOpExpr -- `col IN (...)` or `col = ANY(array)` -- built no scan key
+# and the scan read every row group, while every comparable predicate shape
+# (equality, range, anchored LIKE, parameterized scalar) already pruned (#704).
+#
+# The fix derives a conservative [min, max] range over the array's non-NULL
+# elements and emits two range keys. The executor still rechecks exact
+# membership on surviving rows, so pruning can only be conservative: a group
+# inside the range but holding none of the listed values is read and filtered,
+# never skipped wrongly. A NULL element cannot make `= ANY` true, so ignoring
+# NULLs for the range is exact.
+#
+# The correctness hazards, each with an arm below: a negated SAOP must build no
+# keys (NOT IN admits everything outside the list); an empty or all-NULL array
+# must not crash or mis-count; a parameterized array ($1 on a generic plan) is
+# frozen at Begin like #697's scalars, but a correlated PARAM_EXEC array changes
+# per rescan and must NOT be frozen.
+#
+# Usage:  test/native_saop_pushdown.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+q "CREATE EXTENSION IF NOT EXISTS pgcolumnar;" >/dev/null
+# 40000 rows / 2000 = 20 monotonic groups; values >= 39000 live in the last one.
+# ov = (g%40)*2+10 gives every group the same even-valued range [10,88], so an
+# odd probe value is inside every group's [min,max] but present in none: range
+# keys prune nothing there, only the bloom probe can, which isolates the
+# single-value-list equality-key refinement.
+q "SET pgcolumnar.stripe_row_limit=2000;
+   CREATE DOMAIN intdom AS int;
+   CREATE TABLE t (id int, ts int, txt text COLLATE \"C\", ov int) USING pgcolumnar;
+   INSERT INTO t SELECT g, g, lpad(g::text, 8, '0'), (g % 40)*2 + 10
+     FROM generate_series(1,40000) g;
+   CREATE TABLE thr (lo int[]); INSERT INTO thr VALUES ('{39100}'),('{100,200}');" >/dev/null
+
+psql_c() { env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" -At -c "$1" 2>&1; }
+
+# Chunk groups removed by a query, from EXPLAIN ANALYZE. Prints the count, or
+# NOSCAN when the plan did not use the columnar scan at all -- so a plan-shape
+# change reads as its own failure, not as "0 groups removed".
+groups_removed() {
+	local plan
+	plan="$(psql_c "EXPLAIN (ANALYZE, TIMING off, SUMMARY off) $1")"
+	case "$plan" in
+		*"Chunk Groups Removed by Filter"*)
+			sed -n 's/.*Chunk Groups Removed by Filter: \([0-9]*\).*/\1/p' <<<"$plan" | head -1 ;;
+		*) echo "NOSCAN($plan)" ;;
+	esac
+}
+
+# --- pruning arms (RED before the fix: each reads 0) ---
+
+# The full instrument on the primary arm: the plan pushed both range keys
+# (intent), the reader accepted both as skip predicates (usable), and 19
+# groups were in fact removed (work done). The three lines are distinct
+# counters precisely so intent cannot impersonate work (#477/#479).
+saop_plan="$(psql_c 'EXPLAIN (ANALYZE, TIMING off, SUMMARY off) SELECT count(*) FROM t WHERE ts IN (39100, 39200);')"
+check "an IN-list pushes two filters (intent)" \
+	"$(sed -n 's/.*Columnar Pushed-Down Filters: \([0-9]*\).*/\1/p' <<<"$saop_plan" | head -1)" "2"
+check "both IN-list keys are usable skip predicates" \
+	"$(sed -n 's/.*Columnar Usable Skip Predicates: \([0-9]*\).*/\1/p' <<<"$saop_plan" | head -1)" "2"
+check "an IN-list confined to the last group prunes (19 of 20 removed)" \
+	"$(sed -n 's/.*Chunk Groups Removed by Filter: \([0-9]*\).*/\1/p' <<<"$saop_plan" | head -1)" "19"
+
+check "IN-list count matches the OR-literal equivalent" \
+	"$(q 'SELECT count(*) FROM t WHERE ts IN (39100, 39200);')" \
+	"$(q 'SELECT count(*) FROM t WHERE ts = 39100 OR ts = 39200;')"
+
+check "a NULL element is ignored for the range, not a bailout (19 removed)" \
+	"$(groups_removed 'SELECT count(*) FROM t WHERE ts = ANY (ARRAY[39100, NULL]::int[]);')" "19"
+
+check "NULL-element count is exact" \
+	"$(q 'SELECT count(*) FROM t WHERE ts = ANY (ARRAY[39100, NULL]::int[]);')" "1"
+
+check "a cross-type element array (int col, bigint[] list) prunes (19 removed)" \
+	"$(groups_removed "SELECT count(*) FROM t WHERE ts = ANY ('{39100,39200}'::bigint[]);")" "19"
+
+check "cross-type count is exact" \
+	"$(q "SELECT count(*) FROM t WHERE ts = ANY ('{39100,39200}'::bigint[]);")" "2"
+
+check "a C-collated text IN-list prunes (19 removed)" \
+	"$(groups_removed "SELECT count(*) FROM t WHERE txt IN ('00039100', '00039200');")" "19"
+
+check "text IN-list count is exact" \
+	"$(q "SELECT count(*) FROM t WHERE txt IN ('00039100', '00039200');")" "2"
+
+# Characterization: a domain-element cast arrives with the BASE type's OID in
+# the array header (probed: literal cast, ArrayExpr cast, and a domain-array
+# param all prune with no domain resolution in the builder), so no getBaseType
+# is needed. These arms lock that in; if a PG version changes the header OID,
+# they go red and the builder needs #483's resolution.
+check "a domain-element array prunes (19 removed)" \
+	"$(groups_removed "SELECT count(*) FROM t WHERE ts = ANY ('{39100,39200}'::intdom[]);")" "19"
+
+check "domain-element count is exact" \
+	"$(q "SELECT count(*) FROM t WHERE ts = ANY ('{39100,39200}'::intdom[]);")" "2"
+
+# Fixture premises first (assert-the-fixture-premise). The range probe pins
+# that 25 lies INSIDE every group's stored [min, max] -- range keys alone
+# prune nothing -- so the 20-removed arms below can only be the bloom probe.
+# If the ov formula or the stripe size ever drifts so some group's range
+# excludes 25, this goes red instead of the removal proof quietly dissolving.
+check "fixture premise: 25 is inside every group's range (range keys prune 0)" \
+	"$(groups_removed 'SELECT count(*) FROM t WHERE ov >= 25 AND ov <= 25;')" "0"
+
+check "fixture premise: equality on the overlap column bloom-prunes all 20" \
+	"$(groups_removed 'SELECT count(*) FROM t WHERE ov = 25;')" "20"
+
+# `IN (25)` parses to plain `= 25` (the parser collapses a one-element list),
+# so it exercises the OpExpr path; the `= ANY('{25,25}')` arm below is the
+# SAOP shape and is the removal proof for the single-distinct-value
+# equality-key refinement (as two range keys it removes 0).
+check "a one-element IN-list (parser-collapsed to =) bloom-prunes (20 removed)" \
+	"$(groups_removed 'SELECT count(*) FROM t WHERE ov IN (25);')" "20"
+
+check "a single-DISTINCT-value SAOP list ('{25,25}') bloom-prunes (20 removed)" \
+	"$(groups_removed "SELECT count(*) FROM t WHERE ov = ANY ('{25,25}'::int[]);")" "20"
+
+check "single-value IN-list count is exact (0 rows)" \
+	"$(q 'SELECT count(*) FROM t WHERE ov IN (25);')" "0"
+
+# --- conservativeness arms (must hold before AND after the fix) ---
+
+# A list spanning the whole range prunes nothing but must count exactly: the
+# range is conservative, membership is the executor's recheck.
+check "a range-spanning IN-list is conservative (0 removed, exact count)" \
+	"$(groups_removed 'SELECT count(*) FROM t WHERE ts IN (100, 39900);')/$(q 'SELECT count(*) FROM t WHERE ts IN (100, 39900);')" \
+	"0/2"
+
+# The NOT IN list is confined to ONE group on purpose: a builder that wrongly
+# derived the positive [19000, 19500] range from the negated clause would skip
+# the 19 other groups -- all full of matching rows -- and the count would
+# collapse to 1998. A list spanning the table could not catch that, because a
+# wrong range intersecting every group prunes nothing. The removed=0 companion
+# pins that no keys are built at all.
+check "NOT IN builds no range (0 removed) and stays correct" \
+	"$(groups_removed 'SELECT count(*) FROM t WHERE ts NOT IN (19000, 19500);')/$(q 'SELECT count(*) FROM t WHERE ts NOT IN (19000, 19500);')" \
+	"0/39998"
+
+check "an empty array counts zero and does not crash" \
+	"$(q "SELECT count(*) FROM t WHERE ts = ANY ('{}'::int[]);")" "0"
+
+check "an all-NULL array counts zero and does not crash" \
+	"$(q "SELECT count(*) FROM t WHERE ts = ANY (ARRAY[NULL,NULL]::int[]);")" "0"
+
+# --- parameterized arms (#697 machinery extended to array args) ---
+
+gp_removed() {
+	psql_c "SET plan_cache_mode=force_generic_plan;
+		DEALLOCATE ALL;
+		PREPARE p(int[]) AS SELECT count(*) FROM t WHERE ts = ANY (\$1);
+		EXPLAIN (ANALYZE, TIMING off, SUMMARY off) EXECUTE p('{39100,39200}');" \
+		| sed -n 's/.*Chunk Groups Removed by Filter: \([0-9]*\).*/\1/p' | head -1
+}
+
+check "a generic-plan parameterized array prunes (19 removed)" \
+	"$(gp_removed)" "19"
+
+check "parameterized array count matches the literal count" \
+	"$(psql_c "SET plan_cache_mode=force_generic_plan;
+		DEALLOCATE ALL;
+		PREPARE c(int[]) AS SELECT count(*) FROM t WHERE ts = ANY (\$1);
+		EXECUTE c('{39100,39200}');" | tail -1)" "2"
+
+# A MIXED list -- `IN (literal, $1)` -- stays an unfolded ArrayExpr in a
+# generic plan (eval_const_expressions folds an ArrayExpr only when every
+# element is Const), so it prunes only because the freeze evaluates the WHOLE
+# array argument, not just a bare Param. This is the shape #697 existed for.
+mixed_removed() {
+	psql_c "SET plan_cache_mode=force_generic_plan;
+		DEALLOCATE ALL;
+		PREPARE m(int) AS SELECT count(*) FROM t WHERE ts IN (39100, \$1);
+		EXPLAIN (ANALYZE, TIMING off, SUMMARY off) EXECUTE m(39200);" \
+		| sed -n 's/.*Chunk Groups Removed by Filter: \([0-9]*\).*/\1/p' | head -1
+}
+
+check "a mixed literal+param IN-list prunes on a generic plan (19 removed)" \
+	"$(mixed_removed)" "19"
+
+# The vectorized-aggregate guard: SAOP-derived keys are CONSERVATIVE (a
+# [min,max] range, weaker than the clause), so they must never serve as the
+# batch fold's exact row filter. Today the fold's eligibility gate rejects
+# the clause; if anyone teaches it about SAOP without an exactness marker,
+# this count goes wrong (see #715 for the same hole reached via <>).
+vec_plan="$(psql_c "SET pgcolumnar.enable_ungrouped_vector_agg=on;
+	EXPLAIN (ANALYZE, TIMING off, SUMMARY off) SELECT count(*) FROM t WHERE ts IN (39100, 39150);")"
+check "vector-agg path engaged for the guard arm (plan shape)" \
+	"$(grep -c 'Columnar Vectorized Aggregates' <<<"$vec_plan")" "1"
+# The no/yes pair proves the CLAUSE gate is what excludes the SAOP, not some
+# other eligibility rule: the same aggregate over the equivalent exact range
+# quals folds, so the fold is reachable for this query shape and only the
+# IN-list is refused. If a later change makes count(*)-with-qual take the row
+# path for another reason, the yes-arm goes red and the guard is known dead.
+check "the batch fold refuses the IN-list (Batch Fold: no)" \
+	"$(grep -c 'Columnar Batch Fold: no' <<<"$vec_plan")" "1"
+check "the batch fold accepts the equivalent exact range quals (Batch Fold: yes)" \
+	"$(psql_c "SET pgcolumnar.enable_ungrouped_vector_agg=on;
+		EXPLAIN (ANALYZE, TIMING off, SUMMARY off)
+		SELECT count(*) FROM t WHERE ts >= 39100 AND ts <= 39150;" \
+		| grep -c 'Columnar Batch Fold: yes')" "1"
+check "vector-agg count over an IN-list is exact (conservative keys not folded)" \
+	"$(psql_c "SET pgcolumnar.enable_ungrouped_vector_agg=on;
+		SELECT count(*) FROM t WHERE ts IN (39100, 39150);" | tail -1)" "2"
+
+# A correlated PARAM_EXEC array (LATERAL, array from the outer row) changes per
+# rescan and must not be frozen. The two thr rows land in DIFFERENT chunk
+# groups with different cardinalities (39100 in the last group; 100 and 200 in
+# the first), so a builder that froze the first rescan's array would prune the
+# other rescan's group away and the sum would drop below 1 + 2 = 3.
+check "a correlated PARAM_EXEC array is not mis-pruned (results stay correct)" \
+	"$(q 'SELECT sum(c) FROM thr, LATERAL (SELECT count(*) c FROM t WHERE t.ts = ANY (thr.lo)) s;')" \
+	"3"
+
+check "backend alive" "$(q 'SELECT 1;')" "1"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -172,6 +172,7 @@ SUITES=(
 	native_rewrite
 	native_rewrite_conc
 	native_roundtrip
+	native_saop_pushdown
 	native_skip
 	native_sort_by
 	native_toasted_write


### PR DESCRIPTION
## What

`IN (...)` / `= ANY(array)` quals built no scan key, so they read every row group while equality, ranges, anchored LIKE, and parameterized scalars all pruned (#704). The scan-key builder now handles `ScalarArrayOpExpr`:

- A conservative `[min, max]` range over the array's non-NULL elements, ordered by the column opfamily's own `BTORDER_PROC` under the column collation. Range keys because skip predicates conjoin ANDwise; the executor still rechecks exact membership, so pruning can only be conservative.
- A list with **one distinct value** emits a single equality key instead, which keeps the bloom probe: `x IN (7)` prunes like `x = 7` even where every group's range contains 7.
- The #697 freeze extension now covers the whole array argument of a SAOP, so a generic-plan `= ANY($1)` prunes, **including a mixed `IN (literal, $1)`** (which stays an unfolded ArrayExpr on a generic plan). A correlated PARAM_EXEC array is still refused, same rule as #697.

Design doc: `design/SAOP_ZONEMAP_PLAN.md` (includes the full hazard-analysis disposition).

## Verification (TDD, prove-don't-trust)

New suite `native_saop_pushdown` (30 checks), RED-first: all pruning arms read 0 pre-fix. The primary arm asserts intent (Pushed-Down Filters: 2), acceptance (Usable Skip Predicates: 2), and work done (19 of 20 groups removed) as three separate counters. Conservativeness, NULL/empty/NOT-IN, cross-type (`bigint[]` on an int column), domain-element characterization, text under C collation, and a vector-agg guard pair (`Batch Fold: no` for the SAOP beside `Batch Fold: yes` for the equivalent exact range quals, plus an exact count) are each their own arms.

Removal proofs, run against this exact suite: severing the SAOP dispatch reddens all ten SAOP pruning arms; severing only the freeze extension reddens exactly the two generic-plan parameterized arms; severing only the equality refinement reddens exactly the `'{25,25}'` bloom arm.

Deliberately NOT shipped: a `getBaseType` on the array element type. Probed with the resolution removed — literal `::intdom[]` cast, ArrayExpr cast, and a domain-array parameter all arrive with base-type OIDs and all prune — so the guard fails "can I delete this and stay green". The domain arms stay as characterization locks.

## Found along the way (filed, not fixed here)

- **#715 (wrong results, pre-existing, reproduced)**: with `pgcolumnar.enable_ungrouped_vector_agg=on`, `count(*) WHERE x <> 5` returns 40000 — the batch-fold eligibility gate checks clause convertibility, not whether keys exactly express the clause. This PR adds the load-bearing comment at that gate (SAOP-derived conservative keys must never enter the fold) and the live guard arms; the exactness-marker fix is #715's own TDD PR.
- **#717**: vector-agg paths rebuild scan keys per rescan into `es_query_cxt` without freeing; arrays make the pre-existing growth material.

## Gates

- PG17 (assert), PG18 (non-cassert), PG19 (assert): `native_saop_pushdown` 30/30 on all three.
- Related suites green on PG17: `native_param_pushdown`, `native_zonemap`, `native_zonemap_narrow`, `native_skip`, `native_vecskip`, `native_fold_skipguard`, `zonemap_cost`, `pushdown_report`, `analyze_stats`.
- Cross-cutting: `harness_selftest` (110 checks), `docs_style` green on the final tree.
- Adversarial review: a 4-lens refutation pass (wrong-results, PG13-19 portability, test-instrument validity, house rules) ran on the committed diff; the wrong-results lens found nothing, and every test-gap/style finding it raised is fixed in this version (correlated arm now lands its rescans in different groups, NOT-IN list confined to one group, Batch Fold no/yes pair, comment attribution for what excludes LIKE vs SAOP from the fold).

Closes #704.

🤖 Generated with [Claude Code](https://claude.com/claude-code)