### PR TITLE
fix: keep deferred-decode fetch pfrees out of the caller's context (closes #720)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ## [Unreleased]
 
+### Fixed
+
+- A merge join over index-fetched columnar rows no longer aborts with `pfree is
+  not supported by the bump memory allocator` on PostgreSQL 17 and later. A
+  columnar index scan returns a deferred slot, and when a sort materialises it
+  the current context is PostgreSQL 17's bump context, which forbids `pfree`. The
+  deferred decode pfreed there twice: the needed-column `Bitmapset`
+  (`bms_add_member`/`bms_free`) and, on a storage's first fetch, the
+  format-version check's catalog scan (which frees a btree search stack). Both
+  now run in a private pfree-supporting context; the decoded values are
+  unaffected because they were already copied into the caller's context, where
+  `palloc` is legal. Covered by a new suite, `native_fetch_sort_context` (#720).
+
 ### Added
 
 - `IN (...)` and `= ANY(array)` predicates now drive chunk-group skipping.

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -3416,6 +3416,18 @@ pgcolumnar_fetch_row(Relation rel, Snapshot snapshot, uint64 rowNumber,
 	 * cannot misread. Memoized per command (see the slot above) so a large index
 	 * scan pays one catalog check rather than one per row.
 	 */
+	tmp = AllocSetContextCreate(CurrentMemoryContext, "columnar fetch",
+								ALLOCSET_SMALL_SIZES);
+	oldContext = MemoryContextSwitchTo(tmp);
+
+	/*
+	 * The format-version check opens a catalog table and scans it, and that
+	 * scan frees a btree search stack with pfree. It must run inside this
+	 * AllocSet context, not the caller's: this path is reached from a slot
+	 * materialization during tuplesort_puttupleslot, whose current context on
+	 * PG17 is a bump context that does not support pfree (#720). Running it here
+	 * keeps the transient catalog allocations in a pfree-supporting context.
+	 */
 	if (wantValues &&
 		!(columnarFetchFmtOk && columnarFetchFmtOkStorageId == storageId))
 	{
@@ -3423,10 +3435,6 @@ pgcolumnar_fetch_row(Relation rel, Snapshot snapshot, uint64 rowNumber,
 		columnarFetchFmtOkStorageId = storageId;
 		columnarFetchFmtOk = true;
 	}
-
-	tmp = AllocSetContextCreate(CurrentMemoryContext, "columnar fetch",
-								ALLOCSET_SMALL_SIZES);
-	oldContext = MemoryContextSwitchTo(tmp);
 
 	metaSnapshot = PgColumnarCatalogSnapshot(snapshot);
 

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -286,12 +286,27 @@ pgcolumnar_slot_decode_upto(TupleTableSlot *slot, int natts)
 {
 	PgColumnarSlot *cslot = (PgColumnarSlot *) slot;
 	Bitmapset  *needed = NULL;
+	MemoryContext scratch;
+	MemoryContext oldContext;
 	int			i;
 
 	Assert(cslot->deferred);
 
+	/*
+	 * Build the needed-column set in a private context, not the caller's. This
+	 * runs from a slot materialization during tuplesort_puttupleslot, whose
+	 * current context on PG17 is a bump context that forbids pfree (#720); a
+	 * Bitmapset built and freed there would trip "pfree is not supported by the
+	 * bump memory allocator". The reader below still writes its decoded values
+	 * into the caller's context (palloc is fine there); only the transient set
+	 * lives here, and deleting the context frees it without a pfree upstream.
+	 */
+	scratch = AllocSetContextCreate(CurrentMemoryContext, "columnar decode-upto",
+									ALLOCSET_SMALL_SIZES);
+	oldContext = MemoryContextSwitchTo(scratch);
 	for (i = 0; i < natts; i++)
 		needed = bms_add_member(needed, i);
+	MemoryContextSwitchTo(oldContext);
 
 	/*
 	 * Visibility was settled when the slot was filled, so this cannot fail for a
@@ -306,7 +321,7 @@ pgcolumnar_slot_decode_upto(TupleTableSlot *slot, int natts)
 		(void) PgColumnarBufferedRowByNumber(cslot->rel, cslot->rowNumber,
 										   slot->tts_values, slot->tts_isnull);
 
-	bms_free(needed);
+	MemoryContextDelete(scratch);
 
 	/*
 	 * Attributes past the prefix hold nothing meaningful yet. tts_nvalid is what

--- a/test/native_fetch_sort_context.sh
+++ b/test/native_fetch_sort_context.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# pgColumnar deferred-decode must not pfree in the caller's memory context (#720).
+#
+# A columnar index scan returns a DEFERRED slot: the row's address is stored and
+# its columns are decoded lazily, when something asks for them. One asker is a
+# sort. A merge join sorts its input, and tuplesort materialises each slot with
+# copy_minimal_tuple while ITS OWN memory context is current. On PostgreSQL 17
+# that context is a bump context (the bump allocator is new in 17), and a bump
+# context raises "pfree is not supported by the bump memory allocator" on any
+# pfree.
+#
+# The deferred decode pfreed there twice: the Bitmapset of needed columns (built
+# with bms_add_member, freed with bms_free), and, on a storage's first fetch, the
+# format-version check's catalog scan, which frees a btree search stack. Either
+# aborts a plain query a planner can choose on its own -- a Merge Join over a Sort
+# over an Index Scan.
+#
+# The fix routes both through a pfree-supporting context; the decoded values are
+# unaffected because they are copied into the caller's context, where palloc is
+# legal. This suite drives that plan and asserts the answer matches a heap mirror.
+# It reddens on PostgreSQL 17+ before the fix (the query errors, so no value is
+# returned and the check fails against the numeric oracle) and is a no-op guard on
+# 15/16, which have no bump allocator and never erred.
+#
+# The reproducing shape is a two-key merge condition whose keys are a leading
+# by-VALUE column and a by-REFERENCE column (matching the issue's variants): the
+# leading int becomes tuplesort's datum1 while the by-reference key forces the
+# tuple to be materialised through the deferred slot. A single sort key is the
+# control that already worked and must keep working.
+#
+# Usage:  test/native_fetch_sort_context.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+# Force the plan the bug needs: Merge Join over Sort over Index Scan, with the
+# columnar custom scan off so the fetch goes through the table-AM index path.
+FORCE="SET enable_seqscan=off; SET enable_bitmapscan=off;
+       SET pgcolumnar.enable_custom_scan=off;
+       SET enable_nestloop=off; SET enable_hashjoin=off;"
+
+psql_run "DROP TABLE IF EXISTS f; DROP TABLE IF EXISTS h;
+          SET pgcolumnar.stripe_row_limit=2000;
+          CREATE TABLE f (id int, v text) USING pgcolumnar;
+          INSERT INTO f SELECT g, 'v'||g FROM generate_series(1,100000) g;
+          CREATE INDEX f_id ON f (id);
+          CREATE TABLE h (id int, v text);
+          INSERT INTO h SELECT g, 'v'||g FROM generate_series(1,2000) g;"
+
+# Scalar value under a given SQL. The forced GUCs and the query share one session
+# (the GUCs must apply to the query), so psql echoes a "SET" tag per GUC ahead of
+# the value; the value is the last line. On error psql prints no value line, so
+# the last line is a "SET" tag, which fails the numeric check rather than crashing
+# the suite -- an errored arm reads as a red, which is what the bug does on 17+.
+jv() { q "$FORCE $1" | tail -1; }
+
+# premise: the plan really is a Merge Join over a Sort over an Index Scan on f,
+# or the regression is not being exercised.
+PLAN="$(q "$FORCE EXPLAIN (COSTS OFF) SELECT count(*) FROM h JOIN f ON f.id=h.id AND f.v=h.v;")"
+check "premise: plan is a merge join" \
+	"$(grep -qi 'Merge Join' <<<"$PLAN" && echo yes || echo no)" yes
+check "premise: the columnar side is an index scan under a sort" \
+	"$(grep -qi 'Index Scan using f_id' <<<"$PLAN" && echo yes || echo no)" yes
+
+# The regression: a two-key merge cond, leading by-value int + by-reference text.
+# All 2000 rows of h match f, so the count is 2000 and the id-sum is 2001000.
+check "two-key merge join count is right (#720)" \
+	"$(jv "SELECT count(*) FROM h JOIN f ON f.id=h.id AND f.v=h.v;")" "2000"
+check "two-key merge join sum(id) is right (#720)" \
+	"$(jv "SELECT sum(f.id) FROM h JOIN f ON f.id=h.id AND f.v=h.v;")" "2001000"
+
+# a third key and a residual filter, to widen the decoded prefix past two columns.
+check "three-key merge cond with a filter (#720)" \
+	"$(jv "SELECT count(*) FROM h JOIN f ON f.id=h.id AND f.v=h.v AND f.id<1500;")" "1499"
+
+# controls that already worked before the fix (a single sort key never defers a
+# by-reference second key through the sort): they must stay correct, so the fix
+# did not disturb the working paths.
+check "control: single int key still right" \
+	"$(jv "SELECT count(*) FROM h JOIN f ON f.id=h.id;")" "2000"
+check "control: single text key still right" \
+	"$(jv "SELECT count(*) FROM h JOIN f ON f.v=h.v;")" "2000"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -132,6 +132,7 @@ SUITES=(
 	native_fetch_interrupt
 	native_fetch_position
 	native_fetch_projection
+	native_fetch_sort_context
 	native_fold_deferral
 	native_fold_skipguard
 	native_format


### PR DESCRIPTION
Closes #720.

## The bug

A merge join over index-fetched columnar rows aborts with `pfree is not supported by the bump memory allocator` on PostgreSQL 17+. The plan is `Merge Join → Sort → Index Scan`, which a planner can choose on its own.

## Root cause (the issue's hypothesis was close but the site was different)

A backtrace (`backtrace_functions='BumpFree'`) + `addr2line` pinned it. A columnar index scan returns a **deferred** slot; when tuplesort materialises it via `copy_minimal_tuple` → `pgcolumnar_slot_decode_upto`, `CurrentMemoryContext` is PG17's **bump context**, which forbids `pfree`. The deferred decode pfreed there **twice**, and the first masked the second:

1. `pgcolumnar_slot_decode_upto` (`columnar_tableam.c`) builds the needed-column `Bitmapset` with `bms_add_member` and frees it with `bms_free` — in the ambient (bump) context.
2. `pgcolumnar_fetch_row` (`columnar_reader.c`) runs the per-command format-version check *before* switching into its private `"columnar fetch"` AllocSet; that check opens a catalog table and its btree scan frees a search stack (`_bt_freestack`).

The by-reference key is incidental (it forces the tuple to be materialised through the deferred slot); the illegal operations are the two frees, not any datum. This is why the single-key variants worked — they never defer a second key through the sort.

## The fix

Build the `Bitmapset` in a private AllocSet in `decode_upto`, and move the version check below the context switch in `fetch_row`. Both transient frees now land in a pfree-supporting context. The decoded values are unaffected — they were already copied into the caller's context, where `palloc` is legal — so only the frees were ever the problem. (This also covers a wide table's multi-word `Bitmapset`, whose `repalloc` the bump allocator equally forbids, since the whole set now lives in the private context.)

## Verification (TDD, prove-don't-trust)

New suite **`native_fetch_sort_context`** drives the exact plan and checks the count and `sum(id)` against a heap mirror (an errored query returns no value and fails the numeric check, so the red is the abort itself).

- **RED → GREEN** on PG17 assert: the two-key and three-key arms fail before the fix, all pass after.
- **Per-site removal proof**: reverting *only* the `decode_upto` change reddens (the `bms_free` site returns); reverting *only* the `fetch_row` change reddens (the version-check site returns). Both halves are load-bearing.
- **Majors mapped**: PG15.18 and PG16.14 (no bump allocator) PASS even unfixed — never affected; PG18.4 and PG19 FAIL before, PASS after. So the reachable majors are 17/18/19.
- No regression: `harness_selftest` 110 (registration + C-sort), `docs_style` 9, clean build with zero warnings.

The single-key controls (which always worked) stay green, confirming the fix does not disturb the working paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
