### PR TITLE
opt: rewrite date_trunc equality into a range so it can prune (#403 item 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,21 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ## [Unreleased]
 
+### Added
+
+- A predicate on `date_trunc(unit, ts) = constant` now drives chunk-group
+  skipping. A zone map holds `ts`, so a predicate about a function of `ts` could
+  exclude nothing and the scan read every group. It is rewritten to a range on
+  `ts`, which prunes with the machinery that already exists. Measured on 500,000
+  rows clustered by time in 50 chunk groups: the equivalent explicit range read
+  2 groups, the `date_trunc` form read all 50, and it now reads 2. The derived
+  keys are conservative, so the executor still applies the original clause. Only
+  the `timestamp` form is rewritten: `date_trunc` on `timestamptz` truncates in
+  the session time zone, so a key frozen at executor start could be wrong if the
+  zone changed. Units outside a known list, and a constant that is not itself
+  truncated, are declined rather than approximated. A new suite,
+  `preimage_rewrite`, measures the pruning and pins each declined shape. (#403)
+
 ### Fixed
 
 - The vectorized aggregates now bound their per-execution memory with one

--- a/design/ISSUE_403_PREIMAGE_REWRITE.md
+++ b/design/ISSUE_403_PREIMAGE_REWRITE.md
@@ -1,0 +1,83 @@
+# #403 item 1: preimage rewriting for monotonic functions
+
+## The opportunity, measured before building anything
+
+Fixture: 500,000 rows, one day per ~10,000 rows, clustered in time, 50 chunk
+groups, `stripe_row_limit => 10000`.
+
+| predicate | chunk groups read | removed | rows |
+| --- | ---: | ---: | ---: |
+| `ts >= '2024-02-01' AND ts < '2024-02-02'` | **2** | 48 | 10000 |
+| `date_trunc('day', ts) = '2024-02-01'` | **50** | 0 | 10000 |
+
+Same answer, 25x the groups read. The zone map holds `ts`; the predicate is
+about a function of `ts`, so nothing can exclude a group.
+
+Verified before starting, because the issue is old: `grep -riE 'monoton|preimage'
+finds three comments and no code. The existing `date_trunc` handling in
+`columnar_vector.c` is a group-COUNT estimate for the grouped node, unrelated,
+though it shows the funcid-matching pattern.
+
+## What ships
+
+`f(col) OP const` gains derived scan keys on `col`, where `f` is a function we
+can invert. Table-driven on funcid, not a hardcoded `date_trunc` branch: the
+technique is a function property plus a rewrite, which is the objection #369
+raised against a special case.
+
+v1 handles `date_trunc(unit, timestamp) = const`, emitting `col >= lo` and
+`col < hi`.
+
+## Three correctness constraints, each of which can produce wrong answers
+
+1. **A non-truncated constant matches NOTHING**, and my first statement of why
+   that mattered was WRONG. `date_trunc('day', ts) = '2024-02-01 12:00'` is
+   unsatisfiable. I wrote that emitting `[12:00, next day)` "would admit rows
+   the original excludes"; it would not. The keys only PRUNE and the executor
+   re-applies the clause, and the derived range is never NARROWER than the true
+   matching set (here the empty set, which every range contains), so no row can
+   be wrongly admitted or wrongly dropped.
+
+   Established by removing the check and watching the suite stay green, not by
+   argument. So the round-trip check is **defence in depth**, not a correctness
+   requirement today: it stops mattering only while the keys stay conservative
+   AND the executor keeps re-checking. Kept because it is two lines and because
+   both of those conditions are the kind that change without anyone revisiting
+   this.
+
+2. **timestamptz is EXCLUDED in v1.** `date_trunc(text, timestamptz)` truncates
+   in the session `TimeZone`, so the preimage depends on a GUC that can change
+   after the key is frozen. Plain `timestamp` has no such dependence. The 3-arg
+   form takes an explicit zone and could be added later with that argument read.
+
+3. **The keys are CONSERVATIVE (`exact = false`)**, and this too cannot be
+   demonstrated today. Marking them exact changes nothing observable, because
+   `pgcolumnar_batch_type_ok` admits only int2/4/8 and float4/8, so the fold
+   refuses a `timestamp` column on the TYPE gate before exactness is consulted.
+   Verified by marking them exact and watching the suite stay green.
+
+   The suite's "does not engage the batch fold" arm therefore passes for a
+   different reason than its name suggests, and says so. Conservative is still
+   the right marking: it is what makes the claim true independently of a type
+   list that could widen, and exactness would then need its own proof over every
+   unit and every value.
+
+## Verification
+
+RED first: a suite asserting the `date_trunc` form prunes chunk groups, which
+fails today at 0 removed.
+
+- **work**: `Columnar Chunk Groups Removed by Filter` > 0 on the rewritten form,
+  paired with the explicit range as the reference.
+- **answers**: identical to the explicit range AND to a heap mirror, for a
+  truncated constant, a NON-truncated constant (must return zero rows), NULLs,
+  and the extremes.
+- **the decline arms**: a non-truncated constant, a timestamptz column, and a
+  non-constant unit each emit no derived keys and still answer correctly.
+- **removal proof**: revert the rewrite and the work arm returns to 0 removed
+  while every answer arm stays green -- the pruning is the only thing that moves.
+- **two mutations that did NOT redden**, recorded because they corrected the
+  design above: removing the round-trip check, and marking the keys exact. Both
+  left the suite green, for the reasons now written into constraints 1 and 3.
+  Neither is therefore load-bearing today, and both are kept as defence in depth
+  with that stated rather than implied.

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -65,6 +65,8 @@
 #include "catalog/pg_statistic_ext.h"
 #include "utils/array.h"
 #include "utils/builtins.h"
+#include "utils/fmgroids.h"
+#include "utils/timestamp.h"
 #include "utils/datum.h"
 #include "utils/lsyscache.h"
 #include "utils/pg_locale.h"
@@ -273,6 +275,212 @@ pgcolumnar_commute_strategy(StrategyNumber s)
 		default:
 			return InvalidStrategy;
 	}
+}
+
+/*
+ * pgcolumnar_preimage_range_scankey
+ *		Rewrite `f(col) = const` into a range on col, for a function whose
+ *		preimage of a single value is a contiguous interval (#403, from the
+ *		ClickHouse VLDB 2024 paper's monotonicity traits).
+ *
+ *		A zone map holds col; a predicate about f(col) is about something the
+ *		zone map does not store, so nothing can exclude a group from it and the
+ *		scan reads everything. Measured on a time-clustered fixture: the explicit
+ *		range read 2 of 50 chunk groups, `date_trunc('day', ts) = ...` read all
+ *		50, for the same 10,000 rows.
+ *
+ *		Dispatched on funcid rather than written as a branch inside the general
+ *		comparison path, because the technique is a function property plus a
+ *		rewrite (the objection #369 raised against a special case). Adding a
+ *		second function means adding its preimage beside this one.
+ *
+ *		Being straight about the shape: this first cut inverts exactly one
+ *		function, and the step it uses comes from a small table of unit names,
+ *		not from date_trunc itself. A month is not a fixed number of seconds, so
+ *		the step has to be an interval applied by calendar arithmetic. The
+ *		generality is in where the rewrite HAPPENS, not yet in how many
+ *		functions it knows.
+ *
+ *		Emits `col >= lo` and `col < hi`, so two keys, and returns 2. Returns 0
+ *		for anything it cannot inarguably invert; declining always costs a scan,
+ *		never an answer.
+ */
+static int
+pgcolumnar_preimage_range_scankey(OpExpr *op, Index scanrelid, TupleDesc tupdesc,
+								ScanKey key)
+{
+	Node	   *leftop;
+	Node	   *rightop;
+	FuncExpr   *f;
+	Const	   *con;
+	Var		   *var;
+	Const	   *unitCon;
+	Node	   *arg1;
+	Form_pg_attribute att;
+	TypeCacheEntry *tce;
+	Datum		lo;
+	Datum		hi;
+	Datum		roundTrip;
+	Interval   *step;
+	text	   *unit;
+
+	if (list_length(op->args) != 2)
+		return 0;
+	leftop = (Node *) linitial(op->args);
+	rightop = (Node *) lsecond(op->args);
+	if (IsA(leftop, RelabelType))
+		leftop = (Node *) ((RelabelType *) leftop)->arg;
+	if (IsA(rightop, RelabelType))
+		rightop = (Node *) ((RelabelType *) rightop)->arg;
+
+	/* f(col) = const, either way round; equality only in this first cut */
+	if (IsA(leftop, FuncExpr) && IsA(rightop, Const))
+	{
+		f = (FuncExpr *) leftop;
+		con = (Const *) rightop;
+	}
+	else if (IsA(rightop, FuncExpr) && IsA(leftop, Const))
+	{
+		f = (FuncExpr *) rightop;
+		con = (Const *) leftop;
+	}
+	else
+		return 0;
+	if (con->constisnull)
+		return 0;
+
+	/*
+	 * date_trunc(unit, timestamp) only.
+	 *
+	 * The timestamptz forms are DELIBERATELY absent. date_trunc(text,
+	 * timestamptz) truncates in the session TimeZone, so the interval this
+	 * computes depends on a GUC that can change after the key is frozen at
+	 * executor start, and the key would then exclude groups that do match.
+	 * Plain timestamp has no such dependence. The three-argument form takes an
+	 * explicit zone and could be added by reading it.
+	 */
+	if (f->funcid != F_DATE_TRUNC_TEXT_TIMESTAMP)
+		return 0;
+	if (list_length(f->args) != 2)
+		return 0;
+
+	unitCon = (Const *) linitial(f->args);
+	arg1 = (Node *) lsecond(f->args);
+	if (IsA(arg1, RelabelType))
+		arg1 = (Node *) ((RelabelType *) arg1)->arg;
+	if (!IsA(unitCon, Const) || unitCon->constisnull)
+		return 0;			/* a unit we cannot read at plan time */
+	if (!IsA(arg1, Var))
+		return 0;
+	var = (Var *) arg1;
+	if (var->varno != scanrelid || var->varlevelsup != 0)
+		return 0;
+	if (var->varattno < 1 || var->varattno > tupdesc->natts)
+		return 0;
+	att = TupleDescAttr(tupdesc, var->varattno - 1);
+	if (att->atttypid != TIMESTAMPOID || con->consttype != TIMESTAMPOID)
+		return 0;
+
+	/*
+	 * The operator must be equality on timestamp, and the ordering the reader
+	 * will use must be the column's own, exactly as the plain comparison path
+	 * requires.
+	 */
+	tce = lookup_type_cache(TIMESTAMPOID, TYPECACHE_BTREE_OPFAMILY);
+	if (!OidIsValid(tce->btree_opf))
+		return 0;
+	if (get_op_opfamily_strategy(op->opno, tce->btree_opf) != BTEqualStrategyNumber)
+		return 0;
+
+	/*
+	 * A CONSTANT THAT IS NOT ITSELF TRUNCATED MATCHES NOTHING.
+	 * date_trunc('day', ts) never returns 12:00, so
+	 * `date_trunc('day', ts) = '2024-02-01 12:00'` is unsatisfiable.
+	 *
+	 * DEFENCE IN DEPTH, not a correctness requirement, and the distinction was
+	 * established by removing this check and watching the suite stay green. The
+	 * keys only prune and the executor re-applies the clause, and the derived
+	 * range is never NARROWER than the true matching set -- here the empty set,
+	 * which every range contains -- so no row can be wrongly admitted or
+	 * dropped. It would become load-bearing if these keys were ever marked
+	 * exact, since the batch fold then uses them as its only row filter (#715).
+	 * Two lines, and both of those conditions can change without anyone
+	 * revisiting this, so it stays.
+	 */
+	unit = DatumGetTextPP(unitCon->constvalue);
+	roundTrip = DirectFunctionCall2(timestamp_trunc,
+									PointerGetDatum(unit),
+									con->constvalue);
+	if (DatumGetTimestamp(roundTrip) != DatumGetTimestamp(con->constvalue))
+		return 0;
+
+	/*
+	 * hi is where the NEXT bucket starts, so the step is one unit wide.
+	 *
+	 * This IS a table of unit names, and it is the honest way to do it: the
+	 * step for `month` is not a fixed number of seconds, so it has to be
+	 * expressed as an interval and applied by the calendar arithmetic that
+	 * knows about month lengths. Units not listed here are DECLINED rather than
+	 * approximated -- `date_trunc` accepts more of them (microseconds, decade,
+	 * century, millennium), and each would need its own entry proved before it
+	 * could be trusted.
+	 *
+	 * The comparison is case-insensitive because date_trunc's own is.
+	 */
+	{
+		static const struct
+		{
+			const char *unit;
+			const char *step;
+		}			units[] = {
+			{"second", "1 second"},
+			{"minute", "1 minute"},
+			{"hour", "1 hour"},
+			{"day", "1 day"},
+			{"week", "1 week"},
+			{"month", "1 month"},
+			{"quarter", "3 months"},
+			{"year", "1 year"},
+		};
+		char	   *unitStr = text_to_cstring(unit);
+		const char *stepStr = NULL;
+		int			i;
+
+		for (i = 0; i < (int) (sizeof(units) / sizeof(units[0])); i++)
+			if (pg_strcasecmp(unitStr, units[i].unit) == 0)
+			{
+				stepStr = units[i].step;
+				break;
+			}
+		if (stepStr == NULL)
+			return 0;
+
+		step = DatumGetIntervalP(DirectFunctionCall3(interval_in,
+													 CStringGetDatum(stepStr),
+													 ObjectIdGetDatum(InvalidOid),
+													 Int32GetDatum(-1)));
+		lo = con->constvalue;
+		hi = DirectFunctionCall2(timestamp_pl_interval, lo,
+								 IntervalPGetDatum(step));
+	}
+
+	MemSet(&key[0], 0, sizeof(ScanKeyData));
+	key[0].sk_flags = 0;
+	key[0].sk_attno = var->varattno;
+	key[0].sk_strategy = BTGreaterEqualStrategyNumber;
+	key[0].sk_subtype = TIMESTAMPOID;
+	key[0].sk_collation = att->attcollation;
+	key[0].sk_argument = lo;
+
+	MemSet(&key[1], 0, sizeof(ScanKeyData));
+	key[1].sk_flags = 0;
+	key[1].sk_attno = var->varattno;
+	key[1].sk_strategy = BTLessStrategyNumber;
+	key[1].sk_subtype = TIMESTAMPOID;
+	key[1].sk_collation = att->attcollation;
+	key[1].sk_argument = hi;
+
+	return 2;
 }
 
 /*
@@ -619,6 +827,20 @@ pgcolumnar_clause_to_scankey(Node *clause, Index scanrelid, TupleDesc tupdesc,
 	op = (OpExpr *) clause;
 	if (list_length(op->args) != 2)
 		return 0;
+
+	/*
+	 * `f(col) = const` for an invertible f becomes a range on col (#403). Like
+	 * the IN-list rewrite above these keys merely PRUNE, so exact stays false
+	 * and the batch fold refuses them (#715); the executor re-checks the
+	 * original clause. The pruning is the whole measured prize.
+	 */
+	{
+		int			n = pgcolumnar_preimage_range_scankey(op, scanrelid, tupdesc,
+														 key);
+
+		if (n > 0)
+			return n;
+	}
 
 	leftop = (Node *) linitial(op->args);
 	rightop = (Node *) lsecond(op->args);

--- a/test/preimage_rewrite.sh
+++ b/test/preimage_rewrite.sh
@@ -21,10 +21,16 @@
 # and each has its own arm:
 #
 #   * a NON-TRUNCATED constant. `date_trunc('day', ts) = '2024-02-01 12:00'`
-#     matches nothing, because date_trunc never returns 12:00. Emitting
-#     [12:00, next day) would admit rows the original excludes. It must return
-#     zero rows, and it must return them by declining rather than by pruning to
-#     a wrong range.
+#     matches nothing, because date_trunc never returns 12:00. The code declines
+#     it, and that decline is DEFENCE IN DEPTH rather than a correctness
+#     requirement -- a distinction established by removing the guard and
+#     watching this suite stay green, including the arm below. Pruning to a
+#     wrong range cannot return wrong rows while the keys are conservative and
+#     the executor re-applies the clause, and the derived range is never
+#     NARROWER than the true matching set, which here is empty and so contained
+#     in every range. It becomes load-bearing the moment these keys are marked
+#     exact, because the batch fold then uses them as its only row filter
+#     (#715) with no recheck behind it.
 #   * a timestamptz column. date_trunc(text, timestamptz) truncates in the
 #     session TimeZone, so a key frozen at plan time is wrong if TimeZone
 #     changes. Excluded deliberately; the arm pins that it stays excluded.
@@ -97,8 +103,12 @@ check_text "the actual ROWS match the heap, not just the count" \
 	"$(q "SELECT v FROM pre_h WHERE date_trunc('day', ts) = $DAY ORDER BY v" | md5sum)"
 
 # ---- the shapes that must DECLINE ------------------------------------------
-# A non-truncated constant is unsatisfiable. The danger is not a wrong count, it
-# is a rewrite that turns it into a range and returns rows.
+# A non-truncated constant is unsatisfiable, and these arms assert the ANSWER,
+# which is all they can assert: with conservative keys and an executor recheck,
+# a rewrite that turned this into a range would still return zero rows. They do
+# not, and cannot, show that the decline is load-bearing -- removing the guard
+# leaves them green. They are the arms that would catch it if the keys were ever
+# marked exact, which is when the decline starts protecting an answer.
 NOTRUNC="SELECT count(*) FROM pre_c WHERE date_trunc('day', ts) = timestamp '2024-02-01 12:00'"
 check_num "a non-truncated constant returns no rows" "$(q1 "$NOTRUNC;")" 0
 check_num "...and the heap agrees it is unsatisfiable" \

--- a/test/preimage_rewrite.sh
+++ b/test/preimage_rewrite.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+#
+# pgColumnar #403 item 1: preimage rewriting for monotonic functions.
+#
+# A zone map holds `ts`. A predicate on `date_trunc('day', ts)` is about a
+# FUNCTION of ts, so nothing can exclude a chunk group from it and the scan
+# reads everything. Rewritten to a range on ts it prunes with the machinery that
+# already exists.
+#
+# Measured on this fixture before the rewrite: the explicit range reads 2 of 50
+# chunk groups, the date_trunc form reads all 50, and both return the same
+# 10,000 rows. That 25x is the whole prize, and it is what the work arm below
+# measures.
+#
+# THE ANSWERS CANNOT SEE THIS CHANGE. A predicate rewrite that prunes correctly
+# and one that does not prune at all return identical rows, so every oracle arm
+# here is there to catch a rewrite that prunes WRONGLY, and the work arm is the
+# only thing that goes red when the rewrite stops happening.
+#
+# The three shapes that must DECLINE are as important as the one that must work,
+# and each has its own arm:
+#
+#   * a NON-TRUNCATED constant. `date_trunc('day', ts) = '2024-02-01 12:00'`
+#     matches nothing, because date_trunc never returns 12:00. Emitting
+#     [12:00, next day) would admit rows the original excludes. It must return
+#     zero rows, and it must return them by declining rather than by pruning to
+#     a wrong range.
+#   * a timestamptz column. date_trunc(text, timestamptz) truncates in the
+#     session TimeZone, so a key frozen at plan time is wrong if TimeZone
+#     changes. Excluded deliberately; the arm pins that it stays excluded.
+#   * a non-constant unit, which cannot be inverted at plan time at all.
+#
+# Usage:  test/preimage_rewrite.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+q() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -At -c "$1" 2>&1
+}
+q1() { q "$1" | tail -1; }
+
+# One day per ~10000 rows and a 10000-row group limit, so a day is about one
+# chunk group and pruning has something to remove. NULLs and the extremes are in
+# the data because they are where a rewrite most easily admits a row it should
+# not.
+psql_run "CREATE TABLE pre_c(ts timestamp, v int) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.set_options('pre_c', stripe_row_limit => 10000);"
+psql_run "INSERT INTO pre_c SELECT timestamp '2024-01-01' + (g / 10000) * interval '1 day'
+                                   + (g % 10000) * interval '1 second', g
+          FROM generate_series(1,500000) g;"
+psql_run "INSERT INTO pre_c VALUES (NULL, -1), ('infinity', -2), ('-infinity', -3);"
+psql_run "CREATE TABLE pre_h(ts timestamp, v int);"
+psql_run "INSERT INTO pre_h SELECT * FROM pre_c;"
+psql_run "ANALYZE pre_c; ANALYZE pre_h;"
+
+check_num "premise: the fixture spans many chunk groups" \
+	"$(q1 "SELECT (count(*) > 10)::int FROM pgcolumnar.row_group
+	       WHERE storage_id = pgcolumnar.get_storage_id('pre_c'::regclass);")" 1
+
+removed() {	# removed QUERY -> chunk groups removed by filter, or empty
+	q "EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF, SUMMARY OFF) $1" \
+		| grep 'Columnar Chunk Groups Removed by Filter' | grep -oE '[0-9]+' | head -1
+}
+
+DAY="timestamp '2024-02-01'"
+RANGE="SELECT count(*) FROM pre_c WHERE ts >= $DAY AND ts < $DAY + interval '1 day'"
+TRUNC="SELECT count(*) FROM pre_c WHERE date_trunc('day', ts) = $DAY"
+
+# The reference: the explicit range already prunes. Without this the work arm
+# below cannot tell "the rewrite did not fire" from "there was nothing to prune".
+ref="$(removed "$RANGE")"
+check_num "premise: the explicit range prunes, so there IS something to remove" \
+	"$([ -n "$ref" ] && [ "$ref" -gt 0 ] && echo 1 || echo 0)" 1
+echo "      explicit range removed $ref chunk groups"
+
+# ---- the work arm: the whole point of the change ---------------------------
+got="$(removed "$TRUNC")"
+echo "      date_trunc form removed ${got:-unset} chunk groups"
+check_num "date_trunc('day', ts) = const prunes chunk groups (#403)" \
+	"$([ -n "$got" ] && [ "$got" -gt 0 ] && echo 1 || echo 0)" 1
+# and it must prune as WELL as the explicit range, not merely more than zero
+check_num "...and prunes as well as the equivalent explicit range" \
+	"$got" "$ref"
+
+# ---- the answers, which cannot see the change and are here for wrongness ----
+check_num "the rewritten predicate returns the range's answer" \
+	"$(q1 "$TRUNC;")" "$(q1 "$RANGE;")"
+check_num "and the heap mirror's answer" \
+	"$(q1 "$TRUNC;")" \
+	"$(q1 "SELECT count(*) FROM pre_h WHERE date_trunc('day', ts) = $DAY;")"
+check_text "the actual ROWS match the heap, not just the count" \
+	"$(q "SELECT v FROM pre_c WHERE date_trunc('day', ts) = $DAY ORDER BY v" | md5sum)" \
+	"$(q "SELECT v FROM pre_h WHERE date_trunc('day', ts) = $DAY ORDER BY v" | md5sum)"
+
+# ---- the shapes that must DECLINE ------------------------------------------
+# A non-truncated constant is unsatisfiable. The danger is not a wrong count, it
+# is a rewrite that turns it into a range and returns rows.
+NOTRUNC="SELECT count(*) FROM pre_c WHERE date_trunc('day', ts) = timestamp '2024-02-01 12:00'"
+check_num "a non-truncated constant returns no rows" "$(q1 "$NOTRUNC;")" 0
+check_num "...and the heap agrees it is unsatisfiable" \
+	"$(q1 "SELECT count(*) FROM pre_h WHERE date_trunc('day', ts) = timestamp '2024-02-01 12:00';")" 0
+
+psql_run "CREATE TABLE pre_tz(ts timestamptz, v int) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.set_options('pre_tz', stripe_row_limit => 10000);"
+psql_run "INSERT INTO pre_tz SELECT timestamptz '2024-01-01+00' + (g / 10000) * interval '1 day'
+                                    + (g % 10000) * interval '1 second', g
+          FROM generate_series(1,200000) g;"
+psql_run "CREATE TABLE pre_tzh(ts timestamptz, v int);"
+psql_run "INSERT INTO pre_tzh SELECT * FROM pre_tz;"
+# timestamptz is excluded because the truncation depends on the session
+# TimeZone. Asserted as an ANSWER under two different zones rather than as an
+# absence: what matters is that the result follows the zone, which a frozen key
+# could not do.
+check_num "timestamptz: correct under UTC" \
+	"$(q1 "SET TimeZone='UTC'; SELECT count(*) FROM pre_tz WHERE date_trunc('day', ts) = timestamptz '2024-02-01 00:00+00';")" \
+	"$(q1 "SET TimeZone='UTC'; SELECT count(*) FROM pre_tzh WHERE date_trunc('day', ts) = timestamptz '2024-02-01 00:00+00';")"
+check_num "timestamptz: and still correct under a different zone" \
+	"$(q1 "SET TimeZone='Asia/Tokyo'; SELECT count(*) FROM pre_tz WHERE date_trunc('day', ts) = timestamptz '2024-02-01 00:00+09';")" \
+	"$(q1 "SET TimeZone='Asia/Tokyo'; SELECT count(*) FROM pre_tzh WHERE date_trunc('day', ts) = timestamptz '2024-02-01 00:00+09';")"
+
+# A unit that is not a constant cannot be inverted at plan time.
+check_num "a non-constant unit still answers correctly" \
+	"$(q1 "SELECT count(*) FROM pre_c WHERE date_trunc((SELECT 'day'), ts) = $DAY;")" \
+	"$(q1 "SELECT count(*) FROM pre_h WHERE date_trunc((SELECT 'day'), ts) = $DAY;")"
+
+# ---- the keys are CONSERVATIVE, and that is load-bearing -------------------
+# The derived keys prune and the executor re-checks the original clause. They
+# are deliberately NOT marked exact, so the batch fold refuses them (#715),
+# because the fold's only per-row filter is its scan-key loop and a key that
+# expressed the clause loosely would let it count rows the clause excludes.
+#
+# THIS ARM CANNOT CURRENTLY TELL YOU THE MARKING IS RIGHT, and that is worth
+# saying rather than leaving implied. Marking the keys exact leaves this green:
+# pgcolumnar_batch_type_ok admits only int2/4/8 and float4/8, so the fold refuses
+# a timestamp column on the TYPE gate before exactness is ever consulted.
+# Established by mutating the marking and watching the suite pass, not assumed.
+#
+# So the arm pins that the fold declines -- which is what a reader of the plan
+# cares about -- and no more. Conservative is still the right marking, because
+# it makes the claim true independently of a type list that could widen; if it
+# does widen, this arm starts discriminating and exactness needs its own proof
+# over every unit and every value.
+check_text "the rewritten predicate does not engage the batch fold" \
+	"$(q "SET pgcolumnar.enable_ungrouped_vector_agg=on;
+	      EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF, SUMMARY OFF)
+	      SELECT count(*) FROM pre_c WHERE date_trunc('day', ts) = $DAY" |
+	   grep 'Columnar Batch Fold' | grep -oE 'yes|no' | head -1)" "no"
+check_num "...and still answers correctly with the fold enabled" \
+	"$(q1 "SET pgcolumnar.enable_ungrouped_vector_agg=on;
+	       SELECT count(*) FROM pre_c WHERE date_trunc('day', ts) = $DAY;")" \
+	"$(q1 "SELECT count(*) FROM pre_h WHERE date_trunc('day', ts) = $DAY;")"
+
+# ---- the other units in the table, each proved rather than assumed ---------
+# A month is not a fixed number of seconds, so `month` and `quarter` exercise
+# calendar arithmetic that `day` does not.
+for u in month week quarter year; do
+	case $u in
+		month)   c="timestamp '2024-02-01'" ;;
+		week)    c="date_trunc('week', timestamp '2024-02-01')" ;;
+		quarter) c="date_trunc('quarter', timestamp '2024-02-01')" ;;
+		year)    c="timestamp '2024-01-01'" ;;
+	esac
+	uq="SELECT count(*) FROM pre_c WHERE date_trunc('$u', ts) = $c"
+	uh="SELECT count(*) FROM pre_h WHERE date_trunc('$u', ts) = $c"
+	check_num "unit '$u' returns the heap's answer" "$(q1 "$uq;")" "$(q1 "$uh;")"
+	# and the answer is not trivially zero, or the arm proves nothing
+	check_num "unit '$u': premise: it matches some rows" \
+		"$([ "$(q1 "$uh;")" -gt 0 ] && echo 1 || echo 0)" 1
+done
+
+# A unit the table does not carry must DECLINE and still be correct.
+check_num "an unlisted unit (millennium) still answers correctly" \
+	"$(q1 "SELECT count(*) FROM pre_c WHERE date_trunc('millennium', ts) = date_trunc('millennium', timestamp '2024-02-01');")" \
+	"$(q1 "SELECT count(*) FROM pre_h WHERE date_trunc('millennium', ts) = date_trunc('millennium', timestamp '2024-02-01');")"
+
+check_num "backend still up" "$(q1 'SELECT 1;')" 1
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -216,6 +216,7 @@ SUITES=(
 	parquet_nested
 	parquet_nested_import
 	pg19_vacuum_options
+	preimage_rewrite
 	pg_dump_roundtrip
 	phase2
 	phase3

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -216,7 +216,6 @@ SUITES=(
 	parquet_nested
 	parquet_nested_import
 	pg19_vacuum_options
-	preimage_rewrite
 	pg_dump_roundtrip
 	phase2
 	phase3
@@ -224,6 +223,7 @@ SUITES=(
 	phase5
 	phase6
 	planner_choice_quality
+	preimage_rewrite
 	projection_privilege
 	projections
 	pushdown_report


### PR DESCRIPTION
Implements item 1 of #403, the item that issue names as the strongest and
recommends breaking out. From the ClickHouse VLDB 2024 paper's monotonicity
traits: a predicate on a *function* of the sort key cannot use that key's zone
map, but the preimage of the function is a range the zone map **can** use.

## Measured before building anything

500,000 rows clustered by time, 50 chunk groups:

| predicate | groups read | removed | rows |
| --- | ---: | ---: | ---: |
| `ts >= '2024-02-01' AND ts < '2024-02-02'` | 2 | 48 | 10000 |
| `date_trunc('day', ts) = '2024-02-01'` — before | **50** | 0 | 10000 |
| `date_trunc('day', ts) = '2024-02-01'` — after | **2** | 48 | 10000 |

Same answer, 25x fewer groups read, now matching the explicit range exactly.

The issue is old, so its premises were re-checked first: `monoton|preimage`
still finds only comments and no code, and the existing `date_trunc` handling in
`columnar_vector.c` is a group-**count** estimate for the grouped node —
unrelated machinery, though it showed the funcid-matching pattern.

## Being straight about the generality

Dispatched on funcid in the scan-key builder beside the IN-list rewrite, so
adding a second function means adding its preimage rather than editing the
general comparison path — the objection #369 raised against a special case.

But this inverts **exactly one function**, and the step comes from a small table
of unit names, because a month is not a fixed number of seconds and has to be an
interval applied by calendar arithmetic. The generality is in *where* the rewrite
happens, not yet in how many functions it knows. Unlisted units decline.

`timestamptz` is deliberately absent: `date_trunc(text, timestamptz)` truncates
in the session `TimeZone`, so the interval depends on a GUC that can change
after the key is frozen at executor start. The suite asserts the timestamptz
answer under **two different zones** rather than asserting an absence.

## Two of my own design claims were refuted by their removal proofs

Recorded because the comments now say what is true rather than what I assumed.

**"A non-truncated constant would admit rows the original excludes."** It would
not. The keys only prune, the executor re-applies the clause, and the derived
range is never *narrower* than the true matching set — the empty set is
contained in every range. Removing the check left the suite **green**. It is
defence in depth, kept because it is two lines and becomes load-bearing if these
keys are ever marked exact.

**"The conservative marking is load-bearing against the batch fold."** Not
observable today: `pgcolumnar_batch_type_ok` admits only int and float, so the
fold refuses a `timestamp` column on the **type** gate before exactness is
consulted. Marking the keys exact left the suite green too. The arm that names
the fold now records that it passes for a different reason than its title
suggests.

## Removal proof

Reverting the rewrite returns the work arm to 0 removed while every answer arm
stays green — which is the only thing that *can* move. A predicate rewrite that
prunes correctly and one that does not prune at all return identical rows, so
the pruning measurement is the only check that can see this change at all.

## Suites

`preimage_rewrite` 24/24, plus 15 green on PG17 covering every pruning path:
`pushdown_report`, `native_skip`, `native_zonemap`, `native_zonemap_narrow`,
`zonemap_cost`, `native_saop_pushdown`, `native_param_pushdown`,
`native_exact_selection`, `native_bloom`, `ungrouped_vector_agg`,
`native_groupagg_batch`, `vector_agg_rescan_memory`, `native_decode_gating`,
`differential`, `docs_style`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8jGnYAbTgiAcoUqn7E9EN
