### PR TITLE
fix: the coverage job could never write its counters (#740)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -428,6 +428,22 @@ jobs:
           sudo -E env "PATH=$PATH" \
             bash test/run_coverage.sh /usr/lib/postgresql/18/bin/pg_config
 
+      # The per-suite logs, which were never uploaded. Only coverage/html and
+      # coverage.info were, so when a suite failed inside this job the detail
+      # went away with the runner and the tally line was all anyone could see.
+      # That is how #741's failing suite stayed invisible: the job printed
+      # "1 failed ( extension_upgrade)" every night and the reason was
+      # unreachable. `if: always()` because a failed run is exactly when they
+      # are wanted.
+      - name: Upload the per-suite logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-suite-logs
+          path: coverage/*.log
+          retention-days: 14
+          if-no-files-found: warn
+
       - name: Upload the HTML report
         if: always()
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,11 +38,14 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
   harness runs the server as `postgres` whenever it is root. gcov writes each
   `.gcda` beside its object, as the process that ran the code, so the backend
   could not create one and there was nothing to capture. The counter directories
-  are now made writable by the server user, derived from where the `.gcno` files
-  actually are rather than named, because objects are in both `src` and
-  `objstore`. Measured in the failing configuration: 0 counters before and 34
-  after, through `lcov` and `genhtml` to a report, with 210 suites passing and
-  93.4 percent of lines covered. The runner also refuses a run that captured no
+  are now redirected with `GCOV_PREFIX` to a directory under `/tmp`, which is
+  writable and traversable whoever the server runs as, and returned beside their
+  objects before the report is built. Making the object directories writable was
+  tried first and is not sufficient: creating a file also needs execute on every
+  ancestor, and in CI the tree sits under the runner's home. Measured in a
+  configuration with an ancestor the server user cannot traverse, which defeats
+  the ownership fix: 0 counters before and 33 after, through `lcov` and `genhtml`
+  to a report. The runner also refuses a run that captured no
   counters, and says where they should have been, instead of leaving `lcov` to
   report an empty tree as a tool failure. The per-suite logs are uploaded, so a
   suite that fails inside this job no longer has its detail discarded when the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,23 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ### Fixed
 
+- The nightly coverage report now measures something. It had never captured any
+  coverage: the job failed every night from the night it was added on
+  2026-07-31, always at `lcov capture produced nothing`. `test/run_coverage.sh`
+  runs under `sudo` in CI, so the instrumented build is owned by root, while the
+  harness runs the server as `postgres` whenever it is root. gcov writes each
+  `.gcda` beside its object, as the process that ran the code, so the backend
+  could not create one and there was nothing to capture. The counter directories
+  are now made writable by the server user, derived from where the `.gcno` files
+  actually are rather than named, because objects are in both `src` and
+  `objstore`. Measured in the failing configuration: 0 counters before and 34
+  after, through `lcov` and `genhtml` to a report, with 210 suites passing and
+  93.4 percent of lines covered. The runner also refuses a run that captured no
+  counters, and says where they should have been, instead of leaving `lcov` to
+  report an empty tree as a tool failure. The per-suite logs are uploaded, so a
+  suite that fails inside this job no longer has its detail discarded when the
+  runner is torn down. (#740)
+
 - The extension-upgrade guard now runs in CI, and had never verified an upgrade
   before. `test/extension_upgrade.sh` catches a break that is invisible until a
   user upgrades: a renamed C link name leaves every existing install pointing at

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -280,7 +280,9 @@ test/run_coverage.sh /path/to/pg_config
 ```
 
 Builds instrumented, runs the suites against that build, and writes an HTML
-report to `coverage/html`. It runs nightly and uploads the report as an artifact.
+report to `coverage/html`. It runs nightly and uploads the report as an
+artifact, along with the per-suite logs, so a suite that fails inside the
+coverage job can be read after the fact rather than only counted.
 
 There is no threshold and nothing fails on the number, deliberately. A coverage
 threshold creates pressure to write tests that execute lines rather than tests

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -281,8 +281,8 @@ test/run_coverage.sh /path/to/pg_config
 
 Builds instrumented, runs the suites against that build, and writes an HTML
 report to `coverage/html`. It runs nightly and uploads the report as an
-artifact, along with the per-suite logs, so a suite that fails inside the
-coverage job can be read after the fact rather than only counted.
+artifact. The per-suite logs are uploaded with it, so a suite that fails inside
+the coverage job can be read rather than only counted.
 
 There is no threshold and nothing fails on the number, deliberately. A coverage
 threshold creates pressure to write tests that execute lines rather than tests

--- a/test/run_coverage.sh
+++ b/test/run_coverage.sh
@@ -186,6 +186,15 @@ echo "-- counters returned beside their objects: $_moved"
 _gcno=$(find "$SRCDIR" -name '*.gcno' | wc -l)
 _gcda=$(find "$SRCDIR" -name '*.gcda' | wc -l)
 echo "-- counters: $_gcda .gcda from $_gcno instrumented objects"
+# Broken down by directory, because the two totals differ on the runner (34 of
+# 49) and a bare ratio invites the reading that a third of the objects went
+# uncovered. The report's scope is src/ alone -- `lcov --extract` below restricts
+# it -- so what matters is that every src object has a counter, not that the
+# totals match. Printed from the data rather than argued.
+find "$SRCDIR" \( -name '*.gcno' -o -name '*.gcda' \) -printf '%h %f\n' 2>/dev/null |
+	sed 's/.*\.\(gcno\|gcda\)$/\1/;s#^\(.*\) [^ ]*\.\(gcno\|gcda\)$#\1 \2#' |
+	awk '{ n[$1" "$2]++ } END { for (k in n) printf "     %-6s %s\n", n[k], k }' |
+	sort -k3 | head -20
 if [ "$_gcda" = 0 ]; then
 	echo "FAIL  no .gcda counters were written, so this measures no coverage" >&2
 	echo "      gcov writes them beside the objects, as the user that ran the" >&2

--- a/test/run_coverage.sh
+++ b/test/run_coverage.sh
@@ -52,6 +52,32 @@ fi
 make -C "$SRCDIR" PG_CONFIG="$PGC" COPT="--coverage" install >/dev/null 2>&1 || {
 	echo "FAIL  install failed" >&2; exit 1; }
 
+# gcov writes each .gcda beside its object, at the absolute path recorded at
+# COMPILE time, and it writes it as the process that ran the code. This runner is
+# invoked under sudo in CI, so the build is root-owned, while lib.sh runs the
+# server as `postgres` whenever it is root (lib.sh:150). The backend could not
+# create a counter file next to a root-owned object, no .gcda was ever written,
+# and `lcov --capture` had nothing to find: the report has measured nothing since
+# the job was added (#740).
+#
+# The directories are DERIVED from where the instrumentation actually landed, not
+# named. Objects are in src/ and objstore/ today, and a hardcoded src/ would
+# silently stop covering a directory added later -- and would leave the backend
+# unable to write there, which gcov reports as noise on stderr rather than as a
+# failure.
+#
+# Only when root. Run as an ordinary user the build and the server are the same
+# user and there is nothing to fix.
+if [ "$(id -u)" = 0 ]; then
+	_covdirs=$(find "$SRCDIR" -name '*.gcno' -printf '%h\n' | sort -u)
+	if [ -n "$_covdirs" ]; then
+		# shellcheck disable=SC2086
+		chown postgres $_covdirs
+		echo "-- counter directories made writable by the server user:" \
+			"$(printf '%s' "$_covdirs" | tr '\n' ' ')"
+	fi
+fi
+
 # Every suite except the drivers, the libraries, and the ones that build their
 # own server or need two majors. Kept in step with harness_selftest.sh's list.
 #
@@ -121,6 +147,22 @@ echo "-- suites: $pass passed, $fail failed${failed:+ ($failed)}, $skip skipped$
 if [ "$pass" = 0 ]; then
 	echo "-- NO SUITE RAN, so this measures no coverage"
 	fail=$((fail + 1))
+fi
+
+# A report built from no counters is not a report, which is the same reasoning as
+# the `pass = 0` guard above and the case that has actually been happening (#740).
+# Asserted HERE rather than left to lcov: `lcov --capture` failing on an empty
+# tree reports "capture produced nothing", which reads as a broken tool and sent
+# nobody to look at the permissions for 25 nights.
+_gcno=$(find "$SRCDIR" -name '*.gcno' | wc -l)
+_gcda=$(find "$SRCDIR" -name '*.gcda' | wc -l)
+echo "-- counters: $_gcda .gcda from $_gcno instrumented objects"
+if [ "$_gcda" = 0 ]; then
+	echo "FAIL  no .gcda counters were written, so this measures no coverage" >&2
+	echo "      gcov writes them beside the objects, as the user that ran the" >&2
+	echo "      code. Check that the server user can write to the directories" >&2
+	echo "      holding the .gcno files." >&2
+	exit 1
 fi
 
 echo "-- collect"

--- a/test/run_coverage.sh
+++ b/test/run_coverage.sh
@@ -197,13 +197,25 @@ echo "-- counters: $_gcda .gcda from $_gcno instrumented objects in src/"
 # (34 .gcda from 49 .gcno) and a bare ratio invites the reading that a third of
 # the objects went uncovered. Printed from the data rather than argued.
 find "$SRCDIR" \( -name '*.gcno' -o -name '*.gcda' \) -printf '%h %f\n' 2>/dev/null |
-	awk -v root="$SRCDIR/" '
+	awk -v srcdir="$SRCDIR" -v root="$SRCDIR/" '
 		{ ext = $2; sub(/.*\./, "", ext)
-		  dir = (index($1, root) == 1) ? substr($1, length(root) + 1) : $1
+		  dir = $1
+		  if (dir == srcdir) dir = "."
+		  else if (index(dir, root) == 1) dir = substr(dir, length(root) + 1)
 		  n[dir " " ext]++ }
 		END { for (k in n) { split(k, a, " ")
 			printf "     %-5s %-4s %s\n", n[k], a[2], a[1] } }' |
 	sort -k3,3 -k2,2
+# And NAMED, for anything outside the captured scope. The run above reported 13
+# instrumented objects at the repository root and 3 under objstore/, against 1
+# under objstore/ in the container, and a count is a shape rather than an
+# answer. This is the line that says what they are.
+_outside=$(find "$SRCDIR" -name '*.gcno' -not -path "$SRCDIR/src/*" \
+	-printf '%P\n' 2>/dev/null | sort)
+if [ -n "$_outside" ]; then
+	echo "-- instrumented objects outside src/, which the report does not cover:"
+	printf '     %s\n' $_outside | head -20
+fi
 if [ "$_gcda" = 0 ]; then
 	echo "FAIL  no .gcda counters were written, so this measures no coverage" >&2
 	echo "      gcov writes them beside the objects, as the user that ran the" >&2
@@ -211,7 +223,23 @@ if [ "$_gcda" = 0 ]; then
 	echo "      holding the .gcno files." >&2
 	# Say WHERE they went, if anywhere. A path mismatch and a permission refusal
 	# look identical from "0 counters", and they have different fixes.
-	_stray=$(find / -xdev -name '*.gcda' 2>/dev/null | head -5)
+	#
+	# GCOV_PREFIX is asked FIRST, and deliberately not left to the tree-wide
+	# walk below. That walk carries -xdev, which by definition will not cross a
+	# mount boundary, and /tmp is a separate tmpfs on this project's own dev
+	# container and on most systemd distributions. Counters sitting exactly
+	# where the redirect put them are invisible to it, and the run then reports
+	# "nothing wrote them" -- the opposite diagnosis, sending the reader to
+	# permissions when the counters exist and it is the copy-back that missed.
+	# Measured, one file under a tmpfs /tmp and none elsewhere: 0 found with
+	# -xdev, 1 without it, 1 probing the prefix.
+	#
+	# The tree-wide walk is kept as the fallback, because it answers a
+	# different question: gcov ignoring the redirect altogether and writing
+	# beside an object outside src/, which is on the same filesystem as the
+	# tree and which the src-scoped count above would not see.
+	_stray=$(find "$GCOV_PREFIX" -name '*.gcda' 2>/dev/null | head -5)
+	[ -n "$_stray" ] || _stray=$(find / -xdev -name '*.gcda' 2>/dev/null | head -5)
 	if [ -n "$_stray" ]; then
 		echo "      counters DO exist elsewhere, so this is a path mismatch:" >&2
 		printf '        %s\n' $_stray >&2

--- a/test/run_coverage.sh
+++ b/test/run_coverage.sh
@@ -75,6 +75,27 @@ if [ "$(id -u)" = 0 ]; then
 		chown postgres $_covdirs
 		echo "-- counter directories made writable by the server user:" \
 			"$(printf '%s' "$_covdirs" | tr '\n' ' ')"
+
+		# Prove it, rather than assume the chown was sufficient. Creating a file
+		# needs write AND execute on the directory, and execute on every ancestor
+		# of it, so an ownership change alone is not the whole condition. The
+		# first version of this fix stopped at the chown, and CI still captured
+		# zero counters while reporting the directories as "made writable" (#740).
+		for _d in $_covdirs; do
+			if runuser -u postgres -- test -w "$_d" 2>/dev/null &&
+			   runuser -u postgres -- touch "$_d/.pgc_gcov_probe" 2>/dev/null; then
+				rm -f "$_d/.pgc_gcov_probe"
+			else
+				echo "-- WARNING: the server user cannot create files in $_d" \
+					"($(stat -c '%U:%G %a' "$_d"))"
+				# The ancestors, because traversal is the usual reason.
+				_p="$_d"
+				while [ "$_p" != "/" ]; do
+					echo "     $(stat -c '%U:%G %a' "$_p") $_p"
+					_p="$(dirname "$_p")"
+				done
+			fi
+		done
 	fi
 fi
 
@@ -162,6 +183,15 @@ if [ "$_gcda" = 0 ]; then
 	echo "      gcov writes them beside the objects, as the user that ran the" >&2
 	echo "      code. Check that the server user can write to the directories" >&2
 	echo "      holding the .gcno files." >&2
+	# Say WHERE they went, if anywhere. A path mismatch and a permission refusal
+	# look identical from "0 counters", and they have different fixes.
+	_stray=$(find / -xdev -name '*.gcda' 2>/dev/null | head -5)
+	if [ -n "$_stray" ]; then
+		echo "      counters DO exist elsewhere, so this is a path mismatch:" >&2
+		printf '        %s\n' $_stray >&2
+	else
+		echo "      no .gcda anywhere on this filesystem, so nothing wrote them" >&2
+	fi
 	exit 1
 fi
 

--- a/test/run_coverage.sh
+++ b/test/run_coverage.sh
@@ -183,18 +183,27 @@ echo "-- counters returned beside their objects: $_moved"
 # Asserted HERE rather than left to lcov: `lcov --capture` failing on an empty
 # tree reports "capture produced nothing", which reads as a broken tool and sent
 # nobody to look at the permissions for 25 nights.
-_gcno=$(find "$SRCDIR" -name '*.gcno' | wc -l)
-_gcda=$(find "$SRCDIR" -name '*.gcda' | wc -l)
-echo "-- counters: $_gcda .gcda from $_gcno instrumented objects"
-# Broken down by directory, because the two totals differ on the runner (34 of
-# 49) and a bare ratio invites the reading that a third of the objects went
-# uncovered. The report's scope is src/ alone -- `lcov --extract` below restricts
-# it -- so what matters is that every src object has a counter, not that the
-# totals match. Printed from the data rather than argued.
+#
+# Counted over the directory lcov CAPTURES, not tree-wide. objstore/ is a
+# separate shared library, built alongside but never linked in (Makefile:127),
+# and the report is scoped to src/ by the --extract below. So a tree-wide count
+# can be non-zero while the captured directory holds nothing: one objstore
+# counter satisfies the guard and leaves lcov with an empty tree, which is the
+# exact "capture produced nothing" this guard exists to pre-empt.
+_gcno=$(find "$SRCDIR/src" -name '*.gcno' | wc -l)
+_gcda=$(find "$SRCDIR/src" -name '*.gcda' | wc -l)
+echo "-- counters: $_gcda .gcda from $_gcno instrumented objects in src/"
+# The whole tree, broken down, because the totals differ on the GitHub runner
+# (34 .gcda from 49 .gcno) and a bare ratio invites the reading that a third of
+# the objects went uncovered. Printed from the data rather than argued.
 find "$SRCDIR" \( -name '*.gcno' -o -name '*.gcda' \) -printf '%h %f\n' 2>/dev/null |
-	sed 's/.*\.\(gcno\|gcda\)$/\1/;s#^\(.*\) [^ ]*\.\(gcno\|gcda\)$#\1 \2#' |
-	awk '{ n[$1" "$2]++ } END { for (k in n) printf "     %-6s %s\n", n[k], k }' |
-	sort -k3 | head -20
+	awk -v root="$SRCDIR/" '
+		{ ext = $2; sub(/.*\./, "", ext)
+		  dir = (index($1, root) == 1) ? substr($1, length(root) + 1) : $1
+		  n[dir " " ext]++ }
+		END { for (k in n) { split(k, a, " ")
+			printf "     %-5s %-4s %s\n", n[k], a[2], a[1] } }' |
+	sort -k3,3 -k2,2
 if [ "$_gcda" = 0 ]; then
 	echo "FAIL  no .gcda counters were written, so this measures no coverage" >&2
 	echo "      gcov writes them beside the objects, as the user that ran the" >&2

--- a/test/run_coverage.sh
+++ b/test/run_coverage.sh
@@ -170,6 +170,20 @@ if [ -d "$GCOV_PREFIX" ]; then
 	while IFS= read -r _f; do
 		[ -n "$_f" ] || continue
 		_dest="${_f#$GCOV_PREFIX}"
+		# The destination must be INSIDE the tree, and this is not a tidiness
+		# check. $GCOV_PREFIX is a fixed path at mode 1777 and this loop runs as
+		# root under sudo, so without it any local unprivileged user chooses both
+		# the content and the destination: plant
+		# $GCOV_PREFIX/<anywhere>/x.gcda and root copies it to <anywhere>/x.gcda.
+		# Demonstrated with the loop exactly as it stood, a file planted as
+		# `postgres` and written by root outside the tree. Constrained to names
+		# ending .gcda, and not reachable on GitHub's single-tenant ephemeral
+		# runner, but reachable on any shared or developer box -- which this
+		# script's own header invites, since it documents being run under sudo.
+		case "$_dest" in
+			"$SRCDIR"/*) ;;
+			*) continue ;;
+		esac
 		[ -d "$(dirname "$_dest")" ] || continue
 		cp -p "$_f" "$_dest" 2>/dev/null && _moved=$((_moved + 1))
 	done <<EOF

--- a/test/run_coverage.sh
+++ b/test/run_coverage.sh
@@ -62,10 +62,20 @@ make -C "$SRCDIR" PG_CONFIG="$PGC" COPT="--coverage" install >/dev/null 2>&1 || 
 #
 # The counters are REDIRECTED rather than the source tree being opened up.
 # Chowning the object directories to the server user was the first fix and it is
-# not sufficient: creating a file needs execute on every ANCESTOR too, and in CI
-# the tree sits under the runner's home. Proved by construction -- with an
-# ancestor at mode 700 the chown succeeds, the directories are writable in
-# themselves, and zero counters are still written.
+# not sufficient: creating a file needs execute on every ANCESTOR too. Measured
+# on the runner, with the object directories already chowned:
+#
+#     postgres:runner 755 /home/runner/work/pgcolumnar/pgcolumnar/src
+#     postgres:runner 755 /home/runner/work/pgcolumnar/pgcolumnar
+#     runner:runner   755 /home/runner/work/pgcolumnar
+#     runner:runner   755 /home/runner/work
+#     runner:runner   750 /home/runner        <-- no execute for postgres
+#     root:root       755 /home
+#
+# /home/runner is 750 and postgres is neither its owner nor in the runner group,
+# so it cannot traverse into the workspace at all, however the leaf directories
+# are owned. That route could only work by chmod'ing the runner's home, which is
+# not a thing to do to a shared runner.
 #
 # GCOV_PREFIX makes gcov write to $GCOV_PREFIX/<absolute path>.gcda instead.
 # /tmp is world-writable and world-traversable, so this works whoever the server
@@ -80,6 +90,31 @@ rm -rf "$GCOV_PREFIX"
 mkdir -p "$GCOV_PREFIX"
 chmod 1777 "$GCOV_PREFIX"
 echo "-- counters redirected to $GCOV_PREFIX"
+
+# Every suite except the drivers, the libraries, and the ones that build their
+# own server or need two majors. Kept in step with harness_selftest.sh's list.
+#
+# The two upgrade suites are excluded TOGETHER, and that pairing is the point
+# (#741). run_all_versions.sh gates both behind PGC_RUN_UPGRADE, in one block and
+# for one reason: they build a second copy of the extension and need an old
+# source this runner has no way to supply. pg_upgrade was excluded here when it
+# was written and extension_upgrade was not, so this runner discovered it, ran it
+# with no old source, and its ref fallback could not resolve in a tagless CI
+# checkout. run_coverage maps only rc 66 to SKIP, so that environment shortfall
+# was counted as a failed suite and the nightly read "1 failed
+# ( extension_upgrade)" every night while nothing was wrong with the product.
+#
+# Deciding to run an opt-in guard is run_all_versions.sh's job, not this one's.
+# test/selftest/220 derives the gated list from that block and asserts every name
+# in it is refused here, so a third upgrade suite cannot repeat this.
+not_a_suite() {
+	case "$1" in
+		lib|portlib|run_all_versions|build_all_versions|devloop|rebuild) return 0 ;;
+		native_scale|build_san|run_san|run_coverage) return 0 ;;
+		pg_upgrade|extension_upgrade) return 0 ;;
+		*) return 1 ;;
+	esac
+}
 
 SUITES="${PGC_COV_SUITES:-}"
 if [ -z "$SUITES" ]; then

--- a/test/run_coverage.sh
+++ b/test/run_coverage.sh
@@ -240,8 +240,9 @@ if [ "$_gcda" = 0 ]; then
 	#
 	# GCOV_PREFIX is asked FIRST, and deliberately not left to the tree-wide
 	# walk below. That walk carries -xdev, which by definition will not cross a
-	# mount boundary, and /tmp is a separate tmpfs on this project's own dev
-	# container and on most systemd distributions. Counters sitting exactly
+	# mount boundary, and /tmp is a separate tmpfs on both boxes this was
+	# measured on, this project's dev container and the development host.
+	# How common that is elsewhere I have not measured. Counters sitting exactly
 	# where the redirect put them are invisible to it, and the run then reports
 	# "nothing wrote them" -- the opposite diagnosis, sending the reader to
 	# permissions when the counters exist and it is the copy-back that missed.

--- a/test/run_coverage.sh
+++ b/test/run_coverage.sh
@@ -56,73 +56,30 @@ make -C "$SRCDIR" PG_CONFIG="$PGC" COPT="--coverage" install >/dev/null 2>&1 || 
 # COMPILE time, and it writes it as the process that ran the code. This runner is
 # invoked under sudo in CI, so the build is root-owned, while lib.sh runs the
 # server as `postgres` whenever it is root (lib.sh:150). The backend could not
-# create a counter file next to a root-owned object, no .gcda was ever written,
-# and `lcov --capture` had nothing to find: the report has measured nothing since
+# create a counter file next to a root-owned object, so no .gcda was ever written
+# and `lcov --capture` had nothing to find. The report has measured nothing since
 # the job was added (#740).
 #
-# The directories are DERIVED from where the instrumentation actually landed, not
-# named. Objects are in src/ and objstore/ today, and a hardcoded src/ would
-# silently stop covering a directory added later -- and would leave the backend
-# unable to write there, which gcov reports as noise on stderr rather than as a
-# failure.
+# The counters are REDIRECTED rather than the source tree being opened up.
+# Chowning the object directories to the server user was the first fix and it is
+# not sufficient: creating a file needs execute on every ANCESTOR too, and in CI
+# the tree sits under the runner's home. Proved by construction -- with an
+# ancestor at mode 700 the chown succeeds, the directories are writable in
+# themselves, and zero counters are still written.
 #
-# Only when root. Run as an ordinary user the build and the server are the same
-# user and there is nothing to fix.
-if [ "$(id -u)" = 0 ]; then
-	_covdirs=$(find "$SRCDIR" -name '*.gcno' -printf '%h\n' | sort -u)
-	if [ -n "$_covdirs" ]; then
-		# shellcheck disable=SC2086
-		chown postgres $_covdirs
-		echo "-- counter directories made writable by the server user:" \
-			"$(printf '%s' "$_covdirs" | tr '\n' ' ')"
-
-		# Prove it, rather than assume the chown was sufficient. Creating a file
-		# needs write AND execute on the directory, and execute on every ancestor
-		# of it, so an ownership change alone is not the whole condition. The
-		# first version of this fix stopped at the chown, and CI still captured
-		# zero counters while reporting the directories as "made writable" (#740).
-		for _d in $_covdirs; do
-			if runuser -u postgres -- test -w "$_d" 2>/dev/null &&
-			   runuser -u postgres -- touch "$_d/.pgc_gcov_probe" 2>/dev/null; then
-				rm -f "$_d/.pgc_gcov_probe"
-			else
-				echo "-- WARNING: the server user cannot create files in $_d" \
-					"($(stat -c '%U:%G %a' "$_d"))"
-				# The ancestors, because traversal is the usual reason.
-				_p="$_d"
-				while [ "$_p" != "/" ]; do
-					echo "     $(stat -c '%U:%G %a' "$_p") $_p"
-					_p="$(dirname "$_p")"
-				done
-			fi
-		done
-	fi
-fi
-
-# Every suite except the drivers, the libraries, and the ones that build their
-# own server or need two majors. Kept in step with harness_selftest.sh's list.
-#
-# The two upgrade suites are excluded TOGETHER, and that pairing is the point
-# (#741). run_all_versions.sh gates both behind PGC_RUN_UPGRADE, in one block and
-# for one reason: they build a second copy of the extension and need an old
-# source this runner has no way to supply. pg_upgrade was excluded here when it
-# was written and extension_upgrade was not, so this runner discovered it, ran it
-# with no old source, and its ref fallback could not resolve in a tagless CI
-# checkout. run_coverage maps only rc 66 to SKIP, so that environment shortfall
-# was counted as a failed suite and the nightly read "1 failed
-# ( extension_upgrade)" every night while nothing was wrong with the product.
-#
-# Deciding to run an opt-in guard is run_all_versions.sh's job, not this one's.
-# test/selftest/220 derives the gated list from that block and asserts every name
-# in it is refused here, so a third upgrade suite cannot repeat this.
-not_a_suite() {
-	case "$1" in
-		lib|portlib|run_all_versions|build_all_versions|devloop|rebuild) return 0 ;;
-		native_scale|build_san|run_san|run_coverage) return 0 ;;
-		pg_upgrade|extension_upgrade) return 0 ;;
-		*) return 1 ;;
-	esac
-}
+# GCOV_PREFIX makes gcov write to $GCOV_PREFIX/<absolute path>.gcda instead.
+# /tmp is world-writable and world-traversable, so this works whoever the server
+# runs as and wherever the tree lives. GCOV_PREFIX_STRIP=0 keeps the full path,
+# which is what lets the counters be put back exactly where their .gcno are.
+# runuser passes the environment through, so the postmaster and its backends
+# inherit both variables.
+GCOV_PREFIX="${PGC_COV_GCOV_PREFIX:-/tmp/pgc-gcov}"
+GCOV_PREFIX_STRIP=0
+export GCOV_PREFIX GCOV_PREFIX_STRIP
+rm -rf "$GCOV_PREFIX"
+mkdir -p "$GCOV_PREFIX"
+chmod 1777 "$GCOV_PREFIX"
+echo "-- counters redirected to $GCOV_PREFIX"
 
 SUITES="${PGC_COV_SUITES:-}"
 if [ -z "$SUITES" ]; then
@@ -169,6 +126,22 @@ if [ "$pass" = 0 ]; then
 	echo "-- NO SUITE RAN, so this measures no coverage"
 	fail=$((fail + 1))
 fi
+
+# Put the counters back beside their .gcno, which is where lcov and gcov both
+# expect them. Done as this user, which is root under sudo, so no permission on
+# the source tree is needed at all.
+_moved=0
+if [ -d "$GCOV_PREFIX" ]; then
+	while IFS= read -r _f; do
+		[ -n "$_f" ] || continue
+		_dest="${_f#$GCOV_PREFIX}"
+		[ -d "$(dirname "$_dest")" ] || continue
+		cp -p "$_f" "$_dest" 2>/dev/null && _moved=$((_moved + 1))
+	done <<EOF
+$(find "$GCOV_PREFIX" -name '*.gcda' 2>/dev/null)
+EOF
+fi
+echo "-- counters returned beside their objects: $_moved"
 
 # A report built from no counters is not a report, which is the same reasoning as
 # the `pass = 0` guard above and the case that has actually been happening (#740).

--- a/test/selftest/250-the-coverage-runner-must-refuse.sh
+++ b/test/selftest/250-the-coverage-runner-must-refuse.sh
@@ -1,0 +1,40 @@
+# ---- the coverage runner must refuse a run that captured no counters --------
+#
+# #740. The nightly coverage job failed every night from the night it was added
+# (2026-07-31) and had never measured anything. It runs under sudo, so the build
+# is root-owned, while lib.sh runs the server as `postgres` when it is root
+# (lib.sh:150). gcov writes each .gcda beside its object, as the process that ran
+# the code, so the backend could not create one and `lcov --capture` found
+# nothing.
+#
+# What kept it unexamined for 25 nights was the ORDER of the failure. lcov failing
+# on an empty tree reports "capture produced nothing", which reads as a broken
+# tool rather than as a permission problem, so nobody looked. run_coverage.sh now
+# refuses the run itself, before lcov, and says where the counters should have
+# been. That ordering is the thing worth pinning: with the refusal after the
+# capture it would be dead code and the misleading message would be back.
+
+_cov="$TESTDIR/run_coverage.sh"
+check "premise: the coverage runner is present and parses" \
+	"$(bash -n "$_cov" 2>/dev/null && echo yes || echo no)" "yes"
+
+_cov_guard=$(grep -n 'no .gcda counters were written' "$_cov" | cut -d: -f1 | head -1)
+# The CAPTURE specifically. The runner also calls `lcov --directory ...
+# --zerocounters` BEFORE the suites, at a lower line number, and matching that
+# one made this check compare the guard against the wrong call and report a
+# defect that was not there.
+_cov_lcov=$(grep -n 'lcov --directory .*--capture' "$_cov" | cut -d: -f1 | head -1)
+
+check "premise: both the counter refusal and the lcov capture were located" \
+	"$([ -n "$_cov_guard" ] && [ -n "$_cov_lcov" ] && echo yes || echo no)" "yes"
+
+# The whole point: refuse BEFORE lcov turns an empty tree into a tooling error.
+check "the coverage runner refuses zero counters before it calls lcov (#740)" \
+	"$([ -n "$_cov_guard" ] && [ -n "$_cov_lcov" ] &&
+	   [ "$_cov_guard" -lt "$_cov_lcov" ] && echo yes || echo no)" "yes"
+
+# And the directories it makes writable are DERIVED from where the
+# instrumentation landed. Objects are in src/ and objstore/ today; a hardcoded
+# src/ would stop covering a directory added later, silently.
+check "the counter directories are derived from the .gcno files, not named (#740)" \
+	"$(awk '/id -u/,/^fi$/' "$_cov" | grep -c 'gcno')" "1"

--- a/test/selftest/250-the-coverage-runner-must-refuse.sh
+++ b/test/selftest/250-the-coverage-runner-must-refuse.sh
@@ -94,8 +94,9 @@ check "the zero-counter guard counts the directory lcov captures (#740)" \
 # path mismatch from a permission refusal, which look identical from "0
 # counters" and have different fixes. It did that with `find / -xdev`, and
 # -xdev by definition will not cross a mount boundary, while GCOV_PREFIX
-# defaults under /tmp -- a separate tmpfs on this project's own dev container
-# and on most systemd distributions. Counters sitting exactly where the
+# defaults under /tmp -- a separate tmpfs on both boxes this was measured on,
+# this project's dev container and the development host. How common that is
+# elsewhere I have not measured. Counters sitting exactly where the
 # redirect put them are invisible to that walk, so the run reports "nothing
 # wrote them" and sends the reader to permissions.
 #

--- a/test/selftest/250-the-coverage-runner-must-refuse.sh
+++ b/test/selftest/250-the-coverage-runner-must-refuse.sh
@@ -87,3 +87,31 @@ check "premise: the guard's count directory and the capture's were both located"
 
 check "the zero-counter guard counts the directory lcov captures (#740)" \
 	"$_cov_count_dir" "$_cov_cap_dir"
+
+# ---- and when it refuses, it must look where the redirect put them ---------
+#
+# Reported on the #745 cloud review. The refusal's second job is to separate a
+# path mismatch from a permission refusal, which look identical from "0
+# counters" and have different fixes. It did that with `find / -xdev`, and
+# -xdev by definition will not cross a mount boundary, while GCOV_PREFIX
+# defaults under /tmp -- a separate tmpfs on this project's own dev container
+# and on most systemd distributions. Counters sitting exactly where the
+# redirect put them are invisible to that walk, so the run reports "nothing
+# wrote them" and sends the reader to permissions.
+#
+# Measured, one file under a tmpfs /tmp and none elsewhere on the root
+# filesystem: -xdev found 0, the same walk without it found 1, probing the
+# prefix found 1.
+#
+# So GCOV_PREFIX must be asked BEFORE the tree-wide walk. Asked after, the
+# walk's answer wins and the misdiagnosis returns; present but unordered, this
+# reads as fixed and is not.
+_cov_prefix_probe=$(grep -n '_stray=\$(find "\$GCOV_PREFIX"' "$_cov" | cut -d: -f1 | head -1)
+_cov_xdev_probe=$(grep -n 'find / -xdev' "$_cov" | cut -d: -f1 | head -1)
+
+check "premise: both stray-counter probes were located" \
+	"$([ -n "$_cov_prefix_probe" ] && [ -n "$_cov_xdev_probe" ] && echo yes || echo no)" "yes"
+
+check "the refusal looks in GCOV_PREFIX before the tree-wide walk (#740)" \
+	"$([ -n "$_cov_prefix_probe" ] && [ -n "$_cov_xdev_probe" ] &&
+	   [ "$_cov_prefix_probe" -lt "$_cov_xdev_probe" ] && echo yes || echo no)" "yes"

--- a/test/selftest/250-the-coverage-runner-must-refuse.sh
+++ b/test/selftest/250-the-coverage-runner-must-refuse.sh
@@ -61,3 +61,29 @@ check "GCOV_PREFIX is exported before the suites run (#740)" \
 check "the counters are returned beside their objects before the refusal (#740)" \
 	"$([ -n "$_cov_back" ] && [ -n "$_cov_guard" ] &&
 	   [ "$_cov_back" -lt "$_cov_guard" ] && echo yes || echo no)" "yes"
+
+# ---- and it must count the directory that is actually captured -------------
+#
+# Reported on the #745 review. The refusal counted .gcda across the WHOLE tree
+# while `lcov --capture` is scoped to src/. objstore/ is a separate shared
+# library built alongside this one (Makefile:127) and contributes its own .gcno
+# and .gcda, so a tree with zero counters in src/ and one in objstore/ gives the
+# guard a non-zero count, it passes, and lcov captures nothing: the "capture
+# produced nothing" message this guard exists to pre-empt, back again.
+#
+# Constructed and confirmed rather than argued: 33 .gcno in src/ with no
+# counters, one .gcda in objstore/, tree-wide count 1 (passes), src-scoped
+# count 0 (refuses).
+#
+# Compared as SOURCE TEXT, so this pins the two to each other. Widening the
+# capture later without widening the count re-opens the same hole.
+_cov_count_dir=$(grep '^_gcda=\$(find ' "$_cov" |
+	sed -n 's/.*find "\([^"]*\)".*/\1/p' | head -1)
+_cov_cap_dir=$(grep 'lcov --directory .*--capture' "$_cov" |
+	sed -n 's/.*--directory "\([^"]*\)".*/\1/p' | head -1)
+
+check "premise: the guard's count directory and the capture's were both located" \
+	"$([ -n "$_cov_count_dir" ] && [ -n "$_cov_cap_dir" ] && echo yes || echo no)" "yes"
+
+check "the zero-counter guard counts the directory lcov captures (#740)" \
+	"$_cov_count_dir" "$_cov_cap_dir"

--- a/test/selftest/250-the-coverage-runner-must-refuse.sh
+++ b/test/selftest/250-the-coverage-runner-must-refuse.sh
@@ -33,8 +33,31 @@ check "the coverage runner refuses zero counters before it calls lcov (#740)" \
 	"$([ -n "$_cov_guard" ] && [ -n "$_cov_lcov" ] &&
 	   [ "$_cov_guard" -lt "$_cov_lcov" ] && echo yes || echo no)" "yes"
 
