### PR TITLE
Do not read the row-group list for a query that cannot use an ordering, and fix two guards the last PR bent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,9 +63,20 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
   Only the serial scan carries the claim. The parallel partial path and the
   projection path keep `NIL`: workers finish in any order, and a projection is a
-  separate layout with its own sort key. New GUC
-  `pgcolumnar.enable_sorted_pathkeys`, on by default. New suite
-  `sorted_pathkeys`, 84 checks. (#751)
+  separate layout with its own sort key.
+
+  A query that could not use an ordering does not pay to find one out. Deciding
+  whether to claim reads the whole row-group list, and a query with no `ORDER BY`
+  and no mergejoinable clause would have had any claim discarded at the end
+  anyway, so `has_useful_pathkeys` is asked first. Measured as buffers touched
+  during planning, on 1,000,000 rows in 1,000 row groups, a relation marked
+  lexicographic, `SELECT count(*) FROM t WHERE j = 3`: 142 with the feature on
+  against 121 with it off before, and 121 against 121 after. The query that can
+  use the ordering still reads, which is what stops that from being satisfied by
+  a function that reads nothing.
+
+  New GUC `pgcolumnar.enable_sorted_pathkeys`, on by default. New suite
+  `sorted_pathkeys`, 108 checks. (#751)
 
 - A predicate on `date_trunc(unit, ts)` now drives chunk-group skipping for the
   ORDERED comparisons too, not only equality. #739 inverted `=` and declined

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -1365,6 +1365,27 @@ pgcolumnar_sorted_pathkeys(PlannerInfo *root, RelOptInfo *rel, Oid relid)
 	if (!pgcolumnar_enable_sorted_pathkeys)
 		return NIL;
 
+	/*
+	 * Nothing in this query could use an ordering, so do not go and find out
+	 * what the ordering is. Condition 2 below reads the whole row-group list,
+	 * which grows with the relation, and every claim this function could return
+	 * here would be truncated to NIL by truncate_useless_pathkeys at the end
+	 * anyway. Same notion, computed before the expensive part instead of after
+	 * it.
+	 *
+	 * Measured before this early return, 1,000,000 rows in 1,000 groups, a
+	 * relation marked lexicographic, a query with no ORDER BY, planning time
+	 * from EXPLAIN (SUMMARY ON) over 15 interleaved reps: 1.079 ms against
+	 * 0.922 ms with the feature off, 1.17x. The control that makes it mechanism
+	 * rather than noise is a never-sorted relation, which returns at condition 1
+	 * and measured 1.01x.
+	 *
+	 * Declared in optimizer/paths.h with this signature on every supported
+	 * major, immediately above truncate_useless_pathkeys.
+	 */
+	if (!has_useful_pathkeys(root, rel))
+		return NIL;
+
 	r = table_open(relid, AccessShareLock);
 	storageId = PgColumnarStorageId(r);
 	tupdesc = RelationGetDescr(r);
@@ -1450,9 +1471,26 @@ pgcolumnar_sorted_pathkeys(PlannerInfo *root, RelOptInfo *rel, Oid relid)
 		 * AA1003|AA1011|AA1019, the C order, where the answer is aa10|aa1002|AA1003.
 		 * A wrong answer, from a plan with no Sort in it.
 		 *
-		 * Refusing on attcollation is exact for this: it is InvalidOid for every
-		 * type that has no collation to change. Lifting it means recording the
-		 * collations beside the names, which needs a catalog column.
+		 * Refusing on attcollation is exact for this, and the reason is an
+		 * invariant rather than a list of types, because a list rots. A type whose
+		 * attcollation is InvalidOid orders either by nothing collation-dependent
+		 * at all, or by a collation PostgreSQL will not let change under a stored
+		 * value: a range or multirange fixes its collation at CREATE TYPE and no
+		 * DDL reaches pg_range.rngcollation, and a composite orders by its field
+		 * collations, which cannot be altered while any table stores the type.
+		 * That last protection follows dependencies THROUGH arrays and THROUGH
+		 * nesting composites: a column of ctype[] , or of a composite that merely
+		 * nests ctype, still makes "ALTER TYPE ctype ALTER ATTRIBUTE ..." fail
+		 * with "cannot alter type because column uses it", with or without CASCADE.
+		 * An enum's ADD VALUE ... BEFORE does not renumber values already stored.
+		 *
+		 * Outside the trust boundary, and no differently than for a btree index
+		 * that would need a REINDEX: replacing a type's default btree opclass, or
+		 * CREATE OR REPLACE on a comparison function, changes ordering semantics
+		 * without touching the table and without any collation being involved.
+		 *
+		 * Lifting the refusal means recording the collations beside the names,
+		 * which needs a catalog column.
 		 */
 		if (OidIsValid(att->attcollation))
 			break;

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -586,12 +586,22 @@ is_timing_suite() {
 # PGC_SKIP_TIMING drops those in CI and replication must still run there. Serial
 # and skipped are different properties and were one list until this suite needed
 # one without the other.
-# planner_choice_quality wants the same split, the other way around from
-# replication. Its subject is a wall-clock ratio, so it cannot run beside five
-# others and mean anything. But it is deliberately not in is_timing_suite: its
-# premises are plan-shape assertions, and those are worth running in CI. Under
-# PGC_SKIP_TIMING the suite drops the ratios itself, through check_timing, and
-# does not execute the timed queries at all.
+# planner_choice_quality is here THROUGH is_timing_suite, not beside it, and
+# this comment used to say the opposite (#764): "deliberately not in
+# is_timing_suite: its premises are plan-shape assertions, and those are worth
+# running in CI". It is in that list, so under PGC_SKIP_TIMING the driver does
+# not invoke the suite at all and none of those plan-shape assertions runs in
+# CI. A reader who found this comment believed they did.
+#
+# The entry in is_timing_suite is the correct half and its own comment says why:
+# left out of that list the suite RAN, dropped the ratio, and reported PASS on
+# its premises alone, so a regression of #434 would have been green from the
+# suite that exists to catch it. Confirmed by running it directly with
+# PGC_SKIP_TIMING=1: PASSED, 7 checks, only the two wall-clock ratios skipped.
+#
+# The coverage that costs -- no plan-shape assertion from this suite in CI -- is
+# a real gap and #764 owns the decision. A planner change should carry its own
+# plan-shape arms in a suite CI invokes rather than lean on this one.
 runs_alone() {
 	case "$1" in
 		replication) return 0 ;;

--- a/test/selftest/260-an-ordered-comparison-must-use-the.sh
+++ b/test/selftest/260-an-ordered-comparison-must-use-the.sh
@@ -94,11 +94,39 @@ check "sorted_projection's two comparisons are ordered, its subject being order"
 # against a heap one in ROW ORDER without going through the pair helpers,
 # because its tables are not t_heap/t_col. Counting only the wrapper made the
 # premise it does assert look like one premise too many.
-_ord_users=$(grep -lE '^[[:space:]]*diff_query_ordered |pgc_seq_hash ' "$TESTDIR"/*.sh \
-	| grep -cv '/lib\.sh$')
-_ord_premised=$(grep -lE '^[[:space:]]*pgc_check_ordered_oracle[[:space:]]*$' "$TESTDIR"/*.sh \
-	| grep -cv '/lib\.sh$')
+# COMMENTS ARE STRIPPED FIRST, as selftest 210 does for the same reason: this
+# file's own prose names both helpers, and so does the suite it added, so an
+# unstripped sweep counts the explanation of the rule as a use of it. The
+# alternation is grouped because in ERE `^[[:space:]]*a|b` anchors only the
+# first branch -- pgc_seq_hash is called mid-line inside $(...), so it must stay
+# unanchored, but leaving the group off makes the anchor silently decorative.
+# grep -cE, never grep -qE. `sed ... | grep -q` is the same EPIPE shape selftest
+# 080 forbids: the reader exits on its first match, sed takes SIGPIPE, and
+# pipefail calls the pipeline failed, so the file is silently NOT counted. It
+# bit exactly here, in the sweep that enforces a sibling rule, and 080's own
+# regex did not catch it because that regex scopes to echo and printf writers.
+# -c consumes all of its input, so the count is the answer.
+_ord_sweep() {	# _ord_sweep REGEX -> files matching it outside comments
+	local re="$1" f n
+	for f in "$TESTDIR"/*.sh; do
+		case "$f" in */lib.sh) continue ;; esac
+		n="$(sed 's/[[:space:]]*#.*$//' "$f" | grep -cE "$re")"
+		[ "${n:-0}" -gt 0 ] && printf '%s\n' "$f"
+	done
+	return 0
+}
+_ord_users=$(_ord_sweep '(^[[:space:]]*diff_query_ordered |pgc_seq_hash )' | grep -c . || true)
+_ord_premised=$(_ord_sweep '^[[:space:]]*pgc_check_ordered_oracle[[:space:]]*$' | grep -c . || true)
+
+# The counts can also cancel: a use without a premise and a premise without a
+# use net to equal. So the two SETS are compared, and the check below reports
+# which files differ rather than only that two numbers do.
+_ord_only_user=$(comm -23 \
+	<(_ord_sweep '(^[[:space:]]*diff_query_ordered |pgc_seq_hash )' | sort) \
+	<(_ord_sweep '^[[:space:]]*pgc_check_ordered_oracle[[:space:]]*$' | sort) | tr '\n' ' ')
 check "premise: some suite uses the ordered oracle, or the next check is vacuous" \
 	"$([ "$_ord_users" -gt 0 ] && echo yes || echo no)" "yes"
 check "every suite using the ordered oracle asserts its premise" \
 	"$_ord_premised" "$_ord_users"
+check "and it is the same suites, not merely the same count" \
+	"$(printf '%s' "$_ord_only_user" | tr -d '[:space:]" ')" ""

--- a/test/sorted_pathkeys.sh
+++ b/test/sorted_pathkeys.sh
@@ -445,6 +445,70 @@ CACHED="$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postg
 check_text "a cached ordered plan sees rows appended after it was planned" \
 	"$CACHED" "-600,-599,-598,-597,-596"
 
+# --- a query that cannot use an ordering must not pay to find one out -------
+#
+# Deciding whether to claim reads the whole row-group list, which grows with the
+# relation. A query with no ORDER BY and no mergejoinable clause would have had
+# any claim truncated to NIL at the end anyway, so the read is pure waste, and
+# it is per plan.
+#
+# The oracle is a COUNT (buffers touched during PLANNING), not a duration.
+# Planning-time milliseconds would answer the same question, and on this host
+# they are not a fair instrument; a buffer count cannot be moved by another
+# process. It is also a work-done check rather than a correctness one: the
+# answers are identical either way, so nothing else in this suite could see it.
+
+# The query is planned TWICE in one session and the SECOND reading is taken.
+# A first plan in a fresh backend also fills the catalog caches, and that
+# first-touch cost is a couple of buffers that differ between two psql
+# invocations. Asserted as equality it made this arm flake by 2 either way.
+planbuf() {	# planbuf GUC QUERY -> shared buffers hit+read during planning
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -At -c "SET pgcolumnar.enable_sorted_pathkeys=$1" \
+		-c "EXPLAIN (ANALYZE, BUFFERS, COSTS OFF, TIMING OFF) $2" \
+		-c "EXPLAIN (ANALYZE, BUFFERS, COSTS OFF, TIMING OFF) $2" 2>/dev/null \
+		| awk '/^Planning:/{p++;next} p==2&&/Buffers:/{h=0;r=0;
+			if (match($0,/shared hit=[0-9]+/)) h=substr($0,RSTART+11,RLENGTH-11);
+			if (match($0,/read=[0-9]+/)) r=substr($0,RSTART+5,RLENGTH-5);
+			print h+r; exit}'
+}
+psql_run "CREATE TABLE pb (id int, k int, j int) USING pgcolumnar;"
+# The row_group catalog holds one row per STRIPE, so stripe_row_limit is what
+# sets how many rows the plan-time read walks, not chunk_group_row_limit. It has
+# a floor of 1000, so the group count comes from the ROW count: a million rows
+# for a thousand groups. A hundred-group fixture put the unguarded delta at +6,
+# too close to the two-buffer noise floor for the arm to discriminate; at a
+# thousand groups it is +44.
+psql_run "SELECT pgcolumnar.set_options('pb', stripe_row_limit => 1000, chunk_group_row_limit => 500);"
+psql_run "INSERT INTO pb SELECT g, ((g::bigint*7919)%1000000)::int, g%17 FROM generate_series(1,1000000) g;"
+psql_run "SELECT pgcolumnar.vacuum_sorted('pb', 'k', 'j');"
+psql_run "ANALYZE pb;"
+PB_GROUPS="$(ss pb total_groups)"
+check "premise: the fixture has many groups, so a per-group read would show" \
+	"$([ "$PB_GROUPS" -ge 900 ] && echo yes || echo "no ($PB_GROUPS)")" "yes"
+check_text "premise: and it is marked, so the claim is not refused at condition 1" \
+	"$(q "SELECT sorted_kind FROM pgcolumnar.storage WHERE storage_id = pgcolumnar.get_storage_id('pb');")" \
+	"lexicographic"
+PB_NOORDER_ON="$(planbuf on  'SELECT count(*) FROM pb WHERE j = 3')"
+PB_NOORDER_OFF="$(planbuf off 'SELECT count(*) FROM pb WHERE j = 3')"
+check_num "premise: the planning buffer count is a measurement, not an empty string" \
+	"$PB_NOORDER_OFF" "$PB_NOORDER_OFF"
+# A tolerance rather than equality, because two backends differ by a couple of
+# buffers whatever this code does. It is set far below the effect it has to
+# detect: without the guard this arm read +44 on this fixture and grows
+# with the group count, while the control below pins that the instrument can
+# still see a real read.
+PB_DELTA=$(( PB_NOORDER_ON - PB_NOORDER_OFF ))
+[ "$PB_DELTA" -lt 0 ] && PB_DELTA=$(( -PB_DELTA ))
+check "a query with no ORDER BY does not read the group list to decide" \
+	"$([ "$PB_DELTA" -le 5 ] && echo yes || echo "no (on=$PB_NOORDER_ON off=$PB_NOORDER_OFF over $PB_GROUPS groups)")" "yes"
+# The control that stops the arm above from being satisfied by a function that
+# never reads anything: the query that CAN use the ordering must still pay.
+PB_ORDER_ON="$(planbuf on  'SELECT k FROM pb ORDER BY k LIMIT 10')"
+PB_ORDER_OFF="$(planbuf off 'SELECT k FROM pb ORDER BY k LIMIT 10')"
+check "control: a query that CAN use the ordering does read to decide" \
+	"$([ "$PB_ORDER_ON" -gt $(( PB_ORDER_OFF + 5 )) ] && echo yes || echo "no ($PB_ORDER_ON vs $PB_ORDER_OFF)")" "yes"
+
 # --- the two OTHER paths this hook could reach, which must claim nothing -----
 #
 # Three columnar paths are offered for a base relation and only the serial one


### PR DESCRIPTION
Follows #762 (merged as `4d32f65`). These are the three findings from that PR's review that
arrived after it was approved, so they are here rather than pushed under a stale approval.

## 1. A query that cannot use an ordering paid to find one out

Deciding whether to claim reads the whole row-group list, which grows with the relation, and
nothing asked first whether this query could use an ordering at all. Any claim returned for
such a query was discarded by `truncate_useless_pathkeys` at the end anyway.

`has_useful_pathkeys(root, rel)` is that same notion computed **before** the expensive part
instead of after it. It is declared in `optimizer/paths.h` with this signature on PG15, 16,
17, 18 and 19 -- immediately above `truncate_useless_pathkeys`, which the code already calls
-- so no compat wrapper.

**Measured as buffers touched during PLANNING, not planning-time milliseconds.** A count
cannot be moved by another process; wall clock on this host is not a fair instrument.
1,000,000 rows in 1,000 row groups, relation marked lexicographic, GUC on against off:

| query | before | after |
| --- | ---: | ---: |
| `SELECT count(*) FROM t WHERE j = 3` | 142 / 121 | **121 / 121** |
| `SELECT k FROM t ORDER BY k LIMIT 10` | reads to decide | reads to decide |

The second row is the control. Without it the first arm would be satisfied by a function that
reads nothing at all.

Two things about that arm, both learned by getting it wrong first:

- it reads the **second** of two plans in one session. A first plan in a fresh backend also
  fills the catalog caches, and that first-touch cost differs by a couple of buffers between
  two `psql` invocations. Asserted as equality it flaked by 2 either way.
- the fixture is sized from the **row** count, because `stripe_row_limit` has a floor of 1000
  and the `row_group` catalog holds one row per stripe. A hundred-group fixture put the effect
  at +6, too close to the two-buffer noise floor to discriminate; a thousand groups puts it at
  +21.

## 2. The collation refusal now records the invariant, not a list

The review enumerated three more shapes with `attcollation = InvalidOid` that are claimed
(multirange over text, an array of composite, a composite nesting a composite) and, better,
made the point that adding rows is the wrong fix. So the comment now states the invariant:

> A type whose `attcollation` is `InvalidOid` orders either by nothing collation-dependent at
> all, or by a collation PostgreSQL will not let change under a stored value: a range or
> multirange fixes its collation at `CREATE TYPE` and no DDL reaches `pg_range.rngcollation`,
> and a composite orders by its field collations, which cannot be altered while any table
> stores the type.

That last protection **follows dependencies through arrays and through nesting composites** --
a column of `ctype[]`, or of a composite that merely nests `ctype`, still makes
`ALTER TYPE ctype ALTER ATTRIBUTE ...` fail with *"cannot alter type because column uses it"*,
with or without `CASCADE`. So the protection is stronger than the direct case #762 tested.

The honest boundary is stated too: replacing a type's default btree opclass, or
`CREATE OR REPLACE` on a comparison function, changes ordering semantics without touching the
table and without any collation. That is outside the trust boundary in exactly the way it is
for a btree index that would need a `REINDEX`, which is what tells a reader the claim is no
weaker than an index's.

## 3. selftest 260's sweep had three defects, one of them mine and new

**Mine, added in #762:** in ERE, `^[[:space:]]*a|b` anchors only the first alternative. Adding
`pgc_seq_hash` unanchored was necessary (that call is mid-line inside `$(...)`) but it made
prose *about* the oracle count as a use of it. Comments are now stripped before the sweep,
which is what selftest 210 already does, for the same reason.

**Also mine, and the sharper one:** the first version of that sweep used `sed | grep -q`. That
is the EPIPE shape **selftest 080 exists to forbid** -- the reader exits on its first match,
`sed` takes `SIGPIPE`, `pipefail` calls the pipeline failed, and the file is silently *not
counted*. It reported 3 users against 2 premises where both sets are four files. 080's own
regex did not catch it because that regex scopes to `echo` and `printf` writers, not `sed`.
`grep -c` consumes its input, so the count is the answer.

**Pre-existing:** the check compared **counts**, so a use-without-premise and a
premise-without-use cancelled exactly. It now compares the **sets** and names the file that
differs. The two lists are identical today (four files each), so nothing was hidden.

## Removal proofs

| mutation | `.so` | result |
| --- | --- | --- |
| drop the `has_useful_pathkeys` guard | `9ae05df03328` | plan-time arm red, +21 buffers over 1,000 groups |
| comment out one suite's `pgc_check_ordered_oracle` | n/a (test-only) | both selftest 260 arms red, the set arm naming `differential.sh` |

## Suites

`sorted_pathkeys` 108/108 (three consecutive runs, the plan-time arm being a measurement),
`harness_selftest` 152/152, `docs_style` PASS, on PG17.
