### PR TITLE
vacuum_sorted: self-gate on already-sorted AND nothing-to-reclaim (#760)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,30 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ### Added
 
+- `pgcolumnar.vacuum_sorted()` now self-gates: when the relation is already
+  exactly the requested lexicographic run with nothing appended and nothing to
+  reclaim, it skips the rewrite instead of materializing every live row through
+  a tuplesort again. `pgcolumnar.recluster()` has had the ordering half of this
+  since #415 so a scheduler can call it speculatively;
+  `design/ISSUE_415_AUTOVACUUM.md` promised the mirror here.
+
+  The mirror is not a copy, and that is the whole of the change.
+  `vacuum_sorted` has two jobs: it orders the live rows and it physically
+  reclaims deleted-row space. The obvious gate -- "is it already in this
+  order", which is complete for `recluster` -- would answer yes on a relation
+  that is in order and full of dead rows, and silently stop reclaiming. Ported
+  unchanged into a tree carrying it, that gate leaves 10,000 deleted rows
+  stored where the un-gated call reclaims all of them, with no error and no
+  report.
+
+  So the skip condition is "already in this order AND there is nothing to
+  reclaim": a `lexicographic` run (a `zorder` run over the same columns is not
+  this order, because Z-order over two or more columns is not a sort on any one
+  of them), over exactly these columns in this order, covering every row group,
+  with no deleted row and no empty group. Anything else falls through to the
+  full rewrite, so re-sorting by a new key, re-sorting a Z-ordered table, and
+  reclaiming all still work.
+
 - The columnar scan now tells the planner the order a sorted rewrite left the
   rows in, so `ORDER BY` on that key plans no `Sort`. Every `pathkeys` field in
   the tree was `NIL`, so a table that `pgcolumnar.vacuum_sorted` had physically

