### PR TITLE
Record the ordering an eager rewrite applied, so a Z-ordered table stops reporting a sort key it is not sorted on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,43 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ### Fixed
 
+- Both eager ordering rewrites discarded the ordering they had just applied.
+  `pgcolumnar.storage.sorted_by` and `sorted_kind` exist to record which
+  ordering a rewrite left behind, and the base schema has always specified them
+  as `'zorder'` (`recluster`/`cluster`) or `'lexicographic'` (`vacuum_sorted`).
+  Only the online `recluster` wrote them: both eager paths reached the catalog
+  through one function that passed `NIL` and `NULL`, and the string
+  `lexicographic` had never been written to the catalog at all.
+
+  The two eager layouts were therefore identical in the catalog, and
+  `pgcolumnar.sort_status` falls back to the declared `options.sort_by` when the
+  recorded key is NULL, so both reported the same thing. Measured on 5,000 rows
+  with `sort_by => ARRAY['k']` declared on each:
+
+  | rewrite | `sorted_kind` | `sort_status.sort_key` | inversions on `k` |
+  | --- | --- | --- | ---: |
+  | `vacuum_sorted('t','k')` | was NULL, now `lexicographic` | `{k}` | 0 |
+  | `cluster('t','k','j')` | was NULL, now `zorder` | was `{k}`, now `{k,j}` | 930 |
+
+  Z-order over two or more columns is not a sort on any one of them, so the
+  second row reported an order the rows were not in. A single-column key cannot
+  show this, because single-column Z-order *is* lexicographic order.
+
+  Two consequences go with it. `sort_status` now reports the applied key rather
+  than the declared one on an eagerly clustered table, which is a visible output
+  change for anyone reading that column. And #415's recluster self-gate requires
+  `sorted_kind = 'zorder'`, so after `pgcolumnar.cluster('t','k','j')` it could
+  never fire: an immediately following `pgcolumnar.recluster('t','k','j')` on an
+  already-clustered relation paid a full rewrite of every group. It now returns
+  0 and rewrites nothing, which is the case the gate was written for.
+
+  A storage ordered by an earlier build still has NULL in both columns and still
+  falls back to the declared key, until its next ordering rewrite. A reader that
+  must not be wrong about the physical order should require
+  `sorted_kind = 'lexicographic'` from `pgcolumnar.storage` and treat NULL as
+  unknown, rather than read `sort_status`. An unsorted rewrite continues to
+  claim no ordering. New suite `eager_ordering_record`. (#758)
+
 - `pgcolumnar.vm_selftest` and `pgcolumnar.vm_is_visible` accepted any relation,
   including a plain heap table. `vm_selftest` does not only inspect the
   visibility map, it writes an all-visible bit into it, and a wrongly set bit is

--- a/docs/sql-reference.md
+++ b/docs/sql-reference.md
@@ -269,7 +269,7 @@ Reports how much of a table's sorted order is still in place. Returns one row:
 
 | Column | Type | Meaning |
 | --- | --- | --- |
-| `sort_key` | name[] | The clustering key in effect. It is the key the last `recluster` recorded, or the `sort_by` declared by `set_options`, or NULL. |
+| `sort_key` | name[] | The clustering key in effect. It is the key the last ordering rewrite recorded, or the `sort_by` declared by `set_options`, or NULL. |
 | `total_groups` | bigint | Row groups in the table. |
 | `sorted_groups` | bigint | Row groups written by the last ordering rewrite. |
 | `appended_groups` | bigint | Row groups written after it. |
@@ -294,6 +294,15 @@ FROM pgcolumnar.sort_status('events');
 A table that was never sorted reports zero sorted groups. An unsorted
 `pgcolumnar.vacuum` returns it to that state, because it rewrites the table
 without ordering it.
+
+`sort_key` names the columns, not the arrangement. `pgcolumnar.vacuum_sorted`
+sorts on those columns in order. `pgcolumnar.cluster` and
+`pgcolumnar.recluster` arrange the same columns on a Z-order curve, which is not
+a sort on any one of them.
+
+To read the arrangement, select `sorted_kind` from `pgcolumnar.storage`. It
+holds `lexicographic`, `zorder`, or NULL. NULL means the table was never
+ordered, or was ordered before pgColumnar recorded this.
 
 The row counts are stored rows. Deleted rows stay stored until a maintenance
 operation reclaims them, so they are still counted here. Use

--- a/src/columnar_vacuum.c
+++ b/src/columnar_vacuum.c
@@ -202,6 +202,8 @@ PgColumnarRequireTableOwnerByOid(Oid relid)
 static bool cluster_type_supported(Oid typid);
 static bytea *cluster_zorder_key(Datum *values, bool *isnull, AttrNumber *atts,
 								 int ncols, TupleDesc tupdesc);
+/* Names an ordering rewrite records as its key (defined later, #415) */
+static List *sort_key_names(TupleDesc tupdesc, AttrNumber *atts, int ncols);
 
 /* v1 refuses tables with more groups than this (one advisory lock per group) */
 #define RECLUSTER_MAX_GROUPS 8192
@@ -714,16 +716,8 @@ pgcolumnar_recluster_online(Relation rel, int ncols, AttrNumber *atts)
 		PgColumnarRetireGroup(storageId, oldGroups[i]);
 
 	/* record how far the reordered run reaches (#311) and BY WHAT (#415) */
-	{
-		List	   *keyNames = NIL;
-		int			ci;
-
-		for (ci = 0; ci < ncols; ci++)
-			keyNames = lappend(keyNames,
-							   pstrdup(NameStr(TupleDescAttr(tupdesc, atts[ci] - 1)->attname)));
-		record_online_sorted_extent(rel, storageId, writeState, stripeMark,
-									keyNames, "zorder");
-	}
+	record_online_sorted_extent(rel, storageId, writeState, stripeMark,
+								sort_key_names(tupdesc, atts, ncols), "zorder");
 
 	PopActiveSnapshot();
 	UnregisterSnapshot(snap);
@@ -1081,20 +1075,52 @@ pgcolumnar_relation_storageid(PG_FUNCTION_ARGS)
 }
 
 /*
+ * sort_key_names
+ *		The attribute names behind an ordering rewrite's key, as a list of
+ *		palloc'd strings for pgcolumnar.storage.sorted_by (#415).
+ *
+ *		Names, not attnums, because the column is read back long after the rewrite
+ *		and has to survive an ALTER that renumbers attributes, the same reason
+ *		pgcolumnar.options.sort_by stores names (#288).
+ */
+static List *
+sort_key_names(TupleDesc tupdesc, AttrNumber *atts, int ncols)
+{
+	List	   *names = NIL;
+	int			i;
+
+	for (i = 0; i < ncols; i++)
+		names = lappend(names,
+						pstrdup(NameStr(TupleDescAttr(tupdesc, atts[i] - 1)->attname)));
+	return names;
+}
+
+/*
  * record_sorted_extent
- *		Mark where the ordered run this rewrite just wrote ends (issue #301).
+ *		Mark where the ordered run this rewrite just wrote ends (issue #301), and
+ *		what ordering it is (#415, #758).
  *
  *		Called only by the rewrites that order every live row, after the write
  *		state is flushed, so every group they wrote is in pgcolumnar.row_group and
  *		nothing has been appended yet. The highest group number present is
  *		therefore the end of the run, and later inserts get higher numbers.
  *
+ *		sortByNames and sortedKind say WHICH ordering, and are not optional for a
+ *		caller that applied one. Both eager rewrites used to pass NIL and NULL, so
+ *		an eagerly sorted relation and an eagerly Z-ordered one were identical in
+ *		the catalog: same run extent, same NULL kind, and sort_status fell back to
+ *		reporting the DECLARED options.sort_by for both. Z-order over two or more
+ *		columns is not a sort on any one of them, so that fallback reported an
+ *		order the rows were not in. The base schema has always specified this
+ *		column as 'zorder' (recluster/cluster) or 'lexicographic' (vacuum_sorted);
+ *		only the online recluster wrote it.
+ *
  *		A rewrite that produced no groups at all, meaning the relation held no
  *		live rows, leaves the mark alone. There is no run to record, and the
  *		reader reports no decay because there are no groups.
  */
 static void