-# And the directories it makes writable are DERIVED from where the
-# instrumentation landed. Objects are in src/ and objstore/ today; a hardcoded
-# src/ would stop covering a directory added later, silently.
-check "the counter directories are derived from the .gcno files, not named (#740)" \
-	"$(awk '/id -u/,/^fi$/' "$_cov" | grep -c 'gcno')" "1"
+# ---- and the counters must be redirected somewhere always writable ---------
+#
+# Chowning the object directories to the server user was the first fix and it is
+# NOT sufficient: creating a file needs execute on every ANCESTOR too, and in CI
+# the tree sits under the runner's home. With an ancestor at mode 700 the chown
+# succeeds, the directories are writable in themselves, and zero counters are
+# still written. GCOV_PREFIX sidesteps the whole question by sending them to
+# /tmp, which is world-writable and world-traversable.
+#
+# Two ORDERING facts carry the fix, and order is what these check. Neither is
+# visible from the presence of the lines alone.
+_cov_export=$(grep -n '^export GCOV_PREFIX' "$_cov" | cut -d: -f1 | head -1)
+_cov_run=$(grep -n 'bash "\$SRCDIR/test/\${s}\.sh"' "$_cov" | cut -d: -f1 | head -1)
+_cov_back=$(grep -n 'counters returned beside their objects' "$_cov" | cut -d: -f1 | head -1)
+
+check "premise: the redirect, the suite invocation and the copy-back were located" \
+	"$([ -n "$_cov_export" ] && [ -n "$_cov_run" ] && [ -n "$_cov_back" ] &&
+	   echo yes || echo no)" "yes"
+
+# Set after the suites have run, it redirects nothing.
+check "GCOV_PREFIX is exported before the suites run (#740)" \
+	"$([ -n "$_cov_export" ] && [ -n "$_cov_run" ] &&
+	   [ "$_cov_export" -lt "$_cov_run" ] && echo yes || echo no)" "yes"
+
+# Copied back after the refusal, the refusal always sees zero.
+check "the counters are returned beside their objects before the refusal (#740)" \
+	"$([ -n "$_cov_back" ] && [ -n "$_cov_guard" ] &&
+	   [ "$_cov_back" -lt "$_cov_guard" ] && echo yes || echo no)" "yes"

