### PR TITLE
ci: run the extension-upgrade guard, and stop the coverage runner failing on it (#741)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -531,7 +531,14 @@ jobs:
       # ran, so an environment shortfall is a failure of the job, not a waiver.
       - name: Run the extension-upgrade guard
         run: |
-          set -uo pipefail
+          # `set +e`, NOT `set -uo pipefail`. GitHub runs a `run:` step as
+          # `bash -e {0}`, and -uo pipefail does not cancel that -e: the step
+          # would abort at the suite line and rc, the annotation and the exit
+          # below would never execute. The gate still held -- a non-zero exit
+          # fails the job either way -- but the one case the comment singles out
+          # was the one case that could never announce itself. Only `set +e`
+          # restores the intent (#741 review).
+          set +e
           sudo -E env "PATH=$PATH" \
             bash test/extension_upgrade.sh \
               /usr/lib/postgresql/18/bin/pg_config /tmp/pgc_old_alpha

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -443,3 +443,100 @@ jobs:
           name: coverage-info
           path: coverage/coverage.info
           retention-days: 14
+
+  # The extension-upgrade guard (#382), which until #741 ran nowhere.
+  #
+  # What it catches is invisible to a build and to every other job here: each
+  # SQL-callable function records its C link name in pg_proc.prosrc at CREATE
+  # EXTENSION time, so renaming a link name leaves every EXISTING install
+  # pointing at a symbol the new library no longer exports. It compiles, it
+  # links, every suite passes on a fresh install, and every upgraded install is
+  # inert. Only a real previous release, carrying data, upgraded in place, shows
+  # it.
+  #
+  # Nightly rather than per-PR: it builds the extension twice, and the suite's
+  # own header calls it a second gate beside the matrix rather than part of it.
+  upgrade-guard:
+    name: extension upgrade guard (PG 18)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    if: github.event_name == 'workflow_dispatch' || github.repository == 'commandprompt/pgcolumnar'
+    # Named ONCE. Two steps consume it, and a tag spelled separately in each is
+    # the kind of duplication that goes stale in one place and not the other.
+    env:
+      PGC_OLD_TAG: v1.0-alpha
+    steps:
+      # fetch-depth: 0 for the tags. The coverage job's plain checkout is why
+      # this suite could not resolve its old source at all (#741): actions/checkout
+      # fetches no tags by default, and the suite's ref fallback then fails.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Asserted, and asserted BEFORE the expensive setup, because "the old
+      # source was not available" is precisely the state that made this guard
+      # look like it was running when it was not. A tagless checkout must be a
+      # loud red here, never a skip.
+      - name: Confirm the previous release is present
+        run: |
+          set -euo pipefail
+          git rev-parse --verify -q "$PGC_OLD_TAG^{commit}"
+          echo "$PGC_OLD_TAG resolves to $(git rev-parse "$PGC_OLD_TAG^{commit}")"
+
+      # The DIRECTORY form, which the suite documents, rather than its git-ref
+      # form. The suite runs under sudo (its runpg is an unconditional
+      # `runuser -u postgres`), and a root `git clone` of a workspace owned by
+      # the runner user trips git's dubious-ownership refusal. `git archive` runs
+      # as the ordinary user and yields a plain tree with no .git, which is
+      # exactly the case the directory form exists for.
+      #
+      # Passing it explicitly also sets the suite's EXPLICIT flag, so its
+      # "not a git checkout" SKIP branch is unreachable from here. A guard that
+      # can quietly skip is the failure this job exists to end.
+      - name: Materialise the previous release as a plain tree
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/pgc_old_alpha
+          mkdir -p /tmp/pgc_old_alpha
+          git archive "$PGC_OLD_TAG" | tar -x -C /tmp/pgc_old_alpha
+          test -f /tmp/pgc_old_alpha/Makefile
+          echo "old source: $(find /tmp/pgc_old_alpha -maxdepth 1 | wc -l) top-level entries"
+
+      - name: Add the PGDG repository and refresh the package lists
+        run: |
+          set -euo pipefail
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo curl -fsSL --connect-timeout 15 --max-time 120 \
+            --retry 5 --retry-delay 5 --retry-all-errors \
+            -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+            https://www.postgresql.org/media/keys/ACCC4CF8.asc
+          echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] \
+            https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
+            | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
+          sudo timeout 300 apt-get -o Acquire::Retries=5 update
+
+      - name: Install PostgreSQL 18 and the codec headers
+        run: |
+          set -euo pipefail
+          sudo timeout 600 apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
+            postgresql-18 postgresql-server-dev-18 \
+            liblz4-dev libzstd-dev zlib1g-dev
+
+      - name: Stop the packaged cluster
+        run: sudo systemctl stop postgresql || true
+
+      # Exit 2 is the suite's "the environment could not supply an old source".
+      # run_all_versions.sh maps that to SKIP, which is right for a developer's
+      # box and wrong here: this job's entire purpose is that the guard actually
+      # ran, so an environment shortfall is a failure of the job, not a waiver.
+      - name: Run the extension-upgrade guard
+        run: |
+          set -uo pipefail
+          sudo -E env "PATH=$PATH" \
+            bash test/extension_upgrade.sh \
+              /usr/lib/postgresql/18/bin/pg_config /tmp/pgc_old_alpha
+          rc=$?
+          if [ "$rc" = 2 ]; then
+            echo "::error::the guard skipped for want of an old source; in this job that is a failure"
+          fi
+          exit "$rc"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,22 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ### Fixed
 
