### PR TITLE
Every bench runner refuses an assert build instead of documenting the requirement

### DIFF
--- a/bench/run_bench.sh
+++ b/bench/run_bench.sh
@@ -46,7 +46,23 @@ PG_CONFIG="${1:-/usr/local/pg17_nc/bin/pg_config}"
 # reasoned about, it was 2.5% (#768's per-column ladder, assert against
 # non-assert). Small here; it is allocation- and reset-shaped, so it is not
 # small everywhere, and the point is that nobody knew which case they had.
-BENCH_CASSERT="$("$PG_CONFIG" --configure 2>/dev/null | grep -c 'enable-cassert' || true)"
+# --configure captured ONCE, and an empty capture is a REFUSAL rather than a
+# pass. Written as a single grep -c it could not tell "not an assert build" from
+# "could not tell": a missing, non-executable or failing pg_config gives empty
+# output, grep -c gives 0, and the 2>/dev/null swallows the evidence -- so the
+# guard returns its cleanest verdict on the least information. Reachable, not
+# theoretical: these scripts have default prefixes that do not exist on every
+# machine, so a no-arg invocation can pass a guard on a pg_config that never ran.
+#
+# Refuse when you cannot tell, for the same reason as when the answer is yes.
+BENCH_CONFIGURE="$("$PG_CONFIG" --configure 2>/dev/null || true)"
+if [ -z "$BENCH_CONFIGURE" ]; then
+	echo "FATAL: $PG_CONFIG produced no --configure output, so this script cannot"
+	echo "       tell whether it is an --enable-cassert build. Refusing rather than"
+	echo "       assuming it is not: check the path is right and executable."
+	exit 1
+fi
+BENCH_CASSERT="$(printf '%s' "$BENCH_CONFIGURE" | grep -c 'enable-cassert' || true)"
 if [ "${BENCH_CASSERT:-0}" != "0" ]; then
 	if [ -n "${BENCH_ALLOW_CASSERT:-}" ]; then
 		echo "== WARNING: --enable-cassert build. Every number below includes"

--- a/bench/run_bench.sh
+++ b/bench/run_bench.sh
@@ -26,6 +26,40 @@
 set -euo pipefail
 
 PG_CONFIG="${1:-/usr/local/pg17_nc/bin/pg_config}"
+
+# ---------------------------------------------------------------------------
+# The non-assert requirement, ENFORCED rather than documented
+# ---------------------------------------------------------------------------
+#
+# This script's header has always said to run against a non-assert build. It
+# said so and checked nothing, and the invocation that measured #755, #768, #752
+# and #753 passed an --enable-cassert prefix. That is the failure shape this
+# repository keeps finding: the rule existed, the check did not.
+#
+# Refuse rather than warn, because a benchmark's whole output is numbers and a
+# warning above a table does not travel with the table. The override exists
+# because a comparison between two assert builds is still valid, and because an
+# assert build is sometimes the only one to hand -- but then every figure has to
+# be labelled, which is what the banner does.
+#
+# On the one measurement where the size of the skew was checked rather than
+# reasoned about, it was 2.5% (#768's per-column ladder, assert against
+# non-assert). Small here; it is allocation- and reset-shaped, so it is not
+# small everywhere, and the point is that nobody knew which case they had.
+BENCH_CASSERT="$("$PG_CONFIG" --configure 2>/dev/null | grep -c 'enable-cassert' || true)"
+if [ "${BENCH_CASSERT:-0}" != "0" ]; then
+	if [ -n "${BENCH_ALLOW_CASSERT:-}" ]; then
+		echo "== WARNING: --enable-cassert build. Every number below includes"
+		echo "   validation a production build never runs, and is comparable only"
+		echo "   against another assert build."
+	else
+		echo "FATAL: $("$PG_CONFIG" --bindir) is an --enable-cassert build."
+		echo "       This benchmark's numbers would carry assert-only validation."
+		echo "       Use a non-assert build, or set BENCH_ALLOW_CASSERT=1 to run"
+		echo "       anyway and have the output labelled as such."
+		exit 1
+	fi
+fi
 BINDIR="$("$PG_CONFIG" --bindir)"
 PORT="${BENCH_PORT:-55432}"
 SCALE="${BENCH_SCALE:-6000000}"

