### PR TITLE
opt: memoize the by-row-number fetch's row-group lookup (#709)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,18 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
   assert build. `bench/provision.sh check` continues to report their presence;
   installing them is now a scripted, pinned step instead of a manual one (#702).
 
+### Changed
+
+- An index or bitmap fetch no longer reads the whole row-group list out of
+  the catalog for every row. The list is memoized per command and snapshot,
+  with a refresh on any miss, so a group flushed earlier in the same
+  statement stays visible. Measured on 3000 index-fetched rows: 6001 catalog
+  index scans before, 2 after. The memo resets on subtransaction abort and
+  on row-group retirement, and a new suite, `native_fetch_group_memo`,
+  proves both by resurrection: through an open cursor after ROLLBACK TO
+  SAVEPOINT, and through stale index entries after a same-statement
+  compaction. (#709)
+
 ### Fixed
 
 - The ungrouped vectorized aggregate (`pgcolumnar.enable_ungrouped_vector_agg`)

--- a/design/FETCH_GROUP_LOOKUP_PLAN.md
+++ b/design/FETCH_GROUP_LOOKUP_PLAN.md
@@ -1,0 +1,164 @@
+# O(K·G) index/bitmap fetch row-group lookup (#709)
+
+## Problem
+
+`pgcolumnar_fetch_row` (columnar_reader.c) runs once per fetched TID: per row
+of an index or bitmap scan, per duplicate probe of `_bt_check_unique`, and per
+UPDATE re-fetch. Each call reads the ENTIRE row-group list out of the catalog
+(`PgColumnarReadRowGroupList`: a `systable` index scan over
+`pgcolumnar.row_group` plus one palloc'd node per group) and then walks it
+linearly. K fetches over G groups cost K catalog index scans and O(K·G)
+comparisons; the list read dominates. The code's own comment records the
+reason it was left uncached: a group flushed earlier in the same statement
+must become visible to a later fetch (read-your-writes through
+`PgColumnarCatalogSnapshot`, which advances `curcid`).
+
+## Design
+
+A backend-global row-group-LIST memo beside the existing decoded-group cache
+(`columnarFetchCache`, which already memoizes per `(storageId, groupNumber,
+cid)`), reusing the delete-vector reader's refresh-on-miss discipline
+(`delete_vector_find_row_group`), with these rules:
+
+1. **MVCC snapshots only.** A `SnapshotDirty` probe (`_bt_check_unique`) or
+   `SnapshotAny` fetch (trigger OLD-row re-fetch) keeps today's per-fetch
+   read. Dirty visibility changes as other transactions commit; the unique
+   path relies on seeing current state per probe.
+2. **Key = (storageId, CommandId, full snapshot content).** The cached list
+   is valid only for a snapshot that judges every catalog tuple identically
+   to the one that built it: compare `xmin`, `xmax`, advanced `curcid`,
+   `xcnt` + `xip[]`, `subxcnt` + `subxip[]`, `suboverflowed`,
+   `takenDuringRecovery`. Content comparison, not pointer identity: pointer
+   reuse cannot alias, and two references to one logical snapshot hit. A
+   mismatch on anything rebuilds. A handful of slots (LRU, like the group
+   cache's 4) covers interleaved cursors.
+3. **Refresh on miss.** A rowNumber no cached group covers triggers ONE
+   re-read under a fresh `PgColumnarCatalogSnapshot`, then a second lookup
+   (the delete-vector two-attempt shape). This is what preserves the
+   same-statement-flush contract: a group flushed after the memo was built
+   is a miss, and the refresh sees it (same cid, `curcid` advanced). A group
+   never covers new row numbers after creation, and within one command the
+   own-transaction catalog state visible at `curcid+1` can gain groups but
+   not lose them (reclaim/rewrite runs as its own statement, and cross-
+   transaction deletions are invisible to the same MVCC snapshot by
+   definition), so a HIT cannot be stale.
+4. **Last-hit fast path + linear walk, NO binary search.** The adversarial
+   pass showed a sorted-array binary search is unfalsifiable here: the
+   instrument counts catalog reads, which the memo alone removes, and the
+   residual in-memory walk over G entries (fixtures 20-40 groups; 6M rows at
+   the default stripe is 40) is microseconds. The proven sibling
+   (`delete_vector_find_row_group`) is exactly last-hit + linear + two
+   attempts, unsorted. Shipping a comparator with no removal proof fails the
+   house rule; the memo keeps the sibling's shape.
+5. **Reset with the group cache, PLUS two discards the group cache gets away
+   without.** The memo drops where `columnarFetchCache` drops (top-level
+   commit/abort, executor end), and additionally:
+   - **on subtransaction abort** (the existing subxact callback): a group
+     flushed by a live savepoint is visible when the memo is built, and
+     `ROLLBACK TO SAVEPOINT` flips its `xmin` verdict with NO change in
+     snapshot content, cid, or any reset event the group cache watches.
+     Today's per-fetch read re-judges `xmin` every time; a memo HIT would
+     serve the aborted group's rows off its durably-written file bytes. The
+     decoded-group cache survives this only BECAUSE the per-fetch list read
+     answers first — the memo takes over that role, so it must reset.
+   - **on row-group retirement** (`PgColumnarRetireGroup`) — and the
+     journey of this reset is the record worth keeping. The hazard analysis
+     demanded it; probing on PG17 then showed the mid-statement rewrite path
+     crossing a `CommandCounterIncrement` (the flush's storage-row update),
+     which rebuilds the memo anyway, so the reset failed every PG17 removal
+     proof and was REMOVED under the deletion-proof rule, with the suite's
+     same-statement rewrite arm left as a sentinel. The sentinel then fired
+     on PG18: its rewrite path performs NO such CCI, and the first
+     post-rewrite probe hit the stale memo through the old index entry (one
+     doubled all-NULL row, 501 not 500) before refresh-on-miss healed the
+     slot. The CCI is an accident of one major's flush path, not an
+     invariant, so the reset ships — with the PG18 arm as its removal proof
+     and PG17's masking CCI documented as exactly that, masking. (A FULLY
+     deleted group is refused by `compact_rewrite` — measured: rewrote 0 —
+     and is retired only by vacuum-family commands, which cannot run inside
+     another statement; that shape stays unreachable.)
+6. **The refresh reads under the FETCH's snapshot argument**, i.e. the same
+   `PgColumnarCatalogSnapshot(snapshot)` the per-fetch read uses today — NOT
+   `GetActiveSnapshot()` as the delete-vector sibling does. One MVCC caller
+   (`pgcolumnar_index_delete_tuples`) runs with no active snapshot set, and
+   a refresh under a different snapshot than the key's would store a list
+   the key's snapshot never judged.
+
+Out of scope, recorded for a follow-up: the per-fetch
+`PgColumnarReadDeleteVectorList` read has the same per-fetch-catalog-scan
+shape but cannot use refresh-on-miss (a miss is the common "not deleted"
+answer), so it needs its own invalidation design.
+
+## Instrument (work-done, not timing; hardened by the adversarial pass)
+
+Every `PgColumnarReadRowGroupList` call is one index scan on
+`row_group_pkey`; probed empirically on the unfixed build, K = 3000
+index-fetched rows cost 6001 scans — TWO per fetch (one liveness settle via
+`PgColumnarRowIsLive`, one deferred decode via
+`PgColumnarReadRowByNumberCols`, the #157 slot design) plus setup.
+Instrument discipline the pass demanded:
+
+- `pg_stat_get_xact_numscans` is a pending-entry counter: read the BASELINE
+  and the AFTER value in the SAME psql session as the measured statement and
+  assert the DELTA (the harness's `q()` opens a fresh connection per call,
+  which reads 0 and would fake the RED arm green).
+- Assert the `pgcolumnar.row_group` TABLE scan delta is 0 in the same
+  window: if `row_group_pkey` ever fails to resolve, the read silently
+  degrades to a heap scan and the index counter reads a vacuous 0 (#695's
+  suite pins its sibling the same way).
+- Force the plan and prove it: `enable_seqscan=off`, `enable_bitmapscan=off`,
+  `enable_indexonlyscan=off`, `pgcolumnar.enable_custom_scan=off`,
+  `pgcolumnar.enable_index_fetch_penalty=off`,
+  `max_parallel_workers_per_gather=0`, and an EXPLAIN plan-shape assertion
+  (Index Scan) taken BEFORE the baseline capture, because planning itself
+  reads the list once (`pgcolumnar_relation_estimate_size`).
+- The counted transaction contains exactly: baseline read, ONE SELECT over
+  fully-flushed data, after read. Buffered-row fetches are permanent misses
+  (each refreshes, same cost as today, no win) and UPDATE arms take
+  write-side list reads — both stay OUTSIDE the counted window. Expected
+  post-fix contributors: 1 planning scan + 1 memo build (+ nothing else);
+  bound <= 20 is auditable slack, pre-fix delta is ~2K.
+
+## Test plan (TDD)
+
+New suite `native_fetch_group_memo.sh`:
+
+- RED arm: K = 3000 LATERAL index fetches; scan delta collapses from ~2K
+  (measured 6001) to <= 20, heap-scan delta 0, plan shape pinned.
+- Correctness arms:
+  - scattered index fetches across many groups: values match generated
+    truth;
+  - fetch after same-transaction flush in a LATER statement (new cid
+    rebuilds);
+  - same-statement insert-then-fetch (CTE `INSERT ... RETURNING` joined
+    against an index fetch): characterization, same answer as unfixed;
+  - **subxact-abort arm** (removal proof for the subxact discard): cursor
+    over an index scan; SAVEPOINT; INSERT that flushes a group (stripe limit
+    set IN the arm's session — a fixture-session SET does not carry); MOVE
+    more (memo rebuilds with the subxact's group visible); ROLLBACK TO
+    SAVEPOINT; `MOVE ALL` — its command tag is the row count, and it must
+    read exactly the real rows. Rows, never values: a resurrected row
+    decodes all-NULL (the group comes from the poisoned memo, the fresh
+    column_chunk read sees nothing), so value-counting instruments are
+    blind — the arm's first version was, and its removal proof failed;
+  - **mid-statement rewrite arm** (removal proof for the retirement reset,
+    firing on PG18): `reclaim_coalesce=off`; one statement that
+    warm-fetches, runs `compact_rewrite`, then `count(*)`-fetches ids from
+    the rewritten group — 500 exact; without the reset PG18 reads 501 (the
+    first post-rewrite probe hits the stale memo through the old index
+    entry before refresh-on-miss heals it) while PG17's incidental flush
+    CCI masks the missing reset;
+  - unique-violation with buffered + flushed duplicates (`SnapshotDirty`
+    unchanged); UPDATE re-fetch + AFTER UPDATE trigger OLD row
+    (`SnapshotAny` unchanged); DELETE then fetch in the next statement
+    (delete vectors still read per fetch, uncached).
+- Regression: fetch-family suites (`native_fetch_cache`,
+  `native_fetch_bigcap`, `index_only`, `unique_conc`, trigger/update
+  suites) plus the cross-cutting pair.
+
+Removal proofs: (1) sever the memo lookup (slot never matches, every fetch
+rebuilds) — the scan-delta arm goes RED, correctness arms stay green;
+(2) sever only the subxact reset — the subxact-abort arm's MOVE ALL tag
+reads 3000 high; (3) sever only the retirement reset — the rewrite arm
+reads 501 on PG18 (PG17 stays green there, masked by its incidental flush
+CCI; the matrix carries the proof).

--- a/design/FETCH_GROUP_LOOKUP_PLAN.md
+++ b/design/FETCH_GROUP_LOOKUP_PLAN.md
@@ -77,6 +77,18 @@ cid)`), reusing the delete-vector reader's refresh-on-miss discipline
      deleted group is refused by `compact_rewrite` — measured: rewrote 0 —
      and is retired only by vacuum-family commands, which cannot run inside
      another statement; that shape stays unreachable.)
+   - **on a same-storage metadata wipe** (`PgColumnarDeleteMetadata`, the
+     TRUNCATE table-AM path) — the third loss case, surfaced in cross-review
+     after this ledger claimed the enumeration complete. The vacuum-family
+     callers wipe an OLD storage id no memo can be keyed on; the TRUNCATE
+     path wipes the SAME storage id. A stale HIT is not constructible today
+     because TRUNCATE marks the command id used, so the next fetch's cid
+     differs and the memo rebuilds (probed in review: truncate-then-fetch
+     returns the new data, zero nulls) — but that is precisely the shape of
+     unstated cid invariant the retirement reset was once wrongly rested on.
+     The reset ships; the suite pins the truncate behavior with a
+     characterization arm rather than a removal proof, and this entry is the
+     record of why no removal proof exists for it on current majors.
 6. **The refresh reads under the FETCH's snapshot argument**, i.e. the same
    `PgColumnarCatalogSnapshot(snapshot)` the per-fetch read uses today — NOT
    `GetActiveSnapshot()` as the delete-vector sibling does. One MVCC caller

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -14,6 +14,7 @@
 #include "columnar_metadata.h"
 #include "fmgr.h"
 #include "columnar_compat.h"
+#include "columnar_reader.h"
 #include "access/genam.h"
 #include "access/htup_details.h"
 #include "access/table.h"
@@ -779,6 +780,22 @@ PgColumnarRetireGroup(uint64 storageId, uint64 groupNumber)
 					  Anum_bloom_group_number, storageId, groupNumber);
 	delete_group_rows("row_group", Anum_row_group_storage_id,
 					  Anum_row_group_group_number, storageId, groupNumber);
+
+	/*
+	 * A group-list memo built earlier in the SAME command would serve this
+	 * group after these deletes -- with its delete vectors just gone,
+	 * resurrecting rows -- so drop the memo with the group (#709). This
+	 * reset was once removed on the theory that every reachable
+	 * same-command retirement crosses a CommandCounterIncrement first
+	 * (changing the memo's key), and on PG17 the rewrite path does. On PG18
+	 * it does not: the same-statement rewrite arm of
+	 * native_fetch_group_memo.sh read one doubled row there (the first
+	 * post-rewrite probe hit the stale memo through the old index entry
+	 * before refresh-on-miss healed it). The CCI is an accident of the
+	 * flush's storage-row update, major-dependent, and nothing to lean on;
+	 * that arm is this reset's removal proof.
+	 */
+	PgColumnarGroupMemoReset(true);
 
 	if (haveRange && byteLength > 0)
 		record_free_space(storageId, fileOffset, byteLength);

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -1646,6 +1646,19 @@ PgColumnarDeleteMetadata(uint64 storageId)
 	delete_rows_by_storage_id("free_space", Anum_free_space_storage_id, storageId);
 	delete_rows_by_storage_id("row_group", Anum_row_group_storage_id, storageId);
 	delete_rows_by_storage_id("storage", Anum_native_storage_storage_id, storageId);
+
+	/*
+	 * The third row-group loss path (#709, #721 review). The vacuum-family
+	 * callers pass an OLD storage id a memo cannot be keyed on, but the
+	 * TRUNCATE path (pgcolumnar_relation_nontransactional_truncate) wipes
+	 * the metadata of the SAME storage id a memo may hold. Today a stale HIT
+	 * is additionally masked by TRUNCATE marking the command id used, so the
+	 * next fetch's cid differs -- but that is a cid accident of the current
+	 * truncate path, exactly the class of unstated invariant the retirement
+	 * reset above was once wrongly rested on (it held on PG17 and broke on
+	 * PG18). Reset here so the memo's correctness does not depend on it.
+	 */
+	PgColumnarGroupMemoReset(true);
 }
 
 /*

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -34,6 +34,7 @@
 #include "port/pg_bitutils.h"
 #include "utils/memutils.h"
 #include "utils/rel.h"
+#include "utils/snapmgr.h"
 #include "utils/typcache.h"
 
 /*
@@ -3291,6 +3292,275 @@ PgColumnarDiscardFetchCache(void)
 	columnarFetchFmtOk = false;
 }
 
+/* -------------------------------------------------------------------------
+ * Row-group-list memo (#709).
+ *
+ * pgcolumnar_fetch_row used to read the ENTIRE row-group list out of the
+ * catalog on every call -- twice per index-fetched row (a liveness settle and
+ * the deferred decode, #157), so K fetched rows cost ~2K catalog index scans.
+ * The memo keeps one list per (storage, command, snapshot CONTENT) and walks
+ * it with a last-hit fast path, the shape delete_vector_find_row_group
+ * already proved. No sorted array and no binary search: the catalog read is
+ * the cost the memo removes, the residual walk over tens of groups is noise,
+ * and a comparator would be code no test could turn red.
+ *
+ * What makes a HIT sound: within one (cid, snapshot content), the visible
+ * row_group set can GAIN rows (a flush in this very command becomes visible
+ * because PgColumnarCatalogSnapshot advances curcid) but can lose them only
+ * through events this memo is explicitly reset on. Gains are covered by
+ * refresh-on-miss: a rowNumber no memoized group covers triggers one fresh
+ * catalog read under the fetch's own snapshot -- the exact read the old code
+ * did every time -- so the post-refresh answer is the old answer. Losses:
+ *
+ *  - a SUBTRANSACTION ABORT flips the xmin verdict of a group flushed under
+ *    the savepoint with NO change in snapshot content or cid, so the subxact
+ *    callback resets the memo (the decoded-group cache survives the same
+ *    event only because the per-fetch list read answered first -- the memo
+ *    takes over that role and must reset);
+ *  - a same-command RETIREMENT (compaction is callable mid-statement and
+ *    does not CommandCounterIncrement unconditionally) deletes row_group
+ *    rows a HIT would resurrect, so PgColumnarRetireGroup resets the memo.
+ *
+ * Cross-transaction deletions cannot invalidate a HIT: they are invisible to
+ * the same MVCC snapshot content by definition. Non-MVCC snapshots (the
+ * unique check's SnapshotDirty, a trigger re-fetch's SnapshotAny) never use
+ * the memo: dirty visibility changes as other transactions commit, and the
+ * unique path relies on seeing current state per probe.
+ *
+ * The snapshot key is compared by CONTENT (xmin, xmax, curcid, xip, subxip,
+ * suboverflowed, takenDuringRecovery), never by pointer: equal content means
+ * every catalog tuple gets the same MVCC verdict, and pointer reuse cannot
+ * alias. Contexts hang off TopTransactionContext like the group cache's; the
+ * xact-end reset only clears descriptors and leaves the contexts to die with
+ * their parent (the callback runs before the transaction's memory teardown,
+ * so they are still live there -- just already spoken for); mid-transaction
+ * resets free the contexts themselves.
+ * ------------------------------------------------------------------------- */
+
+#define COLUMNAR_GROUP_MEMO_ENTRIES	4
+
+typedef struct PgColumnarGroupMemo
+{
+	MemoryContext cx;			/* NULL = slot empty; child of TopTransactionContext */
+	uint64		storageId;
+	CommandId	cid;
+	Snapshot	snap;			/* content copy incl. xip/subxip, in cx */
+	List	   *groups;			/* NativeRowGroupMetadata nodes, in cx */
+	NativeRowGroupMetadata *lastGroup;	/* last hit, into groups */
+	uint64		lastUsed;
+} PgColumnarGroupMemo;
+
+static PgColumnarGroupMemo columnarGroupMemo[COLUMNAR_GROUP_MEMO_ENTRIES];
+static uint64 columnarGroupMemoClock = 0;
+
+/*
+ * PgColumnarGroupMemoReset
+ *		Forget every memoized list. contextsLive=true (subxact abort, group
+ *		retirement, executor end) deletes the memo contexts; false (the
+ *		transaction-end and prepare callbacks) only clears the descriptors,
+ *		leaving the still-live contexts to fall with TopTransactionContext
+ *		moments later.
+ */
+void
+PgColumnarGroupMemoReset(bool contextsLive)
+{
+	int			i;
+
+	for (i = 0; i < COLUMNAR_GROUP_MEMO_ENTRIES; i++)
+	{
+		if (contextsLive && columnarGroupMemo[i].cx != NULL)
+			MemoryContextDelete(columnarGroupMemo[i].cx);
+		memset(&columnarGroupMemo[i], 0, sizeof(columnarGroupMemo[i]));
+	}
+	columnarGroupMemoClock = 0;
+}
+
+/* equal MVCC read verdict on every catalog tuple, by content */
+static bool
+pgcolumnar_snapshot_same_read(Snapshot a, Snapshot b)
+{
+	if (a->xmin != b->xmin || a->xmax != b->xmax || a->curcid != b->curcid)
+		return false;
+	if (a->takenDuringRecovery != b->takenDuringRecovery ||
+		a->suboverflowed != b->suboverflowed)
+		return false;
+	if (a->xcnt != b->xcnt || a->subxcnt != b->subxcnt)
+		return false;
+	if (a->xcnt > 0 &&
+		memcmp(a->xip, b->xip, a->xcnt * sizeof(TransactionId)) != 0)
+		return false;
+	if (a->subxcnt > 0 &&
+		memcmp(a->subxip, b->subxip, a->subxcnt * sizeof(TransactionId)) != 0)
+		return false;
+	return true;
+}
+
+/* copy the fields pgcolumnar_snapshot_same_read reads, into cx */
+static Snapshot
+pgcolumnar_snapshot_content_copy(Snapshot src, MemoryContext cx)
+{
+	Snapshot	copy = (Snapshot) MemoryContextAlloc(cx, sizeof(SnapshotData));
+
+	*copy = *src;
+	copy->xip = NULL;
+	copy->subxip = NULL;
+	copy->regd_count = 0;
+	copy->active_count = 0;
+	copy->copied = true;
+	if (src->xcnt > 0)
+	{
+		copy->xip = (TransactionId *)
+			MemoryContextAlloc(cx, src->xcnt * sizeof(TransactionId));
+		memcpy(copy->xip, src->xip, src->xcnt * sizeof(TransactionId));
+	}
+	if (src->subxcnt > 0)
+	{
+		copy->subxip = (TransactionId *)
+			MemoryContextAlloc(cx, src->subxcnt * sizeof(TransactionId));
+		memcpy(copy->subxip, src->subxip, src->subxcnt * sizeof(TransactionId));
+	}
+	return copy;
+}
+
+/* read the list and the snapshot copy into the slot's (empty) context */
+static void
+pgcolumnar_group_memo_fill(PgColumnarGroupMemo *m, uint64 storageId,
+						   CommandId cid, Snapshot metaSnapshot)
+{
+	MemoryContext oldcx = MemoryContextSwitchTo(m->cx);
+
+	m->storageId = storageId;
+	m->cid = cid;
+	m->snap = pgcolumnar_snapshot_content_copy(metaSnapshot, m->cx);
+	m->groups = PgColumnarReadRowGroupList(storageId, metaSnapshot);
+	m->lastGroup = NULL;
+	MemoryContextSwitchTo(oldcx);
+}
+
+/* the covering group in this memo, or NULL */
+static NativeRowGroupMetadata *
+pgcolumnar_group_memo_walk(PgColumnarGroupMemo *m, uint64 rowNumber)
+{
+	ListCell   *lc;
+
+	if (m->lastGroup != NULL &&
+		rowNumber >= m->lastGroup->firstRowNumber &&
+		rowNumber < m->lastGroup->firstRowNumber + m->lastGroup->rowCount)
+		return m->lastGroup;
+
+	foreach(lc, m->groups)
+	{
+		NativeRowGroupMetadata *g = (NativeRowGroupMetadata *) lfirst(lc);
+
+		if (rowNumber >= g->firstRowNumber &&
+			rowNumber < g->firstRowNumber + g->rowCount)
+		{
+			m->lastGroup = g;
+			return g;
+		}
+	}
+	return NULL;
+}
+
+/*
+ * pgcolumnar_lookup_row_group
+ *		The row group covering rowNumber under metaSnapshot, memoized for MVCC
+ *		snapshots, or NULL. The uncached read allocates in the CALLER's current
+ *		context (the fetch's scratch), exactly as the old inline read did.
+ */
+static NativeRowGroupMetadata *
+pgcolumnar_lookup_row_group(uint64 storageId, Snapshot metaSnapshot,
+							uint64 rowNumber)
+{
+	CommandId	cid;
+	PgColumnarGroupMemo *m = NULL;
+	NativeRowGroupMetadata *rg;
+	int			i;
+
+	/*
+	 * SNAPSHOT_MVCC exactly, not IsMVCCSnapshot: that macro also admits
+	 * SNAPSHOT_HISTORIC_MVCC, whose xip array carries the INVERTED meaning
+	 * (committed xids), so a content-equal compare would equate snapshots
+	 * with opposite verdicts. No current caller reaches this with a historic
+	 * snapshot; excluding it costs that caller the memo, never correctness.
+	 */
+	if (metaSnapshot == NULL || metaSnapshot->snapshot_type != SNAPSHOT_MVCC)
+	{
+		List	   *rgList = PgColumnarReadRowGroupList(storageId, metaSnapshot);
+		ListCell   *lc;
+
+		foreach(lc, rgList)
+		{
+			NativeRowGroupMetadata *g = (NativeRowGroupMetadata *) lfirst(lc);
+
+			if (rowNumber >= g->firstRowNumber &&
+				rowNumber < g->firstRowNumber + g->rowCount)
+				return g;
+		}
+		return NULL;
+	}
+
+	cid = GetCurrentCommandId(false);
+	for (i = 0; i < COLUMNAR_GROUP_MEMO_ENTRIES; i++)
+	{
+		PgColumnarGroupMemo *e = &columnarGroupMemo[i];
+
+		if (e->cx != NULL && e->storageId == storageId && e->cid == cid &&
+			pgcolumnar_snapshot_same_read(e->snap, metaSnapshot))
+		{
+			m = e;
+			break;
+		}
+	}
+
+	if (m != NULL)
+	{
+		m->lastUsed = ++columnarGroupMemoClock;
+		rg = pgcolumnar_group_memo_walk(m, rowNumber);
+		if (rg != NULL)
+			return rg;
+
+		/*
+		 * Refresh once: the row may be in a group flushed after this memo was
+		 * built, in this very command. The re-read is the exact read the
+		 * unmemoized path performs, under the same snapshot the key was
+		 * computed from. A row still absent (buffered, deleted, nonexistent)
+		 * costs one read per fetch -- the old cost, no worse.
+		 */
+		MemoryContextReset(m->cx);
+		pgcolumnar_group_memo_fill(m, storageId, cid, metaSnapshot);
+		return pgcolumnar_group_memo_walk(m, rowNumber);
+	}
+
+	/* no slot: reuse an empty one or evict the least recently used */
+	for (i = 0; i < COLUMNAR_GROUP_MEMO_ENTRIES; i++)
+		if (columnarGroupMemo[i].cx == NULL)
+		{
+			m = &columnarGroupMemo[i];
+			break;
+		}
+	if (m == NULL)
+	{
+		uint64		oldest = UINT64_MAX;
+
+		for (i = 0; i < COLUMNAR_GROUP_MEMO_ENTRIES; i++)
+			if (columnarGroupMemo[i].lastUsed < oldest)
+			{
+				oldest = columnarGroupMemo[i].lastUsed;
+				m = &columnarGroupMemo[i];
+			}
+		MemoryContextDelete(m->cx);
+		memset(m, 0, sizeof(*m));
+	}
+	m->cx = AllocSetContextCreate(TopTransactionContext,
+								  "columnar group memo",
+								  ALLOCSET_DEFAULT_SIZES);
+	m->lastUsed = ++columnarGroupMemoClock;
+	pgcolumnar_group_memo_fill(m, storageId, cid, metaSnapshot);
+	/* a fresh build IS the unmemoized read; no second attempt needed */
+	return pgcolumnar_group_memo_walk(m, rowNumber);
+}
+
 /*
  * Find the entry for this group in this command, or prepare an empty one.
  * Returns NULL when nothing should be cached, in which case the caller decodes
@@ -3384,8 +3654,7 @@ pgcolumnar_fetch_row(Relation rel, Snapshot snapshot, uint64 rowNumber,
 	MemoryContext tmp;
 	MemoryContext oldContext;
 	Snapshot	metaSnapshot;
-	List	   *rgList;
-	NativeRowGroupMetadata *rg = NULL;
+	NativeRowGroupMetadata *rg;
 	PgColumnarFetchGroup *entry;
 	bool		hit;
 	int			validityBytes;
@@ -3436,21 +3705,13 @@ pgcolumnar_fetch_row(Relation rel, Snapshot snapshot, uint64 rowNumber,
 	 * and unique enforcement call this. A deleted row (in the group's delete vector or
 	 * a not-yet-flushed buffered delete) is not visible.
 	 *
-	 * The row-group list is read per fetch and deliberately not cached: a group
-	 * flushed earlier in this same statement has to become visible here.
+	 * The lookup is memoized per (storage, command, snapshot content) with a
+	 * refresh on miss (#709), which preserves what the old per-fetch catalog
+	 * read guaranteed: a group flushed earlier in this same statement is
+	 * visible here. See the memo block above pgcolumnar_lookup_row_group for
+	 * the reset events that keep a memo HIT sound.
 	 */
-	rgList = PgColumnarReadRowGroupList(storageId, metaSnapshot);
-	foreach(nlc, rgList)
-	{
-		NativeRowGroupMetadata *g = (NativeRowGroupMetadata *) lfirst(nlc);
-
-		if (rowNumber >= g->firstRowNumber &&
-			rowNumber < g->firstRowNumber + g->rowCount)
-		{
-			rg = g;
-			break;
-		}
-	}
+	rg = pgcolumnar_lookup_row_group(storageId, metaSnapshot, rowNumber);
 	if (rg == NULL)
 	{
 		MemoryContextSwitchTo(oldContext);

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -3319,7 +3319,12 @@ PgColumnarDiscardFetchCache(void)
  *    takes over that role and must reset);
  *  - a same-command RETIREMENT (compaction is callable mid-statement and
  *    does not CommandCounterIncrement unconditionally) deletes row_group
- *    rows a HIT would resurrect, so PgColumnarRetireGroup resets the memo.
+ *    rows a HIT would resurrect, so PgColumnarRetireGroup resets the memo;
+ *  - a METADATA WIPE for the same storage id (the TRUNCATE table-AM path)
+ *    deletes every group at once, so PgColumnarDeleteMetadata resets the
+ *    memo too. Today that path also advances the command id before the
+ *    next fetch, but the retirement reset's history says not to lean on a
+ *    cid accident.
  *
  * Cross-transaction deletions cannot invalidate a HIT: they are invisible to
  * the same MVCC snapshot content by definition. Non-MVCC snapshots (the

--- a/src/columnar_reader.h
+++ b/src/columnar_reader.h
@@ -20,6 +20,7 @@
 #include "columnar.h"
 
 extern void PgColumnarDiscardFetchCache(void);
+extern void PgColumnarGroupMemoReset(bool contextsLive);
 
 extern bool PgColumnarReadNextRowFiltered(PgColumnarReadState *readState,
 										Datum *values, bool *nulls,

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -1921,6 +1921,16 @@ pgcolumnar_xact_callback(XactEvent event, void *arg)
 		case XACT_EVENT_PREPARE:
 			PgColumnarFlushAllPendingWrites();
 			PgColumnarFlushAllDeleteVectors();
+
+			/*
+			 * PREPARE deletes TopTransactionContext without ever reaching the
+			 * COMMIT/ABORT arms below, so a memo slot populated outside any
+			 * executor lifecycle (a fetch during a utility command has no
+			 * executor-end reset) would keep a dangling context pointer into
+			 * the next transaction. Descriptors only; the contexts are still
+			 * live here and fall with the transaction's memory.
+			 */
+			PgColumnarGroupMemoReset(false);
 			break;
 		case XACT_EVENT_COMMIT:
 		case XACT_EVENT_ABORT:
@@ -1929,6 +1939,12 @@ pgcolumnar_xact_callback(XactEvent event, void *arg)
 			PgColumnarDiscardAllPendingWrites();
 			PgColumnarDiscardAllDeleteVectors();
 			PgColumnarDiscardFetchCache();
+			/*
+			 * Descriptors only: the memo contexts are TopTransactionContext
+			 * children, still live at callback time but taken by the
+			 * transaction's memory teardown right after.
+			 */
+			PgColumnarGroupMemoReset(false);
 			break;
 		default:
 			break;
@@ -1948,6 +1964,16 @@ pgcolumnar_subxact_callback(SubXactEvent event, SubTransactionId mySubid,
 		case SUBXACT_EVENT_ABORT_SUB:
 			PgColumnarWriteStateDiscardSubXact(mySubid);
 			PgColumnarDeleteVectorDiscardSubXact(mySubid);
+
+			/*
+			 * The abort flips the xmin verdict on any group the savepoint
+			 * flushed, with no change in snapshot content or command id --
+			 * the two things the group-list memo keys on -- so a memo built
+			 * while the subxact was live would keep serving the aborted
+			 * group's rows. The per-fetch catalog read this memo replaced
+			 * re-judged xmin every time; the reset restores that. (#709)
+			 */
+			PgColumnarGroupMemoReset(true);
 			break;
 		case SUBXACT_EVENT_COMMIT_SUB:
 			PgColumnarWriteStatePromoteSubXact(mySubid, parentSubid);
@@ -1988,6 +2014,8 @@ pgcolumnar_executor_end(QueryDesc *queryDesc)
 	 * in transaction after one UPDATE holds them indefinitely.
 	 */
 	PgColumnarDiscardFetchCache();
+	/* same statement scope for the group-list memo; its contexts are live */
+	PgColumnarGroupMemoReset(true);
 }
 
 /* -------------------------------------------------------------------------

--- a/test/native_fetch_group_memo.sh
+++ b/test/native_fetch_group_memo.sh
@@ -222,6 +222,27 @@ check "a DELETE is visible to the very next fetch (delete vectors uncached)" \
 		SELECT count(x.v) FROM (VALUES (77)) t(p), LATERAL (SELECT v FROM f WHERE f.id = t.p) x;" | tail -1)" \
 	"0"
 
+# --- characterization: same-transaction TRUNCATE then fetch -------------------
+# The third loss path (PgColumnarDeleteMetadata resets the memo; see the
+# ledger). No removal proof is constructible on current majors -- TRUNCATE
+# advances the command id, which rebuilds the memo anyway -- so this arm pins
+# the behavior the reset guarantees independently of that cid accident: after
+# a same-transaction TRUNCATE + reinsert, fetches see exactly the new rows.
+check "same-transaction TRUNCATE then fetch sees only the new rows" \
+	"$(psql_c "SET pgcolumnar.stripe_row_limit=2000;
+	$FORCE
+	BEGIN;
+	CREATE TABLE tw (id int, v text) USING pgcolumnar;
+	INSERT INTO tw SELECT g, 'o'||g FROM generate_series(1,5000) g;
+	CREATE INDEX tw_id ON tw (id);
+	SELECT count(x.v) FROM generate_series(1,50) g, LATERAL (SELECT v FROM tw WHERE tw.id = g) x;
+	TRUNCATE tw;
+	INSERT INTO tw SELECT g, 'w'||g FROM generate_series(1,100) g;
+	SELECT count(*) FROM generate_series(1,5000) g, LATERAL (SELECT v FROM tw WHERE tw.id = g) x;
+	SELECT count(x.v) FROM generate_series(1,5000) g, LATERAL (SELECT v FROM tw WHERE tw.id = g) x;
+	COMMIT;" | grep -E '^[0-9]+$' | tr '\n' '/')" \
+	"50/100/100/"
+
 check "backend alive" "$(q 'SELECT 1;')" "1"
 
 pgc_summary

--- a/test/native_fetch_group_memo.sh
+++ b/test/native_fetch_group_memo.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+#
+# The by-row-number fetch resolves its row group from a memo, not a per-fetch
+# catalog scan (#709).
+#
+# pgcolumnar_fetch_row runs once per fetched TID -- twice, in fact: a liveness
+# settle and a deferred decode (#157) -- and each call read the ENTIRE row-group
+# list out of the catalog (an index scan of pgcolumnar.row_group per call).
+# K fetched rows cost ~2K catalog index scans; measured 6001 scans for 3000
+# rows on the unfixed build. The memo keeps the list per (storage, command,
+# snapshot content) and refreshes on a miss, which is what preserves the old
+# per-fetch read's contract that a group flushed earlier in the same statement
+# is visible.
+#
+# The instrument counts work done, not intent: pg_stat_get_xact_numscans on
+# row_group_pkey, read as a BASELINE/AFTER DELTA inside the one session that
+# runs the measured statement (the counter is a pending-stats entry; a fresh
+# connection reads 0). The row_group TABLE's scan delta must stay 0 in the
+# same window, or a broken index resolution would fake the bound green by
+# degrading to heap scans. The plan shape is pinned from the same session,
+# BEFORE the baseline, because planning itself reads the list once
+# (relation_estimate_size).
+#
+# The savepoint arm is the removal proof for the subxact-abort reset: a
+# group flushed under a savepoint must vanish from the memo at ROLLBACK TO
+# SAVEPOINT, where nothing else changes -- not the cid, not the snapshot
+# content. The same-statement rewrite arm is the removal proof for the
+# retirement reset, and it fires on PG18: PG17's rewrite path happens to
+# cross a CommandCounterIncrement that rebuilds the memo anyway, PG18's does
+# not, and the matrix runs both. Poisoning manifests as all-NULL rows -- the
+# group comes from the memo while the fresh column_chunk read finds
+# nothing -- so both arms count ROWS, never values.
+#
+# Usage:  test/native_fetch_group_memo.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+q "CREATE EXTENSION IF NOT EXISTS pgcolumnar;" >/dev/null
+# 100000 rows / 2000 = 50 groups, id unique and indexed, v reconstructible.
+q "SET pgcolumnar.stripe_row_limit=2000;
+   CREATE TABLE f (id int, v text) USING pgcolumnar;
+   INSERT INTO f SELECT g, 'v'||g FROM generate_series(1,100000) g;
+   CREATE INDEX f_id ON f (id);" >/dev/null
+
+psql_c() { env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" -At -c "$1" 2>&1; }
+
+# Join-method forcing matters as much as scan forcing: with merge join
+# available the planner answers the LATERAL with a Sort over a FULL index
+# scan (every row fetched -- the measured delta once read 199840), which the
+# naive "contains Index Scan" assertion happily matched. Nested loop is the
+# per-probe fetch shape the arm claims to measure, so it is pinned below.
+# (That merge-join shape also trips pre-existing #720 on PG17.)
+# Every GUC here is load-bearing: seqscan/bitmapscan/custom_scan/penalty
+# steer the plan-shape arm to a nested loop of index probes; mergejoin and
+# hashjoin off keep it from the full-scan merge shape; parallel off keeps
+# worker stats out of the xact-local counters. No enable_indexonlyscan: v is
+# in no index, so an IOS is never a legal plan for these queries.
+FORCE="SET enable_seqscan=off; SET enable_bitmapscan=off;
+SET pgcolumnar.enable_custom_scan=off; SET pgcolumnar.enable_index_fetch_penalty=off;
+SET max_parallel_workers_per_gather=0; SET enable_mergejoin=off; SET enable_hashjoin=off;"
+
+FETCHQ="SELECT count(x.v) FROM generate_series(1,3000) g, LATERAL (SELECT v FROM f WHERE f.id = (g*97)%100000+1) x"
+
+# One session, one implicit transaction: plan shape, baseline, the measured
+# statement, after. The deltas are computed from the data, never retyped.
+measured="$(psql_c "$FORCE
+EXPLAIN (COSTS off) $FETCHQ;
+SELECT 'BASE', pg_stat_get_xact_numscans('pgcolumnar.row_group_pkey'::regclass),
+	   pg_stat_get_xact_numscans('pgcolumnar.row_group'::regclass);
+$FETCHQ;
+SELECT 'AFTER', pg_stat_get_xact_numscans('pgcolumnar.row_group_pkey'::regclass),
+	   pg_stat_get_xact_numscans('pgcolumnar.row_group'::regclass);")"
+
+check "the measured plan is a nested loop of index probes (fetch path engaged)" \
+	"$(grep -c 'Nested Loop' <<<"$measured")/$(grep -c 'Index Scan using f_id' <<<"$measured")" \
+	"1/1"
+
+base_idx="$(awk -F'|' '$1=="BASE"{print $2}' <<<"$measured")"
+after_idx="$(awk -F'|' '$1=="AFTER"{print $2}' <<<"$measured")"
+base_seq="$(awk -F'|' '$1=="BASE"{print $3}' <<<"$measured")"
+after_seq="$(awk -F'|' '$1=="AFTER"{print $3}' <<<"$measured")"
+
+check "the fetch count is exact (3000 rows found)" \
+	"$(grep -cx '3000' <<<"$measured")" "1"
+
+# Post-fix contributors inside the window: the statement's own planning scan
+# plus one memo build. 20 is auditable slack; the unfixed build reads ~6000.
+check "3000 index fetches cost a bounded number of row_group reads (delta <= 20)" \
+	"$( [ -n "$base_idx" ] && [ -n "$after_idx" ] && [ $((after_idx - base_idx)) -le 20 ] && echo bounded || echo "unbounded($base_idx -> $after_idx)")" \
+	"bounded"
+
+check "row_group is never heap-scanned in the window (index resolution intact)" \
+	"$((after_seq - base_seq))" "0"
+
+# --- correctness: scattered fetches return the right values -------------------
+# The value comparison sits INSIDE the lateral so it filters on the fetched
+# row directly (the outer-WHERE form flips to the merge-join shape of #720).
+check "scattered index-fetched values are exact" \
+	"$(psql_c "$FORCE SELECT count(*) FROM generate_series(1,2000) g,
+		LATERAL (SELECT v FROM f WHERE f.id = g*50 AND f.v = 'v'||(g*50)) x;" | tail -1)" \
+	"2000"
+
+# --- correctness: a group flushed in an earlier statement of the same
+# --- transaction is fetchable (new cid rebuilds the memo) ---------------------
+check "same-transaction flush then fetch sees the new rows" \
+	"$(psql_c "BEGIN;
+		$FORCE
+		SELECT count(x.v) FROM generate_series(1,50) g, LATERAL (SELECT v FROM f WHERE f.id = g) x;
+		INSERT INTO f SELECT 200000+g, 'n'||g FROM generate_series(1,5000) g;
+		SELECT count(x.v) FROM generate_series(1,50) g, LATERAL (SELECT v FROM f WHERE f.id = 200000+g) x;
+		ROLLBACK;" | tail -2 | head -1)" \
+	"50"
+
+# --- hazard arm 1: savepoint flush, then ROLLBACK TO SAVEPOINT ----------------
+# The cursor's index scan hands out TIDs of the aborted insert (their btree
+# entries remain); the fetch must judge the aborted group invisible. Nothing
+# but the subxact abort separates the poisoned memo from this drain: the cid
+# and the portal snapshot are unchanged.
+# MOVE 5 twice leaves 99990 of the 100000 real rows. The instrument is MOVE
+# ALL's command tag -- a ROW count -- because the resurrected rows decode as
+# all-NULL (the group metadata comes from the poisoned memo while the per-
+# fetch column_chunk read correctly judges the aborted chunk rows invisible),
+# so any value-based count is blind to them. That blindness cost this arm its
+# first removal proof. The stripe limit is set IN THIS SESSION: the fixture's
+# SET was session-local, and without it the savepoint's insert never flushes
+# a group and the arm tests nothing.
+sub_move="$(psql_c "SET pgcolumnar.stripe_row_limit=2000;
+$FORCE
+BEGIN;
+DECLARE cur CURSOR FOR SELECT v FROM f WHERE id BETWEEN 1 AND 300000 ORDER BY id;
+MOVE 5 FROM cur;
+SAVEPOINT s;
+INSERT INTO f SELECT 100000+g, 'a'||g FROM generate_series(1,3000) g;
+MOVE 5 FROM cur;
+ROLLBACK TO SAVEPOINT s;
+MOVE ALL FROM cur;
+COMMIT;" | grep '^MOVE' | tail -1)"
+
+check "rows flushed under an aborted savepoint do not resurrect through the cursor" \
+	"$sub_move" "MOVE 99990"
+
+# --- hazard arm 2: compact_rewrite retires a group INSIDE one statement -------
+# The removal proof for PgColumnarRetireGroup's memo reset -- on PG18.
+# reclaim_coalesce=off removes the coalesce path's CommandCounterIncrement;
+# on PG17 the flush's storage-row update happens to CCI anyway, which forces
+# a key-mismatch rebuild and masks a missing reset, but on PG18 it does not,
+# and without the reset the FIRST post-rewrite probe hits the stale memo
+# through the old index entry (one doubled row, 501) before refresh-on-miss
+# heals the slot. count(*), deliberately not count(v): the resurrected row
+# decodes all-NULL (stale group metadata, fresh column_chunk read sees
+# nothing), and a value count is blind to it.
+q "SET pgcolumnar.stripe_row_limit=2000;
+   CREATE TABLE r (id int, v text) USING pgcolumnar;
+   INSERT INTO r SELECT g, 'r'||g FROM generate_series(1,10000) g;
+   CREATE INDEX r_id ON r (id);
+   DELETE FROM r WHERE id <= 1000;" >/dev/null
+
+# The middle field asserts the rewrite REALLY rewrote one group (= 1, not the
+# >= 0 tautology this arm first shipped with): a refused rewrite would leave
+# nothing retired and the arm green with the hazard untested.
+retire_out="$(psql_c "SET pgcolumnar.reclaim_coalesce=off;
+$FORCE
+SELECT (SELECT count(*) FROM generate_series(1001,1500) g, LATERAL (SELECT v FROM r WHERE r.id = g) x),
+       (SELECT pgcolumnar.compact_rewrite('r'::regclass, 0.1, 0) = 1),
+       (SELECT count(*) FROM generate_series(1001,1500) g, LATERAL (SELECT v FROM r WHERE r.id = g) x);" | tail -1)"
+
+check "a same-statement retire neither loses nor doubles rows (500|t|500)" \
+	"$retire_out" "500|t|500"
+
+# --- hazard arm 3: pgcolumnar.compact() retires a FULLY deleted group ---------
+# compact() is an ordinary SQL function, callable mid-statement, and reaches
+# PgColumnarRetireGroup with NO flush at all -- so no incidental CCI on any
+# major; only the memo reset stands between the post fetch and the retired
+# group, whose delete vectors die with it (every one of its 2000 rows would
+# resurrect as an all-NULL row). On assert builds an assert-only CCI after
+# compact() masks a severed reset, so the removal proof for this arm fires on
+# the matrix's non-assert majors.
+q "SET pgcolumnar.stripe_row_limit=2000;
+   CREATE TABLE fd (id int, v text) USING pgcolumnar;
+   INSERT INTO fd SELECT g, 'f'||g FROM generate_series(1,10000) g;
+   CREATE INDEX fd_id ON fd (id);
+   DELETE FROM fd WHERE id <= 2000;" >/dev/null
+
+compact_out="$(psql_c "SET pgcolumnar.reclaim_coalesce=off;
+$FORCE
+SELECT (SELECT count(*) FROM generate_series(2001,2010) g, LATERAL (SELECT v FROM fd WHERE fd.id = g) x),
+       (SELECT pgcolumnar.compact('fd'::regclass) >= 1),
+       (SELECT count(*) FROM generate_series(1,2000) g, LATERAL (SELECT v FROM fd WHERE fd.id = g) x);" | tail -1)"
+
+check "a same-statement compact() of a fully deleted group resurrects nothing (10|t|0)" \
+	"$compact_out" "10|t|0"
+
+check "the table is exact after the in-statement rewrite" \
+	"$(q 'SELECT count(*) FROM r;')" "9000"
+
+# --- unchanged paths ----------------------------------------------------------
+# SQLSTATE, not error text (house rule): 23505 comes only from the unique
+# check; VERBOSITY=verbose makes psql print it.
+check "a buffered + flushed duplicate still violates a unique index (23505)" \
+	"$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" -At -v VERBOSITY=verbose -c "
+		CREATE TABLE u (id int, v text) USING pgcolumnar;
+		CREATE UNIQUE INDEX u_id ON u (id);
+		INSERT INTO u SELECT g, 'u' FROM generate_series(1,5000) g;
+		INSERT INTO u VALUES (4999, 'dup');" 2>&1 | grep -c 'ERROR:  23505')" \
+	"1"
+
+check "an AFTER UPDATE trigger still sees the OLD row (SnapshotAny re-fetch)" \
+	"$(psql_c "CREATE TABLE trg (id int, v text) USING pgcolumnar;
+		INSERT INTO trg SELECT g, 'o'||g FROM generate_series(1,3000) g;
+		CREATE FUNCTION trg_f() RETURNS trigger LANGUAGE plpgsql AS
+		  \$\$ BEGIN RAISE NOTICE 'old=%', OLD.v; RETURN NEW; END \$\$;
+		CREATE TRIGGER t_au AFTER UPDATE ON trg FOR EACH ROW EXECUTE FUNCTION trg_f();
+		UPDATE trg SET v = 'n' WHERE id = 2500;" | grep -c 'old=o2500')" \
+	"1"
+
+check "a DELETE is visible to the very next fetch (delete vectors uncached)" \
+	"$(psql_c "$FORCE
+		DELETE FROM f WHERE id = 77;
+		SELECT count(x.v) FROM (VALUES (77)) t(p), LATERAL (SELECT v FROM f WHERE f.id = t.p) x;" | tail -1)" \
+	"0"
+
+check "backend alive" "$(q 'SELECT 1;')" "1"
+
+pgc_summary

--- a/test/native_fetch_interrupt.sh
+++ b/test/native_fetch_interrupt.sh
@@ -3,8 +3,9 @@
 # pgColumnar fetch-path interrupt guard (#212).
 #
 # pgcolumnar_fetch_row is reached once per candidate item pointer by
-# _bt_check_unique() during a unique INSERT, and each call reads the row-group
-# list out of the catalog. Before #212 that path had no CHECK_FOR_INTERRUPTS --
+# _bt_check_unique() during a unique INSERT, and each such call reads the
+# row-group list out of the catalog (the unique check runs under SnapshotDirty,
+# which #709's memo never serves). Before #212 that path had no CHECK_FOR_INTERRUPTS --
 # the three checks already in columnar_reader.c are all on the scan/decode path,
 # which a unique liveness check never enters -- so a unique INSERT whose conflict
 # check did a lot of fetch work could not be cancelled and never noticed
@@ -40,13 +41,25 @@ check "pgcolumnar_fetch_row carries an interrupt check" \
 	"$(printf '%s\n' "$body" | grep -c 'CHECK_FOR_INTERRUPTS' | awk '{print ($1>=1)?"yes":"no"}')" \
 	"yes"
 
-# And it has to run before the per-fetch catalog read it guards, or the fetch
+# And it has to run before the row-group resolution it guards, or the fetch
 # does its work before ever reaching a cancellation point -- which is the state
-# #212 was in. Assert the check precedes the PgColumnarReadRowGroupList call.
+# #212 was in. Since #709 the per-fetch catalog read lives behind
+# pgcolumnar_lookup_row_group (memoized, but a miss or an uncached snapshot
+# still reads the catalog), so that call is the guarded work; assert the
+# check precedes it, and separately that the lookup helper is really where
+# the catalog read moved, so this arm cannot rot into comparing against a
+# call that no longer does the work.
 cfi_line="$(printf '%s\n' "$body" | grep -n 'CHECK_FOR_INTERRUPTS' | head -1 | cut -d: -f1)"
-rgl_line="$(printf '%s\n' "$body" | grep -n 'PgColumnarReadRowGroupList' | head -1 | cut -d: -f1)"
-check "the interrupt check precedes the per-fetch catalog read" \
+# match the CALL, with its paren -- the bare name also appears in a comment
+# above the call, and a comment must not satisfy a placement check
+rgl_line="$(printf '%s\n' "$body" | grep -n 'pgcolumnar_lookup_row_group(' | head -1 | cut -d: -f1)"
+check "the interrupt check precedes the row-group resolution" \
 	"$( [ -n "$cfi_line" ] && [ -n "$rgl_line" ] && [ "$cfi_line" -lt "$rgl_line" ] && echo yes || echo no )" \
+	"yes"
+
+lookup_body="$(awk '/^pgcolumnar_lookup_row_group\(/{p=1} p{print} p&&/^}/{exit}' "$SRC/columnar_reader.c")"
+check "the row-group resolution is where the catalog read lives" \
+	"$(printf '%s\n' "$lookup_body" | grep -c 'PgColumnarReadRowGroupList' | awk '{print ($1>=1)?"yes":"no"}')" \
 	"yes"
 
 pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -129,6 +129,7 @@ SUITES=(
 	native_fastdecode
 	native_fetch_bigcap
 	native_fetch_cache
+	native_fetch_group_memo
 	native_fetch_interrupt
 	native_fetch_position
 	native_fetch_projection


### PR DESCRIPTION
## What

`pgcolumnar_fetch_row` read the ENTIRE row-group list out of the catalog on every call — twice per index-fetched row (liveness settle + deferred decode, #157) — so K fetched rows cost ~2K catalog index scans: **measured 6001 scans of `row_group_pkey` for 3000 rows**. The lookup is now memoized per (storage, command, **snapshot content** — xmin/xmax/curcid/xip/subxip compared by value, so pointer reuse cannot alias), with the delete-vector reader's proven last-hit + linear-walk + **refresh-on-miss** shape. The refresh re-reads under the fetch's own snapshot, preserving the old contract that a group flushed earlier in the same statement is visible. Post-fix: the same 3000 fetches cost **2** scans. Only `SNAPSHOT_MVCC` memoizes; SnapshotDirty (unique checks) and SnapshotAny (trigger re-fetches) keep the per-fetch read. No binary search, deliberately: the catalog read is the whole win and a comparator would be code no test can turn red.

Design + full hazard ledger: `design/FETCH_GROUP_LOOKUP_PLAN.md`.

## The two resets, and how each earned its keep

A HIT is sound because within one (cid, snapshot content) the visible group set can only **gain** rows — with two exceptions, both reset and both removal-proven:

- **Subtransaction abort** flips a savepoint-flushed group's xmin verdict with NO key change. Severed: the aborted rows resurrect through an open cursor (`MOVE ALL` reads 102990 for 99990).
- **Row-group retirement.** This one has a story: PG17 probing showed the rewrite path crossing an incidental CCI that masks a missing reset, so it was briefly removed under the deletion-proof rule with a sentinel arm left behind — and the sentinel **fired on PG18** (no such CCI there: one doubled all-NULL row, 501). Adversarial review then found the stronger shape: `pgcolumnar.compact()` retires FULLY deleted groups mid-statement with no flush and no CCI on any major. Severed on a non-assert build, its arm resurrects **all 2000 rows** of the retired group (`10|t|2000`). The reset ships with both arms as its proof (assert builds mask the compact arm via an assert-only CCI; the matrix's non-assert majors carry it).

Poisoning manifests as **all-NULL rows** (group metadata from the memo, fresh `column_chunk` read sees nothing), so every hazard arm counts ROWS, never values — the value-counting first drafts of these arms sat green over 3000 resurrected rows.

## Verification

- `native_fetch_group_memo` (14 checks) **green on PG17 (assert), PG18 (non-assert), PG19 (assert)**. Instrument discipline: xact-numscans BASELINE/AFTER delta in one session, heap-scan delta 0 (a broken index resolution cannot fake the bound), nested-loop plan shape pinned with join methods forced (a merge join turns the probe into a full scan — and separately trips pre-existing #720), 23505 asserted by SQLSTATE.
- Removal proofs, each exact: memo severed → only the scan-delta arm red; subxact reset severed → only the cursor arm red; retirement reset severed → 501 + 2000-resurrected on pg18_nc.
- Regression battery green on PG17: `native_fetch_cache`, `native_fetch_bigcap`, `native_fetch_interrupt` (placement arm updated to pin the check before the lookup CALL and that the lookup owns the catalog read), `native_fetch_position`, `native_fetch_projection`, `index_only`, `unique_conc`, `corruption`, `native_reclaim`, `native_recluster`, `autovacuum`, plus `harness_selftest` (110) and `docs_style`.
- Two multi-agent adversarial passes (design-stage hazards; finished-diff review). The review's material findings are all folded in: the compact() retire path, the `compact_rewrite >= 0` tautology (now `= 1`), a PREPARE-path dangling-context window (memo now resets there), `SNAPSHOT_HISTORIC_MVCC` excluded from the memoizable predicate, an inert forced GUC dropped, and the wrong-fact comments about xact-callback context lifetime corrected.

## Found along the way

- **#720** (filed): merge join with a multi-key merge cond over index-fetched columnar rows errors with `pfree is not supported by the bump memory allocator` on PG17 — pre-existing, minimal repro in the issue.

Closes #709.

🤖 Generated with [Claude Code](https://claude.com/claude-code)