-record_sorted_extent(Relation rel)
+record_sorted_extent(Relation rel, List *sortByNames, const char *sortedKind)
 {
 	uint64		storageId = PgColumnarStorageId(rel);
 	List	   *groups;
@@ -1119,7 +1145,7 @@ record_sorted_extent(Relation rel)
 
 	if (haveGroup)
 		PgColumnarSetSortedExtent(storageId, (int64) firstGroup, (int64) lastGroup,
-								  NIL, NULL);
+								  sortByNames, sortedKind);
 }
 
 /*
@@ -1326,7 +1352,8 @@ pgcolumnar_compact_relation(Relation rel, int nsortkeys, AttrNumber *sortAtts)
 	 * there.
 	 */
 	if (tsort != NULL)
-		record_sorted_extent(rel);
+		record_sorted_extent(rel, sort_key_names(tupdesc, sortAtts, nsortkeys),
+							 "lexicographic");
 
 	if (tsort != NULL)
 		tuplesort_end(tsort);
@@ -1482,7 +1509,7 @@ pgcolumnar_compact_relation_zorder(Relation rel, int ncols, AttrNumber *atts)
 	PgColumnarFlushWriteStateForRelation(relid);
 
 	/* Z-order is an order, so the same extent applies (see record_sorted_extent). */