--- a/bench/run_bench_fsst.sh
+++ b/bench/run_bench_fsst.sh
@@ -46,7 +46,23 @@ PG_CONFIG="${1:-/usr/local/pg17_nc/bin/pg_config}"
 # reasoned about, it was 2.5% (#768's per-column ladder, assert against
 # non-assert). Small here; it is allocation- and reset-shaped, so it is not
 # small everywhere, and the point is that nobody knew which case they had.
-BENCH_CASSERT="$("$PG_CONFIG" --configure 2>/dev/null | grep -c 'enable-cassert' || true)"
+# --configure captured ONCE, and an empty capture is a REFUSAL rather than a
+# pass. Written as a single grep -c it could not tell "not an assert build" from
+# "could not tell": a missing, non-executable or failing pg_config gives empty
+# output, grep -c gives 0, and the 2>/dev/null swallows the evidence -- so the
+# guard returns its cleanest verdict on the least information. Reachable, not
+# theoretical: these scripts have default prefixes that do not exist on every
+# machine, so a no-arg invocation can pass a guard on a pg_config that never ran.
+#
+# Refuse when you cannot tell, for the same reason as when the answer is yes.
+BENCH_CONFIGURE="$("$PG_CONFIG" --configure 2>/dev/null || true)"
+if [ -z "$BENCH_CONFIGURE" ]; then
+	echo "FATAL: $PG_CONFIG produced no --configure output, so this script cannot"
+	echo "       tell whether it is an --enable-cassert build. Refusing rather than"
+	echo "       assuming it is not: check the path is right and executable."
+	exit 1
+fi
+BENCH_CASSERT="$(printf '%s' "$BENCH_CONFIGURE" | grep -c 'enable-cassert' || true)"
 if [ "${BENCH_CASSERT:-0}" != "0" ]; then
 	if [ -n "${BENCH_ALLOW_CASSERT:-}" ]; then
 		echo "== WARNING: --enable-cassert build. Every number below includes"

--- a/bench/run_bench_fsst.sh
+++ b/bench/run_bench_fsst.sh
@@ -26,6 +26,40 @@
 set -euo pipefail
 
 PG_CONFIG="${1:-/usr/local/pg17_nc/bin/pg_config}"
+
+# ---------------------------------------------------------------------------
+# The non-assert requirement, ENFORCED rather than documented
+# ---------------------------------------------------------------------------
+#
+# This script's header has always said to run against a non-assert build. It
+# said so and checked nothing, and the invocation that measured #755, #768, #752
+# and #753 passed an --enable-cassert prefix. That is the failure shape this
+# repository keeps finding: the rule existed, the check did not.
+#
+# Refuse rather than warn, because a benchmark's whole output is numbers and a
+# warning above a table does not travel with the table. The override exists
+# because a comparison between two assert builds is still valid, and because an
+# assert build is sometimes the only one to hand -- but then every figure has to
+# be labelled, which is what the banner does.
+#
+# On the one measurement where the size of the skew was checked rather than
+# reasoned about, it was 2.5% (#768's per-column ladder, assert against
+# non-assert). Small here; it is allocation- and reset-shaped, so it is not
+# small everywhere, and the point is that nobody knew which case they had.
+BENCH_CASSERT="$("$PG_CONFIG" --configure 2>/dev/null | grep -c 'enable-cassert' || true)"
+if [ "${BENCH_CASSERT:-0}" != "0" ]; then
+	if [ -n "${BENCH_ALLOW_CASSERT:-}" ]; then
+		echo "== WARNING: --enable-cassert build. Every number below includes"
+		echo "   validation a production build never runs, and is comparable only"
+		echo "   against another assert build."
+	else
+		echo "FATAL: $("$PG_CONFIG" --bindir) is an --enable-cassert build."
+		echo "       This benchmark's numbers would carry assert-only validation."
+		echo "       Use a non-assert build, or set BENCH_ALLOW_CASSERT=1 to run"
+		echo "       anyway and have the output labelled as such."
+		exit 1
+	fi
+fi
 BINDIR="$("$PG_CONFIG" --bindir)"
 PORT="${BENCH_PORT:-55462}"
 SCALE="${BENCH_SCALE:-3000000}"