+- The extension-upgrade guard now runs in CI, and had never verified an upgrade
+  before. `test/extension_upgrade.sh` catches a break that is invisible until a
+  user upgrades: a renamed C link name leaves every existing install pointing at
+  a symbol the new library no longer exports. No workflow set `PGC_RUN_UPGRADE`,
+  so it ran nowhere, and the one runner that did reach it, the coverage report,
+  discovered it through `not_a_suite()` and invoked it with no old source, then
+  counted the resulting environment shortfall as a failed suite. A nightly job
+  now builds the previous release on PostgreSQL 18, loads data into it and
+  upgrades it in place, and both upgrade suites are excluded from the coverage
+  runner together. Running it also exposed a defect in the suite itself: every
+  connection used `psql -h /tmp`, while the socket directory is decided by how
+  PostgreSQL was built, `/tmp` for a source build and `/var/run/postgresql` for
+  the Debian and PGDG packages, so the suite had never been runnable against a
+  packaged server and reported the connection failure as "old install did not
+  store rows". It now states the directory it connects to. (#741)
+
 - The vectorized aggregates now bound their per-execution memory with one
   mechanism instead of two. The scan-key context added for #717 covered the
   scan keys; the scratch context added for #727 covered the whole scan and so

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -303,7 +303,9 @@ behaviour.
 **Nightly at 06:00 UTC** (`.github/workflows/nightly.yml`): the full packaged
 suite matrix across 15 to 18 on x86_64, and the current major on aarch64. The
 nightly run also includes the ASAN and UBSAN sanitizer gate, against an
-instrumented PostgreSQL, and the coverage report. The sanitizer build stays in a cache, because it takes longer to build
+instrumented PostgreSQL, and the coverage report. It also runs the
+extension-upgrade guard. That guard builds the previous release on PostgreSQL
+18, loads data into it, and upgrades it in place. The sanitizer build stays in a cache, because it takes longer to build
 than to run the suites against it.
 
 The aarch64 run executes the suites rather than only building them. Misaligned

