### PR TITLE
mod: make the Parquet level-width shift unsigned and bounded, and single-source it (#710)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,22 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ### Fixed
 
+- The Parquet level-width helper no longer performs a signed left shift that
+  is undefined for a maximum level at or above 2^30, and no longer has two
+  copies. It computed `1 << b` with `b` reaching 31; real schemas cannot get
+  there, because levels accumulate one per nesting level from a bounded
+  recursion, but it was undefined behaviour in a decoder that reads files it
+  did not write. Making the shift unsigned is not the whole fix on its own: it
+  makes the comparison unsigned too, so a negative maximum converts to a huge
+  value and the loop runs to a 32-place shift that is undefined in turn, and
+  does not terminate under a recovering sanitizer. The helper now returns
+  early for a non-positive maximum and bounds the loop. It also moved to
+  `columnar_parquet_format.h`, which the writer and the reader already share,
+  because a writer and a reader that disagree on a level width produce a file
+  that is silently wrong rather than one that fails to parse. Values are
+  unchanged on every reachable input. A new suite, `parquet_level_width`,
+  pins the parts no query can reach. (#710)
+
 - The object-store write path (export sink, delete, list) now refuses a URL
   with userinfo (`user@host`) with the same error the read path always gave.
   Before, the write parse admitted the URL and failed closed downstream by

--- a/src/columnar_parquet.c
+++ b/src/columnar_parquet.c
@@ -506,15 +506,6 @@ shred_top(TopColumn *tc, PqLeaf *leaves, Datum d, bool isnull)
 	}
 }
 
-static int
-bits_for(int m)
-{
-	int			b = 0;
-
-	while ((1 << b) <= m)
-		b++;
-	return b;
-}
 
 /*
  * Build an RLE/bit-packed hybrid level section (one bit-packed run at the given
@@ -581,9 +572,9 @@ build_leaf_body(StringInfo body, PqLeaf *c)
 {
 	if (c->max_rep > 0)
 		build_rle_levels(body, (const uint8 *) c->reps.data, c->nEntries,
-						 bits_for(c->max_rep));
+						 pq_bits_for(c->max_rep));
 	build_rle_levels(body, (const uint8 *) c->defs.data, c->nEntries,
-					 bits_for(c->max_def));
+					 pq_bits_for(c->max_def));
 	build_values(body, c);
 }
 

--- a/src/columnar_parquet_format.h
+++ b/src/columnar_parquet_format.h
@@ -87,4 +87,43 @@
 #define TC_SET					10
 #define TC_STRUCT				12
 
+/*
+ * pq_bits_for
+ *		The bit width the RLE/bit-pack level encoding uses for a maximum
+ *		definition or repetition level: the smallest b with maxval < 2^b.
+ *
+ *		Shared rather than duplicated for the reason this whole header exists.
+ *		The writer and the reader each had their own copy, byte-identical and
+ *		with nothing making them stay that way, and a writer and a reader that
+ *		disagree on a level width produce a file that is silently wrong rather
+ *		than one that fails to parse (#710).
+ *
+ *		The shift is UNSIGNED and the loop is BOUNDED, and both matter:
+ *
+ *		`1 << b` is signed, so it is undefined once b reaches 31, which the loop
+ *		reaches for any maxval >= 2^30. Not reachable from a real schema --
+ *		levels accumulate one per nesting level from a recursion that
+ *		check_stack_depth bounds -- but it is undefined behaviour sitting in a
+ *		decoder that reads attacker-authored files, and the compiler is entitled
+ *		to assume it cannot happen.
+ *
+ *		`1u << b` alone is NOT the whole fix. It makes the comparison unsigned,
+ *		so a negative maxval converts to a huge unsigned value and the loop runs
+ *		to b == 32, where the unsigned shift is undefined in its own right. The
+ *		non-positive guard and the b < 31 bound close both ends, and make the
+ *		function correct over the whole int domain instead of resting on a
+ *		caller property two files away.
+ */
+static inline int
+pq_bits_for(int maxval)
+{
+	int			b = 0;
+
+	if (maxval <= 0)
+		return 0;				/* zero needs no bits, and negatives have none */
+	while (b < 31 && (1u << b) <= (unsigned int) maxval)
+		b++;
+	return b;
+}
+
 #endif							/* PGCOLUMNAR_PARQUET_FORMAT_H */

--- a/src/columnar_parquet_reader.c
+++ b/src/columnar_parquet_reader.c
@@ -859,15 +859,6 @@ rle_bitpack_decode(const uint8 *buf, size_t len, int bit_width,
 	return true;
 }
 
