### PR TITLE
opt: one mechanism for the vector aggregates' per-execution memory (#717, #727)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ### Fixed
 
+- The vectorized aggregates now bound their per-execution memory with one
+  mechanism instead of two. The scan-key context added for #717 covered the
+  scan keys; the scratch context added for #727 covered the whole scan and so
+  covered the keys as well, on the ungrouped node. The grouped node now has the
+  same scratch wrap, the two Begin-time eligibility checks build in a temporary
+  context they delete, and the scan-key context is gone. No behaviour changes
+  and no measurement moves; what changes is that one thing owns the lifetime,
+  and the regression check for it can name what enforces it again. (#717, #727)
+
 - A columnar scan no longer grows query memory on every rescan. A rescan reuses
   the read state rather than closing and re-opening it, and each restart rebuilt
   the row-group list and its per-group metadata into the read state's own

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -561,17 +561,6 @@ typedef struct PgColumnarAggScanState
 
 	MemoryContext resultContext;	/* holds min/max running values */
 
-	/*
-	 * Scan keys are rebuilt on every execution of this node, not once at Begin
-	 * like the scalar custom scan's (#717). They live here rather than in
-	 * es_query_cxt so that a rescan reclaims the previous build instead of
-	 * stacking it: for a SAOP the build also detoasts the array constant and
-	 * deconstructs it, so the growth is O(rescans x array size) and reached
-	 * 346 MB over 2000 rescans of a LATERAL aggregate with a 20000-element
-	 * IN-list. Reset at the top of each build; the keys stay valid for the whole
-	 * scan that uses them.
-	 */
-	MemoryContext scanKeyContext;
 	bool		done;			/* the single result row was emitted */
 
 	/*
@@ -712,7 +701,6 @@ typedef struct PgColumnarGroupAggScanState
 	int			nGroups;
 	int			maxGroups;		/* GUC cap enforced at execution (pgcolumnar_groupagg_lookup) */
 
-	MemoryContext scanKeyContext;	/* pushdown scan keys, rebuilt per exec (#717) */
 	MemoryContext keyContext;	/* copied key Datums */
 	MemoryContext specContext;	/* per-group specs + running min/max/numeric */
 	MemoryContext hashContext;	/* the entries array itself */
@@ -2103,9 +2091,6 @@ PgColumnarBeginAggScan(CustomScanState *node, EState *estate, int eflags)
 	state->resultContext = AllocSetContextCreate(estate->es_query_cxt,
 												 "columnar vec agg result",
 												 ALLOCSET_SMALL_SIZES);
-	state->scanKeyContext = AllocSetContextCreate(estate->es_query_cxt,
-												  "columnar vec agg scan keys",
-												  ALLOCSET_SMALL_SIZES);
 	state->done = false;
 	state->haveStats = false;
 
@@ -2147,8 +2132,23 @@ PgColumnarBeginAggScan(CustomScanState *node, EState *estate, int eflags)
 		if (state->projected == NULL)
 			state->projected = bms_make_singleton(0);
 
-		state->batchEligible =
-			pgcolumnar_batch_shape_eligible(state, tupdesc, NULL, NULL);
+		/*
+		 * Eligibility BUILDS keys to inspect and throws them away, so bound them
+		 * here rather than leaving them in the executor's context for the life
+		 * of the query. At execution the enclosing scratch does this job; Begin
+		 * has no scratch, so it makes one.
+		 */
+		{
+			MemoryContext tmp = AllocSetContextCreate(CurrentMemoryContext,
+													  "columnar vec agg eligibility",
+													  ALLOCSET_SMALL_SIZES);
+			MemoryContext oldcxt = MemoryContextSwitchTo(tmp);
+
+			state->batchEligible =
+				pgcolumnar_batch_shape_eligible(state, tupdesc, NULL, NULL);
+			MemoryContextSwitchTo(oldcxt);
+			MemoryContextDelete(tmp);
+		}
 	}
 
 	/*
@@ -3201,23 +3201,17 @@ static bool
 pgcolumnar_batch_shape_eligible(PgColumnarAggScanState *state, TupleDesc tupdesc,
 							  ScanKey *keysOut, int *nkeysOut)
 {
-	MemoryContext old;
-	bool		ok;
-
 	/*
 	 * The gates BUILD scan keys to inspect them, and for a SAOP that detoasts
-	 * and deconstructs the array constant (#717). Build into the node's own
-	 * context so a rescan reclaims the previous attempt: this runs once per
-	 * execution, and the keys it hands back are used for the whole scan that
-	 * follows, so resetting on entry is the right moment.
+	 * and deconstructs the array constant (#717). Those allocations are the
+	 * CALLER's to bound, and every caller now does: at execution the enclosing
+	 * scratch context reclaims them when the scan returns (#727), and at Begin
+	 * the caller wraps this in a temp context it deletes, because it discards
+	 * the keys anyway.
 	 */