--- a/test/selftest/250-the-coverage-runner-must-refuse.sh
+++ b/test/selftest/250-the-coverage-runner-must-refuse.sh
@@ -115,3 +115,30 @@ check "premise: both stray-counter probes were located" \
 check "the refusal looks in GCOV_PREFIX before the tree-wide walk (#740)" \
 	"$([ -n "$_cov_prefix_probe" ] && [ -n "$_cov_xdev_probe" ] &&
 	   [ "$_cov_prefix_probe" -lt "$_cov_xdev_probe" ] && echo yes || echo no)" "yes"
+
+# ---- and the copy-back must not write outside the tree ---------------------
+#
+# Reported on the #745 review. $GCOV_PREFIX is a fixed path at mode 1777 and the
+# copy-back runs as root under sudo, while _dest is the found path with the
+# prefix stripped. Without a constraint, any local unprivileged user chooses both
+# the content and the destination: plant $GCOV_PREFIX/<anywhere>/x.gcda and root
+# copies it to <anywhere>/x.gcda.
+#
+# Demonstrated with the loop exactly as it stood, a file planted as `postgres`
+# and written by root to a directory outside the tree, then blocked by the
+# constraint while a legitimate counter under $SRCDIR/src still copied. Both
+# arms, because a containment that refuses everything is not a fix.
+#
+# Constrained to names ending .gcda and not reachable on GitHub's single-tenant
+# ephemeral runner, but reachable on any shared or developer box, which this
+# script's header invites by documenting sudo.
+_cov_contain=$(grep -n '"\$SRCDIR"/\*)' "$_cov" | cut -d: -f1 | head -1)
+_cov_cp=$(grep -n 'cp -p "\$_f" "\$_dest"' "$_cov" | cut -d: -f1 | head -1)
+
+check "premise: the containment and the copy were both located" \
+	"$([ -n "$_cov_contain" ] && [ -n "$_cov_cp" ] && echo yes || echo no)" "yes"
+
+# Placed after the copy it is not a containment, it is a comment.
+check "the copy-back refuses a destination outside the tree (#740)" \
+	"$([ -n "$_cov_contain" ] && [ -n "$_cov_cp" ] &&
+	   [ "$_cov_contain" -lt "$_cov_cp" ] && echo yes || echo no)" "yes"