--- a/bench/run_bench_join.sh
+++ b/bench/run_bench_join.sh
@@ -94,7 +94,23 @@ PG_CONFIG="${1:-/usr/local/pg18n/bin/pg_config}"
 # reasoned about, it was 2.5% (#768's per-column ladder, assert against
 # non-assert). Small here; it is allocation- and reset-shaped, so it is not
 # small everywhere, and the point is that nobody knew which case they had.
-BENCH_CASSERT="$("$PG_CONFIG" --configure 2>/dev/null | grep -c 'enable-cassert' || true)"
+# --configure captured ONCE, and an empty capture is a REFUSAL rather than a
+# pass. Written as a single grep -c it could not tell "not an assert build" from
+# "could not tell": a missing, non-executable or failing pg_config gives empty
+# output, grep -c gives 0, and the 2>/dev/null swallows the evidence -- so the
+# guard returns its cleanest verdict on the least information. Reachable, not
+# theoretical: these scripts have default prefixes that do not exist on every
+# machine, so a no-arg invocation can pass a guard on a pg_config that never ran.
+#
+# Refuse when you cannot tell, for the same reason as when the answer is yes.
+BENCH_CONFIGURE="$("$PG_CONFIG" --configure 2>/dev/null || true)"
+if [ -z "$BENCH_CONFIGURE" ]; then
+	echo "FATAL: $PG_CONFIG produced no --configure output, so this script cannot"
+	echo "       tell whether it is an --enable-cassert build. Refusing rather than"
+	echo "       assuming it is not: check the path is right and executable."
+	exit 1
+fi
+BENCH_CASSERT="$(printf '%s' "$BENCH_CONFIGURE" | grep -c 'enable-cassert' || true)"
 if [ "${BENCH_CASSERT:-0}" != "0" ]; then
 	if [ -n "${BENCH_ALLOW_CASSERT:-}" ]; then
 		echo "== WARNING: --enable-cassert build. Every number below includes"

--- a/bench/run_bench_join.sh
+++ b/bench/run_bench_join.sh
@@ -74,6 +74,40 @@
 set -uo pipefail
 
 PG_CONFIG="${1:-/usr/local/pg18n/bin/pg_config}"
+
+# ---------------------------------------------------------------------------
+# The non-assert requirement, ENFORCED rather than documented
+# ---------------------------------------------------------------------------
+#
+# This script's header has always said to run against a non-assert build. It
+# said so and checked nothing, and the invocation that measured #755, #768, #752
+# and #753 passed an --enable-cassert prefix. That is the failure shape this
+# repository keeps finding: the rule existed, the check did not.
+#
+# Refuse rather than warn, because a benchmark's whole output is numbers and a
+# warning above a table does not travel with the table. The override exists
+# because a comparison between two assert builds is still valid, and because an
+# assert build is sometimes the only one to hand -- but then every figure has to
+# be labelled, which is what the banner does.
+#
+# On the one measurement where the size of the skew was checked rather than
+# reasoned about, it was 2.5% (#768's per-column ladder, assert against
+# non-assert). Small here; it is allocation- and reset-shaped, so it is not
+# small everywhere, and the point is that nobody knew which case they had.
+BENCH_CASSERT="$("$PG_CONFIG" --configure 2>/dev/null | grep -c 'enable-cassert' || true)"
+if [ "${BENCH_CASSERT:-0}" != "0" ]; then
+	if [ -n "${BENCH_ALLOW_CASSERT:-}" ]; then
+		echo "== WARNING: --enable-cassert build. Every number below includes"
+		echo "   validation a production build never runs, and is comparable only"
+		echo "   against another assert build."
+	else
+		echo "FATAL: $("$PG_CONFIG" --bindir) is an --enable-cassert build."
+		echo "       This benchmark's numbers would carry assert-only validation."
+		echo "       Use a non-assert build, or set BENCH_ALLOW_CASSERT=1 to run"
+		echo "       anyway and have the output labelled as such."
+		exit 1
+	fi
+fi
 SCALE="${BENCH_SCALE:-20000000}"
 REPS="${BENCH_REPS:-3}"
 PORT="${BENCH_PORT:-55471}"

