### PR TITLE
fix: gate the batch fold on exactly-keyed quals (closes #715, count(*) WHERE x<>5 over-counts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,21 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ## [Unreleased]
 
+### Fixed
+
+- The ungrouped vectorized aggregate (`pgcolumnar.enable_ungrouped_vector_agg`)
+  no longer returns wrong results for a filter whose operator has no btree
+  strategy, such as `<>`. The batch fold's only per-row filter is the scan-key
+  loop, but eligibility only checked that each clause was a strict comparison,
+  not that it became a scan key. A `<>` clause is strict yet builds no key, so on
+  an all-by-value shape the fold engaged and counted the excluded rows
+  (`count(*) WHERE x <> 5` over-counted by one). Eligibility now requires every
+  clause to be expressed exactly by scan keys (`PgColumnarQualsExactlyKeyed`);
+  conservative prune-only keys (anchored LIKE, and IN-list ranges once #704
+  lands) are marked inexact and also disqualify the fold, which then falls back
+  to the correct scalar path. Covered by new cases in `ungrouped_vector_agg`
+  (#715).
+
 ## [1.0-alpha2] - 2026-08-18
 
 ### Added

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -911,6 +911,8 @@ typedef struct PgColumnarGroupStats
 
 extern ScanKey PgColumnarBuildScanKeys(List *qual, Index scanrelid,
 									 TupleDesc tupdesc, int *nkeys);
+extern bool PgColumnarQualsExactlyKeyed(List *qual, Index scanrelid,
+									  TupleDesc tupdesc);
 
 /*
  * How many chunk groups the planner samples when estimating how much a

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -407,7 +407,7 @@ pgcolumnar_like_prefix_scankey(OpExpr *op, Var *var, Const *con,
 
 static int
 pgcolumnar_clause_to_scankey(Node *clause, Index scanrelid, TupleDesc tupdesc,
-						   ScanKey key)
+						   ScanKey key, bool *exact)
 {
 	OpExpr	   *op;
 	Node	   *leftop;
@@ -417,6 +417,16 @@ pgcolumnar_clause_to_scankey(Node *clause, Index scanrelid, TupleDesc tupdesc,
 	bool		varOnLeft;
 	TypeCacheEntry *tce;
 	StrategyNumber strat;
+
+	/*
+	 * An EXACT key expresses its clause completely: a row satisfies the clause
+	 * iff it satisfies the key. Only the plain btree comparison below is exact.
+	 * Conservative keys that merely PRUNE (the anchored-LIKE bound, #426) leave
+	 * exact = false, so a caller that re-checks keys as its whole filter (the
+	 * batch fold, #715) can refuse them. Default false; a dropped clause (return
+	 * 0) is not exact either.
+	 */
+	*exact = false;
 
 	if (!IsA(clause, OpExpr))
 		return 0;
@@ -503,6 +513,7 @@ pgcolumnar_clause_to_scankey(Node *clause, Index scanrelid, TupleDesc tupdesc,
 	key->sk_collation = con->constcollid;
 	key->sk_argument = con->constvalue;
 
+	*exact = true;
 	return 1;
 }
 
@@ -530,11 +541,50 @@ PgColumnarBuildScanKeys(List *qual, Index scanrelid, TupleDesc tupdesc,
 	 */
 	keys = (ScanKey) palloc0(sizeof(ScanKeyData) * 2 * list_length(qual));
 	foreach(lc, qual)
+	{
+		bool		exact;	/* not needed here; skipping is conservative-safe */
+
 		n += pgcolumnar_clause_to_scankey((Node *) lfirst(lc), scanrelid, tupdesc,
-										&keys[n]);
+										&keys[n], &exact);
+	}
 
 	*nkeys = n;
 	return keys;
+}
+
+/*
+ * PgColumnarQualsExactlyKeyed
+ *		Whether the entire restriction list is expressed EXACTLY by scan keys:
+ *		every clause produces at least one key AND every one of those keys is
+ *		exact (a plain btree comparison), not a conservative prune-only key.
+ *
+ *		PgColumnarBuildScanKeys silently drops a clause it cannot turn into a key
+ *		(for example `<>`, which has no btree strategy) and emits conservative
+ *		bounds for others (anchored LIKE, #426; IN-list ranges once #704 lands).
+ *		That is correct for chunk-group skipping, where the executor still
+ *		re-applies the clause as a filter. It is WRONG for the batch fold, whose
+ *		only per-row filter IS the scan-key loop: a dropped or merely-pruning
+ *		clause lets non-matching rows be counted (issue #715). The fold gates on
+ *		this; an empty qual list is exactly keyed (there is nothing to filter).
+ */
+bool
+PgColumnarQualsExactlyKeyed(List *qual, Index scanrelid, TupleDesc tupdesc)
+{
+	ListCell   *lc;
+
+	foreach(lc, qual)
+	{
+		ScanKeyData scratch[2];	/* an anchored LIKE writes two keys */
+		bool		exact = false;
+		int			n;
+
+		n = pgcolumnar_clause_to_scankey((Node *) lfirst(lc), scanrelid, tupdesc,
+									   &scratch[0], &exact);
+		if (n < 1 || !exact)
+			return false;
+	}
+
+	return true;
 }
 
 /*

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -3028,6 +3028,17 @@ pgcolumnar_batch_shape_eligible(PgColumnarAggScanState *state, TupleDesc tupdesc
 		return false;
 
 	/*
+	 * allConvertible only means every clause is a strict OpExpr the fold could
+	 * evaluate; it does NOT mean the clause becomes a scan key. The fold's only
+	 * per-row filter is the scan-key loop, so a clause that produces no key
+	 * (`<>`, strict but with no btree strategy) or only a conservative pruning
+	 * key would let non-matching rows be counted (#715). Require every clause to
+	 * be expressed EXACTLY by scan keys before folding.
+	 */
+	if (!PgColumnarQualsExactlyKeyed(state->quals, state->scanrelid, tupdesc))
+		return false;
+
+	/*
 	 * Every column the fold will GATHER must be passed BY VALUE (#423).
 	 *
 	 * The gather does pointer arithmetic on attlen and hardcodes attbyval:

--- a/test/ungrouped_vector_agg.sh
+++ b/test/ungrouped_vector_agg.sh
@@ -198,4 +198,23 @@ check "a fixed-width BY-REFERENCE column also falls back (uuid)" \
 check "and name, which is 64 bytes by reference" \
 	"$(fold_of "SELECT count(nm) FROM vfold WHERE i > 100")" "Columnar Batch Fold: no"
 
+# issue #715: a strict operator with NO btree strategy (`<>`) passes the
+# convertibility check but builds no scan key, and the fold's only per-row filter
+# IS the scan-key loop. On an all-by-value shape (count/sum over int i) the fold
+# used to engage and count the rows the filter excludes. It must fall back off the
+# fold, not fold and over-count. i ranges 1..200000, so `i <> 100` drops one row.
+check "issue #715: count(*) WHERE i <> 100 agrees with heap" \
+	"$(vq "SELECT count(*) FROM vfold WHERE i <> 100")" \
+	"$(q  "SELECT count(*) FROM vfoldh WHERE i <> 100")"
+check "issue #715: sum(i) WHERE i <> 100 agrees with heap" \
+	"$(vq "SELECT sum(i) FROM vfold WHERE i <> 100")" \
+	"$(q  "SELECT sum(i) FROM vfoldh WHERE i <> 100")"
+check "issue #715: the no-scan-key op (<>) falls back off the fold" \
+	"$(fold_of "SELECT count(*) FROM vfold WHERE i <> 100")" "Columnar Batch Fold: no"
+# control: an exact btree op on the SAME by-value column still folds and is right,
+# so the gate rejects only the unkeyable clause, not every filter on that column.
+check "control: i > 100 (exact key) still folds and agrees with heap" \
+	"$(vq "SELECT count(*) FROM vfold WHERE i > 100")" \
+	"$(q  "SELECT count(*) FROM vfoldh WHERE i > 100")"
+
 pgc_summary


### PR DESCRIPTION
Closes #715.

## The bug

With `pgcolumnar.enable_ungrouped_vector_agg` on, `count(*) WHERE x <> 5` returned the **unfiltered** count — it counted the rows the filter excludes.

Reproduced on pg18a assert (heap oracle 39999):

| arm | `count(*) WHERE x <> 5` |
|---|---|
| vec agg **off** | 39999 ✓ |
| vec agg **on** (main) | **40000 ✗** |

## Mechanism

The batch fold's only per-row filter is the scan-key loop, and its eligibility assumed every qual became a scan key. But it checked a *different* property: `PgColumnarCountConvertibleQuals` accepts any strict `OpExpr` over Var/Const, while a scan key needs a btree strategy. `<>` is strict yet has `InvalidStrategy`, so it converts to a predicate but builds **zero keys**; the key-validation loop is vacuous at `nkeys=0`, the fold filters nothing, and every row is counted. Any strict operator with no btree strategy on a by-value column hits the same hole. (The existing `WHERE k <> 3` test didn't catch it because its `sum(numeric)` is non-by-value, which disqualifies the fold for an unrelated reason.)

## The fix

Require every clause to be expressed **exactly** by scan keys before folding. `pgcolumnar_clause_to_scankey` now reports whether the key it built is exact, and `PgColumnarQualsExactlyKeyed` demands one exact key per clause. This also rejects **conservative prune-only keys** — the anchored-LIKE bound (#426), and IN-list ranges once #704/#718 lands — from serving as the fold's WHERE, which the older by-value guard would not have caught on a by-value column. An unkeyable or merely-pruning clause falls back to the correct scalar path.

> **Note for #718 (#704):** that PR introduces conservative IN-range keys. This fix marks them inexact via the same `exact` signal, so they will correctly disqualify the fold rather than silently prune-and-miscount on a by-value column. The two should be verified together on merge.

## Proof (pg18a assert, TDD, three distinct `.so` fingerprints)

| build | `pgcolumnar.so` md5 | `<>` arms |
|---|---|---|
| main `1fbffb14` | `1a26440d…` | over-count 40000, fold engages — **RED** |
| this fix | `2e02e589…` | 39999, fold falls back — **GREEN** |
| fix with **only the gate** reverted | `1b27ce0b…` | over-count again — **RED**, gate load-bearing |

New cases in `ungrouped_vector_agg` (already registered): the `<>` over-count, a `sum` arm off by exactly the excluded value (100), an EXPLAIN assertion that `<>` falls off the fold (`Batch Fold: no`), and a control that an exact key (`i > 100`) on the same by-value column still folds and is correct.

No regression: `ungrouped_vector_agg` 49, `parallel_vector_agg` 29, `native_agg` 25, `batch_fold_explain` 7, `native_batch_fold_projection` 4, `native_groupagg` 72, `harness_selftest` 110, `docs_style` 9 — all PASSED on the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