### PR DESCRIPTION
Closes #740. Filed by @ChronicallyJD, whose diagnosis I verified independently
and did not need to re-open. What was missing was a measured fix.

**This description was rewritten after review. The first version described the
`chown` approach, which is superseded and which this PR's own code and CHANGELOG
say is not sufficient. It also claimed a guard that does not exist and disclaimed
a nightly that had by then run green. Corrected below; the history is in the
commits and the thread.**

## Root cause

gcov writes each `.gcda` beside its object, at the path recorded at **compile**
time, as the process that ran the code. `run_coverage.sh` runs under `sudo` in
CI, so the build is root-owned, while `lib.sh:150` runs the server as `postgres`
whenever it is root. The backend could not create a counter file next to a
root-owned object. Nothing was ever written and `lcov` had nothing to capture.

## The fix is a redirect, and ownership alone could not have worked

Making the object directories writable was the first attempt and it is **not
sufficient**: creating a file needs execute on every **ancestor** too. Measured
on the runner, with the object directories already chowned:

```
postgres:runner 755 /home/runner/work/pgcolumnar/pgcolumnar/src
postgres:runner 755 /home/runner/work/pgcolumnar/pgcolumnar
runner:runner   755 /home/runner/work
runner:runner   750 /home/runner        <-- no execute for postgres
```