--- a/bench/run_bench_readstream.sh
+++ b/bench/run_bench_readstream.sh
@@ -41,7 +41,23 @@ PG_CONFIG="${1:-/usr/local/pg18_uring/bin/pg_config}"
 # reasoned about, it was 2.5% (#768's per-column ladder, assert against
 # non-assert). Small here; it is allocation- and reset-shaped, so it is not
 # small everywhere, and the point is that nobody knew which case they had.
-BENCH_CASSERT="$("$PG_CONFIG" --configure 2>/dev/null | grep -c 'enable-cassert' || true)"
+# --configure captured ONCE, and an empty capture is a REFUSAL rather than a
+# pass. Written as a single grep -c it could not tell "not an assert build" from
+# "could not tell": a missing, non-executable or failing pg_config gives empty
+# output, grep -c gives 0, and the 2>/dev/null swallows the evidence -- so the
+# guard returns its cleanest verdict on the least information. Reachable, not
+# theoretical: these scripts have default prefixes that do not exist on every
+# machine, so a no-arg invocation can pass a guard on a pg_config that never ran.
+#
+# Refuse when you cannot tell, for the same reason as when the answer is yes.
+BENCH_CONFIGURE="$("$PG_CONFIG" --configure 2>/dev/null || true)"
+if [ -z "$BENCH_CONFIGURE" ]; then
+	echo "FATAL: $PG_CONFIG produced no --configure output, so this script cannot"
+	echo "       tell whether it is an --enable-cassert build. Refusing rather than"
+	echo "       assuming it is not: check the path is right and executable."
+	exit 1
+fi
+BENCH_CASSERT="$(printf '%s' "$BENCH_CONFIGURE" | grep -c 'enable-cassert' || true)"
 if [ "${BENCH_CASSERT:-0}" != "0" ]; then
 	if [ -n "${BENCH_ALLOW_CASSERT:-}" ]; then
 		echo "== WARNING: --enable-cassert build. Every number below includes"

--- a/bench/run_bench_readstream.sh
+++ b/bench/run_bench_readstream.sh
@@ -21,6 +21,40 @@
 set -uo pipefail
 
 PG_CONFIG="${1:-/usr/local/pg18_uring/bin/pg_config}"