-	MemoryContextReset(state->scanKeyContext);
-	old = MemoryContextSwitchTo(state->scanKeyContext);
-	ok = pgcolumnar_batch_gates_ok(state->specs, state->naggs, state->quals,
-								 state->scanrelid, state->projected, tupdesc,
-								 keysOut, nkeysOut);
-	MemoryContextSwitchTo(old);
-	return ok;
+	return pgcolumnar_batch_gates_ok(state->specs, state->naggs, state->quals,
+								   state->scanrelid, state->projected, tupdesc,
+								   keysOut, nkeysOut);
 }
 
 /* Reset the accumulators to their initial state (for a clean fall-back). */
@@ -3694,16 +3688,12 @@ pgcolumnar_native_scan_agg(PgColumnarAggScanState *state,
 	{
 		/*
 		 * Reached only when the fold declined, so any keys it built are already
-		 * dead (it ended its read before returning false) and resetting here is
-		 * safe. Rebuilt on every rescan, hence the node's own context (#717).
+		 * dead (it ended its read before returning false). These live until the
+		 * enclosing scratch context is deleted at the end of the scan (#727),
+		 * which is after the reader that uses them has finished.
 		 */
-		MemoryContext oldcxt;
-
-		MemoryContextReset(state->scanKeyContext);
-		oldcxt = MemoryContextSwitchTo(state->scanKeyContext);
 		keys = PgColumnarBuildScanKeys(state->quals, state->scanrelid, tupdesc,
 									 &nScanKeys);
-		MemoryContextSwitchTo(oldcxt);
 	}
 
 	rs = PgColumnarBeginRead(rel, estate->es_snapshot, NULL, projected,
@@ -4178,9 +4168,6 @@ PgColumnarBeginGroupAggScan(CustomScanState *node, EState *estate, int eflags)
 	int			a;
 	int			x;
 
-	state->scanKeyContext = AllocSetContextCreate(estate->es_query_cxt,
-												  "columnar groupagg scan keys",
-												  ALLOCSET_SMALL_SIZES);
 	state->specContext = AllocSetContextCreate(estate->es_query_cxt,
 											   "columnar groupagg specs",
 											   ALLOCSET_SMALL_SIZES);
@@ -4269,8 +4256,18 @@ PgColumnarBeginGroupAggScan(CustomScanState *node, EState *estate, int eflags)
 		projected = bms_make_singleton(0);	/* count(*) with no keys touched */
 	state->projected = projected;
 
-	state->batchEligible =
-		pgcolumnar_groupagg_batch_eligible(state, basedesc, NULL, NULL);
+	{
+		/* the keys are discarded; bound them, as the ungrouped Begin does */
+		MemoryContext tmp = AllocSetContextCreate(CurrentMemoryContext,
+												  "columnar groupagg eligibility",
+												  ALLOCSET_SMALL_SIZES);
+		MemoryContext oldcxt = MemoryContextSwitchTo(tmp);
+
+		state->batchEligible =
+			pgcolumnar_groupagg_batch_eligible(state, basedesc, NULL, NULL);
+		MemoryContextSwitchTo(oldcxt);
+		MemoryContextDelete(tmp);
+	}
 	state->batchFolded = false;
 
 	if (eflags & EXEC_FLAG_EXPLAIN_ONLY)
@@ -4624,20 +4621,11 @@ pgcolumnar_groupagg_batch_eligible(PgColumnarGroupAggScanState *state,
 			return false;
 	}
 
-	{
-		MemoryContext old;
-		bool		ok;
-
-		/* build the inspected keys in the node's own context (#717) */
-		MemoryContextReset(state->scanKeyContext);
-		old = MemoryContextSwitchTo(state->scanKeyContext);
-		ok = pgcolumnar_batch_gates_ok(state->aggTemplate, state->naggs,
-									 state->quals, state->scanrelid,
-									 state->projected, tupdesc,
-									 keysOut, nkeysOut);
-		MemoryContextSwitchTo(old);
-		return ok;
-	}
+	/* the caller bounds these allocations; see pgcolumnar_batch_shape_eligible */
+	return pgcolumnar_batch_gates_ok(state->aggTemplate, state->naggs,
+								   state->quals, state->scanrelid,
+								   state->projected, tupdesc,
+								   keysOut, nkeysOut);
 }
 
 /*
@@ -4949,16 +4937,9 @@ pgcolumnar_groupagg_build(PgColumnarGroupAggScanState *state)
 		return;
 	}
 
-	{
-		/* same lifetime as the ungrouped row path above (#717) */
-		MemoryContext oldcxt;
-
-		MemoryContextReset(state->scanKeyContext);
-		oldcxt = MemoryContextSwitchTo(state->scanKeyContext);
-		keys = PgColumnarBuildScanKeys(state->quals, state->scanrelid, basedesc,
-									 &nScanKeys);
-		MemoryContextSwitchTo(oldcxt);
-	}
+	/* same lifetime as the ungrouped row path: the enclosing scratch owns it */
+	keys = PgColumnarBuildScanKeys(state->quals, state->scanrelid, basedesc,
+								 &nScanKeys);
 	rs = PgColumnarBeginRead(rel, estate->es_snapshot, NULL, state->projected,
 						   nScanKeys, keys);
 
