### PR TITLE
explain: report the ungrouped vector aggregate's pushdown counts on a plain EXPLAIN (#726)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ### Fixed
 
+- A plain `EXPLAIN` of the ungrouped vectorized aggregate now reports the
+  filters it pushes down. The counts were assigned after the node's
+  EXPLAIN-only return, so a plain plan printed zero for both
+  `Columnar Pushed-Down Filters` and `Columnar Vector Predicates` however many
+  there really were, while `EXPLAIN ANALYZE` of the same query reported them
+  correctly. A hard zero reads as pushdown not happening rather than as a number
+  that was never filled in, and it left the two vectorized nodes disagreeing
+  about one label, since the grouped node has always counted before its own
+  return. Both counts are catalog and plan work only. (#726)
+
 - The FSST decoder now checks for interrupts inside its decode loop. Every
   other value decoder already did. The loop is bounded by the encoded length
   of one vector, so this is a latency bound rather than the uncancellable hang

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -2151,6 +2151,37 @@ PgColumnarBeginAggScan(CustomScanState *node, EState *estate, int eflags)
 			pgcolumnar_batch_shape_eligible(state, tupdesc, NULL, NULL);
 	}
 
+	/*
+	 * The EXPLAIN counts, settled BEFORE the EXPLAIN-only return (#726).
+	 *
+	 * They were assigned below it, so a plain EXPLAIN of this node printed the
+	 * palloc0 zero for both, whatever the truth was: a query whose filter really
+	 * did become scan keys still reported "Columnar Pushed-Down Filters: 0".
+	 * Under ANALYZE the same plan reported the real number, which is why every
+	 * existing arm in pushdown_report.sh missed it.
+	 *
+	 * That is the #602 shape on another line, a plain-EXPLAIN value that was
+	 * never computed, and it left the two vectorized nodes disagreeing about one
+	 * label: the grouped node has always counted before its own return. Both
+	 * calls are catalog and plan only and do no I/O, which is the same argument
+	 * the scalar node already makes for computing its keys in EXPLAIN-only mode.
+	 *
+	 * Only the count survives, and only EXPLAIN reads it. The predicate array was
+	 * stored here and never read: what would have applied it had no call site
+	 * anywhere in the tree and is deleted (issue #200).
+	 *
+	 * The call stays rather than the count being hardcoded to zero. This path is
+	 * only chosen when the relation has no quals, so the count is always zero
+	 * today and the call looks redundant, but that is an inference from a
+	 * planner early return several hundred lines away, and it is the kind that
+	 * stops being true without anyone noticing. Computing it costs one walk of
+	 * an empty list.
+	 */
+	PgColumnarCountConvertibleQuals(state->quals, state->scanrelid, tupdesc,
+								  &state->npreds, &allConvertible);
+	state->nscankeys = PgColumnarCountScanKeys(state->quals, state->scanrelid,
+											 tupdesc);
+
 	if (eflags & EXEC_FLAG_EXPLAIN_ONLY)
 	{
 		table_close(rel, AccessShareLock);
@@ -2186,23 +2217,6 @@ PgColumnarBeginAggScan(CustomScanState *node, EState *estate, int eflags)
 			spec->typlen = att->attlen;
 		}
 	}
