### PR TITLE
Name the invariant the pathkeys early-out rests on, since it lives in planner.c and not in either function it relates

### DIFF
--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -1385,24 +1385,32 @@ pgcolumnar_sorted_pathkeys(PlannerInfo *root, RelOptInfo *rel, Oid relid)
 	 *
 	 * THE TWO ARE NOT THE SAME PREDICATE, and the equivalence relied on here
 	 * comes from planner.c rather than from either function body.
-	 * truncate_useless_pathkeys counts strictly more sources than
-	 * has_useful_pathkeys tests:
+	 * truncate_useless_pathkeys counts more sources than has_useful_pathkeys
+	 * tests, and neither list is stable across majors:
 	 *
-	 *   PG15/16  truncate: merging, ordering
-	 *   PG17     truncate: merging, ordering, grouping, setop
-	 *   PG18/19  truncate: merging, ordering, grouping, distinct, setop
-	 *   all      has_useful: merging, grouping, query_pathkeys
+	 *   major     truncate counts                              has_useful tests
+	 *   PG15/16   merging, ordering                             merging, query_pathkeys
+	 *   PG17      merging, ordering, grouping, setop            merging, group, query_pathkeys
+	 *   PG18      merging, ordering, grouping, distinct, setop  merging, group, query_pathkeys
+	 *   PG19      merging, sort, window, setop, group, distinct merging, query_pathkeys
 	 *
 	 * Read that way, a query whose only use for an ordering is DISTINCT or a
 	 * set operation looks like it would be skipped here while the old code kept
 	 * the claim. It is not, because standard_qp_callback assigns
 	 * root->query_pathkeys from whichever clause the query has -- group, else
-	 * window, else distinct, else sort, else setop, else NIL -- so every extra
-	 * source truncate counts is one of the five that funnel into query_pathkeys.
-	 * has_useful_pathkeys false therefore implies truncate_useless_pathkeys
-	 * would have returned NIL. Checked in planner.c on 15, 17, 18 and 19.
+	 * window, else distinct, else sort, else setop, else NIL -- so every source
+	 * truncate counts beyond merging is one of the five that funnel into
+	 * query_pathkeys. has_useful_pathkeys false therefore implies
+	 * truncate_useless_pathkeys would have returned NIL. Read in planner.c and
+	 * pathkeys.c on 15, 16, 17, 18 and 19.
 	 *
-	 * That is worth stating because it is the assumption a later major can
+	 * The right-hand column is itself the evidence that the funnel is deliberate
+	 * rather than incidental. PG17 added grouping to truncate AND a group_pathkeys
+	 * test to has_useful; PG19 REMOVED that test again while keeping grouping in
+	 * truncate, which is only correct because group_pathkeys reaches
+	 * query_pathkeys. Core relies on the same identity this does.
+	 *
+	 * It is still worth stating, because it is the assumption a later major can
 	 * break. If those five stop funnelling through query_pathkeys -- PG19 has
 	 * already restructured this area once -- this early return starts dropping
 	 * legitimate claims SILENTLY, and no test can see it: the result is a lost

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -1382,6 +1382,31 @@ pgcolumnar_sorted_pathkeys(PlannerInfo *root, RelOptInfo *rel, Oid relid)
 	 *
 	 * Declared in optimizer/paths.h with this signature on every supported
 	 * major, immediately above truncate_useless_pathkeys.
