### PR TITLE
fix: set_options must refuse with 42809, not plpgsql's default P0001

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,16 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
   part. Buffer counts are unchanged, which is the expected shape: a catcache or
   relcache lookup reads no buffers once warm, so the buffers a probe costs are
   the index scan. (#744)
+
+- `pgcolumnar.set_options` refused a non-columnar relation with SQLSTATE `P0001`
+  rather than `42809`. plpgsql's `RAISE EXCEPTION` defaults to `P0001` unless an
+  `ERRCODE` is given, and the guard shipped without one, so the identical message
+  `relation "..." is not a columnar table` carried one SQLSTATE from this
+  function and another from the C paths, which raise it with
+  `ERRCODE_WRONG_OBJECT_TYPE`. A caller keying on SQLSTATE, which is what this
+  project's own privilege suites do deliberately, got different answers depending
+  on which path refused it. The guard now sets `wrong_object_type` explicitly and
+  `audit.sh` asserts the code. (#403)
 - A `date_trunc` predicate within one bucket of the end of the `timestamp` range
   raised `ERROR: timestamp out of range` on a columnar table instead of
   answering. The rewrite computes the next bucket boundary as `lo + step`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
   `ERRCODE_WRONG_OBJECT_TYPE`. A caller keying on SQLSTATE, which is what this
   project's own privilege suites do deliberately, got different answers depending
   on which path refused it. The guard now sets `wrong_object_type` explicitly and
-  `audit.sh` asserts the code. (#403)
+  `audit.sh` asserts the code. (#757)
 - A `date_trunc` predicate within one bucket of the end of the `timestamp` range
   raised `ERROR: timestamp out of range` on a columnar table instead of
   answering. The rewrite computes the next bucket boundary as `lo + step`, and

--- a/pgcolumnar--1.0-alpha--1.0-alpha2.sql
+++ b/pgcolumnar--1.0-alpha--1.0-alpha2.sql
@@ -638,6 +638,12 @@ BEGIN
 	 * (measured), so options set after the conversion apply to the same relation
 	 * a caller would have been trying to name before it.
 	 *
+	 * The ERRCODE is explicit. plpgsql's RAISE EXCEPTION defaults to P0001, and
+	 * the C paths raise this same sentence with ERRCODE_WRONG_OBJECT_TYPE
+	 * (42809). Without it the identical message carried two different SQLSTATEs
+	 * depending on which path refused the caller, in a tree whose own privilege
+	 * suites deliberately assert SQLSTATE rather than message text.
+	 *
 	 * relkind is part of the test, and it is what makes the guard match the
 	 * cleanup rather than merely look strict. The drop hook returns before it
 	 * examines the access method for anything that is not an ordinary table
@@ -658,7 +664,8 @@ BEGIN
 					  AND a.amname = 'pgcolumnar'
 					  AND c.relkind = 'r') THEN
 		RAISE EXCEPTION 'relation "%" is not a columnar table', table_name
-			USING HINT = 'Per-table options are read by the columnar writer and '
+			USING ERRCODE = 'wrong_object_type',
+				HINT = 'Per-table options are read by the columnar writer and '
 				'apply only to an ordinary table using the pgcolumnar access '
 				'method. A partitioned table has no storage of its own: set the '
 				'options on each partition. Otherwise convert the table first '

--- a/pgcolumnar--1.0-alpha2.sql
+++ b/pgcolumnar--1.0-alpha2.sql
@@ -389,6 +389,12 @@ BEGIN
 	 * (measured), so options set after the conversion apply to the same relation
 	 * a caller would have been trying to name before it.
 	 *
+	 * The ERRCODE is explicit. plpgsql's RAISE EXCEPTION defaults to P0001, and
+	 * the C paths raise this same sentence with ERRCODE_WRONG_OBJECT_TYPE
+	 * (42809). Without it the identical message carried two different SQLSTATEs
+	 * depending on which path refused the caller, in a tree whose own privilege
+	 * suites deliberately assert SQLSTATE rather than message text.
+	 *
 	 * relkind is part of the test, and it is what makes the guard match the
 	 * cleanup rather than merely look strict. The drop hook returns before it
 	 * examines the access method for anything that is not an ordinary table
@@ -409,7 +415,8 @@ BEGIN
 					  AND a.amname = 'pgcolumnar'
 					  AND c.relkind = 'r') THEN
 		RAISE EXCEPTION 'relation "%" is not a columnar table', table_name
-			USING HINT = 'Per-table options are read by the columnar writer and '
+			USING ERRCODE = 'wrong_object_type',
+				HINT = 'Per-table options are read by the columnar writer and '
 				'apply only to an ordinary table using the pgcolumnar access '
 				'method. A partitioned table has no storage of its own: set the '
 				'options on each partition. Otherwise convert the table first '

--- a/test/audit.sh
+++ b/test/audit.sh
@@ -234,6 +234,27 @@ check "the refusal says the relation is not columnar" \
 	"yes"
 check "nothing was recorded for the heap table" \
 	"$(q "SELECT count(*) FROM pgcolumnar.options WHERE regclass = 'opt_heap'::regclass;")" "0"
+
+# The SQLSTATE, not the message text. The C paths raise this same sentence with
+# ERRCODE_WRONG_OBJECT_TYPE (42809), so a caller that keys on SQLSTATE -- which
+# is what this project's own privilege suites do, deliberately -- has to get the
+# same answer whichever path refuses it. plpgsql's RAISE EXCEPTION defaults to
+# P0001 unless an ERRCODE is given, and the guard shipped without one.
+#
+# VERBOSITY=verbose makes psql print `ERROR:  <sqlstate>: <message>`, which is
+# read here instead of a DO block: this suite passes SQL through `bash -lc`, and
+# a dollar-quoted block nested in that is the quoting trap the tree already has
+# scars from.
+sqlstate() {	# sqlstate <sql> -> the SQLSTATE of the failure, or empty
+	local out
+	out="$(run_pg "$PSQL -v ON_ERROR_STOP=0 -v VERBOSITY=verbose -c \"$1\"" 2>&1 || true)"
+	printf '%s\n' "$out" | grep -oE '^ERROR:  [0-9A-Z]{5}' | awk '{print $2}' | head -1
+}
+check "premise: the SQLSTATE probe reads a known code" \
+	"$(sqlstate 'SELECT 1/0;')" "22012"
+check "set_options on a non-columnar relation raises 42809, not P0001" \
+	"$(sqlstate "SELECT pgcolumnar.set_options('opt_heap'::regclass, chunk_group_row_limit => 1000);")" \
+	"42809"
 q "DROP TABLE opt_heap;" >/dev/null
 
 # A PARTITIONED parent is the same leak through a different door, and the access


### PR DESCRIPTION
`pgcolumnar.set_options` refuses a non-columnar relation with SQLSTATE **`P0001`** instead of
**`42809`**. My defect, from #747, already merged. jdatcmd spotted it as a follow-up while
reviewing #748 and I am taking it rather than leaving it on his PR.

## The split

plpgsql's `RAISE EXCEPTION` defaults to `P0001` unless an `ERRCODE` is given, and the guard
shipped without one:

```sql
RAISE EXCEPTION 'relation "%" is not a columnar table', table_name
    USING HINT = '...';           -- no ERRCODE
```

The C paths raise the **same sentence** with `errcode(ERRCODE_WRONG_OBJECT_TYPE)` — `42809` —
and that is also what #748's new visibility-map guard returns. Measured on merged `main`:

```
set_options on a heap table   ->  SQLSTATE=P0001
the C paths, same message     ->  42809
```

So the identical message text carries two different SQLSTATEs depending on which path refuses
the caller, in a tree whose own privilege suites deliberately assert SQLSTATE rather than
message text. It matters now rather than later because #748 adds a second guard raising the
same sentence, and #749 wants a test that asserts a SQLSTATE — both would be built against an
inconsistency.

## Test first

The arm went into `audit.sh` before the fix and was demonstrated red:

```
PASS  premise: the SQLSTATE probe reads a known code: 22012
FAIL  set_options on a non-columnar relation raises 42809, not P0001: got [P0001] want [42809]
```

The premise matters: it reads `22012` from `SELECT 1/0` so a probe that returned nothing for
any reason could not be mistaken for a pass.

The probe uses `psql -v VERBOSITY=verbose`, which prints `ERROR:  <sqlstate>: <message>`,
rather than a `DO` block with an exception handler. `audit.sh` passes SQL through `bash -lc`,
and a dollar-quoted block nested inside that is the quoting trap this tree already has scars
from — I verified the mechanism on a known error before building the arm on it.

## Gate

| | |
| --- | --- |
| `audit` | **PASSED on 15, 16, 17, 18 and 19** — the 42809 arm green on all five |
| `native_upgrade_converge` | PASSED, 5 checks, on 17, 18 and 19 |
| base vs upgrade `set_options` body | **identical: True**, 6,527 bytes each |
| `docs_style` / `shellcheck -S error -s bash` | PASSED, 9 / clean |

Removal proof — drop the `ERRCODE` from both scripts:

| mutation | result |
| --- | --- |
| `USING ERRCODE = 'wrong_object_type',` removed | **RED** `got [P0001] want [42809]`, premise still green |

The guard is mirrored into the `1.0-alpha` → `1.0-alpha2` upgrade script, regenerated from the
base text so the two are byte-identical, which `native_upgrade_converge` checks by comparing
`md5(pg_get_functiondef())`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
