### PR TITLE
fix: set_options must refuse a relation that is not columnar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,39 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
   packaged server and reported the connection failure as "old install did not
   store rows". It now states the directory it connects to. (#741)
 
+- `pgcolumnar.set_options` accepted a relation that is not columnar, and silently
+  recorded options for it. The row was not merely useless, because options are
+  read by the columnar writer and a heap table has none. It also leaked: the object
+  access hook that clears `pgcolumnar.options` fires only for columnar relations,
+  so the row outlived the table. Measured on one cluster: `set_options` on a
+  `USING heap` table stored a row, `DROP TABLE` left it behind, and `regclass`
+  then rendered as the bare oid, which a later relation reusing that oid would
+  inherit; the identical sequence on a columnar table cleaned up. `set_options`
+  now raises `relation "..." is not a columnar table`, matching the wording the C
+  paths already use, with a hint pointing at `ALTER TABLE ... SET ACCESS METHOD`.
+  The test is on the access method **and** on `relkind`, which is what makes it
+  match the cleanup rather than merely look strict: the drop hook returns before
+  it examines the access method for anything that is not an ordinary table, so
+  `'r'` is exactly the set whose options row can ever be cleared. That matters
+  from PG17, where a partitioned table may itself carry an access method: an
+  access-method test alone accepted a partitioned parent, which has no storage,
+  which the writer never writes, and whose row the hook would never clear.
+  Measured on 17.6: accepted, one row recorded, still present after `DROP TABLE`
+  keyed to the dropped oid, while an ordinary columnar table in the same run
+  cleaned up. PG16 and earlier refuse `PARTITION BY ... USING pgcolumnar`
+  outright (checked on 16.14). Partitions themselves are ordinary tables and are
+  still accepted, which is where the options belong. A materialized view is
+  refused for the same reason: `CREATE MATERIALIZED VIEW ... USING pgcolumnar`
+  works and its rows read back, but options recorded for one are inert, measured
+  against a live fixture that moves the same measurement from 3 to 21 on an
+  ordinary table, and its row leaks on `DROP` exactly as the others do.
+  That conversion keeps the relation's oid (measured), so the one workflow that
+  might have wanted the old order, options first and convert second, is served by
+  setting them after the conversion. Nothing in the test corpus called
+  `set_options` on a non-columnar relation. The guard is mirrored into the
+  `1.0-alpha` → `1.0-alpha2` upgrade script, so an upgraded catalog still matches
+  a fresh install. (#432 follow-up)
+
 - The vectorized aggregates now bound their per-execution memory with one
   mechanism instead of two. The scan-key context added for #717 covered the
   scan keys; the scratch context added for #727 covered the whole scan and so

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -128,6 +128,18 @@ apply to the data that the writer writes after the change. The data that is
 already on disk does not change. It changes only when a command rewrites the
 table, for example `pgcolumnar.vacuum`.
 
+The table must already be an ordinary table using the `pgcolumnar` access method.
+Setting options on anything else raises `relation "..." is not a columnar table`.
+
+A partitioned table is rejected as well. It holds no data of its own, so options
+set on it would never be read. Set them on each partition, which is where the
+rows are written. For an ordinary table, convert it first, then set its options:
+
+```sql
+ALTER TABLE events SET ACCESS METHOD pgcolumnar;
+SELECT pgcolumnar.set_options('events', compression => 'zstd');
+```
+
 ```sql
 SELECT pgcolumnar.set_options(
     'events',
@@ -139,7 +151,7 @@ SELECT pgcolumnar.set_options(
 
 | Argument | Type | Description |
 | --- | --- | --- |
-| `table_name` | regclass | The columnar table to change. |
+| `table_name` | regclass | The columnar table to change. Anything that is not an ordinary table using the `pgcolumnar` access method is rejected, including a partitioned table. |
 | `chunk_group_row_limit` | integer | Per-table override of `pgcolumnar.chunk_group_row_limit`. |
 | `stripe_row_limit` | integer | Per-table override of `pgcolumnar.stripe_row_limit`. |
 | `compression` | name | One of `none`, `pglz`, `lz4`, `zstd`. |

--- a/pgcolumnar--1.0-alpha--1.0-alpha2.sql
+++ b/pgcolumnar--1.0-alpha--1.0-alpha2.sql
@@ -605,6 +605,146 @@ CREATE OR REPLACE FUNCTION pgcolumnar.require_caller_select(rel regclass)
 AS '$libdir/pgcolumnar', $function$pgcolumnar_require_caller_select$function$
 ;
 
+-- set_options gained a guard in 1.0-alpha2: it now rejects a relation that
+-- does not use the pgcolumnar access method, rather than recording a row in
+-- pgcolumnar.options that nothing can read and that the drop hook (columnar
+-- relations only) would leave behind as a dangling oid.
+CREATE OR REPLACE FUNCTION pgcolumnar.set_options(
+	table_name regclass,
+	chunk_group_row_limit int DEFAULT NULL,
+	stripe_row_limit int DEFAULT NULL,
+	compression name DEFAULT NULL,
+	compression_level int DEFAULT NULL,
+	encode_effort name DEFAULT NULL,
+	sort_by name[] DEFAULT NULL)
+	RETURNS void
+	LANGUAGE plpgsql
+	AS $set_options$
+DECLARE
+	col name;
+BEGIN
+	/*
+	 * The options are per-relation and are read by the columnar writer, so a row
+	 * recorded for a relation that is not columnar can never be used. Storing one
+	 * is not merely useless: the drop hook that clears pgcolumnar.options fires
+	 * only for columnar relations, so the row outlives the table and is left
+	 * keyed to a dangling oid that a later relation reusing that oid inherits.
+	 * Measured before this guard, on the same cluster: set_options on a heap
+	 * table stored a row, DROP TABLE left it behind, and regclass then rendered
+	 * as the bare oid; the identical sequence on a columnar table cleaned up.
+	 *
+	 * Rejecting is safe for the one workflow that could want the other order:
+	 * ALTER TABLE ... SET ACCESS METHOD pgcolumnar keeps the relation's oid
+	 * (measured), so options set after the conversion apply to the same relation
+	 * a caller would have been trying to name before it.
+	 *
+	 * relkind is part of the test, and it is what makes the guard match the
+	 * cleanup rather than merely look strict. The drop hook returns before it
+	 * examines the access method for anything that is not an ordinary table
+	 * (columnar_tableam.c: `if (get_rel_relkind(objectId) != RELKIND_RELATION)
+	 * return;`), so 'r' is exactly the set of relations whose options row can
+	 * ever be cleaned up. From PG17 a PARTITIONED table may carry an access
+	 * method, so `relam = pgcolumnar` alone admits a parent that has no storage,
+	 * that the writer never writes, and whose row the hook will never clear.
+	 * Measured on 17.6 with the amname-only test: accepted, one row recorded,
+	 * and the row still there after DROP TABLE keyed to the dropped oid, while
+	 * an ordinary columnar table in the same run cleaned up. PG16 and earlier
+	 * cannot reach it -- they refuse `PARTITION BY ... USING pgcolumnar`
+	 * outright, checked on 16.14 -- so this is PG17, 18 and 19.
+	 */
+	IF NOT EXISTS (SELECT 1 FROM pg_class c
+					 JOIN pg_am a ON a.oid = c.relam
+					WHERE c.oid = table_name
+					  AND a.amname = 'pgcolumnar'
+					  AND c.relkind = 'r') THEN
+		RAISE EXCEPTION 'relation "%" is not a columnar table', table_name
+			USING HINT = 'Per-table options are read by the columnar writer and '
+				'apply only to an ordinary table using the pgcolumnar access '
+				'method. A partitioned table has no storage of its own: set the '
+				'options on each partition. Otherwise convert the table first '
+				'with ALTER TABLE ... SET ACCESS METHOD pgcolumnar, then set '
+				'the options.';
+	END IF;
+
+	IF encode_effort IS NOT NULL AND
+	   encode_effort NOT IN ('full', 'fast') THEN
+		RAISE EXCEPTION 'unknown columnar encode_effort "%"', encode_effort
+			USING HINT = 'Valid values are "full" and "fast".';
+	END IF;
+
+	IF compression IS NOT NULL AND
+	   compression NOT IN ('none', 'pglz', 'lz4', 'zstd') THEN
+		RAISE EXCEPTION 'unknown columnar compression "%"', compression;
+	END IF;
+
+	/*
+	 * Bound the integer limits to the same valid ranges as the instance-wide
+	 * GUCs (pgcolumnar.chunk_group_row_limit, pgcolumnar.stripe_row_limit,
+	 * pgcolumnar.compression_level). A per-table value outside these ranges is
+	 * rejected here rather than stored: a limit of zero or below would produce
+	 * a stripe whose recorded chunk_row_count is zero and make the row-number
+	 * arithmetic (chunk id = offset / chunk_row_count) divide by zero on
+	 * delete, update, and index fetch.
+	 */
+	IF chunk_group_row_limit IS NOT NULL AND chunk_group_row_limit < 100 THEN
+		RAISE EXCEPTION 'chunk_group_row_limit must be at least 100';
+	END IF;
+	IF stripe_row_limit IS NOT NULL AND stripe_row_limit < 1000 THEN
+		RAISE EXCEPTION 'stripe_row_limit must be at least 1000';
+	END IF;
+	IF compression_level IS NOT NULL AND
+	   (compression_level < 1 OR compression_level > 22) THEN
+		RAISE EXCEPTION 'compression_level must be between 1 and 22';
+	END IF;
+
+	/*
+	 * sort_by declares the physical sort key applied by vacuum_sorted() with no
+	 * explicit columns (#288). This is a cheap early check only: each named
+	 * column must exist, not be dropped, and not be a VIRTUAL generated column
+	 * (its value is not stored, so it cannot be sorted on). Orderability
+	 * (a default btree ordering operator) is NOT checked here -- the C apply
+	 * path is authoritative and re-resolves and re-validates the names every
+	 * run, because a column can be dropped or altered after it is declared.
+	 * attgenerated is '' or 's' before PG18; 'v' only exists from PG18, so the
+	 * "<> 'v'" test is correct and inert on older majors.
+	 */
+	IF sort_by IS NOT NULL THEN
+		FOREACH col IN ARRAY sort_by LOOP
+			IF NOT EXISTS (SELECT 1 FROM pg_attribute a
+						   WHERE a.attrelid = table_name
+							 AND a.attname = col
+							 AND a.attnum > 0
+							 AND NOT a.attisdropped
+							 AND a.attgenerated <> 'v') THEN
+				RAISE EXCEPTION 'column "%" cannot be used in sort_by for table %',
+					col, table_name
+					USING HINT = 'The column must exist, must not be dropped, '
+						'and must not be a VIRTUAL generated column.';
+			END IF;
+		END LOOP;
+	END IF;
+
+	INSERT INTO pgcolumnar.options AS o
+		(regclass, chunk_group_row_limit, stripe_row_limit,
+		 compression, compression_level, encode_effort, sort_by)
+	VALUES (table_name, chunk_group_row_limit, stripe_row_limit,
+			compression, compression_level, encode_effort, sort_by)
+	ON CONFLICT (regclass) DO UPDATE SET
+		chunk_group_row_limit =
+			COALESCE(EXCLUDED.chunk_group_row_limit, o.chunk_group_row_limit),
+		stripe_row_limit =
+			COALESCE(EXCLUDED.stripe_row_limit, o.stripe_row_limit),
+		compression =
+			COALESCE(EXCLUDED.compression, o.compression),
+		compression_level =
+			COALESCE(EXCLUDED.compression_level, o.compression_level),
+		encode_effort =
+			COALESCE(EXCLUDED.encode_effort, o.encode_effort),
+		sort_by =
+			COALESCE(EXCLUDED.sort_by, o.sort_by);
+END;
+$set_options$;
+
 CREATE OR REPLACE FUNCTION pgcolumnar.sort_status(rel regclass, OUT sort_key name[], OUT total_groups bigint, OUT sorted_groups bigint, OUT appended_groups bigint, OUT sorted_rows bigint, OUT appended_rows bigint)
  RETURNS record
  LANGUAGE plpgsql

--- a/pgcolumnar--1.0-alpha2.sql
+++ b/pgcolumnar--1.0-alpha2.sql
@@ -374,6 +374,49 @@ CREATE FUNCTION pgcolumnar.set_options(
 DECLARE
 	col name;
 BEGIN
+	/*
+	 * The options are per-relation and are read by the columnar writer, so a row
+	 * recorded for a relation that is not columnar can never be used. Storing one
+	 * is not merely useless: the drop hook that clears pgcolumnar.options fires
+	 * only for columnar relations, so the row outlives the table and is left
+	 * keyed to a dangling oid that a later relation reusing that oid inherits.
+	 * Measured before this guard, on the same cluster: set_options on a heap
+	 * table stored a row, DROP TABLE left it behind, and regclass then rendered
+	 * as the bare oid; the identical sequence on a columnar table cleaned up.
+	 *
+	 * Rejecting is safe for the one workflow that could want the other order:
+	 * ALTER TABLE ... SET ACCESS METHOD pgcolumnar keeps the relation's oid
+	 * (measured), so options set after the conversion apply to the same relation
+	 * a caller would have been trying to name before it.
+	 *
+	 * relkind is part of the test, and it is what makes the guard match the
+	 * cleanup rather than merely look strict. The drop hook returns before it
+	 * examines the access method for anything that is not an ordinary table
+	 * (columnar_tableam.c: `if (get_rel_relkind(objectId) != RELKIND_RELATION)
+	 * return;`), so 'r' is exactly the set of relations whose options row can
+	 * ever be cleaned up. From PG17 a PARTITIONED table may carry an access
+	 * method, so `relam = pgcolumnar` alone admits a parent that has no storage,
+	 * that the writer never writes, and whose row the hook will never clear.
+	 * Measured on 17.6 with the amname-only test: accepted, one row recorded,
+	 * and the row still there after DROP TABLE keyed to the dropped oid, while
+	 * an ordinary columnar table in the same run cleaned up. PG16 and earlier
+	 * cannot reach it -- they refuse `PARTITION BY ... USING pgcolumnar`
+	 * outright, checked on 16.14 -- so this is PG17, 18 and 19.
+	 */
+	IF NOT EXISTS (SELECT 1 FROM pg_class c
+					 JOIN pg_am a ON a.oid = c.relam
+					WHERE c.oid = table_name
+					  AND a.amname = 'pgcolumnar'
+					  AND c.relkind = 'r') THEN
+		RAISE EXCEPTION 'relation "%" is not a columnar table', table_name
+			USING HINT = 'Per-table options are read by the columnar writer and '
+				'apply only to an ordinary table using the pgcolumnar access '
+				'method. A partitioned table has no storage of its own: set the '
+				'options on each partition. Otherwise convert the table first '
+				'with ALTER TABLE ... SET ACCESS METHOD pgcolumnar, then set '
+				'the options.';
+	END IF;
+
 	IF encode_effort IS NOT NULL AND
 	   encode_effort NOT IN ('full', 'fast') THEN
 		RAISE EXCEPTION 'unknown columnar encode_effort "%"', encode_effort

--- a/test/audit.sh
+++ b/test/audit.sh
@@ -212,12 +212,74 @@ expect_error "reject stripe_row_limit 5" \
 expect_error "reject compression_level 99" \
 	"SELECT pgcolumnar.set_options('opt'::regclass, compression_level => 99);"
 
+# A relation that is not columnar must be refused rather than recorded. The drop
+# hook that clears pgcolumnar.options fires only for columnar relations, so a row
+# stored for a heap table outlives the table and is left keyed to a dangling oid,
+# which a later relation reusing that oid inherits. Measured before the guard, on
+# one cluster: the heap table's row survived DROP TABLE and regclass then rendered
+# as the bare oid, while the identical sequence on a columnar table cleaned up.
+q "CREATE TABLE opt_heap (a int) USING heap;" >/dev/null
+expect_error "reject set_options on a heap table" \
+	"SELECT pgcolumnar.set_options('opt_heap'::regclass, chunk_group_row_limit => 1000);"
+# expect_error passes on ANY error, including a typo in this file's own SQL, so
+# assert the reason too. Captured and then matched: piping an erroring psql into
+# grep reports on the pipeline rather than on the message.
+# `|| true` because this file runs under `set -e` and the call is EXPECTED to
+# fail: without it the assignment takes the non-zero status and aborts the suite
+# right here, which is what it did the first time. expect_error above survives
+# only because it sits inside an `if`.
+opt_heap_err="$(run_pg "$PSQL -c \"SELECT pgcolumnar.set_options('opt_heap'::regclass, chunk_group_row_limit => 1000);\"" 2>&1 || true)"
+check "the refusal says the relation is not columnar" \
+	"$(case "$opt_heap_err" in *"is not a columnar table"*) echo yes ;; *) echo "no [$opt_heap_err]" ;; esac)" \
+	"yes"
+check "nothing was recorded for the heap table" \
+	"$(q "SELECT count(*) FROM pgcolumnar.options WHERE regclass = 'opt_heap'::regclass;")" "0"
+q "DROP TABLE opt_heap;" >/dev/null
+
+# A PARTITIONED parent is the same leak through a different door, and the access
+# method alone does not close it. From PG17 a partitioned table may carry an
+# access method, so `relam = pgcolumnar` admits a parent that has no storage of
+# its own, that the writer never writes, and whose options row the drop hook will
+# never clear: the hook returns early for anything that is not RELKIND_RELATION
+# (columnar_tableam.c). Measured on 17.6 before the relkind test was added:
+# accepted, one row recorded, and the row still present after DROP TABLE keyed to
+# the dropped oid. PG16 and earlier refuse `PARTITION BY ... USING pgcolumnar`
+# outright (checked on 16.14), so the arm is gated rather than skipped silently.
+audit_srv="$(q 'SHOW server_version_num')"
+if [ "$audit_srv" -ge 170000 ]; then
+	q "CREATE TABLE opt_part (id int, v text) PARTITION BY RANGE (id) USING pgcolumnar;" >/dev/null
+	# relkind is type "char", so it needs the cast: without it the concatenation
+	# raises `operator is not unique: "char" || unknown`, the premise returns empty,
+	# and the arm below would be believed on no evidence.
+	check "premise: this major really lets a partitioned parent carry the AM" \
+		"$(q "SELECT c.relkind::text || '/' || a.amname FROM pg_class c JOIN pg_am a ON a.oid = c.relam WHERE c.relname = 'opt_part';")" \
+		"p/pgcolumnar"
+	expect_error "reject set_options on a partitioned parent" \
+		"SELECT pgcolumnar.set_options('opt_part'::regclass, chunk_group_row_limit => 1000);"
+	check "nothing was recorded for the partitioned parent" \
+		"$(q "SELECT count(*) FROM pgcolumnar.options WHERE regclass = 'opt_part'::regclass;")" "0"
+	# And the leaf, which is an ordinary table, must still be accepted -- the guard
+	# has to refuse the parent without refusing the thing that actually stores rows.
+	q "CREATE TABLE opt_part_1 PARTITION OF opt_part FOR VALUES FROM (0) TO (100);" >/dev/null
+	q "SELECT pgcolumnar.set_options('opt_part_1'::regclass, chunk_group_row_limit => 1000);" >/dev/null
+	check "the partition itself is still accepted" \
+		"$(q "SELECT count(*) FROM pgcolumnar.options WHERE regclass = 'opt_part_1'::regclass;")" "1"
+	q "DROP TABLE opt_part;" >/dev/null
+else
+	echo "-- PG$((audit_srv / 10000)) refuses PARTITION BY ... USING pgcolumnar; parent arm not applicable"
+fi
+
 # valid values are accepted, and delete/update work (no divide-by-zero)
 q "SELECT pgcolumnar.set_options('opt'::regclass,
      chunk_group_row_limit => 1000, stripe_row_limit => 2000, compression_level => 9);" >/dev/null
 q "INSERT INTO opt SELECT g FROM generate_series(1,10) g;" >/dev/null
 q "DELETE FROM opt WHERE a=5;" >/dev/null
 check "valid options delete works" "$(q "SELECT count(*) FROM opt;")" "9"
+# The positive control for the refusal above: the same call, on a columnar table,
+# is accepted AND recorded. Without this the deny arm could pass because
+# set_options rejects everything.
+check "the same call on a columnar table is recorded" \
+	"$(q "SELECT count(*) FROM pgcolumnar.options WHERE regclass = 'opt'::regclass;")" "1"
 q "DROP TABLE opt;" >/dev/null
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`pgcolumnar.set_options` accepted any relation, and silently recorded options for it.

## What it did

```
=> CREATE TABLE h_only (id int) USING heap;
=> SELECT pgcolumnar.set_options('h_only', chunk_group_row_limit => 1234);
 set_options
-------------          <- no error, no warning, void
=> SELECT * FROM pgcolumnar.options;
 regclass | chunk_group_row_limit | ...
----------+-----------------------+
 h_only   |                  1234 |
```

`docs/configuration.md` documents the argument as "The columnar table to change", and
options are read by the columnar writer, so the row can never be used by a heap table.

## Why it is worth an error rather than a comment

The row is not merely useless. **It leaks.** The object access hook that clears
`pgcolumnar.options` fires only for columnar relations, so the row outlives the table.
Measured, arm and control on one cluster:

| | options row before `DROP` | after `DROP` |
| --- | ---: | ---: |
| `USING heap` (arm) | 1 | **1** |
| `USING pgcolumnar` (control) | 1 | 0 |

After the drop, `regclass` renders as the bare oid (`16554`), because the reference is
dangling. A later relation that reuses that oid inherits the stale options.

## The one workflow this could have broken, and why it does not

"Set options first, convert the table second" is the only sensible reason to call this on a
heap table. `ALTER TABLE ... SET ACCESS METHOD pgcolumnar` **keeps the relation's oid**
(measured: 16560 before, 16560 after), so setting the options after the conversion reaches
the same relation. The hint says so:

```
ERROR:  relation "h_only" is not a columnar table
HINT:   Per-table options are read by the columnar writer and apply only to a table
        using the pgcolumnar access method. Convert it first with
        ALTER TABLE ... SET ACCESS METHOD pgcolumnar, then set the options.
```

The wording matches what the C paths already raise (`columnar_arrow.c:1014`,
`columnar_parquet.c:1174`, and two more).

Nothing in the 215-suite corpus calls `set_options` on a non-columnar relation, so no
existing test changes behaviour. I checked every call site, including the three suites that
build partitioned tables: all of them target a table created `USING pgcolumnar`.

## The upgrade script

`native_upgrade_converge` compares `md5(pg_get_functiondef(p.oid))`, so a body change in the
base script that is not mirrored into `1.0-alpha--1.0-alpha2` makes an upgraded catalog
diverge from a fresh install. The new definition is mirrored, generated from the base script
text so the two are byte-identical (verified: 4,995 bytes each, `identical: True`).

Removal proof:

| mutation | result |
| --- | --- |
| drop the `CREATE OR REPLACE` from the upgrade script | **RED** — `native_upgrade_converge` fails on exactly one row, the `set_options` definition: `edcf1ff8...` against `62f03e87...` |

## Test

`audit.sh` section 3 already owns per-table option validation. The new arm sits beside the
existing bounds rejections, with two things the surrounding checks did not have:

- **The message is asserted, not just the failure.** `expect_error` passes on *any* error,
  including a typo in the suite's own SQL, so the error text is captured and matched for
  `is not a columnar table`. Captured then matched rather than piped, because an erroring
  `psql` into `grep` reports on the pipeline.
- **A positive control.** The same call on a columnar table is asserted to be accepted *and
  recorded*, so the deny arm cannot pass because `set_options` rejects everything.

## Not in this PR

Rows already orphaned by the old behaviour are left alone. Deleting user rows in an upgrade
script is your call, not mine, and the guard stops new ones. Say the word and I will add it.

## Gate

Container `pgcolumnar-audit`, assert builds.

| gate | PG18 | PG19 |
| --- | --- | --- |
| `audit` | PASS | PASS |
| `native_upgrade_converge` | PASS, 5 checks | PASS, 5 checks |
| `extension_upgrade` | | rc=0 |
| `harness_selftest` | PASSED, 126 checks | |
| `docs_style` | PASSED, 9 checks | |
| `shellcheck -S error -s bash` | clean | |

The four new assertions, identical on both majors:

```
PASS  reject set_options on a heap table (rejected)
PASS  the refusal says the relation is not columnar: yes
PASS  nothing was recorded for the heap table: 0
PASS  the same call on a columnar table is recorded: 1
```

The suite aborted the first time I ran it: `audit.sh` runs under `set -e`, and capturing the
error text from a call that is *expected* to fail takes the non-zero status and ends the
script. `expect_error` survives only because it sits inside an `if`. Fixed with `|| true`
and a comment saying why, since the next person to capture an error here will hit it too.

CHANGELOG and `docs/configuration.md` included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