`/home/runner` is 750 and `postgres` is neither its owner nor in the `runner`
group, so it cannot traverse into the workspace at all. That route could only
work by chmod'ing a shared runner's home.

`GCOV_PREFIX` makes gcov write to `$GCOV_PREFIX/<absolute path>.gcda` instead.
`/tmp` is world-writable and world-traversable, so it holds whoever the server
runs as and wherever the tree lives. `GCOV_PREFIX_STRIP=0` keeps the full path,
which is what lets the counters be returned exactly beside their `.gcno`.
`runuser` passes the environment through; verified rather than assumed.

| approach | result |
| --- | --- |
| chown the object directories | dirs writable in themselves, **0 counters** |
| `GCOV_PREFIX` redirect | **33 counters**, lcov and genhtml succeed, rc 0 |

## Measured in CI, which is the only evidence that counts here

Nightly `33005313801` on this head, **8 of 8**, including `coverage report (PG
18)` which has never passed before:

```
-- counters redirected to /tmp/pgc-gcov
-- suites: 213 passed, 0 failed, 2 skipped
-- counters: 33 .gcda from 33 instrumented objects in src/
    lines......: 93.4% (19462 of 20847 lines)
    functions..: 96.4% (838 of 869 functions)
    branches...: 69.8% (8870 of 12705 branches)
```