--- a/docs/sql-reference.md
+++ b/docs/sql-reference.md
@@ -86,6 +86,17 @@ SELECT pgcolumnar.set_options('events', sort_by => ARRAY['customer_id']);
 SELECT pgcolumnar.vacuum_sorted('events');                         -- declared key
 ```
 
+Re-running `vacuum_sorted` with the same key on a table that is still in that
+order is a fast no-op. It skips the rewrite on four conditions. The recorded
+key matches. The recorded kind is a sort and not a Z-order. The sorted run
+already covers every row group. No row group holds a deleted row.
+
+That last condition is part of the gate because `vacuum_sorted` both orders the
+rows and reclaims deleted-row space. A table that is in order but holds deleted
+rows is rewritten, so the space is still reclaimed. Deletes, inserts, a
+different key, or a table arranged by `cluster()` all fall through to the full
+rewrite.
+
 A sort key is a **trade** and not a free gain. A sort by a segment key puts the
 rows of each segment together, so a filter on that key skips most groups. It also
 spreads each *other* dimension across every group.

--- a/src/columnar_vacuum.c
+++ b/src/columnar_vacuum.c
@@ -204,6 +204,8 @@ static bytea *cluster_zorder_key(Datum *values, bool *isnull, AttrNumber *atts,
 								 int ncols, TupleDesc tupdesc);
 /* Names an ordering rewrite records as its key (defined later, #415) */
 static List *sort_key_names(TupleDesc tupdesc, AttrNumber *atts, int ncols);
+static bool vacuum_sorted_gate_is_noop(Relation rel, int ncols,
+									   AttrNumber *atts);
 
 /* v1 refuses tables with more groups than this (one advisory lock per group) */
 #define RECLUSTER_MAX_GROUPS 8192
@@ -1591,6 +1593,126 @@ pgcolumnar_vacuum(PG_FUNCTION_ARGS)
 }
 
 /*
+ * vacuum_sorted_gate_is_noop
+ *		Would pgcolumnar.vacuum_sorted(rel, atts...) change anything?
+ *
+ *		#415 gave the online recluster a self-gate so a scheduler can call it
+ *		speculatively without paying a full rewrite each time;
+ *		design/ISSUE_415_AUTOVACUUM.md promises the mirror here, and #760 says
+ *		why the mirror cannot be a copy.
+ *
+ *		vacuum_sorted has TWO jobs, not one: it orders the live rows AND it
+ *		physically reclaims deleted-row space and combines small stripes
+ *		(docs/ARCHITECTURE.md). recluster only orders, so "is it already in
+ *		this order" is a complete skip condition there and is NOT one here --
+ *		it would answer yes on a relation that is in order and full of dead
+ *		rows, and silently stop reclaiming. That is a data-size regression
+ *		with no error and no report, which is worse than the rewrite it saves.
+ *
+ *		So the gate is "already in this order AND there is nothing to reclaim":
+ *
+ *		  1. the recorded run is lexicographic (a zorder run over the same
+ *		     columns is NOT this order -- Z-order over two or more columns is
+ *		     not a sort on any one of them);
+ *		  2. the recorded key is exactly these columns, in this order;
+ *		  3. every row group lies inside [sorted_from, sorted_through], so no
+ *		     group was appended past the run or drawn by a concurrent writer
+ *		     below it. This also covers stripe-combining: a group inside the
+ *		     run was produced BY the rewrite that set the mark, so it is
+ *		     already combined;
+ *		  4. no group carries a deleted row, and none is empty. This is the
+ *		     half recluster does not need and the reason #760 exists.
+ *
+ *		Any mismatch falls through to the full rewrite, so re-sorting by a new
+ *		key, re-sorting a Z-ordered table, and reclaiming all still work. A
+ *		mark written before sorted_from/sorted_kind existed leaves them unset
+ *		and never gates, which is the safe pre-#415 default.
+ */
+static bool
+vacuum_sorted_gate_is_noop(Relation rel, int ncols, AttrNumber *atts)
+{
+	uint64		storageId = PgColumnarStorageId(rel);
+	TupleDesc	tupdesc = RelationGetDescr(rel);
+	int64		sfrom,
+				sthrough;
+	List	   *skey;
+	char	   *skind;
+	Snapshot	snap;
+	List	   *rgList;
+	ListCell   *lc;
+	int			i;
+	bool		noop = true;
+
+	PgColumnarGetSortedInfo(storageId, &sfrom, &sthrough, &skey, &skind);
+
+	/* 1 + 2: a lexicographic run over exactly this key */
+	if (skind == NULL || strcmp(skind, "lexicographic") != 0)
+		return false;
+	if (list_length(skey) != ncols)
+		return false;
+	i = 0;
+	foreach(lc, skey)
+	{
+		const char *want = NameStr(TupleDescAttr(tupdesc, atts[i] - 1)->attname);
+
+		if (strcmp((char *) lfirst(lc), want) != 0)
+			return false;
+		i++;
+	}
+	if (sfrom < 0 || sthrough < 0)
+		return false;
+
+	/*
+	 * Own pending work must be persisted before the group list and the delete
+	 * vectors are read, or an insert or delete made earlier in this same
+	 * transaction is invisible here and the gate fires on a relation that does
+	 * need the rewrite. Both flushes are idempotent, and
+	 * pgcolumnar_compact_relation repeats them on the fall-through path.
+	 */
+	PgColumnarFlushWriteStateForRelation(RelationGetRelid(rel));
+	PgColumnarFlushDeleteVectorForRelation(rel);
+
+	snap = RegisterSnapshot(GetLatestSnapshot());
+	rgList = PgColumnarReadRowGroupList(storageId, snap);
+	if (rgList == NIL)
+		noop = false;			/* nothing written: let the ordinary path run */
+	foreach(lc, rgList)
+	{
+		NativeRowGroupMetadata *rg = (NativeRowGroupMetadata *) lfirst(lc);
+		List	   *rmList;
+		ListCell   *lc2;
+
+		/* 3: inside the recorded run */
+		if ((int64) rg->groupNumber < sfrom || (int64) rg->groupNumber > sthrough)
+		{
+			noop = false;
+			break;
+		}
+
+		/* 4: an empty group is space a rewrite would drop, so it is work */
+		if (rg->rowCount == 0)
+		{
+			noop = false;
+			break;
+		}
+		rmList = PgColumnarReadDeleteVectorList(storageId, rg->groupNumber, snap);
+		foreach(lc2, rmList)
+		{
+			if (((DeleteVectorMetadata *) lfirst(lc2))->deletedCount > 0)
+			{
+				noop = false;
+				break;
+			}
+		}
+		if (!noop)
+			break;
+	}
+	UnregisterSnapshot(snap);
+
+	return noop;
+}
+
+/*
  * pgcolumnar_vacuum_sorted
  *		SQL: columnar.vacuum_sorted(tablename regclass, VARIADIC sort_columns name[]).
  *		Like columnar.vacuum, but rewrites the live rows physically sorted
@@ -1736,7 +1858,17 @@ pgcolumnar_vacuum_sorted(PG_FUNCTION_ARGS)
 		sortAtts[i++] = attno;
 	}
 
-	pgcolumnar_compact_relation(rel, ncols, sortAtts);
+	/*
+	 * Self-gate (#760): skip the rewrite when the relation is already exactly
+	 * this lexicographic run with nothing appended and nothing to reclaim. See
+	 * vacuum_sorted_gate_is_noop for why the reclaim half is not optional.
+	 */
+	if (vacuum_sorted_gate_is_noop(rel, ncols, sortAtts))
+		ereport(DEBUG1,
+				(errmsg("pgcolumnar: \"%s\" is already sorted on this key with nothing to reclaim, skipping rewrite",
+						RelationGetRelationName(rel))));
+	else
+		pgcolumnar_compact_relation(rel, ncols, sortAtts);
 
 	/* keep the lock until end of transaction */
 	table_close(rel, NoLock);

--- a/src/columnar_vacuum.c
+++ b/src/columnar_vacuum.c
@@ -1663,11 +1663,23 @@ vacuum_sorted_gate_is_noop(Relation rel, int ncols, AttrNumber *atts)
 		return false;
 
 	/*
-	 * Own pending work must be persisted before the group list and the delete
-	 * vectors are read, or an insert or delete made earlier in this same
-	 * transaction is invisible here and the gate fires on a relation that does
-	 * need the rewrite. Both flushes are idempotent, and
-	 * pgcolumnar_compact_relation repeats them on the fall-through path.
+	 * Persist own pending work before reading the group list and the delete
+	 * vectors, as pgcolumnar_compact_relation does on the fall-through path.
+	 * Both flushes are idempotent.
+	 *
+	 * Stated honestly: this is defensive, not a fix for an observed hole, and
+	 * no arm in test/vacuum_sorted_gate.sh goes red without it. The write
+	 * state and the delete vector are both flushed at end of statement, so by
+	 * the time a later vacuum_sorted() runs, everything an earlier statement
+	 * in the same transaction wrote is already in row_group (measured: a
+	 * 500-row insert below chunk_group_row_limit shows storedrows=20500
+	 * immediately, inside the transaction).
+	 *
+	 * It stays because the gate SKIPS A REWRITE on what it reads, so reading
+	 * stale state is a silent correctness bug, and the invariant that makes
+	 * the flush unnecessary belongs to another module. The transaction arms in
+	 * that suite pin the invariant rather than this flush: if end-of-statement
+	 * flushing ever stops holding, they go red and this becomes load-bearing.
 	 */
 	PgColumnarFlushWriteStateForRelation(RelationGetRelid(rel));
 	PgColumnarFlushDeleteVectorForRelation(rel);

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -251,6 +251,7 @@ SUITES=(
 	unique_conc
 	update_conc
 	vacuum_lock_privilege
+	vacuum_sorted_gate
 	vacuum_stripe_count
 	vector_agg_rescan_memory
 	vector_agg_tlist_shape

--- a/test/vacuum_sorted_gate.sh
+++ b/test/vacuum_sorted_gate.sh
@@ -175,25 +175,31 @@ psql_run "SELECT pgcolumnar.vacuum_sorted('vg_u','k','j');"
 check "so vacuum_sorted after a plain vacuum rewrites" "$(did_rewrite vg_u "$SU")" "yes"
 
 # ---- uncommitted work in the SAME transaction must not be missed -------------
-# The gate reads the row-group list and the delete vectors, so it must persist
-# this backend's pending writes first. Without the flush, work done earlier in
-# the same transaction is invisible and the gate fires on a relation that does
-# need the rewrite.
+# The gate SKIPS A REWRITE on what it reads, so reading stale state would be a
+# silent correctness bug. These arms pin the INVARIANT that makes it safe:
+# work done by an earlier statement in the same transaction is visible to a
+# later vacuum_sorted().
 #
-# The insert must be SMALLER than chunk_group_row_limit. A larger one flushes
-# complete groups during the INSERT itself, leaving nothing pending -- which is
-# what an earlier version of this arm did, and it stayed green with both
-# flushes deleted.
+# They do NOT prove the gate's own flush is load-bearing, and this file should
+# not claim they do -- deleting both flushes leaves every arm here green,
+# because the write state and the delete vector are flushed at end of
+# statement. Measured, not assumed: a 500-row insert below
+# chunk_group_row_limit reports storedrows=20500 from inside the transaction.
+# If that ever stops holding, these arms go red and the flush becomes the fix.
+#
+# The insert is still deliberately SMALLER than chunk_group_row_limit: a larger
+# one flushes complete groups during the INSERT itself, which is a weaker
+# fixture for the same claim.
 mk vg_x
 psql_run "SELECT pgcolumnar.vacuum_sorted('vg_x','k','j');"
-check_num "premise: the tail is smaller than the chunk group limit, so it stays PENDING" \
+check_num "premise: the tail is smaller than the chunk group limit" \
 	"$([ 500 -lt $CG ] && echo 1 || echo 0)" "1"
 psql_run "BEGIN;
           INSERT INTO vg_x SELECT g, (g*2654435761)::bigint % 1000, g % 97, md5(g::text)
             FROM generate_series(200001,200500) g;
           SELECT pgcolumnar.vacuum_sorted('vg_x','k','j');
           COMMIT;"
-check "a PENDING insert in the same transaction defeats the gate (rows come out ordered)" \
+check "an insert earlier in the same transaction defeats the gate (rows come out ordered)" \
 	"$(q "SELECT bool_and(ok) FROM (SELECT (k,j) >= lag((k,j)) OVER (ORDER BY ctid) IS NOT FALSE AS ok FROM vg_x) s;")" \
 	"t"
 check_num "and every row is still there" "$(liverows vg_x)" "20500"
@@ -206,7 +212,7 @@ psql_run "BEGIN;
           DELETE FROM vg_d WHERE id % 2 = 0;
           SELECT pgcolumnar.vacuum_sorted('vg_d','k','j');
           COMMIT;"
-check_num "a PENDING delete in the same transaction defeats the gate (space reclaimed)" \
+check_num "a delete earlier in the same transaction defeats the gate (space reclaimed)" \
 	"$(deadrows vg_d)" "0"
 check_num "and the rewrite really happened: the live rows are all that is stored" \
 	"$(q "SELECT COALESCE(sum(rowcount),0) FROM pgcolumnar.stats('vg_d');")" "10000"

--- a/test/vacuum_sorted_gate.sh
+++ b/test/vacuum_sorted_gate.sh
@@ -176,20 +176,40 @@ check "so vacuum_sorted after a plain vacuum rewrites" "$(did_rewrite vg_u "$SU"
 
 # ---- uncommitted work in the SAME transaction must not be missed -------------
 # The gate reads the row-group list and the delete vectors, so it must persist
-# this backend's pending writes first. Without the flush an insert made earlier
-# in the same transaction is invisible and the gate fires on a relation that
-# does need the rewrite.
+# this backend's pending writes first. Without the flush, work done earlier in
+# the same transaction is invisible and the gate fires on a relation that does
+# need the rewrite.
+#
+# The insert must be SMALLER than chunk_group_row_limit. A larger one flushes
+# complete groups during the INSERT itself, leaving nothing pending -- which is
+# what an earlier version of this arm did, and it stayed green with both
+# flushes deleted.
 mk vg_x
 psql_run "SELECT pgcolumnar.vacuum_sorted('vg_x','k','j');"
+check_num "premise: the tail is smaller than the chunk group limit, so it stays PENDING" \
+	"$([ 500 -lt $CG ] && echo 1 || echo 0)" "1"
 psql_run "BEGIN;
-           INSERT INTO vg_x SELECT g, (g*2654435761)::bigint % 1000, g % 97, md5(g::text)
-             FROM generate_series(200001,203000) g;
-           SELECT pgcolumnar.vacuum_sorted('vg_x','k','j');
-           COMMIT;"
-check "an insert earlier in the SAME transaction defeats the gate (rows come out ordered)" \
+          INSERT INTO vg_x SELECT g, (g*2654435761)::bigint % 1000, g % 97, md5(g::text)
+            FROM generate_series(200001,200500) g;
+          SELECT pgcolumnar.vacuum_sorted('vg_x','k','j');
+          COMMIT;"
+check "a PENDING insert in the same transaction defeats the gate (rows come out ordered)" \
 	"$(q "SELECT bool_and(ok) FROM (SELECT (k,j) >= lag((k,j)) OVER (ORDER BY ctid) IS NOT FALSE AS ok FROM vg_x) s;")" \
 	"t"
-check_num "and every row is still there" "$(liverows vg_x)" "23000"
+check_num "and every row is still there" "$(liverows vg_x)" "20500"
+
+# the same for a PENDING delete, which lives in a different buffer
+mk vg_d
+psql_run "SELECT pgcolumnar.vacuum_sorted('vg_d','k','j');"
+check_num "premise: nothing is deleted before the transaction" "$(deadrows vg_d)" "0"
+psql_run "BEGIN;
+          DELETE FROM vg_d WHERE id % 2 = 0;
+          SELECT pgcolumnar.vacuum_sorted('vg_d','k','j');
+          COMMIT;"
+check_num "a PENDING delete in the same transaction defeats the gate (space reclaimed)" \
+	"$(deadrows vg_d)" "0"
+check_num "and the rewrite really happened: the live rows are all that is stored" \
+	"$(q "SELECT COALESCE(sum(rowcount),0) FROM pgcolumnar.stats('vg_d');")" "10000"
 
 # ---- correctness: a skipped rewrite changed nothing --------------------------
 psql_run "CREATE TABLE vg_h (id int, k int, j int, pad text);"

--- a/test/vacuum_sorted_gate.sh
+++ b/test/vacuum_sorted_gate.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+#
+# pgColumnar #760: vacuum_sorted() self-gates -- it skips the rewrite when the
+# relation is already exactly this lexicographic run with nothing appended AND
+# nothing to reclaim.
+#
+# #415 gave recluster() the ordering half of this gate. The mirror could not be
+# a copy: vacuum_sorted has TWO jobs, ordering and physically reclaiming
+# deleted-row space, so an ordering-only gate would answer "nothing to do" on a
+# relation that is in order and full of dead rows and silently stop reclaiming.
+# That is a data-size regression with no error and no report.
+#
+# The arm this suite exists for is therefore NOT "the gate fires". It is
+# "deleted rows DEFEAT the gate": the wrong gate passes every other arm here.
+#
+# Usage:  test/vacuum_sorted_gate.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+CG=1000
+
+mk() {
+	psql_run "DROP TABLE IF EXISTS $1;"
+	psql_run "CREATE TABLE $1 (id int, k int, j int, pad text) USING pgcolumnar;"
+	psql_run "SELECT pgcolumnar.set_options('$1', chunk_group_row_limit => $CG);"
+	psql_run "INSERT INTO $1 SELECT g, (g*2654435761)::bigint % 1000, g % 97, md5(g::text)
+	          FROM generate_series(1,20000) g;"
+}
+
+# "Did this call rewrite?" -- the signal, and the one that does NOT work.
+#
+# STORAGE ID is the signal. An ordering rewrite materializes the live rows into
+# a NEW storage row and swaps it in, so the id moves on a rewrite and does not
+# on a skip.
+#
+# The (group_number, file_offset, rowcount) multiset -- which is the right
+# signal for recluster (#415), because recluster rewrites INSIDE the existing
+# storage and so reallocates offsets -- is useless here for exactly that
+# reason. A vacuum_sorted rewrite starts a fresh storage, so group numbers and
+# offsets restart from zero and the multiset comes out BYTE-IDENTICAL on a real
+# rewrite of unchanged data. It cannot distinguish the two cases, and an arm
+# built on it would have called every rewrite a no-op.
+#
+# It is still worth taking on the NO-OP arms, where it is a second, independent
+# witness that nothing moved. So: storage id decides, layout corroborates, and
+# a disagreement on a no-op arm is itself a failure rather than a quiet pass.
+physlayout() { q "SELECT md5(string_agg(stripeid::text||':'||fileoffset::text||':'||rowcount::text, ',' ORDER BY stripeid)) FROM pgcolumnar.stats('$1');"; }
+storid()    { q "SELECT pgcolumnar.get_storage_id('$1');"; }
+deadrows()  { q "SELECT COALESCE(sum(deletedrows),0) FROM pgcolumnar.stats('$1');"; }
+liverows()  { q "SELECT count(*) FROM $1;"; }
+
+did_rewrite() {          # storage id only: see above
+	local t="$1" s0="$2"
+	[ "$s0" = "$(storid "$t")" ] && echo no || echo yes
+}
+stayed_put() {           # for no-op arms: BOTH witnesses must say nothing moved
+	local t="$1" p0="$2" s0="$3" p1 s1
+	p1="$(physlayout "$t")"; s1="$(storid "$t")"
+	if [ "$s0" != "$s1" ]; then echo "rewritten(storage moved)"
+	elif [ "$p0" != "$p1" ]; then echo "rewritten(layout moved)"
+	else echo same; fi
+}
+
+# ---- fixture: sort once by (k,j) ---------------------------------------------
+mk vg_t
+P0="$(physlayout vg_t)"; S0="$(storid vg_t)"
+psql_run "SELECT pgcolumnar.vacuum_sorted('vg_t','k','j');"
+check "premise: the first vacuum_sorted does real work (layout and storage both move)" \
+	"$(did_rewrite vg_t "$S0")" "yes"
+check "premise: it recorded a LEXICOGRAPHIC run (not zorder)" \
+	"$(q "SELECT s.sorted_kind FROM pgcolumnar.storage s WHERE s.storage_id = pgcolumnar.get_storage_id('vg_t');")" \
+	"lexicographic"
+check "premise: over exactly the requested key" \
+	"$(q "SELECT sort_key::text FROM pgcolumnar.sort_status('vg_t');")" "{k,j}"
+check "premise: the run covers the whole relation (0 appended groups)" \
+	"$(q "SELECT appended_groups FROM pgcolumnar.sort_status('vg_t');")" "0"
+check_num "premise: nothing is deleted yet" "$(deadrows vg_t)" "0"
+
+# ---- the gate fires ----------------------------------------------------------
+P1="$(physlayout vg_t)"; S1="$(storid vg_t)"
+psql_run "SELECT pgcolumnar.vacuum_sorted('vg_t','k','j');"
+check "a second vacuum_sorted on the same key does NOT rewrite" \
+	"$(stayed_put vg_t "$P1" "$S1")" "same"
+P2="$(physlayout vg_t)"; S2="$(storid vg_t)"
+psql_run "SELECT pgcolumnar.vacuum_sorted('vg_t','k','j');"
+check "a third identical call is also a no-op" "$(stayed_put vg_t "$P2" "$S2")" "same"
+
+# the gate must not have cost the ordering it is claiming to preserve
+check "and the relation is still physically in (k,j) order after the skips" \
+	"$(q "SELECT bool_and(ok) FROM (SELECT (k,j) >= lag((k,j)) OVER (ORDER BY ctid) IS NOT FALSE AS ok FROM vg_t) s;")" \
+	"t"
+
+# ---- THE ARM THIS SUITE EXISTS FOR: deleted rows defeat the gate --------------
+# An ordering-only gate -- the obvious mirror of #415 -- passes every other arm
+# in this file and fails exactly here, leaving the dead rows stored forever.
+psql_run "DELETE FROM vg_t WHERE id % 2 = 0;"
+DEAD="$(deadrows vg_t)"
+check "premise: the delete left dead rows INSIDE the run, appending nothing" \
+	"$([ "${DEAD:-0}" -gt 0 ] && echo yes || echo no)/$(q "SELECT appended_groups FROM pgcolumnar.sort_status('vg_t');")" \
+	"yes/0"
+check "premise: so an ORDERING-only gate would see 'already sorted, nothing appended'" \
+	"$(q "SELECT s.sorted_kind||'/'||s.sorted_by::text FROM pgcolumnar.storage s WHERE s.storage_id = pgcolumnar.get_storage_id('vg_t');")" \
+	"lexicographic/{k,j}"
+P3="$(physlayout vg_t)"; S3="$(storid vg_t)"
+LIVE3="$(liverows vg_t)"
+psql_run "SELECT pgcolumnar.vacuum_sorted('vg_t','k','j');"
+check "vacuum_sorted with dead rows DOES rewrite, gate or no gate" \
+	"$(did_rewrite vg_t "$S3")" "yes"
+check_num "and it reclaimed the space: deleted rows go to zero" "$(deadrows vg_t)" "0"
+check_num "without losing a live row" "$(liverows vg_t)" "$LIVE3"
+
+# and having reclaimed, the gate is armed again
+P4="$(physlayout vg_t)"; S4="$(storid vg_t)"
+psql_run "SELECT pgcolumnar.vacuum_sorted('vg_t','k','j');"
+check "the call after the reclaim is a no-op again" "$(stayed_put vg_t "$P4" "$S4")" "same"
+
+# ---- an appended tail defeats the gate ---------------------------------------
+psql_run "INSERT INTO vg_t SELECT g, (g*2654435761)::bigint % 1000, g % 97, md5(g::text)
+          FROM generate_series(100001,105000) g;"
+check "premise: the insert appended groups outside the run" \
+	"$(q "SELECT appended_groups > 0 FROM pgcolumnar.sort_status('vg_t');")" "t"
+P5="$(physlayout vg_t)"; S5="$(storid vg_t)"
+psql_run "SELECT pgcolumnar.vacuum_sorted('vg_t','k','j');"
+check "vacuum_sorted after an append DOES rewrite" "$(did_rewrite vg_t "$S5")" "yes"
+check_num "and folds the tail back into the run" \
+	"$(q "SELECT appended_groups FROM pgcolumnar.sort_status('vg_t');")" "0"
+
+# ---- a DIFFERENT key defeats the gate ----------------------------------------
+P6="$(physlayout vg_t)"; S6="$(storid vg_t)"
+psql_run "SELECT pgcolumnar.vacuum_sorted('vg_t','j','k');"
+check "vacuum_sorted by a DIFFERENT key (same columns, other order) rewrites" \
+	"$(did_rewrite vg_t "$S6")" "yes"
+check "and records the new key" \
+	"$(q "SELECT sort_key::text FROM pgcolumnar.sort_status('vg_t');")" "{j,k}"
+P7="$(physlayout vg_t)"; S7="$(storid vg_t)"
+psql_run "SELECT pgcolumnar.vacuum_sorted('vg_t','k');"
+check "a PREFIX of the recorded key is a different key, so it rewrites" \
+	"$(did_rewrite vg_t "$S7")" "yes"
+
+# ---- a Z-ORDER run over the same columns defeats the gate --------------------
+# Z-order over two or more columns is not a sort on any one of them, so a gate
+# keyed on the column list alone would skip here and leave the table unsorted
+# while sort_status reported the key. The kind is what separates them.
+mk vg_z
+psql_run "SELECT pgcolumnar.cluster('vg_z','k','j');"
+check "premise: cluster() recorded a ZORDER run over the same columns" \
+	"$(q "SELECT s.sorted_kind||'/'||s.sorted_by::text FROM pgcolumnar.storage s WHERE s.storage_id = pgcolumnar.get_storage_id('vg_z');")" \
+	"zorder/{k,j}"
+check "premise: and the Z-ordered table is NOT in k order (else this arm proves nothing)" \
+	"$(q "SELECT bool_and(ok) FROM (SELECT k >= lag(k) OVER (ORDER BY ctid) IS NOT FALSE AS ok FROM vg_z) s;")" \
+	"f"
+PZ="$(physlayout vg_z)"; SZ="$(storid vg_z)"
+psql_run "SELECT pgcolumnar.vacuum_sorted('vg_z','k','j');"
+check "vacuum_sorted over a ZORDER run of the same columns DOES rewrite" \
+	"$(did_rewrite vg_z "$SZ")" "yes"
+check "and the result really is in (k,j) order" \
+	"$(q "SELECT bool_and(ok) FROM (SELECT (k,j) >= lag((k,j)) OVER (ORDER BY ctid) IS NOT FALSE AS ok FROM vg_z) s;")" \
+	"t"
+check "and the kind is now lexicographic" \
+	"$(q "SELECT s.sorted_kind FROM pgcolumnar.storage s WHERE s.storage_id = pgcolumnar.get_storage_id('vg_z');")" \
+	"lexicographic"
+
+# ---- an unsorted vacuum() clears the mark, so the next call rewrites ---------
+mk vg_u
+psql_run "SELECT pgcolumnar.vacuum_sorted('vg_u','k','j');"
+psql_run "SELECT pgcolumnar.vacuum('vg_u');"
+check "premise: a plain vacuum() leaves no lexicographic mark" \
+	"$(q "SELECT COALESCE(s.sorted_kind,'none') FROM pgcolumnar.storage s WHERE s.storage_id = pgcolumnar.get_storage_id('vg_u');")" \
+	"none"
+PU="$(physlayout vg_u)"; SU="$(storid vg_u)"
+psql_run "SELECT pgcolumnar.vacuum_sorted('vg_u','k','j');"
+check "so vacuum_sorted after a plain vacuum rewrites" "$(did_rewrite vg_u "$SU")" "yes"
+
+# ---- uncommitted work in the SAME transaction must not be missed -------------
+# The gate reads the row-group list and the delete vectors, so it must persist
+# this backend's pending writes first. Without the flush an insert made earlier
+# in the same transaction is invisible and the gate fires on a relation that
+# does need the rewrite.
+mk vg_x
+psql_run "SELECT pgcolumnar.vacuum_sorted('vg_x','k','j');"
+psql_run "BEGIN;
+           INSERT INTO vg_x SELECT g, (g*2654435761)::bigint % 1000, g % 97, md5(g::text)
+             FROM generate_series(200001,203000) g;
+           SELECT pgcolumnar.vacuum_sorted('vg_x','k','j');
+           COMMIT;"
+check "an insert earlier in the SAME transaction defeats the gate (rows come out ordered)" \
+	"$(q "SELECT bool_and(ok) FROM (SELECT (k,j) >= lag((k,j)) OVER (ORDER BY ctid) IS NOT FALSE AS ok FROM vg_x) s;")" \
+	"t"
+check_num "and every row is still there" "$(liverows vg_x)" "23000"
+
+# ---- correctness: a skipped rewrite changed nothing --------------------------
+psql_run "CREATE TABLE vg_h (id int, k int, j int, pad text);"
+psql_run "INSERT INTO vg_h SELECT id,k,j,pad FROM vg_t;"
+check "the gated calls preserved the exact row set (columnar == heap mirror)" \
+	"$(q "SELECT count(*)||'/'||sum(k)||'/'||sum(j)||'/'||md5(string_agg(pad,',' ORDER BY id, pad)) FROM vg_t;")" \
+	"$(q "SELECT count(*)||'/'||sum(k)||'/'||sum(j)||'/'||md5(string_agg(pad,',' ORDER BY id, pad)) FROM vg_h;")"
+
+pgc_summary


### PR DESCRIPTION
Closes #760.

`pgcolumnar.recluster()` has self-gated since #415 so a scheduler can call it
speculatively without paying a full rewrite each time, and
`design/ISSUE_415_AUTOVACUUM.md` promises the mirror for `vacuum_sorted`. #758 put
the information the gate needs into the catalog (`sorted_kind`, `sorted_by`), so
this is the follow-through.

## The mirror is not a copy, and that is the whole of the PR

`vacuum_sorted` has **two** jobs: it orders the live rows and it physically
reclaims deleted-row space. The obvious gate -- "is it already in this order",
which is complete for `recluster` -- answers yes on a relation that is in order
and full of dead rows, and silently stops reclaiming. No error, no report, a
data-size regression.

So the skip condition is "already in this order **and** there is nothing to
reclaim". Four conditions, in `vacuum_sorted_gate_is_noop`:

1. the recorded run is `lexicographic`. A `zorder` run over the same columns is
   not this order: Z-order over two or more columns is not a sort on any one of
   them;
2. the recorded key is exactly these columns, in this order;
3. every row group lies inside `[sorted_from, sorted_through]`. This also covers
   stripe-combining -- a group inside the run was produced *by* the rewrite that
   set the mark, so it is already combined;
4. no group carries a deleted row, and none is empty.

Anything else falls through to the full rewrite, so re-sorting by a new key,
re-sorting a Z-ordered table, and reclaiming all still work. A mark written
before `sorted_from`/`sorted_kind` existed leaves them unset and never gates,
which is the safe pre-#415 default.

## Removal proofs

Three mutations, each run against the full 34-check suite.

**A. delete the gate** (`if (false && ...)`) -- exactly the three no-op arms go
red, nothing else:

```
FAIL  a second vacuum_sorted on the same key does NOT rewrite: got [rewritten(storage moved)] want [same]
FAIL  a third identical call is also a no-op: got [rewritten(storage moved)] want [same]
FAIL  the call after the reclaim is a no-op again: got [rewritten(storage moved)] want [same]
```

**B. the WRONG MIRROR** -- port #415's ordering-only gate by deleting conditions
3 and 4. This is the mutation the suite exists for, and it is the one that would
ship silently:

```
FAIL  vacuum_sorted with dead rows DOES rewrite, gate or no gate: got [no] want [yes]
FAIL  and it reclaimed the space: deleted rows go to zero: got [10000] want [0]
```

10,000 rows stay stored where the un-gated call reclaims all of them.

**Correction, from the review.** I originally wrote that mutation B reddens
*exactly those two* arms. That was true when I ran it and is now stale: the
transaction arms were added to the suite afterwards, and they must redden under
any removal of condition 4. Re-run by the reviewer, deleting conditions 3+4
reddens **6** arms and deleting condition 4 alone reddens **4**. The suite is
stronger than the PR first advertised; only the count was wrong. The two arms
quoted above are still the ones the suite exists for.

**C. delete both flushes** -- *the suite stays green*, and the PR says so rather
than implying otherwise. See below.

## Two things I got wrong on the way, both left visible in the tree

**The rewrite signal.** I first detected "did this rewrite" the way
`recluster_gate.sh` does, from the `(group_number, file_offset, rowcount)`
multiset. That is right for `recluster`, which rewrites *inside* the existing
storage and so reallocates offsets. It is useless here for exactly that reason: a
`vacuum_sorted` rewrite starts a **fresh storage**, so group numbers and offsets
restart from zero and the multiset comes out byte-identical on a real rewrite of
unchanged data. It would have called every rewrite a no-op.

It did not get through, because the helper cross-checked two independent signals
and reported disagreement as a failure instead of picking one:

```
FAIL  premise: the first vacuum_sorted does real work: got [DISAGREE(phys=no storage=yes)] want [yes]
```

Storage id now decides; the layout hash is kept on the no-op arms as a second
witness that nothing moved.

**A vacuous arm, and an honest label instead of a fix.** The transaction arms
first inserted 3,000 rows with `chunk_group_row_limit = 1000`, which flushes three
complete groups during the `INSERT` itself -- so nothing was ever pending and the
arms stayed green with both flushes deleted. I shrank the tail below the chunk
group limit and they still stayed green. Measured why, rather than assuming:
a 500-row insert reports `storedrows=20500` from *inside* the transaction,
because the write state and the delete vector are both flushed at end of
statement.

So **no arm in this suite proves the gate's flush is load-bearing**, and neither
the code comment nor the test file claims one does. The flush stays because the
gate *skips a rewrite* on what it reads, so reading stale state would be a silent
correctness bug, and the invariant that makes it unnecessary belongs to another
module. The arms pin that invariant instead: if end-of-statement flushing ever
stops holding, they go red and the flush becomes the fix.

## Tests

`test/vacuum_sorted_gate.sh`, 34 checks, registered in `run_all_versions.sh` in
its C-order slot (verified with `--list-suites | LC_ALL=C sort -c`, and
`harness_selftest` 153/153).

PG17: the new suite plus the 13 neighbours that touch ordering, reclaim and the
sorted mark -- `eager_ordering_record`, `recluster_gate`, `recluster_extent`,
`native_recluster`, `maintenance_due`, `autovacuum`, `native_reclaim_frag`,
`native_reclaim_cycles`, `native_reclaim_reconcile`, `vacuum_stripe_count`,
`vacuum_lock_privilege`, `sorted_pathkeys`, `native_ownership` -- all PASSED.
`docs_style` PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaQ4vThXcmTCf3KRQpUDrE

