### PR TITLE
opt: invert the ordered operators too, not just equality (#403 item 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,29 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ### Added
 
+- A predicate on `date_trunc(unit, ts)` now drives chunk-group skipping for the
+  ORDERED comparisons too, not only equality. #739 inverted `=` and declined
+  every other operator, so `date_trunc('day', ts) >= '2024-02-01'` still read
+  every chunk group, which is the shape a time-series filter usually takes.
+  Monotonicity is what makes the ordered operators invertible, so they come from
+  the same unit table for one scan key each rather than equality's two. Measured
+  on the existing 500,000-row time-clustered fixture, chunk groups removed by the
+  filter, `date_trunc` form against the explicit range it is equivalent to:
+
+  | predicate | before | after | the equivalent range |
+  | --- | ---: | ---: | ---: |
+  | `date_trunc('day', ts) >= c` | 0 | 30 | 30 |
+  | `date_trunc('day', ts) > c` | 0 | 31 | 31 |
+  | `date_trunc('day', ts) < c` | 0 | 19 | 19 |
+  | `date_trunc('day', ts) <= c` | 0 | 18 | 18 |
+
+  Two cases carry their own risk and their own arms. With the constant on the
+  LEFT the strategy has to be commuted, because `c < f(ts)` is `f(ts) > c`; for
+  equality that was a no-op, which is why it never came up before. And an
+  untruncated constant, which equality treats as unsatisfiable, is satisfiable
+  here and moves the bound to the next bucket boundary instead of emptying the
+  result. `timestamptz` stays declined for the reason #739 gives. (#403)
+
 - A predicate on `date_trunc(unit, ts) = constant` now drives chunk-group
   skipping. A zone map holds `ts`, so a predicate about a function of `ts` could
   exclude nothing and the scan read every group. It is rewritten to a range on
@@ -30,6 +53,16 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
   `preimage_rewrite`, measures the pruning and pins each declined shape. (#403)
 
 ### Fixed
+
+- A `date_trunc` predicate within one bucket of the end of the `timestamp` range
+  raised `ERROR: timestamp out of range` on a columnar table instead of
+  answering. The rewrite computes the next bucket boundary as `lo + step`, and
+  that addition throws near the maximum, which fails the whole query rather than
+  declining to prune. Reachable on `main` before this release through equality
+  alone: `date_trunc('year', ts) = timestamp '294276-01-01'` errored while the
+  heap returned the row. The rewrite now declines within one step of the end.
+  Infinities are unaffected, because interval arithmetic on them saturates rather
+  than overflowing. (#403)
 
 - The nightly coverage report now measures something. It had never captured any
   coverage: the job failed every night from the night it was added on

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -190,7 +190,12 @@ parallel paths, so plans are stable). The custom scan computes the referenced
 column set from the target list and restriction clauses and pushes it into the
 reader (projection pushdown), and translates simple `column op const` clauses
 into scan keys so the reader's zone maps remove row groups and vectors that
-cannot match (qual pushdown). The executor always re-applies the full
+cannot match (qual pushdown). A clause of the form `f(column) op const` is also
+translated, when `f` is a function whose preimage is a contiguous interval. The
+only such function today is `date_trunc` on `timestamp`. A zone map holds the
+column and not the function of it, so without this the scan reads every group.
+Equality becomes two keys, one for each end of the bucket. The ordered
+comparisons become one key each. The executor always re-applies the full
 restriction clauses as a filter, so skipping never changes results. The scan is
 the scalar per-row path (`PgColumnarScanNext`). Through a `create_upper_paths_hook`
 the module adds the vectorized aggregate path for a supported

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -279,7 +279,7 @@ pgcolumnar_commute_strategy(StrategyNumber s)
 
 /*
  * pgcolumnar_preimage_range_scankey
- *		Rewrite `f(col) = const` into a range on col, for a function whose
+ *		Rewrite `f(col) OP const` into a bound on col, for a function whose
  *		preimage of a single value is a contiguous interval (#403, from the
  *		ClickHouse VLDB 2024 paper's monotonicity traits).
  *
@@ -294,15 +294,18 @@ pgcolumnar_commute_strategy(StrategyNumber s)
  *		rewrite (the objection #369 raised against a special case). Adding a
  *		second function means adding its preimage beside this one.
  *
- *		Being straight about the shape: this first cut inverts exactly one
+ *		Being straight about the shape: this inverts exactly one
  *		function, and the step it uses comes from a small table of unit names,
  *		not from date_trunc itself. A month is not a fixed number of seconds, so
  *		the step has to be an interval applied by calendar arithmetic. The
  *		generality is in where the rewrite HAPPENS, not yet in how many
  *		functions it knows.
  *
- *		Emits `col >= lo` and `col < hi`, so two keys, and returns 2. Returns 0
- *		for anything it cannot inarguably invert; declining always costs a scan,
+ *		Equality is the bounded interval: `col >= lo` and `col < hi`, two keys,
+ *		returns 2. The ordered operators need ONE bound each and return 1 --
+ *		monotonicity is exactly what makes them invertible, so they come from the
+ *		same unit table for less work than equality, not more. Returns 0 for
+ *		anything it cannot inarguably invert; declining always costs a scan,
  *		never an answer.
  */
 static int
@@ -323,6 +326,9 @@ pgcolumnar_preimage_range_scankey(OpExpr *op, Index scanrelid, TupleDesc tupdesc
 	Datum		roundTrip;
 	Interval   *step;
 	text	   *unit;
+	StrategyNumber strat;
+	bool		constOnLeft = false;
+	bool		truncated;
 
 	if (list_length(op->args) != 2)
 		return 0;
@@ -343,6 +349,7 @@ pgcolumnar_preimage_range_scankey(OpExpr *op, Index scanrelid, TupleDesc tupdesc
 	{
 		f = (FuncExpr *) rightop;
 		con = (Const *) leftop;
+		constOnLeft = true;
 	}
 	else
 		return 0;
@@ -389,8 +396,30 @@ pgcolumnar_preimage_range_scankey(OpExpr *op, Index scanrelid, TupleDesc tupdesc
 	tce = lookup_type_cache(TIMESTAMPOID, TYPECACHE_BTREE_OPFAMILY);
 	if (!OidIsValid(tce->btree_opf))
 		return 0;
-	if (get_op_opfamily_strategy(op->opno, tce->btree_opf) != BTEqualStrategyNumber)
-		return 0;
+	strat = get_op_opfamily_strategy(op->opno, tce->btree_opf);
+
+	/*
+	 * With the constant on the LEFT the strategy has to be COMMUTED, because
+	 * `c < f(ts)` is `f(ts) > c` and not `f(ts) < c`. For equality this is a
+	 * no-op, which is why #739 could take either operand order without doing it
+	 * and be right. For the ordered operators, reusing the unswapped strategy
+	 * inverts the bound and silently drops every row it should return, so this
+	 * is the line the reversed-operand arms in preimage_rewrite.sh exist to pin.
+	 */
+	if (constOnLeft)
+		strat = pgcolumnar_commute_strategy(strat);
+
+	switch (strat)
+	{
+		case BTEqualStrategyNumber:
+		case BTLessStrategyNumber:
+		case BTLessEqualStrategyNumber:
+		case BTGreaterEqualStrategyNumber:
+		case BTGreaterStrategyNumber:
+			break;
+		default:
+			return 0;
+	}
 
 	/*
 	 * A CONSTANT THAT IS NOT ITSELF TRUNCATED MATCHES NOTHING.
@@ -411,8 +440,19 @@ pgcolumnar_preimage_range_scankey(OpExpr *op, Index scanrelid, TupleDesc tupdesc
 	roundTrip = DirectFunctionCall2(timestamp_trunc,
 									PointerGetDatum(unit),
 									con->constvalue);
-	if (DatumGetTimestamp(roundTrip) != DatumGetTimestamp(con->constvalue))
+	truncated = (DatumGetTimestamp(roundTrip) ==
+				 DatumGetTimestamp(con->constvalue));
+	if (!truncated && strat == BTEqualStrategyNumber)
 		return 0;
+
+	/*
+	 * For the ORDERED operators an untruncated constant is satisfiable, and it
+	 * moves the bound to the next boundary rather than emptying the result.
+	 * date_trunc only ever returns truncated values, so with lo < c < hi:
+	 * `f(k) >= c` admits exactly the buckets at hi and above, and `f(k) < c`
+	 * exactly those below hi. Treating it the way equality treats it would drop
+	 * every row in the partial bucket instead of returning them.
+	 */
 
 	/*
 	 * hi is where the NEXT bucket starts, so the step is one unit wide.
@@ -459,17 +499,92 @@ pgcolumnar_preimage_range_scankey(OpExpr *op, Index scanrelid, TupleDesc tupdesc
 													 CStringGetDatum(stepStr),
 													 ObjectIdGetDatum(InvalidOid),
 													 Int32GetDatum(-1)));
-		lo = con->constvalue;
+		/*
+		 * lo is the TRUNCATED constant, not the constant. They are the same
+		 * value whenever the constant is already truncated, which is the only
+		 * case that reached here before the ordered operators were added -- so
+		 * the shipped equality path was right by construction and this line
+		 * carried a latent assumption. With an untruncated constant admitted,
+		 * `con` would put hi half a bucket late (12:00 rather than 00:00 for a
+		 * day) and the `>=` key would then exclude rows that do match. Measured
+		 * before the fix: 180,001 rows returned against the heap's 180,002, and
+		 * one chunk group over-pruned.
+		 */
+		lo = roundTrip;
+
+		/*
+		 * hi = lo + step RAISES near the end of the timestamp range, and an
+		 * ereport here fails the whole query rather than declining to prune.
+		 * This is not new: on main today
+		 * `date_trunc('year', ts) = timestamp '294276-01-01'` already answers
+		 * `ERROR: timestamp out of range` on a columnar table while the heap
+		 * returns the row. Inverting the ordered operators reaches the same
+		 * arithmetic from four more predicates, so it is fixed here rather than
+		 * left to widen.
+		 *
+		 * Declining conservatively rather than catching the error: the widest
+		 * step in the table above is one year, so anything within 366 days of
+		 * END_TIMESTAMP is refused. The comparison is `>=` and not `>` because
+		 * the case that motivated it lands exactly on the bound: lo for
+		 * `294276-01-01` is 9223339708800000000, and
+		 * END_TIMESTAMP - 366 * USECS_PER_DAY is the same number, so `>` left
+		 * the guard silent on the one value it was written for. Infinities are exempt because interval
+		 * arithmetic on them saturates instead of overflowing, which the
+		 * `date_trunc('day', ts) >= 'infinity'` arm measures.
+		 */
+		if (!TIMESTAMP_NOT_FINITE(DatumGetTimestamp(lo)) &&
+			DatumGetTimestamp(lo) >=
+			END_TIMESTAMP - (int64) 366 * USECS_PER_DAY)
+			return 0;
+
 		hi = DirectFunctionCall2(timestamp_pl_interval, lo,
 								 IntervalPGetDatum(step));
 	}
 
+	/*
+	 * Emit the preimage. Equality is the bounded interval and needs two keys;
+	 * each ordered operator needs ONE, and which boundary it takes depends on
+	 * the operator and on whether the constant was already truncated:
+	 *
+	 *     predicate      c truncated      c not truncated
+	 *     f(k) >= c      k >= lo          k >= hi
+	 *     f(k) >  c      k >= hi          k >= hi
+	 *     f(k) <  c      k <  lo          k <  hi
+	 *     f(k) <= c      k <  hi          k <  hi
+	 */
 	MemSet(&key[0], 0, sizeof(ScanKeyData));
 	key[0].sk_flags = 0;
 	key[0].sk_attno = var->varattno;
-	key[0].sk_strategy = BTGreaterEqualStrategyNumber;
 	key[0].sk_subtype = TIMESTAMPOID;
 	key[0].sk_collation = att->attcollation;
+
+	switch (strat)
+	{
+		case BTGreaterEqualStrategyNumber:
+			key[0].sk_strategy = BTGreaterEqualStrategyNumber;
+			key[0].sk_argument = truncated ? lo : hi;
+			return 1;
+
+		case BTGreaterStrategyNumber:
+			key[0].sk_strategy = BTGreaterEqualStrategyNumber;
+			key[0].sk_argument = hi;
+			return 1;
+
+		case BTLessStrategyNumber:
+			key[0].sk_strategy = BTLessStrategyNumber;
+			key[0].sk_argument = truncated ? lo : hi;
+			return 1;
+
+		case BTLessEqualStrategyNumber:
+			key[0].sk_strategy = BTLessStrategyNumber;
+			key[0].sk_argument = hi;
+			return 1;
+
+		default:
+			break;				/* equality: the bounded interval below */
+	}
+
+	key[0].sk_strategy = BTGreaterEqualStrategyNumber;
 	key[0].sk_argument = lo;
 
 	MemSet(&key[1], 0, sizeof(ScanKeyData));

--- a/test/preimage_rewrite.sh
+++ b/test/preimage_rewrite.sh
@@ -102,6 +102,96 @@ check_text "the actual ROWS match the heap, not just the count" \
 	"$(q "SELECT v FROM pre_c WHERE date_trunc('day', ts) = $DAY ORDER BY v" | md5sum)" \
 	"$(q "SELECT v FROM pre_h WHERE date_trunc('day', ts) = $DAY ORDER BY v" | md5sum)"
 
+# ---- the ordered operators (#403 item 1 residue) ---------------------------
+#
+# #739 inverted equality only. Monotonicity is what makes the ORDERED operators
+# invertible too, and they are the shape a time-series filter actually takes:
+# `date_trunc('day', ts) >= X` reads every chunk group today while the range it
+# is equivalent to reads two.
+#
+# Each arm names the explicit range it is equivalent to and asserts against THAT
+# and against the heap. Deriving the expected answer here rather than hardcoding
+# it is deliberate: the fixture carries NULL, 'infinity' and '-infinity' rows, and
+# the heap mirror is the only oracle that gets those right without me restating
+# date_trunc's semantics in the test.
+ord_arm() {	# ord_arm <label> <trunc-predicate> <equivalent-range-predicate>
+	local label="$1" tp="$2" rp="$3"
+	local r g
+	r="$(removed "SELECT count(*) FROM pre_c WHERE $rp")"
+	g="$(removed "SELECT count(*) FROM pre_c WHERE $tp")"
+	check_num "premise: the range for [$label] prunes, so there is something to remove" \
+		"$([ -n "$r" ] && [ "$r" -gt 0 ] && echo 1 || echo 0)" 1
+	check_num "[$label] prunes chunk groups" \
+		"$([ -n "$g" ] && [ "$g" -gt 0 ] && echo 1 || echo 0)" 1
+	check_num "[$label] prunes as well as the equivalent explicit range" "$g" "$r"
+	check_num "[$label] returns the range's answer" \
+		"$(q1 "SELECT count(*) FROM pre_c WHERE $tp;")" \
+		"$(q1 "SELECT count(*) FROM pre_c WHERE $rp;")"
+	check_num "[$label] returns the heap's answer" \
+		"$(q1 "SELECT count(*) FROM pre_c WHERE $tp;")" \
+		"$(q1 "SELECT count(*) FROM pre_h WHERE $tp;")"
+	check_text "[$label] returns the heap's ROWS, not just its count" \
+		"$(q "SELECT v FROM pre_c WHERE $tp ORDER BY v" | md5sum)" \
+		"$(q "SELECT v FROM pre_h WHERE $tp ORDER BY v" | md5sum)"
+}
+
+NEXT="timestamp '2024-02-02'"
+ord_arm "ts_trunc >= c"  "date_trunc('day', ts) >= $DAY"  "ts >= $DAY"
+ord_arm "ts_trunc > c"   "date_trunc('day', ts) > $DAY"   "ts >= $NEXT"
+ord_arm "ts_trunc < c"   "date_trunc('day', ts) < $DAY"   "ts < $DAY"
+ord_arm "ts_trunc <= c"  "date_trunc('day', ts) <= $DAY"  "ts < $NEXT"
+
+# The operand order is swapped. For equality that is a no-op; for these it
+# COMMUTES the strategy, and reusing the unswapped one inverts the bound and
+# drops rows. `c < f(ts)` is `f(ts) > c`, not `f(ts) < c`.
+ord_arm "c < ts_trunc (reversed)"  "$DAY < date_trunc('day', ts)"  "ts >= $NEXT"
+ord_arm "c >= ts_trunc (reversed)" "$DAY >= date_trunc('day', ts)" "ts < $NEXT"
+
+# A constant that is not itself truncated. Under equality this is unsatisfiable
+# and #739 declines it. Under the ordered operators it is SATISFIABLE, and the
+# bound moves to the next boundary because date_trunc only ever returns truncated
+# values. Treating it the way equality treats it would lose every row in the
+# partial bucket.
+HALF="timestamp '2024-02-01 12:00'"
+ord_arm "ts_trunc >= c, c not truncated" "date_trunc('day', ts) >= $HALF" "ts >= $NEXT"
+ord_arm "ts_trunc < c, c not truncated"  "date_trunc('day', ts) < $HALF"  "ts < $NEXT"
+
+# ---- near the end of the timestamp range, the rewrite must DECLINE ---------
+#
+# hi = lo + step raises `timestamp out of range` within one step of the maximum,
+# and an ereport in the planner fails the whole query instead of declining to
+# prune. This was reachable on main before the ordered operators existed:
+# `date_trunc('year', ts) = timestamp '294276-01-01'` answered ERROR on a
+# columnar table while the heap returned the row. Inverting the ordered
+# operators reaches the same arithmetic from four more predicates.
+#
+# A separate fixture, because putting a near-maximum row in pre_c would move
+# every count and premise above it.
+psql_run "CREATE TABLE pre_edge(ts timestamp, v int) USING pgcolumnar;"
+psql_run "INSERT INTO pre_edge SELECT timestamp '2024-01-01' + g * interval '1 day', g
+          FROM generate_series(1,1000) g;"
+psql_run "INSERT INTO pre_edge VALUES ('294276-12-31 23:00', -1), ('infinity', -2);"
+psql_run "CREATE TABLE pre_edgeh(ts timestamp, v int);"
+psql_run "INSERT INTO pre_edgeh SELECT * FROM pre_edge;"
+MAXY="timestamp '294276-01-01'"
+edge_arm() {	# edge_arm <label> <predicate>
+	check_num "[$1] answers instead of raising, and agrees with the heap" \
+		"$(q1 "SELECT count(*) FROM pre_edge WHERE $2;")" \
+		"$(q1 "SELECT count(*) FROM pre_edgeh WHERE $2;")"
+}
+# 2, not 1: the near-maximum row AND 'infinity' both satisfy this.
+check_num "premise: the near-maximum row is really there" \
+	"$(q1 "SELECT count(*) FROM pre_edgeh WHERE ts > timestamp '294276-01-01';")" 2
+edge_arm "year = max"  "date_trunc('year', ts) = $MAXY"
+edge_arm "year >= max" "date_trunc('year', ts) >= $MAXY"
+edge_arm "year > max"  "date_trunc('year', ts) > $MAXY"
+edge_arm "year <= max" "date_trunc('year', ts) <= $MAXY"
+edge_arm "year < max"  "date_trunc('year', ts) < $MAXY"
+# Infinity is exempt: interval arithmetic saturates there rather than
+# overflowing, so those predicates still rewrite and still prune.
+edge_arm "day >= infinity" "date_trunc('day', ts) >= timestamp 'infinity'"
+edge_arm "day < infinity"  "date_trunc('day', ts) < timestamp 'infinity'"
+
 # ---- the shapes that must DECLINE ------------------------------------------
 # A non-truncated constant is unsatisfiable, and these arms assert the ANSWER,
 # which is all they can assert: with conservative keys and an executor recheck,


### PR DESCRIPTION
#403 item 1 shipped in #739 with a stated limit: it inverts `date_trunc(unit, ts) = const`
and declines every other operator. This finishes the predicate half. `date_trunc('day', ts)
>= X` is the shape a time-series filter usually takes, and it read every chunk group.

Monotonicity is what makes the ordered comparisons invertible, so this is completing the item
rather than extending it: equality is the *harder* case (a bounded interval, two scan keys),
and the ordered operators fall out of the same unit table with **one key each**.

## Measured

Existing 500,000-row time-clustered fixture, chunk groups removed by the filter, the
`date_trunc` form against the explicit range it is equivalent to:

| predicate | before | after | the equivalent range |
| --- | ---: | ---: | ---: |
| `date_trunc('day', ts) >= c` | 0 | **30** | 30 |
| `date_trunc('day', ts) > c` | 0 | **31** | 31 |
| `date_trunc('day', ts) < c` | 0 | **19** | 19 |
| `date_trunc('day', ts) <= c` | 0 | **18** | 18 |

## Written test-first, and the tests earned it

The 16 checks went in **before** the `src/` change and were demonstrated red: every one failed
at `got [0]` while the equivalent range removed 18-31 groups, with the premise arms green so
they were not passing on an unprunable fixture. The answer arms passed in both runs, which is
the honest picture — this was a pruning defect, not a correctness one.

**They then caught two real bugs in my own implementation.**

**1. Lost rows.** `lo` was `con->constvalue`, the *untruncated* constant, so `hi` landed half a
bucket late and `>=` excluded rows that match: **180,001 returned against the heap's 180,002**,
and one chunk group over-pruned. The shipped equality path was correct only because it returned
0 before ever reaching that line; admitting untruncated constants inherited a latent
assumption. Now `lo = roundTrip`.

**2. A guard that never fired.** My overflow guard used `>`, and the value that motivated it
sits *exactly* on the derived bound — `lo` for `294276-01-01` is `9223339708800000000` and so
is `END_TIMESTAMP - 366 * USECS_PER_DAY`. `>=` fixed it. Only caught because the arm asserts
the query *answers*, not that the guard is present.

## A pre-existing bug in #739, fixed here

```
date_trunc('year', ts) = timestamp '294276-01-01'
```

raises **`ERROR: timestamp out of range`** on a columnar table on **unmodified main**, while
the heap returns the row. `hi = lo + step` overflows near the type maximum, and an ereport in
the planner fails the whole query instead of declining to prune. Verified against main's own
build (`columnar_customscan.c` md5 `c45df19a`), not inferred. Inverting the ordered operators
reaches that arithmetic from four more predicates, so it is fixed here rather than left to
widen. Infinities are exempt and stay pruning, because interval arithmetic on them saturates.

## Two traps, each with its own arm

**Reversed operands must commute the strategy.** `c < f(ts)` is `f(ts) > c`. For equality that
is a no-op, which is why #739 could take either operand order without doing it. Reuses the
in-file `pgcolumnar_commute_strategy` rather than a second switch.

**An untruncated constant is satisfiable here.** Equality treats it as unsatisfiable; the
ordered operators move the bound to the next boundary, because `date_trunc` only ever returns
truncated values.

## Removal proofs — each reddens only its own arms

| mutation | result |
| --- | --- |
| back to equality-only | **16 RED**, equality arm still green |
| drop the operand commutation | reversed arms RED — `c < ts_trunc` returns **1 row instead of 180,002** — normal-order 4/4 green |
| `lo` back to the untruncated constant | untruncated arms RED, truncated 4/4 green |
| overflow guard `>=` back to `>` | 5 year arms RED, infinity and ordered arms green |
| overflow guard removed | 5 year arms RED |

Controls unchanged throughout: `timestamptz` under two zones, non-constant unit, unlisted unit
(millennium), equality's unsatisfiable case, and the batch-fold decline.

## Gate

**Full matrix `ALL VERSIONS PASSED`** — PG18 213/215 (`native_repack`, `pg19_vacuum_options`
skip, both expected on 18), PG19 215/215, 0 failures. `preimage_rewrite` 80 checks PASS on
both. Builds clean with 0 warnings on **15, 16 and 17**. `docs_style` PASSED,
`shellcheck -S error -s bash` clean.

CHANGELOG and `docs/ARCHITECTURE.md` in the same PR — the architecture section described this
function as translating "simple `column op const`" clauses and never mentioned the rewrite at
all, which #739 also missed.

Still declined, unchanged: `timestamptz` (session `TimeZone` can change after the key is
frozen), the 3-argument explicit-zone form, and units outside the table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
