### PR TITLE
Assert the claim the whole of #754 rests on: a columnar table is not a logical decoding source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,30 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
   truncated, are declined rather than approximated. A new suite,
   `preimage_rewrite`, measures the pruning and pins each declined shape. (#403)
 
+### Added
+
+- A suite for the claim under `docs/limitations.md`'s "Replication and backup":
+  that a columnar table is not a logical decoding source. The whole of #754 rests
+  on that sentence and nothing asserted it. The only other logical-replication
+  coverage, `logical_subscriber`, tests the opposite direction, a heap publisher
+  into a columnar subscriber.
+
+  Measured through a `test_decoding` slot created before any row is written, on a
+  heap table and a columnar table of identical shape holding the same 50 rows:
+
+  | | decoded changes |
+  | --- | ---: |
+  | `public.heap_t` (control) | 50 |
+  | `public.col_t` (columnar) | **0** |
+  | `pgcolumnar.*` (internal) | 8 |
+
+  The heap control is the load-bearing arm, because zero decoded changes is also
+  what a broken slot, a mis-built plugin or a query against the wrong slot looks
+  like. The second documented behaviour is asserted too: the slot is not silent,
+  it carries pgcolumnar's own catalog writes, and that churn scales with row
+  groups and chunks rather than rows. 100 times the rows gives 8 records against
+  10, not 800. New suite `logical_decoding_source`. (#754)
+
 ### Fixed
 
 - `docs/limitations.md`'s account of parallel scans stated two things that are

--- a/test/logical_decoding_source.sh
+++ b/test/logical_decoding_source.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+#
+# pgColumnar is not a logical decoding source (#754).
+#
+# docs/limitations.md states it: logical decoding reads the WAL records of heap
+# tuples, columnar data reaches WAL as full-page images which carry no tuple
+# structure, so no change to a columnar table is emitted. That sentence is the
+# premise under a whole class of user expectations -- CDC, blue-green upgrades,
+# selective logical replication -- and until this suite it was asserted nowhere.
+#
+# The only other logical-replication coverage in the tree, logical_subscriber.sh,
+# tests the OPPOSITE direction: a heap publisher into a columnar subscriber. That
+# direction works and is the shape most likely to bring users. Nothing tested
+# the source direction, which is the one the limitation is about.
+#
+# WHY THE HEAP CONTROL IS THE LOAD-BEARING ARM. "Zero changes decoded" is what a
+# working exclusion looks like and it is also what a broken slot, a mis-built
+# plugin, or a query against the wrong slot looks like. The columnar arm cannot
+# mean anything on its own. So a heap table of identical shape is written in the
+# same transaction, through the same slot, and asserted to decode -- proving the
+# instrument sees changes before the absence of one is believed.
+#
+# Usage:  test/logical_decoding_source.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# Logical decoding needs the WAL to carry enough to decode from, and the level
+# cannot be raised without a restart.
+export PGC_EXTRA_CONF="wal_level=logical
+max_replication_slots=8
+max_wal_senders=8"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+# test_decoding is stock contrib, but it is not built by default in a source
+# install. A missing dependency is an environment defect rather than a pass.
+if [ ! -f "$("$PGC_PG_CONFIG" --pkglibdir)/test_decoding.so" ]; then
+	pgc_skip "test_decoding" "test_decoding.so is not in $("$PGC_PG_CONFIG" --pkglibdir); build contrib/test_decoding"
+fi
+
+check "premise: the server is running at wal_level=logical" \
+	"$(q "SHOW wal_level;")" "logical"
+
+# Identical shape, identical rows, one heap and one columnar.
+psql_run "CREATE TABLE heap_t (id int PRIMARY KEY, v text) USING heap;"
+psql_run "CREATE TABLE col_t (id int PRIMARY KEY, v text) USING pgcolumnar;"
+
+# THE SLOT IS CREATED BEFORE ANY ROW IS WRITTEN. A slot only carries changes
+# made after it exists, so rows written first would be absent from BOTH arms and
+# the heap control would fail for the wrong reason.
+#
+# Created with pg_create_logical_replication_slot rather than CREATE
+# SUBSCRIPTION: a subscription pointed at its own cluster self-deadlocks, since
+# it runs in a transaction and logical slot creation waits for running
+# transactions including that one. It hangs with the walsender on
+# Lock/transactionid rather than failing.
+psql_run "SELECT pg_create_logical_replication_slot('pgc_754', 'test_decoding');"
+check "premise: the slot exists and is logical" \
+	"$(q "SELECT slot_type FROM pg_replication_slots WHERE slot_name = 'pgc_754';")" "logical"
+
+psql_run "INSERT INTO heap_t SELECT g, 'h' || g FROM generate_series(1, 50) g;"
+psql_run "INSERT INTO col_t  SELECT g, 'c' || g FROM generate_series(1, 50) g;"
+
+check_num "premise: both tables hold the same 50 rows" \
+	"$(q 'SELECT count(*) FROM heap_t;')" "$(q 'SELECT count(*) FROM col_t;')"
+
+# Drain the slot once into a temp table; every count below reads that snapshot,
+# so the arms cannot disagree about which changes they saw.
+psql_run "CREATE TABLE decoded AS
+          SELECT data FROM pg_logical_slot_get_changes('pgc_754', NULL, NULL);"
+
+d() { q "SELECT count(*) FROM decoded WHERE data LIKE '%$1%';"; }
+
+check "premise: the slot decoded something at all" \
+	"$([ "$(q 'SELECT count(*) FROM decoded;')" -gt 0 ] && echo yes || echo no)" "yes"
+
+# ------------------------------------------------------- the control, first
+
+check_num "CONTROL: the heap table's 50 inserts ARE decoded" \
+	"$(d 'table public.heap_t: INSERT')" "50"
+
+# ------------------------------------------------------- the claim itself
+
+check_num "a columnar table emits no decodable change" \
+	"$(d 'table public.col_t:')" "0"
+
+# And not because the rows are missing: they are in the table, and the heap
+# control above proves the slot was live across the same window.
+check_num "although the rows are there" "$(q 'SELECT count(*) FROM col_t;')" "50"
+
+# ---------------------------------------- the slot is not silent, it is noisy
+
+# The second half of the documented behaviour: a slot on a database holding
+# columnar tables is not empty, it carries pgcolumnar's own catalog writes. A
+# consumer sees internal churn it cannot interpret rather than nothing at all.
+check "the slot carries pgcolumnar's internal catalog instead" \
+	"$([ "$(d 'table pgcolumnar.')" -gt 0 ] && echo yes || echo no)" "yes"
+
+# That churn scales with GROUPS and CHUNKS, not with rows, which is what makes
+# it useless as a change stream: it does not carry the data and it does not even
+# carry a row count. Asserted by writing 100x the rows into a second columnar
+# table and showing the record count does not follow.
+psql_run "CREATE TABLE col_big (id int PRIMARY KEY, v text) USING pgcolumnar;"
+psql_run "SELECT pg_create_logical_replication_slot('pgc_754b', 'test_decoding');"
+psql_run "INSERT INTO col_big SELECT g, 'c' || g FROM generate_series(1, 5000) g;"
+psql_run "CREATE TABLE decoded_big AS
+          SELECT data FROM pg_logical_slot_get_changes('pgc_754b', NULL, NULL);"
+SMALL="$(d 'table pgcolumnar.')"
+BIG="$(q "SELECT count(*) FROM decoded_big WHERE data LIKE '%table pgcolumnar.%';")"
+check "premise: the 100x table really holds 100x the rows" \
+	"$(q 'SELECT count(*) FROM col_big;')" "5000"
+check_num "and it too emits no decodable change of its own" \
+	"$(q "SELECT count(*) FROM decoded_big WHERE data LIKE '%table public.col_big:%';")" "0"
+echo "-- internal pgcolumnar records: $SMALL for 50 rows, $BIG for 5000"
+check "100x the rows does not give 100x the internal records" \
+	"$([ "$BIG" -lt $(( SMALL * 10 )) ] && echo yes || echo "no ($SMALL then $BIG)")" "yes"
+
+psql_run "SELECT pg_drop_replication_slot('pgc_754');"
+psql_run "SELECT pg_drop_replication_slot('pgc_754b');"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -108,6 +108,7 @@ SUITES=(
 	index_only
 	isolation
 	local_open_race_free
+	logical_decoding_source
 	logical_subscriber
 	maintenance_due
 	native_agg


### PR DESCRIPTION
`docs/limitations.md` states it and #754 is built on it. **Nothing in the tree asserted it.**

The only other logical-replication coverage, `logical_subscriber.sh`, tests the **opposite**
direction — a heap publisher into a columnar subscriber (`:87` heap, `:90` columnar) — and
every slot in `replication.sh` is physical. The source direction, which is the one the
limitation is about, had no test behind it.

## Measured

A `test_decoding` slot created **before any row is written**, a heap table and a columnar
table of identical shape, the same 50 rows into each:

| | decoded changes |
| --- | ---: |
| `public.heap_t` (control) | **50** |
| `public.col_t` (columnar) | **0** |
| `pgcolumnar.*` (internal) | 8 |

## The heap control is the load-bearing arm

Zero decoded changes is what a working exclusion looks like. It is equally what a broken slot,
a mis-built plugin, a slot created after the writes, or a query against the wrong slot looks
like. **The columnar arm cannot mean anything on its own.**

So a heap table of identical shape is written through the same slot in the same window and
asserted to decode. That establishes the instrument sees changes before the absence of one is
believed — the same shape as proving a secret is a secret before measuring how well it leaks.

## The second documented behaviour, also asserted

The slot is **not silent**: it carries pgcolumnar's own catalog writes, so a consumer sees
internal churn it cannot interpret rather than nothing at all. And that churn scales with
**row groups and chunks, not rows**, which is what makes it useless as a change stream — it
carries neither the data nor even a row count:

```
internal pgcolumnar records: 8 for 50 rows, 10 for 5000
```

100x the rows, 1.25x the records.

## Removal proofs — two, because a zero has at least two ways of being true for the wrong reason

**A zero is the headline assertion here**, so it needs a demonstrated guard against each way it
could be satisfied by accident. There are two, and they are independent.

**1. Wrong storage type.** Making `col_t` a heap table:

```
FAIL  a columnar table emits no decodable change: got [50] want [0]
FAIL  the slot carries pgcolumnar's internal catalog instead: got [no] want [yes]
FAIL  100x the rows does not give 100x the internal records: got [no (0 then 10)] want [yes]
```

So the claim discriminates on the storage type.

**2. Slot not live across the write window.** Moving
`pg_create_logical_replication_slot` to **after** both `INSERT`s, nothing else changed (run by
the reviewer):

```
PASS  a columnar table emits no decodable change          <-- the claim, now VACUOUS
FAIL  CONTROL: the heap table's 50 inserts ARE decoded: got [0] want [50]
FAIL  premise: the slot decoded something at all: got [no] want [yes]
FAIL  the slot carries pgcolumnar's internal catalog instead: got [no] want [yes]
FAIL  100x the rows does not give 100x the internal records: got [no (0 then 10)] want [yes]
```

**The claim arm passes against a slot that decoded nothing at all**, and four independent
guards catch it. That is the mutation that tests the sentence "the heap control is the
load-bearing arm", and it confirms it — while showing the control is not alone, which is the
right amount of redundancy for a suite whose headline is a zero.

The second proof could only come from the reviewer: it is an attack on the arm the author
wrote in order to be trustworthy, and the author is the one person who cannot run it.

## Two traps recorded in the suite's comments

- **`CREATE SUBSCRIPTION` against the same cluster self-deadlocks.** It runs in a transaction
  and logical slot creation waits for running transactions including its own; it hangs with
  the walsender on `Lock/transactionid` rather than failing. The slot is created with
  `pg_create_logical_replication_slot` and read directly.
- **`test_decoding` is stock contrib but is not built by default in a source install.** Its
  absence is reported as an environment defect through `pgc_skip`, not passed over. Building
  it in-tree with `make install PG_CONFIG=…` ignores the flag and returns 0, so verify the
  artifact landed rather than the exit status.

`wal_level=logical` cannot be raised without a restart, so it is set through `PGC_EXTRA_CONF`
before the cluster starts.

## It runs in CI, checked rather than assumed

A suite gated on a contrib plugin is one `pgc_skip` away from never running where it matters,
which is the #764 shape exactly. The `suites` legs install PG from PGDG apt packages
(`ci.yml:331-341`) and `postgresql-18` ships `test_decoding.so`. The only from-source build is
the PG19 beta **build** job, which runs `make -C src install` (`ci.yml:292`) and so has no
contrib — but it compiles the extension and runs no suites. So the `pgc_skip` is a correct
guard for a developer box, not a hole in the gate.

Worth confirming on the finished run that the summary line reads
`logical_decoding_source=PASS` and not `=SKIP`: those are indistinguishable from the job
colour, and this is precisely the suite where a silent skip would restore the situation it was
written to end.

## Gate

`logical_decoding_source` 11/11, `harness_selftest` 152/152, `logical_subscriber` PASS,
`docs_style` PASS, on PG17. Registered in `run_all_versions.sh`.

Credit to the reviewer for testing the claim and for both traps above; this reproduces their
result independently and turns it into an arm.
