### PR TITLE
sec: refuse userinfo on the objstore write path, matching the read path (#706)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ### Fixed
 
+- The object-store write path (export sink, delete, list) now refuses a URL
+  with userinfo (`user@host`) with the same error the read path always gave.
+  Before, the write parse admitted the URL and failed closed downstream by
+  accident: the allow-list cannot match a host with an embedded `@`, and a
+  `user:pass@` URL split at the wrong colon into a rejected port. A new
+  suite, `objstore_userinfo`, pins all three entry points on the SQLSTATE
+  and the guard's own message. (#706)
+
 - A merge join over index-fetched columnar rows no longer aborts with `pfree is
   not supported by the bump memory allocator` on PostgreSQL 17 and later. A
   columnar index scan returns a deferred slot, and when a sort materialises it

--- a/objstore/columnar_objstore_module.c
+++ b/objstore/columnar_objstore_module.c
@@ -1698,6 +1698,21 @@ os_write_handle(const char *url, const PgColumnarObjStoreConfig *cfg)
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 					 errmsg("columnar: \"%s\" has no object path", url)));
+
+		/*
+		 * Same userinfo refusal as os_open and http_request (#706). Without
+		 * it a `user@host` write target parsed with the '@' embedded in the
+		 * host (or, with `user:pass@`, split at the userinfo colon into a
+		 * garbage port). Both shapes still failed closed downstream -- the
+		 * allow-list cannot match an '@'-carrying host, and port 0 is
+		 * refused -- but by accident and with the wrong diagnostic, and the
+		 * userinfo bytes rode along in the handle's url.
+		 */
+		if (memchr(authority, '@', slash - authority) != NULL)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("columnar: userinfo in \"%s\" is not supported", url)));
+
 		oldcxt = MemoryContextSwitchTo(TopMemoryContext);
 		h->abspath = pstrdup(slash);
 		colon = memchr(authority, ':', slash - authority);

--- a/test/objstore_userinfo.sh
+++ b/test/objstore_userinfo.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# pgColumnar objstore: userinfo in a URL is refused on EVERY entry point (#706).
+#
+# The read path (os_open) and the ABI http_request refused `user@host` in an
+# http(s) authority from the start: userinfo smuggles bytes into the host part,
+# the classic SSRF-parser-confusion shape. The write path (os_write_handle:
+# export sink, delete, list) parsed the same authority WITHOUT the guard, so a
+# userinfo URL sailed past the parse with the '@' embedded in the host field.
+# It still failed closed -- the allow-list match at connect cannot match a host
+# with an embedded '@' -- but as the wrong error (42501, an allow-list refusal)
+# with the userinfo bytes carried through the handle, and fail-closed-by-
+# accident is one endpoint-matching refactor away from not failing at all.
+#
+# These arms need no object-store server: both the guard (22023) and the
+# allow-list refusal (42501) fire before any network I/O. The SQLSTATE is the
+# discriminator -- 22023 comes only from the parse guards, 42501 only from the
+# allow-list -- and the message arm pins WHICH 22023 guard fired.
+#
+# Removal proof: revert the os_write_handle guard and the write arms read
+# 42501 again while the read arms stay 22023.
+#
+# Usage:  test/objstore_userinfo.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+export PGC_EXTRA_CONF="pgcolumnar.objstore_allowed_endpoints='127.0.0.1'"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+q "CREATE EXTENSION IF NOT EXISTS pgcolumnar;" >/dev/null
+q "CREATE TABLE ex (id int, v text) USING pgcolumnar;
+   INSERT INTO ex SELECT g, 'v'||g FROM generate_series(1,100) g;" >/dev/null
+
+sqlstate_of() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -qtA 2>&1 <<SQLEOF | sed -n 's/^ERROR:  \([0-9A-Z]\{5\}\).*/\1/p' | head -1
+\\set VERBOSITY sqlstate
+$1;
+SQLEOF
+}
+
+msg_of() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -qtA -c "$1" 2>&1 | grep -c 'userinfo'
+}
+
+URL="http://u:p@127.0.0.1:1/x.parquet"
+
+# --- premise: the read path refuses userinfo with the parse guard ------------
+check "read_parquet refuses userinfo (22023, the parse guard)" \
+	"$(sqlstate_of "SELECT * FROM pgcolumnar.read_parquet('$URL') AS t(v int)")" "22023"
+check "and its message names userinfo" \
+	"$(msg_of "SELECT * FROM pgcolumnar.read_parquet('$URL') AS t(v int)")" "1"
+
+# --- the gap: the write path must refuse with the SAME guard -----------------
+# Pre-fix these read 42501: the parse admits the URL and the '@'-carrying host
+# then fails the allow-list at connect -- fail closed, wrong reason.
+check "export_parquet refuses userinfo (22023, not an allow-list 42501)" \
+	"$(sqlstate_of "SELECT pgcolumnar.export_parquet('ex', '$URL')")" "22023"
+check "and its message names userinfo" \
+	"$(msg_of "SELECT pgcolumnar.export_parquet('ex', '$URL')")" "1"
+check "export_arrow refuses userinfo through the same handle (22023)" \
+	"$(sqlstate_of "SELECT pgcolumnar.export_arrow('ex', 'http://u@127.0.0.1:1/x.arrow')")" "22023"
+
+# --- the allow-list still does its own job on a clean URL --------------------
+# The guard must not have swallowed the 42501 class: a userinfo-free URL to a
+# non-allowed endpoint is still the allow-list's refusal.
+check "a clean URL to a non-allowed endpoint is still the allow-list's 42501" \
+	"$(sqlstate_of "SELECT pgcolumnar.export_parquet('ex', 'http://127.0.0.2:1/x.parquet')")" "42501"
+
+check "backend alive" "$(q 'SELECT 1;')" "1"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -199,6 +199,7 @@ SUITES=(
 	objstore_sink_write
 	objstore_stash_recovery
 	objstore_tls_read
+	objstore_userinfo
 	parallel
 	parallel_copy
 	parallel_degree


### PR DESCRIPTION
## What

`os_open` (read) and `http_request` refused `user@host` in an http(s) authority from the start; `os_write_handle` (export sink, delete, list) parsed the same authority **without** the guard. The write path still failed closed — an `@`-carrying host cannot match the allow-list (42501), and a `user:pass@` URL split at the userinfo colon into a rejected port — but by accident, with the wrong diagnostic, and with the userinfo bytes carried in the handle's URL. This adds the siblings' guard to `os_write_handle`, before the colon parse.

## Verification (TDD)

New suite `objstore_userinfo` (7 checks, **no server needed**: both the guard's 22023 and the allow-list's 42501 fire pre-network). RED on unfixed was instructive: `export_parquet` with `user:pass@` read 22023 *even unfixed* — via the **port** check (the parse splits at the userinfo colon), the wrong guard — so the suite pins SQLSTATE **and** the guard's own message; the message arm is load-bearing. `export_arrow` with bare `user@` showed the true divergence (42501).

- GREEN: 7/7 on PG17 assert, zero warnings.
- Removal proof: severing only the `os_write_handle` guard (the second of the three occurrences) reddens exactly the two write arms — 42501 returns on `user@`, and the accidental 22023 loses its userinfo message — while the read arms stay green.
- A clean-URL arm proves the guard did not swallow the allow-list's own 42501.
- Regression green: `objstore_crlf`, `objstore_allowlist`, `objstore_sink_write`, `harness_selftest` (110), `docs_style`.

First of the #705–#708 batch (claimed on the issues); #707 next.

Closes #706.

🤖 Generated with [Claude Code](https://claude.com/claude-code)