-
-	/*
-	 * Only the count survives, and only EXPLAIN reads it. The predicate array was
-	 * stored here and never read: what would have applied it had no call site
-	 * anywhere in the tree and is deleted (issue #200).
-	 *
-	 * The call stays rather than the count being hardcoded to zero. This path is
-	 * only chosen when the relation has no quals, so the count is always zero
-	 * today and the call looks redundant, but that is an inference from a
-	 * planner early return several hundred lines away, and it is the kind that
-	 * stops being true without anyone noticing. Computing it costs one walk of
-	 * an empty list.
-	 */
-	PgColumnarCountConvertibleQuals(state->quals, state->scanrelid, tupdesc,
-								  &state->npreds, &allConvertible);
-	state->nscankeys = PgColumnarCountScanKeys(state->quals, state->scanrelid,
-											 tupdesc);
 
 	/*
 	 * Scan-fold mode reads and rechecks every surviving row (#289): a virtual

--- a/test/pushdown_report.sh
+++ b/test/pushdown_report.sh
@@ -290,6 +290,59 @@ check "ungrouped: the usable arm removes chunk groups" \
 check "ungrouped: the unusable arm removes none" \
 	"$(field "$u_unusable" 'Columnar Chunk Groups Removed by Filter')" "0"
 
+# ---- plain EXPLAIN must report the count too (#726) -------------------------
+# Every arm in this file so far uses EXPLAIN ANALYZE, and that is exactly how
+# this went unnoticed. The ungrouped node assigns nscankeys and npreds AFTER its
+# EXEC_FLAG_EXPLAIN_ONLY return, so under ANALYZE the numbers are right and under
+# a plain EXPLAIN they are still their palloc0 zero -- whatever the truth is.
+#
+# It is the #602 shape on a different line: a plain-EXPLAIN value that was never
+# computed. `Columnar Pushed-Down Filters` is a line people read to decide
+# whether pushdown is working, and a hard zero reads as "pushdown is not
+# happening" rather than "this number was not filled in". It is also the line a
+# pushdown measurement pins its premise on, and a premise that is always zero
+# cannot fail for the right reason.
+#
+# The GROUPED node has always done this correctly, so the two vectorized nodes
+# disagreed about the same label -- which is what #493 exists to prevent.
+plainplan() {  # plainplan <guc> <sql>
+	q "SET pgcolumnar.enable_qual_pushdown = on;
+	   SET $1 = on;
+	   EXPLAIN (COSTS OFF) $2;"
+}
+PDR_Q="SELECT count(*), sum(b) FROM pdr_u WHERE plain > $((ROWS - 10000))"
+u_plain="$(plainplan $UAGG "$PDR_Q")"
+
+check "premise: the plain EXPLAIN arm is the ungrouped vectorized aggregate" \
+	"$(has "$u_plain" 'Columnar Vectorized Aggregates')" "yes"
+# The premise that makes a zero meaningful: under ANALYZE the number is NOT zero,
+# so a zero on the plain plan is a value that was never filled in rather than an
+# honest report of no pushdown.
+check "premise: the same query under ANALYZE reports a non-zero count" \
+	"$([ "$(field "$u_usable" 'Columnar Pushed-Down Filters')" -gt 0 ] && echo yes || echo no)" "yes"
+
+check "plain EXPLAIN reports the ungrouped node's pushed-down filters (#726)" \
+	"$(field "$u_plain" 'Columnar Pushed-Down Filters')" \
+	"$(field "$u_usable" 'Columnar Pushed-Down Filters')"
+check "plain EXPLAIN reports the ungrouped node's vector predicates (#726)" \
+	"$(field "$u_plain" 'Columnar Vector Predicates')" \
+	"$(field "$u_usable" 'Columnar Vector Predicates')"
+
+# And the two vectorized nodes must agree with each other on a plain plan, which
+# is the property that was actually broken: one label, one quantity, every node.
+# The same shape the grouped arms below already use, so the node is genuinely
+# planned. Written first with a GROUP BY on a column this table does not have,
+# which errored, reported "no such node", and SKIPPED -- a check that proves
+# nothing while looking like coverage. The node assertion below is what turns
+# that into a failure instead of a shrug.
+g_plain="$(plainplan pgcolumnar.enable_group_vectorization \
+	"SELECT b, count(*) FROM pdr_u WHERE plain > $((ROWS - 10000)) GROUP BY 1")"
+check "premise: the grouped node IS planned for the cross-node arm" \
+	"$(has "$g_plain" 'Columnar Vectorized Group Keys')" "yes"
+check "plain EXPLAIN: the grouped node agrees with the ungrouped one (#493, #726)" \
+	"$(field "$g_plain" 'Columnar Pushed-Down Filters')" \
+	"$(field "$u_plain" 'Columnar Pushed-Down Filters')"
+
 # One label, one quantity, on every node (#493).
 #
 # "Columnar Pushed-Down Filters" used to come from PgColumnarCountConvertibleQuals


### PR DESCRIPTION
Closes #726.

`PgColumnarBeginAggScan` assigned `nscankeys` and `npreds` **after** its
`EXEC_FLAG_EXPLAIN_ONLY` return, so a plain `EXPLAIN` of the node printed the
`palloc0` zero for both `Columnar Pushed-Down Filters` and
`Columnar Vector Predicates` however many there really were.

`EXPLAIN ANALYZE` of the same query reported them correctly — which is exactly
why this went unnoticed: **every existing arm in `pushdown_report.sh` uses
ANALYZE.**

## Why a wrong zero here is worse than it looks

It is the #602 shape on another line: a plain-EXPLAIN value that was never
computed. A hard zero reads as *pushdown is not happening* rather than *this
number was not filled in*. It is also the line a pushdown measurement pins its
premise on, and a premise that is always zero cannot fail for the right reason.

And it left the two vectorized nodes disagreeing about one label — the grouped
node has always counted before its own return — which is the thing #493 exists
to prevent.

Both calls are catalog and plan work only and do no I/O, the same argument the
scalar node already makes for computing its keys in EXPLAIN-only mode.

## The arms

Four, on plain `EXPLAIN` rather than ANALYZE:

- each count compared against what **ANALYZE reports for the same query**, so a
  zero is known to be a missing value rather than an honest one
- a **cross-node** arm requiring the grouped and ungrouped nodes to agree on the
  shared label

### Removal proof

Moving the assignments back below the return reddens all three value arms —
including the cross-node one, which then shows the grouped node reporting 1
against the ungrouped node's 0.

### The cross-node arm needed fixing before it was worth anything

Written first with a `GROUP BY` on a column `pdr_u` does not have, it errored,
reported "no such node", and **SKIPPED** — a check that proves nothing while
looking like coverage. It now uses the shape the file's own grouped arms use,
with a premise asserting the node really is planned, so a future planner change
fails here instead of shrugging.

## Suites

10 green on PG17, including every suite in the tree that reads either of these
lines (`pushdown_report`, `native_skip`, `vector_agg_rescan_memory`,
`native_saop_pushdown`, `ungrouped_vector_agg`) plus `native_groupagg`,
`native_agg`, `batch_fold_explain`, `zonemap_cost`, `docs_style`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8jGnYAbTgiAcoUqn7E9EN
