### PR TITLE
opt: fold the grouped vectorized aggregate column at a time (#708)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,28 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ### Changed
 
+- The grouped vectorized aggregate (`pgcolumnar.enable_group_vectorization`)
+  now folds column at a time instead of row at a time. Where every group key is
+  a plain column, every aggregate is one the fold accumulates (`count`, `sum`
+  and `avg` over integer and float columns), and the whole `WHERE` is expressed
+  exactly by scan keys, the node walks row groups and reads each column's
+  packed values directly. The row path paid, for every row scanned,
+  `PgColumnarReadNextRow`, an expression context reset, staging the row into a
+  virtual slot, `ExecQual`, and one expression evaluation per group key; the
+  fold pays none of those, and the group hash and the probe equality are inline
+  for integer, `oid`, `date`, `time` and `timestamp` keys. Float keys keep the
+  type's own hash and equality functions, because `-0.0` and `0.0` are one
+  group with two bit patterns. Measured on 4,000,000 rows with 8 groups, 5
+  repetitions, counting instructions retired by the backend: 15,850,896,522
+  before and 7,352,675,551 after without a filter (2.16x), and 13,899,374,785
+  before and 6,292,504,808 after with one (2.21x). `EXPLAIN` reports
+  `Columnar Batch Fold` on the grouped node, as it already did on the ungrouped
+  one, so a plan states whether the fold ran. Shapes the fold declines, among
+  them a by-reference key such as `text`, an expression key, `min` and `max`,
+  and a filter no scan key expresses exactly, run the row path and return the
+  same results. A new suite, `native_groupagg_batch`, proves the results
+  against a heap mirror and proves the work separately from them. (#708)
+
 - An index or bitmap fetch no longer reads the whole row-group list out of
   the catalog for every row. The list is memoized per command and snapshot,
   with a refresh on any miss, so a group flushed earlier in the same

--- a/docs/features.md
+++ b/docs/features.md
@@ -56,7 +56,11 @@ settings see the [configuration reference](configuration.md); for constraints se
   data. Set `pgcolumnar.enable_vectorization` to `off` to force an ordinary
   aggregate over the scan instead. An opt-in path vectorizes `GROUP BY` too. Set
   `pgcolumnar.enable_group_vectorization` to `on` to group and aggregate in one
-  pass over the reader. It is off by default.
+  pass over the reader. It is off by default. Where the query groups by plain
+  columns, aggregates with `count`, `sum` or `avg`, and filters only with
+  comparisons the scan keys express, that pass reads each column's values
+  directly instead of one row at a time. `EXPLAIN` reports `Columnar Batch Fold`
+  on the node, and other shapes read row at a time and return the same results.
 - Column statistics. `ANALYZE` samples rows from across the row groups. It stores
   the null fraction, the distinct counts, the most-common values, the histograms
   and the correlation. The planner then estimates predicate selectivity from that

--- a/docs/features.md
+++ b/docs/features.md
@@ -56,11 +56,12 @@ settings see the [configuration reference](configuration.md); for constraints se
   data. Set `pgcolumnar.enable_vectorization` to `off` to force an ordinary
   aggregate over the scan instead. An opt-in path vectorizes `GROUP BY` too. Set
   `pgcolumnar.enable_group_vectorization` to `on` to group and aggregate in one
-  pass over the reader. It is off by default. Where the query groups by plain
-  columns, aggregates with `count`, `sum` or `avg`, and filters only with
-  comparisons the scan keys express, that pass reads each column's values
-  directly instead of one row at a time. `EXPLAIN` reports `Columnar Batch Fold`
-  on the node, and other shapes read row at a time and return the same results.
+  pass over the reader. It is off by default. That pass applies where the
+  query groups by plain columns, aggregates with `count`, `sum` or `avg`, and
+  filters only with comparisons the scan keys express. There it reads each
+  column's values directly instead of one row at a time. `EXPLAIN` reports
+  `Columnar Batch Fold` on the node. Other shapes read row at a time and return
+  the same results.
 - Column statistics. `ANALYZE` samples rows from across the row groups. It stores
   the null fraction, the distinct counts, the most-common values, the histograms
   and the correlation. The planner then estimates predicate selectivity from that

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -4244,8 +4244,23 @@ PgColumnarBeginGroupAggScan(CustomScanState *node, EState *estate, int eflags)
  *		The HASH is private to this hash table and never leaves it, so any hash
  *		consistent with the equality relation is correct. The EQUALITY is the
  *		part that has to match how core groups, and that is what this list is
- *		asserting -- one entry at a time, for types whose equality function is a
- *		plain integer compare of the stored width.
+ *		asserting -- one entry at a time.
+ *
+ *		STATE THE INVARIANT PRECISELY, because the next person to extend this
+ *		list will read this sentence instead of re-deriving it. The requirement
+ *		is NOT "the type's equality is an integer compare of the stored width".
+ *		It is that two values this type calls EQUAL must produce identical Datum
+ *		BITS *after fetch_att* -- which is a property of the GATHER as much as of
+ *		the equality operator.
+ *
+ *		oid is the entry that shows the difference. fetch_att SIGN-EXTENDS a
+ *		len-4 column, so an oid above 2^31 arrives with the high half set, which
+ *		the narrower rule does not describe at all. It is still correct here,
+ *		and only because the sign extension is CONSISTENT: the same oid always
+ *		yields the same bits, so equal values stay equal and unequal values stay
+ *		unequal. A type for which that did not hold would satisfy the narrower
+ *		rule and still group wrongly. (Found in review, by probing oid values
+ *		above 2^31 against a heap oracle rather than by reading the list.)
  *
  *		float4 and float8 are deliberately ABSENT even though they are passed by
  *		value and the fold reads them happily: -0.0 and 0.0 are ONE group and

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -650,6 +650,19 @@ typedef struct PgColumnarGroupKey
 	bool		byval;
 	FmgrInfo	hashFn;			/* type hash function */
 	FmgrInfo	eqFn;			/* type equality operator function */
+
+	/*
+	 * Batch fold (#708). attidx is the base column this key reads when the key
+	 * is a plain Var of the scanned relation, and -1 otherwise; the fold takes
+	 * the value straight out of the gathered column instead of running
+	 * ExecEvalExpr per row, and refuses the shape when any key is -1.
+	 *
+	 * simple says the type's equality IS bitwise equality of the Datum, so the
+	 * fold can hash the bits and compare with ==. See
+	 * pgcolumnar_groupagg_simple_key for what that excludes and why.
+	 */
+	int			attidx;
+	bool		simple;
 } PgColumnarGroupKey;
 
 typedef struct PgColumnarGroupEntry
@@ -695,6 +708,16 @@ typedef struct PgColumnarGroupAggScanState
 	int			emitPos;		/* next entry index to emit */
 
 	/*
+	 * Batch fold (#708). batchEligible is decided at Begin from the query shape
+	 * alone, so a plain EXPLAIN can report what will be attempted; batchFolded
+	 * records that the fold actually ran. They disagree exactly where the
+	 * ungrouped node's pair does (#602): a column added after some row groups is
+	 * predicted eligible and then refused at execution.
+	 */
+	bool		batchEligible;
+	bool		batchFolded;
+
+	/*
 	 * Parallel grouped fold (#349). A partial node emits each group's per-worker
 	 * transition state instead of the finalized value, and its reader claims
 	 * distinct row groups through parallelCounter -- the same shared atomic the
@@ -725,6 +748,10 @@ typedef struct PgColumnarGroupAggScanState
 
 static const CustomExecMethods pgcolumnar_groupagg_exec_methods;
 static const CustomExecMethods pgcolumnar_groupagg_parallel_exec_methods;
+static bool pgcolumnar_groupagg_simple_key(Oid typ);
+static bool pgcolumnar_groupagg_batch_eligible(PgColumnarGroupAggScanState *state,
+											 TupleDesc tupdesc, ScanKey *keysOut,
+											 int *nkeysOut);
 static void PgColumnarTryGroupAggPath(PlannerInfo *root, RelOptInfo *input_rel,
 									RelOptInfo *output_rel, void *extra);
 static bool pgcolumnar_batch_shape_eligible(PgColumnarAggScanState *state,
@@ -2998,17 +3025,33 @@ pgcolumnar_batch_agg_ok(PgColumnarAggKind kind)
 }
 
 /*
- * pgcolumnar_batch_shape_eligible
- *		Whether this aggregate's shape can use the batch fold: every aggregate is
- *		batch-accumulable, the whole WHERE converts to scan keys (no residual), and
- *		every key is a supported btree comparison on a batch-readable column. When
- *		keysOut is non-NULL the built scan keys are returned for the fold to reuse;
- *		otherwise they are only inspected. Deterministic from the query shape, so
- *		Begin can report it in EXPLAIN before execution.
+ * pgcolumnar_batch_gates_ok
+ *		The batch fold's shape gates, shared by the ungrouped node
+ *		(pgcolumnar_native_batch_fold) and the grouped one
+ *		(pgcolumnar_groupagg_batch_fold, #708).
+ *
+ *		Every aggregate is batch-accumulable, the whole WHERE converts to scan
+ *		keys EXACTLY (no residual, no merely-conservative key), every column the
+ *		fold will gather is passed by value, and every scan key is a supported
+ *		btree comparison on a batch-readable column. When keysOut is non-NULL the
+ *		built scan keys are returned for the fold to reuse; otherwise they are
+ *		only inspected. Deterministic from the query shape, so Begin can report
+ *		it in EXPLAIN before execution.
+ *
+ *		Single-sourced rather than copied per node ON PURPOSE. Both folds gather
+ *		packed column values themselves and filter rows with a scan-key loop and
+ *		nothing else, so both need exactly these guarantees, and every one of
+ *		them below was added to fix a wrong answer or a crash. A second fold
+ *		arriving with a stale copy of the list is precisely how #715 comes back.
+ *
+ *		The GROUPED caller has one further requirement of its own -- each group
+ *		key must be a plain Var it can read out of a gathered column -- which is
+ *		specific to that node and stays there.
  */
 static bool
-pgcolumnar_batch_shape_eligible(PgColumnarAggScanState *state, TupleDesc tupdesc,
-							  ScanKey *keysOut, int *nkeysOut)
+pgcolumnar_batch_gates_ok(const PgColumnarAggSpec *specs, int naggs,
+						List *quals, Index scanrelid, Bitmapset *projected,
+						TupleDesc tupdesc, ScanKey *keysOut, int *nkeysOut)
 {
 	ScanKey		keys;
 	int			nkeys = 0;
@@ -3018,11 +3061,11 @@ pgcolumnar_batch_shape_eligible(PgColumnarAggScanState *state, TupleDesc tupdesc
 	int			k;
 	bool		ok = true;
 
-	for (a = 0; a < state->naggs; a++)
-		if (!pgcolumnar_batch_agg_ok(state->specs[a].kind))
+	for (a = 0; a < naggs; a++)
+		if (!pgcolumnar_batch_agg_ok(specs[a].kind))
 			return false;
 
-	PgColumnarCountConvertibleQuals(state->quals, state->scanrelid, tupdesc,
+	PgColumnarCountConvertibleQuals(quals, scanrelid, tupdesc,
 								  &npred, &allConvertible);
 	if (!allConvertible)
 		return false;
@@ -3045,7 +3088,7 @@ pgcolumnar_batch_shape_eligible(PgColumnarAggScanState *state, TupleDesc tupdesc
 	 * native_saop_pushdown.sh's vector-agg arms and ungrouped_vector_agg.sh's
 	 * #715 arms go red if this regresses.
 	 */
-	if (!PgColumnarQualsExactlyKeyed(state->quals, state->scanrelid, tupdesc))
+	if (!PgColumnarQualsExactlyKeyed(quals, scanrelid, tupdesc))
 		return false;
 
 	/*
@@ -3082,7 +3125,7 @@ pgcolumnar_batch_shape_eligible(PgColumnarAggScanState *state, TupleDesc tupdesc
 	{
 		int			c = -1;
 
-		while ((c = bms_next_member(state->projected, c)) >= 0)
+		while ((c = bms_next_member(projected, c)) >= 0)
 		{
 			if (c < 0 || c >= tupdesc->natts)
 				continue;
@@ -3091,7 +3134,7 @@ pgcolumnar_batch_shape_eligible(PgColumnarAggScanState *state, TupleDesc tupdesc
 		}
 	}
 
-	keys = PgColumnarBuildScanKeys(state->quals, state->scanrelid, tupdesc, &nkeys);
+	keys = PgColumnarBuildScanKeys(quals, scanrelid, tupdesc, &nkeys);
 	for (k = 0; k < nkeys; k++)
 	{
 		ScanKey		key = &keys[k];
@@ -3118,6 +3161,19 @@ pgcolumnar_batch_shape_eligible(PgColumnarAggScanState *state, TupleDesc tupdesc
 		*nkeysOut = nkeys;
 	}
 	return true;
+}
+
+/*
+ * pgcolumnar_batch_shape_eligible
+ *		The ungrouped node's view of pgcolumnar_batch_gates_ok.
+ */
+static bool
+pgcolumnar_batch_shape_eligible(PgColumnarAggScanState *state, TupleDesc tupdesc,
+							  ScanKey *keysOut, int *nkeysOut)
+{
+	return pgcolumnar_batch_gates_ok(state->specs, state->naggs, state->quals,
+								   state->scanrelid, state->projected, tupdesc,
+								   keysOut, nkeysOut);
 }
 
 /* Reset the accumulators to their initial state (for a clean fall-back). */
@@ -4056,6 +4112,70 @@ PgColumnarBeginGroupAggScan(CustomScanState *node, EState *estate, int eflags)
 	state->nscankeys = PgColumnarCountScanKeys(state->quals, state->scanrelid,
 											 basedesc);
 
+	/*
+	 * Everything the batch fold's eligibility depends on is a property of the
+	 * PLAN, not of executor state, so it is settled here -- ahead of the
+	 * EXPLAIN-only return, and ahead of any ExecInitExpr. A plain EXPLAIN must
+	 * be able to report what the fold will attempt, and the ungrouped node
+	 * learned the hard way (#423) that deciding eligibility against a projected
+	 * set that had not been built yet reports "yes" for a shape that falls back
+	 * at execution.
+	 *
+	 * The per-key executor machinery (ExecInitExpr, the hash and equality
+	 * FmgrInfos) stays below the return, where it belongs: an EXPLAIN-only node
+	 * must not initialise executor state.
+	 */
+	for (k = 0; k < state->nkeys; k++)
+	{
+		PgColumnarGroupKey *key = &state->keys[k];
+		Oid			type = exprType((Node *) key->expr);
+
+		key->type = type;
+		key->collation = exprCollation((Node *) key->expr);
+		get_typlenbyval(type, &key->typlen, &key->byval);
+
+		/*
+		 * A key the fold can read straight out of a gathered column: a plain Var
+		 * of the relation this node scans. Anything else -- an expression, a
+		 * cast, a Var from another level -- keeps attidx at -1 and the fold
+		 * declines the shape rather than growing an expression evaluator.
+		 */
+		key->attidx = -1;
+		if (IsA(key->expr, Var))
+		{
+			Var		   *v = (Var *) key->expr;
+
+			if (v->varno == state->scanrelid && v->varlevelsup == 0 &&
+				v->varattno >= 1 && v->varattno <= basedesc->natts)
+				key->attidx = v->varattno - 1;
+		}
+		key->simple = key->byval && pgcolumnar_groupagg_simple_key(type);
+
+		keyExprList = lappend(keyExprList, key->expr);
+	}
+
+	/* project the columns the keys, WHERE and aggregates reference */
+	pull_varattnos((Node *) keyExprList, state->scanrelid, &proj);
+	pull_varattnos((Node *) state->quals, state->scanrelid, &proj);
+	x = -1;
+	while ((x = bms_next_member(proj, x)) >= 0)
+	{
+		AttrNumber	attno = x + FirstLowInvalidHeapAttributeNumber;
+
+		if (attno > 0)
+			projected = bms_add_member(projected, attno - 1);
+	}
+	for (a = 0; a < state->naggs; a++)
+		if (state->aggTemplate[a].attidx >= 0)
+			projected = bms_add_member(projected, state->aggTemplate[a].attidx);
+	if (projected == NULL)
+		projected = bms_make_singleton(0);	/* count(*) with no keys touched */
+	state->projected = projected;
+
+	state->batchEligible =
+		pgcolumnar_groupagg_batch_eligible(state, basedesc, NULL, NULL);
+	state->batchFolded = false;
+
 	if (eflags & EXEC_FLAG_EXPLAIN_ONLY)
 	{
 		table_close(rel, AccessShareLock);
@@ -4070,22 +4190,21 @@ PgColumnarBeginGroupAggScan(CustomScanState *node, EState *estate, int eflags)
 	state->baseSlot = MakeSingleTupleTableSlot(CreateTupleDescCopy(basedesc),
 											   &TTSOpsVirtual);
 
-	/* group-key ExprStates and their hash/equality machinery */
+	/*
+	 * The group keys' executor machinery. Their type, collation, width and
+	 * fold-readability were settled above, before the EXPLAIN-only return; what
+	 * is left is the state an executing node needs.
+	 */
 	for (k = 0; k < state->nkeys; k++)
 	{
 		PgColumnarGroupKey *key = &state->keys[k];
-		Oid			type = exprType((Node *) key->expr);
-		TypeCacheEntry *tce = lookup_type_cache(type,
+		TypeCacheEntry *tce = lookup_type_cache(key->type,
 												TYPECACHE_HASH_PROC_FINFO |
 												TYPECACHE_EQ_OPR_FINFO);
 
 		key->exprState = ExecInitExpr(key->expr, &node->ss.ps);
-		key->type = type;
-		key->collation = exprCollation((Node *) key->expr);
-		get_typlenbyval(type, &key->typlen, &key->byval);
 		fmgr_info_copy(&key->hashFn, &tce->hash_proc_finfo, estate->es_query_cxt);
 		fmgr_info_copy(&key->eqFn, &tce->eq_opr_finfo, estate->es_query_cxt);
-		keyExprList = lappend(keyExprList, key->expr);
 	}
 
 	/* residual WHERE recheck (the scan keys only prune groups) */
@@ -4112,25 +4231,70 @@ PgColumnarBeginGroupAggScan(CustomScanState *node, EState *estate, int eflags)
 		}
 	}
 
-	/* project the columns the keys, WHERE and aggregates reference */
-	pull_varattnos((Node *) keyExprList, state->scanrelid, &proj);
-	pull_varattnos((Node *) state->quals, state->scanrelid, &proj);
-	x = -1;
-	while ((x = bms_next_member(proj, x)) >= 0)
-	{
-		AttrNumber	attno = x + FirstLowInvalidHeapAttributeNumber;
-
-		if (attno > 0)
-			projected = bms_add_member(projected, attno - 1);
-	}
-	for (a = 0; a < state->naggs; a++)
-		if (state->aggTemplate[a].attidx >= 0)
-			projected = bms_add_member(projected, state->aggTemplate[a].attidx);
-	if (projected == NULL)
-		projected = bms_make_singleton(0);	/* count(*) with no keys touched */
-	state->projected = projected;
-
 	table_close(rel, AccessShareLock);
+}
+
+/*
+ * pgcolumnar_groupagg_simple_key
+ *		Whether a group-key type's equality operator is exactly bitwise equality
+ *		of the Datum, and every value of it has one representation. For such a
+ *		type the hash probe can hash the Datum's bits and compare Datums with ==
+ *		instead of paying an fmgr call per key per row (#708).
+ *
+ *		The HASH is private to this hash table and never leaves it, so any hash
+ *		consistent with the equality relation is correct. The EQUALITY is the
+ *		part that has to match how core groups, and that is what this list is
+ *		asserting -- one entry at a time, for types whose equality function is a
+ *		plain integer compare of the stored width.
+ *
+ *		float4 and float8 are deliberately ABSENT even though they are passed by
+ *		value and the fold reads them happily: -0.0 and 0.0 are ONE group and
+ *		have different bit patterns, so a bitwise probe would split them into
+ *		two. They keep the type's own hash and equality functions and still
+ *		fold, just without this shortcut. test/native_groupagg_batch.sh's
+ *		"float8 zero" arms go red if float8 is ever added here, which is the
+ *		removal proof for the exclusion.
+ *
+ *		By-reference types cannot reach this at all: the fold's gather passes
+ *		attbyval = true to fetch_att (#423) and pgcolumnar_batch_gates_ok
+ *		already requires it of every projected column.
+ */
+static bool
+pgcolumnar_groupagg_simple_key(Oid typ)
+{
+	switch (typ)
+	{
+		case INT2OID:
+		case INT4OID:
+		case INT8OID:
+		case OIDOID:
+		case DATEOID:
+		case TIMEOID:
+		case TIMESTAMPOID:
+		case TIMESTAMPTZOID:
+			return true;
+		default:
+			return false;
+	}
+}
+
+/*
+ * A cheap, well-mixed hash of a Datum's bits, for the key types
+ * pgcolumnar_groupagg_simple_key admits. It does not have to agree with the
+ * type's own hash function -- only with itself -- because the table it indexes
+ * is private to this node.
+ */
+static inline uint32
+pgcolumnar_groupagg_hash_datum(Datum d)
+{
+	uint64		x = (uint64) d;
+
+	x ^= x >> 33;
+	x *= UINT64CONST(0xff51afd7ed558ccd);
+	x ^= x >> 33;
+	x *= UINT64CONST(0xc4ceb9fe1a85ec53);
+	x ^= x >> 33;
+	return (uint32) x;
 }
 
 /*
@@ -4152,6 +4316,13 @@ pgcolumnar_groupagg_keys_equal(PgColumnarGroupAggScanState *state,
 			return false;
 		if (keynulls[k])
 			continue;
+		if (state->keys[k].simple)
+		{
+			/* bitwise equality IS this type's equality (#708) */
+			if (e->keys[k] != keyvals[k])
+				return false;
+			continue;
+		}
 		if (!DatumGetBool(FunctionCall2Coll(&state->keys[k].eqFn,
 											state->keys[k].collation,
 											e->keys[k], keyvals[k])))
@@ -4237,6 +4408,8 @@ pgcolumnar_groupagg_lookup(PgColumnarGroupAggScanState *state,
 
 		if (keynulls[k])
 			h = 0x9e3779b9u;	/* fixed contribution for a null key */
+		else if (state->keys[k].simple)
+			h = pgcolumnar_groupagg_hash_datum(keyvals[k]);	/* #708 */
 		else
 			h = DatumGetUInt32(FunctionCall1Coll(&state->keys[k].hashFn,
 												 state->keys[k].collation,
@@ -4302,6 +4475,321 @@ pgcolumnar_groupagg_lookup(PgColumnarGroupAggScanState *state,
 }
 
 /*
+ * pgcolumnar_groupagg_batch_eligible
+ *		Whether this grouped aggregate can use the batch fold: the shape gates
+ *		every fold needs (pgcolumnar_batch_gates_ok), plus the one this node adds
+ *		of its own -- every group key must be a plain Var of the scanned
+ *		relation, so the fold can take the key value out of a gathered column
+ *		instead of evaluating an expression per row.
+ *
+ *		Decided from the query shape alone, so Begin can report it before there
+ *		is any execution to report.
+ */
+static bool
+pgcolumnar_groupagg_batch_eligible(PgColumnarGroupAggScanState *state,
+								 TupleDesc tupdesc, ScanKey *keysOut,
+								 int *nkeysOut)
+{
+	int			k;
+
+	if (state->nkeys <= 0)
+		return false;			/* the grouped node is never planned without one */
+
+	for (k = 0; k < state->nkeys; k++)
+	{
+		if (state->keys[k].attidx < 0)
+			return false;
+
+		/*
+		 * The fold reads the key out of cval[attidx], which is only gathered for
+		 * columns in the projected set. Begin builds that set from these very
+		 * key expressions, so this cannot fail today; it is here so that the
+		 * fold's dependency is stated where the fold is decided rather than left
+		 * as an invariant two functions apart, and so that a future change to
+		 * the projected set is refused instead of reading an ungathered slot.
+		 */
+		if (!bms_is_member(state->keys[k].attidx, state->projected))
+			return false;
+	}
+
+	return pgcolumnar_batch_gates_ok(state->aggTemplate, state->naggs,
+								   state->quals, state->scanrelid,
+								   state->projected, tupdesc,
+								   keysOut, nkeysOut);
+}
+
+/*
+ * pgcolumnar_groupagg_reset_table
+ *		Drop everything the fold accumulated, so the row path can redo the whole
+ *		scan from an empty hash table. Used only on the mid-scan fall-back below.
+ */
+static void
+pgcolumnar_groupagg_reset_table(PgColumnarGroupAggScanState *state)
+{
+	MemoryContextReset(state->keyContext);
+	MemoryContextReset(state->specContext);
+	MemoryContextReset(state->hashContext);
+	state->entries = NULL;
+	state->capacity = 0;
+	state->nGroups = 0;
+}
+
+/*
+ * pgcolumnar_groupagg_batch_fold
+ *		Fold the whole grouped scan column-at-a-time (#708). Returns false --
+ *		having folded nothing the caller cannot redo -- when the shape is not
+ *		eligible or a group is missing a needed column, in which case the caller
+ *		runs the always-correct row path.
+ *
+ *		This is the grouped twin of pgcolumnar_native_batch_fold, and it is
+ *		deliberately the same loop: walk row groups, gather each needed column's
+ *		packed values, honour the delete mask and the skipped-vector map, apply
+ *		the scan keys inline, then probe and fold. What the row path pays per row
+ *		and this does not: PgColumnarReadNextRow, ResetExprContext, staging the
+ *		row into a virtual slot, ExecStoreVirtualTuple, ExecQual, and one
+ *		ExecEvalExpr per group key. What is left of the fmgr traffic -- the hash
+ *		and the probe equality -- goes inline for the key types
+ *		pgcolumnar_groupagg_simple_key admits.
+ *
+ *		It does NOT take the ungrouped fold's payload deferral (#405). Group key
+ *		columns are needed for every surviving row by definition, so only the
+ *		aggregate payload could ever be deferred, and the two-phase gather is
+ *		surface this path has no measured need of yet.
+ *
+ *		The per-value delete/skip/scan-key handling below is load-bearing in
+ *		exactly the ways the ungrouped fold documents at length, and the reasons
+ *		are not repeated here: read pgcolumnar_native_batch_fold for why the
+ *		present index must advance across a skipped or deleted row, why skipVec
+ *		is exact rather than merely safe, and why an absent column cannot be
+ *		fallen back from under a parallel partial node.
+ */
+static bool
+pgcolumnar_groupagg_batch_fold(PgColumnarGroupAggScanState *state, Relation rel,
+							 TupleDesc tupdesc)
+{
+	EState	   *estate = state->css.ss.ps.state;
+	ScanKey		keys = NULL;
+	int			nScanKeys = 0;
+	int			natts = tupdesc->natts;
+	PgColumnarReadState *rs;
+	const char **cvalidity = (const char **) palloc0(sizeof(char *) * natts);
+	const char **cpacked = (const char **) palloc0(sizeof(char *) * natts);
+	int16	   *cattlen = (int16 *) palloc0(sizeof(int16) * natts);
+	uint64	   *cpresent = (uint64 *) palloc0(sizeof(uint64) * natts);
+	bool	   *cneeded = (bool *) palloc0(sizeof(bool) * natts);
+	Datum	   *cval = (Datum *) palloc0(sizeof(Datum) * natts);
+	bool	   *cisnull = (bool *) palloc0(sizeof(bool) * natts);
+	/*
+	 * The compact list of columns to gather, so the per-row loop steps over the
+	 * columns this query reads rather than all natts. Order is column order and
+	 * each column's cursor is independent, so walking the list is equivalent to
+	 * walking the full range under the cneeded mask.
+	 */
+	int		   *needCols = (int *) palloc(sizeof(int) * Max(natts, 1));
+	int			nNeed = 0;
+	Datum	   *keyvals = (Datum *) palloc(sizeof(Datum) * Max(state->nkeys, 1));
+	bool	   *keynulls = (bool *) palloc(sizeof(bool) * Max(state->nkeys, 1));
+	int			a;
+	int			k;
+	int			col;
+	int			ci;
+
+	if (!pgcolumnar_groupagg_batch_eligible(state, tupdesc, &keys, &nScanKeys))
+		return false;
+
+	col = -1;
+	while ((col = bms_next_member(state->projected, col)) >= 0)
+		if (col >= 0 && col < natts)
+			cneeded[col] = true;
+	for (col = 0; col < natts; col++)
+		if (cneeded[col])
+			needCols[nNeed++] = col;
+
+	rs = PgColumnarBeginRead(rel, estate->es_snapshot, NULL, state->projected,
+						   nScanKeys, keys);
+
+	/*
+	 * Parallel partial run (#349): claim row groups through the shared atomic so
+	 * each worker folds a distinct set and the core Finalize combines them by
+	 * key. A partial node with no counter would fold every group in every worker
+	 * and the Finalize would sum the duplicates -- a wrong answer, not a crash.
+	 */
+	if (state->parallelCounter != NULL)
+		PgColumnarReadSetParallelCounter(rs, state->parallelCounter);
+	else if (state->isPartial)
+	{
+		PgColumnarEndRead(rs);
+		elog(ERROR, "parallel columnar grouped aggregate ran without a shared group counter");
+	}
+
+	while (PgColumnarReadFoldNextGroup(rs))
+	{
+		uint64		nrows;
+		const char *dmask;
+		uint32		dlen;
+		const bool *skipVec;
+		bool		decodeSkipped;
+		const uint32 *vecStart;
+		int			vcount;
+		int			curVec;
+		uint64		r;
+
+		PgColumnarReadFoldGroupInfo(rs, &nrows, &dmask, &dlen,
+								  &skipVec, &decodeSkipped, &vecStart, &vcount);
+
+		if (decodeSkipped && (skipVec == NULL || vecStart == NULL || vcount <= 0))
+			elog(ERROR,
+				 "pgcolumnar: the grouped vectorized aggregate cannot fold a row "
+				 "group whose decode skipped vectors without the per-vector map (#512)");
+
+		for (ci = 0; ci < nNeed; ci++)
+		{
+			const char *vbits;
+			const char *pk;
+			int16		al;
+			const uint32 *vrl;
+
+			col = needCols[ci];
+			cpresent[col] = 0;
+			if (!PgColumnarReadFoldColumn(rs, col, &vbits, &pk, &al, &vrl))
+			{
+				/*
+				 * The column is absent from this group (a later ADD COLUMN). The
+				 * batch path cannot supply its missing value, so throw away what
+				 * has been folded and let the caller redo the whole scan on the
+				 * row path, which handles it.
+				 *
+				 * A parallel partial node cannot take that fall-back: this group
+				 * and the ones before it were already claimed through the shared
+				 * counter, so the row path would re-open with the counter
+				 * advanced past them and undercount. Fail cleanly rather than
+				 * return a wrong answer.
+				 */
+				PgColumnarEndRead(rs);
+				pgcolumnar_groupagg_reset_table(state);
+				if (state->isPartial)
+					elog(ERROR, "parallel columnar grouped aggregate cannot fold a "
+						 "relation with a column added after some row groups; "
+						 "set pgcolumnar.enable_parallel_vector_agg = off");
+				return false;
+			}
+			cvalidity[col] = vbits;
+			cpacked[col] = pk;
+			cattlen[col] = al;
+		}
+
+		curVec = 0;
+		for (r = 0; r < nrows; r++)
+		{
+			bool		pass = true;
+			bool		vecSkipped = false;
+			PgColumnarGroupEntry *e;
+
+			CHECK_FOR_INTERRUPTS();
+
+			/*
+			 * Which vector holds this row, and was it ruled out? vecStart is
+			 * cumulative row spans with a [vcount] terminator and r only ever
+			 * increases, so this walk costs one step per vector boundary across
+			 * the group rather than a search per row.
+			 */
+			if (skipVec != NULL && vecStart != NULL && vcount > 0)
+			{
+				while (curVec < vcount && r >= vecStart[curVec + 1])
+					curVec++;
+				vecSkipped = (curVec < vcount && skipVec[curVec]);
+			}
+
+			/*
+			 * Gather. The present index advances for every present value whether
+			 * or not the value is read: the stream is packed by presence, so a
+			 * skipped row's slot is consumed either way, and getting that wrong
+			 * misaligns every later vector rather than losing one row. A skipped
+			 * vector's bytes were never decoded, so consume the slot and do not
+			 * read it.
+			 */
+			for (ci = 0; ci < nNeed; ci++)
+			{
+				col = needCols[ci];
+				if ((cvalidity[col][r >> 3] >> (r & 7)) & 1)
+				{
+					if (!vecSkipped)
+					{
+						cval[col] = fetch_att(cpacked[col] + cpresent[col] * cattlen[col],
+											  true, cattlen[col]);
+						cisnull[col] = false;
+					}
+					cpresent[col]++;
+				}
+				else
+					cisnull[col] = true;
+			}
+
+			if (vecSkipped)
+				continue;
+			if (dmask != NULL && (r >> 3) < dlen &&
+				(dmask[r >> 3] & (1 << (r & 7))) != 0)
+				continue;		/* deleted */
+
+			for (k = 0; k < nScanKeys; k++)
+			{
+				ScanKey		key = &keys[k];
+				int			attidx = key->sk_attno - 1;
+
+				if (cisnull[attidx] ||
+					!pgcolumnar_batch_key_pass(TupleDescAttr(tupdesc, attidx)->atttypid,
+											 cval[attidx], key->sk_strategy,
+											 key->sk_argument))
+				{
+					pass = false;
+					break;
+				}
+			}
+			if (!pass)
+				continue;
+
+			/*
+			 * The group keys are plain Vars (eligibility requires it), so the
+			 * value is already gathered and there is no expression to evaluate.
+			 */
+			for (k = 0; k < state->nkeys; k++)
+			{
+				int			ai = state->keys[k].attidx;
+
+				keyvals[k] = cval[ai];
+				keynulls[k] = cisnull[ai];
+			}
+
+			e = pgcolumnar_groupagg_lookup(state, keyvals, keynulls);
+
+			for (a = 0; a < state->naggs; a++)
+			{
+				PgColumnarAggSpec *spec = &e->specs[a];
+
+				if (spec->attidx >= 0)
+					pgcolumnar_apply_one(state->specContext, spec,
+									   cval[spec->attidx], cisnull[spec->attidx]);
+				else
+					pgcolumnar_apply_one(state->specContext, spec, (Datum) 0, true);
+			}
+		}
+	}
+
+	PgColumnarReadStats(rs, &state->groupsRead, &state->groupsSkipped,
+					  &state->groupsTotal);
+	state->usablePreds = PgColumnarReadUsablePredicates(rs);
+	state->vectorsSkipped = PgColumnarVectorsSkipped(rs);
+	state->vectorsDecoded = PgColumnarVectorsDecoded(rs);
+	state->vectorDecodes = PgColumnarVectorDecodes(rs);
+	state->vectorsRuledOutByValue = PgColumnarVectorsRuledOutByValue(rs);
+	state->haveStats = true;
+	state->batchFolded = true;
+
+	PgColumnarEndRead(rs);
+	return true;
+}
+
+/*
  * pgcolumnar_groupagg_build
  *		Scan the relation once and fold every surviving row into its group. The
  *		reader prunes groups and vectors with the pushed-down WHERE; each row is
@@ -4327,6 +4815,17 @@ pgcolumnar_groupagg_build(PgColumnarGroupAggScanState *state)
 
 	PgColumnarFlushWriteStateForRelation(state->relid);
 	PgColumnarFlushDeleteVectorForRelation(rel);
+
+	/*
+	 * Fold column-at-a-time when the shape allows it (#708). A false return
+	 * means nothing was folded and nothing was claimed, so the row path below
+	 * runs the whole scan from an empty table exactly as it did before.
+	 */
+	if (pgcolumnar_groupagg_batch_fold(state, rel, basedesc))
+	{
+		table_close(rel, AccessShareLock);
+		return;
+	}
 
 	keys = PgColumnarBuildScanKeys(state->quals, state->scanrelid, basedesc,
 								 &nScanKeys);
@@ -4494,6 +4993,7 @@ PgColumnarReScanGroupAggScan(CustomScanState *node)
 	state->capacity = 0;
 	state->entries = NULL;
 	state->haveStats = false;
+	state->batchFolded = false;
 	MemoryContextReset(state->keyContext);
 	MemoryContextReset(state->specContext);
 	MemoryContextReset(state->hashContext);
@@ -4509,6 +5009,22 @@ PgColumnarExplainGroupAggScan(CustomScanState *node, List *ancestors,
 						   state->nkeys, es);
 	ExplainPropertyInteger("Columnar Vectorized Aggregates", NULL,
 						   state->naggs, es);
+
+	/*
+	 * The work-done line for #708, and the only assertion that goes red when
+	 * this fold stops folding: the answers are identical either way, so no
+	 * correctness check can see the difference (the #545 rule).
+	 *
+	 * Plain EXPLAIN has no execution to report and so shows the shape
+	 * prediction; once the node has run, report what actually happened, because
+	 * a predicted-eligible fold can still fall back to the row path (a column
+	 * added after some row groups). Printing the prediction under ANALYZE is the
+	 * #602 defect, and this node inherits the pattern that caused it.
+	 */
+	ExplainPropertyText("Columnar Batch Fold",
+						(state->haveStats ? state->batchFolded
+										  : state->batchEligible)
+						? "yes" : "no", es);
 	PgColumnarExplainPushedDown(state->nscankeys, es);
 	PgColumnarExplainVectorPredicates(state->npreds, es);
 

--- a/test/native_groupagg_batch.sh
+++ b/test/native_groupagg_batch.sh
@@ -77,19 +77,25 @@ PLAIN_PFX="EXPLAIN (COSTS OFF)"
 # its heap mirror and require byte-identical ordered output. TBL is substituted.
 # Both sides must be non-empty, so a query that errors on one arm fails here
 # rather than comparing nothing with nothing (#418).
-agree() {	# agree LABEL "SELECT ... FROM %T ..."
-	local label="$1" tmpl="$2" col heap
-	col="$(q "$(printf '%s' "${tmpl//%T/gbb}")" | sort | md5sum | cut -d' ' -f1)"
-	heap="$(q "$(printf '%s' "${tmpl//%T/gbb_h}")" | sort | md5sum | cut -d' ' -f1)"
+# The table pair is a parameter, not a constant. It was hardcoded to gbb/gbb_h
+# at first, so the later gbs fixture substituted the WRONG table into %T, the
+# query errored on a column that table does not have, and the arm reported "the
+# columnar arm returned no rows" -- which reads exactly like over-aggressive
+# vector skipping returning an empty result, and was not.
+agree_in() {	# agree_in TABLE LABEL "SELECT ... FROM %T ..."
+	local tbl="$1" label="$2" tmpl="$3" col heap
+	col="$(q "${tmpl//%T/$tbl}" | sort | md5sum | cut -d' ' -f1)"
+	heap="$(q "${tmpl//%T/${tbl}_h}" | sort | md5sum | cut -d' ' -f1)"
 	# md5 of empty input is a fixed string, so require the columnar arm produced
 	# rows at all before trusting the comparison.
-	if [ -z "$(q "$(printf '%s' "${tmpl//%T/gbb}")" | head -1)" ]; then
+	if [ -z "$(q "${tmpl//%T/$tbl}" | head -1)" ]; then
 		PGC_CHECKS=$((PGC_CHECKS + 1)); PGC_FAIL=1
 		echo "FAIL  $label: the columnar arm returned no rows, so nothing was compared"
 		return 1
 	fi
 	check_text "$label" "$col" "$heap"
 }
+agree() { agree_in gbb "$1" "$2"; }
 
 # ---- fixture ---------------------------------------------------------------
 # 200k rows over several row groups. k is the ordinary integer group key (8
@@ -256,6 +262,59 @@ check_num "float8 zero: -0.0 and 0.0 are one group, exactly as the heap says" \
 check_text "float8 zero: the grouped sums match the heap" \
 	"$(q 'SELECT f, sum(v) FROM gbz GROUP BY f ORDER BY 1' | md5sum)" \
 	"$(q 'SELECT f, sum(v) FROM gbz_h GROUP BY f ORDER BY 1' | md5sum)"
+
+# ---- the skipped-vector cursor, actually exercised --------------------------
+# The fold's per-row loop must advance each column's present index across a
+# SKIPPED vector without reading it: the stream is packed by presence, so a
+# skipped row's slot is consumed whether or not its value is read, and getting
+# that wrong misaligns every later vector rather than losing one row. It is
+# silent, and it only shows on data whose zone maps rule something out.
+#
+# Every arm above runs with `Columnar Vectors Skipped: 0`, so none of them reach
+# that code at all. The loop was present and unexecuted, and a check that cannot
+# reach the code it names is not evidence. This fixture makes the skip happen
+# and asserts that it did before comparing anything: a small vector against a
+# large row group, and a selector that matches in only a few vectors, so group
+# level pruning cannot remove the whole row group and vector level skipping is
+# what is left to do the work.
+psql_run "CREATE TABLE gbs(k int, sel int, p1 int, p2 int, p3 int, p4 int, p5 int) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.set_options('gbs', stripe_row_limit => 65536, chunk_group_row_limit => 1024);"
+SGEN="SELECT g % 8, CASE WHEN (g / 1024) % 40 = 0 THEN 1 ELSE 0 END,
+             g, g % 3, g % 5, g % 7, g % 11
+      FROM generate_series(1,200000) g"
+psql_run "INSERT INTO gbs $SGEN;"
+psql_run "CREATE TABLE gbs_h(k int, sel int, p1 int, p2 int, p3 int, p4 int, p5 int);"
+psql_run "INSERT INTO gbs_h $SGEN;"
+
+Q_SKIP="SELECT k, count(*), sum(p1) FROM %T WHERE sel = 1 GROUP BY k"
+skip_plan="$(q "$ANALYZE_PFX ${Q_SKIP//%T/gbs}")"
+check_text "skipped vectors: the fold ran" \
+	"$(grep 'Columnar Batch Fold' <<<"$skip_plan" | grep -oE 'yes|no' | head -1)" yes
+# THE PREMISE, and the whole point of this fixture. Without it the arm below is
+# satisfied by a scan that skipped nothing, which is what every other arm here
+# already is.
+skipped="$(grep 'Columnar Vectors Skipped' <<<"$skip_plan" | grep -oE '[0-9]+' | head -1)"
+check_num "skipped vectors: premise: the scan really skipped vectors" \
+	"$([ -n "$skipped" ] && [ "$skipped" -gt 0 ] && echo 1 || echo 0)" 1
+echo "      (Columnar Vectors Skipped = ${skipped:-unset})"
+# And the row group was NOT pruned whole: if it had been there would be no
+# surviving vectors for the cursor to step over, and the skip count above would
+# be describing a scan that read nothing.
+groups_read="$(grep 'Columnar Chunk Groups Read' <<<"$skip_plan" | grep -oE '[0-9]+' | head -1)"
+check_num "skipped vectors: premise: a row group was still read" \
+	"$([ -n "$groups_read" ] && [ "$groups_read" -gt 0 ] && echo 1 || echo 0)" 1
+agree_in gbs "skipped vectors: answers match the heap mirror" "$Q_SKIP"
+# Aggregates over four payload columns, so a cursor that misaligns on any one of
+# them shows up as a wrong sum instead of being masked by a column that happens
+# to stay in step. Four and not five: at five payload aggregates the cost model
+# prefers core's GroupAggregate and this node is not chosen at all, which would
+# make the arm test nothing. The node assertion below is what would say so.
+Q_SKIP4="SELECT k, count(*), sum(p1), sum(p2), sum(p3), sum(p4) FROM %T WHERE sel = 1 GROUP BY k"
+check_text "skipped vectors: premise: the wide arm is still the grouped node" \
+	"$(is_groupvec "${Q_SKIP4//%T/gbs}")" yes
+check_text "skipped vectors: four payload columns all stay in step" \
+	"$(fold_of "$ANALYZE_PFX" "${Q_SKIP4//%T/gbs}")" yes
+agree_in gbs "skipped vectors: and their sums match the heap mirror" "$Q_SKIP4"
 
 # ---- the parallel partial grouped fold --------------------------------------
 # The fold has its own isPartial branch: each worker claims row groups through

--- a/test/native_groupagg_batch.sh
+++ b/test/native_groupagg_batch.sh
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+#
+# pgColumnar #708: the grouped vectorized aggregate folds column-at-a-time.
+#
+# Before this, the grouped path (GROUP BY over one columnar relation) was fully
+# row-at-a-time: PgColumnarReadNextRow per row, then slot staging,
+# ExecStoreVirtualTuple, ExecQual, one ExecEvalExpr per group key, one
+# FunctionCall1Coll hash per key and one FunctionCall2Coll equality per probe --
+# six to eight fmgr calls a row, measured at ~920 instructions per row. The
+# ungrouped path already had pgcolumnar_native_batch_fold; grouped had no
+# equivalent.
+#
+# The grouped batch fold walks row groups, gathers each needed column's packed
+# values directly, applies the delete mask, the skipped-vector map and the scan
+# keys inline, and hash-probes with an inline hash and equality for key types
+# whose equality IS bitwise Datum equality.
+#
+# TWO THINGS MUST BE PROVED SEPARATELY, and this suite is built around the
+# distinction (the #545 rule, `assert-work-done-not-only-correctness`):
+#
+#   * The ANSWERS are unchanged. An optimisation that stops optimising still
+#     returns correct answers, so the oracle arms below cannot see the fold at
+#     all. They exist to catch a fold that folds WRONGLY.
+#
+#   * The WORK happened. "Columnar Batch Fold: yes" on the grouped node under
+#     EXPLAIN ANALYZE is the only assertion that goes red when the fold stops
+#     running. Delete the pgcolumnar_groupagg_batch_fold call in
+#     pgcolumnar_groupagg_build and every oracle arm here stays green while the
+#     work-done arms go red. That is the removal proof.
+#
+# Eligibility is asserted in BOTH directions. A gate that never refuses is not a
+# gate, so every shape the fold must decline has its own arm AND its own oracle:
+# a by-reference key, an expression key, a non-batchable aggregate, and a `<>`
+# filter that no scan key expresses exactly (#715 -- if that gate did not carry
+# over to the grouped path, the fold's scan-key loop would count the excluded
+# rows, which is a wrong answer and not a slow one).
+#
+# Usage:  test/native_groupagg_batch.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+# The grouped path is opt-in. Set it on the database so every connection the
+# helpers open inherits it.
+psql_run "ALTER DATABASE $PGC_DB SET pgcolumnar.enable_group_vectorization = on;"
+
+q() {	# q QUERY -> rows, one per line, tab separated
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -At -F$'\t' -c "$1" 2>/dev/null
+}
+
+# One scalar.
+q1() { q "$1" | tail -1; }
+
+# Is this planned as the grouped vectorized node? "Columnar Vectorized Group
+# Keys" is emitted by no other node, so a positive grep proves the node rather
+# than an absence test a fallback would also satisfy.
+is_groupvec() {	# query -> yes|no
+	q "EXPLAIN (COSTS OFF) $1" | grep -q 'Columnar Vectorized Group Keys' \
+		&& echo yes || echo no
+}
+
+# The grouped node's "Columnar Batch Fold" value, or empty when the plan has no
+# such line. check_text refuses empty, so a fixture that lost the custom node
+# fails by name instead of passing vacuously.
+fold_of() {	# fold_of <explain-prefix> <query> -> yes|no
+	q "$1 $2" | grep 'Columnar Batch Fold' | grep -oE 'yes|no' | head -1
+}
+
+ANALYZE_PFX="EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF, SUMMARY OFF)"
+PLAIN_PFX="EXPLAIN (COSTS OFF)"
+
+# agree LABEL QUERY_TEMPLATE: run the same query against the columnar table and
+# its heap mirror and require byte-identical ordered output. TBL is substituted.
+# Both sides must be non-empty, so a query that errors on one arm fails here
+# rather than comparing nothing with nothing (#418).
+agree() {	# agree LABEL "SELECT ... FROM %T ..."
+	local label="$1" tmpl="$2" col heap
+	col="$(q "$(printf '%s' "${tmpl//%T/gbb}")" | sort | md5sum | cut -d' ' -f1)"
+	heap="$(q "$(printf '%s' "${tmpl//%T/gbb_h}")" | sort | md5sum | cut -d' ' -f1)"
+	# md5 of empty input is a fixed string, so require the columnar arm produced
+	# rows at all before trusting the comparison.
+	if [ -z "$(q "$(printf '%s' "${tmpl//%T/gbb}")" | head -1)" ]; then
+		PGC_CHECKS=$((PGC_CHECKS + 1)); PGC_FAIL=1
+		echo "FAIL  $label: the columnar arm returned no rows, so nothing was compared"
+		return 1
+	fi
+	check_text "$label" "$col" "$heap"
+}
+
+# ---- fixture ---------------------------------------------------------------
+# 200k rows over several row groups. k is the ordinary integer group key (8
+# groups); k8 a bigint second key; f a float8 key (by value, so eligible, but
+# its equality is NOT bitwise -- -0.0 equals 0.0 -- so it must group through the
+# type's own equality function); t a text key (by reference, ineligible); v and
+# w the aggregate payloads. Every 997th row has a NULL k, so the null-key group
+# is exercised on the fold path rather than assumed.
+#
+# ts and d are here because timestamp and date are in the fold's
+# bitwise-equality key list and nothing else in this tree groups a folded query
+# by either. They are also different widths (8 bytes and 4), so they exercise
+# two different gather strides rather than one.
+DDL="k int, k8 bigint, f float8, t text, ts timestamp, d date, v int, w int"
+GEN="SELECT CASE WHEN g % 997 = 0 THEN NULL ELSE g % 8 END,
+            (g % 5)::bigint,
+            (g % 4)::float8,
+            't' || (g % 6),
+            timestamp '2024-01-01 00:00:00' + ((g % 7) * interval '1 day'),
+            date '2024-03-01' + (g % 9),
+            g,
+            g % 100
+     FROM generate_series(1,200000) g"
+
+psql_run "CREATE TABLE gbb($DDL) USING pgcolumnar;"
+psql_run "INSERT INTO gbb $GEN;"
+psql_run "CREATE TABLE gbb_h($DDL);"
+psql_run "INSERT INTO gbb_h $GEN;"
+
+check_num "premise: fixture loaded every row (columnar)" "$(q1 'SELECT count(*) FROM gbb;')" 200000
+check_num "premise: fixture loaded every row (heap)"     "$(q1 'SELECT count(*) FROM gbb_h;')" 200000
+check_num "premise: the fixture really has null keys" \
+	"$(q1 'SELECT count(*) FROM gbb WHERE k IS NULL;')" \
+	"$(q1 'SELECT count(*) FROM gbb_h WHERE k IS NULL;')"
+check_num "premise: the fixture spans more than one row group" \
+	"$(q1 "SELECT (count(*) > 1)::int FROM pgcolumnar.row_group
+	       WHERE storage_id = pgcolumnar.get_storage_id('gbb'::regclass);")" 1
+
+# ---- the shapes the fold must take -----------------------------------------
+Q_PLAIN="SELECT k, count(*), sum(v) FROM %T GROUP BY k"
+Q_FILT="SELECT k, count(*), sum(v) FROM %T WHERE v < 50000 GROUP BY k"
+Q_TWOKEY="SELECT k, k8, count(*), sum(w) FROM %T GROUP BY k, k8"
+Q_FLOAT="SELECT f, count(*), sum(v) FROM %T GROUP BY f"
+Q_COUNTSTAR="SELECT k, count(*) FROM %T GROUP BY k"
+Q_TS="SELECT ts, count(*), sum(v) FROM %T GROUP BY ts"
+Q_DATE="SELECT d, count(*), sum(w) FROM %T GROUP BY d"
+
+for pair in "plain:$Q_PLAIN" "filtered:$Q_FILT" "two keys:$Q_TWOKEY" \
+            "float8 key:$Q_FLOAT" "count(*):$Q_COUNTSTAR" \
+            "timestamp key:$Q_TS" "date key:$Q_DATE"; do
+	label="${pair%%:*}"; tmpl="${pair#*:}"
+	qcol="${tmpl//%T/gbb}"
+	check_text "$label: the grouped node is planned" "$(is_groupvec "$qcol")" yes
+	check_text "$label: the fold ran (work done)" \
+		"$(fold_of "$ANALYZE_PFX" "$qcol")" yes
+	agree "$label: answers match the heap mirror" "$tmpl"
+done
+
+# ---- the shapes the fold must DECLINE, each with its own oracle -------------
+# A gate that never refuses is not a gate. Each of these must still be the
+# grouped node (so the "no" is the fold declining, not the node being absent)
+# and must still return the right answer on the row path.
+Q_TEXTKEY="SELECT t, count(*), sum(v) FROM %T GROUP BY t"
+Q_EXPRKEY="SELECT k + 1, count(*) FROM %T GROUP BY k + 1"
+Q_MINMAX="SELECT k, min(v), max(v) FROM %T GROUP BY k"
+Q_NEQ="SELECT k, count(*), sum(v) FROM %T WHERE v <> 5 GROUP BY k"
+
+for pair in "text key:$Q_TEXTKEY" "expression key:$Q_EXPRKEY" \
+            "min/max:$Q_MINMAX" "<> filter:$Q_NEQ"; do
+	label="${pair%%:*}"; tmpl="${pair#*:}"
+	qcol="${tmpl//%T/gbb}"
+	if [ "$(is_groupvec "$qcol")" = yes ]; then
+		check_text "$label: the fold declined" \
+			"$(fold_of "$ANALYZE_PFX" "$qcol")" no
+	else
+		# The node itself declined the shape; there is no fold line to read and
+		# nothing for this suite to gate. Say so rather than assert a missing line.
+		echo "SKIP  $label: the grouped node is not planned for this shape"
+	fi
+	agree "$label: answers match the heap mirror" "$tmpl"
+done
+
+# The <> arm is the #715 gate carried onto the grouped path, and it is the one
+# whose failure is a WRONG ANSWER rather than a slow one: the fold's only
+# per-row filter is the scan-key loop, and `<>` produces no scan key at all.
+# Pin the count independently of the md5 so the failure names the number.
+check_num "<> filter: the excluded rows really are excluded" \
+	"$(q1 'SELECT count(*) FROM gbb WHERE v <> 5;')" \
+	"$(q1 'SELECT count(*) FROM gbb_h WHERE v <> 5;')"
+check_num "premise: the <> filter excludes something at all" \
+	"$(q1 'SELECT (count(*) < 200000)::int FROM gbb_h WHERE v <> 5;')" 1
+
+# ---- deletes: the fold must honour the delete mask --------------------------
+psql_run "DELETE FROM gbb   WHERE v % 7 = 0;"
+psql_run "DELETE FROM gbb_h WHERE v % 7 = 0;"
+check_num "premise: the delete removed rows" \
+	"$(q1 'SELECT (count(*) < 200000)::int FROM gbb;')" 1
+check_text "deletes: the fold still ran" \
+	"$(fold_of "$ANALYZE_PFX" "${Q_PLAIN//%T/gbb}")" yes
+agree "deletes: answers match the heap mirror" "$Q_PLAIN"
+
+# ---- toggle-differential: byte-exact against the same rows, path off --------
+# The fold changes accumulation ORDER for nothing: it folds in row order exactly
+# as the row path does. Exact aggregates must be byte-identical with the grouped
+# path off (a scalar Agg over the columnar scan), which is a stronger statement
+# than agreeing with a heap whose physical order differs.
+#
+# The "off" arm sets the GUC through PGOPTIONS rather than a leading SET in the
+# same -c string. psql prints a "SET" command tag into -At output, so the two
+# arms differed by one line and the comparison failed on the tag rather than on
+# any answer -- a difference that would have read as a real defect.
+tog() {	# tog LABEL QUERY(on gbb)
+	local label="$1" query="$2" off on
+	off="$(PGOPTIONS='-c pgcolumnar.enable_group_vectorization=off' \
+		q "$query" | sort | md5sum)"
+	check_text "$label [premise: node fires with the path on]" "$(is_groupvec "$query")" yes
+	on="$(q "$query" | sort | md5sum)"
+	# A premise for the OFF arm too: with the path off the grouped node must NOT
+	# be planned, or both arms ran the same plan and the differential is vacuous.
+	check_text "$label [premise: the off arm is not the grouped node]" \
+		"$(PGOPTIONS='-c pgcolumnar.enable_group_vectorization=off' \
+		   is_groupvec "$query")" no
+	check_text "$label" "$off" "$on"
+}
+tog "toggle-differential: plain"    "${Q_PLAIN//%T/gbb}"
+tog "toggle-differential: filtered" "${Q_FILT//%T/gbb}"
+tog "toggle-differential: two keys" "${Q_TWOKEY//%T/gbb}"
+
+# ---- float8 keys group by the type's equality, not by bits ------------------
+# -0.0 and 0.0 are ONE group in PostgreSQL and have different bit patterns, so a
+# fold that hashed or compared raw Datum bits for float8 would split them. This
+# arm is why float8 keys go through the type's own hash and equality functions
+# even though the column is passed by value and the fold can read it.
+# The negative zero has to be written as '-0'::float8, and the premise below
+# asserts the sign bit really is set in storage. Spelled `-0.0` in a VALUES list
+# it is an untyped literal, so it goes through NUMERIC -- which has no signed
+# zero -- and reaches the column as +0.0. The first version of this fixture did
+# exactly that: it stored three identical +0.0 bit patterns, so a bitwise probe
+# would have grouped them correctly and the arm passed while proving nothing.
+psql_run "CREATE TABLE gbz(f float8, v int) USING pgcolumnar;"
+psql_run "INSERT INTO gbz VALUES ('0'::float8, 1), ('-0'::float8, 2), ('0'::float8, 4), ('NaN'::float8, 8), ('NaN'::float8, 16);"
+psql_run "CREATE TABLE gbz_h(f float8, v int);"
+psql_run "INSERT INTO gbz_h SELECT * FROM gbz;"
+check_text "float8 zero: the fixture really stores a NEGATIVE zero" \
+	"$(q1 "SELECT encode(float8send(f),'hex') FROM gbz WHERE v = 2;")" \
+	"8000000000000000"
+check_text "float8 zero: and a positive one beside it" \
+	"$(q1 "SELECT encode(float8send(f),'hex') FROM gbz WHERE v = 1;")" \
+	"0000000000000000"
+check_text "float8 zero: the grouped node is planned" \
+	"$(is_groupvec 'SELECT f, sum(v) FROM gbz GROUP BY f')" yes
+# Without this the arm below is satisfied by a fold that never ran, which is the
+# only way the bitwise-probe hazard it guards could reach the data at all.
+check_text "float8 zero: and the fold actually ran on it" \
+	"$(fold_of "$ANALYZE_PFX" 'SELECT f, sum(v) FROM gbz GROUP BY f')" yes
+# Count the groups by counting the ROWS the folding query returns, not by
+# wrapping it in an outer count(*): the wrapper changes the plan, the grouped
+# node is not chosen underneath it, and the arm then reports on a query the fold
+# never touched. It sat green through the float8 mutation for exactly that
+# reason while the sums arm beside it went red.
+check_num "float8 zero: -0.0 and 0.0 are one group, exactly as the heap says" \
+	"$(q 'SELECT f, sum(v) FROM gbz GROUP BY f' | wc -l)" \
+	"$(q 'SELECT f, sum(v) FROM gbz_h GROUP BY f' | wc -l)"
+check_text "float8 zero: the grouped sums match the heap" \
+	"$(q 'SELECT f, sum(v) FROM gbz GROUP BY f ORDER BY 1' | md5sum)" \
+	"$(q 'SELECT f, sum(v) FROM gbz_h GROUP BY f ORDER BY 1' | md5sum)"
+
+# ---- the parallel partial grouped fold --------------------------------------
+# The fold has its own isPartial branch: each worker claims row groups through
+# the shared atomic and emits per-worker transition states for a core Finalize to
+# combine (#349). Nothing else in this tree exercises it, because
+# parallel_vector_agg.sh's grouped arms all use a text key or an IS NOT NULL
+# filter and so decline the fold. Untested new code is a claim like any other.
+#
+# The premises here are what stop this being satisfied by core's own parallel
+# grouped plan, which also has a Gather and also launches workers: assert OUR
+# parallel-aware node, assert workers were launched, and assert the fold ran.
+PAR_GUC="SET max_parallel_workers_per_gather=4;
+         SET parallel_setup_cost=0; SET parallel_tuple_cost=0;
+         SET min_parallel_table_scan_size=0; SET min_parallel_index_scan_size=0;
+         SET pgcolumnar.enable_parallel_vector_agg=on;"
+Q_PAR="SELECT k, count(*), sum(v) FROM gbb GROUP BY k"
+PEA="$(q "$PAR_GUC $ANALYZE_PFX $Q_PAR")"
+check_text "parallel: our parallel-aware grouped node is under the Gather" \
+	"$(grep -qi 'Parallel Custom Scan (PgColumnarScan)' <<<"$PEA" &&
+	   grep -qi 'Columnar Vectorized Group Keys' <<<"$PEA" && echo yes || echo no)" yes
+check_text "parallel: workers actually launched for that node" \
+	"$(grep -qiE 'Workers Launched: [1-9]' <<<"$PEA" &&
+	   grep -qi 'Columnar Vectorized Group Keys' <<<"$PEA" && echo yes || echo no)" yes
+check_text "parallel: the fold ran in the partial node (work done)" \
+	"$(grep 'Columnar Batch Fold' <<<"$PEA" | grep -oE 'yes|no' | head -1)" yes
+# Values: the parallel fold must agree with the serial one, byte for byte. Each
+# worker folds a distinct set of row groups, so a claim bug shows up here as a
+# double count rather than an error.
+#
+# The settings go through PGOPTIONS, not a leading SET, for the same reason the
+# toggle-differential above does: psql prints a "SET" command tag per statement
+# into -At output, so an arm with six SETs and an arm with one differ by five
+# lines before any row is compared. Written the obvious way this arm was red
+# with byte-identical data underneath, which reads exactly like a parallel
+# double-count and is not one.
+PAR_OPTS='-c max_parallel_workers_per_gather=4 -c parallel_setup_cost=0 -c parallel_tuple_cost=0 -c min_parallel_table_scan_size=0 -c min_parallel_index_scan_size=0 -c pgcolumnar.enable_parallel_vector_agg=on'
+check_text "parallel: the answers equal the serial fold, byte for byte" \
+	"$(PGOPTIONS="$PAR_OPTS" q "$Q_PAR ORDER BY k" | md5sum)" \
+	"$(PGOPTIONS='-c max_parallel_workers_per_gather=0' q "$Q_PAR ORDER BY k" | md5sum)"
+check_text "parallel: and they equal the heap mirror" \
+	"$(PGOPTIONS="$PAR_OPTS" q "$Q_PAR ORDER BY k" | md5sum)" \
+	"$(q "SELECT k, count(*), sum(v) FROM gbb_h GROUP BY k ORDER BY k" | md5sum)"
+# And the premise those two need: the parallel arm really did run in parallel.
+# Without it both arms are the same serial plan and the comparison is vacuous.
+check_text "parallel: premise: the value arm's own plan launches workers" \
+	"$(PGOPTIONS="$PAR_OPTS" q "$ANALYZE_PFX $Q_PAR" |
+	   grep -qiE 'Workers Launched: [1-9]' && echo yes || echo no)" yes
+
+# ---- a column added after some row groups: predicted yes, ran no ------------
+# Same shape as #602 on the ungrouped node. The old row groups have no chunk for
+# v, so the fold refuses the relation at execution and the whole scan runs the
+# row path. Plain EXPLAIN has no execution to report and keeps the prediction.
+psql_run "CREATE TABLE gba(k int) USING pgcolumnar;"
+psql_run "INSERT INTO gba SELECT g % 8 FROM generate_series(1,50000) g;"
+psql_run "ALTER TABLE gba ADD COLUMN v int;"
+psql_run "INSERT INTO gba SELECT g % 8, g FROM generate_series(1,10000) g;"
+Q_ADD="SELECT k, count(*), sum(v) FROM gba GROUP BY k"
+check_text "add column: plain EXPLAIN reports the prediction" \
+	"$(fold_of "$PLAIN_PFX" "$Q_ADD")" yes
+check_text "add column: ANALYZE reports the row-path run" \
+	"$(fold_of "$ANALYZE_PFX" "$Q_ADD")" no
+check_num "add column: the answer is still right" \
+	"$(q1 "SELECT sum(s) FROM (SELECT sum(v) AS s FROM gba GROUP BY k) x;")" \
+	"$(q1 'SELECT sum(g) FROM generate_series(1,10000) g;')"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -140,6 +140,7 @@ SUITES=(
 	native_format
 	native_gap
 	native_groupagg
+	native_groupagg_batch
 	native_groupagg_wide_cost
 	native_index
 	native_index_fetch_stripe_cost


### PR DESCRIPTION
Closes #708.

The grouped vectorized aggregate was fully row-at-a-time. This gives it the
column-at-a-time fold the ungrouped node has had since #289, and measures the
result with an instrument that is fair on this host.

## What it does

`pgcolumnar_groupagg_batch_fold` walks row groups, gathers each needed column's
packed values directly, applies the delete mask, the skipped-vector map and the
scan keys inline, then probes the group hash table and folds. The row path paid,
for every row scanned: `PgColumnarReadNextRow`, `ResetExprContext`, the
`bms_next_member` slot-staging loop, `ExecStoreVirtualTuple`, `ExecQual`, and one
`ExecEvalExprSwitchContext` per group key. The fold pays none of them. What was
left of the fmgr traffic, the hash and the probe equality, goes inline for key
types whose equality **is** bitwise equality of the Datum.

The shape gates are now single-sourced in `pgcolumnar_batch_gates_ok`, shared
with the ungrouped fold, rather than copied. Every one of those gates was added
to fix a wrong answer or a crash, and a second fold arriving with a stale copy of
the list is precisely how #715 comes back. The grouped node adds one gate of its
own: every group key must be a plain `Var` it can read out of a gathered column.

## Measurement

Instructions retired by the backend (`perf stat -e instructions -p`), which host
contention does not move. 4,000,000 rows, `k int` with 8 distinct groups, `v int`,
PG17, 5 repetitions, warm scan excluded, the plan asserted on **both** arms
(`Columnar Batch Fold: yes` on the new arm; the baseline build has no such line
at all). Same cluster and same fixture for both arms, with only the `.so` swapped.

| query | `main` (row path) | #708 (fold) | ratio | per row |
| --- | ---: | ---: | ---: | --- |
| `SELECT k, count(*), sum(v) ... GROUP BY k` | 15,850,896,522 | 7,352,675,551 | **2.16x** | 793 to 368 |
| the same with `WHERE v < 3000000` | 13,899,374,785 | 6,292,504,808 | **2.21x** | 695 to 315 |

Run again with the arm order reversed, the same four figures came back within
0.68% (base plain 15,853,308,490; base filtered 13,899,612,015; fold plain
7,402,825,977; fold filtered 6,293,789,323), so the ordering effect that makes
wall clock unusable here is absent. One warm repetition moved 227ms to 116ms,
which corroborates the direction independently.

### Three instrument defects, each of which produced a confident wrong number

Worth recording, because two of them looked like results.

1. **This is a hybrid CPU, so `perf` prints two `instructions` lines**, one per
   PMU, each scaled by the fraction of the window that PMU was counting.
   `head -1` took the E-core line alone (6.5e9 of a 14.1e9 backend). **Summing
   them is worse**: one run showed `cpu_core` 15.85e9 at 99.70% beside
   `cpu_atom` 11.07e9 at **0.30%**, an eleven-billion "count" extrapolated 333x
   from three-tenths of one percent, which reported 26.9e9 for an arm two other
   runs put at 15.85e9. Read the PMU that held the window; refuse the run if
   none did.
2. A non-interactive shell starts async children with `SIGINT` **ignored**, and
   the disposition is inherited, so `kill -INT $perfpid` was silently a no-op.
3. `perf stat ... -- sleep N` runs the sleep as a child that inherits the
   command FIFO. On interrupt it was orphaned, kept the write end open, `psql`
   never saw EOF, and the measurement hung in `wait()`. `--timeout` has neither
   problem.

## Verification

`test/native_groupagg_batch.sh`, 62 checks, built RED before the code existed.
It separates the two claims, because an optimisation that stops optimising still
returns correct answers:

- **Answers.** A heap mirror for every shape, plus a toggle-differential against
  the same rows with the path off, which is byte-exact.
- **Work.** `Columnar Batch Fold` on the grouped node under `EXPLAIN ANALYZE`,
  which is the only assertion that can go red when the fold stops folding.

Eligibility is asserted in both directions: a by-reference key, an expression
key, `min`/`max`, and a `<>` filter each have an arm proving the fold **declines**
and an oracle proving the row path still answers correctly.

### Removal proofs

| mutation | result |
| --- | --- |
| delete the `pgcolumnar_groupagg_batch_fold` call | **10 work-done arms red, all 52 correctness arms green** |
| add `FLOAT8OID` to the bitwise-equality key list | **red**: `-0.0` and `0.0` become 3 groups where the heap has 2 |
| drop `PgColumnarQualsExactlyKeyed` from the gates | **red**: the `<>` arm folds and returns a wrong answer |

The float8 proof needed the fixture fixed first: written `(-0.0, 2)` in a
`VALUES` list the literal goes through `numeric`, which has no signed zero, and
reached the column as `+0.0`. The arm passed the mutation while proving nothing.
It now asserts `float8send` is `8000000000000000` before it compares anything.

Two arms were also weaker than they read. Wrapping the grouped query in an outer
`count(*)` changes the plan so the fold never runs underneath it, and the
parallel value arms compared md5s that differed only by `psql`'s `SET` command
tags, which reads exactly like a parallel double-count and was not one.

### Suites

`native_groupagg_batch` 62/62, and green on `native_groupagg`,
`native_groupagg_wide_cost`, `ungrouped_vector_agg`, `batch_fold_explain`,
`parallel_vector_agg`, `native_agg`, `native_agg_addcolumn`, `native_agg_deletes`,
`native_fold_deferral`, `native_fold_skipguard`, `native_vecdecode`,
`native_saop_pushdown`, `rewrite_group_scan`, `native_fetch_group_memo`,
`native_late_materialization`, `column_projection`.

Builds clean with zero warnings on PostgreSQL 15, 16, 17, 18 and 19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8jGnYAbTgiAcoUqn7E9EN