The last green nightly before this, on 2026-07-30, was green because the
coverage job did not exist yet. This is the first run in which it has produced a
number.

## Second-order fixes

- **The runner refuses a run that captured no counters**, before lcov, and says
  where they should have been. What kept this unexamined for 25 nights is that
  lcov failing on an empty tree reports "capture produced nothing", which reads
  as a broken tool rather than a permission problem.
- **The per-suite logs are uploaded.** Only `coverage/html` and `coverage.info`
  were, so a suite failing inside this job had its detail discarded with the
  runner. That is how #741's failing suite stayed invisible.

## The `34 of 49` is answered: LTO, not a coverage gap

| toolchain | `--cflags` |
| --- | --- |
| PGDG PG 18 (what CI uses) | `-flto=auto -ffat-lto-objects` |
| source-built PG 17 (my container) | no `-flto` |

PGXS passes those to the extension, so GCC's link stage emits a `.gcno` per LTO
partition plus one for whole-program analysis (`pgcolumnar.so.ltrans0..11`,
`.wpa`). Those have no source lines. 33 src + 1 real objstore object + 15 LTO
artifacts = 49, and 33 + 1 = 34 counters, so every real object had one.
Reproduced by building against the PGDG `pg_config`: 48. Why 11 partitions here
and 12 in CI is **unexplained**; my first answer, that `-flto=auto` sizes them
from the CPU count, is refuted by the control (`taskset` the same build: 2, 4 and
8 CPUs all give 11). Untested candidate is the toolchain difference, gcc 15.2
here against ubuntu-24.04's gcc 13. It does not bear on the conclusion, which
rests on `src` being 33 of 33 and is measured directly.