@@ -5045,7 +5026,34 @@ PgColumnarExecGroupAggScan(CustomScanState *node)
 
 	if (!state->started)
 	{
+		/*
+		 * The grouped twin of the ungrouped node's scratch context (#727), so
+		 * that ONE mechanism owns the lifetime of everything a scan allocates
+		 * on both nodes rather than two overlapping ones.
+		 *
+		 * Everything this build RETAINS already lives in a context of its own:
+		 * the group keys in keyContext, the accumulators in specContext and the
+		 * table in hashContext, each switched into explicitly by
+		 * pgcolumnar_groupagg_lookup and pgcolumnar_groupagg_grow. What is left
+		 * -- the scan keys, the per-row value and null arrays, the reader's own
+		 * state -- is scratch for the duration of the build, and is what this
+		 * reclaims.
+		 *
+		 * Wrapped at the call site for the same reason as the ungrouped one:
+		 * the fold's early return, the ADD COLUMN fall-back and the normal end
+		 * would each need their own restore, and missing one leaks the context
+		 * instead of the memory.
+		 */
+		MemoryContext buildCxt = AllocSetContextCreate(CurrentMemoryContext,
+													   "columnar groupagg build",
+													   ALLOCSET_DEFAULT_SIZES);
+		MemoryContext oldCxt = MemoryContextSwitchTo(buildCxt);
+
 		pgcolumnar_groupagg_build(state);
+
+		MemoryContextSwitchTo(oldCxt);
+		MemoryContextDelete(buildCxt);
+
 		state->started = true;
 		state->emitPos = 0;
 	}

--- a/test/vector_agg_rescan_memory.sh
+++ b/test/vector_agg_rescan_memory.sh
@@ -180,21 +180,21 @@ echo "      (peaks: with ${with_small} -> ${with_large}; without ${without_small
 # the defect and far above the noise.
 excess="$(awk -v a="$with_slope" -v b="$without_slope" 'BEGIN { d = a - b; print (d < 0 ? 0 : d) }')"
 echo "      excess attributable to the IN-list: ${excess} bytes per rescan"
-# NAMED FOR THE INVARIANT, NOT FOR ONE FIX, and that distinction is the point.
+# ONE MECHANISM, ONE ARM, and the history is worth keeping because it is how a
+# green check stopped meaning anything for a while.
 #