-	record_sorted_extent(rel);
+	record_sorted_extent(rel, sort_key_names(tupdesc, atts, ncols), "zorder");
 
 	tuplesort_end(tsort);
 	ExecDropSingleTupleTableSlot(augSlot);

--- a/test/eager_ordering_record.sh
+++ b/test/eager_ordering_record.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+#
+# pgColumnar eager rewrites record the ordering they applied (#758).
+#
+# pgcolumnar.storage.sorted_by and sorted_kind exist (#415) to say WHAT ordering
+# the last rewrite left behind, so that a later reader can tell a lexicographic
+# run from a Z-order run without guessing. Only the online recluster wrote them;
+# both eager rewrites reached the catalog through record_sorted_extent(), which
+# passed NIL and NULL, so an eagerly sorted table and an eagerly Z-ordered table
+# were indistinguishable in the catalog.
+#
+# They are not the same layout. Z-order over two or more columns is not a sort
+# on any one of them, and sort_status falls back to the DECLARED options.sort_by
+# when storage.sorted_by is NULL -- so a Z-ordered table reported "fully sorted,
+# no tail, on key {k}" while its physical order held hundreds of inversions on
+# k. Anything reading that to decide an ordering (#751 pathkeys) would be
+# silently wrong on LIMIT and on merge joins.
+#
+# THE FIXTURE MUST USE A TWO-COLUMN KEY. Single-column Z-order IS lexicographic
+# order, so a one-column fixture cannot tell the two apart and every arm below
+# would pass by construction. The inversion counts asserted as premises are what
+# keeps that honest: they fail if the fixture ever stops discriminating.
+#
+# Usage:  test/eager_ordering_record.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+# 5000 rows at 500 rows a chunk group and 1000 a stripe gives 5 groups: enough
+# that an appended tail would be countable, few enough to read.
+mk() {	# mk TABLE -- identical data in every arm, {k} declared as the sort_by
+	psql_run "CREATE TABLE $1 (id int, k int, j int) USING pgcolumnar;"
+	psql_run "SELECT pgcolumnar.set_options('$1', stripe_row_limit => 1000, chunk_group_row_limit => 500);"
+	psql_run "INSERT INTO $1 SELECT g, (g*7919)%5000, g%13 FROM generate_series(1,5000) g;"
+	psql_run "SELECT pgcolumnar.set_options('$1', sort_by => ARRAY['k']::name[]);"
+}
+skind() { q "SELECT coalesce(sorted_kind::text,'<NULL>') FROM pgcolumnar.storage WHERE storage_id = pgcolumnar.get_storage_id('$1');"; }
+sby()   { q "SELECT coalesce(sorted_by::text,'<NULL>')   FROM pgcolumnar.storage WHERE storage_id = pgcolumnar.get_storage_id('$1');"; }
+skey()  { q "SELECT coalesce(sort_key::text,'<NULL>') FROM pgcolumnar.sort_status('$1');"; }
+# Inversions in the order the scan actually returns rows. This is the physical
+# fact every other arm is about, and it is taken from the data, never assumed.
+inv()   { q "SELECT count(*) FROM (SELECT k, lag(k) OVER () AS p FROM $1) s WHERE p > k;"; }
+
+# ------------------------------------------------- eager lexicographic rewrite
+
+mk lex
+psql_run "SELECT pgcolumnar.vacuum_sorted('lex', 'k');"
+
+check_num "premise: the lexicographic rewrite really ordered the rows on k" "$(inv lex)" "0"
+check "premise: it left no unsorted tail" \
+	"$(q "SELECT appended_groups FROM pgcolumnar.sort_status('lex');")" "0"
+check_text "eager vacuum_sorted records the kind it applied" "$(skind lex)" "lexicographic"
+check_text "eager vacuum_sorted records the key it applied" "$(sby lex)" "{k}"
+
+# ------------------------------------------------------ eager Z-order rewrite
+
+mk zo
+psql_run "SELECT pgcolumnar.cluster('zo', 'k', 'j');"
+
+# The premise the whole issue rests on: this table is NOT in k order, even
+# though {k} is its declared sort_by and the run covers every group. If this
+# ever reports 0 the fixture has stopped discriminating and every arm below is
+# vacuous -- see the two-column note at the top.
+check "premise: the Z-ordered table is NOT ordered on k" \
+	"$([ "$(inv zo)" -gt 0 ] && echo yes || echo no)" "yes"
+check "premise: it too reports a full run with no tail" \
+	"$(q "SELECT appended_groups FROM pgcolumnar.sort_status('zo');")" "0"
+check_text "eager cluster records the kind it applied" "$(skind zo)" "zorder"
+check_text "eager cluster records the key it applied" "$(sby zo)" "{k,j}"
+
+# The consequence, stated as the discrimination it buys: two tables that report
+# the same run extent and the same declared key must no longer look the same.
+check "the two eager layouts are now distinguishable in the catalog" \
+	"$([ "$(skind lex)" != "$(skind zo)" ] && echo yes || echo no)" "yes"
+check_text "sort_status reports the APPLIED key on the Z-ordered table, not the declared {k}" \
+	"$(skey zo)" "{k,j}"
+check_text "sort_status still reports {k} on the lexicographically sorted table" \
+	"$(skey lex)" "{k}"
+
+# ------------------------------------------- the self-gate the record unblocks
+#
+# #415's gate skips a full reorg when the relation is already exactly the
+# Z-order run over the requested columns. It requires sorted_kind = 'zorder',
+# so after an eager cluster it could never fire and recluster rewrote all five
+# groups of an already-clustered table.
+
+# A return of 0 is NOT evidence that the gate fired. It is also what an empty
+# relation, a single group, an early return on some unrelated condition, or a
+# return value simply not wired to the gate would produce. So the arms below
+# corroborate with the LAYOUT: the exact set of (group_number, file_offset)
+# rows in pgcolumnar.row_group. A gate that fired rewrote nothing and that set
+# is byte-identical; a fall-through retires every group and writes new ones, so
+# the set always moves. The return value is asserted too, as the secondary.
+layout() { q "SELECT coalesce(md5(string_agg(group_number || ':' || file_offset, ',' ORDER BY group_number)), 'EMPTY') FROM pgcolumnar.row_group WHERE storage_id = pgcolumnar.get_storage_id('$1');"; }
+
+mk gate
+psql_run "SELECT pgcolumnar.cluster('gate', 'k', 'j');"
+# Premise, so that "nothing changed" cannot be true because there was nothing
+# there: the fixture must have live rows in more than one group.
+check "premise: the gate fixture has more than one group" \
+	"$([ "$(q "SELECT total_groups FROM pgcolumnar.sort_status('gate');")" -gt 1 ] && echo yes || echo no)" "yes"
+check_num "premise: and live rows in them" "$(q 'SELECT count(*) FROM gate;')" "5000"
+
+GATE_BEFORE="$(layout gate)"
+check "recluster on the key the eager cluster already applied does nothing" \
+	"$(q "SELECT pgcolumnar.recluster('gate', 'k', 'j');")" "0"
+check_text "and it rewrote no group: the physical layout is unchanged" \
+	"$(layout gate)" "$GATE_BEFORE"
+
+# Removal proof for that arm: the gate must DISCRIMINATE, not always skip. A
+# different key on the same table has to fall through to the full rewrite, or
+# both arms above would be satisfied by a gate that never looks at anything.
+check "control: recluster on a DIFFERENT key still rewrites every group" \
+	"$(q "SELECT pgcolumnar.recluster('gate', 'j', 'k');")" "5"
+check "control: and that rewrite really moved the layout" \
+	"$([ "$(layout gate)" != "$GATE_BEFORE" ] && echo moved || echo unchanged)" "moved"
+
+# The other half of the gate condition: nothing appended past the run. One row
+# inserted after the cluster must defeat it, on the same key.
+mk tailgate
+psql_run "SELECT pgcolumnar.cluster('tailgate', 'k', 'j');"
+TAIL_BEFORE="$(layout tailgate)"
+psql_run "INSERT INTO tailgate VALUES (90001, 42, 1);"
+check "premise: the insert appended past the recorded run" \
+	"$([ "$(q "SELECT appended_groups FROM pgcolumnar.sort_status('tailgate');")" -gt 0 ] && echo yes || echo no)" "yes"
+check "control: recluster with an appended tail does not skip" \
+	"$([ "$(q "SELECT pgcolumnar.recluster('tailgate', 'k', 'j');")" -gt 0 ] && echo yes || echo no)" "yes"
+check "control: and it moved the layout" \
+	"$([ "$(layout tailgate)" != "$TAIL_BEFORE" ] && echo moved || echo unchanged)" "moved"
+
+# And the mirror: a lexicographic run is not a Z-order run, so recluster must
+# not skip it however the key matches.
+mk lexgate
+psql_run "SELECT pgcolumnar.vacuum_sorted('lexgate', 'k');"
+LEXGATE_BEFORE="$(layout lexgate)"
+check "control: recluster does not skip a LEXICOGRAPHIC run of the same lead column" \
+	"$(q "SELECT pgcolumnar.recluster('lexgate', 'k');")" "5"
+check "control: and it moved the layout" \
+	"$([ "$(layout lexgate)" != "$LEXGATE_BEFORE" ] && echo moved || echo unchanged)" "moved"
+
+# ------------------------------------------------- an unsorted rewrite records nothing
+
+mk un
+psql_run "SELECT pgcolumnar.vacuum_sorted('un', 'k');"
+check_text "premise: the mark is set before the unsorted rewrite" "$(skind un)" "lexicographic"
+psql_run "SELECT pgcolumnar.vacuum('un');"
+check_text "an unsorted rewrite claims no ordering" "$(skind un)" "<NULL>"
+check_text "and records no key" "$(sby un)" "<NULL>"
+
+# --------------------------------------------- the declared key is what is applied
+
+mk dec
+# No explicit columns: vacuum_sorted falls back to the declared sort_by.
+psql_run "SELECT pgcolumnar.vacuum_sorted('dec');"
+check_text "vacuum_sorted with no columns records the DECLARED key it applied" \
+	"$(sby dec)" "{k}"
+check_text "and records it as a lexicographic run" "$(skind dec)" "lexicographic"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -70,6 +70,7 @@ SUITES=(
 	differential
 	docs_style
 	drop_cleanup
+	eager_ordering_record
 	encode_effort
 	encode_invariants
 	entry_point_privilege


### PR DESCRIPTION
Closes #758.

## What was wrong

`pgcolumnar.storage.sorted_by` and `sorted_kind` exist to say which ordering the last
rewrite left behind. The base schema has always specified them:

```
	-- sorted_kind is 'zorder' (recluster/cluster) or 'lexicographic' (vacuum_sorted).
```

Only the online `recluster` wrote them. Both eager rewrites reached the catalog through one
function that passed `NIL, NULL`, and the string `lexicographic` had never been written to
the catalog anywhere in the tree.

`sort_status` falls back to the declared `options.sort_by` when the recorded key is NULL, so
the two eager layouts reported the same thing. Measured, PG 17, 5,000 rows,
`chunk_group_row_limit => 500`, `sort_by => ARRAY['k']` declared on each:

| rewrite | `sorted_kind` before | after | `sort_status.sort_key` before | after | inversions on `k` |
| --- | --- | --- | --- | --- | ---: |
| `vacuum_sorted('t','k')` | NULL | `lexicographic` | `{k}` | `{k}` | 0 |
| `cluster('t','k','j')` | NULL | `zorder` | `{k}` | `{k,j}` | **930** |

Z-order over two or more columns is not a sort on any one of them, so row 2 reported an
order the rows were not in. **A single-column key cannot show this** (single-column Z-order
*is* lexicographic order), which is why the fixture uses two and asserts the inversion counts
as premises.

## The change

`record_sorted_extent()` takes the key and the kind; both eager call sites pass what they
applied. A new `sort_key_names()` builds the name list, and the online path now shares it
instead of open-coding the same loop.

## Two consequences

1. `sort_status` reports the **applied** key instead of the declared one on an eagerly
   clustered table. That is a user-visible output change and the CHANGELOG says so.
2. #415's recluster self-gate requires `sorted_kind = 'zorder'`, so after
   `pgcolumnar.cluster('t','k','j')` it could never fire: an immediately following
   `pgcolumnar.recluster('t','k','j')` on an already-clustered relation paid a full rewrite
   of all five groups. It now returns 0 and rewrites nothing.

## Test, and why the self-gate arms are not vacuous

New suite `test/eager_ordering_record.sh`, 27 checks, registered in `run_all_versions.sh`.

`recluster(...) = 0` is **not** evidence the gate fired: an empty relation, a single group,
an unrelated early return, or a return value not wired to the gate all produce 0. So the arms
corroborate with the **layout** -- the `(group_number, file_offset)` set from
`pgcolumnar.row_group`, asserted byte-identical across the call. A fall-through retires every
group and writes new ones, so that set always moves. The return value is asserted too, as the
secondary. Premises assert the fixture has more than one group and 5,000 live rows, so
"nothing changed" cannot be true because there was nothing there.

Controls, each asserting both the return value and that the layout moved:

- recluster by a **different key** on the same table rewrites all 5 groups;
- one row inserted after the cluster (an appended tail) defeats the gate on the **same** key;
- a **lexicographic** run of the same lead column is not skipped.

## Removal proof

Reverting only the two call-site arguments back to `NIL, NULL` (keeping the new signature,
the helper, the online path, and the tests) turns **11 of 27 arms red**. Verified against a
distinctly-hashed `.so` on each arm:

| arm | installed `.so` md5 | result |
| --- | --- | --- |
| unfixed source, new tests | `2340966b22f6` | FAILED, 10 red |
| fixed | `500a19ae367c` | PASSED, 27/27 |
| fixed, call-site arguments reverted | `eaa45ff67891` | FAILED, 11 red |

## Suites run, PG 17

Derived by `grep -l` over `test/*.sh` for the identifiers this diff touches
(`sorted_kind`, `sorted_by`, `sort_status`, `vacuum_sorted`, `pgcolumnar.cluster`,
`pgcolumnar.recluster`, `maintenance_due`, `recluster_due`), not hand-picked:

`analyze_stats` `autovacuum` `docs_style` `eager_ordering_record` `entry_point_privilege`
`maintenance_due` `native_cluster` `native_ownership` `native_recluster` `native_reclaim`
`native_reclaim_frag` `native_scale` `native_sort_by` `native_vacuum_race`
`pg_dump_roundtrip` `recluster_extent` `recluster_gate` `sort_status` `sort_status_privilege`
`sorted_projection` `vacuum_lock_privilege` -- all PASSED.
`analyze_function` SKIPPED (needs `pg_restore_attribute_stats`, PG18+).

## Deliberately not in this PR

- **The declared-key fallback in `sort_status` is kept.** A storage ordered by an earlier
  build still has NULL in both columns, and the fallback is the only thing that reports
  anything for it. The residue is documented: a reader that must not be wrong about physical
  order should require `sorted_kind = 'lexicographic'` from `pgcolumnar.storage` and treat
  NULL as unknown, rather than read `sort_status`. That is what #751 will do.
- **No mirror gate for `vacuum_sorted`.** `docs/ARCHITECTURE.md` states that `vacuum_sorted`
  "runs the same rewrite" as `pgcolumnar.vacuum`, which "physically reclaims deleted-row
  space". A gate keyed only on ordering would silently stop reclaiming, and I measured the
  shape on the existing recluster gate: after deleting half of 5,000 rows,
  `recluster('t','k','j')` returns 0 and leaves 2,500 dead rows in place. That is within
  `recluster`'s documented contract (clustering, not reclamation) but it is not within
  `vacuum_sorted`'s. Filing separately.
- **No `sorted_kind` column on `sort_status`.** It is the right end state, but it changes a
  function signature and so needs an `alpha2 -> alpha3` upgrade script. Filing separately.