--- a/test/extension_upgrade.sh
+++ b/test/extension_upgrade.sh
@@ -136,6 +136,22 @@ runpg "$BINDIR/initdb" -D "$DATA" --locale=C -U postgres >/dev/null 2>&1 \
 {
 	echo "shared_preload_libraries='pgcolumnar'"
 	echo "port=$PORT"
+	# Every connection below is `psql -h /tmp`, and where the socket actually
+	# lands is a property of how PostgreSQL was BUILT, not of this suite: a
+	# source build defaults to /tmp, while the Debian and PGDG packages compile
+	# in /var/run/postgresql. So against a packaged server every psql here failed
+	# with `connection to server on socket "/tmp/.s.PGSQL.NNNN" failed`, and the
+	# suite reported "old install did not store rows" -- a connection fault
+	# wearing the costume of a product failure.
+	#
+	# It went unseen because the two never met: developers run this against
+	# source builds, and #741 is the issue that CI had never run it at all. The
+	# first CI run after wiring it up failed here.
+	#
+	# Stated rather than inherited, so -h /tmp is true by construction on either
+	# kind of build. lib.sh sidesteps the whole question by connecting over TCP;
+	# this suite carries its own harness and connects by socket.
+	echo "unix_socket_directories='/tmp'"
 } >> "$DATA/postgresql.conf"
 runpg "$BINDIR/pg_ctl" -D "$DATA" -l "$LOG" -w start >/dev/null 2>&1 \
 	|| { echo "FAIL  start"; tail -10 "$LOG"; exit 1; }

--- a/test/run_coverage.sh
+++ b/test/run_coverage.sh
@@ -54,10 +54,25 @@ make -C "$SRCDIR" PG_CONFIG="$PGC" COPT="--coverage" install >/dev/null 2>&1 || 
 
 # Every suite except the drivers, the libraries, and the ones that build their
 # own server or need two majors. Kept in step with harness_selftest.sh's list.
+#
+# The two upgrade suites are excluded TOGETHER, and that pairing is the point
+# (#741). run_all_versions.sh gates both behind PGC_RUN_UPGRADE, in one block and
+# for one reason: they build a second copy of the extension and need an old
+# source this runner has no way to supply. pg_upgrade was excluded here when it
+# was written and extension_upgrade was not, so this runner discovered it, ran it
+# with no old source, and its ref fallback could not resolve in a tagless CI
+# checkout. run_coverage maps only rc 66 to SKIP, so that environment shortfall
+# was counted as a failed suite and the nightly read "1 failed
+# ( extension_upgrade)" every night while nothing was wrong with the product.
+#
+# Deciding to run an opt-in guard is run_all_versions.sh's job, not this one's.
+# test/selftest/220 derives the gated list from that block and asserts every name
+# in it is refused here, so a third upgrade suite cannot repeat this.
 not_a_suite() {
 	case "$1" in
 		lib|portlib|run_all_versions|build_all_versions|devloop|rebuild) return 0 ;;
-		native_scale|build_san|run_san|run_coverage|pg_upgrade) return 0 ;;
+		native_scale|build_san|run_san|run_coverage) return 0 ;;
+		pg_upgrade|extension_upgrade) return 0 ;;
 		*) return 1 ;;
 	esac
 }