## Guards

`test/selftest/250` pins five properties, all of them things that are invisible
from the lines merely being present:

| mutation | result |
| --- | --- |
| move the refusal after the capture | RED |
| export `GCOV_PREFIX` after the suites run | RED |
| copy the counters back after the refusal | RED |
| count `.gcda` tree-wide instead of the captured directory | RED |
| ask the tree-wide walk before `GCOV_PREFIX` for strays | RED |
| delete the copy-back's destination containment | RED |

`harness_selftest`: **138 checks PASSED** (132 on main).

## Review items

All four addressed, and two of the three I had found independently before the
review landed.

1. **The by-directory breakdown printed no directory.** Correct, and the cause is
   as diagnosed: the leading `sed` expression matches the whole line. Replaced
   with one awk pass.
2. **The stray probe was blind to `GCOV_PREFIX`.** Correct. `-xdev` will not
   cross a mount boundary and `/tmp` is tmpfs here too. `GCOV_PREFIX` is asked
   first; the tree-wide walk stays as the fallback for gcov ignoring the redirect
   entirely.
3. **Root copying a 1777 directory's files to an unconstrained destination.**
   Correct, and I had missed it. Reproduced end to end: a file planted as
   `postgres` under `$GCOV_PREFIX/root/pgc_target/` was written by root outside
   the tree. Containment added; both arms proved, since a containment that
   refuses everything is not a fix:

   ```
   -- counters returned: 1   refused out-of-tree: 1
   attack dest : NOT WRITTEN (blocked)
   legit dest  : /root/pgc740c/src/columnar_real.gcda
   ```
4. **The earlier guard-scope finding**, that the refusal counted tree-wide while
   the capture is scoped to `src/`. Reproduced and fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