+
+# ---------------------------------------------------------------------------
+# The non-assert requirement, ENFORCED rather than documented
+# ---------------------------------------------------------------------------
+#
+# This script's header has always said to run against a non-assert build. It
+# said so and checked nothing, and the invocation that measured #755, #768, #752
+# and #753 passed an --enable-cassert prefix. That is the failure shape this
+# repository keeps finding: the rule existed, the check did not.
+#
+# Refuse rather than warn, because a benchmark's whole output is numbers and a
+# warning above a table does not travel with the table. The override exists
+# because a comparison between two assert builds is still valid, and because an
+# assert build is sometimes the only one to hand -- but then every figure has to
+# be labelled, which is what the banner does.
+#
+# On the one measurement where the size of the skew was checked rather than
+# reasoned about, it was 2.5% (#768's per-column ladder, assert against
+# non-assert). Small here; it is allocation- and reset-shaped, so it is not
+# small everywhere, and the point is that nobody knew which case they had.
+BENCH_CASSERT="$("$PG_CONFIG" --configure 2>/dev/null | grep -c 'enable-cassert' || true)"
+if [ "${BENCH_CASSERT:-0}" != "0" ]; then
+	if [ -n "${BENCH_ALLOW_CASSERT:-}" ]; then
+		echo "== WARNING: --enable-cassert build. Every number below includes"
+		echo "   validation a production build never runs, and is comparable only"
+		echo "   against another assert build."
+	else
+		echo "FATAL: $("$PG_CONFIG" --bindir) is an --enable-cassert build."
+		echo "       This benchmark's numbers would carry assert-only validation."
+		echo "       Use a non-assert build, or set BENCH_ALLOW_CASSERT=1 to run"
+		echo "       anyway and have the output labelled as such."
+		exit 1
+	fi
+fi
 BINDIR="$("$PG_CONFIG" --bindir)"
 PORT="${BENCH_PORT:-55490}"
 ROWS="${BENCH_ROWS:-60000000}"

--- a/bench/run_clickbench.sh
+++ b/bench/run_clickbench.sh
@@ -127,7 +127,23 @@ PG_CONFIG="${1:-/usr/local/pg18n/bin/pg_config}"
 # reasoned about, it was 2.5% (#768's per-column ladder, assert against
 # non-assert). Small here; it is allocation- and reset-shaped, so it is not
 # small everywhere, and the point is that nobody knew which case they had.
-BENCH_CASSERT="$("$PG_CONFIG" --configure 2>/dev/null | grep -c 'enable-cassert' || true)"
+# --configure captured ONCE, and an empty capture is a REFUSAL rather than a
+# pass. Written as a single grep -c it could not tell "not an assert build" from
+# "could not tell": a missing, non-executable or failing pg_config gives empty
+# output, grep -c gives 0, and the 2>/dev/null swallows the evidence -- so the
+# guard returns its cleanest verdict on the least information. Reachable, not
+# theoretical: these scripts have default prefixes that do not exist on every
+# machine, so a no-arg invocation can pass a guard on a pg_config that never ran.
+#
+# Refuse when you cannot tell, for the same reason as when the answer is yes.
+BENCH_CONFIGURE="$("$PG_CONFIG" --configure 2>/dev/null || true)"
+if [ -z "$BENCH_CONFIGURE" ]; then
+	echo "FATAL: $PG_CONFIG produced no --configure output, so this script cannot"
+	echo "       tell whether it is an --enable-cassert build. Refusing rather than"
+	echo "       assuming it is not: check the path is right and executable."
+	exit 1
+fi
+BENCH_CASSERT="$(printf '%s' "$BENCH_CONFIGURE" | grep -c 'enable-cassert' || true)"
 if [ "${BENCH_CASSERT:-0}" != "0" ]; then
 	if [ -n "${BENCH_ALLOW_CASSERT:-}" ]; then
 		echo "== WARNING: --enable-cassert build. Every number below includes"

--- a/bench/run_clickbench.sh
+++ b/bench/run_clickbench.sh
@@ -107,6 +107,40 @@
 set -uo pipefail
 
 PG_CONFIG="${1:-/usr/local/pg18n/bin/pg_config}"