--- a/test/selftest/220-an-opt-in-upgrade-guard-must.sh
+++ b/test/selftest/220-an-opt-in-upgrade-guard-must.sh
@@ -1,0 +1,115 @@
+# ---- an opt-in upgrade guard must run somewhere, and not in the wrong runner --
+#
+# #741. test/extension_upgrade.sh is the guard for the break that is invisible
+# until a user upgrades, and in CI it had never verified an upgrade. Two separate
+# defects, which is why there are two groups of checks here.
+#
+# 1. run_all_versions.sh gates both upgrade suites behind PGC_RUN_UPGRADE, and
+#    run_coverage.sh's not_a_suite() excluded pg_upgrade but not
+#    extension_upgrade. So the coverage runner discovered it and ran it with no
+#    old source, its ref fallback could not resolve in a tagless CI checkout, and
+#    run_coverage counted the environment shortfall as a failed suite. The
+#    nightly read "1 failed ( extension_upgrade)" every night.
+#
+# 2. Nothing in .github/workflows set PGC_RUN_UPGRADE or invoked the suite, so
+#    the guard never actually ran anywhere. That is the failure mode #257 exists
+#    to close, and the comment at run_all_versions.sh:856-860 is about the last
+#    time it happened to this same suite (#396).
+#
+# The opt-in suites are DERIVED from run_all_versions.sh rather than named here.
+# A third one added to that block is then covered by this check on the day it is
+# added, which a hand-maintained list of two names cannot do.
+
+_upg_block() {	# the suites run_all_versions invokes only under PGC_RUN_UPGRADE
+	awk '/if \[ "\$\{PGC_RUN_UPGRADE:-0\}" = 1 \]; then/,/^fi$/' \
+		"$TESTDIR/run_all_versions.sh" |
+		grep -oE 'test/[a-z_]+\.sh' | sed 's|test/||; s|\.sh$||' | sort -u
+}
+_upg_optin="$(_upg_block)"
+
+check "premise: the PGC_RUN_UPGRADE block was found and names at least one suite" \
+	"$([ -n "$_upg_optin" ] && echo yes || echo no)" "yes"
+echo "-- opt-in upgrade suites, derived: $(echo $_upg_optin)"
+
+# not_a_suite is the thing under test, so it is evaluated rather than grepped.
+# Its call site is asserted separately: a function nothing calls would pass every
+# check below while the runner went on discovering the suite anyway.
+check "premise: run_coverage.sh defines not_a_suite and calls it" \
+	"$([ "$(grep -c '^not_a_suite()' "$TESTDIR/run_coverage.sh")" -ge 1 ] &&
+	   [ "$(grep -c 'not_a_suite "\$n"' "$TESTDIR/run_coverage.sh")" -ge 1 ] &&
+	   echo yes || echo no)" "yes"
+
+_upg_refuses() {	# 0 when run_coverage.sh's not_a_suite refuses $1
+	( eval "$(sed -n '/^not_a_suite()/,/^}/p' "$TESTDIR/run_coverage.sh")"
+	  not_a_suite "$1" )
+}
+
+# The instrument must be able to say both things, or "nothing was missed" is not
+# evidence. A name that is plainly a suite must NOT be refused.
+check "premise: not_a_suite says no to an ordinary suite, so its yes means something" \
+	"$(_upg_refuses smoke && echo refused || echo run)" "run"
+
+_upg_missing=""
+for _u in $_upg_optin; do
+	_upg_refuses "$_u" || _upg_missing="$_upg_missing $_u"
+done
+check "every PGC_RUN_UPGRADE-gated suite is excluded from the coverage runner (#741)" \
+	"$(printf '%s' "$_upg_missing" | sed 's/^ //')" ""
+
+# ---- and the guard must actually be run by something ------------------------
+#
+# Premised on the workflow directory being non-empty, because a population that
+# is empty makes the search below pass without looking at anything.
+_upg_wfdir="$TESTDIR/../.github/workflows"
+_upg_wfcount=$(ls "$_upg_wfdir"/*.yml 2>/dev/null | wc -l)
+check "premise: there are workflow files to search" \
+	"$([ "$_upg_wfcount" -ge 1 ] && echo yes || echo no)" "yes"
+
+# An invocation, not a mention: a commented-out line naming the suite would
+# otherwise satisfy this and the guard would still never run.
+_upg_ci=$(grep -rhE '^[^#]*(extension_upgrade\.sh|PGC_RUN_UPGRADE=1)' \
+	"$_upg_wfdir"/*.yml 2>/dev/null | wc -l)
+check "CI runs the extension-upgrade guard somewhere (#741)" \
+	"$([ "$_upg_ci" -ge 1 ] && echo yes || echo no)" "yes"
+
+# ---- and the two not_a_suite lists must actually agree ----------------------
+#
+# There are two copies of this list, and run_coverage.sh's own comment says it is
+# "Kept in step with harness_selftest.sh's list". It was not: the selftest copy
+# in 040 already named extension_upgrade and run_coverage's did not, which is the
+# whole of #741's second half. A comment claiming two things agree is not a
+# mechanism that makes them agree.
+#
+# So the claim is asserted over the WHOLE population of test files rather than
+# for the two names that happened to drift, and in both directions. A name either
+# copy would treat differently is a failure whichever copy is wrong, which is
+# what makes this able to catch the next drift rather than this one.
+#
+# Both functions are extracted from their files and evaluated, so this compares
+# what the runners will actually do, not two pieces of source text that look
+# alike.
+_upg_fn_cov="$(sed -n '/^not_a_suite()/,/^}/p' "$TESTDIR/run_coverage.sh")"
+_upg_fn_self="$(sed -n '/^not_a_suite()/,/^}/p' "$TESTDIR"/selftest/040-*.sh)"
+
+check "premise: both not_a_suite definitions were found" \
+	"$([ -n "$_upg_fn_cov" ] && [ -n "$_upg_fn_self" ] && echo yes || echo no)" "yes"
+
+_upg_pop=0
+_upg_disagree=""
+for _f in "$TESTDIR"/*.sh; do
+	_b="$(basename "$_f" .sh)"
+	_upg_pop=$((_upg_pop + 1))
+	_c=$( ( eval "$_upg_fn_cov";  not_a_suite "$_b" ) && echo excl || echo run )
+	_s=$( ( eval "$_upg_fn_self"; not_a_suite "$_b" ) && echo excl || echo run )
+	[ "$_c" = "$_s" ] || _upg_disagree="$_upg_disagree ${_b}(coverage=$_c,selftest=$_s)"
+done
+
+# Printed from the data, beside the claim it supports.
+echo "-- not_a_suite agreement: $_upg_pop test files compared,\
+ $(printf '%s' "$_upg_disagree" | wc -w) disagreements"
+
+check "premise: the population is the real test directory, not an empty glob" \
+	"$([ "$_upg_pop" -gt 50 ] && echo yes || echo no)" "yes"
+
+check "the coverage runner's not_a_suite agrees with the selftest's, both ways (#741)" \
+	"$(printf '%s' "$_upg_disagree" | sed 's/^ //')" ""

--- a/test/selftest/230-a-suite-connecting-by-socket-must.sh
+++ b/test/selftest/230-a-suite-connecting-by-socket-must.sh
@@ -1,0 +1,45 @@
+# ---- a suite connecting by unix socket must SAY where the socket is ---------
+#
+# Where a server puts its unix socket is a property of how PostgreSQL was BUILT,
+# not of the suite connecting to it. A source build defaults to /tmp; the Debian
+# and PGDG packages compile in /var/run/postgresql. So a suite that runs
+# `psql -h /tmp` without setting unix_socket_directories works on one kind of
+# build and fails on the other, with `connection to server on socket
+# "/tmp/.s.PGSQL.NNNN" failed`.
+#
+# That is not hypothetical and it is not cosmetic. extension_upgrade.sh did
+# exactly this, and the failure arrives dressed as a product failure: every psql
+# returns an error string, the row count is not 1000, and the suite reports
+# "old install did not store rows". Developers never saw it because they run
+# against source builds, and CI never saw it because #741 is the issue that CI
+# had never run this suite at all. The first CI run after wiring it up failed
+# here.
+#
+# Most suites are immune for a different reason: lib.sh connects over TCP
+# (-h 127.0.0.1, with listen_addresses set to match), so the socket location
+# never arises. This check is about the ones that carry their own harness.
+
+_sock_users=""
+_sock_missing=""
+for _f in "$TESTDIR"/*.sh; do
+	# A filesystem path, not 127.0.0.1. `-h /` is the discriminator.
+	grep -qE '\-h /' "$_f" || continue
+	_b="$(basename "$_f" .sh)"
+	_sock_users="$_sock_users $_b"
+	grep -q 'unix_socket_directories' "$_f" || _sock_missing="$_sock_missing $_b"
+done
+
+echo "-- suites connecting by socket path:$(printf '%s' "${_sock_users:- none}")"
+
+# Without this the loop below can pass by finding nothing to check, which is the
+# same as not running. See the population rule in CONTEXT.md.
+check "premise: at least one suite connects by a socket path, so this is not vacuous" \
+	"$([ -n "$_sock_users" ] && echo yes || echo no)" "yes"
+
+# And the discriminator must not simply match everything: the TCP suites must NOT
+# be in the population, or "they all set it" would be meaningless.
+check "premise: a TCP suite is not counted as a socket user" \
+	"$(grep -qE '\-h /' "$TESTDIR/lib.sh" && echo counted || echo not-counted)" "not-counted"
+
+check "every suite that connects by socket path sets unix_socket_directories" \
+	"$(printf '%s' "$_sock_missing" | sed 's/^ //')" ""

--- a/test/selftest/230-a-suite-connecting-by-socket-must.sh
+++ b/test/selftest/230-a-suite-connecting-by-socket-must.sh
@@ -18,12 +18,29 @@
 # Most suites are immune for a different reason: lib.sh connects over TCP
 # (-h 127.0.0.1, with listen_addresses set to match), so the socket location
 # never arises. This check is about the ones that carry their own harness.
+#
+# The discriminator matches a -h argument that is a PATH or a VARIABLE, quoted or
+# not, on a non-comment line. Every part of that earns its place:
+#
+#   -h /tmp          extension_upgrade
+#   -h '$WORKDIR'    concurrency, unique_conc, update_conc  (single quotes)
+#   -h 127.0.0.1     NOT a socket user, and must stay out
+#
+# The first version asked only for `-h /` and found ONE suite. It missed three,
+# because the spelling that actually dominates the tree is the quoted variable.
+# A population of one that looks complete is the thing the premise below cannot
+# see, so the population is printed beside the claim (#741 review).
+#
+# Comment lines are excluded deliberately, not incidentally: fuzz_parquet carries
+# `-h "$PGC_WORKDIR"` in a comment describing what an EARLIER version did, and it
+# connects over TCP. Matching it would put a TCP suite in the population and
+# report a defect that does not exist -- the too-loose direction, which costs an
+# afternoon chasing nothing.
 
 _sock_users=""
 _sock_missing=""
 for _f in "$TESTDIR"/*.sh; do
-	# A filesystem path, not 127.0.0.1. `-h /` is the discriminator.
-	grep -qE '\-h /' "$_f" || continue
+	grep -qE "^[^#]*-h ['\"]?[/\$]" "$_f" || continue
 	_b="$(basename "$_f" .sh)"
 	_sock_users="$_sock_users $_b"
 	grep -q 'unix_socket_directories' "$_f" || _sock_missing="$_sock_missing $_b"
@@ -38,8 +55,15 @@ check "premise: at least one suite connects by a socket path, so this is not vac
 
 # And the discriminator must not simply match everything: the TCP suites must NOT
 # be in the population, or "they all set it" would be meaningless.
-check "premise: a TCP suite is not counted as a socket user" \
-	"$(grep -qE '\-h /' "$TESTDIR/lib.sh" && echo counted || echo not-counted)" "not-counted"
+# Three named TCP users, not one: lib.sh (every ordinary suite), fuzz_parquet
+# (whose comment names the old socket spelling) and isolation (PGHOST=127.0.0.1).
+# If any of them enters the population the discriminator has gone too loose.
+_sock_tcp=""
+for _t in lib fuzz_parquet isolation; do
+	grep -qE "^[^#]*-h ['\"]?[/\$]" "$TESTDIR/$_t.sh" 2>/dev/null && _sock_tcp="$_sock_tcp $_t"
+done
+check "premise: no TCP suite is counted as a socket user" \
+	"$(printf '%s' "$_sock_tcp" | sed 's/^ //')" ""
 
 check "every suite that connects by socket path sets unix_socket_directories" \
 	"$(printf '%s' "$_sock_missing" | sed 's/^ //')" ""

--- a/test/selftest/240-the-nightly-enumeration-must-not.sh
+++ b/test/selftest/240-the-nightly-enumeration-must-not.sh
@@ -1,0 +1,59 @@
+# ---- the docs' nightly enumeration must not go stale by addition ------------
+#
+# docs/testing.md enumerates what the nightly contains. An enumeration goes stale
+# by ADDITION: it stays true about everything it lists while silently
+# under-describing the workflow the moment a job is added. #741 added a fourth
+# job and the sentence still named three, which is the same shape as #671.
+#
+# So the enumeration is derived from the workflow and checked, rather than
+# trusted. Two decisions, and the first version got the second one wrong:
+#
+# 1. The token compared is the JOB KEY, not the display name and not the prose. A
+#    key is stable and machine-owned; a display name carries a matrix expression
+#    and prose gets reworded. Hyphens and underscores are normalised to spaces, so
+#    `upgrade-guard` is satisfied by "extension-upgrade guard".
+#
+# 2. The search is scoped to the NIGHTLY PARAGRAPH, not the whole file. The first
+#    version searched the whole document for the key's first word, and its own
+#    removal proof exposed it: delete the sentence naming the upgrade guard and
+#    the check STAYED GREEN, because "upgrade" already appears eleven times in
+#    this file for unrelated reasons (pg_upgrade, PGC_RUN_UPGRADE). It caught an
+#    invented job name and missed the case it was written for, which is the
+#    too-loose failure in CONTEXT.md. The proof is what found that, not review.
+
+_nl_wf="$TESTDIR/../.github/workflows/nightly.yml"
+_nl_doc="$TESTDIR/../docs/testing.md"
+
+check "premise: the nightly workflow and the testing doc are both present" \
+	"$([ -r "$_nl_wf" ] && [ -r "$_nl_doc" ] && echo yes || echo no)" "yes"
+
+# Job keys: the two-space-indented mapping keys under `jobs:`. Read from the
+# workflow so a job added later is covered on the day it is added.
+_nl_jobs="$(awk '/^jobs:/{inj=1;next} inj && /^  [a-zA-Z_-]+:[[:space:]]*$/{
+	k=$1; sub(/:$/,"",k); print k}' "$_nl_wf")"
+_nl_n=$(printf '%s\n' "$_nl_jobs" | grep -c .)
+
+echo "-- nightly jobs, derived: $(echo $_nl_jobs) ($_nl_n found)"
+
+# Without this the loop can pass by iterating over nothing, which is the failure
+# this file exists to prevent, occurring inside the check for it.
+check "premise: at least three nightly jobs were parsed, so the list is real" \
+	"$([ "${_nl_n:-0}" -ge 3 ] && echo yes || echo no)" "yes"
+
+# The nightly paragraph alone: from its bold heading to the next blank line,
+# with hyphens and underscores flattened so "extension-upgrade guard" reads as
+# "extension upgrade guard".
+_nl_para="$(awk '/\*\*Nightly at/{p=1} p{print} p&&/^$/{exit}' "$_nl_doc" |
+	tr '\n' ' ' | tr '_-' '  ')"
+
+check "premise: the nightly paragraph was located and is not empty" \
+	"$([ "$(printf '%s' "$_nl_para" | wc -c)" -gt 100 ] && echo yes || echo no)" "yes"
+
+_nl_missing=""
+for _j in $_nl_jobs; do
+	_w="$(printf '%s' "$_j" | tr '_-' '  ')"
+	grep -qi -- "$_w" <<<"$_nl_para" || _nl_missing="$_nl_missing $_j"
+done
+
+check "every nightly job is named in docs/testing.md (#741)" \
+	"$(printf '%s' "$_nl_missing" | sed 's/^ //')" ""


### PR DESCRIPTION
Closes #741.

`test/extension_upgrade.sh` guards the break that is invisible until a user
upgrades. In CI it had never verified an upgrade. Two separate defects, fixed
separately.

## 1. Nothing ran it

No workflow set `PGC_RUN_UPGRADE`, so the block at `run_all_versions.sh:855-900`
never executed and the suite was absent from every `suites (PG N)` job.

Added a nightly `upgrade-guard` job on PG18. Three details are deliberate:

- `fetch-depth: 0`, because `actions/checkout` fetches no tags by default and the
  suite's ref fallback then cannot resolve. That is the whole of defect 2's
  symptom.
- The previous release is asserted to resolve **before** any expensive setup. A
  tagless checkout must be a loud red, never a skip, since "the old source was
  not available" is exactly the state that made this guard look like it was
  running when it was not.
- The old source is materialised with `git archive` into a plain tree and passed
  explicitly, i.e. the suite's documented **directory** form. The suite runs
  under `sudo` (its `runpg` is an unconditional `runuser`), and a root
  `git clone` of a workspace owned by the runner user trips git's
  dubious-ownership refusal. Passing it explicitly also sets the suite's
  `EXPLICIT` flag, so its "not a git checkout" SKIP branch is unreachable from
  here. Exit 2 is a failure of this job rather than a waiver, for the same
  reason.

## 2. The one path that did reach it could not work

`run_coverage.sh` discovers every `test/*.sh` not named in `not_a_suite()`, which
excluded `pg_upgrade` but not `extension_upgrade`, although `run_all_versions`
gates both in one block for one reason. It ran with no old source, and since
`run_coverage` maps only `rc = 66` to SKIP, the environment shortfall was counted
as a failed suite. Hence `1 failed ( extension_upgrade)` every night.

Both upgrade suites are now excluded together. Deciding to run an opt-in guard is
`run_all_versions.sh`'s job, not the coverage runner's.

### The comment was already false

There are two copies of that list, and `run_coverage.sh`'s comment said it was
"Kept in step with harness_selftest.sh's list". It was not: the selftest copy in
`040` already named `extension_upgrade`. A comment claiming two things agree is
not a mechanism that makes them agree, so `test/selftest/220` now asserts it over
the whole population of test files (227 compared), in both directions.

The gated suite list is **derived** from the `PGC_RUN_UPGRADE` block rather than
naming the two suites, so a third one added there is covered the day it is added.

## Verified end to end, not by inspection

On PG17 in the container, one variable between the arms:

| arm | change | result |
| --- | --- | --- |
| ARM | tagless checkout, invoked as `run_coverage.sh` does | rc 1, `v1.0-alpha is not present` |
| CONTROL | same tree, old source materialised by `git archive` | rc 0 |

The ARM reproduces the nightly's failure exactly. The CONTROL upgrades 1.0-dev to
1.0-alpha2 with 7 PASS lines including the 149-object catalog convergence check,
so the upgrade path itself is sound today and the red really was the missing old
source.

## Removal proofs, each in isolation

| mutation | check that goes red |
| --- | --- |
| revert `not_a_suite` | "every PGC_RUN_UPGRADE-gated suite is excluded", got `[extension_upgrade]` |
| remove the workflow job | "CI runs the extension-upgrade guard somewhere" |
| mention the suite only in a **comment** in a workflow | still red, so a commented-out line cannot satisfy it |
| drift **either** `not_a_suite` copy | agreement check red, naming which copy drifted |

And the instrument is shown to say both things: `not_a_suite` is asserted to
REFUSE an ordinary suite, so its acceptance of these two means something.

`harness_selftest`: 119 checks, PASSED.

## What this does not do

- **It does not fix #740, and the nightly stays red until that lands.** Once
  `lcov` succeeds, `run_coverage` reaches its real verdict at line 142. The two
  are a pair, and neither alone reaches green.
- It does not teach `run_coverage.sh` the exit-2 SKIP contract that
  `run_all_versions.sh` honours. With both upgrade suites excluded, no discovered
  suite exits 2 today, so that would be untested handling for a case that cannot
  currently arise. Worth doing if a suite ever needs it.
- It does not run the `pg_upgrade` cross-major pair matrix, which is the other
  half of `PGC_RUN_UPGRADE` and a much larger job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EYZNZ2hPeFxTNQNeCmce4E
