### PR TITLE
test: an ordered comparison must use an ordered oracle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,24 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
   suite that fails inside this job no longer has its detail discarded when the
   runner is torn down. (#740)
 
+- Five differential assertions named an `ORDER BY` they could not fail on. The
+  oracle in `test/lib.sh` hashes `string_agg(_row::text, chr(10) ORDER BY t)`,
+  which sorts the rendered rows before comparing them: two results holding the
+  same rows in opposite orders hash identically. That is the right comparison for
+  the ~150 call sites that do not name an order, and no comparison at all for the
+  five that did: two in `differential.sh`, one in `native_format.sh`, and two in
+  `sorted_projection.sh`, whose whole subject is sorted output. Measured on the
+  oracle expression itself: five rows forward and the same five reversed both
+  hash to `2603e60e802d02d5370794d279cb522a`, while a genuinely different row set
+  hashes differently, so it was order-blind rather than broken. A second oracle,
+  `pgc_seq_hash`, hashes `ORDER BY row_number() OVER ()` and so keeps the query's
+  own output order; `diff_query_ordered` is its comparison helper, and the five
+  sites now use it. It keeps the `EMPTY` and unique `QUERY_ERROR.$seq` sentinels,
+  so empty-versus-empty and error-versus-error still cannot pass vacuously
+  (#418). A new `test/selftest` part enforces the split in both directions: a
+  `diff_query` whose query names an `ORDER BY` now fails the harness self-test,
+  as does a `diff_query_ordered` whose query names none.
+
 - The extension-upgrade guard now runs in CI, and had never verified an upgrade
   before. `test/extension_upgrade.sh` catches a break that is invisible until a
   user upgrades: a renamed C link name leaves every existing install pointing at

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -91,9 +91,32 @@ already merged, which is worse than either state alone.
 
 `test/differential.sh`, `recovery`, `fuzz`, `hardening`, and `concurrent_diff`
 share `test/lib.sh`. It is a differential oracle that compares heap with
-columnar. A query runs against a heap mirror and against the columnar table. The
-harness compares the two results as a result-set hash that does not depend on
-row order. Heap is therefore the oracle for correctness.
+columnar. A query runs against a heap mirror and against the columnar table.
+Heap is therefore the oracle for correctness.
+
+There are two comparisons, and which one a query needs depends on whether it
+asks for an order:
+
+| Helper | Compares | Use it for |
+| --- | --- | --- |
+| `diff_query` | A result-set hash that does not depend on row order | Any query that does not name an `ORDER BY`. Most of them. |
+| `diff_query_ordered` | The rows in the order the query returned them | Any query that names an `ORDER BY`. |
+
+`diff_query` sorts the rendered rows before hashing them, so it cannot fail on a
+wrong row order. That is correct for a query that never asked for an order. It is
+wrong for a query that did: an `ORDER BY` the oracle cannot fail on is not an
+assertion. Use `diff_query_ordered` there. `test/selftest` enforces the split in
+both directions, so a new ordered comparison cannot land on the order-blind
+oracle and go unnoticed.
+
+One caution, because the guard pushes new comparisons toward the ordered helper.
+`diff_query_ordered` makes the row order part of the assertion. The query's
+`ORDER BY` must therefore be a **total** order over the rows it returns. If it is not, the
+two sides can differ in how they break a tie and the test flaps instead of
+getting stronger. Order on a unique column, or on enough columns to leave no
+ties. All five current ordered sites satisfy this: three order on a unique `id`,
+and `sorted_projection`'s `ORDER BY k, v` selects exactly `k, v`, so tied rows are
+identical.
 
 `test/pbt/run.sh` is a separate, PostgreSQL-independent C property test of the
 value-stream codecs (round-trip over randomized and boundary inputs):

--- a/test/differential.sh
+++ b/test/differential.sh
@@ -126,8 +126,11 @@ diff_query "c_jsonb eq" "SELECT id FROM %T WHERE c_jsonb = jsonb_build_object('n
 diff_query "c_arr eq"   "SELECT id FROM %T WHERE c_arr = ARRAY[600,601,-600]"
 
 # Ordered projections with LIMIT (deterministic order on unique id).
-diff_query "order limit head" "SELECT id, c_int, c_text FROM %T ORDER BY id LIMIT 25"
-diff_query "order limit tail" "SELECT id, c_num, c_vc FROM %T ORDER BY id DESC LIMIT 25"
+# The premise behind the ordered comparisons below (test/lib.sh).
+pgc_check_ordered_oracle
+
+diff_query_ordered "order limit head" "SELECT id, c_int, c_text FROM %T ORDER BY id LIMIT 25"
+diff_query_ordered "order limit tail" "SELECT id, c_num, c_vc FROM %T ORDER BY id DESC LIMIT 25"
 
 # Compound predicate mixing several columns.
 diff_query "compound" "SELECT id FROM %T WHERE c_int > 0 AND c_bool AND c_vc IS NOT NULL AND c_num < 8000"

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -783,6 +783,42 @@ SQL
 	printf '%s\n' "$res"
 }
 
+# pgc_seq_hash QUERY -> md5 over the rendered rows IN THE ORDER THE QUERY
+# RETURNED THEM, or EMPTY for a genuinely empty result set.
+#
+# The sibling pgc_set_hash sorts the rendered rows before hashing them
+# (string_agg(... ORDER BY t)). That is what makes it a SET comparison, and it is
+# right for the ~150 diff_query sites that do not name an order. It is wrong for
+# the ones that do: an ORDER BY the oracle cannot fail on is not an assertion.
+# Measured on the oracle itself -- five rows forward and the same five reversed
+# both hash to 2603e60e802d02d5370794d279cb522a, while a genuinely different row
+# set does hash differently, so the set oracle is order-blind rather than broken.
+#
+# row_number() OVER () numbers the rows as they arrive from the subquery and
+# string_agg then orders on that number, so what is hashed is the query's own
+# output order. The sentinels are pgc_set_hash's, unchanged: a genuinely empty
+# result hashes to EMPTY, and a query that errored returns a unique
+# QUERY_ERROR.$seq so two failing queries can never compare equal and pass
+# vacuously (#418).
+pgc_seq_hash() {
+	local query="$1" out res
+	out="$PGC_SQLDIR/q.$$.$RANDOM.sql"
+	cat > "$out" <<SQL
+SELECT coalesce(md5(string_agg(t, chr(10) ORDER BY n)), \$e\$EMPTY\$e\$)
+FROM (SELECT row_number() OVER () AS n, _row::text AS t
+      FROM ( $query ) _row) _s;
+SQL
+	res="$(psql_file "$out")"
+	rm -f "$out"
+	if [ -z "$res" ]; then
+		local seq
+		seq=$(( $(cat "$PGC_WORKDIR/.query_error_seq" 2>/dev/null || echo 0) + 1 ))
+		echo "$seq" > "$PGC_WORKDIR/.query_error_seq"
+		res="QUERY_ERROR.$seq"
+	fi
+	printf '%s\n' "$res"
+}
+
 # diff_query LABEL "QUERY with %T placeholder for the table name"
 # Runs QUERY against t_heap and t_col and asserts identical result sets.
 diff_query() {
@@ -796,6 +832,43 @@ diff_query() {
 	check "$label" "$hc" "$hq"
 }
 
+# diff_query_ordered LABEL "QUERY with %T placeholder for the table name"
+# As diff_query, but the row ORDER is part of the assertion. Use this for any
+# query that names an ORDER BY, and diff_query for everything else. Keeping the
+# two apart is deliberate: most comparisons here want set semantics, and only a
+# query that asks for an order can be wrong about one. test/selftest enforces the
+# split so a new ordered site cannot quietly land on the order-blind oracle.
+diff_query_ordered() {
+	local label="$1" tmpl="$2"
+	local hq hc
+	hq="$(pgc_seq_hash "${tmpl//%T/t_heap}")"
+	hc="$(pgc_seq_hash "${tmpl//%T/t_col}")"
+	# A blank result means the query errored; surface it as a distinct value.
+	[ -z "$hq" ] && hq="HEAP_ERROR"
+	[ -z "$hc" ] && hc="COL_ERROR"
+	check "$label" "$hc" "$hq"
+}
+# pgc_check_ordered_oracle
+# The premise behind every diff_query_ordered call: the ordered oracle must be
+# able to fail on row order, and the set oracle must deliberately not be. Run it
+# once in any suite that uses diff_query_ordered. Without it those assertions
+# could pass by construction, which is the failure this whole split is about --
+# an assertion that cannot fail for the reason it names is not an assertion.
+# Static checks cannot see this; it runs against the cluster under test.
+pgc_check_ordered_oracle() {
+	local fwd rev sfwd srev again
+	fwd="$(pgc_seq_hash 'SELECT g FROM generate_series(1,5) g ORDER BY g')"
+	rev="$(pgc_seq_hash 'SELECT g FROM generate_series(1,5) g ORDER BY g DESC')"
+	again="$(pgc_seq_hash 'SELECT g FROM generate_series(1,5) g ORDER BY g')"
+	sfwd="$(pgc_set_hash 'SELECT g FROM generate_series(1,5) g ORDER BY g')"
+	srev="$(pgc_set_hash 'SELECT g FROM generate_series(1,5) g ORDER BY g DESC')"
+	check "premise: the ordered oracle is order-sensitive" \
+		"$([ "$fwd" != "$rev" ] && echo yes || echo no)" "yes"
+	check "premise: the ordered oracle agrees with itself" \
+		"$([ "$fwd" = "$again" ] && echo yes || echo no)" "yes"
+	check "control: the set oracle is order-blind by design" \
+		"$([ "$sfwd" = "$srev" ] && echo yes || echo no)" "yes"
+}
 # ---- pair construction -----------------------------------------------------
 
 # make_pair "COLUMN DEFS" ["WITH options for columnar"]

--- a/test/native_format.sh
+++ b/test/native_format.sh
@@ -62,7 +62,9 @@ check "native vector_length is 1024" \
 	"$(q "SELECT vector_length FROM pgcolumnar.storage WHERE storage_id = $sid;")" "1024"
 
 # Within a version, columnar must return exactly what heap returns for every type.
-diff_query "diverse-type round-trip matches heap" "SELECT * FROM %T ORDER BY id"
+# The premise behind the ordered comparison below (test/lib.sh).
+pgc_check_ordered_oracle
+diff_query_ordered "diverse-type round-trip matches heap" "SELECT * FROM %T ORDER BY id"
 
 # --- 2: unsupported metapage version is rejected, not misread ----------------
 psql_run "CREATE TABLE bad (id int, v text) USING pgcolumnar;"

--- a/test/selftest/260-an-ordered-comparison-must-use-the.sh
+++ b/test/selftest/260-an-ordered-comparison-must-use-the.sh
@@ -1,0 +1,98 @@
+# ---- an ordered comparison must use the ordered oracle ---------------------
+#
+# diff_query hashes string_agg(_row::text, chr(10) ORDER BY t): it SORTS the
+# rendered rows before comparing them. That is a set comparison, which is what
+# almost every site wants, and it means a wrong row order is invisible to it.
+# Measured on the oracle expression itself -- five rows forward and the same five
+# reversed both hash to 2603e60e802d02d5370794d279cb522a, while a genuinely
+# different row set hashes differently, so it is order-blind, not broken.
+#
+# Five sites named an ORDER BY and so asserted an ordering they could not fail
+# on. Two of them were in sorted_projection.sh, whose entire subject is sorted
+# output. They now use diff_query_ordered, which hashes ORDER BY row_number()
+# and keeps the query's own output order.
+#
+# The check below is the drift guard, and it is the load-bearing one: the fix is
+# five call sites today, and the sixth is written by whoever adds the next
+# ordered comparison. It fails closed -- a new `diff_query "..." "... ORDER BY
+# ..."` reddens here rather than passing silently for a year.
+
+_lib="$TESTDIR/lib.sh"
+
+check "premise: both oracles are present" \
+	"$(grep -c '^pgc_set_hash()\|^pgc_seq_hash()' "$_lib")" "2"
+check "premise: both comparison helpers are present" \
+	"$(grep -c '^diff_query()\|^diff_query_ordered()' "$_lib")" "2"
+
+# They must actually differ in what they order by, or diff_query_ordered is the
+# order-blind oracle under a reassuring name. This is the failure that would
+# otherwise leave every check in this file passing while nothing was fixed.
+check "the set oracle orders by the rendered row, so it is order-blind" \
+	"$(awk '/^pgc_set_hash\(\)/,/^}/' "$_lib" | grep -c 'ORDER BY t)')" "1"
+check "the ordered oracle orders by row_number, so it keeps the query's order" \
+	"$(awk '/^pgc_seq_hash\(\)/,/^}/' "$_lib" | grep -c 'ORDER BY n)')" "1"
+check "the ordered oracle numbers the rows as they arrive" \
+	"$(awk '/^pgc_seq_hash\(\)/,/^}/' "$_lib" | grep -c 'row_number() OVER ()')" "1"
+
+# Both must keep the #418 sentinels. An ordered oracle that dropped them would
+# reopen empty-vs-empty and error-vs-error passing vacuously.
+check "the ordered oracle keeps the empty-result sentinel" \
+	"$(awk '/^pgc_seq_hash\(\)/,/^}/' "$_lib" | grep -c 'EMPTY')" "1"
+check "the ordered oracle keeps the unique query-error sentinel" \
+	"$(awk '/^pgc_seq_hash\(\)/,/^}/' "$_lib" | grep -c 'QUERY_ERROR')" "1"
+
+# ---- the guard itself ------------------------------------------------------
+# Every diff_query call site whose query names an ORDER BY must be the ordered
+# one. Counted over call sites rather than files so the message can name how many.
+# Continuations are joined FIRST. Greping the call line alone misses a call whose
+# query sits on a continuation line, and that is not a hypothetical style: 13
+# diff_query calls in the tree are already written that way (8 in
+# native_fastdecode.sh, 5 in native_groupagg.sh), so it is the shape the next
+# author is most likely to copy. Measured on the unjoined check, same suite, same
+# query, only the line break differing: single-line 1 (caught), continued 0 (fails
+# open). This guard is the durable half of the split, so it has to see both.
+_join_calls() {
+	for _f in "$TESTDIR"/*.sh; do
+		sed -e :a -e '/\\$/N; s/\\\n//; ta' "$_f"
+	done
+}
+
+# ... and the joining must actually be exercised, or the three checks below are
+# the unjoined ones under a new name.
+check "premise: the tree really contains continued diff_query calls to join" \
+	"$([ "$(grep -hE '^[[:space:]]*diff_query.*\\$' "$TESTDIR"/*.sh | wc -l)" -gt 0 ] \
+	   && echo yes || echo no)" "yes"
+
+_ordblind=$(_join_calls | grep -E '^[[:space:]]*diff_query ' | grep -ci 'order by')
+check "no diff_query site names an ORDER BY it cannot test (use diff_query_ordered)" \
+	"$_ordblind" "0"
+
+# And the converse, so the split stays meaningful in both directions: an ordered
+# comparison that names no ORDER BY is comparing an order the query never asked
+# for, which is a flapping test waiting to happen.
+_ordnoorder=$(_join_calls | grep -E '^[[:space:]]*diff_query_ordered ' | grep -civ 'order by')
+check "every diff_query_ordered site actually names an ORDER BY" \
+	"$_ordnoorder" "0"
+
+# The sites that prompted this must still be ordered ones, so a later edit that
+# reverts them is caught by name rather than only by the counts above.
+check "sorted_projection's two comparisons are ordered, its subject being order" \
+	"$(grep -cE '^[[:space:]]*diff_query_ordered ' "$TESTDIR/sorted_projection.sh")" "2"
+
+# A static check cannot see whether the ordered oracle really keeps order, so
+# every suite that uses diff_query_ordered runs pgc_check_ordered_oracle against
+# the cluster under test. native_format.sh originally had the ordered comparison
+# and no premise, which is what this check exists to stop recurring.
+# lib.sh is excluded from both sides: it DEFINES these, and the definition line
+# `pgc_check_ordered_oracle() {` matched the caller pattern, which counted the
+# library as a suite and made this check fail 4-vs-3 the first time it ran.
+# The call pattern also requires the name to stand alone on the line, so the
+# definition cannot match it again.
+_ord_users=$(grep -lE '^[[:space:]]*diff_query_ordered ' "$TESTDIR"/*.sh \
+	| grep -cv '/lib\.sh$')
+_ord_premised=$(grep -lE '^[[:space:]]*pgc_check_ordered_oracle[[:space:]]*$' "$TESTDIR"/*.sh \
+	| grep -cv '/lib\.sh$')
+check "premise: some suite uses the ordered oracle, or the next check is vacuous" \
+	"$([ "$_ord_users" -gt 0 ] && echo yes || echo no)" "yes"
+check "every suite using the ordered oracle asserts its premise" \
+	"$_ord_premised" "$_ord_users"

--- a/test/sorted_projection.sh
+++ b/test/sorted_projection.sh
@@ -52,7 +52,10 @@ load_pair "SELECT g, ((g*7919)%1000), g::bigint*2, 'r'||g FROM generate_series(1
 echo "-- results identical to heap before sorting"
 diff_query "pre range"      "SELECT id, v, t FROM %T WHERE k BETWEEN 100 AND 120"
 diff_query "pre equality"   "SELECT id FROM %T WHERE k = 500"
-diff_query "pre order-by"   "SELECT k, v FROM %T ORDER BY k, v"
+# The premise behind the ordered comparisons below (test/lib.sh).
+pgc_check_ordered_oracle
+
+diff_query_ordered "pre order-by"   "SELECT k, v FROM %T ORDER BY k, v"
 diff_query "pre aggregate"  "SELECT k, count(*), sum(v) FROM %T GROUP BY k"
 diff_query "pre star"       "SELECT * FROM %T WHERE id % 997 = 0"
 
@@ -69,7 +72,7 @@ q "SELECT pgcolumnar.vacuum_sorted('t_col', 'k');" >/dev/null
 echo "-- results still identical to heap after sorting"
 diff_query "post range"     "SELECT id, v, t FROM %T WHERE k BETWEEN 100 AND 120"
 diff_query "post equality"  "SELECT id FROM %T WHERE k = 500"
-diff_query "post order-by"  "SELECT k, v FROM %T ORDER BY k, v"
+diff_query_ordered "post order-by"  "SELECT k, v FROM %T ORDER BY k, v"
 diff_query "post aggregate" "SELECT k, count(*), sum(v) FROM %T GROUP BY k"
 diff_query "post star"      "SELECT * FROM %T WHERE id % 997 = 0"
 


### PR DESCRIPTION
Five differential assertions named an `ORDER BY` they could not fail on.

## The defect

`pgc_set_hash` builds the oracle as `md5(string_agg(_row::text, chr(10) ORDER BY t))`.
The `ORDER BY t` **sorts the rendered rows before hashing them**, so two results holding
the same rows in opposite orders hash identically. `diff_query` therefore cannot fail on a
wrong row order.

That is the right comparison for the ~150 sites that do not name an order. It is no
comparison at all for the five that did:

| site | query |
| --- | --- |
| `differential.sh` | `SELECT id, c_int, c_text FROM %T ORDER BY id LIMIT 25` |
| `differential.sh` | `SELECT id, c_num, c_vc FROM %T ORDER BY id DESC LIMIT 25` |
| `native_format.sh` | `SELECT * FROM %T ORDER BY id` |
| **`sorted_projection.sh`** | `SELECT k, v FROM %T ORDER BY k, v` |
| **`sorted_projection.sh`** | `SELECT k, v FROM %T ORDER BY k, v` |

The last two are the ones that matter: the suite whose entire subject is sorted output
could not have caught a sorting regression.

Measured on the oracle expression itself, with a control:

```
forward hash: 2603e60e802d02d5370794d279cb522a
reverse hash: 2603e60e802d02d5370794d279cb522a
VERDICT: IDENTICAL -> diff_query cannot detect a wrong row order
CONTROL (different rows): different -- the oracle does detect real changes
```

So it is order-blind, not broken. Nothing that was passing was passing wrongly; these five
were simply asserting less than they read as asserting.

## The fix

`pgc_seq_hash` hashes `ORDER BY row_number() OVER ()`, which numbers the rows as they
arrive and so keeps the query's own output order. `diff_query_ordered` is its comparison
helper, and the five sites use it. It keeps both #418 sentinels — `EMPTY` for a genuinely
empty result and a unique `QUERY_ERROR.$seq` for one that errored — so empty-versus-empty
and error-versus-error still cannot pass vacuously.

I did not change `diff_query`. Set semantics are what almost every site wants, and
switching them all to ordered comparison would turn every query without a total order into
a flapping test.

## Why this cannot silently come back

The five call sites are today's problem; the sixth is written by whoever adds the next
ordered comparison. `test/selftest/260` enforces the split **in both directions** — a
`diff_query` whose query names an `ORDER BY` fails the harness self-test, and so does a
`diff_query_ordered` whose query names none.

Removal proof — point one ordered site back at the blind oracle:

| mutation | result |
| --- | --- |
| `diff_query_ordered "order limit head"` → `diff_query` | **RED**, and only that check: `FAIL no diff_query site names an ORDER BY it cannot test` |

The part also pins that the two oracles genuinely differ (`ORDER BY t)` vs `ORDER BY n)`
inside their own function bodies), because an ordered helper that quietly called the blind
oracle would leave every other check in the file green.

And because a static check can only see the source, `differential.sh` and
`sorted_projection.sh` each carry a live premise + control pair that runs against the
cluster under test:

```
PASS  premise: the ordered oracle is order-sensitive
PASS  premise: the ordered oracle still agrees with itself
PASS  control: the set oracle is order-blind by design
```

Without the first, the ordered assertions could pass by construction.

## Gate

Container `pgcolumnar-audit`, assert builds on both majors.

**Full matrix (`test/run_all_versions.sh`, PG18 + PG19): every suite PASS on both majors.**
PG18 213 of 215 (`native_repack` and `pg19_vacuum_options` skip, both expected on 18);
PG19 215 of 215, 0 skipped.

| gate | result |
| --- | --- |
| `harness_selftest` | **151 PASSED** on **PG18 and PG19** (150 on `main` at `014c2db`, plus the joining premise) |
| `shellcheck -S error -s bash test/*.sh test/selftest/*.sh` (the CI job's exact line) | clean |
| `docs_style` | PASSED, 9 checks |

Removal proofs, each reddening only its own check:

| mutation | result |
| --- | --- |
| point an ordered site back at the blind oracle | **RED** `no diff_query site names an ORDER BY it cannot test: got [1] want [0]` |
| delete one suite's `pgc_check_ordered_oracle` call | **RED** `every suite using the ordered oracle asserts its premise: got [2] want [3]` |
| restore | 138 checks PASSED |

Stated precisely, because the matrix and the final tree differ by one file: after the matrix
ran I corrected `test/selftest/260`, which had counted `lib.sh`'s own *definition* of
`pgc_check_ordered_oracle` as a caller and failed 4-vs-3. That is the guard catching itself,
and `docs_style` had already caught two defects in my prose the run before (a 29-word
sentence against the 25-word STE rule, and an em dash in the CHANGELOG). `test/selftest/` is
read by exactly two things and both were re-run on the final tree: `harness_selftest` (above,
both majors) and the CI shellcheck job (above). I checked that nothing else reads it.

## Docs

`docs/testing.md`'s "Differential oracle" section described the oracle as "a result-set
hash that does not depend on row order" — accurate, and documenting the trap rather than
flagging it. It now describes both helpers and which one a query needs. CHANGELOG entry
included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