+
+# ---------------------------------------------------------------------------
+# The non-assert requirement, ENFORCED rather than documented
+# ---------------------------------------------------------------------------
+#
+# This script's header has always said to run against a non-assert build. It
+# said so and checked nothing, and the invocation that measured #755, #768, #752
+# and #753 passed an --enable-cassert prefix. That is the failure shape this
+# repository keeps finding: the rule existed, the check did not.
+#
+# Refuse rather than warn, because a benchmark's whole output is numbers and a
+# warning above a table does not travel with the table. The override exists
+# because a comparison between two assert builds is still valid, and because an
+# assert build is sometimes the only one to hand -- but then every figure has to
+# be labelled, which is what the banner does.
+#
+# On the one measurement where the size of the skew was checked rather than
+# reasoned about, it was 2.5% (#768's per-column ladder, assert against
+# non-assert). Small here; it is allocation- and reset-shaped, so it is not
+# small everywhere, and the point is that nobody knew which case they had.
+BENCH_CASSERT="$("$PG_CONFIG" --configure 2>/dev/null | grep -c 'enable-cassert' || true)"
+if [ "${BENCH_CASSERT:-0}" != "0" ]; then
+	if [ -n "${BENCH_ALLOW_CASSERT:-}" ]; then
+		echo "== WARNING: --enable-cassert build. Every number below includes"
+		echo "   validation a production build never runs, and is comparable only"
+		echo "   against another assert build."
+	else
+		echo "FATAL: $("$PG_CONFIG" --bindir) is an --enable-cassert build."
+		echo "       This benchmark's numbers would carry assert-only validation."
+		echo "       Use a non-assert build, or set BENCH_ALLOW_CASSERT=1 to run"
+		echo "       anyway and have the output labelled as such."
+		exit 1
+	fi
+fi
 CB_DATA="${PGC_CB_DATA:-/srv/clickbench}"
 CB_ROWS="${PGC_CB_ROWS:-10000000}"
 CB_TRIES="${PGC_CB_TRIES:-3}"

--- a/bench/run_profile.sh
+++ b/bench/run_profile.sh
@@ -105,7 +105,18 @@ fi
 # treatment: refuse, rather than emit a number that looks like data. The override
 # exists because an assert build is still worth profiling when it is the only one
 # to hand, and a comparison between two assert builds is valid.
-CASSERT="$("$PG_CONFIG" --configure | grep -c 'enable-cassert' || true)"
+# An empty --configure capture is a REFUSAL, not a pass: a missing or failing
+# pg_config gives no output, grep -c gives 0, and the guard would return its
+# cleanest verdict on the least information. Refuse when you cannot tell, for the
+# same reason as when the answer is yes.
+PROFILE_CONFIGURE="$("$PG_CONFIG" --configure 2>/dev/null || true)"
+if [ -z "$PROFILE_CONFIGURE" ]; then
+	echo "FATAL: $PG_CONFIG produced no --configure output, so this script cannot"
+	echo "       tell whether it is an --enable-cassert build. Refusing rather than"
+	echo "       assuming it is not: check the path is right and executable."
+	exit 1
+fi
+CASSERT="$(printf '%s' "$PROFILE_CONFIGURE" | grep -c 'enable-cassert' || true)"
 if [ "${CASSERT:-0}" != "0" ]; then
 	if [ -n "${PROFILE_ALLOW_CASSERT:-}" ]; then
 		echo "-- WARNING: assert build (--enable-cassert). Percentages below include"

--- a/test/bench_guards.sh
+++ b/test/bench_guards.sh
@@ -70,7 +70,16 @@ for _bp in "$(dirname "${BASH_SOURCE[0]}")/../bench/"run_*.sh; do
 	check "[$_bs] and offers a named override rather than only refusing" \
 		"$([ "$(grep -cE 'ALLOW_CASSERT' "$_bp")" -gt 0 ] && echo yes || echo no)" "yes"
 	check "[$_bs] and exits non-zero rather than warning past it" \
