### PR TITLE
Give the columnar scan the order a sorted rewrite left the rows in, so ORDER BY on a clustered table plans no Sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,57 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ### Added
 
+- The columnar scan now tells the planner the order a sorted rewrite left the
+  rows in, so `ORDER BY` on that key plans no `Sort`. Every `pathkeys` field in
+  the tree was `NIL`, so a table that `pgcolumnar.vacuum_sorted` had physically
+  ordered still paid a full sort to be read in that order, and
+  `ORDER BY ... LIMIT n` could not stop early.
+
+  Measured on 4,000,000 rows in 27 row groups, `vacuum_sorted('t','k','j')`,
+  `sort_status` reporting key `{k,j}`, 27 sorted groups, 0 appended, 0
+  inversions on `k` in scan order. Instructions retired by one pinned backend,
+  same query, `pgcolumnar.enable_sorted_pathkeys` off against on, and both arms
+  return byte-identical answers:
+
+  | query | Sort (off) | no Sort (on) | ratio |
+  | --- | ---: | ---: | ---: |
+  | `ORDER BY k, j LIMIT 10` | 5,545,800,871 | 14,133,342 | 392x |
+  | `ORDER BY k, j OFFSET 3999990` | 8,395,455,193 | 3,392,835,665 | 2.47x |
+
+  The second row is the whole relation consumed, so it is the sort itself:
+  2,099 instructions a row against 848, about 1,251 a row that the sort was
+  costing. The first is the early stop the sort made impossible. Re-run with the
+  arm order reversed the four figures reproduce within 0.8%.
+
+  **A claim the rows do not satisfy is a wrong answer, not a slow plan**, since
+  the `Sort` that would have fixed the order is gone. The claim is therefore
+  refused unless all of: the last ordering rewrite was lexicographic and
+  recorded itself as such (#758), so a Z-order run and an unknown one are
+  refused rather than guessed at; every row group lies inside the recorded run,
+  so one appended or updated row retracts it; no sort column is collatable; and
+  the requested ordering is a prefix of the recorded key, ascending, NULLS LAST,
+  which is what the rewrite's own tuplesort applies.
+
+  Collatable sort columns are refused because only the column names are
+  recorded. `ALTER TABLE t ALTER COLUMN k TYPE text COLLATE "en_US.utf8"` on a
+  column already `text COLLATE "C"` needs no transformation, so PostgreSQL
+  updates `pg_attribute` and leaves every row where it is: same storage, mark
+  intact, ordering silently a different one. A text sort key therefore gets no
+  ordered path. Lifting that needs the collations recorded beside the names.
+
+  The claim lives in a plan, and no catalog object the plan cache watches
+  changes when rows are appended, so a group written outside the run now
+  invalidates the relation's cached plans. Without it a prepared
+  `ORDER BY k NULLS LAST LIMIT 5` answered from the ordered run alone after 600
+  rows were appended below it. It fires once per row group and only on a
+  relation that has a mark.
+
+  Only the serial scan carries the claim. The parallel partial path and the
+  projection path keep `NIL`: workers finish in any order, and a projection is a
+  separate layout with its own sort key. New GUC
+  `pgcolumnar.enable_sorted_pathkeys`, on by default. New suite
+  `sorted_pathkeys`, 84 checks. (#751)
+
 - A predicate on `date_trunc(unit, ts)` now drives chunk-group skipping for the
   ORDERED comparisons too, not only equality. #739 inverted `=` and declined
   every other operator, so `date_trunc('day', ts) >= '2024-02-01'` still read

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -75,6 +75,7 @@ disk. It never changes the values that a table returns.
 | --- | --- | --- | --- |
 | `pgcolumnar.enable_index_only_scan` | boolean | `on` | Allow index-only scans on columnar tables, served by the columnar visibility-map fork. Set to `off` to force a plain index scan. |
 | `pgcolumnar.enable_projection_scan` | boolean | `on` | Let the planner scan a covering projection instead of the base table when one serves the query better. |
+| `pgcolumnar.enable_sorted_pathkeys` | boolean | `on` | Let the columnar scan tell the planner the order a sorted rewrite left the rows in, so `ORDER BY` on that key needs no `Sort`. Only a lexicographic run recorded by `pgcolumnar.vacuum_sorted` that still covers every row group is advertised. Set to `off` to restore the behaviour of always planning a `Sort`. |
 
 ### Maintenance and disk reclaim
 

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -213,6 +213,7 @@ extern bool pgcolumnar_enable_index_only_scan;	/* allow index-only scans (gap 28
 extern bool pgcolumnar_bulk_parallel_writer;	/* internal: parallel_copy loader skips the storage-row creation lock (#300) */
 extern bool pgcolumnar_parallel_flush;	/* dispatch the per-column stripe flush across bgworkers (#445 slice 3) */
 extern bool pgcolumnar_enable_projection_scan;	/* scan a covering projection (gap 26) */
+extern bool pgcolumnar_enable_sorted_pathkeys;	/* advertise a sorted run's order (#751) */
 extern bool pgcolumnar_enable_index_fetch_penalty;	/* price a columnar index scan's per-row fetch (#355) */
 
 /*

--- a/src/columnar_compat.h
+++ b/src/columnar_compat.h
@@ -497,6 +497,20 @@ PgColumnarReindexRelation(Oid relid, int flags)
 #endif
 
 /* -------------------------------------------------------------------------
+ * build_expression_pathkey() lost its nullable_relids parameter in PG16, when
+ * outer-join-aware equivalence classes replaced it (core commit 2489d76c).
+ * Every caller here passes no nullable relids, so the wrapper takes the modern
+ * five arguments and fills NULL on PG15.
+ * ------------------------------------------------------------------------- */
+#if PG_VERSION_NUM >= 160000
+#define COLUMNAR_BUILD_EXPRESSION_PATHKEY(root, expr, opno, rel, create_it) \
+	build_expression_pathkey((root), (expr), (opno), (rel), (create_it))
+#else
+#define COLUMNAR_BUILD_EXPRESSION_PATHKEY(root, expr, opno, rel, create_it) \
+	build_expression_pathkey((root), (expr), NULL, (opno), (rel), (create_it))
+#endif
+
+/* -------------------------------------------------------------------------
  * Executor index maintenance on the import path (#168).
  *
  * Two signatures move independently here, so they get one macro each rather

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -26,6 +26,7 @@
  */
 #include "columnar.h"
 
+#include "columnar_metadata.h"
 #include "columnar_customscan.h"
 #include "columnar_reader.h"
 #include <math.h>
@@ -78,6 +79,7 @@
 bool		pgcolumnar_enable_custom_scan = true;
 /* GUC: let the planner scan a covering projection instead of the base (gap 26) */
 bool		pgcolumnar_enable_projection_scan = true;
+bool		pgcolumnar_enable_sorted_pathkeys = true;
 /* GUC: price a columnar index scan's per-row heap fetch (#355) */
 bool		pgcolumnar_enable_index_fetch_penalty = true;
 
@@ -1285,6 +1287,207 @@ PgColumnarPlanCustomPath(PlannerInfo *root, RelOptInfo *rel,
 }
 
 /*
+ * pgcolumnar_sorted_pathkeys
+ *		The ordering the stored rows are ACTUALLY in, as pathkeys, or NIL (#751).
+ *
+ *		pgcolumnar.vacuum_sorted physically orders every live row through a
+ *		tuplesort, and until #751 nothing told the planner: an ORDER BY on a
+ *		table already in that order planned a Sort over the whole scan, and an
+ *		ORDER BY ... LIMIT could not stop early.
+ *
+ *		WHAT MAKES THIS DANGEROUS is that claiming an order the rows are not in
+ *		is not a slow plan, it is a WRONG ANSWER: the Sort that would have fixed
+ *		the order is removed, so a LIMIT returns the wrong rows and a merge join
+ *		matches the wrong ones. No correctness test on unordered data would see
+ *		it, because such a test's plan keeps its Sort either way. So every
+ *		condition below is a refusal, and the default is NIL.
+ *
+ *		The rows are in a plain ascending lexicographic order on a known key
+ *		only when all of these hold:
+ *
+ *		1. The last ordering rewrite was a LEXICOGRAPHIC one and said so.
+ *		   pgcolumnar.cluster and pgcolumnar.recluster arrange rows on a Z-order
+ *		   curve, which is not a sort on any single column, and a NULL kind is a
+ *		   storage ordered before pgColumnar recorded which (#758). Both are
+ *		   refused here rather than guessed at, and neither can be told from a
+ *		   sorted run by the run extent alone.
+ *
+ *		2. Every row group lies inside the recorded run [sorted_from,
+ *		   sorted_through]. A group above it was appended after the rewrite, in
+ *		   insert order; a group below it was written by a concurrent writer
+ *		   whose stripe id was drawn first (#342). Either way the relation is a
+ *		   sorted run plus rows that are not in it, which is a merge and not a
+ *		   scan. An UPDATE lands in an appended group, so this also retracts the
+ *		   claim after any row is updated.
+ *
+ *		3. No sort key column is collatable. Only the column names are recorded,
+ *		   so nothing can tell whether the collation the rewrite sorted under is
+ *		   still the column's collation, and a collation-only ALTER changes it
+ *		   without rewriting a single row. See the refusal below for the measured
+ *		   wrong answer this prevents.
+ *
+ *		4. The requested ordering is a PREFIX of the recorded key, ascending,
+ *		   NULLS LAST, in the key's own collation. That is exactly what
+ *		   pgcolumnar_compact_relation's tuplesort applies: the type's default
+ *		   '<' operator, the column's own collation, nullsFirst = false. Asking
+ *		   build_expression_pathkey for that same '<' operator reproduces those
+ *		   three properties rather than restating them, so the claim cannot
+ *		   drift from the sort that produced it.
+ *
+ *		The scan returns groups in ascending group number (the reader sorts the
+ *		list with row_group_cmp) and rows within a group in stored order, so a
+ *		run that covers every group is returned in the order the rewrite wrote
+ *		it. Deleted rows are skipped, which removes rows but does not reorder
+ *		the ones that remain.
+ *
+ *		Column identity is by NAME, because that is what sorted_by records. A
+ *		renamed or dropped sort column stops resolving and the claim lapses,
+ *		which is the safe direction.
+ *
+ *		Only the serial scan may use this. The parallel path hands whole stripes
+ *		to workers that finish in any order, and a projection is a different
+ *		physical layout with its own sort key.
+ */
+static List *
+pgcolumnar_sorted_pathkeys(PlannerInfo *root, RelOptInfo *rel, Oid relid)
+{
+	Relation	r;
+	TupleDesc	tupdesc;
+	uint64		storageId;
+	int64		sortedFrom,
+				sortedThrough;
+	List	   *keyNames;
+	char	   *sortedKind;
+	List	   *groups;
+	List	   *pathkeys = NIL;
+	ListCell   *lc;
+
+	if (!pgcolumnar_enable_sorted_pathkeys)
+		return NIL;
+
+	r = table_open(relid, AccessShareLock);
+	storageId = PgColumnarStorageId(r);
+	tupdesc = RelationGetDescr(r);
+
+	PgColumnarGetSortedInfo(storageId, &sortedFrom, &sortedThrough,
+							&keyNames, &sortedKind);
+
+	/* condition 1: a lexicographic run, recorded as one */
+	if (sortedKind == NULL || strcmp(sortedKind, "lexicographic") != 0 ||
+		keyNames == NIL || sortedFrom < 0 || sortedThrough < 0)
+	{
+		table_close(r, AccessShareLock);
+		return NIL;
+	}
+
+	/*
+	 * Condition 2. The list is sorted ascending by group number, so its first
+	 * and last bound every group. An empty relation is refused rather than
+	 * called trivially ordered: there is nothing to order, and a claim on it
+	 * would have to survive the rows that arrive next.
+	 */
+	groups = PgColumnarReadRowGroupList(storageId,
+										PgColumnarCatalogSnapshot(GetActiveSnapshot()));
+	if (groups == NIL ||
+		(int64) ((NativeRowGroupMetadata *) linitial(groups))->groupNumber < sortedFrom ||
+		(int64) ((NativeRowGroupMetadata *) llast(groups))->groupNumber > sortedThrough)
+	{
+		list_free_deep(groups);
+		table_close(r, AccessShareLock);
+		return NIL;
+	}
+	list_free_deep(groups);
+
+	/*
+	 * Conditions 3 and 4, one key column at a time, in the order the rewrite sorted
+	 * on. This mirrors core's build_index_pathkeys: a column the query has no
+	 * equivalence class for ends the useful prefix, because no lower-order
+	 * column can help once an earlier one is not being ordered on. A column
+	 * whose class is a constant (WHERE k = 5) or a repeat is skipped rather
+	 * than ending the prefix -- every row in the scan shares that value, so the
+	 * rows are ordered by what follows it.
+	 */
+	foreach(lc, keyNames)
+	{
+		char	   *colname = (char *) lfirst(lc);
+		AttrNumber	attno = get_attnum(relid, colname);
+		Form_pg_attribute att;
+		TypeCacheEntry *tce;
+		Var		   *var;
+		List	   *one;
+		PathKey    *pk;
+
+		if (attno == InvalidAttrNumber || attno <= 0 ||
+			attno > tupdesc->natts)
+			break;
+		att = TupleDescAttr(tupdesc, attno - 1);
+		if (att->attisdropped)
+			break;
+
+		/*
+		 * The same lookup pgcolumnar_compact_relation used to pick the sort
+		 * operator. Reproducing the lookup rather than a remembered operator
+		 * oid is what keeps the claim tied to the sort: build_expression_pathkey
+		 * derives ascending / NULLS LAST from this operator being the type's
+		 * '<', and the tuplesort derived the same three properties from it.
+		 */
+		tce = lookup_type_cache(att->atttypid, TYPECACHE_LT_OPR);
+		if (!OidIsValid(tce->lt_opr))
+			break;
+
+		/*
+		 * A COLLATABLE sort column is refused, and this is a real limitation
+		 * rather than caution. The rewrite sorted under the collation the column
+		 * had at the time, and only the column NAMES are recorded, so nothing here
+		 * can tell whether that is still the collation.
+		 *
+		 * It is reachable without a rewrite. "ALTER TABLE t ALTER COLUMN k TYPE
+		 * text COLLATE \"en_US.utf8\"" on a column already text COLLATE "C" needs
+		 * no transformation, so PostgreSQL updates pg_attribute and leaves the
+		 * stored rows alone: same storage id, mark intact, ordering silently now
+		 * a different one. Measured on 4,000 rows chosen so the two collations
+		 * disagree (in C, 'B' sorts before 'a'): ORDER BY k LIMIT 3 returned
+		 * AA1003|AA1011|AA1019, the C order, where the answer is aa10|aa1002|AA1003.
+		 * A wrong answer, from a plan with no Sort in it.
+		 *
+		 * Refusing on attcollation is exact for this: it is InvalidOid for every
+		 * type that has no collation to change. Lifting it means recording the
+		 * collations beside the names, which needs a catalog column.
+		 */
+		if (OidIsValid(att->attcollation))
+			break;
+
+		var = makeVar(rel->relid, attno, att->atttypid, att->atttypmod,
+					  att->attcollation, 0);
+		one = COLUMNAR_BUILD_EXPRESSION_PATHKEY(root, (Expr *) var, tce->lt_opr,
+												rel->relids, false);
+		if (one == NIL)
+			break;				/* not an ordering this query can use */
+
+		pk = (PathKey *) linitial(one);
+		if (!EC_MUST_BE_REDUNDANT(pk->pk_eclass))
+		{
+			bool		dup = false;
+			ListCell   *plc;
+
+			foreach(plc, pathkeys)
+				if (((PathKey *) lfirst(plc))->pk_eclass == pk->pk_eclass)
+				{
+					dup = true;
+					break;
+				}
+			if (!dup)
+				pathkeys = lappend(pathkeys, pk);
+		}
+	}
+
+	table_close(r, AccessShareLock);
+
+	/* drop any trailing keys this query has no use for */
+	return truncate_useless_pathkeys(root, rel, pathkeys);
+}
+
+/*
  * pgcolumnar_choose_projection
  *		Pick a projection that serves this scan better than the base: it must
  *		cover every referenced column (so no base reconstruction is needed at
@@ -2310,7 +2513,13 @@ PgColumnarSetRelPathlist(PlannerInfo *root, RelOptInfo *rel, Index rti,
 	pgcolumnar_refined_scan_cost(rel, rte->relid, seqpath,
 								 &cpath->path.startup_cost,
 								 &cpath->path.total_cost);
-	cpath->path.pathkeys = NIL;
+	/*
+	 * The order the stored rows are actually in, when that is knowable and the
+	 * query can use it (#751). NIL for every other relation, and NIL for the
+	 * parallel and projection paths below: workers claim whole stripes and
+	 * finish in any order, and a projection is a separate physical layout.
+	 */
+	cpath->path.pathkeys = pgcolumnar_sorted_pathkeys(root, rel, rte->relid);
 	cpath->flags = 0;
 	cpath->custom_paths = NIL;
 	cpath->custom_private = NIL;

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -2763,6 +2763,18 @@ _PG_init(void)
 							 0,
 							 NULL, NULL, NULL);
 
+	DefineCustomBoolVariable("pgcolumnar.enable_sorted_pathkeys",
+							 "Let the columnar scan advertise the order a sorted rewrite "
+							 "left the rows in, so ORDER BY on that key needs no Sort (#751).",
+							 "Only a lexicographic run recorded by pgcolumnar.vacuum_sorted "
+							 "and covering every row group is advertised. Off restores the "
+							 "behaviour of always planning a Sort.",
+							 &pgcolumnar_enable_sorted_pathkeys,
+							 true,
+							 PGC_USERSET,
+							 0,
+							 NULL, NULL, NULL);
+
 	DefineCustomBoolVariable("pgcolumnar.enable_index_fetch_penalty",
 							 "Add the cost of the row-group decodes a columnar index "
 							 "scan's per-row heap fetches force (#355).",

--- a/src/columnar_write_state.c
+++ b/src/columnar_write_state.c
@@ -38,6 +38,7 @@
 #include "utils/fmgroids.h"
 #include "utils/fmgrprotos.h"
 #include "utils/guc.h"
+#include "utils/inval.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
 #include "utils/rel.h"
@@ -2763,6 +2764,39 @@ pgcolumnar_flush_row_group(PgColumnarWriteState *writeState)
 		s.vectorLength = COLUMNAR_NATIVE_VECTOR_LENGTH;
 		s.rowGroupLimit = writeState->stripeRowLimit;
 		PgColumnarInsertNativeStorageRow(&s);
+	}
+
+	/*
+	 * A group written OUTSIDE the recorded ordered run retracts the scan's claim
+	 * to be sorted (#751), and that claim lives in a PLAN rather than in a
+	 * catalog object the plan cache watches. Nothing invalidates a cached plan
+	 * on an append, so a plan prepared while the relation was fully ordered would
+	 * keep its ordered path and answer ORDER BY ... LIMIT from the run alone.
+	 *
+	 * That is a WRONG ANSWER, not a stale cost. Measured before this call
+	 * existed, on a relation sorted on k and then given 600 rows with k from -1
+	 * to -600: a prepared "SELECT k FROM pc ORDER BY k NULLS LAST LIMIT 5"
+	 * returned 0,0,0,0,0 instead of -600,-599,-598,-597,-596. Pinned by the
+	 * cached-plan arm of test/sorted_pathkeys.sh.
+	 *
+	 * Gated on the storage actually having a mark, and on this group falling
+	 * outside it, so an ordinary bulk load into an unordered relation invalidates
+	 * nothing. When it does fire it is once per row group, not once per row. A
+	 * rewrite's own groups do not fire it: a rewrite writes into a fresh storage
+	 * whose mark is not set until it finishes, and the relfilenode swap
+	 * invalidates the relation anyway.
+	 */
+	{
+		int64		sortedFrom,
+					sortedThrough;
+		List	   *sortedNames;
+		char	   *sortedKind;
+
+		PgColumnarGetSortedInfo(writeState->storageId, &sortedFrom, &sortedThrough,
+								&sortedNames, &sortedKind);
+		if (sortedThrough >= 0 &&
+			((int64) groupNumber > sortedThrough || (int64) groupNumber < sortedFrom))
+			CacheInvalidateRelcacheByRelid(writeState->relid);
 	}
 	/*
 	 * #445: share one open per metadata table across this flush's inserts. The

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -242,6 +242,7 @@ SUITES=(
 	smoke
 	sort_status
 	sort_status_privilege
+	sorted_pathkeys
 	sorted_projection
 	stats_privilege
 	temporal

--- a/test/selftest/260-an-ordered-comparison-must-use-the.sh
+++ b/test/selftest/260-an-ordered-comparison-must-use-the.sh
@@ -88,7 +88,13 @@ check "sorted_projection's two comparisons are ordered, its subject being order"
 # library as a suite and made this check fail 4-vs-3 the first time it ran.
 # The call pattern also requires the name to stand alone on the line, so the
 # definition cannot match it again.
-_ord_users=$(grep -lE '^[[:space:]]*diff_query_ordered ' "$TESTDIR"/*.sh \
+# diff_query_ordered is the wrapper; pgc_seq_hash is the oracle underneath it,
+# and a suite that calls the oracle directly needs the same premise for the same
+# reason. sorted_pathkeys.sh does exactly that: it compares a columnar answer
+# against a heap one in ROW ORDER without going through the pair helpers,
+# because its tables are not t_heap/t_col. Counting only the wrapper made the
+# premise it does assert look like one premise too many.
+_ord_users=$(grep -lE '^[[:space:]]*diff_query_ordered |pgc_seq_hash ' "$TESTDIR"/*.sh \
 	| grep -cv '/lib\.sh$')
 _ord_premised=$(grep -lE '^[[:space:]]*pgc_check_ordered_oracle[[:space:]]*$' "$TESTDIR"/*.sh \
 	| grep -cv '/lib\.sh$')

--- a/test/sorted_pathkeys.sh
+++ b/test/sorted_pathkeys.sh
@@ -1,0 +1,579 @@
+#!/usr/bin/env bash
+#
+# pgColumnar ordered paths on a physically sorted table (#751).
+#
+# pgcolumnar.vacuum_sorted physically orders a relation, and until this change
+# the columnar scan told the planner nothing about it: every pathkeys field in
+# the tree was NIL, so ORDER BY on a table that was already in that order still
+# planned a Sort over the whole scan, and ORDER BY ... LIMIT n could not stop
+# early.
+#
+# THE FAILURE MODE THIS SUITE EXISTS FOR IS SILENT WRONGNESS, NOT A MISSING
+# SPEED-UP. A scan that claims an ordering the rows are not in produces wrong
+# answers for LIMIT and for merge joins, and no correctness test on unordered
+# data would notice, because the planner would put a Sort above it anyway. So
+# the arms are in two groups and the first group is the important one:
+#
+#   REFUSAL arms   -- every shape where the rows are NOT in the claimed order
+#                     must plan a Sort, AND must return the same rows as a heap
+#                     table holding identical data. These pass trivially when
+#                     no pathkeys exist at all, so they are proved by the
+#                     over-claiming mutation described in the PR, not by being
+#                     green here.
+#   CLAIM arms     -- the shapes where the ordering is real must lose the Sort.
+#                     These are what goes red without the change.
+#
+# Every arm that asserts a plan also asserts the ANSWER against a heap oracle
+# with the same rows, because a plan check alone cannot see a wrong result and
+# an answer check alone cannot see that the Sort was never removed.
+#
+# Usage:  test/sorted_pathkeys.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# pgcolumnar.parallel_copy prepares one transaction per worker, and
+# max_prepared_transactions cannot be raised without a restart, so it is set
+# before the cluster starts rather than with a SET that would silently not take.
+# The parallel_copy arm is the only place the invalidation has to cross a
+# process boundary; without this it errors out and the arm reads as a failure
+# of the product rather than of the fixture.
+export PGC_EXTRA_CONF="max_prepared_transactions=8"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+pgc_check_ordered_oracle
+
+# Does the plan for this query contain a Sort (or Incremental Sort) node?
+sorts() {	# sorts QUERY -> yes|no
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -At -c "EXPLAIN (COSTS OFF) $1" 2>/dev/null \
+		| grep -qE '^ *(->)? *(Incremental )?Sort' && echo yes || echo no
+}
+inv() {		# inversions on the lead column in the order the scan returns rows
+	q "SELECT count(*) FROM (SELECT $2, lag($2) OVER () AS p FROM $1) s WHERE p > $2;"
+}
+ss() { q "SELECT $2 FROM pgcolumnar.sort_status('$1');"; }
+
+# ---------------------------------------------------------------- the fixture
+#
+# A columnar table and a heap table holding identical rows. Every answer arm
+# compares the two, so a claimed ordering that reorders or drops rows is caught
+# by the answer and not only by the plan.
+#
+# k has duplicates and NULLs on purpose: NULLS LAST is part of what the claim
+# says, and a tie on k is where a wrong secondary order would show.
+psql_run "CREATE TABLE h (id int, k int, j int, t text) USING heap;"
+psql_run "INSERT INTO h SELECT g, CASE WHEN g % 97 = 0 THEN NULL ELSE (g*7919)%500 END, g%13, 'v'||g FROM generate_series(1,20000) g;"
+psql_run "CREATE TABLE c (id int, k int, j int, t text) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.set_options('c', stripe_row_limit => 2000, chunk_group_row_limit => 500);"
+psql_run "INSERT INTO c SELECT * FROM h;"
+psql_run "SELECT pgcolumnar.vacuum_sorted('c', 'k', 'j');"
+
+check_num "premise: the fixture is physically ordered on k" "$(inv c k)" "0"
+check "premise: with no unsorted tail" "$(ss c appended_groups)" "0"
+check "premise: recorded as a lexicographic run" \
+	"$(q "SELECT sorted_kind FROM pgcolumnar.storage WHERE storage_id = pgcolumnar.get_storage_id('c');")" \
+	"lexicographic"
+check "premise: on the key it was given" \
+	"$(q "SELECT sorted_by::text FROM pgcolumnar.storage WHERE storage_id = pgcolumnar.get_storage_id('c');")" \
+	"{k,j}"
+check "premise: the fixture has NULLs in the sort column" \
+	"$([ "$(q 'SELECT count(*) FROM c WHERE k IS NULL;')" -gt 0 ] && echo yes || echo no)" "yes"
+check "premise: and ties on it" \
+	"$([ "$(q 'SELECT count(*) FROM (SELECT k FROM c WHERE k IS NOT NULL GROUP BY k HAVING count(*) > 1) s;')" -gt 0 ] && echo yes || echo no)" "yes"
+check "premise: the columnar table is read by the columnar scan" \
+	"$(pgc_is_columnar_scan 'SELECT k FROM c ORDER BY k')" "yes"
+
+# ansp LABEL HEAP COLUMNAR QUERY-with-%T -- the columnar answer must equal the
+# heap answer, ROW ORDER INCLUDED (pgc_seq_hash, not pgc_set_hash). A set
+# comparison cannot fail on order, which is the only thing a wrong pathkey
+# claim breaks.
+ansp() {
+	local label="$1" ht="$2" ct="$3" tmpl="$4"
+	check_text "$label" "$(pgc_seq_hash "${tmpl//%T/$ct}")" "$(pgc_seq_hash "${tmpl//%T/$ht}")"
+}
+ans() { ansp "$1" h c "$2"; }
+
+# ============================================================== CLAIM arms
+#
+# The ordering is real on these shapes, so the Sort must be gone. Each is
+# paired with the answer, because losing the Sort is only correct if the rows
+# still come back in that order.
+
+check "ORDER BY the sort key plans no Sort" "$(sorts 'SELECT k FROM c ORDER BY k')" "no"
+ans   "and returns the same rows in the same order as heap" \
+	'SELECT id, k, j FROM %T ORDER BY k, j, id'
+
+check "ORDER BY the full key plans no Sort" "$(sorts 'SELECT k, j FROM c ORDER BY k, j')" "no"
+check "ORDER BY the key prefix plans no Sort" "$(sorts 'SELECT k FROM c ORDER BY k ASC NULLS LAST')" "no"
+
+check "ORDER BY k LIMIT plans no Sort" "$(sorts 'SELECT k FROM c ORDER BY k LIMIT 10')" "no"
+ans   "and LIMIT returns the same first rows as heap" \
+	'SELECT k, j FROM %T ORDER BY k NULLS LAST, j LIMIT 10'
+ans   "and a larger LIMIT does too" \
+	'SELECT k, j, id FROM %T ORDER BY k NULLS LAST, j, id LIMIT 500'
+
+check "MIN over the sort key plans no Sort" "$(sorts 'SELECT k FROM c WHERE k IS NOT NULL ORDER BY k LIMIT 1')" "no"
+ans   "and the first row matches heap" \
+	'SELECT k FROM %T WHERE k IS NOT NULL ORDER BY k LIMIT 1'
+
+# ============================================================= REFUSAL arms
+#
+# Each of these is a shape where the physical order does NOT satisfy the
+# requested order. A Sort must remain. These arms are green with no feature at
+# all, which is exactly why the PR proves them by over-claiming instead.
+
+check "REFUSE: DESC is not the order the rows are in" \
+	"$(sorts 'SELECT k FROM c ORDER BY k DESC')" "yes"
+ans   "and DESC still answers correctly" 'SELECT k, j, id FROM %T ORDER BY k DESC NULLS FIRST, j DESC, id DESC LIMIT 200'
+
+check "REFUSE: NULLS FIRST is not the null placement the rows are in" \
+	"$(sorts 'SELECT k FROM c ORDER BY k NULLS FIRST')" "yes"
+ans   "and NULLS FIRST still answers correctly" 'SELECT k, id FROM %T ORDER BY k NULLS FIRST, id LIMIT 300'
+
+check "REFUSE: a non-prefix of the key is not an order the rows are in" \
+	"$(sorts 'SELECT j FROM c ORDER BY j')" "yes"
+ans   "and it still answers correctly" 'SELECT j, id FROM %T ORDER BY j, id LIMIT 300'
+
+check "REFUSE: a column that is not in the key at all" \
+	"$(sorts 'SELECT id FROM c ORDER BY id')" "yes"
+ans   "and it still answers correctly" 'SELECT id FROM %T ORDER BY id LIMIT 300'
+
+check "REFUSE: the key columns in the wrong order" \
+	"$(sorts 'SELECT k, j FROM c ORDER BY j, k')" "yes"
+
+# --- an unsorted tail: the run is still ordered, the relation is not ---------
+
+psql_run "CREATE TABLE tailc (LIKE c) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.set_options('tailc', stripe_row_limit => 2000, chunk_group_row_limit => 500);"
+psql_run "INSERT INTO tailc SELECT * FROM c;"
+psql_run "SELECT pgcolumnar.vacuum_sorted('tailc', 'k', 'j');"
+psql_run "CREATE TABLE tailh (LIKE h) USING heap;"
+psql_run "INSERT INTO tailh SELECT * FROM tailc;"
+# Rows whose k values fall BELOW the run's minimum, so a scan that returned the
+# run first and the tail afterwards would give a wrong LIMIT answer rather than
+# merely an unordered one.
+psql_run "INSERT INTO tailc SELECT g, -g, g%13, 'x'||g FROM generate_series(1,600) g;"
+psql_run "INSERT INTO tailh SELECT g, -g, g%13, 'x'||g FROM generate_series(1,600) g;"
+
+check "premise: the tail really appended past the run" \
+	"$([ "$(ss tailc appended_groups)" -gt 0 ] && echo yes || echo no)" "yes"
+check "premise: and the relation is no longer in k order" \
+	"$([ "$(inv tailc k)" -gt 0 ] && echo yes || echo no)" "yes"
+# Read from the HEAP twin, not from tailc. min() over the columnar table is
+# itself a candidate for the ordered path, so a premise taken there would be
+# measuring the thing under test: an over-claiming build answered it wrongly.
+check "premise: the tail holds values below the run's minimum" \
+	"$(q 'SELECT (min(k) < 0)::text FROM tailh;')" "true"
+check "REFUSE: a run with an appended tail is not an ordered relation" \
+	"$(sorts 'SELECT k FROM tailc ORDER BY k')" "yes"
+# The arm that would catch a wrong claim as a WRONG ANSWER rather than a slow
+# plan: with the tail below the run, the first ten rows of a claimed order are
+# not the first ten rows.
+ansp  "and ORDER BY k LIMIT still returns the true first rows" tailh tailc \
+	'SELECT k, id FROM %T ORDER BY k NULLS LAST, id LIMIT 10'
+ansp  "and the whole ordered result matches heap" tailh tailc \
+	'SELECT k, j, id FROM %T ORDER BY k NULLS LAST, j, id'
+
+# --- a Z-order run: an order, but not a sort on any one column --------------
+
+psql_run "CREATE TABLE zc (LIKE c) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.set_options('zc', stripe_row_limit => 2000, chunk_group_row_limit => 500);"
+psql_run "INSERT INTO zc SELECT * FROM h WHERE k IS NOT NULL;"
+psql_run "SELECT pgcolumnar.set_options('zc', sort_by => ARRAY['k','j']::name[]);"
+psql_run "SELECT pgcolumnar.cluster('zc', 'k', 'j');"
+psql_run "CREATE TABLE zh (LIKE h) USING heap;"
+psql_run "INSERT INTO zh SELECT * FROM zc;"
+
+check "premise: the Z-ordered table records a full run with no tail" \
+	"$(ss zc appended_groups)" "0"
+check "premise: recorded as a zorder run, not lexicographic" \
+	"$(q "SELECT sorted_kind FROM pgcolumnar.storage WHERE storage_id = pgcolumnar.get_storage_id('zc');")" \
+	"zorder"
+check "premise: and it is NOT in k order" \
+	"$([ "$(inv zc k)" -gt 0 ] && echo yes || echo no)" "yes"
+check "REFUSE: a Z-order run is not a sort on its lead column" \
+	"$(sorts 'SELECT k FROM zc ORDER BY k')" "yes"
+ansp  "and it still answers correctly" zh zc \
+	'SELECT k, j, id FROM %T ORDER BY k, j, id LIMIT 300'
+
+# --- an unsorted relation ---------------------------------------------------
+
+psql_run "CREATE TABLE uc (LIKE c) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.set_options('uc', stripe_row_limit => 2000, chunk_group_row_limit => 500);"
+psql_run "INSERT INTO uc SELECT * FROM h;"
+psql_run "SELECT pgcolumnar.set_options('uc', sort_by => ARRAY['k','j']::name[]);"
+check "premise: an unsorted relation records no kind" \
+	"$(q "SELECT coalesce(sorted_kind,'<NULL>') FROM pgcolumnar.storage WHERE storage_id = pgcolumnar.get_storage_id('uc');")" \
+	"<NULL>"
+check "premise: even though sort_status reports the declared key" "$(ss uc sort_key)" "{k,j}"
+check "REFUSE: a DECLARED sort key is an intention, not a layout" \
+	"$(sorts 'SELECT k FROM uc ORDER BY k')" "yes"
+
+# --- an unsorted rewrite retracts the claim ---------------------------------
+
+psql_run "CREATE TABLE rc (LIKE c) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.set_options('rc', stripe_row_limit => 2000, chunk_group_row_limit => 500);"
+psql_run "INSERT INTO rc SELECT * FROM h;"
+psql_run "SELECT pgcolumnar.vacuum_sorted('rc', 'k', 'j');"
+check "premise: the claim is live before the unsorted rewrite" \
+	"$(sorts 'SELECT k FROM rc ORDER BY k')" "no"
+psql_run "SELECT pgcolumnar.vacuum('rc');"
+check "REFUSE: an unsorted vacuum retracts the ordered path" \
+	"$(sorts 'SELECT k FROM rc ORDER BY k')" "yes"
+
+# --- a collatable sort key is refused, and here is the wrong answer it saves --
+#
+# Only the column NAMES are recorded, so nothing at plan time can tell whether
+# the collation the rewrite sorted under is still the column's collation. And
+# it can change with no rewrite at all: ALTER COLUMN k TYPE text COLLATE X on a
+# column that is already text needs no transformation, so PostgreSQL updates
+# pg_attribute and leaves every stored row where it is.
+#
+# The values are chosen so the two collations DISAGREE: in C, 'B' (0x42) sorts
+# before 'a' (0x61), and in en_US it does not. Without that the arm cannot fail.
+
+psql_run "CREATE TABLE colh (id int, k text COLLATE \"C\") USING heap;"
+psql_run "INSERT INTO colh SELECT g, (ARRAY['aB','Ab','aa','AA','Ba','bA','_x','Zz'])[1+(g%8)] || g FROM generate_series(1,4000) g;"
+psql_run "CREATE TABLE colc (id int, k text COLLATE \"C\") USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.set_options('colc', stripe_row_limit => 1000, chunk_group_row_limit => 250);"
+psql_run "INSERT INTO colc SELECT * FROM colh;"
+psql_run "SELECT pgcolumnar.vacuum_sorted('colc', 'k');"
+
+check "premise: the rewrite recorded a lexicographic run on the text column" \
+	"$(q "SELECT sorted_kind FROM pgcolumnar.storage WHERE storage_id = pgcolumnar.get_storage_id('colc');")" \
+	"lexicographic"
+check "premise: with no tail, so only the collation stands between it and a claim" \
+	"$(ss colc appended_groups)" "0"
+check "REFUSE: a collatable sort column is not claimed, whatever its collation" \
+	"$(sorts 'SELECT k FROM colc ORDER BY k')" "yes"
+ansp  "and it answers in C order, matching heap" colh colc \
+	'SELECT k, id FROM %T ORDER BY k, id'
+
+# The demonstration of WHY: a collation-only ALTER changes the ordering the
+# column asks for without rewriting a single row. It needs two collations that
+# DISAGREE, and a server that has one is not guaranteed, so this half degrades
+# to a named skip. The refusal itself is asserted above, on COLLATE "C", which
+# every server has.
+ALTCOLL="$(q "SELECT collname FROM pg_collation WHERE collname IN ('en_US.utf8','en_US.UTF-8','en_US','und-x-icu') ORDER BY 1 LIMIT 1;")"
+if [ -z "$ALTCOLL" ] || \
+   [ "$(q "SELECT (min(k) COLLATE \"C\") = (SELECT min(k COLLATE \"$ALTCOLL\") FROM colh) FROM colh;" 2>/dev/null)" != "f" ]; then
+	echo "SKIP  the collation-change demonstration: this server has no collation that"
+	echo "      disagrees with C on ASCII, so the arm could not fail and is not run."
+	echo "      The refusal it demonstrates is asserted above on COLLATE \"C\"."
+else
+	check "premise: C and $ALTCOLL really disagree on this data" \
+		"$([ "$(q "SELECT k FROM colh ORDER BY k COLLATE \"C\" LIMIT 1;")" \
+		 != "$(q "SELECT k FROM colh ORDER BY k COLLATE \"$ALTCOLL\" LIMIT 1;")" ] && echo yes || echo no)" "yes"
+
+	SID_BEFORE_ALTER="$(storage_id_of colc)"
+	psql_run "ALTER TABLE colc ALTER COLUMN k TYPE text COLLATE \"$ALTCOLL\";"
+	psql_run "ALTER TABLE colh ALTER COLUMN k TYPE text COLLATE \"$ALTCOLL\";"
+	check "premise: the collation ALTER rewrote nothing (same storage id)" \
+		"$([ "$SID_BEFORE_ALTER" = "$(storage_id_of colc)" ] && echo same || echo rewritten)" "same"
+	check "premise: so the run is still recorded as lexicographic" \
+		"$(q "SELECT sorted_kind FROM pgcolumnar.storage WHERE storage_id = pgcolumnar.get_storage_id('colc');")" \
+		"lexicographic"
+	check "premise: and the column's collation really did change" \
+		"$(q "SELECT collname FROM pg_collation WHERE oid = (SELECT attcollation FROM pg_attribute WHERE attrelid = 'colc'::regclass AND attname = 'k');")" \
+		"$ALTCOLL"
+	check "REFUSE: the order the rows are in is no longer the order the column asks for" \
+		"$(sorts 'SELECT k FROM colc ORDER BY k')" "yes"
+	# Without the refusal this returned the C order, AA1003|AA1011|AA1019, where
+	# the answer is aa10|aa1002|AA1003. A wrong answer from a plan with no Sort.
+	ansp  "and ORDER BY k LIMIT returns the new collation's first rows, matching heap" colh colc \
+		'SELECT k, id FROM %T ORDER BY k, id LIMIT 3'
+	ansp  "and the whole ordered result matches heap" colh colc \
+		'SELECT k, id FROM %T ORDER BY k, id'
+fi
+
+# --- a rewrite that a type change forces retracts the claim -----------------
+
+psql_run "CREATE TABLE atc (id int, k int) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.set_options('atc', stripe_row_limit => 2000, chunk_group_row_limit => 500);"
+psql_run "INSERT INTO atc SELECT g, (g*7919)%500 FROM generate_series(1,20000) g;"
+psql_run "SELECT pgcolumnar.vacuum_sorted('atc', 'k');"
+check "premise: the claim is live before the type change" \
+	"$(sorts 'SELECT k FROM atc ORDER BY k')" "no"
+ATC_SID="$(storage_id_of atc)"
+psql_run "ALTER TABLE atc ALTER COLUMN k TYPE text;"
+check "premise: a type change DID rewrite the storage" \
+	"$([ "$ATC_SID" = "$(storage_id_of atc)" ] && echo same || echo rewritten)" "rewritten"
+check "REFUSE: integer order is not text order, and the rewrite dropped the mark" \
+	"$(sorts 'SELECT k FROM atc ORDER BY k')" "yes"
+
+# --- an UPDATE lands outside the run, so the claim lapses -------------------
+
+psql_run "CREATE TABLE upc (LIKE c) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.set_options('upc', stripe_row_limit => 2000, chunk_group_row_limit => 500);"
+psql_run "INSERT INTO upc SELECT * FROM h;"
+psql_run "SELECT pgcolumnar.vacuum_sorted('upc', 'k', 'j');"
+check "premise: the claim is live before the update" \
+	"$(sorts 'SELECT k FROM upc ORDER BY k')" "no"
+psql_run "UPDATE upc SET k = -1 WHERE id = 1;"
+check "premise: the new row version appended past the run" \
+	"$([ "$(ss upc appended_groups)" -gt 0 ] && echo yes || echo no)" "yes"
+check "REFUSE: one updated row is a row outside the run" \
+	"$(sorts 'SELECT k FROM upc ORDER BY k')" "yes"
+check "and ORDER BY k LIMIT 1 finds the updated row" \
+	"$(q 'SELECT k FROM upc ORDER BY k LIMIT 1;')" "-1"
+
+# --- a column rename makes the recorded name stop resolving -----------------
+
+psql_run "CREATE TABLE rnc (LIKE c) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.set_options('rnc', stripe_row_limit => 2000, chunk_group_row_limit => 500);"
+psql_run "INSERT INTO rnc SELECT * FROM h;"
+psql_run "SELECT pgcolumnar.vacuum_sorted('rnc', 'k', 'j');"
+psql_run "ALTER TABLE rnc RENAME COLUMN k TO kk;"
+check "premise: the recorded key still names the old column" \
+	"$(q "SELECT sorted_by::text FROM pgcolumnar.storage WHERE storage_id = pgcolumnar.get_storage_id('rnc');")" \
+	"{k,j}"
+check "REFUSE: a recorded name that no longer resolves is not a claim" \
+	"$(sorts 'SELECT kk FROM rnc ORDER BY kk')" "yes"
+
+# --- the GUC is the escape hatch and it works both ways ---------------------
+
+# sorts() runs one statement, so the SET has to travel with the connection.
+sorts_off() {
+	env PATH="$PGC_BINDIR:$PATH" PGOPTIONS="-c pgcolumnar.enable_sorted_pathkeys=off" \
+		psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" -At \
+		-c "EXPLAIN (COSTS OFF) $1" 2>/dev/null \
+		| grep -qE '^ *(->)? *(Incremental )?Sort' && echo yes || echo no
+}
+check "premise: the claim is live with the GUC on" "$(sorts 'SELECT k FROM c ORDER BY k')" "no"
+check "control: pgcolumnar.enable_sorted_pathkeys = off restores the Sort" \
+	"$(sorts_off 'SELECT k FROM c ORDER BY k')" "yes"
+
+# --- a cached plan must not outlive the ordering it was planned on ----------
+#
+# The pathkeys come from the DATA, not from a catalog object the plan cache
+# tracks. A plan prepared while the relation was fully ordered would keep
+# claiming that order after an INSERT appended a tail, and answer ORDER BY ...
+# LIMIT from the run alone. Nothing in the plan cache invalidates on an append.
+
+psql_run "CREATE TABLE pc (LIKE c) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.set_options('pc', stripe_row_limit => 2000, chunk_group_row_limit => 500);"
+psql_run "INSERT INTO pc SELECT * FROM h;"
+psql_run "SELECT pgcolumnar.vacuum_sorted('pc', 'k', 'j');"
+# One session: prepare and execute enough times that a generic plan is chosen
+# and cached, then append a tail below the run, then execute again.
+PLAN_SQL="$PGC_SQLDIR/cachedplan.sql"
+cat > "$PLAN_SQL" <<'SQL'
+PREPARE p AS SELECT k FROM pc ORDER BY k NULLS LAST LIMIT 5;
+EXECUTE p \g /dev/null
+EXECUTE p \g /dev/null
+EXECUTE p \g /dev/null
+EXECUTE p \g /dev/null
+EXECUTE p \g /dev/null
+EXECUTE p \g /dev/null
+INSERT INTO pc SELECT g, -g, g%13, 'x'||g FROM generate_series(1,600) g;
+EXECUTE p;
+SQL
+CACHED="$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+	-d "$PGC_DB" -At -f "$PLAN_SQL" 2>&1 | tail -5 | tr '\n' ',' | sed 's/,$//')"
+check_text "a cached ordered plan sees rows appended after it was planned" \
+	"$CACHED" "-600,-599,-598,-597,-596"
+
+# --- the two OTHER paths this hook could reach, which must claim nothing -----
+#
+# Three columnar paths are offered for a base relation and only the serial one
+# may carry this claim. A projection is a different physical layout with its own
+# sort key (pgcolumnar.projection.sort_key), unrelated to storage.sorted_by, so
+# base-table pathkeys reaching a projection path would be a wrong answer with no
+# Sort in the plan. And pathkeys on a PARTIAL path describe one worker's output,
+# which a plain Gather interleaves.
+
+psql_run "CREATE TABLE prc (LIKE c) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.set_options('prc', stripe_row_limit => 2000, chunk_group_row_limit => 500);"
+psql_run "INSERT INTO prc SELECT * FROM h;"
+psql_run "SELECT pgcolumnar.vacuum_sorted('prc', 'k', 'j');"
+psql_run "SELECT pgcolumnar.add_projection('prc', 'p_on_j', ARRAY['k','j'], ARRAY['j']);"
+psql_run "CREATE TABLE prc_h (LIKE h) USING heap;"
+psql_run "INSERT INTO prc_h SELECT * FROM h;"
+# sort_key is stored as attnums; j is attnum 3, so a projection sorted on {3} is
+# sorted on a column that is NOT the base relation's lead sort column.
+check "premise: the projection exists and is sorted on a DIFFERENT key" \
+	"$(q "SELECT sort_key::text FROM pgcolumnar.projection WHERE projection_id > 0 AND storage_id = pgcolumnar.get_storage_id('prc');")" \
+	"{3}"
+check "premise: the base relation still records its own lexicographic run on {k,j}" \
+	"$(q "SELECT sorted_by::text FROM pgcolumnar.storage WHERE storage_id = pgcolumnar.get_storage_id('prc');")" \
+	"{k,j}"
+ansp  "a query the projection can serve still answers in the requested order" prc_h prc \
+	'SELECT k, j FROM %T WHERE j = 3 ORDER BY k, j'
+ansp  "and with a LIMIT, which is where a borrowed claim would show" prc_h prc \
+	'SELECT k, j FROM %T WHERE j = 3 ORDER BY k, j LIMIT 10'
+
+# --- parallel: the claim must not survive into a plan that interleaves --------
+
+check "premise: the fixture is columnar and ordered" "$(inv c k)" "0"
+par() {	# run with parallelism on, since pgc_setup pins the gather workers to 0
+	env PATH="$PGC_BINDIR:$PATH" \
+		PGOPTIONS="-c max_parallel_workers_per_gather=4 -c parallel_setup_cost=0 -c parallel_tuple_cost=0 -c min_parallel_table_scan_size=0" \
+		psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" -At -c "$1" 2>&1
+}
+PARPLAN="$(par "EXPLAIN (COSTS OFF) SELECT k, j FROM c ORDER BY k, j LIMIT 20")"
+check "premise: parallelism was actually available in that session" \
+	"$([ -n "$PARPLAN" ] && echo yes || echo no)" "yes"
+# grep -c, never grep -q: a reader that exits early takes the writer down with
+# EPIPE under pipefail and reports the pattern ABSENT whatever the string held
+# (selftest 080). -c consumes all of its input, so the count is the answer.
+PAR_BARE_GATHER=$(printf '%s\n' "$PARPLAN" | grep -cE '^ *(->)? *Gather$' || true)
+PAR_ORDER_KEEPER=$(printf '%s\n' "$PARPLAN" | grep -cE 'Gather Merge|(Incremental )?Sort' || true)
+check "a plain Gather never sits above a scan claiming an order" \
+	"$([ "$PAR_BARE_GATHER" -gt 0 ] && [ "$PAR_ORDER_KEEPER" -eq 0 ] && echo bad || echo ok)" "ok"
+check_text "and the parallel answer matches the serial one" \
+	"$(par "SELECT string_agg(k || ':' || j, ',') FROM (SELECT k, j FROM c ORDER BY k, j LIMIT 20) s")" \
+	"$(q "SELECT string_agg(k || ':' || j, ',') FROM (SELECT k, j FROM c ORDER BY k, j LIMIT 20) s;")"
+
+# --- every write path that can append a group must retract a cached plan -----
+#
+# The invalidation lives in one flush function. That is the single caller of
+# PgColumnarInsertRowGroupRow today, but a writer that grew its own path would
+# bypass it silently, so each way of appending gets its own arm rather than
+# trusting the funnel. The two opt-in GUCs are included because a suite at
+# defaults never exercises them and a gap there would be invisible.
+
+cached_first5() {	# cached_first5 TABLE EXTRA_GUCS APPEND_SQL
+	local tbl="$1" gucs="$2" appendsql="$3"
+	local f="$PGC_SQLDIR/cp.$tbl.sql"
+	# The LAST statement must be EXECUTE p, not an equivalent ad-hoc SELECT.
+	# It was an ad-hoc SELECT first, and every arm below stayed green with the
+	# invalidation disabled: a fresh query is planned from scratch, so it can
+	# never observe a stale plan. The whole point is to re-run the CACHED one.
+	{
+		echo "PREPARE p AS SELECT k FROM $tbl ORDER BY k NULLS LAST LIMIT 5;"
+		for _ in 1 2 3 4 5 6; do echo "EXECUTE p \\g /dev/null"; done
+		echo "$appendsql"
+		echo "EXECUTE p;"
+	} > "$f"
+	env PATH="$PGC_BINDIR:$PATH" PGOPTIONS="$gucs" \
+		psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" -At -f "$f" 2>&1 \
+		| tail -5 | paste -sd,
+}
+mk_sorted() {	# mk_sorted TABLE
+	psql_run "CREATE TABLE $1 (id int, k int, j int, t text) USING pgcolumnar;"
+	psql_run "SELECT pgcolumnar.set_options('$1', stripe_row_limit => 2000, chunk_group_row_limit => 500);"
+	psql_run "INSERT INTO $1 SELECT * FROM h;"
+	psql_run "SELECT pgcolumnar.vacuum_sorted('$1', 'k', 'j');"
+}
+# The appended rows carry k = -600..-1, all below the run, so a plan still
+# claiming the old order answers 0,0,0,0,0 instead of -600,-599,-598,-597,-596.
+WANT="-600,-599,-598,-597,-596"
+
+mk_sorted w_ins
+check_text "cached plan retracted by a plain INSERT" \
+	"$(cached_first5 w_ins "" "INSERT INTO w_ins SELECT g, -g, g%13, 'x'||g FROM generate_series(1,600) g;")" "$WANT"
+
+mk_sorted w_isel
+psql_run "CREATE TABLE feed AS SELECT g AS id, -g AS k, g%13 AS j, 'x'||g AS t FROM generate_series(1,600) g;"
+check_text "cached plan retracted by INSERT ... SELECT from another table" \
+	"$(cached_first5 w_isel "" "INSERT INTO w_isel SELECT * FROM feed;")" "$WANT"
+
+mk_sorted w_copy
+COPYF="$PGC_WORKDIR/feed.csv"
+psql_run "COPY (SELECT g, -g, g%13, 'x'||g FROM generate_series(1,600) g) TO '$COPYF' WITH (FORMAT csv);"
+check_text "cached plan retracted by COPY" \
+	"$(cached_first5 w_copy "" "COPY w_copy FROM '$COPYF' WITH (FORMAT csv);")" "$WANT"
+
+# pgcolumnar.bulk_parallel_writer is deliberately NOT an arm here. It does not
+# change the write path: its only consulted site is
+# PgColumnarInsertNativeStorageRow, where it skips an advisory lock when the
+# storage row already exists, and pgcolumnar.parallel_copy sets it in its loader
+# sessions. An arm for it would be this plain-INSERT arm wearing a GUC, and
+# would read as coverage it does not buy. The path it looks like it covers is
+# parallel_copy, which has its own arm below.
+
+# parallel_flush has FOUR conjuncts in its gate (columnar_write_state.c), two of
+# which fail silently in ordinary fixture shapes: a table created in the same
+# transaction as the insert takes the serial path, and so does anything narrower
+# than two columns. So the dispatch line it emits at DEBUG1 is asserted as the
+# premise; without it this arm is a plain INSERT wearing a GUC.
+# The dispatch premise runs on its OWN table. Taken on w_pflush it appended a
+# tail before the plan was ever prepared, so the relation had no ordered path to
+# retract and the arm passed with the invalidation disabled -- vacuous for the
+# second time, in the same suite, for a different reason.
+mk_sorted w_pflush_probe
+PFLUSH_DISPATCH="$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+	-d "$PGC_DB" -c "SET client_min_messages=debug1;" -c "SET pgcolumnar.parallel_flush=on;" \
+	-c "INSERT INTO w_pflush_probe SELECT g, -g, g%13, 'x'||g FROM generate_series(1,600) g;" 2>&1 |
+	grep -oE 'parallel_flush dispatch: .*-> (parallel|serial)' | tail -1 | sed 's/^.*-> //')"
+check_text "premise: parallel_flush dispatches parallel on exactly this shape" \
+	"$PFLUSH_DISPATCH" "parallel"
+mk_sorted w_pflush
+check_text "cached plan retracted with pgcolumnar.parallel_flush on" \
+	"$(cached_first5 w_pflush "-c pgcolumnar.parallel_flush=on" \
+		"INSERT INTO w_pflush SELECT g, -g, g%13, 'x'||g FROM generate_series(1,600) g;")" "$WANT"
+
+# pgcolumnar.parallel_copy is the one write path where separate BACKENDS flush
+# groups in their own transactions, so it is the only one where the invalidation
+# has to cross a process boundary. It needs N+2 worker slots: eight loaders
+# against eight stock slots load ZERO rows, which is a vacuous arm that reads as
+# a pass, so the row count is asserted before anything else.
+mk_sorted w_pcopy
+PCOPYF="$PGC_WORKDIR/pcopy.txt"
+psql_run "COPY (SELECT g, -g, g%13, 'x'||g FROM generate_series(1,600) g) TO '$PCOPYF';"
+PCOPY_ROWS="$(q "SELECT pgcolumnar.parallel_copy('w_pcopy', '$PCOPYF', 2);")"
+check_num "premise: parallel_copy actually loaded its rows (worker slots sufficed)" \
+	"$PCOPY_ROWS" "600"
+check "premise: and they appended past the run" \
+	"$([ "$(ss w_pcopy appended_groups)" -gt 0 ] && echo yes || echo no)" "yes"
+# The load already happened, so this arm prepares AFTER it and appends again
+# through parallel_copy, which is the cross-backend case.
+mk_sorted w_pcopy2
+check_text "cached plan retracted by pgcolumnar.parallel_copy" \
+	"$(cached_first5 w_pcopy2 "" \
+		"SELECT pgcolumnar.parallel_copy('w_pcopy2', '$PCOPYF', 2);")" "$WANT"
+
+# --- the invariant the whole invalidation gate rests on ---------------------
+#
+# The gate is "the storage has a mark AND this group falls outside it". It goes
+# quiet if a new group can land INSIDE a stale mark. Group numbers are monotonic
+# within a storage, and TRUNCATE does restart them at 1 -- but it also makes a
+# NEW storage, whose mark is NULL. THE MARK AND THE GROUP NUMBERING LIVE IN THE
+# SAME STORAGE ROW, so numbering can only reset together with a mark that resets
+# to NULL. This arm exists because that invariant is invisible: anything that
+# reused a storage id, or reset numbering within one, would silence the gate and
+# bring stale ordered plans back with no other test noticing.
+
+mk_sorted trunc
+TRUNC_SID="$(storage_id_of trunc)"
+check "premise: the mark is set and numbering starts at 1 before the truncate" \
+	"$(q "SELECT (sorted_from = min(group_number))::text FROM pgcolumnar.row_group, pgcolumnar.storage WHERE pgcolumnar.storage.storage_id = pgcolumnar.get_storage_id('trunc') AND pgcolumnar.row_group.storage_id = pgcolumnar.storage.storage_id GROUP BY sorted_from;")" \
+	"true"
+psql_run "TRUNCATE trunc;"
+psql_run "INSERT INTO trunc SELECT * FROM h;"
+check "TRUNCATE restarts group numbering" \
+	"$(q "SELECT (min(group_number) = 1)::text FROM pgcolumnar.row_group WHERE storage_id = pgcolumnar.get_storage_id('trunc');")" \
+	"true"
+check "but in a NEW storage, so the mark it could collide with is gone" \
+	"$([ "$TRUNC_SID" != "$(storage_id_of trunc)" ] && echo new || echo reused)" "new"
+check_text "and that new storage claims no ordering" \
+	"$(q "SELECT coalesce(sorted_kind,'<NULL>') FROM pgcolumnar.storage WHERE storage_id = pgcolumnar.get_storage_id('trunc');")" \
+	"<NULL>"
+check "REFUSE: so a restarted group number cannot land inside a live mark" \
+	"$(sorts 'SELECT k FROM trunc ORDER BY k')" "yes"
+
+# CTAS creates a new relation, so there is no earlier plan to retract; the arm
+# is that the fresh relation claims nothing, having never been ordered.
+psql_run "CREATE TABLE w_ctas USING pgcolumnar AS SELECT * FROM h;"
+check "a CTAS relation was never ordered, so it claims nothing" \
+	"$(sorts 'SELECT k FROM w_ctas ORDER BY k')" "yes"
+
+# --- a reclaiming rewrite retracts the claim even though the rows stay ordered
+#
+# Group numbers are monotonic: a reclaiming rewrite writes ABOVE the mark rather
+# than reusing numbers inside it, so the run no longer covers every group and
+# the claim lapses while the data is still in order. That is conservative and
+# deliberate, and this arm exists so a later optimisation cannot quietly remove
+# the conservatism without a red.
+
+mk_sorted rec
+psql_run "DELETE FROM rec WHERE id % 2 = 0;"
+psql_run "SELECT pgcolumnar.compact_rewrite('rec');"
+check "premise: the reclaiming rewrite moved every group above the mark" \
+	"$([ "$(ss rec sorted_groups)" -eq 0 ] && echo yes || echo no)" "yes"
+check "premise: and the rows are still physically in k order" "$(inv rec k)" "0"
+check "REFUSE: a run that no longer covers every group is not a claim" \
+	"$(sorts 'SELECT k FROM rec ORDER BY k')" "yes"
+
+pgc_summary

--- a/test/sorted_pathkeys.sh
+++ b/test/sorted_pathkeys.sh
@@ -300,6 +300,64 @@ else
 		'SELECT k, id FROM %T ORDER BY k, id'
 fi
 
+# --- which types the collation refusal actually covers -----------------------
+#
+# The refusal is `OidIsValid(att->attcollation)`, and the claim is that this is
+# EXACT for "has an ordering that can change under us". A type where
+# attcollation is InvalidOid and the ordering can still change would be a wrong
+# answer the refusal does not reach. These arms pin the reason for each family
+# rather than the reasoning, because the reasoning is what would rot.
+
+psql_run "CREATE DOMAIN dom_t AS text COLLATE \"C\";"
+psql_run "CREATE TABLE t_dom (id int, k dom_t) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.set_options('t_dom', stripe_row_limit => 1000, chunk_group_row_limit => 250);"
+psql_run "INSERT INTO t_dom SELECT g, ('v' || g)::dom_t FROM generate_series(1,2000) g;"
+psql_run "SELECT pgcolumnar.vacuum_sorted('t_dom', 'k');"
+check "REFUSE: a DOMAIN over text carries the base type's collation" \
+	"$(sorts 'SELECT k FROM t_dom ORDER BY k')" "yes"
+
+psql_run "CREATE TABLE t_arr (id int, k text[]) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.set_options('t_arr', stripe_row_limit => 1000, chunk_group_row_limit => 250);"
+psql_run "INSERT INTO t_arr SELECT g, ARRAY['v' || g] FROM generate_series(1,2000) g;"
+psql_run "SELECT pgcolumnar.vacuum_sorted('t_arr', 'k');"
+check "REFUSE: an ARRAY of a collatable type is collatable" \
+	"$(sorts 'SELECT k FROM t_arr ORDER BY k')" "yes"
+
+# A COMPOSITE has attcollation InvalidOid while comparing by its FIELD
+# collations, which looks like a hole. It is closed by PostgreSQL, not by this
+# extension: a composite's attribute cannot be altered while any column uses the
+# type. The arm asserts the refusal, so if that ever stops being true this goes
+# red rather than going quietly wrong.
+psql_run "CREATE TYPE comp_t AS (a text COLLATE \"C\", b int);"
+psql_run "CREATE TABLE t_comp (id int, k comp_t) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.set_options('t_comp', stripe_row_limit => 1000, chunk_group_row_limit => 250);"
+psql_run "INSERT INTO t_comp SELECT g, ROW('v' || g, g)::comp_t FROM generate_series(1,2000) g;"
+psql_run "SELECT pgcolumnar.vacuum_sorted('t_comp', 'k');"
+check "premise: a composite column's attcollation is InvalidOid, so it IS claimed" \
+	"$(q "SELECT (attcollation = 0)::text FROM pg_attribute WHERE attrelid = 't_comp'::regclass AND attname = 'k';")" \
+	"true"
+check "premise: and it is claimed" "$(sorts 'SELECT k FROM t_comp ORDER BY k')" "no"
+check_text "PostgreSQL refuses to change a composite's field collation while a column uses it" \
+	"$(psql_run "ALTER TYPE comp_t ALTER ATTRIBUTE a TYPE text COLLATE \"C\" CASCADE;" 2>&1 | grep -oE 'cannot alter type' | head -1)" \
+	"cannot alter type"
+
+# An ENUM also has attcollation InvalidOid. ALTER TYPE ... ADD VALUE ... BEFORE
+# slots a new value in without renumbering the existing ones, and the new value
+# cannot be in already-stored rows, so the stored order survives.
+psql_run "CREATE TYPE enum_t AS ENUM ('b','d','f');"
+psql_run "CREATE TABLE t_enum (id int, k enum_t) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.set_options('t_enum', stripe_row_limit => 1000, chunk_group_row_limit => 250);"
+psql_run "INSERT INTO t_enum SELECT g, (ARRAY['b','d','f'])[1+(g%3)]::enum_t FROM generate_series(1,2000) g;"
+psql_run "CREATE TABLE t_enum_h (id int, k enum_t) USING heap;"
+psql_run "INSERT INTO t_enum_h SELECT * FROM t_enum;"
+psql_run "SELECT pgcolumnar.vacuum_sorted('t_enum', 'k');"
+check "premise: an enum sort key is claimed" "$(sorts 'SELECT k FROM t_enum ORDER BY k')" "no"
+psql_run "ALTER TYPE enum_t ADD VALUE 'a' BEFORE 'b';"
+check "an enum ADD VALUE ... BEFORE does not renumber the values already stored" \
+	"$(sorts 'SELECT k FROM t_enum ORDER BY k')" "no"
+ansp  "and the ordered answer still matches heap" t_enum_h t_enum \
+	'SELECT k, id FROM %T ORDER BY k, id'
+
 # --- a rewrite that a type change forces retracts the claim -----------------
 
 psql_run "CREATE TABLE atc (id int, k int) USING pgcolumnar;"

--- a/test/sorted_pathkeys.sh
+++ b/test/sorted_pathkeys.sh
@@ -113,6 +113,19 @@ ans   "and LIMIT returns the same first rows as heap" \
 ans   "and a larger LIMIT does too" \
 	'SELECT k, j, id FROM %T ORDER BY k NULLS LAST, j, id LIMIT 500'
 
+# A constant leading key is SKIPPED and the prefix continues, mirroring core's
+# build_index_pathkeys. Every row the scan returns has k = 5, so within that
+# restriction the rows are ordered by j and ORDER BY j is satisfied by the run
+# on (k,j). Without the skip-and-continue this would end the prefix at k and
+# plan a Sort. The bare "ORDER BY j" refusal arm below is its control: j alone,
+# with no equality on k, is NOT an order the rows are in.
+check "premise: the equality really selects rows, so the arm is not empty" \
+	"$([ "$(q 'SELECT count(*) FROM c WHERE k = 5;')" -gt 1 ] && echo yes || echo no)" "yes"
+check "a constant leading key is skipped, so ORDER BY the next key plans no Sort" \
+	"$(sorts 'SELECT j FROM c WHERE k = 5 ORDER BY j')" "no"
+ansp  "and it answers in j order, matching heap" h c \
+	'SELECT j, id FROM %T WHERE k = 5 ORDER BY j, id'
+
 check "MIN over the sort key plans no Sort" "$(sorts 'SELECT k FROM c WHERE k IS NOT NULL ORDER BY k LIMIT 1')" "no"
 ans   "and the first row matches heap" \
 	'SELECT k FROM %T WHERE k IS NOT NULL ORDER BY k LIMIT 1'


### PR DESCRIPTION
Closes #751.

Every `pathkeys` field in the tree was `NIL`, so a table `pgcolumnar.vacuum_sorted` had
physically ordered still planned a `Sort` to be read in that order.

## The measurement the issue asked for

4,000,000 rows in 27 row groups, `vacuum_sorted('t','k','j')`, `sort_status` reporting key
`{k,j}`, 27 sorted groups, 0 appended, 0 inversions on `k` in scan order. Instructions
retired by one pinned backend (`cpu_core` at 100.00% on every arm; wall clock is not a fair
instrument on this host). Both arms return byte-identical answers, and the plan is asserted
on both.

| query | Sort (`enable_sorted_pathkeys=off`) | no Sort (`on`) | ratio |
| --- | ---: | ---: | ---: |
| `ORDER BY k, j LIMIT 10` | 5,545,800,871 | 14,133,342 | **392x** |
| `ORDER BY k, j OFFSET 3999990` | 8,395,455,193 | 3,392,835,665 | **2.47x** |

The second row is the whole relation consumed, so it is the sort itself: 2,099 instructions
a row against 848, about 1,251 a row the sort was costing. The first is the early stop the
sort made impossible. Re-run with the arm order reversed, the four figures reproduce within
0.8%.

The first attempt at this measurement was void and is worth recording: `(g*7919)%1000000`
overflows int32 above g = 271,181, the fixture INSERT failed with `integer out of range`, and
every arm measured an empty table while reporting clean numbers. `rows=4000000` is now
asserted before any arm runs.

## Why this is a correctness change, not a performance one

**A claim the rows do not satisfy is a wrong answer, not a slow plan**, because the `Sort`
that would have fixed the order is gone. No correctness test on unordered data notices, since
its plan keeps a `Sort` either way. The claim is refused unless all of:

1. the last ordering rewrite was **lexicographic and recorded itself as such** (#758) -- a
   Z-order run and an unknown one are refused rather than guessed at, and after #758 they can
   be told apart;
2. **every row group lies inside the recorded run**, so one appended or updated row retracts
   it;
3. **no sort column is collatable** (see below);
4. the requested ordering is a **prefix of the recorded key**, taken from the same type's
   `<` operator the rewrite's tuplesort used. Asking `build_expression_pathkey` for that
   operator is what makes it ascending / NULLS LAST / in the key's own collation, rather than
   a restatement of those three properties that could drift from the sort that produced them.

### Two wrong answers found during development, both now arms

**A collation-only ALTER changes the order without rewriting a row.**
`ALTER TABLE t ALTER COLUMN k TYPE text COLLATE "en_US.utf8"` on a column already
`text COLLATE "C"` needs no transformation, so PostgreSQL updates `pg_attribute` and leaves
every stored row where it is: same storage id, groups unchanged, mark intact. Measured on
4,000 rows chosen so the two collations disagree (in C, `'B'` 0x42 sorts before `'a'` 0x61):

```
plan after the ALTER : Custom Scan (PgColumnarScan) on b      <- no Sort
ORDER BY k LIMIT 3   : AA1003|AA1011|AA1019                    <- the C order
heap oracle, en_US   : aa10|aa1002|AA1003                      <- the answer
```

Refused on `OidIsValid(att->attcollation)`. The claim that this is **exact** for "has an
ordering that can change under us" is measured per type family rather than reasoned:

| type | `attcollation` | claim | why that is safe |
| --- | --- | --- | --- |
| domain over `text COLLATE "C"` | `C` | refused | carries the base type's collation |
| `text[]` | `default` | refused | an array of a collatable type is collatable |
| composite over `text` | `InvalidOid` | **claimed** | PostgreSQL refuses `ALTER TYPE ... ALTER ATTRIBUTE ... TYPE text COLLATE x` with *"cannot alter type because column uses it"* while any column stores the type |
| range over `text` | `InvalidOid` | **claimed** | `typcollation` is 0, the collation is fixed at `CREATE TYPE`, and there is no DDL to change `pg_range.rngcollation` |
| enum | `InvalidOid` | **claimed** | `ADD VALUE ... BEFORE` slots a value in without renumbering existing ones, and the new value cannot be in stored rows |

The composite and enum rows are the two that looked like holes, and both are closed by
PostgreSQL rather than by this extension. Each has an arm: the composite arm runs the `ALTER`
and matches the refusal text, so it goes red if that ever stops being true; the enum arm
asserts a heap-oracle **answer** after `ADD VALUE 'a' BEFORE 'b'`, not only a plan. **This costs text sort keys an ordered path**, and
that is a stated limitation, not caution. Lifting it means recording the collations beside the
names, which needs a catalog column, so it belongs with #761's upgrade script.

**A cached plan outlives the ordering it was planned on.** The claim lives in a plan, and no
catalog object the plan cache watches changes when rows are appended. Measured before the fix:
a prepared `SELECT k FROM pc ORDER BY k NULLS LAST LIMIT 5` returned `0,0,0,0,0` after 600
rows with `k` from -1 to -600 were appended below the run, where the answer is
`-600,-599,-598,-597,-596`. A group written outside the run now invalidates the relation's
cached plans, gated so it fires only when the storage has a mark and this group falls outside
it: once per row group, never on a bulk load into an unordered relation.

It sits in `pgcolumnar_flush_row_group`, which is below all **six** of its own call sites in
`columnar_write_state.c` (including `pgcolumnar_flush_row_group(w->innerWs)`) and is the only
caller of `PgColumnarInsertRowGroupRow`. "One caller" understates what it covers, which is why
each write path gets its own arm rather than a reading of the grep.

## Where the claim is NOT attached

Only the serial base scan. `columnar_customscan.c:2373` (projection) and `:2508` (parallel
partial) keep `NIL`, and both now have arms: a projection is a separate physical layout with
its own sort key in `pgcolumnar.projection.sort_key`, unrelated to `storage.sorted_by`; and
pathkeys on a partial path describe one worker's output, which a plain `Gather` interleaves.
The four `columnar_vector.c` sites (ungrouped and grouped vector aggregates) also keep `NIL`;
the grouped one is what would serve `GROUP BY k` and is left for a follow-up.

## Test

`test/sorted_pathkeys.sh`, **103 checks**, registered in `run_all_versions.sh`. Two groups:

- **CLAIM arms** -- the shapes where the ordering is real must lose the `Sort`. These are what
  goes red without the change (6 arms).
- **REFUSE arms** -- every shape where the rows are not in the claimed order must keep the
  `Sort` **and** return the same rows in the same order as a heap table holding identical
  data. **These pass trivially when no pathkeys exist at all**, so they are proved by
  over-claiming mutations rather than by being green.

One CLAIM arm is about the *skip-and-continue* branch rather than a refusal: a leading key
whose equivalence class is a constant (`WHERE k = 5`) is skipped and the prefix continues,
mirroring core's `build_index_pathkeys`, because every row the scan returns shares that value
and the rows are therefore ordered by what follows it. `ORDER BY j` under `WHERE k = 5` on a
`(k,j)` run plans no `Sort` and answers in `j` order against the heap twin; the bare
`ORDER BY j` refusal arm is its control.

Refusals covered: `DESC`; `NULLS FIRST`; a non-prefix of the key; a column not in the key;
the key columns in the wrong order; an appended tail (with values *below* the run, so a wrong
claim is a wrong answer and not merely an unordered one); a Z-order run; a declared-but-never-
applied `sort_by`; an unsorted `vacuum`; a collatable column; a collation-only ALTER; a type
change; one `UPDATE`d row; a renamed column; a reclaiming `compact_rewrite`; the GUC off.

## Removal proofs

Each mutation was built and the installed `.so` fingerprinted, so no arm is reported against a
binary that does not contain it.

| mutation | `.so` | arms red |
| --- | --- | --- |
| baseline, fixed | `82558b862d50` | 0 of 92 |
| feature absent (main) | `2340966b22f6` | the 6 CLAIM arms |
| drop the `lexicographic` gate | `0a9c681abf28` | Z-order refusal **+ its heap-oracle answer arm** |
| drop the run-coverage gate | `a580989cda9c` | tail refusal **+ 2 answer arms + the cached-plan arm** |
| drop the collatable refusal | `3b90b692c831` | 2 refusals **+ 2 heap-oracle answer arms** |
| `lt_opr` -> `gt_opr` | (rebuilt) | `DESC` refusal **+ its heap-oracle answer arm** |
| disable the invalidation | `fe5cb0c3d751` | all **6** cached-plan arms |
| end the prefix on a redundant key instead of skipping it | `0543d84a5755` | the constant-leading-key arm |

Every mutation reddens at least one *answer* arm, not only a plan arm.

## Three vacuous arms of my own, caught before they shipped

Recorded because the shape recurs and the reviewer's per-path suggestion is what exposed the
first two:

1. Five write-path arms named the cached plan and ended in an equivalent **ad-hoc SELECT**
   instead of `EXECUTE p`. A fresh query is planned from scratch and can never observe a stale
   plan, so all five stayed green with the invalidation disabled while the original arm went
   red alone.
2. The `parallel_flush` dispatch premise ran on the same table as its cached-plan arm, so it
   appended a tail *before* the plan was prepared and there was no ordered path left to
   retract. Vacuous again, in the same suite, for a different reason. Separate fixtures now.
3. A `bulk_parallel_writer` arm that was a plain-INSERT arm wearing a GUC. That GUC does not
   change the write path at all; its only consulted site is
   `PgColumnarInsertNativeStorageRow`, where it skips an advisory lock, and
   `pgcolumnar.parallel_copy` sets it in its loader sessions. Removed and replaced with a real
   `pgcolumnar.parallel_copy` arm, which is the one write path where separate **backends**
   flush groups in their own (prepared) transactions, so it is the only place the invalidation
   crosses a process boundary. It needs `max_prepared_transactions >= workers`, set in
   `PGC_EXTRA_CONF` because it cannot be raised without a restart, and the loaded row count is
   asserted first so an under-provisioned run cannot read as a pass.

Two of my own checks were also caught by `harness_selftest`, and both were real: a
`printf | grep -q` in the Gather arm (the EPIPE shape selftest 080 exists to stop, now
`grep -c`), and selftest 260 counting only `diff_query_ordered` users as needing
`pgc_check_ordered_oracle` -- this suite calls the oracle directly through `pgc_seq_hash`, so
260's grep is widened rather than the premise dropped.

## Suites run

**Full PG17 matrix, `test/run_all_versions.sh`: 213 of 218 suites ran, ALL PASSED**, 5 skipped
(`analyze_differential`, `analyze_function`, `native_repack`, `pg19_vacuum_options`,
`temporal` -- all pre-existing PG18+/optional skips). The whole tree was run rather than a
derived subset, because this change alters path selection and a `grep -l` for the identifiers
it touches returns 98 of the suites.

That matrix run included `sorted_pathkeys` at 84 checks. The last 8 arms (`parallel_copy`,
the split `parallel_flush` fixtures, the TRUNCATE invariant) were added after it and have been
run standalone, 92 of 92, plus the removal proof above. CI covers the full matrix on the final
tree.

## Deliberately not in this PR

- **Text sort keys get no ordered path**, per the collation limitation above. Needs the
  collations recorded in the catalog.
- **`GROUP BY k` still gets no Group Aggregate.** That consequence is served by
  `PgColumnarTryGroupAggPath` in `columnar_vector.c`, not by any path this PR touches.
- **A sorted run plus a sorted tail is a merge, not a scan**, and is not attempted.

## One note on `truncate_useless_pathkeys`

It is called at the end for hygiene, and it can only ever shorten the claim to a prefix of
itself. A prefix of a valid ordering is a valid ordering, and a shorter claim makes
`pathkeys_contained_in` more likely to fail, which adds a `Sort` rather than removing one. So
it cannot turn a sound claim into an unsound one; the worst it can do is cost an optimisation.
