### PR TITLE
opt: resolve zone_map once per scan, not once per group (#744)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,22 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ### Fixed
 
+- The columnar scan resolved `pgcolumnar.zone_map` once per chunk group per
+  predicate column instead of once per scan. Every group a predicate could
+  exclude ran a relation open with a lock and two catalog name lookups, then
+  closed again; the reuse cache that the write path uses for the same catalogs
+  is gated on a flag only the write path sets, so the read path never reached
+  it. The scan now holds the relation and the resolved index for its own
+  duration. Measured at 160 chunk groups with one predicate column, the same
+  binary with only the cache defeated, backend instructions pinned to one PMU:
+  18,280,385 per query before and 14,013,418 after, a saving of 26,669 per
+  chunk group and 1.304x on the query. That is 87% of the cost #744 measured
+  for locating the surviving groups at that size; the remainder is the index
+  probe itself. Buffer counts are unchanged, which is the expected shape: a
+  catcache or relcache lookup reads no buffers once warm, so the buffers a
+  probe costs are the index scan and the CPU it costs was mostly the open.
+  (#744)
+
 - The nightly coverage report now measures something. It had never captured any
   coverage: the job failed every night from the night it was added on
   2026-07-31, always at `lcov capture produced nothing`. `test/run_coverage.sh`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,15 +37,15 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
   closed again; the reuse cache that the write path uses for the same catalogs
   is gated on a flag only the write path sets, so the read path never reached
   it. The scan now holds the relation and the resolved index for its own
-  duration. Measured at 160 chunk groups with one predicate column, the same
-  binary with only the cache defeated, backend instructions pinned to one PMU:
-  18,280,385 per query before and 14,013,418 after, a saving of 26,669 per
-  chunk group and 1.304x on the query. That is 87% of the cost #744 measured
-  for locating the surviving groups at that size; the remainder is the index
-  probe itself. Buffer counts are unchanged, which is the expected shape: a
-  catcache or relcache lookup reads no buffers once warm, so the buffers a
-  probe costs are the index scan and the CPU it costs was mostly the open.
-  (#744)
+  duration. Measured at 640 chunk groups with one predicate column, the same
+  binary with the session bypassed, backend instructions pinned to one PMU and
+  normalised by completed queries: 29,694,459 per query before and 26,676,590
+  after, a saving of 4,715 per chunk group and 1.113x on the query. That is 15%
+  of the cost #744 measured for locating the surviving groups at that size, so
+  the systable index probe, which stays inside the loop, remains the larger
+  part. Buffer counts are unchanged, which is the expected shape: a catcache or
+  relcache lookup reads no buffers once warm, so the buffers a probe costs are
+  the index scan. (#744)
 
 - The nightly coverage report now measures something. It had never captured any
   coverage: the job failed every night from the night it was added on

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -470,9 +470,35 @@ extern void PgColumnarCheckNativeFormatVersion(uint64 storageId, const char *rel
 extern List *PgColumnarReadRowGroupList(uint64 storageId, Snapshot snapshot);
 extern List *PgColumnarReadZoneMapList(uint64 storageId, uint64 groupNumber,
 									 Snapshot snapshot);
+/*
+ * #744: one scan's handle on pgcolumnar.zone_map.
+ *
+ * The skip loop probes zone_map once per chunk group per predicate column, and
+ * each probe used to open the relation and resolve two names. This holds them
+ * for the scan instead. It lives in the scan's own read state rather than in a
+ * static, deliberately: a scan that ereports never runs its end hook, and a
+ * shared static would then carry a Relation the resource owner has already
+ * released into the NEXT scan. Per-scan, the pointer dies with the scan, and on
+ * abort the resource owner releases the relation silently (resowner.c prints
+ * leak warnings only when isCommit).
+ *
+ * probes and opens are the pair that makes the saving measurable rather than
+ * asserted: without the cache they are equal, with it opens is 1.
+ */
+typedef struct PgColumnarZoneMapSession
+{
+	Relation	rel;
+	Oid			idxOid;
+	uint64		probes;
+	uint64		opens;
+} PgColumnarZoneMapSession;
+
+/* sess may be NULL, which is the old open-per-probe behaviour. */
 extern NativeZoneMapMetadata *PgColumnarReadZoneMapForColumn(uint64 storageId,
 									 uint64 groupNumber, int columnIndex,
-									 Snapshot snapshot);
+									 Snapshot snapshot,
+									 PgColumnarZoneMapSession *sess);
+extern void PgColumnarCloseZoneMapSession(PgColumnarZoneMapSession *sess);
 extern void PgColumnarDeleteMetadata(uint64 storageId);
 
 /* per-table options catalog (spec 7.4) */

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -325,6 +325,31 @@ PgColumnarResetMetadataFlush(void)
 }
 
 /*
+ * #744: close one scan's zone_map handle.
+ *
+ * Called from PgColumnarEndRead on the normal path. On an error path it is not
+ * called at all, and must not be: the resource owner has already released the
+ * relation by then, and it does so silently because leak warnings are printed
+ * only when isCommit (resowner.c). The session lives in the scan's read state,
+ * so the pointer goes away with the scan and can never reach another one.
+ */
+void
+PgColumnarCloseZoneMapSession(PgColumnarZoneMapSession *sess)
+{
+	if (sess == NULL)
+		return;
+	if (sess->rel != NULL)
+	{
+		table_close(sess->rel, AccessShareLock);
+		sess->rel = NULL;
+	}
+	sess->idxOid = InvalidOid;
+	if (message_level_is_interesting(DEBUG1))
+		elog(DEBUG1, "pgcolumnar zone map read: probes=%lu opens=%lu",
+			 (unsigned long) sess->probes, (unsigned long) sess->opens);
+}
+
+/*
  * pgcolumnar_index_oid
  *		The OID of one of the metadata indexes, by name. Returns InvalidOid when
  *		it cannot be resolved, which callers pass through to systable_beginscan
@@ -2631,15 +2656,39 @@ PgColumnarReadZoneMapList(uint64 storageId, uint64 groupNumber, Snapshot snapsho
  */
 NativeZoneMapMetadata *
 PgColumnarReadZoneMapForColumn(uint64 storageId, uint64 groupNumber,
-							   int columnIndex, Snapshot snapshot)
+							   int columnIndex, Snapshot snapshot,
+							   PgColumnarZoneMapSession *sess)
 {
-	Relation	rel = open_columnar_table("zone_map", AccessShareLock);
-	TupleDesc	tupdesc = RelationGetDescr(rel);
+	Relation	rel;
+	TupleDesc	tupdesc;
 	ScanKeyData key[3];
 	SysScanDesc scan;
 	Oid			idxOid;
 	HeapTuple	tuple;
 	NativeZoneMapMetadata *result = NULL;
+
+	/*
+	 * #744. Inside a read session the relation and the index oid are resolved
+	 * once and held for the scan; outside one this behaves exactly as before.
+	 */
+	if (sess != NULL)
+	{
+		sess->probes++;
+		if (sess->rel == NULL)
+		{
+			sess->rel = open_columnar_table("zone_map", AccessShareLock);
+			sess->idxOid = pgcolumnar_index_oid("zone_map_pkey");
+			sess->opens++;
+		}
+		rel = sess->rel;
+		idxOid = sess->idxOid;
+	}
+	else
+	{
+		rel = open_columnar_table("zone_map", AccessShareLock);
+		idxOid = pgcolumnar_index_oid("zone_map_pkey");
+	}
+	tupdesc = RelationGetDescr(rel);
 
 	ScanKeyInit(&key[0], Anum_zone_map_storage_id, BTEqualStrategyNumber,
 				F_INT8EQ, Int64GetDatum((int64) storageId));
@@ -2661,7 +2710,8 @@ PgColumnarReadZoneMapForColumn(uint64 storageId, uint64 groupNumber,
 		break;
 	}
 	systable_endscan(scan);
-	table_close(rel, AccessShareLock);
+	if (sess == NULL)
+		table_close(rel, AccessShareLock);
 
 	return result;
 }

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -218,6 +218,13 @@ struct PgColumnarReadState
 	MemoryContext groupContext;		/* reset per chunk group (decompressed) */
 	MemoryContext rowContext;		/* reset per row */
 	MemoryContext skipContext;		/* scratch for skip-list evaluation */
+
+	/*
+	 * #744: this scan's zone_map handle, so the skip loop resolves the relation
+	 * and the index once instead of once per chunk group per predicate column.
+	 * Per-scan rather than static: see the comment on the type.
+	 */
+	PgColumnarZoneMapSession zmSession;
 };
 
 static void pgcolumnar_build_predicates(PgColumnarReadState *readState,
@@ -1378,7 +1385,8 @@ pgcolumnar_native_group_can_match(PgColumnarReadState *rs, uint64 groupNumber)
 		{
 			byColZone[pred->attidx] =
 				PgColumnarReadZoneMapForColumn(rs->storageId, groupNumber,
-											   pred->attidx, rs->metaSnapshot);
+											   pred->attidx, rs->metaSnapshot,
+											   &rs->zmSession);
 			zoneLookedUp[pred->attidx] = true;
 		}
 
@@ -4236,6 +4244,8 @@ PgColumnarRescanRead(PgColumnarReadState *readState)
 void
 PgColumnarEndRead(PgColumnarReadState *readState)
 {
+	/* Before the context goes: readState itself is allocated inside it. */
+	PgColumnarCloseZoneMapSession(&readState->zmSession);
 	MemoryContextDelete(readState->readContext);
 }
 

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -1954,7 +1954,6 @@ pgcolumnar_xact_callback(XactEvent event, void *arg)
 			PgColumnarDiscardAllPendingWrites();
 			PgColumnarDiscardAllDeleteVectors();
 			PgColumnarDiscardFetchCache();
-
 			/*
 			 * Descriptors only: the memo contexts are TopTransactionContext
 			 * children, still live at callback time but taken by the

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -1954,6 +1954,7 @@ pgcolumnar_xact_callback(XactEvent event, void *arg)
 			PgColumnarDiscardAllPendingWrites();
 			PgColumnarDiscardAllDeleteVectors();
 			PgColumnarDiscardFetchCache();
+
 			/*
 			 * Descriptors only: the memo contexts are TopTransactionContext
 			 * children, still live at callback time but taken by the

--- a/test/native_zonemap_session.sh
+++ b/test/native_zonemap_session.sh
@@ -11,19 +11,31 @@
 # md_flush reuse cache could not help: it is gated on md_flush.active, which only
 # columnar_write_state.c ever sets, so the read path never reached it.
 #
-# Measured at 160 chunk groups, one predicate column, the same binary with only
-# the cache defeated, backend instructions with the process pinned to one PMU:
+# Measured at 640 chunk groups, one predicate column, the same binary with the
+# session bypassed (sess = NULL, which is byte-for-byte the old open-and-close
+# path), backend instructions pinned to one PMU and normalised by the number of
+# queries that completed in the window:
 #
-#     baseline  18,280,385 instructions per query
-#     cached    14,013,418
-#     saved     4,266,968  =  26,669 per chunk group,  1.304x
+#     baseline  29,699,977 / 29,688,941   ->  29,694,459 per query
+#     session   26,674,578 / 26,678,602   ->  26,676,590
+#     saved     3,017,869  =  4,715 per chunk group,  1.113x
 #
-# That is 87% of the whole locate cost #744 priced at this size, so what remains
-# is the systable index probe. Buffers did NOT move (186/314/567 at N=40/80/160
-# on both arms): a catcache or relcache lookup reads no buffers once warm, so
-# the buffer cost of a probe is the index scan alone and the CPU cost was mostly
-# the open. The two instruments measure different halves and neither alone
-# prices this.
+# Within-arm spread is 0.04% and 0.02% against a 10.2% effect. That is 15% of
+# the locate cost #744 priced at this size, so the systable index probe, which
+# stays inside the loop, is the larger part and #403 item 2 is not diminished
+# by this change.
+#
+# An earlier version of this comment claimed 1.304x and 87%. Both were wrong,
+# and the cause is worth keeping: the baseline arm defeated the cache with
+# `if (1)` while leaving `sess` non-NULL, so every probe opened a relation and
+# NONE of them closed, because the close is gated on `sess == NULL`. That arm
+# leaked a reference per group and did strictly more work than the code it was
+# standing in for. The tell was arithmetic: the "saving" exceeded the entire
+# cost of the component being optimised. Bypass with sess = NULL, which is the
+# real path, not a mutation of it.
+#
+# Buffers did NOT move on either arm: a catcache or relcache lookup reads no
+# buffers once warm, so the buffer cost of a probe is the index scan alone.
 #
 # WHAT THIS SUITE ASSERTS is the work done, not the answer. A scan returns the
 # same rows either way, so a correctness test cannot see this land or regress.

--- a/test/native_zonemap_session.sh
+++ b/test/native_zonemap_session.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+#
+# The skip loop must resolve pgcolumnar.zone_map ONCE per scan, not once per
+# chunk group per predicate column (#744).
+#
+# What it cost. pgcolumnar_native_group_can_match calls
+# PgColumnarReadZoneMapForColumn for every group a predicate could exclude, and
+# that call used to run open_columnar_table (pgcolumnar_schema_oid,
+# get_relname_relid, table_open with a lock and a resource-owner remember) plus
+# pgcolumnar_index_oid (a second get_relname_relid), then close again. The
+# md_flush reuse cache could not help: it is gated on md_flush.active, which only
+# columnar_write_state.c ever sets, so the read path never reached it.
+#
+# Measured at 160 chunk groups, one predicate column, the same binary with only
+# the cache defeated, backend instructions with the process pinned to one PMU:
+#
+#     baseline  18,280,385 instructions per query
+#     cached    14,013,418
+#     saved     4,266,968  =  26,669 per chunk group,  1.304x
+#
+# That is 87% of the whole locate cost #744 priced at this size, so what remains
+# is the systable index probe. Buffers did NOT move (186/314/567 at N=40/80/160
+# on both arms): a catcache or relcache lookup reads no buffers once warm, so
+# the buffer cost of a probe is the index scan alone and the CPU cost was mostly
+# the open. The two instruments measure different halves and neither alone
+# prices this.
+#
+# WHAT THIS SUITE ASSERTS is the work done, not the answer. A scan returns the
+# same rows either way, so a correctness test cannot see this land or regress.
+# The runner's DEBUG1 witness reports probes and real opens, and the pair is the
+# assertion: probes scales with the group count, opens must stay at one.
+#
+# The lifetime arms are here because the first implementation of this was WRONG
+# in a way no correctness test caught. It held the relation in a static shared
+# across scans, and a scan that ereports never runs its end hook, so after a
+# subtransaction rollback the next scan reused a Relation the subtransaction's
+# resource owner had already released. Every functional check still passed: a
+# released relcache entry is refcount-decremented rather than freed, so the
+# stale pointer read correctly. It showed up only as a missing witness. The
+# session now lives in the scan's own read state, so nothing crosses scans.
+#
+# Usage:  test/native_zonemap_session.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+N=40
+ROWS=$((N * 10000))
+psql_run "DROP TABLE IF EXISTS zs;
+	CREATE TABLE zs (k bigint, w bigint, v bigint) USING pgcolumnar;
+	SELECT pgcolumnar.set_options('zs', stripe_row_limit => 10000);
+	INSERT INTO zs SELECT g, g, g FROM generate_series(1, $ROWS) g;" >/dev/null 2>&1
+
+# The group count comes FROM THE DATA, never from rows/stripe_row_limit.
+groups=$(q "SELECT count(*) FROM pgcolumnar.row_group
+            WHERE storage_id = pgcolumnar.get_storage_id('zs');")
+check "premise: the fixture really has more than one chunk group" \
+	"$([ "${groups:-0}" -gt 1 ] && echo yes || echo no)" "yes"
+
+witness() {	# witness "<where clause>" -> "probes=N opens=M"
+	psql_run "SET client_min_messages=debug1; SET max_parallel_workers_per_gather=0;
+		SET enable_indexscan=off; SET enable_bitmapscan=off;
+		SELECT count(*) FROM zs WHERE $1;" 2>&1 |
+		grep -oE 'probes=[0-9]+ opens=[0-9]+' | tail -1
+}
+w="$(witness 'k <= 10000')"
+probes="$(printf '%s' "$w" | grep -oE 'probes=[0-9]+' | grep -oE '[0-9]+')"
+opens="$(printf '%s' "$w" | grep -oE 'opens=[0-9]+' | grep -oE '[0-9]+')"
+echo "-- one predicate column over $groups groups: $w"
+
+# The premise first: if the scan probed nothing, "opens=1" would be trivially
+# satisfied by a scan that did no work at all, which is the shape that let
+# zonemap_cost price pruning for a year while pruning zero groups.
+check "premise: the scan really probed the zone maps, once per group" \
+	"$probes" "$groups"
+check "the scan resolves zone_map ONCE, not once per group (#744)" "$opens" "1"
+
+# A second predicate column must not add a second open either. It adds only one
+# probe here, not one per group: native_zone_excludes returns as soon as the
+# first predicate rules a group out, so the second column is consulted only for
+# the group that survives.
+w2="$(witness 'k <= 10000 AND w <= 10000')"
+echo "-- two predicate columns: $w2"
+check "a second predicate column still resolves zone_map once" \
+	"$(printf '%s' "$w2" | grep -oE 'opens=[0-9]+' | grep -oE '[0-9]+')" "1"
+check "and the short circuit means it adds one probe, not one per group" \
+	"$(printf '%s' "$w2" | grep -oE 'probes=[0-9]+' | grep -oE '[0-9]+')" "$((groups + 1))"
+
+# ---- lifetime -------------------------------------------------------------
+psql_run "DROP TABLE IF EXISTS zs2;
+	CREATE TABLE zs2 (k bigint, v bigint) USING pgcolumnar;
+	SELECT pgcolumnar.set_options('zs2', stripe_row_limit => 1000);
+	INSERT INTO zs2 SELECT g, g FROM generate_series(1,20000) g;" >/dev/null 2>&1
+
+nested=$(q "SET enable_indexscan=off; SET max_parallel_workers_per_gather=0;
+	SELECT count(*) FROM zs2 a JOIN zs2 b ON a.k = b.k
+	 WHERE a.k <= 1000 AND b.k <= 1000;" | tail -1)
+check "nested columnar scans each hold their own handle" "$nested" "1000"
+
+# An erroring scan never runs its end hook. What must be true afterwards is that
+# the NEXT scan opens for itself rather than inheriting anything.
+cat > "$PGC_WORKDIR/zsub.sql" <<'SQL'
+SET client_min_messages=debug1;
+SET enable_indexscan=off;
+SELECT count(*) FROM zs2 WHERE k <= 1000;
+BEGIN;
+SAVEPOINT s1;
+SELECT count(*) FROM zs2 WHERE k <= 5000 AND 1/(v-4000) > 0;
+ROLLBACK TO s1;
+SELECT count(*) FROM zs2 WHERE k <= 1000;
+COMMIT;
+SELECT count(*) FROM zs2 WHERE k <= 1000;
+SQL
+out="$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+	-d "$PGC_DB" -At -v ON_ERROR_STOP=0 -f "$PGC_WORKDIR/zsub.sql" 2>&1)"
+check "premise: the middle scan really did error inside the subtransaction" \
+	"$(printf '%s' "$out" | grep -c 'division by zero')" "1"
+# THREE scans complete: before, after ROLLBACK TO, after COMMIT. Each must
+# report. Two would mean one of them ran on state left behind by the error,
+# which is exactly the defect the first implementation had.
+check "every scan around an aborted one reports its own session (#744)" \
+	"$(printf '%s' "$out" | grep -c 'zone map read: probes=')" "3"
+check "and each of them opened exactly once" \
+	"$(printf '%s' "$out" | grep -c 'zone map read: probes=[0-9]* opens=1')" "3"
+check "the scan after the subtransaction abort returns the right answer" \
+	"$(printf '%s' "$out" | grep -cE '^1000$')" "3"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -191,6 +191,7 @@ SUITES=(
 	native_writer
 	native_zonemap
 	native_zonemap_narrow
+	native_zonemap_session
 	objstore_addressing
 	objstore_allowlist
 	objstore_credentials


### PR DESCRIPTION
Closes #744 step 1, and answers the measurement that issue left open.

## What it cost

The skip loop called `PgColumnarReadZoneMapForColumn` for every chunk group a
predicate could exclude. Each call ran `open_columnar_table`
(`pgcolumnar_schema_oid`, `get_relname_relid`, `table_open` with a lock and a
resource-owner remember) plus `pgcolumnar_index_oid` (a second
`get_relname_relid`), then closed again. The `md_flush` reuse cache cannot help:
it is gated on `md_flush.active`, which only `columnar_write_state.c` ever sets.

## The split #744 asked for

#744 priced one whole call at 25,185 instructions / 6.00 buffers per group per predicate
column and said explicitly it had **not** split that into the open-and-lookup half and the
index-probe half.

**Corrected after review.** An earlier version of this section claimed 1.304x and 87%. Both
were wrong and the cause was my baseline arm, not the fixture: it defeated the cache with
`if (1)` while leaving `sess` non-NULL, and the close is gated on `sess == NULL`, so every
probe opened a relation and none closed. That arm leaked a reference per group and did
strictly more work than the code it stood in for. See the correction comment below.

Baseline is now `sess = NULL`, which is byte-for-byte the old open-and-close path rather
than a mutation of it, and the window is normalised by queries completed rather than a fixed
rep count. 640 chunk groups, one predicate column, pinned to one PMU:

| arm | run 1 | run 2 | per query |
| --- | ---: | ---: | ---: |
| baseline (`sess = NULL`) | 29,699,977 | 29,688,941 | 29,694,459 |
| session | 26,674,578 | 26,678,602 | 26,676,590 |

**Saved 3,017,869 per query = 4,715 per chunk group = 1.113x.** Within-arm spread is 0.04%
and 0.02% against a 10.2% effect.

Against the 19,572,693 that #744 measured for locating the surviving groups at 640 groups,
this removes **15%**. The systable index probe stays inside the loop and is the larger part,
so **#403 item 2's sparse index is not diminished by this change** -- the opposite of what
this PR originally concluded.

**The fixture question is answered.** My baseline total at 640 groups is 29,694,459 against
#744's 29,760,395, **0.22% apart**, so at this size the two are comparable and the ratio is
like-for-like. The N=160 disagreement raised on review was my inflated arm.

**Buffers did not move** on either arm, as predicted before measuring: catcache and relcache
lookups read no buffers once warm, so the buffers a probe costs are the index scan alone.

## Per scan, not static, and that is the design

My first version held the relation in a file-level static with a depth counter
and abort hooks. **It was wrong.** A scan that `ereport`s never runs its end
hook, so after a subtransaction rollback the next scan reused a `Relation` the
subtransaction's resource owner had already released.

No correctness test caught it. Nested scans, post-abort scans and rescans all
returned correct answers, because a released relcache entry is
refcount-decremented rather than freed, so the stale pointer still read
correctly. It was visible only as a **missing witness**: three scans should each
report and only two did.

The session now lives in `PgColumnarReadState`. It dies with the scan, nothing
crosses scans, and there is no depth, no static and no abort wiring. The normal
path closes in `PgColumnarEndRead`; an error path correctly does not, because
the resource owner has already released the relation and does so silently --
`resowner.c` prints leak warnings only when `isCommit`, which I read in the PG17
source rather than assumed.

## Test

`test/native_zonemap_session.sh`, 10 checks, asserts **work done** and not the
answer, since the rows are identical either way:

```
probes=40 opens=1    40 groups, one predicate column
probes=41 opens=1    two predicate columns: ONE extra probe, not one per group,
                     because native_zone_excludes returns as soon as the first
                     predicate excludes a group
```

That second line also corrects #744's `S2 - S1` decomposition, which assumed a
second predicate column doubles the per-group cost. It does not, on a fixture
where the first predicate is the selective one.

Plus lifetime arms: nested scans, and three scans around one that errors inside
a subtransaction, each of which must report its own session.

| mutation | result |
| --- | --- |
| defeat only the caching | **RED** x3: `got [40] want [1]`, `got [41] want [1]`, `got [0] want [3]`, premises green |

## Gates

`harness_selftest` **151 PASSED**; `shellcheck -S error` clean; `docs_style` 9;
and `native_zonemap`, `native_zonemap_narrow`, `zonemap_cost`, `native_skip`,
`native_bloom`, `column_projection`, `differential` all PASS on PG17.

This holds a relation across a scan, so it earns the sanitizer gate. Dispatching
the nightly on this branch; I will post what it says before asking for a merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