-		"$([ "$(grep -A14 'enable-cassert' "$_bp" | grep -c 'exit 1')" -gt 0 ] && echo yes || echo no)" "yes"
+		"$([ "$(grep -A24 'enable-cassert' "$_bp" | grep -c 'exit 1')" -gt 0 ] && echo yes || echo no)" "yes"
+	# "not an assert build" and "could not tell" are different answers and only
+	# one of them is a pass. Written as a bare `--configure | grep -c`, a missing
+	# or failing pg_config gives empty output, grep -c gives 0, and the guard
+	# returns its cleanest verdict on the least information -- so it must capture
+	# the output and refuse an empty one.
+	check "[$_bs] refuses when it CANNOT TELL, rather than treating that as a pass" \
+		"$([ "$(grep -c 'produced no --configure output' "$_bp")" -gt 0 ] && echo yes || echo no)" "yes"
+	check "[$_bs] and does not decide from an unbuffered pipe into grep -c" \
+		"$([ "$(grep -cE '\$\("\$PG_CONFIG" --configure[^)]*\| *grep -c' "$_bp")" -eq 0 ] && echo yes || echo no)" "yes"
 done
 
 # The control: the scan has to be reading files that exist, or four greps over

--- a/test/bench_guards.sh
+++ b/test/bench_guards.sh
@@ -67,6 +67,16 @@ for _bp in "$(dirname "${BASH_SOURCE[0]}")/../bench/"run_*.sh; do
 	_bs="$(basename "$_bp")"
 	check "[$_bs] refuses an assert build rather than documenting the requirement" \
 		"$([ "$(grep -c 'enable-cassert' "$_bp")" -gt 0 ] && echo yes || echo no)" "yes"
+	# EVERY assertion here keys on shared TEXT, never on a prefix, and that is
+	# load-bearing rather than incidental: run_profile.sh uses PROFILE_* where
+	# the other five use BENCH_*, so a check written against `BENCH_ALLOW_CASSERT`
+	# would pass on five runners and silently stop covering the sixth. Proved:
+	# keying that one check on BENCH_ALLOW_CASSERT leaves run_profile.sh as the
+	# only red. The unprefixed match below is what keeps it in scope.
+	#
+	# If anyone tidies the prefixes to match, this comment says the checks need
+	# no change. If anyone tidies the CHECKS to match the prefixes, that is the
+	# moment coverage is lost with nothing going red.
 	check "[$_bs] and offers a named override rather than only refusing" \
 		"$([ "$(grep -cE 'ALLOW_CASSERT' "$_bp")" -gt 0 ] && echo yes || echo no)" "yes"
 	check "[$_bs] and exits non-zero rather than warning past it" \

--- a/test/bench_guards.sh
+++ b/test/bench_guards.sh
@@ -52,6 +52,42 @@ fi
 
 echo "== pgColumnar test: $(basename "$0") =="
 
+# ---- the non-assert requirement must be ENFORCED, not merely documented -----
+#
+# Every bench script's header said to run against a non-assert build. They said
+# so and checked nothing, and the invocations that produced the #755, #768, #752
+# and #753 figures passed an --enable-cassert prefix. A header that states a
+# requirement the script does not enforce is the same shape as selftest 080 not
+# scanning bench/: the rule existed, the check did not.
+#
+# Asserted on the SOURCE rather than by running the benchmarks, because running
+# them takes minutes and the question is whether the guard is present and shaped
+# right.
+for _bp in "$(dirname "${BASH_SOURCE[0]}")/../bench/"run_*.sh; do
+	_bs="$(basename "$_bp")"
+	check "[$_bs] refuses an assert build rather than documenting the requirement" \
+		"$([ "$(grep -c 'enable-cassert' "$_bp")" -gt 0 ] && echo yes || echo no)" "yes"
+	check "[$_bs] and offers a named override rather than only refusing" \
+		"$([ "$(grep -cE 'ALLOW_CASSERT' "$_bp")" -gt 0 ] && echo yes || echo no)" "yes"
+	check "[$_bs] and exits non-zero rather than warning past it" \
+		"$([ "$(grep -A14 'enable-cassert' "$_bp" | grep -c 'exit 1')" -gt 0 ] && echo yes || echo no)" "yes"
+done
+
+# The control: the scan has to be reading files that exist, or four greps over
+# nothing would report compliance.
+# EVERY runner, derived from the directory rather than a hand-kept list: a new
+# bench script must not be able to arrive without this guard just because nobody
+# remembered to add it here. Proved by adding one -- a fresh runner with the
+# guard stripped is named by the loop above.
+#
+# A LOWER BOUND, not an equality. The premise's job is to show the scan read
+# something rather than globbing nothing; an equality would turn a legitimate new
+# benchmark into a red here, which is a check that punishes the thing it exists
+# to cover.
+_bench_runners="$(ls "$(dirname "${BASH_SOURCE[0]}")/../bench/"run_*.sh 2>/dev/null | grep -c .)"
+check "premise: every bench runner was read, not a hand-kept subset" \
+	"$([ "${_bench_runners:-0}" -ge 6 ] && echo yes || echo "no (found $_bench_runners)")" "yes"
+
 # ---- max_prepared_transactions must be preflighted, not discovered ----------
 #
 # Raising it needs a postmaster restart, so finding out during the load means the


