### PR TITLE
sec: check for interrupts inside the FSST decode loop (#712)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ### Fixed
 
+- The FSST decoder now checks for interrupts inside its decode loop. Every
+  other value decoder already did. The loop is bounded by the encoded length
+  of one vector, so this is a latency bound rather than the uncancellable hang
+  the Thrift and Avro skip loops had, but a large vector could still hold a
+  backend past a cancel or a `statement_timeout`. The check uses an iteration
+  counter rather than a byte offset, because the stride is a mask and a code
+  that advances the pointer by two can step over the exact multiple and never
+  fire. `decode_interrupts` now covers this decoder, and asserts the check sits
+  in the decode loop rather than in the bounded symbol-table parse above it.
+  (#712)
+
 - The object-store write path (export sink, delete, list) now refuses a URL
   with userinfo (`user@host`) with the same error the read path always gave.
   Before, the write parse admitted the URL and failed closed downstream by

--- a/src/columnar_encoding.c
+++ b/src/columnar_encoding.c
@@ -2044,6 +2044,7 @@ decode_fsst_shared(const char *enc, uint32 encLen, const char *table,
 	uint32		nSym;
 	uint32		outPos = 0;
 	uint32		i;
+	uint32		iter = 0;		/* decode-loop iterations, for the interrupt stride */
 
 	/* parse the shared table (pointers reference the caller's descriptor bytes) */
 	if (tableLen < 1)
@@ -2069,9 +2070,25 @@ decode_fsst_shared(const char *enc, uint32 encLen, const char *table,
 		tp += L;
 	}
 
+	/*
+	 * The decode loop, and the one that needs the interrupt check (#712). The
+	 * symbol-table parse above is bounded by tableLen, a few KB at most; this
+	 * one is bounded by encLen, which is a whole vector's code stream.
+	 *
+	 * A separate iteration counter rather than a byte offset, because the stride
+	 * check is a mask: `p` advances by one or two per code, so a test on
+	 * (p - enc) can STEP OVER the exact multiple and never fire. Counting
+	 * iterations advances by exactly one and cannot skip the boundary. Starting
+	 * at zero also means the first iteration always checks, so a vector shorter
+	 * than the stride is still interruptible at its start.
+	 */
 	while (p < end)
 	{
-		unsigned char c = (unsigned char) *p++;
+		unsigned char c;
+
+		COLUMNAR_DECODE_INTERRUPT(iter);
+		iter++;
+		c = (unsigned char) *p++;
 
 		if (c == FSST_ESCAPE)
 		{

--- a/test/decode_interrupts.sh
+++ b/test/decode_interrupts.sh
@@ -71,7 +71,7 @@ checks_in() {  # function-name -> count of interrupt checks in its body
 # Every decoder that walks values one at a time. bitunpack is included because
 # the bit-packed decoders reach their value count through it.
 for f in bitunpack decode_rle decode_for decode_delta decode_gorilla decode_dod \
-         decode_alp decode_dict; do
+         decode_alp decode_dict decode_fsst_shared; do
 	check "$f was found" \
 		"$([ "$(range_of "$f")" != "0 0" ] && echo yes || echo no)" "yes"
 	check "$f checks for interrupts" \
@@ -92,6 +92,22 @@ check "decode_rle's inner value loop was found" \
 check "decode_rle checks inside its value loop, not only around it" \
 	"$(awk -v s="$inner" -v e="$rle_e" \
 		'NR > s && NR <= e && /COLUMNAR_DECODE_INTERRUPT\(/ {n++} END {print n+0}' "$FN" \
+		| awk '{print ($1 >= 1) ? "yes" : "no"}')" "yes"
+
+# decode_fsst_shared is the second place where placement matters rather than
+# presence (#712). It has TWO loops: a symbol-table parse bounded by tableLen,
+# which is a few KB, and the decode loop bounded by encLen, which is a whole
+# vector's code stream. A check in the first satisfies "checks for interrupts"
+# above while leaving the loop that needs it unguarded, so assert the check sits
+# after the decode loop begins.
+fsst_r="$(range_of decode_fsst_shared)"
+fsst_loop="$(awk -v s="${fsst_r% *}" -v e="${fsst_r#* }" \
+	'NR >= s && NR <= e && /while \(p < end\)/ {print NR; exit}' "$FN")"
+check "decode_fsst_shared's decode loop was found" \
+	"$([ -n "$fsst_loop" ] && echo yes || echo no)" "yes"
+check "decode_fsst_shared checks inside its decode loop, not only in the table parse" \
+	"$(awk -v s="$fsst_loop" -v e="${fsst_r#* }" \
+		'NR >= s && NR <= e && /COLUMNAR_DECODE_INTERRUPT\(/ {n++} END {print n+0}' "$FN" \
 		| awk '{print ($1 >= 1) ? "yes" : "no"}')" "yes"
 
 # The stride is what makes the check cheap enough to sit in a per-value loop. A


### PR DESCRIPTION
Closes #712.

`decode_fsst_shared` was the one value decoder with no
`COLUMNAR_DECODE_INTERRUPT`. Its loop is bounded by `encLen`, one vector's code
stream, so this is a latency bound rather than the uncancellable hang the Thrift
and Avro skip loops had (#694) — but a large vector can still hold a backend
past a cancel or a `statement_timeout`, and every other decoder already checks.

## An iteration counter, not a byte offset

The stride is a **mask**, and an FSST code advances the pointer by one or two
bytes, so a test on `(p - enc)` can step over the exact multiple and never fire.
Counting iterations advances by exactly one and cannot skip the boundary.

Starting at zero also means the first iteration always checks, so a vector
shorter than the stride is interruptible at its start rather than only at 65,536
codes in. That is what stops the check being dead code on ordinary data.

## Why shape and not a live cancel

Same reason `decode_interrupts` and the `av_skip` arm of
`decode_skip_interrupts` already give: the window is bounded and far too small
to race a `statement_timeout` against reliably, so a timing test here would be
flaky rather than informative. The reachable-now behaviour of the whole
interrupt-check class is already proven functionally by the Thrift bomb in
`decode_skip_interrupts`.

`decode_fsst_shared` joins the existing decoder list, and a second arm pins
**placement**, because the function has two loops and only one needs this: the
symbol-table parse is bounded by `tableLen`, a few KB at most.

## Removal proofs

The second is the reason the placement arm exists at all.

| mutation | presence arm | placement arm |
| --- | --- | --- |
| remove the check entirely | **red** | **red** |
| move it into the symbol-table parse loop | pass | **red** |

So the presence arm on its own would have accepted a check sitting in the loop
that does not need one.

## Suites

10 green on PG17: `decode_interrupts`, `write_fsst_compressed`, `fsst_margin`,
`fsst_verdict_cache`, `encode_invariants`, `native_encoding`,
`native_roundtrip`, `differential`, `decode_skip_interrupts`, `cancel_decode`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8jGnYAbTgiAcoUqn7E9EN