-static int
-bits_for(int maxval)
-{
-	int			b = 0;
-
-	while ((1 << b) <= maxval)
-		b++;
-	return b;
-}
 
 /* -------------------------------------------------------------------------
  * Per-column import plan derived from the target tuple descriptor.
@@ -2021,14 +2012,14 @@ decode_leaf_entries(PqSource *src, PqChunk *ch,
 				{
 					preps = palloc(sizeof(uint32) * npage);
 					if (!rle_bitpack_decode(levels, h.rep_levels_len,
-											bits_for(max_rep), npage, preps))
+											pq_bits_for(max_rep), npage, preps))
 						return false;
 				}
 				if (max_def > 0)
 				{
 					pdefs = palloc(sizeof(uint32) * npage);
 					if (!rle_bitpack_decode(levels + h.rep_levels_len,
-											h.def_levels_len, bits_for(max_def),
+											h.def_levels_len, pq_bits_for(max_def),
 											npage, pdefs))
 						return false;
 				}
@@ -2072,7 +2063,7 @@ decode_leaf_entries(PqSource *src, PqChunk *ch,
 					if (off + llen > pblen)
 						return false;
 					preps = palloc(sizeof(uint32) * npage);
-					if (!rle_bitpack_decode(pb + off, llen, bits_for(max_rep),
+					if (!rle_bitpack_decode(pb + off, llen, pq_bits_for(max_rep),
 											npage, preps))
 						return false;
 					off += llen;
@@ -2088,7 +2079,7 @@ decode_leaf_entries(PqSource *src, PqChunk *ch,
 					if (off + llen > pblen)
 						return false;
 					pdefs = palloc(sizeof(uint32) * npage);
-					if (!rle_bitpack_decode(pb + off, llen, bits_for(max_def),
+					if (!rle_bitpack_decode(pb + off, llen, pq_bits_for(max_def),
 											npage, pdefs))
 						return false;
 					off += llen;

--- a/test/parquet_level_width.sh
+++ b/test/parquet_level_width.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# pgColumnar #710: the Parquet level-width helper, pinned as a source invariant.
+#
+# pq_bits_for computes the bit width the RLE/bit-pack level encoding uses for a
+# maximum definition or repetition level. Two things about it cannot be reached
+# from SQL, and so cannot be tested behaviourally:
+#
+#   1. It was DUPLICATED, once in the writer and once in the reader, byte
+#      identical with nothing making them stay that way. A writer and a reader
+#      that disagree on a level width produce a file that is silently wrong
+#      rather than one that fails to parse, which is the same hazard
+#      columnar_parquet_format.h was created to end for the format constants.
+#
+#   2. Its loop was `while ((1 << b) <= maxval)`, and `1 << b` is signed, so it
+#      is undefined once b reaches 31 -- which the loop reaches for any
+#      maxval >= 2^30. Levels accumulate one per nesting level from a recursion
+#      that check_stack_depth bounds, so a real schema cannot get there; but it
+#      is undefined behaviour in a decoder that reads attacker-authored files,
+#      and a compiler is entitled to assume it cannot happen.
+#
+# The VALUES are already covered behaviourally: parquet_nested,
+# parquet_nested_import and native_parquet_multifile all round-trip schemas with
+# real definition and repetition levels, and an implementation that computed a
+# different width would corrupt them. Verified separately that old and new agree
+# on every reachable input (0 through 2^29) before this shipped, so those suites
+# are the correctness gate and this suite is not duplicating them.
+#
+# What this pins is the part no query can reach. It is deliberately a source
+# check, in the same spirit as the placement arms in decode_interrupts.sh.
+#
+# Usage:  test/parquet_level_width.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/src"
+HDR="$SRC/columnar_parquet_format.h"
+
+# The body, so every assertion below reads the shared definition and not a
+# comment that happens to mention it.
+body="$(awk '/^pq_bits_for\(int maxval\)/{f=1} f{print} f&&/^}/{exit}' "$HDR")"
+
+check "the shared level-width helper exists" \
+	"$([ -n "$body" ] && echo yes || echo no)" "yes"
+
+# SINGLE-SOURCED. A local copy reappearing in either .c file is the drift this
+# is here to catch, and it would not fail any other check in the tree.
+check "no local copy of the helper survives in the writer or the reader" \
+	"$(grep -cE '^[a-z_]*bits_for\(int' "$SRC/columnar_parquet.c" "$SRC/columnar_parquet_reader.c" \
+		| awk -F: '{n += $2} END {print n+0}')" "0"
+check "and both callers reach the shared one" \
+	"$([ "$(grep -c 'pq_bits_for(' "$SRC/columnar_parquet.c")" -ge 1 ] &&
+	   [ "$(grep -c 'pq_bits_for(' "$SRC/columnar_parquet_reader.c")" -ge 1 ] &&
+	   echo yes || echo no)" "yes"
+
+# UNSIGNED. This is the #710 defect itself.
+check "the shift is unsigned" \
+	"$(grep -c '1u <<' <<<"$body")" "1"
+check "and no signed 1 << remains in it" \
+	"$(grep -cE '\(1 <<|[^u] 1 <<' <<<"$body")" "0"
+
+# BOUNDED, which `1u <<` alone does NOT give. Making the shift unsigned also
+# makes the comparison unsigned, so a negative maxval converts to a huge value
+# and the loop runs to b == 32, where the unsigned shift is undefined in its own
+# right -- and under a recovering sanitizer it does not terminate at all.
+# Measured: the literal 1u<<b form ran past 200 iterations on maxval = -1 while
+# this form returns 0. Both ends are asserted because only fixing one moves the
+# bug rather than removing it.
+check "the loop is bounded below 32 shifts" \
+	"$(grep -c 'b < 31' <<<"$body")" "1"
+check "a non-positive maximum returns before shifting at all" \
+	"$(grep -c 'maxval <= 0' <<<"$body")" "1"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -211,6 +211,7 @@ SUITES=(
 	parquet_count_bounds
 	parquet_export
 	parquet_import
+	parquet_level_width
 	parquet_nested
 	parquet_nested_import
 	pg19_vacuum_options


### PR DESCRIPTION
Closes #710.

## The issue's proposed fix would have been worse than the defect

Worth leading with, because it is the substance of this PR.

`bits_for` computed `1 << b` with `b` reaching 31, undefined for any
`maxval >= 2^30`. The issue proposed `1u << b`. Applied literally, that makes
the **comparison** unsigned too, so a negative `maxval` converts to a huge value
and the loop runs to `b == 32` — where the unsigned shift is undefined in its
own right, and under a recovering sanitizer the loop **does not terminate**.

Measured on a standalone UBSan harness, all three forms side by side:

| form | `maxval = 1<<30` | `maxval = -1` |
| --- | --- | --- |
| shipped `1 << b` | `runtime error: left shift of 1 by 31 places cannot be represented in type 'int'` | 0 |
| the issue's `1u << b` | fine | `runtime error: shift exponent 32 is too large` — **and ran past a 200-iteration cap** |
| this PR | 31 | 0 |

So this also returns early for a non-positive maximum and bounds the loop at 31.
Negatives are not reachable — `max_def`/`max_rep` only increment from zero — but
the guard costs nothing and makes the function correct over its whole `int`
domain rather than resting on a caller property two files away.

## It was also duplicated

Byte-identical, once in the writer and once in the reader, with nothing making
them stay that way. It moves to `columnar_parquet_format.h`, which both already
include and which exists for exactly this hazard — its own preamble says the
constants "were previously declared twice … the values did agree, but nothing
made them", and a writer and a reader that disagree on a level width produce a
file that is **silently wrong** rather than one that fails to parse.

## Values are unchanged

Verified against the original on every reachable input, 0 through 2^29: they
agree at every one. So the existing nested-Parquet round-trip suites remain the
correctness gate and this PR is not changing behaviour.

## What the new suite pins, and why it is a source check

`test/parquet_level_width.sh`. Both properties above are unreachable from SQL —
one is a duplication hazard, the other is UB a real schema cannot trigger — so
there is no query that can go red for them. It pins single-sourcing, the
unsigned shift, and the bound, in the spirit of the placement arms in
`decode_interrupts.sh`.

### Removal proofs

| mutation | result |
| --- | --- |
| revert to the signed `1 << b` | **4 arms red** |
| apply the issue's literal `1u << b` | unsigned arms pass, **both bound arms red** |

The second is what makes the bound arms load-bearing rather than decoration.

## Suites

13 green on PG17: `parquet_level_width`, `parquet_nested`,
`parquet_nested_import`, `parquet_import`, `parquet_export`,
`native_parquet_multifile`, `native_parquet_projection`,
`native_parquet_schema`, `native_read_parquet`, `native_parquet_hardening`,
`native_parquet_units`, `parquet_count_bounds`, `arrow_nested`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8jGnYAbTgiAcoUqn7E9EN
