### PR TITLE
selftest 080 never scanned bench/, and bench/ had six instances of the shape it forbids

### DIFF
--- a/bench/run_bench_join.sh
+++ b/bench/run_bench_join.sh
@@ -273,7 +273,10 @@ plan_of() {  # plan_of <table> <sql-with-%T>
 note "== premises on the plans"
 for shape in "${SHAPE_A[@]}"; do
 	ct=$(fact_name columnar "$shape")
-	printf '%s\n' "${ARM_A[@]}" | grep -q columnar || continue
+	# grep -c, not grep -q: -q exits on its first match, the printf takes
+	# SIGPIPE, and under pipefail the pipeline is called failed -- reporting the
+	# arm ABSENT whatever the list held (selftest 080). -c consumes its input.
+	[ "$(printf '%s\n' "${ARM_A[@]}" | grep -c '^columnar$')" -gt 0 ] || continue
 
 	# The claim this whole issue turns on: our vectorized aggregate sits directly
 	# above our scan, so a join between them disables it. Asserted on both sides,

--- a/bench/run_clickbench.sh
+++ b/bench/run_clickbench.sh
@@ -518,7 +518,7 @@ done
 # fails on hits.Title and leaves an EMPTY table, and the queries then all "run"
 # while measuring nothing.
 DUCK_DB="$CB_DATA/clickbench.duckdb"
-if printf '%s\n' "${ARMS[@]}" | grep -qx duckdb; then
+if [ "$(printf '%s\n' "${ARMS[@]}" | grep -cx duckdb)" -gt 0 ]; then
 	command -v duckdb >/dev/null 2>&1 || die "the duckdb arm was asked for and duckdb is not on PATH"
 	note "== loading duckdb (persistent file, not in memory)"
 	rm -f "$DUCK_DB" "$DUCK_DB.wal"
@@ -677,7 +677,7 @@ require "the sample spans many counters, not a handful" \
 # The columnar arm must actually be reading through the columnar scan. If the
 # planner falls back, this measures PostgreSQL reading columnar storage badly
 # and reports it as a columnar result.
-if printf '%s\n' "${ARMS[@]}" | grep -qx columnar; then
+if [ "$(printf '%s\n' "${ARMS[@]}" | grep -cx columnar)" -gt 0 ]; then
 	plan=$($PSQL -At -c "EXPLAIN (COSTS OFF) SELECT count(*) FROM hits_col WHERE CounterID = 62" 2>&1)
 	require "the columnar arm plans a columnar scan" \
 		"$(grep -qi 'columnar' <<<"$plan" && echo yes || echo no)" "yes" || fail=1
@@ -686,7 +686,7 @@ fi
 # And the tuned arm must actually be vectorizing. EXPLAIN prints the same node
 # name, Custom Scan (ColumnarScan), whether or not the aggregate is vectorized,
 # so the node name cannot tell them apart. The property line can.
-if printf '%s\n' "${ARMS[@]}" | grep -qx columnar_tuned; then
+if [ "$(printf '%s\n' "${ARMS[@]}" | grep -cx columnar_tuned)" -gt 0 ]; then
 	vplan=$($PSQL -At -c "$(arm_settings columnar_tuned)
 		EXPLAIN (COSTS OFF) SELECT CounterID, count(*) FROM hits_col GROUP BY CounterID" 2>&1)
 	require "the tuned arm plans a vectorized aggregate" \
@@ -823,9 +823,9 @@ require "every query in the file ran" "$qn" "$NQUERIES" || fail=1
 echo
 echo "================= CLICKBENCH, pgColumnar $EXTVER ================="
 cb_cold_tag "$CB_DROP_HOW"
-printf '%s\n' "${ARMS[@]}" | grep -qx duckdb && \
+[ "$(printf '%s\n' "${ARMS[@]}" | grep -cx duckdb)" -gt 0 ] && \
 	echo "duckdb: PERSISTENT database file, not :memory:, so it stores what it loaded like the others"
-printf '%s\n' "${ARMS[@]}" | grep -qx citus && \
+[ "$(printf '%s\n' "${ARMS[@]}" | grep -cx citus)" -gt 0 ] && \
 	echo "citus:  citus_columnar USING columnar, co-loaded with pgcolumnar (possible since #429)"
 echo "rows: $TSV_ROWS    tries: $CB_TRIES    host: $(nproc) cores, $(( MEMKB / 1024 / 1024 )) GB"
 echo

--- a/test/selftest/080-no-suite-pipes-a-captured-string.sh
+++ b/test/selftest/080-no-suite-pipes-a-captured-string.sh
@@ -50,8 +50,28 @@ check "control: piping a large string into grep -q reports a match as absent" \
 # Scoped to echo and printf deliberately for the same reason. A pipeline out of
 # psql or a file is a different question with a different answer, and a rule that
 # flagged those too would be argued with rather than kept.
-_epipe_hits="$(grep -rnE '(echo|printf)[^|]*\|[[:space:]]*grep -[a-zA-Z]*q' \
-	"$TESTDIR"/*.sh 2>/dev/null | grep -v '/harness_selftest.sh:' || true)"
+# bench/ IS SCANNED TOO, and it was not. The PATTERN scoping to echo and printf
+# is a stated decision above. The DIRECTORY scoping to test/ was never a decision
+# at all -- it fell out of writing "$TESTDIR"/*.sh -- and bench/ held six
+# instances of the exact shape this rule forbids, one of them guarding a premise
+# loop with `|| continue`, in files the rule never looked at.
+#
+# They were latent rather than live: each writer is a printf of a few arm names,
+# far under the 64 KB pipe buffer, so it completes before grep -q exits and never
+# takes EPIPE. That is precisely the "passes almost every time and then does not"
+# the control above demonstrates, which is the reason to fix them rather than to
+# record that they happen to work.
+#
+# NON-RECURSIVE, one glob per directory, which is what the original did: it
+# passed "$TESTDIR"/*.sh, so its -r never applied. Handing grep the DIRECTORIES
+# instead would activate it and sweep test/selftest/ -- where this file's own
+# explanation of the rule, and the deliberate piped() demo above, both match the
+# pattern they exist to describe. Sweeping the file that enforces a rule for
+# instances of that rule is selftest 260's mistake once removed.
+_epipe_globs=("$TESTDIR"/*.sh)
+[ -d "$TESTDIR/../bench" ] && _epipe_globs+=("$TESTDIR"/../bench/*.sh)
+_epipe_hits="$(grep -nE '(echo|printf)[^|]*\|[[:space:]]*grep -[a-zA-Z]*q' \
+	"${_epipe_globs[@]}" 2>/dev/null | grep -v '/harness_selftest.sh:' || true)"
 _epipe_count="$(printf '%s' "$_epipe_hits" | grep -c . || true)"
 [ -n "$_epipe_hits" ] || _epipe_count=0
 check "no suite pipes a captured string into an early-exit reader" \
@@ -60,7 +80,7 @@ check "no suite pipes a captured string into an early-exit reader" \
 
 # And the scan has to be looking at something. A glob that matched nothing, or a
 # TESTDIR that moved, would report zero hits and read as compliance.
-_epipe_scanned="$(grep -rlE 'grep' "$TESTDIR"/*.sh 2>/dev/null | grep -c . || true)"
+_epipe_scanned="$(grep -lE 'grep' "${_epipe_globs[@]}" 2>/dev/null | grep -c . || true)"
 check "and the scan examined the suites rather than finding nothing to read" \
 	"$([ "${_epipe_scanned:-0}" -ge 20 ] && echo yes || echo "no (scanned $_epipe_scanned)")" "yes"
 

--- a/test/selftest/080-no-suite-pipes-a-captured-string.sh
+++ b/test/selftest/080-no-suite-pipes-a-captured-string.sh
@@ -80,7 +80,12 @@ check "no suite pipes a captured string into an early-exit reader" \
 
 # And the scan has to be looking at something. A glob that matched nothing, or a
 # TESTDIR that moved, would report zero hits and read as compliance.
-_epipe_scanned="$(grep -lE 'grep' "${_epipe_globs[@]}" 2>/dev/null | grep -c . || true)"
+#
+# BOTH premises below are computed from ONE list of the files the sweep actually
+# read, rather than from two independent re-derivations. That is the whole point:
+# a premise that recomputes its condition tests the world, not the code.
+_epipe_files="$(grep -lE 'grep' "${_epipe_globs[@]}" 2>/dev/null || true)"
+_epipe_scanned="$(printf '%s' "$_epipe_files" | grep -c . || true)"
 check "and the scan examined the suites rather than finding nothing to read" \
 	"$([ "${_epipe_scanned:-0}" -ge 20 ] && echo yes || echo "no (scanned $_epipe_scanned)")" "yes"
 
@@ -97,13 +102,19 @@ check "and the scan examined the suites rather than finding nothing to read" \
 #
 # Which is this rule's own failure mode one level up: coverage narrowing with
 # nothing able to see that it narrowed.
-# Asserted on THE GLOB LIST THE SWEEP ACTUALLY USED, not by globbing bench/
-# again here. The first version of this check did the latter -- it counted
-# bench/*.sh matching 'grep' independently -- and so it asserted that bench/
-# EXISTS, not that the sweep read it. Deleting the bench glob from _epipe_globs
-# left it green. A check that cannot fail for the reason it names is the thing
-# this whole file is about, and it took its own removal proof to see it.
-_epipe_bench="$(printf '%s\n' "${_epipe_globs[@]}" | grep -c '/bench/' || true)"
+# Counted from the FILES READ, not from the glob list, and this is the third
+# version of this one check. Each earlier one was a step short:
+#
+#   v1  globbed bench/*.sh again here      -> asserted bench/ EXISTS
+#   v2  counted entries in _epipe_globs    -> asserted bench/ is LISTED
+#   v3  counts bench paths among the files actually read
+#
+# v2 was one step short because bash leaves an UNMATCHED GLOB LITERAL unless
+# nullglob is set, and nothing in this harness sets it. So a bench/ holding no
+# .sh files still contributes one array entry -- the literal ".../bench/*.sh" --
+# and v2 passes while the sweep read nothing from it. Verified: an array built
+# over a nonexistent directory has size 1, not 0.
+_epipe_bench="$(printf '%s' "$_epipe_files" | grep -c '/bench/' || true)"
 check "and bench/ was in the scan, which is the hole this rule had" \
-	"$([ "${_epipe_bench:-0}" -ge 1 ] && echo yes || echo "no (bench globs in sweep: $_epipe_bench)")" "yes"
+	"$([ "${_epipe_bench:-0}" -ge 1 ] && echo yes || echo "no (bench files read: $_epipe_bench)")" "yes"
 

--- a/test/selftest/080-no-suite-pipes-a-captured-string.sh
+++ b/test/selftest/080-no-suite-pipes-a-captured-string.sh
@@ -84,3 +84,26 @@ _epipe_scanned="$(grep -lE 'grep' "${_epipe_globs[@]}" 2>/dev/null | grep -c . |
 check "and the scan examined the suites rather than finding nothing to read" \
 	"$([ "${_epipe_scanned:-0}" -ge 20 ] && echo yes || echo "no (scanned $_epipe_scanned)")" "yes"
 
+# bench/ IS SEPARATELY ASSERTED, and the check above cannot stand in for it.
+# The bench glob is added conditionally, so if $TESTDIR/../bench ever stops
+# resolving -- bench moved or renamed, this file relocated, a differently laid
+# out worktree -- the && quietly drops it and the sweep reverts to test/ only.
+#
+# The count premise does not notice: test/*.sh alone matches 'grep' in 159 files
+# against a threshold of 20, so it passes with bench/ silently absent. A count of
+# files scanned is a premise that the sweep read SOMETHING. It is not a premise
+# that it read the directory this rule was widened to cover, and it cannot tell
+# "scanned test/ and bench/" from "scanned test/ and gave up on bench/".
+#
+# Which is this rule's own failure mode one level up: coverage narrowing with
+# nothing able to see that it narrowed.
+# Asserted on THE GLOB LIST THE SWEEP ACTUALLY USED, not by globbing bench/
+# again here. The first version of this check did the latter -- it counted
+# bench/*.sh matching 'grep' independently -- and so it asserted that bench/
+# EXISTS, not that the sweep read it. Deleting the bench glob from _epipe_globs
+# left it green. A check that cannot fail for the reason it names is the thing
+# this whole file is about, and it took its own removal proof to see it.
+_epipe_bench="$(printf '%s\n' "${_epipe_globs[@]}" | grep -c '/bench/' || true)"
+check "and bench/ was in the scan, which is the hole this rule had" \
+	"$([ "${_epipe_bench:-0}" -ge 1 ] && echo yes || echo "no (bench globs in sweep: $_epipe_bench)")" "yes"
+


### PR DESCRIPTION
Test harness and bench only; no product code.

## The hole

selftest 080 forbids `echo|printf … | grep -q`: the reader exits on its first match, the
writer takes `SIGPIPE`, and under `pipefail` the pipeline is called failed — so **the thing
you were looking for is reported ABSENT** whatever the string held. It scanned `test/` only.

`bench/` held **six** instances of exactly that shape, in files the rule never looked at:

```
bench/run_bench_join.sh:286    printf ... | grep -q  columnar || continue
bench/run_clickbench.sh:521    printf ... | grep -qx duckdb
bench/run_clickbench.sh:680    printf ... | grep -qx columnar
bench/run_clickbench.sh:689    printf ... | grep -qx columnar_tuned
bench/run_clickbench.sh:826    printf ... | grep -qx duckdb
bench/run_clickbench.sh:828    printf ... | grep -qx citus
```

## Severity, stated honestly

**Latent, not live.** Each writer is a `printf` of a handful of arm names, far under the 64 KB
pipe buffer, so it completes before `grep -q` exits and never takes EPIPE. None is failing
today.

That is exactly the "passes almost every time and then does not" that 080's own control
demonstrates, which is the argument for fixing them rather than recording that they happen to
work. And `run_bench_join.sh:286` guards a **premise loop** with `|| continue` — if `ARM_A`
ever grows, the premises silently stop running, which is the same failure direction the rule
names.

## What changed, and what deliberately did not

- **The pattern scoping to `echo`/`printf` stays.** It is a stated decision in 080, and
  dropping it gives **31** hits across `test/`, `bench/` and `selftest/` — so it is
  load-bearing.
- **The directory scoping to `test/` was never a decision.** It fell out of writing
  `"$TESTDIR"/*.sh`. `bench/*.sh` is added.
- **The sweep stays non-recursive**, one glob per directory, which is what the original
  actually did — it passed a glob, so its `-r` never applied. Handing `grep` the *directories*
  would activate it and sweep `test/selftest/`, where 080's own explanation of the rule and its
  deliberate `piped()` demo both match the pattern they exist to describe. Sweeping the file
  that enforces a rule for instances of that rule is selftest 260's mistake once removed.

## bench/ coverage is conditional, so it is separately asserted

The bench glob is added with `[ -d … ] &&`. If `$TESTDIR/../bench` ever stops resolving —
bench moved or renamed, this file relocated, a differently laid out worktree — the `&&`
quietly drops it and the sweep reverts to `test/` only.

**Nothing would notice.** The existing premise counts files scanned against a threshold of 20:

```
test/*.sh  matching 'grep'   159 files
bench/*.sh matching 'grep'     8 files
premise threshold           >= 20
```

159 ≥ 20, so it passes with `bench/` silently absent. A count of files scanned is a premise
that the sweep read *something*; it cannot distinguish "scanned test/ and bench/" from
"scanned test/ and gave up on bench/". **Which is this rule's own failure mode one level up**:
coverage narrowing with nothing able to see that it narrowed.

### That premise took three versions, and each earlier one was a step short

| | what it did | what it actually asserted |
| --- | --- | --- |
| v1 | globbed `bench/*.sh` again here | bench/ **exists** |
| v2 | counted entries in `_epipe_globs` | bench/ is **listed** |
| **v3** | counts bench paths among the **files read** | bench/ was **read** |

v1 died to its own removal proof: deleting the bench glob left it green.

v2 died to the next one. **Bash leaves an unmatched glob literal unless `nullglob` is set**,
and nothing in `lib.sh`, `harness_selftest.sh` or `test/selftest/*.sh` sets it — verified
directly, an array built over a nonexistent directory has size **1**, not 0, holding the
literal pattern. So a `bench/` containing no `.sh` files still contributes one array entry and
v2 passes while the sweep reads nothing from it. On the real tree the two agree (array 10,
files 8) and diverge only in the case the premise exists to catch.

Both premises now come from **one** list of the files the sweep actually read, rather than two
independent re-derivations — which also drops a second `grep -lE`:

```sh
_epipe_files="$(grep -lE 'grep' "${_epipe_globs[@]}" 2>/dev/null || true)"
_epipe_scanned="$(printf '%s' "$_epipe_files" | grep -c . || true)"
_epipe_bench="$(printf '%s' "$_epipe_files" | grep -c '/bench/' || true)"
```

## Removal proofs — three

1. **Reintroduce one bench instance, widened glob in place** → **RED**:
   `no suite pipes a captured string into an early-exit reader: got [1] want [0]`.
2. **Reintroduce it AND revert the widening** → **GREEN**. That is the hole this PR closes,
   demonstrated rather than argued. **Proof 1 alone would not have been enough** — a rule can
   go red for an instance it was already catching, so only the pair distinguishes "the rule
   works" from "the rule now looks somewhere it did not".
3. **Drop the bench glob with the six fixes still in place** → the new premise goes red
   **alone** while the hits check and the count premise both stay green. That is what makes it
   load-bearing rather than decorative, and it is what killed v1.
4. **Point the bench glob at a directory holding no `.sh` files** → the file-based premise goes
   **RED** (`bench files read: 0`) while the other two stay green — *and the array-based v2 of
   the same premise stays **GREEN** on the identical fixture*. Both halves run, because only
   the pair shows that v2 could not have caught it.

## Four instances of one shape, in one change

The rule did not scan `bench/`. The premise written to detect that had the same hole. The
premise that replaced it had the same hole one level further in. Each was invisible until a
proof was written that could tell the two apart.

**The recursion stops only because the proof was named rather than the fix.** A rule, a
premise, and a premise-for-the-premise can each be decorative in exactly the same way, and
only a mutation that removes the thing they claim to watch distinguishes them.

## Gate

`harness_selftest` 153/153 on PG17.

Found by the reviewer while reviewing #770, which edits one of the affected files. Kept
separate from #770 on their recommendation rather than widening a bench PR into a harness fix.

