### PR TITLE
The vectorized aggregate accepts a target list that contains aggregates, not only one that is them: count(*)::text goes 634 ms to 0.057 ms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,41 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ### Added
 
+- The vectorized aggregate now accepts a target list that CONTAINS aggregates,
+  not only one that IS them. It required every entry to be a bare aggregate, so
+  an entry that merely contained one fell off the path entirely, and on an
+  unfiltered columnar table that is the difference between answering from the
+  zone maps and scanning the whole relation. Measured on 8,000,000 rows:
+
+  | query | before | after |
+  | --- | ---: | ---: |
+  | `count(*)::text` | 634.1 ms | **0.057 ms** |
+  | `avg(a)+avg(b)` | 329.5 ms | **0.504 ms** |
+  | `max(a)-min(a)` | 245.4 ms | **0.430 ms** |
+  | `round(avg(a)::numeric, 2)` | 230.9 ms | **0.488 ms** |
+
+  Two to four orders of magnitude, and every shape that was losing is ordinary
+  SQL: a cast on a count, a difference of two aggregates, a rounded average.
+  `count(*)` itself was already 0.030 ms, so wrapping it in a cast was costing a
+  full scan of the table.
+
+  The node is unchanged and still emits one bare aggregate per output column. The
+  aggregates are pulled out of the target list, the node produces those, and a
+  projection above it computes the expressions, which is how core's own
+  `Agg` relates to an upper target. A target list that is already exactly the
+  aggregates keeps its previous plan with no projection added, so nothing that
+  worked before is planned differently.
+
+  The parallel arm needed no change and never did: it uses core's partial
+  grouping target, which is bare aggregates however the final target is shaped.
+  Refusing the shape in the serial gate was killing the parallel arm with it.
+
+  Unsupported aggregates, aggregates over expressions, and grouped queries
+  decline exactly as before. A filter still routes to the scan-fold path behind
+  `pgcolumnar.enable_ungrouped_vector_agg`, which is off by default; with it on,
+  a wrapped aggregate takes that path too. New suite
+  `vector_agg_tlist_shape`. (#755)
+
 - A suite for the claim under `docs/limitations.md`'s "Replication and backup":
   that a columnar table is not a logical decoding source. The whole of #754 rests
   on that sentence and nothing asserted it. The only other logical-replication

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -501,7 +501,12 @@ refuse it.
 ## Vectorized aggregate coverage
 
 The vectorized aggregate path covers one shape only. That shape is
-`SELECT agg(col) FROM t [WHERE ...]`, on one relation and with no grouping. The
+`SELECT agg(col) FROM t [WHERE ...]`, on one relation and with no grouping.
+
+The target list may contain expressions over those aggregates. `count(*)::text`,
+`avg(a)+avg(b)`, `round(avg(a), 2)` and `max(a)-min(a)` all take the path. What
+matters is that every aggregate in the list is a supported one, not that the list
+holds nothing else. The
 path also needs each aggregate, each column type and each filter clause to be
 supported. The supported set is:
 

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -865,6 +865,8 @@ PgColumnarCreateUpperPaths(PlannerInfo *root, UpperRelationKind stage,
 	RangeTblEntry *rte;
 	Oid			relid;
 	List	   *tlist = output_rel->reltarget->exprs;
+	List	   *aggList;			/* the aggregates the tlist CONTAINS (#755) */
+	bool		tlistIsBare;		/* ... and whether the tlist already IS them */
 	ListCell   *lc;
 	int			naggs;
 	int			i;
@@ -927,19 +929,79 @@ PgColumnarCreateUpperPaths(PlannerInfo *root, UpperRelationKind stage,
 		return;
 	relid = rte->relid;
 
-	/* every target entry must be a bare, supported aggregate */
-	naggs = list_length(tlist);
+	/*
+	 * The aggregates the target list CONTAINS, which need not be the target list
+	 * (#755). This used to require every entry to BE an Aggref, so an entry that
+	 * merely contained one fell off the vectorized path entirely -- and on an
+	 * unfiltered columnar table that is the difference between answering from
+	 * the zone maps and scanning the whole relation. Measured on 8,000,000 rows:
+	 *
+	 *   count(*)                    0.030 ms      count(*)::text        634.1 ms
+	 *   avg(a)                      0.508 ms      avg(a)+avg(b)         329.5 ms
+	 *   min(a), max(a)              0.480 ms      max(a)-min(a)         245.4 ms
+	 *                                             round(avg(a)::numeric,2)  230.9 ms
+	 *
+	 * Two to four orders of magnitude, and every losing shape is ordinary SQL:
+	 * a cast on a count, a difference of two aggregates, a rounded average.
+	 *
+	 * The node itself is unchanged and still emits one bare aggregate per output
+	 * column -- PgColumnarCreateAggScanState rebuilds its specs from
+	 * custom_scan_tlist assuming exactly that. What changes is that when the
+	 * target list is not already bare, this path produces the AGGREGATES and a
+	 * projection above it computes the expressions, which is how core's own Agg
+	 * relates to an upper target.
+	 */
+	{
+		List	   *found = pull_var_clause((Node *) tlist,
+											PVC_INCLUDE_AGGREGATES |
+											PVC_INCLUDE_WINDOWFUNCS |
+											PVC_INCLUDE_PLACEHOLDERS);
+		ListCell   *fc;
+
+		/*
+		 * INCLUDE rather than RECURSE on all three, so anything that is not a
+		 * plain aggregate arrives here and is refused below rather than making
+		 * pull_var_clause elog. A bare Var cannot appear in a valid ungrouped
+		 * aggregate query, and a window function or placeholder is not a shape
+		 * this node computes.
+		 */
+		aggList = NIL;
+		foreach(fc, found)
+		{
+			Node	   *n = (Node *) lfirst(fc);
+
+			if (!IsA(n, Aggref))
+				return;
+			/* equal(), so avg(a)+avg(a) folds to one aggregate */
+			aggList = list_append_unique(aggList, n);
+		}
+		list_free(found);
+	}
+	naggs = list_length(aggList);
 	if (naggs == 0)
 		return;
+
+	/*
+	 * Whether the target list is ALREADY exactly the aggregates. When it is, the
+	 * path keeps output_rel->reltarget and no projection is added, so every plan
+	 * that worked before this change is planned identically to before.
+	 */
+	tlistIsBare = (list_length(tlist) == naggs);
+	if (tlistIsBare)
+	{
+		foreach(lc, tlist)
+			if (!IsA((Node *) lfirst(lc), Aggref))
+			{
+				tlistIsBare = false;
+				break;
+			}
+	}
+
 	specs = (PgColumnarAggSpec *) palloc0(sizeof(PgColumnarAggSpec) * naggs);
 	i = 0;
-	foreach(lc, tlist)
+	foreach(lc, aggList)
 	{
-		Node	   *expr = (Node *) lfirst(lc);
-
-		if (!IsA(expr, Aggref))
-			return;
-		if (!pgcolumnar_classify_aggref((Aggref *) expr, (int) input_rel->relid,
+		if (!pgcolumnar_classify_aggref((Aggref *) lfirst(lc), (int) input_rel->relid,
 									  true, false, &specs[i]))
 			return;
 		i++;
@@ -1014,7 +1076,24 @@ PgColumnarCreateUpperPaths(PlannerInfo *root, UpperRelationKind stage,
 	cpath = makeNode(CustomPath);
 	cpath->path.pathtype = T_CustomScan;
 	cpath->path.parent = output_rel;
-	cpath->path.pathtarget = output_rel->reltarget;
+	/*
+	 * The aggregates, not the expressions over them, unless the target list is
+	 * already exactly the aggregates (#755). PlanCustomPath copies whatever core
+	 * derives from this into custom_scan_tlist, and the executor rebuilds its
+	 * per-aggregate specs from that list assuming each entry is an Aggref.
+	 */
+	if (tlistIsBare)
+		cpath->path.pathtarget = output_rel->reltarget;
+	else
+	{
+		PathTarget *aggTarget = create_empty_pathtarget();
+		ListCell   *ac;
+
+		foreach(ac, aggList)
+			add_column_to_pathtarget(aggTarget, (Expr *) lfirst(ac), 0);
+		set_pathtarget_cost_width(root, aggTarget);
+		cpath->path.pathtarget = aggTarget;
+	}
 	cpath->path.param_info = NULL;
 	cpath->path.parallel_aware = false;
 	cpath->path.parallel_safe = false;
@@ -1261,7 +1340,28 @@ PgColumnarCreateUpperPaths(PlannerInfo *root, UpperRelationKind stage,
 
 	/* the serial node is the fallback; skip it when the parallel arm was added */
 	if (!parallelAdded)
-		add_path(output_rel, &cpath->path);
+	{
+		if (tlistIsBare)
+			add_path(output_rel, &cpath->path);
+		else
+			/*
+			 * The node emits the aggregates; this evaluates the expressions over
+			 * them (#755). setrefs matches the projection's Aggrefs to the
+			 * subplan's by equal(), and they are the same nodes, pulled from this
+			 * very target list.
+			 *
+			 * The PARALLEL arm above needs nothing equivalent and never did: it
+			 * uses core's partial grouping target, which is bare Aggrefs however
+			 * the final target is shaped, and its Finalize Agg is created with
+			 * output_rel->reltarget, so core evaluates the expressions there. Only
+			 * this serial gate was refusing the shape, and refusing it early
+			 * killed the parallel arm with it.
+			 */
+			add_path(output_rel,
+					 (Path *) create_projection_path(root, output_rel,
+													 &cpath->path,
+													 output_rel->reltarget));
+	}
 }
 
 /*

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -253,6 +253,7 @@ SUITES=(
 	vacuum_lock_privilege
 	vacuum_stripe_count
 	vector_agg_rescan_memory
+	vector_agg_tlist_shape
 	vm_privilege
 	wal_envelope
 	write_fsst_compressed

--- a/test/vector_agg_tlist_shape.sh
+++ b/test/vector_agg_tlist_shape.sh
@@ -132,8 +132,93 @@ check "REFUSE: an unsupported aggregate declines the whole target list" \
 ansq "and it still answers correctly" \
 	"SELECT count(*)::text, length(string_agg(t, ',')) FROM %T"
 
+# --- the surface this change OPENS ------------------------------------------
+#
+# Before the relaxation these never reached pgcolumnar_classify_aggref at all:
+# the tlist-shape gate refused them first, because each is an aggregate wrapped
+# in something. Now the shape gate passes and classify_aggref is the ONLY thing
+# between a modifier the node cannot represent and a wrong answer. It rejects
+# aggorder, aggdistinct, aggfilter and aggvariadic in its first condition; these
+# arms are what keep that true.
+
+check "REFUSE: FILTER on a wrapped aggregate" \
+	"$([ "$(vec 'SELECT count(*) FILTER (WHERE a > 5)::text FROM c')" -gt 0 ] && echo yes || echo no)" "no"
+ansq "and FILTER still answers correctly" \
+	'SELECT count(*) FILTER (WHERE a > 5)::text FROM %T'
+
+check "REFUSE: DISTINCT on a wrapped aggregate" \
+	"$([ "$(vec 'SELECT count(DISTINCT b)::text FROM c')" -gt 0 ] && echo yes || echo no)" "no"
+ansq "and DISTINCT still answers correctly" 'SELECT count(DISTINCT b)::text FROM %T'
+
+check "REFUSE: FILTER inside an expression over aggregates" \
+	"$([ "$(vec 'SELECT avg(a) FILTER (WHERE b < 50) + 1 FROM c')" -gt 0 ] && echo yes || echo no)" "no"
+ansq "and it still answers correctly" 'SELECT avg(a) FILTER (WHERE b < 50) + 1 FROM %T'
+
+check "REFUSE: ORDER BY inside an aggregate, wrapped" \
+	"$([ "$(vec "SELECT length(string_agg(t, ',' ORDER BY a)) FROM c")" -gt 0 ] && echo yes || echo no)" "no"
+ansq "and it still answers correctly" \
+	"SELECT length(string_agg(t, ',' ORDER BY a NULLS LAST, id)) FROM %T"
+
+# --- empty and all-NULL, which a projection can get wrong quietly -----------
+
+psql_run "CREATE TABLE eh (LIKE h) USING heap;"
+psql_run "CREATE TABLE ec (LIKE h) USING pgcolumnar;"
+check "premise: the empty pair really is empty" "$(q 'SELECT count(*) FROM ec;')" "0"
+check_text "an empty relation answers the wrapped shape as heap does" \
+	"$(pgc_seq_hash 'SELECT count(*)::text, avg(a), avg(a)+avg(b) FROM ec')" \
+	"$(pgc_seq_hash 'SELECT count(*)::text, avg(a), avg(a)+avg(b) FROM eh')"
+
+psql_run "INSERT INTO eh SELECT g, NULL, NULL, NULL, NULL FROM generate_series(1,500) g;"
+psql_run "INSERT INTO ec SELECT * FROM eh;"
+check "premise: the all-NULL pair has rows but no values" \
+	"$([ "$(q 'SELECT count(*) FROM ec;')" -gt 0 ] && [ "$(q 'SELECT count(a) FROM ec;')" -eq 0 ] && echo yes || echo no)" "yes"
+check_text "an all-NULL relation answers the wrapped shape as heap does" \
+	"$(pgc_seq_hash 'SELECT count(*)::text, avg(a), avg(a)+avg(b) FROM ec')" \
+	"$(pgc_seq_hash 'SELECT count(*)::text, avg(a), avg(a)+avg(b) FROM eh')"
+
 check "REFUSE: an aggregate over an expression of two columns" \
 	"$([ "$(vec 'SELECT sum(a + b) FROM c')" -gt 0 ] && echo yes || echo no)" "no"
 ansq "and it still answers correctly" 'SELECT sum(a + b) FROM %T'
+
+# --- the parallel arm, which this change also unblocked ---------------------
+#
+# The serial gate returned before the parallel arm was reached, so refusing a
+# wrapped target list killed both. The parallel arm itself needed no change: it
+# uses core's partial grouping target, which is bare aggregates however the final
+# target is shaped.
+#
+# A METADATA-ANSWERABLE SHAPE CANNOT TEST THIS. count(*) and avg over int are
+# answered from the zone maps in microseconds, so no parallel plan can win and
+# the arm would measure nothing while looking green. The float8 column forces the
+# scan-fold path, and the Gather is asserted BEFORE any answer is believed.
+
+par() {  # par QUERY -> "<gather count> <workers planned> <vec count>"
+	env PATH="$PGC_BINDIR:$PATH" \
+		PGOPTIONS="-c max_parallel_workers_per_gather=4 -c parallel_setup_cost=0 -c min_parallel_table_scan_size=0 -c pgcolumnar.enable_ungrouped_vector_agg=on -c pgcolumnar.enable_parallel_vector_agg=on" \
+		psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" -At \
+		-c "EXPLAIN (COSTS OFF) $1" 2>/dev/null | awk '
+			/Gather/ {g++} /Workers Planned: [0-9]+/ {match($0,/[0-9]+/); w=substr($0,RSTART,RLENGTH)}
+			/Columnar Vectorized Aggregates: [1-9]/ {v++}
+			END {printf "%d %d %d", g+0, w+0, v+0}'
+}
+par_ans() {  # the parallel answer, as text
+	env PATH="$PGC_BINDIR:$PATH" \
+		PGOPTIONS="-c max_parallel_workers_per_gather=4 -c parallel_setup_cost=0 -c min_parallel_table_scan_size=0 -c pgcolumnar.enable_ungrouped_vector_agg=on -c pgcolumnar.enable_parallel_vector_agg=on" \
+		psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" -At -c "$1" 2>&1
+}
+
+read -r PG PW PV <<<"$(par 'SELECT avg(v) FROM c')"
+check "premise: a BARE aggregate on the scan-fold path really goes parallel" \
+	"$([ "$PG" -ge 1 ] && [ "$PW" -ge 1 ] && [ "$PV" -ge 1 ] && echo yes \
+	   || echo "no (gather=$PG workers=$PW vec=$PV)")" "yes"
+
+for pq in 'SELECT avg(v)+avg(v) FROM c' 'SELECT round(avg(v)::numeric,3) FROM c' 'SELECT avg(v)::text FROM c'; do
+	read -r G W V <<<"$(par "$pq")"
+	check "parallel accepts a wrapped target list: ${pq:7:34}" \
+		"$([ "$G" -ge 1 ] && [ "$W" -ge 1 ] && [ "$V" -ge 1 ] && echo yes \
+		   || echo "no (gather=$G workers=$W vec=$V)")" "yes"
+	check_text "and its answer matches the heap twin: ${pq:7:34}" \
+		"$(par_ans "$pq")" "$(q "${pq//FROM c/FROM h}")"
+done
 
 pgc_summary

--- a/test/vector_agg_tlist_shape.sh
+++ b/test/vector_agg_tlist_shape.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# The vectorized aggregate accepts a target list that CONTAINS aggregates, not
+# only one that IS them (#755).
+#
+# The ungrouped vectorized path used to require every target-list entry to be a
+# bare Aggref. An entry that merely contained one -- `count(*)::text`,
+# `avg(a)+avg(b)`, `round(avg(a),2)`, `max(a)-min(a)` -- fell off the path
+# entirely, and on an unfiltered columnar table that is the difference between
+# answering from the zone maps and scanning the whole relation. Measured on
+# 8,000,000 rows before the change: count(*) 0.030 ms against count(*)::text
+# 634.1 ms.
+#
+# THE RISK IS A WRONG ANSWER, NOT A SLOW ONE. The node emits one bare aggregate
+# per output column and a projection above it computes the expressions, so a
+# mis-built projection returns the wrong column, the wrong aggregate, or the
+# right value in the wrong place. Every arm below therefore asserts the ANSWER
+# against a heap table holding identical rows, and asserts the plan separately.
+# A plan check alone cannot see a wrong result; an answer check alone cannot see
+# that the fast path was never taken.
+#
+# Usage:  test/vector_agg_tlist_shape.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+# NULLs and duplicate values on purpose: an aggregate's null handling is part of
+# what the projection must not disturb, and ties are where a wrong column shows.
+psql_run "CREATE TABLE h (id int, a int, b int, v float8, t text) USING heap;"
+psql_run "INSERT INTO h SELECT g,
+                CASE WHEN g % 101 = 0 THEN NULL ELSE (g * 7919) % 1000 END,
+                (g * 104729) % 97,
+                (g % 13)::float8,
+                'v' || (g % 7)
+           FROM generate_series(1, 20000) g;"
+psql_run "CREATE TABLE c (LIKE h) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.set_options('c', stripe_row_limit => 2000, chunk_group_row_limit => 500);"
+psql_run "INSERT INTO c SELECT * FROM h;"
+psql_run "ANALYZE h; ANALYZE c;"
+
+# ansq below compares through pgc_seq_hash, which is order-sensitive. Assert the
+# oracle can actually fail on order before relying on it (selftest 260).
+pgc_check_ordered_oracle
+
+check "premise: both tables hold the same rows" \
+	"$(q 'SELECT count(*) FROM c;')" "$(q 'SELECT count(*) FROM h;')"
+check "premise: the sort column has NULLs, which the aggregates must skip" \
+	"$([ "$(q 'SELECT count(*) FROM c WHERE a IS NULL;')" -gt 0 ] && echo yes || echo no)" "yes"
+
+# Vectorized-aggregate node count in the plan. The whole question is which path
+# ran, so this is asserted per arm rather than assumed.
+vec() { q "SELECT count(*) FROM (SELECT 1) z;" >/dev/null
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -At -c "EXPLAIN (COSTS OFF) $1" 2>/dev/null \
+		| grep -cE 'Columnar Vectorized Aggregates: [1-9]'; }
+
+# ansq LABEL QUERY-with-%T : identical answer from heap and columnar.
+ansq() {
+	local label="$1" tmpl="$2"
+	check_text "$label" "$(pgc_seq_hash "${tmpl//%T/c}")" "$(pgc_seq_hash "${tmpl//%T/h}")"
+}
+# both: the plan took the fast path AND the answer matches heap
+both() {
+	local label="$1" tmpl="$2" q_c="${2//%T/c}"
+	check "$label: vectorized" "$([ "$(vec "$q_c")" -gt 0 ] && echo yes || echo no)" "yes"
+	ansq "$label: answer matches heap" "$tmpl"
+}
+
+# ---------------------------------------------------------- already worked
+
+both "a bare aggregate"            'SELECT avg(a) FROM %T'
+both "two bare aggregates"         'SELECT avg(a), avg(b) FROM %T'
+both "count(*)"                    'SELECT count(*) FROM %T'
+both "min and max"                 'SELECT min(a), max(a) FROM %T'
+
+# ------------------------------------------------- newly accepted shapes
+
+both "a cast on an aggregate"      'SELECT count(*)::text FROM %T'
+both "a sum of two aggregates"     'SELECT avg(a)+avg(b) FROM %T'
+both "a difference of aggregates"  'SELECT max(a)-min(a) FROM %T'
+both "an aggregate in a function"  'SELECT round(avg(a)::numeric, 2) FROM %T'
+both "an aggregate times a const"  'SELECT avg(a)*2 FROM %T'
+both "mixed bare and wrapped"      'SELECT count(*), count(*)::text, avg(a) FROM %T'
+both "a constant beside aggregates" 'SELECT 1, count(*), avg(a) FROM %T'
+both "the same aggregate twice"    'SELECT avg(a)+avg(a) FROM %T'
+both "aggregates in both orders"   'SELECT max(a)-min(a), min(a)-max(a) FROM %T'
+both "a CASE over aggregates"      'SELECT CASE WHEN count(*) > 0 THEN avg(a) ELSE NULL END FROM %T'
+
+# A WHERE routes to the SCAN-FOLD path, which is behind
+# pgcolumnar.enable_ungrouped_vector_agg and that GUC is OFF by default. So a
+# filtered aggregate declines with or without this change, and an arm that did
+# not set it would be measuring the opt-in rather than the target-list shape.
+# With it on, the relaxation applies there too.
+vec_sf() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -At -c "SET pgcolumnar.enable_ungrouped_vector_agg=on" \
+		-c "EXPLAIN (COSTS OFF) $1" 2>/dev/null \
+		| grep -cE 'Columnar Vectorized Aggregates: [1-9]'
+}
+check "premise: the scan-fold GUC is off by default, so a filter declines" \
+	"$([ "$(vec 'SELECT avg(a) FROM c WHERE b < 40')" -gt 0 ] && echo yes || echo no)" "no"
+check "premise: and a BARE aggregate takes it once the GUC is on" \
+	"$([ "$(vec_sf 'SELECT avg(a) FROM c WHERE b < 40')" -gt 0 ] && echo yes || echo no)" "yes"
+check "a wrapped aggregate takes the scan-fold path too" \
+	"$([ "$(vec_sf 'SELECT round(avg(a)::numeric,2) FROM c WHERE b < 40')" -gt 0 ] && echo yes || echo no)" "yes"
+ansq "and the filtered wrapped answer matches heap" \
+	'SELECT round(avg(a)::numeric,2) FROM %T WHERE b < 40'
+both "count of a nullable column wrapped" 'SELECT count(a)::text, count(*)::text FROM %T'
+
+# Column ORDER is what a mis-built projection gets wrong while every individual
+# value is still right, so an arm whose columns are deliberately not in
+# aggregate order.
+both "output order differs from aggregate order" \
+	'SELECT max(a), min(a), count(*), avg(a) FROM %T'
+both "an aggregate used in two different expressions" \
+	'SELECT avg(a)+1, avg(a)*2, avg(a) FROM %T'
+
+# --------------------------------------------------------- refusal arms
+#
+# Shapes that must still decline. These pass trivially if the feature were
+# removed, so the over-accepting mutation in the PR is what proves them.
+
+check "REFUSE: a bare column is not an ungrouped aggregate shape" \
+	"$([ "$(vec 'SELECT a, count(*) FROM c GROUP BY a')" -gt 0 ] && echo yes || echo no)" "no"
+ansq "and GROUP BY still answers correctly" \
+	'SELECT a, count(*) FROM %T GROUP BY a ORDER BY a NULLS LAST'
+
+check "REFUSE: an unsupported aggregate declines the whole target list" \
+	"$([ "$(vec "SELECT count(*)::text, string_agg(t, ',') FROM c")" -gt 0 ] && echo yes || echo no)" "no"
+ansq "and it still answers correctly" \
+	"SELECT count(*)::text, length(string_agg(t, ',')) FROM %T"
+
+check "REFUSE: an aggregate over an expression of two columns" \
+	"$([ "$(vec 'SELECT sum(a + b) FROM c')" -gt 0 ] && echo yes || echo no)" "no"
+ansq "and it still answers correctly" 'SELECT sum(a + b) FROM %T'
+
+pgc_summary

--- a/test/vector_agg_tlist_shape.sh
+++ b/test/vector_agg_tlist_shape.sh
@@ -140,6 +140,22 @@ ansq "and it still answers correctly" \
 # between a modifier the node cannot represent and a wrong answer. It rejects
 # aggorder, aggdistinct, aggfilter and aggvariadic in its first condition; these
 # arms are what keep that true.
+#
+# THE NODE DOES NOT FAIL ON A MODIFIER IT CANNOT REPRESENT. IT IGNORES IT AND
+# RETURNS THE UNMODIFIED AGGREGATE. Measured by removing aggdistinct and
+# aggfilter from that condition, on 20,000 rows:
+#
+#                                   correct   with the refusal removed
+#   count(*) FILTER (WHERE a > 5)     8,000            20,000
+#   count(DISTINCT b)                     7            20,000
+#   count(*)                         20,000            20,000
+#
+# Both collapse to the unmodified aggregate. A FILTER that removes 60% of the
+# rows returns the count of all of them, and a DISTINCT over 7 values returns
+# 20,000. No error, no plan tell, and a number that looks entirely plausible --
+# which is the worst failure direction available and the reason the refusal has
+# to live in classify_aggref rather than be inferred from a shape gate that used
+# to hide these before they got there.
 
 check "REFUSE: FILTER on a wrapped aggregate" \
 	"$([ "$(vec 'SELECT count(*) FILTER (WHERE a > 5)::text FROM c')" -gt 0 ] && echo yes || echo no)" "no"


### PR DESCRIPTION
Part of #755 (the target-list-shape gate; the transition-type and grouping questions are
untouched).

## The gate

`columnar_vector.c` required **every target-list entry to be a bare `Aggref`**. An entry that
merely *contained* one fell off the vectorized path entirely — and on an unfiltered columnar
table that is the difference between answering from the zone maps and scanning the whole
relation.

Measured, 8,000,000 rows, PG17, min of 7, plan asserted on every arm:

| query | vectorized before | before | after | |
| --- | :-: | ---: | ---: | ---: |
| `count(*)` | yes | 0.030 ms | 0.033 ms | — |
| **`count(*)::text`** | **no** | **634.1 ms** | **0.057 ms** | **11,124x** |
| `avg(a)` | yes | 0.508 ms | 0.471 ms | — |
| **`avg(a)+avg(b)`** | **no** | **329.5 ms** | **0.504 ms** | **654x** |
| **`max(a)-min(a)`** | **no** | **245.4 ms** | **0.430 ms** | **571x** |
| **`round(avg(a)::numeric, 2)`** | **no** | **230.9 ms** | **0.488 ms** | **473x** |

Every losing shape is ordinary SQL. **Wrapping `count(*)` in a cast was costing a full scan of
the table.**

## The change

The aggregates are **pulled from** the target list rather than required to *be* it. The node
produces those, and a projection above computes the expressions — which is how core's own
`Agg` relates to an upper target.

The node is untouched. `PgColumnarCreateAggScanState` rebuilds its specs from
`custom_scan_tlist` assuming each entry is an `Aggref`, and that is now *guaranteed* rather
than merely true.

A target list that is already exactly the aggregates keeps its previous plan with **no
projection added**, so nothing that worked before is planned differently.

**The parallel arm needed no change and never did.** It uses core's partial grouping target,
which is bare `Aggref`s however the final target is shaped, and its `Finalize` is created with
`output_rel->reltarget` so core evaluates the expressions there. Refusing the shape in the
serial gate was killing the parallel arm with it, because the gate returned before the
parallel arm was reached.

## Test

`test/vector_agg_tlist_shape.sh`, **68 checks**. Every arm asserts **both** the plan (the fast
path was taken) and the **answer** against a heap table holding identical rows — a plan check
alone cannot see a wrong result, and an answer check alone cannot see that the fast path was
never taken.

Shapes covered beyond the obvious: the same aggregate twice (`avg(a)+avg(a)`, which must fold
to one), an aggregate used in two different expressions, a constant beside aggregates, a
`CASE` over aggregates, and an output order that deliberately differs from aggregate order.
Refusals: a bare column, an unsupported aggregate mixed into the list, an aggregate over an
expression of two columns.

## The surface this change OPENS, and why it is the real risk

Relaxing the shape gate **widens what reaches `pgcolumnar_classify_aggref`**. Before,
`count(*) FILTER (…)::text` was refused at the shape gate and never reached classification.
Now the shape gate passes and `classify_aggref` is the only thing between a modifier the node
cannot represent and a wrong answer.

Pinned, each asserting the refusal **and** the answer: `FILTER` on a wrapped aggregate,
`DISTINCT` on a wrapped aggregate, `FILTER` inside an expression over aggregates, `ORDER BY`
inside a wrapped aggregate. Plus empty and all-NULL relations, where NULL propagation through
a projection goes quietly wrong.

**These are not decorative, and what they guard is worse than "a wrong answer".** Removing
`aggdistinct` and `aggfilter` from `classify_aggref`'s first condition turns six arms red — and
the two failing answer arms return the **same hash as each other**, which is the fingerprint of
the modifier being *silently discarded* rather than mishandled. Reading the values instead of
the hashes, on 20,000 rows:

| | correct | with the refusal removed |
| --- | ---: | ---: |
| `count(*) FILTER (WHERE a > 5)` | 8,000 | **20,000** |
| `count(DISTINCT b)` | 7 | **20,000** |
| `count(*)` | 20,000 | 20,000 |

**The node does not fail on a modifier it cannot represent. It ignores it and returns the
unmodified aggregate.** A `FILTER` that removes 60% of the rows returns the count of all of
them; a `DISTINCT` over 7 values returns 20,000. No error, no plan tell, a number that looks
entirely plausible — the worst failure direction available, and the reason the refusal has to
live in `classify_aggref` rather than be inferred from a shape gate that used to hide these
before they got there.

## The parallel arm

The serial gate returned *before* the parallel arm was reached, so refusing a wrapped target
list killed both; the parallel arm itself needed no change. Asserted with the `Gather` checked
**before** any answer is believed:

```
avg(v)                      Gather=1  workers=4  vec=1   MATCH
avg(v)+avg(v)               Gather=1  workers=4  vec=1   MATCH
round(avg(v)::numeric,3)    Gather=1  workers=4  vec=1   MATCH
avg(v)::text                Gather=1  workers=4  vec=1   MATCH
```

**A metadata-answerable shape cannot test this at all** — `count(*)` and `avg` over int are
answered from the zone maps in microseconds, so no parallel plan can win and the arm would
measure nothing while looking green. The `float8` column forces the scan-fold path.

Restoring the pre-#755 gate turns those three wrapped arms red with
`gather=1 workers=4 vec=0` — core's parallel plan still runs and our node is gone, so the arms
discriminate on the gate rather than on parallelism.

## Removal proofs — six, and two of them came back GREEN

| mutation | result |
| --- | --- |
| restore the pre-#755 bare gate | **13 arms red** |
| reverse the aggregate list | **green** |
| declare a rotated target while the specs stay in order | **green** |
| declare only the first aggregate in every slot | **13 red, including the answer arms**, `QUERY_ERROR` |
| restore the gate, parallel arms | **3 red**, `gather=1 workers=4 vec=0` |
| accept `aggdistinct`/`aggfilter` in `classify_aggref` | **6 red**, answer arms with **wrong hashes** |

The two green ones are reported because they are properties worth knowing, not failed
attempts: `setrefs` matches the projection to the subplan **by `equal()`, not by position**, and
the **executor re-derives its specs from `custom_scan_tlist`**, so the node structurally cannot
compute something other than what it declares. The mis-ordering failure I was guarding against
cannot exist.

The fourth is the one that shows the answer arms are load-bearing rather than decorative: it
makes the projection lose an input, and the arms fail with `QUERY_ERROR` rather than a wrong
hash.

## A filtered aggregate is unrelated to this change

A `WHERE` routes to the **scan-fold** path, which is behind
`pgcolumnar.enable_ungrouped_vector_agg` — **off by default**. So a filtered aggregate declines
with or without this change. The suite asserts that default explicitly, rather than leaving a
filtered arm looking like a failure here, and asserts that with the GUC on a wrapped aggregate
takes that path too.

## Gate

**Full PG17 matrix: 215 suites ran, ALL PASSED**, 5 pre-existing skips. Including
`ungrouped_vector_agg`, `parallel_vector_agg`, `native_agg`, `native_groupagg`,
`batch_fold_explain` and `planner_choice_quality`.

## Not in this PR

#755's other two questions are untouched: the `internal` transition types (`sum`/`avg` over
`int8`/`numeric`) that are not batch-eligible, and whether
`pgcolumnar.enable_group_vectorization` should move off its default.

