### PR TITLE
opt: reclaim the row-group list a columnar rescan rebuilds (#734)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ### Fixed
 
+- A columnar scan no longer grows query memory on every rescan. A rescan reuses
+  the read state rather than closing and re-opening it, and each restart rebuilt
+  the row-group list and its per-group metadata into the read state's own
+  context without reclaiming the previous one, so a LATERAL or parameterized
+  scan accumulated one list per outer row. The list now has a context the
+  rescan resets. Measured against the same query over a heap table with
+  identical data, so the figure is what pgcolumnar adds rather than what
+  re-executing any node costs: 198 bytes per rescan against a 33 byte heap
+  floor before, 33 against 33 after. (#734)
+
 - A plain `EXPLAIN` of the ungrouped vectorized aggregate now reports the
   filters it pushes down. The counts were assigned after the node's
   EXPLAIN-only return, so a plain plan printed zero for both

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -133,7 +133,16 @@ struct PgColumnarReadState
 	 * bitmap and nativeValueCursor[c] advances through its uncompressed values.
 	 * Both stay NULL for a column that was not read.
 	 */
-	List	   *rowGroupList;		/* NativeRowGroupMetadata* */
+	List	   *rowGroupList;		/* NativeRowGroupMetadata*, in groupListContext */
+	/*
+	 * The row-group list's own context (#734). A rescan REUSES the read state
+	 * rather than ending and re-opening it, so anything the (re)start allocates
+	 * in readContext lives for every rescan that follows. This list and its
+	 * per-group metadata are rebuilt on each start, so they need a context a
+	 * rescan can reset; readContext itself cannot be reset, since the read state
+	 * and its missing values live there too.
+	 */
+	MemoryContext groupListContext;
 	int			rowGroupIndex;		/* next row group to load */
 	NativeRowGroupMetadata *nativeGroup;
 	char	   *nativeBuffer;		/* whole current row group, in groupContext */
@@ -546,6 +555,9 @@ PgColumnarBeginReadWithStorage(Relation rel, Snapshot snapshot,
 	readState->skipContext = AllocSetContextCreate(readContext,
 												   "columnar read skip",
 												   ALLOCSET_DEFAULT_SIZES);
+	readState->groupListContext = AllocSetContextCreate(readContext,
+														"columnar read group list",
+														ALLOCSET_SMALL_SIZES);
 
 	if (pgcolumnar_enable_qual_pushdown)
 		pgcolumnar_build_predicates(readState, nkeys, keys);
@@ -796,7 +808,14 @@ pgcolumnar_read_start(PgColumnarReadState *readState)
 
 	if (!readState->exhausted)
 	{
-		MemoryContext oldContext = MemoryContextSwitchTo(readState->readContext);
+		/*
+		 * Into groupListContext, not readContext (#734). Built fresh on every
+		 * start, and a rescan is a start: in readContext the previous list and
+		 * its per-group metadata were simply dropped, so a LATERAL scan
+		 * accumulated one list per outer row. Measured at ~165 bytes a rescan
+		 * above what re-executing any node costs.
+		 */
+		MemoryContext oldContext = MemoryContextSwitchTo(readState->groupListContext);
 
 		readState->rowGroupList =
 			PgColumnarReadRowGroupList(readState->storageId,
@@ -4188,6 +4207,15 @@ PgColumnarRescanRead(PgColumnarReadState *readState)
 	MemoryContextReset(readState->stripeContext);
 	readState->started = false;
 	readState->exhausted = false;
+
+	/*
+	 * Reclaim the previous start's row-group list (#734). Clearing the pointer
+	 * below is not enough on its own: the list is rebuilt on the next start, and
+	 * without this the old one stayed in the read state's memory for the life of
+	 * the scan. Safe here because every pointer into it -- rowGroupList itself
+	 * and nativeGroup -- is cleared immediately below.
+	 */
+	MemoryContextReset(readState->groupListContext);
 
 	/* native format cursors */
 	readState->rowGroupList = NIL;

--- a/test/vector_agg_rescan_memory.sh
+++ b/test/vector_agg_rescan_memory.sh
@@ -241,8 +241,8 @@ check_num "premise: the heap mirror has the same rows" \
 	"$(q1 'SELECT count(*) FROM vam_heap;')" "$(q1 'SELECT count(*) FROM vam_rs;')"
 
 # Peak RSS, which is monotone and so cannot be missed by a sampler.
-rescan_peak() {	# rescan_peak TABLE NROWS -> kB above idle, or empty
-	local tbl="$1" nrows="$2" fifo pid="" n=0 base pk query
+rescan_peak() {	# rescan_peak TABLE NROWS [GUC] -> kB above idle, or empty
+	local tbl="$1" nrows="$2" guc="${3:-$GUC}" fifo pid="" n=0 base pk query
 	query="SELECT sum(s.c) FROM (SELECT i FROM vam_drv LIMIT $nrows) d, LATERAL (SELECT count(*) c FROM $tbl WHERE v > d.i) s"
 	fifo="$PGC_WORKDIR/rs.$tbl.$nrows"; rm -f "$fifo"; mkfifo "$fifo"
 	env PATH="$PGC_BINDIR:$PATH" PGAPPNAME="pgc727_${tbl}_$nrows" \
@@ -256,7 +256,7 @@ rescan_peak() {	# rescan_peak TABLE NROWS -> kB above idle, or empty
 	done
 	if [ -z "$pid" ]; then exec 9>&-; echo ""; return 1; fi
 	base=$(awk '/VmHWM/{print $2}' "/proc/$pid/status" 2>/dev/null)
-	echo "$GUC $query;" >&9
+	echo "$guc $query;" >&9
 	n=0
 	while [ "$(q1 "SELECT count(*) FROM pg_stat_activity WHERE pid = $pid AND state = 'idle';")" != 1 ] && [ $n -lt 4000 ]; do
 		n=$((n+1)); sleep 0.1
@@ -265,9 +265,9 @@ rescan_peak() {	# rescan_peak TABLE NROWS -> kB above idle, or empty
 	exec 9>&-; wait 2>/dev/null; rm -f "$fifo" "$fifo.out"
 	[ -n "$base" ] && [ -n "$pk" ] && echo $(( pk - base )) || echo ""
 }
-rescan_slope() {	# rescan_slope TABLE -> bytes per rescan
-	local tbl="$1" lo hi
-	lo="$(rescan_peak "$tbl" "$RS_LO")"; hi="$(rescan_peak "$tbl" "$RS_HI")"
+rescan_slope() {	# rescan_slope TABLE [GUC] -> bytes per rescan
+	local tbl="$1" guc="${2:-$GUC}" lo hi
+	lo="$(rescan_peak "$tbl" "$RS_LO" "$guc")"; hi="$(rescan_peak "$tbl" "$RS_HI" "$guc")"
 	[ -z "$lo" ] || [ -z "$hi" ] && { echo ""; return 1; }
 	awk -v a="$hi" -v b="$lo" -v d="$(( RS_HI - RS_LO ))" 'BEGIN { printf "%d", ((a - b) * 1024) / d }'
 }
@@ -290,6 +290,38 @@ check_num "the vectorized aggregate does not grow query memory per rescan (#727)
 # standing in for correctness.
 check_num "the rescanned aggregate still returns the heap's answer" \
 	"$(q1 "$GUC SELECT sum(s.c) FROM (SELECT i FROM vam_drv LIMIT 200) d, LATERAL (SELECT count(*) c FROM vam_rs WHERE v > d.i) s;")" \
+	"$(q1 "SELECT sum(s.c) FROM (SELECT i FROM vam_drv LIMIT 200) d, LATERAL (SELECT count(*) c FROM vam_heap WHERE v > d.i) s;")"
+
+# ---- the PLAIN columnar scan's own per-rescan footprint (#734) --------------
+# The arms above cover the vectorized aggregate. This covers the scan UNDER it,
+# which is a different code path with a different lifetime and was measured
+# separately: with the vectorized aggregate turned off, the columnar scan alone
+# still grew query memory per rescan while the heap did not.
+#
+# The mechanism, pinned by a memory-context dump rather than guessed: the growth
+# is in the read state's own "columnar read" context, and it is the ROW-GROUP
+# LIST. A rescan reuses the read state (PgColumnarRescanRead, not an end and
+# re-open), that function sets rowGroupList to NIL without freeing it, and the
+# next start rebuilds a fresh list and a fresh metadata struct per group into the
+# same context. Nothing reclaims the previous one.
+GUC_OFF="SET pgcolumnar.enable_ungrouped_vector_agg=off; SET pgcolumnar.enable_group_vectorization=off; SET enable_material=off;"
+check_text "premise: with the aggregate off the arm is the plain columnar scan" \
+	"$(q "$GUC_OFF EXPLAIN (COSTS OFF) SELECT sum(s.c) FROM (SELECT i FROM vam_drv LIMIT 100) d, LATERAL (SELECT count(*) c FROM vam_rs WHERE v > d.i) s" |
+	   grep -q 'Custom Scan (PgColumnarScan)' && echo yes || echo no)" yes
+check_text "premise: and it is NOT the vectorized aggregate node" \
+	"$(q "$GUC_OFF EXPLAIN (COSTS OFF) SELECT sum(s.c) FROM (SELECT i FROM vam_drv LIMIT 100) d, LATERAL (SELECT count(*) c FROM vam_rs WHERE v > d.i) s" |
+	   grep -q 'Columnar Vectorized Aggregates' && echo yes || echo no)" no
+plain_slope="$(rescan_slope vam_rs "$GUC_OFF")"
+plain_heap="$(rescan_slope vam_heap "$GUC_OFF")"
+echo "      per-rescan growth: plain columnar scan = ${plain_slope:-unset} B, heap floor = ${plain_heap:-unset} B"
+check_num "premise: both plain-scan slopes were measured" \
+	"$([ -n "$plain_slope" ] && [ -n "$plain_heap" ] && echo 1 || echo 0)" 1
+plain_excess="$(awk -v a="$plain_slope" -v b="$plain_heap" 'BEGIN { d = a - b; print (d < 0 ? 0 : d) }')"
+echo "      excess over the heap floor: ${plain_excess} B per rescan"
+check_num "the plain columnar scan does not grow query memory per rescan (#734)" \
+	"$([ "$plain_excess" -lt 100 ] && echo 1 || echo 0)" 1
+check_num "the rescanned plain scan still returns the heap's answer" \
+	"$(q1 "$GUC_OFF SELECT sum(s.c) FROM (SELECT i FROM vam_drv LIMIT 200) d, LATERAL (SELECT count(*) c FROM vam_rs WHERE v > d.i) s;")" \
 	"$(q1 "SELECT sum(s.c) FROM (SELECT i FROM vam_drv LIMIT 200) d, LATERAL (SELECT count(*) c FROM vam_heap WHERE v > d.i) s;")"
 
 # ---- the row path's keys, pinned as WORK ------------------------------------


### PR DESCRIPTION
Closes #734.

A rescan **reuses** the read state rather than closing and re-opening it
(`PgColumnarReScanCustomScan` → `PgColumnarRescanRead`), and that function sets
`rowGroupList` to `NIL` without freeing it. The next start rebuilds the list and
a `NativeRowGroupMetadata` per group into the read state's own context, so a
LATERAL or parameterized scan accumulated one list per outer row for the life of
the query.

## The mechanism was pinned first, not guessed

A memory-context dump named it: **`columnar read`, 8,388,608 bytes** over 40,000
rescans. `readContext` itself cannot simply be reset — the read state and its
missing values live there too — so the list gets a child context the rescan
resets.

(I filed this issue deliberately without a hypothesis, having been wrong twice
guessing at this class on #727 and #731.)

## Measured against a heap floor, not against zero

| arm | before | after |
| --- | ---: | ---: |
| plain columnar scan | 198 B/rescan | **33 B** |
| heap table, identical data | 33 B/rescan | 33 B |

## Two proofs

**Removal.** Reverting gives 190 B against a 35 B floor — 155 B excess, arm red
— while the vectorized-aggregate arm beside it stays at 1 B, so the two arms are
independent.

**Lifetime.** This frees metadata structs, so a reset in the wrong place is a
use-after-free. Injecting one (reset while the list is live) is loudly fatal:
`ERROR: invalid memory alloc request size 7741792704550691685` from a freed
struct, with every premise collapsing. Per `asan-cannot-see-context-reset` ASAN
cannot see a `MemoryContextReset` use-after-free at all, so validating that the
suite *can* see it is the check that matters here.

## Gated on the full 209-suite PG17 matrix

Not a chosen neighbourhood — this is in the core reader and every read path uses
it, so picking neighbours would have been a guess about blast radius.

**One suite failed, and it is not this change.** `native_upgrade_converge` fails
identically on clean `main`, CI passes it on the same commit, and the cause is
two stale extension base scripts in the local sharedir that the repo no longer
ships (`pgcolumnar--1.0-alpha.sql` dated Aug 16, `pgcolumnar--1.0-dev.sql` dated
Aug 4), left behind by an August run of `extension_upgrade.sh`. The stale alpha
script already creates the Iceberg FDW; the current upgrade script then creates
it again.

They were present on **every** major, so the five-major release gate would have
failed on all of them for a reason that is not the code. Moved aside (not
deleted — the suite regenerates them when it can run); the suite then passes
5 of 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8jGnYAbTgiAcoUqn7E9EN