-# This arm was written for #717 and labelled with it. Since #727 wrapped the
-# ungrouped scan in a per-call scratch context, it no longer tests #717
-# SPECIFICALLY: reverting #717's scan-key contexts entirely, keeping #727,
-# leaves this arm GREEN, because the broader wrap reclaims those allocations
-# too. An arm that stays green when the fix it names is removed is falsely
-# attributing, whatever else it is doing.
+# Written for #717 and labelled with it. #727 then wrapped the ungrouped scan in
+# a per-call scratch context, which reclaimed the same allocations, and this arm
+# stayed GREEN with #717's contexts fully reverted -- falsely attributing, since
+# the fix it named was gone and it could not tell. It was relabelled to the
+# invariant and given the joint removal proof.
 #
-# It is still a sound lock on the INVARIANT, and its removal proof is that
-# reverting BOTH mechanisms reddens it at 179,927 bytes per rescan. So it is
-# named for the property now, and the proof is stated as the joint one it
-# actually has. #717 keeps its own targeted guard for the grouped node and the
-# Begin-time eligibility build, where #727's wrap does not reach.
-check_num "an IN-list does not add per-rescan query memory (jointly #717, #727)" \
+# The scan-key contexts have since been removed outright: the scratch wrap now
+# covers both nodes, both row paths and both Begin-time eligibility builds, so
+# there is exactly one mechanism behind this property again. Removing it reddens
+# this arm on its own, at 180,843 bytes per rescan. The label can mean what it
+# says.
+check_num "an IN-list does not add per-rescan query memory" \
 	"$([ "$excess" -lt 20000 ] && echo 1 || echo 0)" 1
 
 # ---- the node's own per-rescan footprint, against core's floor (#727) -------


### PR DESCRIPTION
The single-mechanism refactor for the #717/#727 overlap, as suggested in review.

#717 gave the scan keys their own context, reset at each build. #727 then
wrapped the whole ungrouped scan in a scratch context released when it returns —
which reclaims the keys as well. Two mechanisms for one property, overlapping on
one path and not the other.

## The cost was the attribution, not the redundancy

An arm named for #717 **stayed green with #717's contexts fully reverted**,
because #727's wrap covered it. A check that survives the removal of the fix it
names cannot tell you anything about that fix.

## What changes

- the **grouped** node gets the same scratch wrap — the node #727 never reached
- both Begin-time eligibility checks build in a temporary context they delete,
  since they discard their keys anyway
- both row-path key builds are owned by the enclosing scratch
- `scanKeyContext` is removed from both node states

Safe on the grouped node because everything the build **retains** already has a
context of its own — group keys in `keyContext`, accumulators in `specContext`,
the table in `hashContext`, each switched into explicitly. Only scratch is left
for the new context to reclaim. Wrapped at the call site so the fold's early
return, the ADD COLUMN fall-back and the normal end are covered by construction.

## Two proofs, rather than the paragraph above

**Grouped lifetime** (the proof asked for by name in review, since this is the
node #727's wrap doesn't reach). Retaining the group keys in the scratch instead
of `keyContext` — the realistic mistake for this change — makes `native_groupagg`
fail **35 checks**. Garbage group keys break the oracle comparisons, so a
lifetime error here is loud. That matters because ASAN cannot see a
`MemoryContextReset` use-after-free at all.

**Attribution restored.** With `scanKeyContext` gone, disabling the scratch wraps
reddens the invariant arm **on its own at 180,843 B/rescan**, where before it
took reverting both mechanisms. The arm is renamed to the property it locks and
can mean what it says. The #734 arm stays at 0 throughout, so the reader fix is
independent of this.

## No behaviour changes, no measurement moves

`vector_agg_rescan_memory` 23/23, and 15 suites green including
`parallel_vector_agg` (the partial path) and all three grouped suites:
`native_groupagg`, `native_groupagg_batch`, `native_groupagg_wide_cost`,
`ungrouped_vector_agg`, `native_agg`, `native_agg_deletes`,
`native_agg_addcolumn`, `native_saop_pushdown`, `native_param_pushdown`,
`batch_fold_explain`, `rewrite_group_scan`, `pushdown_report`, `docs_style`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8jGnYAbTgiAcoUqn7E9EN
