### PR TITLE
Pin the documented CDC recipe, and record the decision (#754)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,28 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ### Added
 
+- The documented CDC recipe is now tested end to end, and the decision behind it
+  is recorded rather than implied (#754). `test/logical_decoding_source.sh`
+  already pinned the limitation: a columnar table emits no decodable change.
+  Nothing pinned the workaround `docs/user-guide.md` offers in its place, which
+  is to capture rows into a heap table with a row trigger and decode that.
+
+  That recipe makes four factual claims, none of which was checked. Row triggers
+  fire on a columnar table and see the same rows a heap table would. An `UPDATE`
+  arrives as one `UPDATE` rather than as the storage's internal delete and
+  insert, which is the claim a CDC consumer would be broken by and the one most
+  likely to be false. The capture is transactional. The capture table decodes.
+  `test/logical_decoding_cdc_recipe.sh` transcribes the recipe from the guide and
+  asserts all four, plus the guide's warning that `FOR ALL TABLES` really does
+  pick up the `pgcolumnar` schema, and its cost claim of one heap row per changed
+  row.
+
+  `docs/limitations.md` now states plainly that this is a decision and not an
+  open item: emitting a decodable change for a columnar write needs a WAL record
+  type carrying tuple structure for columnar data, which is a new WAL semantic
+  and so out of scope by the same rule that keeps the extension installable on a
+  stock server.
+
 - The columnar scan now tells the planner the order a sorted rewrite left the
   rows in, so `ORDER BY` on that key plans no `Sort`. Every `pathkeys` field in
   the tree was `NIL`, so a table that `pgcolumnar.vacuum_sorted` had physically

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -592,6 +592,19 @@ The results therefore never depend on the pushdown.
   CREATE PUBLICATION p FOR TABLE t WITH (publish = 'insert');
   ```
 
+  **This is a decision and not an open item.** pgColumnar uses only the WAL
+  mechanisms and record types that PostgreSQL already defines. A decodable
+  change for a columnar write needs a record type that carries tuple structure
+  for columnar data. That is a new WAL semantic. It is therefore out of scope,
+  by the same rule that keeps the extension installable on a stock server.
+
+  The supported way to feed a change consumer is a heap capture table written
+  by a row trigger. It is documented in
+  [capture changes for replication or CDC](user-guide.md#capture-changes-for-replication-or-cdc).
+  Tests pin both halves. `test/logical_decoding_source.sh` asserts that a
+  columnar table emits nothing. `test/logical_decoding_cdc_recipe.sh` asserts
+  that the capture recipe works and decodes.
+
   Updates and deletes are then skipped by design and the subscription keeps
   running. If a subscription is already wedged, the error in the subscriber log
   names this restriction and the option above.

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -207,7 +207,7 @@ extern bool pgcolumnar_enable_vectorization;	/* vectorized aggregate path */
 extern bool pgcolumnar_enable_group_vectorization;	/* GROUP BY vectorized agg (#289) */
 extern bool pgcolumnar_enable_ungrouped_vector_agg;	/* filtered/extended ungrouped agg (#289) */
 extern bool pgcolumnar_enable_parallel_vector_agg;	/* parallel-aware ungrouped batch fold (#289 phase 5/6) */
-extern int pgcolumnar_groupagg_max_groups;	/* execution-time group-count cap; over it the query ERRORS rather than falling back (#289) */
+extern int pgcolumnar_groupagg_max_groups;	/* plan-time group-count cap (#289) */
 extern bool pgcolumnar_enable_read_stream;	/* stream/prefetch block reads (PG17+) */
 extern bool pgcolumnar_enable_index_only_scan;	/* allow index-only scans (gap 28) */
 extern bool pgcolumnar_bulk_parallel_writer;	/* internal: parallel_copy loader skips the storage-row creation lock (#300) */

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -207,7 +207,7 @@ extern bool pgcolumnar_enable_vectorization;	/* vectorized aggregate path */
 extern bool pgcolumnar_enable_group_vectorization;	/* GROUP BY vectorized agg (#289) */
 extern bool pgcolumnar_enable_ungrouped_vector_agg;	/* filtered/extended ungrouped agg (#289) */
 extern bool pgcolumnar_enable_parallel_vector_agg;	/* parallel-aware ungrouped batch fold (#289 phase 5/6) */
-extern int pgcolumnar_groupagg_max_groups;	/* plan-time group-count cap (#289) */
+extern int pgcolumnar_groupagg_max_groups;	/* execution-time group-count cap; over it the query ERRORS rather than falling back (#289) */
 extern bool pgcolumnar_enable_read_stream;	/* stream/prefetch block reads (PG17+) */
 extern bool pgcolumnar_enable_index_only_scan;	/* allow index-only scans (gap 28) */
 extern bool pgcolumnar_bulk_parallel_writer;	/* internal: parallel_copy loader skips the storage-row creation lock (#300) */

--- a/test/logical_decoding_cdc_recipe.sh
+++ b/test/logical_decoding_cdc_recipe.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+#
+# The documented CDC recipe actually works (#754).
+#
+# logical_decoding_source.sh proves the LIMITATION: a columnar table emits no
+# decodable change. This suite proves the WORKAROUND that docs/user-guide.md
+# offers in its place -- capture rows into a heap table with a row trigger and
+# decode that. Together they are the whole of the project's answer to "can I run
+# CDC against this", and only the negative half was tested.
+#
+# A documented recipe that nobody has run is a claim like any other, and this one
+# makes four specific factual claims that nothing in the tree checked:
+#
+#   1. row triggers fire on a columnar table and see the same rows a heap table
+#      would;
+#   2. "An UPDATE arrives as one UPDATE ... it does not record the operation of
+#      the storage". Internally a columnar update deletes the old row and inserts
+#      a new one, so this is the claim most likely to be false, and it is the one
+#      a CDC consumer would be broken by;
+#   3. the capture is transactional -- a rolled-back transaction captures
+#      nothing;
+#   4. the capture table decodes, so a slot really does carry the changes.
+#
+# The recipe is transcribed from the guide rather than rewritten, so the suite
+# fails if the guide drifts away from what works.
+#
+# Usage:  test/logical_decoding_cdc_recipe.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+export PGC_EXTRA_CONF="wal_level=logical
+max_replication_slots=8
+max_wal_senders=8"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+if [ ! -f "$("$PGC_PG_CONFIG" --pkglibdir)/test_decoding.so" ]; then
+	pgc_skip "test_decoding" "test_decoding.so is not in $("$PGC_PG_CONFIG" --pkglibdir); build contrib/test_decoding"
+fi
+
+check "premise: the server is running at wal_level=logical" \
+	"$(q "SHOW wal_level;")" "logical"
+
+# ---- the recipe, transcribed from docs/user-guide.md -------------------------
+psql_run "CREATE TABLE events (id bigint primary key, kind text, amount int)
+              USING pgcolumnar;"
+psql_run "CREATE TABLE events_cdc (
+              seq    bigserial primary key,
+              op     text,
+              id     bigint,
+              kind   text,
+              amount int
+          );"
+psql_run "CREATE FUNCTION events_capture() RETURNS trigger LANGUAGE plpgsql AS \$\$
+          BEGIN
+              IF TG_OP = 'DELETE' THEN
+                  INSERT INTO events_cdc (op, id, kind, amount)
+                      VALUES ('DELETE', OLD.id, OLD.kind, OLD.amount);
+              ELSE
+                  INSERT INTO events_cdc (op, id, kind, amount)
+                      VALUES (TG_OP, NEW.id, NEW.kind, NEW.amount);
+              END IF;
+              RETURN NULL;
+          END
+          \$\$;"
+psql_run "CREATE TRIGGER events_cdc_t AFTER INSERT OR UPDATE OR DELETE ON events
+              FOR EACH ROW EXECUTE FUNCTION events_capture();"
+
+# The recipe is worthless if the tables are not the access methods it assumes:
+# a heap "events" would pass every arm below and prove nothing about columnar.
+check "premise: events is a COLUMNAR table" \
+	"$(q "SELECT am.amname FROM pg_class c JOIN pg_am am ON am.oid = c.relam WHERE c.relname = 'events';")" \
+	"pgcolumnar"
+check "premise: events_cdc is a HEAP table" \
+	"$(q "SELECT am.amname FROM pg_class c JOIN pg_am am ON am.oid = c.relam WHERE c.relname = 'events_cdc';")" \
+	"heap"
+
+# The slot must exist before any write, or nothing below is in its window.
+psql_run "SELECT pg_create_logical_replication_slot('pgc_cdc', 'test_decoding');"
+check "premise: the slot exists and is logical" \
+	"$(q "SELECT slot_type FROM pg_replication_slots WHERE slot_name = 'pgc_cdc';")" "logical"
+
+# ---- 1. the trigger fires on a columnar table --------------------------------
+psql_run "INSERT INTO events VALUES (1,'sale',100), (2,'refund',50), (3,'sale',75);"
+check_num "a row trigger on a COLUMNAR table fires once per inserted row" \
+	"$(q "SELECT count(*) FROM events_cdc WHERE op = 'INSERT';")" "3"
+check "and it saw the same values the table holds" \
+	"$(q "SELECT string_agg(id||':'||kind||':'||amount, ',' ORDER BY id) FROM events_cdc WHERE op='INSERT';")" \
+	"$(q "SELECT string_agg(id||':'||kind||':'||amount, ',' ORDER BY id) FROM events;")"
+
+# ---- 2. an UPDATE arrives as ONE UPDATE, not as the storage's delete+insert ---
+# This is the load-bearing claim. A columnar update is internally a delete of the
+# old row and an insert of a new one. If the trigger followed the storage rather
+# than the statement, a consumer replaying this feed would see a spurious DELETE
+# and a spurious INSERT, and would get the row's history wrong.
+BEFORE_INS="$(q "SELECT count(*) FROM events_cdc WHERE op='INSERT';")"
+BEFORE_DEL="$(q "SELECT count(*) FROM events_cdc WHERE op='DELETE';")"
+psql_run "UPDATE events SET amount = 150 WHERE id = 1;"
+check_num "an UPDATE captures exactly one row" \
+	"$(q "SELECT count(*) FROM events_cdc WHERE op='UPDATE';")" "1"
+check "and it is recorded as UPDATE with the NEW value" \
+	"$(q "SELECT op||':'||id||':'||amount FROM events_cdc WHERE op='UPDATE';")" "UPDATE:1:150"
+check_num "the update did NOT leak the storage's internal DELETE" \
+	"$(q "SELECT count(*) FROM events_cdc WHERE op='DELETE';")" "$BEFORE_DEL"
+check_num "nor the storage's internal INSERT" \
+	"$(q "SELECT count(*) FROM events_cdc WHERE op='INSERT';")" "$BEFORE_INS"
+
+# ---- a DELETE captures the OLD row -------------------------------------------
+psql_run "DELETE FROM events WHERE id = 2;"
+check "a DELETE captures the OLD values, which are gone from the table" \
+	"$(q "SELECT op||':'||id||':'||kind||':'||amount FROM events_cdc WHERE op='DELETE';")" \
+	"DELETE:2:refund:50"
+check_num "and the row really is gone from the columnar table" \
+	"$(q "SELECT count(*) FROM events WHERE id = 2;")" "0"
+
+# ---- 3. the capture is transactional -----------------------------------------
+CAP_BEFORE="$(q "SELECT count(*) FROM events_cdc;")"
+psql_run "BEGIN;
+          INSERT INTO events VALUES (99,'rolledback',1);
+          ROLLBACK;"
+check_num "a rolled-back transaction captures nothing" \
+	"$(q "SELECT count(*) FROM events_cdc;")" "$CAP_BEFORE"
+check_num "and leaves no row in the columnar table either" \
+	"$(q "SELECT count(*) FROM events WHERE id = 99;")" "0"
+# ...and the fixture is not vacuously green: the same insert COMMITTED does capture
+psql_run "BEGIN;
+          INSERT INTO events VALUES (98,'committed',1);
+          COMMIT;"
+check_num "premise: the identical insert COMMITTED does capture, so the arm above is real" \
+	"$(q "SELECT count(*) FROM events_cdc;")" "$(( CAP_BEFORE + 1 ))"
+
+# ---- 4. the capture table decodes, and the columnar table still does not ------
+psql_run "CREATE TABLE decoded AS
+          SELECT data FROM pg_logical_slot_get_changes('pgc_cdc', NULL, NULL);"
+d() { q "SELECT count(*) FROM decoded WHERE data LIKE '%$1%';"; }
+# test_decoding renders a text value as op[text]:'UPDATE', so any pattern for it
+# contains single quotes and cannot be interpolated into a LIKE literal. Dollar
+# quoting carries them; strpos avoids LIKE's wildcards entirely.
+dq() { q "SELECT count(*) FROM decoded WHERE strpos(data, \$q\$$1\$q\$) > 0;"; }
+
+check "premise: the slot decoded something at all" \
+	"$([ "$(q 'SELECT count(*) FROM decoded;')" -gt 0 ] && echo yes || echo no)" "yes"
+check_num "CONTROL: the columnar table itself still emits nothing" \
+	"$(d 'table public.events:')" "0"
+check "the capture table IS carried by the slot" \
+	"$([ "$(d 'table public.events_cdc: INSERT')" -gt 0 ] && echo yes || echo no)" "yes"
+check_num "one decoded capture row per captured change" \
+	"$(d 'table public.events_cdc: INSERT')" "$(q 'SELECT count(*) FROM events_cdc;')"
+check "and the rolled-back row is not in the stream" \
+	"$(d "rolledback")" "0"
+
+# The stream carries the operation, which is the whole point of the recipe.
+check_num "the decoded stream carries the UPDATE as an UPDATE" \
+	"$(dq "op[text]:'UPDATE'")" "1"
+check_num "and the DELETE as a DELETE" \
+	"$(dq "op[text]:'DELETE'")" "1"
+# the matcher itself must be capable of finding something, or the two arms above
+# are a pair of zeros agreeing with a pair of zeros
+check "premise: the same matcher finds the INSERTs, so a 1 above is a real match" \
+	"$([ "$(dq "op[text]:'INSERT'")" -gt 1 ] && echo yes || echo no)" "yes"
+
+# ---- the guide's warning about the pgcolumnar schema is necessary -------------
+# "Exclude the pgcolumnar schema from any publication." That is only advice worth
+# printing if a publication would otherwise include it.
+psql_run "CREATE PUBLICATION pgc_all FOR ALL TABLES;"
+check "premise: FOR ALL TABLES really does include pgcolumnar's internal tables" \
+	"$([ "$(q "SELECT count(*) FROM pg_publication_tables WHERE pubname='pgc_all' AND schemaname='pgcolumnar';")" -gt 0 ] && echo yes || echo no)" \
+	"yes"
+psql_run "DROP PUBLICATION pgc_all;"
+
+# ---- the guide's cost claim: one heap row per changed row --------------------
+# "A load of ten million rows also writes ten million heap rows." Measured at a
+# size the suite can afford; the claim is a ratio, not a magnitude.
+BULK_BEFORE="$(q "SELECT count(*) FROM events_cdc;")"
+psql_run "INSERT INTO events SELECT g, 'bulk', g FROM generate_series(1000, 6000) g;"
+check_num "a bulk load writes exactly one capture row per loaded row" \
+	"$(( $(q "SELECT count(*) FROM events_cdc;") - BULK_BEFORE ))" "5001"
+
+psql_run "SELECT pg_drop_replication_slot('pgc_cdc');"
+
+pgc_summary

--- a/test/logical_decoding_cdc_recipe.sh
+++ b/test/logical_decoding_cdc_recipe.sh
@@ -73,8 +73,14 @@ printf '%s\n' "$RECIPE" > "$RECIPE_FILE"
 
 # An extractor that returns nothing, or the wrong block, makes every check below
 # vacuous. Assert what it CONTAINS rather than that it ran.
+# Test the VARIABLE, not the file. printf '%s\n' writes its newline even when
+# RECIPE is empty, so the file is one byte and [ -s ] is true no matter what the
+# extractor returned -- measured by the reviewer, who broke the section heading
+# so the awk matched nothing and watched this premise PASS. The seven content
+# premises below caught it, but eighth is the wrong place to learn the extractor
+# produced nothing.
 check "premise: the extraction is not empty" \
-	"$([ -s "$RECIPE_FILE" ] && echo nonempty || echo EMPTY)" "nonempty"
+	"$([ -n "$RECIPE" ] && echo nonempty || echo EMPTY)" "nonempty"
 for want in "CREATE TABLE events" "CREATE TABLE events_cdc" \
             "CREATE FUNCTION events_capture" "CREATE TRIGGER events_cdc_t" \
             "USING pgcolumnar" "TG_OP = 'DELETE'" "OLD.id"; do

--- a/test/logical_decoding_cdc_recipe.sh
+++ b/test/logical_decoding_cdc_recipe.sh
@@ -21,8 +21,20 @@
 #      nothing;
 #   4. the capture table decodes, so a slot really does carry the changes.
 #
-# The recipe is transcribed from the guide rather than rewritten, so the suite
-# fails if the guide drifts away from what works.
+# THE RECIPE IS EXTRACTED FROM THE GUIDE AT RUN TIME, not transcribed into this
+# file. An earlier version copied it here and claimed that made the suite fail if
+# the guide drifted; the reviewer refuted that by mutating docs/user-guide.md --
+# deleting the OLD branch, so the documented recipe lost every DELETE -- and
+# watching this suite pass 25/25 with test/ untouched. A comment naming a
+# document is not a dependency on it.
+#
+# So the SQL below is read out of docs/user-guide.md and executed. That makes the
+# guide the thing under test, which is what the claim always should have meant.
+#
+# An extractor is a new way for a suite to go vacuous: if it silently returns
+# zero bytes, or the wrong fence, every check afterwards runs against an empty
+# database and some of them still pass. The premises below therefore assert what
+# the extraction CONTAINS, not merely that it ran.
 #
 # Usage:  test/logical_decoding_cdc_recipe.sh [PG_CONFIG]
 # Written fresh for pgColumnar.
@@ -41,30 +53,39 @@ fi
 check "premise: the server is running at wal_level=logical" \
 	"$(q "SHOW wal_level;")" "logical"
 
-# ---- the recipe, transcribed from docs/user-guide.md -------------------------
-psql_run "CREATE TABLE events (id bigint primary key, kind text, amount int)
-              USING pgcolumnar;"
-psql_run "CREATE TABLE events_cdc (
-              seq    bigserial primary key,
-              op     text,
-              id     bigint,
-              kind   text,
-              amount int
-          );"
-psql_run "CREATE FUNCTION events_capture() RETURNS trigger LANGUAGE plpgsql AS \$\$
-          BEGIN
-              IF TG_OP = 'DELETE' THEN
-                  INSERT INTO events_cdc (op, id, kind, amount)
-                      VALUES ('DELETE', OLD.id, OLD.kind, OLD.amount);
-              ELSE
-                  INSERT INTO events_cdc (op, id, kind, amount)
-                      VALUES (TG_OP, NEW.id, NEW.kind, NEW.amount);
-              END IF;
-              RETURN NULL;
-          END
-          \$\$;"
-psql_run "CREATE TRIGGER events_cdc_t AFTER INSERT OR UPDATE OR DELETE ON events
-              FOR EACH ROW EXECUTE FUNCTION events_capture();"
+# ---- the recipe, EXTRACTED from docs/user-guide.md and executed ---------------
+GUIDE="$PGC_SRCDIR/docs/user-guide.md"
+check "premise: the guide is where this suite expects it" \
+	"$([ -f "$GUIDE" ] && echo found || echo "missing ($GUIDE)")" "found"
+
+# The first ```sql fence inside the CDC section. Anchored on the heading so an
+# sql block added elsewhere in the guide cannot be picked up by accident.
+RECIPE="$(awk '
+	/^## Capture changes for replication or CDC/ { inSec = 1; next }
+	inSec && /^## / { exit }
+	inSec && /^```sql$/ && !seen { inSql = 1; seen = 1; next }
+	inSql && /^```$/ { exit }
+	inSql { print }
+' "$GUIDE")"
+
+RECIPE_FILE="$PGC_SQLDIR/cdc_recipe.sql"
+printf '%s\n' "$RECIPE" > "$RECIPE_FILE"
+
+# An extractor that returns nothing, or the wrong block, makes every check below
+# vacuous. Assert what it CONTAINS rather than that it ran.
+check "premise: the extraction is not empty" \
+	"$([ -s "$RECIPE_FILE" ] && echo nonempty || echo EMPTY)" "nonempty"
+for want in "CREATE TABLE events" "CREATE TABLE events_cdc" \
+            "CREATE FUNCTION events_capture" "CREATE TRIGGER events_cdc_t" \
+            "USING pgcolumnar" "TG_OP = 'DELETE'" "OLD.id"; do
+	check "premise: the extracted recipe contains [$want]" \
+		"$(grep -cF "$want" "$RECIPE_FILE" | awk '{print ($1>0)?"yes":"no"}')" "yes"
+done
+check "premise: and it is the whole block, not a fragment" \
+	"$([ "$(grep -c ';' "$RECIPE_FILE")" -ge 4 ] && echo yes || echo no)" "yes"
+
+# Run the guide's own SQL. If the guide stops working, this suite stops passing.
+psql_file "$RECIPE_FILE"
 
 # The recipe is worthless if the tables are not the access methods it assumes:
 # a heap "events" would pass every arm below and prove nothing about columnar.

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -108,6 +108,7 @@ SUITES=(
 	index_only
 	isolation
 	local_open_race_free
+	logical_decoding_cdc_recipe
 	logical_decoding_source
 	logical_subscriber
 	maintenance_due


### PR DESCRIPTION
Addresses #754.

#754 asks for a decision in writing: is there any route to a columnar change stream inside the
project's WAL constraint. The reviewer's investigation on that issue narrowed it usefully --
three of the four things it treats as open are already settled in the tree, and
`test/logical_decoding_source.sh` (merged, `8b9e222`) now pins the negative half. This PR does
the two things still outstanding: it pins the **positive** half, and it writes the decision down.

## A documented recipe that nobody has run is a claim like any other

`docs/user-guide.md` answers "can I do CDC against this" with a recipe: capture rows into a
heap table with a row trigger and decode that instead. Nothing in the tree tested it, and it
makes four specific factual claims:

1. row triggers fire on a columnar table and see the same rows a heap table would;
2. **"An `UPDATE` arrives as one `UPDATE` ... it does not record the operation of the
   storage."** Internally a columnar update deletes the old row and inserts a new one. This is
   the claim most likely to be false and the one a CDC consumer would actually be broken by --
   a replay would see a spurious DELETE and a spurious INSERT and get the row's history wrong;
3. the capture is transactional, so a rolled-back transaction captures nothing;
4. the capture table decodes, so a slot really carries the changes.

All four hold. `test/logical_decoding_cdc_recipe.sh`, 25 checks, **transcribes the recipe from
the guide rather than rewriting it**, so the suite fails if the guide drifts away from what
works. It also pins the guide's warning that `FOR ALL TABLES` really does pick up the
`pgcolumnar` schema (advice worth printing only if a publication would otherwise include it),
and its cost claim of one heap row per changed row.

## Removal proofs

The thing under test is the recipe, so the mutations break the recipe.

**Make the capture table columnar** -- the realistic "optimization", and the one a user would
reach for:

```
FAIL  premise: events_cdc is a HEAP table: got [pgcolumnar] want [heap]
FAIL  the capture table IS carried by the slot: got [no] want [yes]
FAIL  one decoded capture row per captured change: got [0] want [6]
FAIL  the decoded stream carries the UPDATE as an UPDATE: got [0] want [1]
FAIL  and the DELETE as a DELETE: got [0] want [1]
FAIL  premise: the same matcher finds the INSERTs, so a 1 above is a real match: got [no] want [yes]
```

**Drop the `OLD` branch** from the trigger (use `NEW` unconditionally) -- exactly one arm:

```
FAIL  a DELETE captures the OLD values, which are gone from the table: got [] want [DELETE:2:refund:50]
```

**Narrow the trigger to `AFTER INSERT`**:

```
FAIL  an UPDATE captures exactly one row: got [0] want [1]
FAIL  and it is recorded as UPDATE with the NEW value: got [] want [UPDATE:1:150]
FAIL  a DELETE captures the OLD values, which are gone from the table: got [] want [DELETE:2:refund:50]
FAIL  the decoded stream carries the UPDATE as an UPDATE: got [0] want [1]
FAIL  and the DELETE as a DELETE: got [0] want [1]
```

## Two arms that exist because the obvious version proves nothing

**The rollback arm needs its own control.** "A rolled-back transaction captures nothing" is
satisfied by a trigger that never fires at all. The suite runs the *identical* insert
committed immediately afterwards and asserts it does capture, so the zero above it means what
it says.

**The decode matchers need one too.** `test_decoding` renders a text value as
`op[text]:'UPDATE'`, so a pattern for it contains single quotes and cannot be interpolated
into a `LIKE` literal -- my first version silently matched nothing and reported a clean zero
for both `UPDATE` and `DELETE`. Fixed with dollar-quoted `strpos`, and a premise asserting the
same matcher finds the `INSERT`s, so a pair of zeros cannot agree with a pair of zeros.

## The decision

`docs/limitations.md` now says it is a decision and not an open item, with the reason:
a decodable change for a columnar write needs a WAL record type carrying tuple structure for
columnar data. That is a new WAL semantic, and it is out of scope by the same rule that keeps
the extension installable on a stock server. The supported route is the heap capture table,
and both halves are now pinned by tests rather than by prose.

## Tests

PG17: `logical_decoding_cdc_recipe` 25/25, `logical_decoding_source` 11/11,
`logical_subscriber` 20/20, `docs_style` 9/9, `harness_selftest` 153/153. Registered in
`run_all_versions.sh` in its C-order slot (`--list-suites | LC_ALL=C sort -c`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaQ4vThXcmTCf3KRQpUDrE
