### PR TITLE
Correct the parallel-scan limitation: it does not ship fewer rows, and the heap does not flip at half the rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,13 +130,14 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
   The effect itself is real and larger than recorded. Over the eleven query
   shapes where the planner chose the serial scan, the parallel plan ran 1.8 to
-  2.6 times faster on the median, and in every shape the slowest parallel run
-  beat the fastest serial run. "Narrow" turns out to mean narrow in **columns**.
-  Two mechanisms produce it, both now stated: `parallel_tuple_cost` is charged
-  per row and is blind to width, overstating a narrow row by about 1.9 times at a
-  constant volume of data shipped; and the columnar scan cost is a half to a
-  fifth of what its real time implies, by an amount that varies with the number
-  of columns read. (#753)
+  2.5 times faster on the median, and in every shape the slowest parallel run
+  beat the fastest serial run, by 1.45 times at the narrowest margin. "Narrow"
+  turns out to mean narrow in **columns**. Two mechanisms produce it, both now
+  stated: `parallel_tuple_cost` is charged per row and is blind to width,
+  overstating a narrow row by about 1.9 times at a constant volume of data
+  shipped; and the columnar scan cost is two fifths to seven tenths of what its
+  real time implies, by an amount that is largest on the narrowest projection.
+  (#753)
 
 - Both eager ordering rewrites discarded the ordering they had just applied.
   `pgcolumnar.storage.sorted_by` and `sorted_kind` exist to record which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,28 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ### Fixed
 
+- `docs/limitations.md`'s account of parallel scans stated two things that are
+  not true, and gave a cause the arithmetic does not support. It said a columnar
+  scan "ships fewer, already-decoded rows" than a heap scan, and that "a heap
+  scan on the same shape also flipped" at about half the default
+  `parallel_tuple_cost`.
+
+  Re-measured on 4,000,000 rows in a 14 column table with a heap twin holding the
+  same rows. The two plans ship the **same** number of rows, 999,987, so the
+  Gather charge is identical at 99,999; what differs is tuple width, three
+  projected columns against fourteen. And the heap does not flip at half the
+  default: columnar turns parallel at 0.060 and the heap at 0.030.
+
+  The effect itself is real and larger than recorded. Over the eleven query
+  shapes where the planner chose the serial scan, the parallel plan ran 1.8 to
+  2.6 times faster on the median, and in every shape the slowest parallel run
+  beat the fastest serial run. "Narrow" turns out to mean narrow in **columns**.
+  Two mechanisms produce it, both now stated: `parallel_tuple_cost` is charged
+  per row and is blind to width, overstating a narrow row by about 1.9 times at a
+  constant volume of data shipped; and the columnar scan cost is a half to a
+  fifth of what its real time implies, by an amount that varies with the number
+  of columns read. (#753)
+
 - Both eager ordering rewrites discarded the ordering they had just applied.
   `pgcolumnar.storage.sorted_by` and `sorted_kind` exist to record which
   ordering a rewrite left behind, and the base schema has always specified them

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -347,8 +347,9 @@ parallel one is faster.
 
 This was measured on 4,000,000 rows in a table of 14 columns. Eleven query shapes
 were tested, all of them shapes where the planner chose the serial scan. The
-parallel plan ran 1.8 to 2.6 times faster on the median. In every shape the
-slowest parallel run still beat the fastest serial run.
+parallel plan ran 1.8 to 2.5 times faster on the median. In every shape the
+slowest parallel run was still faster than the fastest serial run, by 1.45 times
+at the narrowest margin.
 
 "Narrow" here means few columns, not few rows. A scan that reads three columns of
 fourteen decodes little. The serial plan is therefore cheap, and a fixed per row
@@ -367,10 +368,11 @@ times. This applies to any narrow projection, on a heap table as much as a
 columnar one.
 
 Second, the columnar scan cost is low against the time it takes. The same query
-was measured on a heap table holding the same rows. The columnar scan is priced
-at a half to a fifth of what its real time implies. The size of that error changes
-with the number of columns read. That is recorded separately, because it affects
-every plan comparison and not only this one.
+was measured on a heap table holding the same rows, over a ladder of one to eight
+integer columns. The columnar scan is priced at two fifths to seven tenths of what
+its real time implies. The error is largest on the narrowest projection, which is
+where this problem lives. That is recorded separately, because it affects every
+plan comparison and not only this one.
 
 `parallel_tuple_cost` is a global setting applied through the core Gather cost.
 An access method cannot set its own value without a core change. Lowering the

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -342,31 +342,45 @@ A columnar scan can run in parallel, and the planner builds a parallel path for
 it. On a wide projection it now chooses that path, because the per-column decode
 cost is priced and a parallel plan divides it across workers.
 
-On a narrow but selective scan the planner still prefers the serial plan even
-where the parallel one is faster. Measured: a three-column selective scan of a
-four-million-row table ran up to 2.5x faster in parallel, and the planner chose
-serial anyway.
+On a narrow projection the planner still prefers the serial plan where the
+parallel one is faster.
 
-The cause is the cost of the Gather node. The planner prices each row passed from
-a worker to the leader at `parallel_tuple_cost`, the same rate it uses for a heap
-scan. A columnar scan ships fewer, already-decoded rows, so that rate overstates
-its Gather cost. On the shape above the Gather cost reached almost the whole cost
-of the serial scan. The serial plan won on cost while losing on the clock.
+This was measured on 4,000,000 rows in a table of 14 columns. Eleven query shapes
+were tested, all of them shapes where the planner chose the serial scan. The
+parallel plan ran 1.8 to 2.6 times faster on the median. In every shape the
+slowest parallel run still beat the fastest serial run.
 
-The default rate is conservative for any row-returning parallel scan, not only a
-columnar one. A heap scan on the same shape also flipped and ran faster at the
-lower rate. A columnar scan is affected most, because its own cost is low and the
-Gather cost then dominates. About half the default rate picks the faster plan on
-the shape above.
+"Narrow" here means few columns, not few rows. A scan that reads three columns of
+fourteen decodes little. The serial plan is therefore cheap, and a fixed per row
+charge above it then decides the comparison.
 
-That rate is a global setting, applied through the core Gather cost. An access
-method cannot set its own value without a core change. Lowering the global setting
-is not the fix, because it changes the rate for every table on the system and the
-evidence is one workload.
+Two things produce this and both apply.
+
+First, the planner charges each row passed from a worker to the leader at
+`parallel_tuple_cost`. That is a fixed amount per row. It does not depend on how
+wide the row is.
+
+This was measured at a constant volume of data shipped. Tripling the row count
+and thirding the width raised the real cost of the transfer by 1.56 times. The
+charge rose by 3 times. The charge therefore overstates a narrow row by about 1.9
+times. This applies to any narrow projection, on a heap table as much as a
+columnar one.
+
+Second, the columnar scan cost is low against the time it takes. The same query
+was measured on a heap table holding the same rows. The columnar scan is priced
+at a half to a fifth of what its real time implies. The size of that error changes
+with the number of columns read. That is recorded separately, because it affects
+every plan comparison and not only this one.
+
+`parallel_tuple_cost` is a global setting applied through the core Gather cost.
+An access method cannot set its own value without a core change. Lowering the
+global setting is not a general fix, because it changes the rate for every table
+on the system.
 
 The workaround is to force the parallel plan when it helps, with `SET
 max_parallel_workers_per_gather` and a lower `SET parallel_tuple_cost` for the
-session.
+session. On the shape above the columnar plan turns parallel at 0.060. A heap
+plan on the same rows turns parallel at 0.030. The default is 0.100.
 
 ## Index-only scans
 


### PR DESCRIPTION
Documentation only. Closes nothing; it corrects what `docs/limitations.md` says about #753,
which is now measured (see the measurement comment on #753).

## Two statements that are not true

**"A columnar scan ships fewer, already-decoded rows, so that rate overstates its Gather
cost."** It ships the same number of rows. Measured on 4,000,000 rows in a 14-column table
against a heap twin holding the same rows, both ship 999,987, so the Gather tuple charge is
identical at 99,999. What differs is tuple **width** (3 projected columns against 14) and the
denominator:

| | serial cost | Gather charge at 0.1 | as % of serial |
| --- | ---: | ---: | ---: |
| columnar | 83,196 | 99,999 | **120%** |
| heap | 158,109 | 99,999 | 63% |

**"A heap scan on the same shape also flipped ... About half the default rate picks the faster
plan."** The heap does not flip at half. Columnar turns parallel at `parallel_tuple_cost`
0.060, the heap at 0.030, against a default of 0.100 — so at the doc's own 0.05, columnar
flips and the heap does not.

## The effect is real, and larger than the doc recorded

Over the **eleven** query shapes where the planner chose the serial scan, the parallel plan
ran 1.8 to 2.6 times faster on the median, and **in every shape the slowest parallel run beat
the fastest serial run**. The finding is that non-overlap, not a ratio.

Every parallel arm asserts `Workers Launched == Workers Planned` (a plan can say `Gather` and
run with zero workers, and it still says `Gather`), and chunk groups read was 27 of 27 in
every cell, so no cell is confounded by zone-map pruning leaving the parallel arm nothing to
divide. Host loadavg 0.70 to 1.29 throughout; contention biases *against* finding a parallel
speedup, and it was found anyway.

## "Narrow but selective" means narrow in COLUMNS

Fewer columns means less decode, so the serial scan is cheap, and a fixed per-row charge above
it decides the comparison. That is why the doc's own shape could not be reproduced on a
5-column fixture: projecting 3 of 5 is not narrow.

## Two mechanisms, both now stated

**`parallel_tuple_cost` is charged per row and is blind to width.** At a constant volume of
data shipped (11.44 MiB both arms), tripling the row count and thirding the width raised the
real transfer cost by 1.56x while the charge rose by 3.00x — so a narrow row is overstated by
about 1.9x. Narrowness is a projection property, not a storage-format one, so this half is
core's and applies to a heap with the same narrow projection.

**The columnar scan cost is low against the time it takes**, by an amount that varies with the
number of columns read. That half is ours and is #766, kept separate on purpose: the scan cost
is the scale every other path comparison is judged against, including the index-fetch penalty
(#355, #362) and the point-lookup regression #171 exists for, so a recalibration cannot ride
along under a parallelism ticket.

## Gate

`docs_style` PASS. Documentation only, no code.