### PR DESCRIPTION
Bench and test harness only; no product code.

## The gap

Every bench script's header said to run against a non-assert build. **They said so and checked
nothing.** The invocations that produced this session's #755, #768, #752 and #753 figures
passed `/usr/local/pg17`, which is `--enable-cassert`, and nobody noticed until
`AllocSetCheck` turned up at 4–5% of a profile.

That is the shape this repository has found **three times today**:

| | rule | check |
| --- | --- | --- |
| #771 | selftest 080 forbids an EPIPE pattern | did not scan `bench/` |
| #764 | `runs_alone` documented an arrangement | the code had the opposite one |
| **here** | headers require a non-assert build | the invocation used an assert one |

## The fix

`run_profile.sh` **already had exactly this guard** and the others did not, so the shape is
copied rather than invented: refuse, with a named override that *labels* the output rather
than suppressing the objection.

Refuse rather than warn, because a benchmark's whole output is numbers and **a warning above a
table does not travel with the table**.

Applied to all six runners: `run_bench.sh`, `run_bench_join.sh`, `run_bench_fsst.sh`,
`run_bench_readstream.sh`, `run_clickbench.sh`, and `run_profile.sh` which had it.

Verified all three ways: an assert prefix **exits 1** with the FATAL text,
`BENCH_ALLOW_CASSERT=1` warns and continues, a non-assert prefix is silent.

## The guard is itself guarded, and the list is derived

`bench_guards.sh` now asserts three properties per runner — it refuses, it offers a named
override, it exits non-zero rather than warning past — and **derives the list from the
directory** rather than keeping one by hand.

### Removal proofs, three

1. **Strip the guard from one runner** → `bench_guards` names that runner, 3 red.
2. **Add a *new* runner with the guard stripped** → named too. That is what the
   directory-derived loop buys over a hand-kept list: a future bench script cannot arrive
   unguarded because nobody remembered to add it here.
3. **Empty the bench directory** → the count premise fails, so the loop cannot report
   compliance by globbing nothing.

The premise is a **lower bound, not an equality**. Its job is to show the scan read something;
an equality would turn a legitimate new benchmark into a red here, which is a check that
punishes the thing it exists to cover.

## On the size of the skew, since that is the obvious question

On the one measurement where it was **checked rather than reasoned about**, it was **2.5%** —
#768's per-column ladder, assert against non-assert:

| | assert | non-assert |
| --- | ---: | ---: |
| ms per added int column | 29.2 | 28.9 |
| ms per added text column | 268.3 | 261.6 |

Small there, and inside the ±20% already attached to that figure. `AllocSetCheck` runs per
**context reset**, not per `palloc`, so it does not concentrate on an allocating arm the way I
first assumed. But it is allocation- and reset-shaped, so it is not small everywhere — and the
point of the guard is that nobody knew which case they had.