### PR TITLE
sec: size the Iceberg name-mapping allocation by the cap, not the file (#711)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,19 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
   in the decode loop rather than in the bounded symbol-table parse above it.
   (#712)
 
+- The Iceberg name-mapping parse sizes its first allocation by the name cap
+  rather than by the element count the file declares. The cap
+  (`ICE_MAX_NAME_MAPPING`, 100000) was applied inside the loop, after an
+  allocation taken from the document, so a mapping declaring N entries asked
+  for 12N bytes up front however few names it actually held. The surplus is
+  never written, so it costs address space rather than resident memory, and
+  the effect on peak RSS measured 28 kB out of 1196 MB; this is
+  defense-in-depth rather than a memory saving, independent of the 64 MB
+  metadata bound several layers away that was the only other thing limiting
+  it. `iceberg_name_mapping` gains arms at and one over the cap, built as a
+  single entry carrying many names, which is the shape where the opening
+  capacity and the real ceiling are furthest apart. (#711)
+
 - The object-store write path (export sink, delete, list) now refuses a URL
   with userinfo (`user@host`) with the same error the read path always gave.
   Before, the write parse admitted the URL and failed closed downstream by

--- a/src/columnar_iceberg.c
+++ b/src/columnar_iceberg.c
@@ -1760,7 +1760,26 @@ ice_name_mapping(JsonbContainer *root, const char *path,
 						path)));
 	arr = &arrjb->root;
 	ne = JsonContainerSize(arr);
-	cap = Max(ne, 1);
+
+	/*
+	 * Size the FIRST allocation by the cap, not by the element count the file
+	 * declares (#711).
+	 *
+	 * ne is attacker-controlled and is not an upper bound on the name count
+	 * anyway -- one entry carries a list of names, so n can exceed ne -- which
+	 * is why the array grows by doubling below. It is only an opening guess,
+	 * and taking it from the file meant a document of N tiny entries asked for
+	 * 12N bytes up front: about four bytes of allocation per byte of input,
+	 * from a path whose only other bound is the 64 MB metadata slurp several
+	 * layers away, which protects a different thing and could change without
+	 * this being reconsidered.
+	 *
+	 * ICE_MAX_NAME_MAPPING is the real ceiling: the loop below refuses the
+	 * document once n reaches it, so n can never exceed it and any capacity
+	 * beyond it could never be used. The doubling may still overshoot the cap
+	 * by up to one step, which is bounded and not worth a second clamp.
+	 */
+	cap = Max(Min(ne, (uint32) ICE_MAX_NAME_MAPPING), 1);
 	names = (char **) palloc(sizeof(char *) * cap);
 	ids = (int *) palloc(sizeof(int) * cap);
 

--- a/test/iceberg_name_mapping.sh
+++ b/test/iceberg_name_mapping.sh
@@ -122,4 +122,60 @@ check "...and its other columns still carry real data" \
 	      AS t(id bigint, region text, amount int) ORDER BY id LIMIT 1")" "eu"
 check "backend still up after the null-fill reads" "$(q 'SELECT 1')" "1"
 
+# ---- the name cap, and the allocation that opens for it (#711) --------------
+# ICE_MAX_NAME_MAPPING bounds the NAME count, and the entry count is not an
+# upper bound on it: one entry carries a whole list of names, so a single entry
+# can drive the count to the cap on its own. These fixtures are built that way
+# on purpose -- one entry, many names -- because that is the shape where the
+# array's opening capacity (taken from the entry count) and its real ceiling
+# (the cap) are furthest apart, and it is the shape the growth path has to
+# handle correctly.
+CAP=100000
+python3 - "$MDIR" "$CAP" <<'PY_CAP'
+import json, sys
+d, cap = sys.argv[1], int(sys.argv[2])
+base = json.load(open(d + "/nmapply.metadata.json"))
+real = json.loads(base["properties"]["schema.name-mapping.default"])
+
+def write(tag, extra):
+    md = json.loads(json.dumps(base))
+    # one entry carrying `extra` unique filler names, beside the real mapping
+    filler = {"field-id": 1, "names": ["f%d" % i for i in range(extra)]}
+    md["properties"]["schema.name-mapping.default"] = json.dumps(real + [filler])
+    open(d + "/" + tag + ".metadata.json", "w").write(json.dumps(md))
+
+# the real mapping already contributes 3 names, so `cap - 3` reaches exactly the
+# cap and `cap - 2` is the first document over it
+write("nmcap_at", cap - 3)
+write("nmcap_over", cap - 2)
+PY_CAP
+
+# At the cap: accepted, and the mapping still binds. A fixture that errored here
+# would make the over-cap arm below vacuous, since both would just be errors.
+check "a mapping with exactly the cap in names is accepted" \
+	"$(q "SELECT count(*) FROM pgcolumnar.iceberg_scan('$MDIR/nmcap_at.metadata.json')
+	      AS t(id bigint, region text, amount int)")" "5"
+
+# One over: refused, by SQLSTATE and not by message text. 54000 comes from
+# ERRCODE_PROGRAM_LIMIT_EXCEEDED and nothing else on this path returns it.
+check "one name over the cap is refused" \
+	"$(sqlstate_of "SELECT * FROM pgcolumnar.iceberg_scan('$MDIR/nmcap_over.metadata.json')
+	                AS t(id bigint, region text, amount int)")" "54000"
+check "...and the refusal names the cap" \
+	"$(errmsg_of "SELECT * FROM pgcolumnar.iceberg_scan('$MDIR/nmcap_over.metadata.json')
+	              AS t(id bigint, region text, amount int)" | grep -c "more than $CAP names")" "1"
+
+# The opening allocation is sized by the cap, not by the count the file declares.
+# This is a source check because it is not observable from SQL: the surplus is
+# palloc'd and never written, and untouched pages never become resident, so it
+# costs address space rather than memory and no query can see it. Measured: a
+# 6.4 MB mapping moved peak RSS by 28 kB out of 1,196 MB with and without the
+# fix. (That 1,196 MB is a separate and much larger defect, filed as #731; it is
+# not this one, and this arm deliberately does not claim it.)
+ICE_SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/src/columnar_iceberg.c"
+check "the opening capacity is bounded by the cap, not by the declared count" \
+	"$(grep -c 'cap = Max(Min(ne, (uint32) ICE_MAX_NAME_MAPPING), 1)' "$ICE_SRC")" "1"
+
+check "backend still up after the cap reads" "$(q 'SELECT 1')" "1"
+
 pgc_summary


### PR DESCRIPTION
Closes #711.

`ice_name_mapping` took its opening capacity from `JsonContainerSize`, the
element count the document declares, and applied `ICE_MAX_NAME_MAPPING` only
inside the loop. A mapping declaring N entries therefore asked for 12N bytes up
front however few names it actually carried. `n` can never exceed the cap,
because the loop refuses the document at it, so any capacity beyond the cap
could never be used.

## What this fix is actually worth: almost nothing, measurably

Leading with this because I measured it and would rather say so.

The surplus is `palloc`'d and **never written**, and untouched pages never become
resident. So it costs address space, not memory. On a 6.4 MB mapping of 1.6M
empty entries, peak RSS moved **28 kB out of 1,196 MB** with and without the fix.

It is genuine defense-in-depth, exactly as the issue framed it — independent of
the 64 MB metadata bound several layers away, which guards a different thing and
could change without this being reconsidered. It is not a memory win, and the
suite arm for it is a **source** check for the same reason: no query can observe
an allocation nobody touches.

## The measurement found something much bigger, filed as #731

That 1,196 MB is a real defect and it is **not this one**. The name-mapping parse
allocates roughly **190 bytes of resident memory per byte of input**, linearly,
from elements that contribute zero names:

| padding entries | metadata file | peak RSS delta |
| ---: | ---: | ---: |
| 100,000 | ~0.4 MB | 77 MB |
| 400,000 | ~1.6 MB | 301 MB |
| 1,600,000 | ~6.4 MB | 1,196 MB |

Through the 64 MB metadata bound that is roughly **12 GB from one file**,
reachable by anyone who can name a metadata file. Filed as #731 with the numbers,
the instrument, and an explicitly unverified hypothesis about which allocation
dominates. Not chased here, because it is not #711.

## The boundary arms, and why one entry carries many names

The entry count is **not** an upper bound on the name count — one entry carries a
whole list — so a single entry can drive the count to the cap by itself. That is
the shape where the opening capacity and the real ceiling are furthest apart, and
where the growth path has to be right, so the fixtures are built that way rather
than as N entries of one name each.

- at exactly the cap: accepted, and the mapping still binds (5 rows). A fixture
  that errored here would make the arm below vacuous, since both would be errors.
- one name over: refused, asserted by **SQLSTATE 54000**, not by message text,
  with a separate arm on the message naming the cap.

## Removal proofs

| mutation | result |
| --- | --- |
| revert the allocation to `Max(ne, 1)` | source arm **red** |
| remove the name cap entirely | **both boundary arms red** |

The second is what makes the boundary arms evidence about the cap rather than
about the fixture.

## Suites

9 green on PG17: `iceberg_name_mapping` (22 checks), `iceberg_scan`,
`iceberg_catalog`, `iceberg_malformed`, `iceberg_data_files`, `iceberg_deletes`,
`iceberg_fdw`, `iceberg_rest`, `docs_style`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8jGnYAbTgiAcoUqn7E9EN