+	 *
+	 * THE TWO ARE NOT THE SAME PREDICATE, and the equivalence relied on here
+	 * comes from planner.c rather than from either function body.
+	 * truncate_useless_pathkeys counts strictly more sources than
+	 * has_useful_pathkeys tests:
+	 *
+	 *   PG15/16  truncate: merging, ordering
+	 *   PG17     truncate: merging, ordering, grouping, setop
+	 *   PG18/19  truncate: merging, ordering, grouping, distinct, setop
+	 *   all      has_useful: merging, grouping, query_pathkeys
+	 *
+	 * Read that way, a query whose only use for an ordering is DISTINCT or a
+	 * set operation looks like it would be skipped here while the old code kept
+	 * the claim. It is not, because standard_qp_callback assigns
+	 * root->query_pathkeys from whichever clause the query has -- group, else
+	 * window, else distinct, else sort, else setop, else NIL -- so every extra
+	 * source truncate counts is one of the five that funnel into query_pathkeys.
+	 * has_useful_pathkeys false therefore implies truncate_useless_pathkeys
+	 * would have returned NIL. Checked in planner.c on 15, 17, 18 and 19.
+	 *
+	 * That is worth stating because it is the assumption a later major can
+	 * break. If those five stop funnelling through query_pathkeys -- PG19 has
+	 * already restructured this area once -- this early return starts dropping
+	 * legitimate claims SILENTLY, and no test can see it: the result is a lost
+	 * optimisation, not a wrong answer.
 	 */
 	if (!has_useful_pathkeys(root, rel))
 		return NIL;

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -1415,6 +1415,23 @@ pgcolumnar_sorted_pathkeys(PlannerInfo *root, RelOptInfo *rel, Oid relid)
 	 * already restructured this area once -- this early return starts dropping
 	 * legitimate claims SILENTLY, and no test can see it: the result is a lost
 	 * optimisation, not a wrong answer.
+	 *
+	 * The risk that carries is bounded, and by the same yardstick the collation
+	 * refusal below uses. This is not a novel shortcut: it is the guard core puts
+	 * in front of a btree index's pathkeys. indxpath.c gates, builds, then
+	 * truncates, in that order, on every supported major:
+	 *
+	 *     pathkeys_possibly_useful = (scantype != ST_BITMAPSCAN &&
+	 *                                 has_useful_pathkeys(root, rel));
+	 *     if (index_is_ordered && pathkeys_possibly_useful) {
+	 *         index_pathkeys = build_index_pathkeys(...);
+	 *         useful_pathkeys = truncate_useless_pathkeys(root, rel, index_pathkeys);
+	 *     }
+	 *
+	 * has_useful_pathkeys has three callers in core and that one is structurally
+	 * identical to this. So if the funnel ever breaks, an ordered index on the
+	 * same column loses the same optimisation in the same query. No weaker than
+	 * an index is the bar, and it is met.
 	 */
 	if (!has_useful_pathkeys(root, rel))
 		return NIL;


### PR DESCRIPTION
Follows #763. Comment only, no behaviour change.

The review of #763 made a point I had glossed: I wrote that `has_useful_pathkeys` is "the
same notion" as `truncate_useless_pathkeys` computed earlier. **From the two function bodies
alone that is false.** `truncate_useless_pathkeys` counts strictly more sources:

| | truncate counts | has_useful tests |
| --- | --- | --- |
| PG15/16 | merging, ordering | merging, grouping, `query_pathkeys` |
| PG17 | merging, ordering, grouping, setop | merging, grouping, `query_pathkeys` |
| PG18/19 | merging, ordering, grouping, distinct, setop | merging, grouping, `query_pathkeys` |

Read that way, a query whose only use for an ordering is `DISTINCT` or a set operation looks
like it would be skipped by the early return while the old code kept the claim.

**It is not, and what closes it is in `planner.c`.** `standard_qp_callback` assigns
`root->query_pathkeys` from whichever clause the query has -- group, else window, else
distinct, else sort, else setop, else NIL -- so every extra source `truncate` counts is one of
the five that funnel into `query_pathkeys`. `has_useful_pathkeys` false therefore implies
`truncate_useless_pathkeys` would have returned NIL.

Read in `planner.c` on **15, 17, 18 and 19** rather than taken on the argument (PG15 has no
setop branch because `setop_pathkeys` did not exist yet, which does not weaken it).

## Why a comment is worth a PR here

The funnel is the assumption a later major can break, and PG19 has already restructured this
area once. If it breaks, the early return starts dropping legitimate claims **silently**, and
**no test can see it**: the result is a lost optimisation, not a wrong answer, so there is
nothing to go red. What was written before was the conclusion; a reader could not have checked
it without re-deriving this.

Credit to the reviewer of #763 for catching that the stated reason did not support the stated
conclusion, and for locating the assignment that does.

`sorted_pathkeys` 108/108 on PG17.