### PR TITLE
fix: the ordering mark must follow a column rename (#778)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,42 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ## [Unreleased]
 
+### Fixed
+
+- The ordering mark now follows `ALTER TABLE ... RENAME COLUMN`, so neither
+  ordering self-gate skips work it must do (#778). `pgcolumnar.storage` records
+  the applied sort key as column **names**, and both gates compare that stored
+  list against the current `attname`: `pgcolumnar.vacuum_sorted`'s gate and the
+  online `pgcolumnar.recluster`'s. Nothing maintained the mark across a rename.
+
+  A three-statement swap made the stored name resolve to a different column:
+
+  ```sql
+  ALTER TABLE t RENAME COLUMN a TO tmp;
+  ALTER TABLE t RENAME COLUMN b TO a;
+  ALTER TABLE t RENAME COLUMN tmp TO b;
+  SELECT pgcolumnar.vacuum_sorted('t','a');   -- reported success, did nothing
+  ```
+
+  The gate reported "already in this order" about a column that was never
+  sorted, and the table was left neither ordered nor reclaimed with no error
+  raised. For `vacuum_sorted` that is the failure the gate exists to prevent,
+  reached through another door. `recluster` returned 0, which a scheduler reads
+  as "nothing to do".
+
+  The mark is renamed rather than cleared. A rename does not move data, so the
+  ordering is still true of whichever column now carries the name, and following
+  the rename keeps a real optimisation instead of discarding it on every rename.
+  It composes through the swap above: `{a}` to `{tmp}` to `{b}`, which is the
+  column the rows are ordered by. A rename that touches no sort-key column does
+  not rewrite the storage row at all.
+
+  One behaviour improves as a result. The sorted-pathkey claim used to be
+  refused after a rename, because the recorded name stopped resolving; it now
+  survives, so `ORDER BY` on the renamed column plans no `Sort`. That claim is
+  sound for the same reason the mark is: the rows really are still in that
+  order.
+
 ### Added
 
 - `pgcolumnar.vacuum_sorted()` now self-gates: when the relation is already

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ### Fixed
 
-- The ordering mark now follows `ALTER TABLE ... RENAME COLUMN`, so neither
-  ordering self-gate skips work it must do (#778). `pgcolumnar.storage` records
+- `ORDER BY` no longer returns unordered rows after a column rename, and neither
+  ordering self-gate skips work it must do (#778). Both follow from one cause:
+  nothing maintained the recorded sort key across a rename. `pgcolumnar.storage` records
   the applied sort key as column **names**, and both gates compare that stored
   list against the current `attname`: `pgcolumnar.vacuum_sorted`'s gate and the
   online `pgcolumnar.recluster`'s. Nothing maintained the mark across a rename.
@@ -43,6 +44,29 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
   It composes through the swap above: `{a}` to `{tmp}` to `{b}`, which is the
   column the rows are ordered by. A rename that touches no sort-key column does
   not rewrite the storage row at all.
+
+  The wrong-answer half is the more serious one. The sorted-pathkey code (#751)
+  reads the same mark, so a stale mark made the planner claim an ordering that
+  did not hold: after the swap above, `SELECT a FROM t ORDER BY a` planned with
+  no `Sort` node and returned 1,990 descents out of 2,000 rows.
+
+  The rename **cascades** to inheritance children and partitions, which are
+  separate relations with their own storage and their own marks, so the fix
+  walks every columnar descendant. PostgreSQL refuses
+  `ALTER TABLE child RENAME COLUMN` with "cannot rename inherited column", so
+  for a columnar partition the parent is the only route a user has, and a fix
+  that looked only at the relation named in the statement would never have fired
+  for it at all.
+
+  The declared key in `pgcolumnar.options` is maintained the same way, and it is
+  not optional once the mark is. Before, both were consistently stale; renaming
+  only the mark would make the two catalogs name different columns, so a bare
+  `pgcolumnar.vacuum_sorted(t)` would silently rewrite on a different physical
+  key than it did the day before, with no change to the call and no change to
+  the declared intent. `options.sort_by` holds names deliberately, because
+  `options` is the catalog carried through `pg_dump` where attnums renumber and
+  names do not, so maintaining them across a rename is the correct repair rather
+  than a workaround.
 
   One behaviour improves as a result. The sorted-pathkey claim used to be
   refused after a rename, because the recorded name stopped resolving; it now

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -44,6 +44,7 @@
 #define Anum_options_compression 5
 #define Anum_options_encode_effort 6
 #define Anum_options_sort_by 7
+#define Natts_options 7
 
 /* attribute numbers for columnar.projection (gap 26, format 2.2) */
 #define Anum_projection_declaration_rel 1
@@ -1882,6 +1883,96 @@ insert_row:
 	tuple = heap_form_tuple(tupdesc, values, nulls);
 	metadata_flush_insert(rel, tuple);
 	heap_freetuple(tuple);
+	metadata_flush_close(rel, RowExclusiveLock);
+}
+
+/*
+ * PgColumnarRenameDeclaredSortByColumn
+ *		Follow a column rename through the DECLARED sort key in
+ *		pgcolumnar.options (#778).
+ *
+ *		options.sort_by is what pgcolumnar.vacuum_sorted(t) resolves when it is
+ *		called with no explicit columns, and it holds NAMES for a deliberate
+ *		reason the catalog comment gives: options is the one pgcolumnar catalog
+ *		carried through pg_dump and restore, where attnums renumber and names do
+ *		not. So names are correct there, and maintaining them across a rename is
+ *		the only correction available.
+ *
+ *		Maintaining it here is not optional once the ordering mark is
+ *		maintained. Before, both were consistently stale and a bare
+ *		vacuum_sorted(t) at least agreed with the mark. Renaming only the mark
+ *		makes the two catalogs point at DIFFERENT columns, so the same call with
+ *		the same declared intent silently rewrites on a different physical key
+ *		than it did yesterday.
+ */
+void
+PgColumnarRenameDeclaredSortByColumn(Oid relid, const char *oldName,
+									 const char *newName)
+{
+	Relation	rel;
+	TupleDesc	tupdesc;
+	ScanKeyData key[1];
+	SysScanDesc scan;
+	HeapTuple	tuple;
+
+	CommandCounterIncrement();
+
+	rel = open_columnar_table("options", RowExclusiveLock);
+	tupdesc = RelationGetDescr(rel);
+	ScanKeyInit(&key[0], Anum_options_regclass, BTEqualStrategyNumber,
+				F_OIDEQ, ObjectIdGetDatum(relid));
+	scan = systable_beginscan(rel, InvalidOid, false, NULL, 1, key);
+	if (HeapTupleIsValid(tuple = systable_getnext(scan)))
+	{
+		bool		isnull;
+		Datum		d = heap_getattr(tuple, Anum_options_sort_by, tupdesc, &isnull);
+
+		if (!isnull)
+		{
+			ArrayType  *arr = DatumGetArrayTypeP(d);
+			Datum	   *elems;
+			bool	   *elnulls;
+			int			n;
+			int			i;
+			bool		hit = false;
+
+			deconstruct_array(arr, NAMEOID, NAMEDATALEN, false, 'c',
+							  &elems, &elnulls, &n);
+			for (i = 0; i < n; i++)
+			{
+				if (elnulls[i])
+					continue;
+				if (strcmp(NameStr(*DatumGetName(elems[i])), oldName) == 0)
+				{
+					elems[i] = DirectFunctionCall1(namein,
+												   CStringGetDatum((char *) newName));
+					hit = true;
+				}
+			}
+
+			/* a rename touching no declared column must not rewrite the row */
+			if (hit)
+			{
+				Datum		values[Natts_options];
+				bool		nulls[Natts_options];
+				bool		replace[Natts_options];
+				HeapTuple	newTuple;
+
+				memset(values, 0, sizeof(values));
+				memset(nulls, false, sizeof(nulls));
+				memset(replace, false, sizeof(replace));
+				values[Anum_options_sort_by - 1] =
+					PointerGetDatum(construct_array(elems, n, NAMEOID,
+													NAMEDATALEN, false,
+													TYPALIGN_CHAR));
+				replace[Anum_options_sort_by - 1] = true;
+				newTuple = heap_modify_tuple(tuple, tupdesc, values, nulls, replace);
+				CatalogTupleUpdate(rel, &newTuple->t_self, newTuple);
+				heap_freetuple(newTuple);
+			}
+		}
+	}
+	systable_endscan(scan);
 	metadata_flush_close(rel, RowExclusiveLock);
 }
 

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -1886,6 +1886,69 @@ insert_row:
 }
 
 /*
+ * PgColumnarRenameSortKeyColumn
+ *		Follow an ALTER TABLE ... RENAME COLUMN through the ordering mark (#778).
+ *
+ *		pgcolumnar.storage records the applied sort key as a list of column
+ *		NAMES, and both ordering self-gates compare that list against the
+ *		CURRENT attname of the columns they were asked about -- vacuum_sorted's
+ *		gate (#760) and the online recluster's (#415). Column names are not
+ *		stable, and nothing else maintains the mark.
+ *
+ *		A three-statement swap (a->tmp, b->a, tmp->b) therefore leaves the
+ *		stored name resolving to a DIFFERENT column: the gate reports "already
+ *		in this order" about a column that was never sorted and skips the
+ *		rewrite. For vacuum_sorted that is the failure #760 exists to prevent,
+ *		reached through another door, and the table ends up neither ordered nor
+ *		reclaimed with no error raised.
+ *
+ *		Renaming the entry rather than clearing the mark is deliberate. The
+ *		DATA has not moved, so the ordering is still true of whichever column
+ *		now carries the name, and following the rename keeps that fact instead
+ *		of throwing away a real optimisation on every rename. It composes
+ *		correctly through the swap above: {a} -> {tmp} -> {tmp} -> {b}, which is
+ *		the column the rows are actually ordered by.
+ *
+ *		Called after the rename has executed, so a rename that ERRORS leaves the
+ *		mark untouched.
+ */
+void
+PgColumnarRenameSortKeyColumn(uint64 storageId, const char *oldName,
+							  const char *newName)
+{
+	int64		sfrom,
+				sthrough;
+	List	   *skey;
+	char	   *skind;
+	List	   *renamed = NIL;
+	ListCell   *lc;
+	bool		hit = false;
+
+	PgColumnarGetSortedInfo(storageId, &sfrom, &sthrough, &skey, &skind);
+	if (skey == NIL || skind == NULL)
+		return;					/* no mark to maintain */
+
+	foreach(lc, skey)
+	{
+		char	   *nm = (char *) lfirst(lc);
+
+		if (strcmp(nm, oldName) == 0)
+		{
+			renamed = lappend(renamed, pstrdup(newName));
+			hit = true;
+		}
+		else
+			renamed = lappend(renamed, pstrdup(nm));
+	}
+
+	/* a rename that touches no sort-key column must not rewrite the row */
+	if (!hit)
+		return;
+
+	PgColumnarSetSortedExtent(storageId, sfrom, sthrough, renamed, skind);
+}
+
+/*
  * PgColumnarSetSortedThrough
  *		Record the row group number the last ordering rewrite ended at, so a
  *		reader can tell how much of the layout is still ordered (issue #301).

--- a/src/columnar_metadata.h
+++ b/src/columnar_metadata.h
@@ -47,6 +47,8 @@ extern void PgColumnarSetSortedExtent(uint64 storageId, int64 firstGroup,
 /* #415: the current run's clustering key (a list of column-name strings, NIL
  * if unknown) and kind ('zorder'/'lexicographic'/NULL), for recluster's
  * self-gate and sort_status. */
+extern void PgColumnarRenameSortKeyColumn(uint64 storageId, const char *oldName,
+										  const char *newName);
 extern void PgColumnarGetSortedInfo(uint64 storageId, int64 *firstGroup,
 									int64 *lastGroup, List **sortByNames,
 									char **sortedKind);

--- a/src/columnar_metadata.h
+++ b/src/columnar_metadata.h
@@ -47,6 +47,8 @@ extern void PgColumnarSetSortedExtent(uint64 storageId, int64 firstGroup,
 /* #415: the current run's clustering key (a list of column-name strings, NIL
  * if unknown) and kind ('zorder'/'lexicographic'/NULL), for recluster's
  * self-gate and sort_status. */
+extern void PgColumnarRenameDeclaredSortByColumn(Oid relid, const char *oldName,
+												 const char *newName);
 extern void PgColumnarRenameSortKeyColumn(uint64 storageId, const char *oldName,
 										  const char *newName);
 extern void PgColumnarGetSortedInfo(uint64 storageId, int64 *firstGroup,

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -54,6 +54,7 @@
 #include "catalog/indexing.h"
 #include "catalog/namespace.h"
 #include "catalog/pg_am.h"
+#include "catalog/pg_inherits.h"
 #include "catalog/pg_constraint.h"
 #include "tcop/utility.h"
 #include "utils/fmgroids.h"
@@ -2334,13 +2335,57 @@ pgcolumnar_process_utility(PlannedStmt *pstmt, const char *queryString,
 		{
 			Oid			relid = RangeVarGetRelid(rs->relation, NoLock, true);
 
-			if (OidIsValid(relid) && PgColumnarIsColumnarRelation(relid))
+			if (OidIsValid(relid))
 			{
-				Relation	rel = relation_open(relid, NoLock);
+				List	   *kin;
+				ListCell   *lc;
 
-				PgColumnarRenameSortKeyColumn(PgColumnarStorageId(rel),
-											  rs->subname, rs->newname);
-				relation_close(rel, NoLock);
+				/*
+				 * Every INHERITANCE CHILD and PARTITION too, not just the
+				 * relation named in the statement. A column rename cascades to
+				 * descendants, which are separate relations with their own
+				 * storage and their own marks, and PostgreSQL REFUSES
+				 * "ALTER TABLE child RENAME COLUMN" with "cannot rename
+				 * inherited column" -- so for a columnar partition the parent is
+				 * the only route, and a hook that looked only at the named
+				 * relation would never fire for it at all.
+				 *
+				 * Not gated on the named relation being columnar, deliberately:
+				 * a partitioned parent is not itself a columnar relation, and
+				 * testing it here would close the door before the columnar
+				 * children are reached. The per-descendant test below is the
+				 * one that decides.
+				 *
+				 * The rename already holds the locks it needs on the whole
+				 * hierarchy, so NoLock here takes no new lock and cannot race.
+				 */
+				kin = find_all_inheritors(relid, NoLock, NULL);
+				foreach(lc, kin)
+				{
+					Oid			kid = lfirst_oid(lc);
+
+					if (!PgColumnarIsColumnarRelation(kid))
+						continue;
+
+					{
+						Relation	rel = relation_open(kid, NoLock);
+
+						PgColumnarRenameSortKeyColumn(PgColumnarStorageId(rel),
+													  rs->subname, rs->newname);
+						relation_close(rel, NoLock);
+					}
+
+					/*
+					 * And the DECLARED key, which vacuum_sorted(t) resolves
+					 * when called with no columns. Maintaining the mark without
+					 * this would make the two catalogs name different columns,
+					 * so the same call with the same declared intent would
+					 * silently rewrite on a different physical key.
+					 */
+					PgColumnarRenameDeclaredSortByColumn(kid, rs->subname,
+														 rs->newname);
+				}
+				list_free(kin);
 			}
 		}
 	}

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -2311,6 +2311,39 @@ pgcolumnar_process_utility(PlannedStmt *pstmt, const char *queryString,
 	else
 		standard_ProcessUtility(pstmt, queryString, readOnlyTree, context,
 								params, queryEnv, dest, qc);
+
+	/*
+	 * A column rename must be carried through the ordering mark (#778). The
+	 * mark records its sort key as column NAMES and both ordering self-gates
+	 * compare those against the current attname, so a rename that moves a name
+	 * onto another column makes a gate skip work it must do. See
+	 * PgColumnarRenameSortKeyColumn.
+	 *
+	 * AFTER the statement, deliberately: a rename that errors, or that names a
+	 * column or relation which does not exist, must leave the mark alone. By
+	 * this point the rename has committed to the catalog and holds
+	 * AccessExclusiveLock on the relation, so the lookup below cannot race and
+	 * needs no lock of its own.
+	 */
+	if (parsetree != NULL && IsA(parsetree, RenameStmt))
+	{
+		RenameStmt *rs = (RenameStmt *) parsetree;
+
+		if (rs->renameType == OBJECT_COLUMN && rs->relation != NULL &&
+			rs->subname != NULL && rs->newname != NULL)
+		{
+			Oid			relid = RangeVarGetRelid(rs->relation, NoLock, true);
+
+			if (OidIsValid(relid) && PgColumnarIsColumnarRelation(relid))
+			{
+				Relation	rel = relation_open(relid, NoLock);
+
+				PgColumnarRenameSortKeyColumn(PgColumnarStorageId(rel),
+											  rs->subname, rs->newname);
+				relation_close(rel, NoLock);
+			}
+		}
+	}
 }
 
 static void

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -2356,6 +2356,20 @@ pgcolumnar_process_utility(PlannedStmt *pstmt, const char *queryString,
 				 * children are reached. The per-descendant test below is the
 				 * one that decides.
 				 *
+				 * And the walk cannot be too WIDE, which is the natural worry
+				 * about it -- moving a mark for a descendant whose column never
+				 * changed. PostgreSQL refuses both halves of that. A child
+				 * alone is refused with "cannot rename inherited column", and
+				 * the parent alone is refused too: ALTER TABLE ONLY p RENAME
+				 * COLUMN gives "inherited column must be renamed in child
+				 * tables too". So every rename that reaches this hook has
+				 * already cascaded to the whole hierarchy, and walking it
+				 * unconditionally is CORRECT rather than merely safe.
+				 *
+				 * That is the argument to keep. Without it the walk reads as
+				 * over-broad and invites a later condition that reintroduces
+				 * the bug (ChronicallyJD, #779 review).
+				 *
 				 * The rename already holds the locks it needs on the whole
 				 * hierarchy, so NoLock here takes no new lock and cannot race.
 				 */

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -243,6 +243,7 @@ SUITES=(
 	smoke
 	sort_status
 	sort_status_privilege
+	sorted_mark_rename
 	sorted_pathkeys
 	sorted_projection
 	stats_privilege

--- a/test/sorted_mark_rename.sh
+++ b/test/sorted_mark_rename.sh
@@ -115,6 +115,109 @@ psql_run "SELECT pgcolumnar.vacuum_sorted('vr_o','a');"
 check "and the gate still fires" \
 	"$([ "$S" = "$(storid vr_o)" ] && echo noop || echo rewrote)" "noop"
 
+# ==================== inheritance and partitions =============================
+# A column rename CASCADES to children, which are separate relations with their
+# own storage and their own marks. PostgreSQL refuses
+# "ALTER TABLE child RENAME COLUMN" with "cannot rename inherited column", so
+# for a columnar partition the parent is the ONLY route: a hook that looked at
+# the relation named in the statement would never fire for the child at all.
+#
+# This is the wrong-ANSWER half of #778, not the redundant-work half. The stale
+# name still resolves, so #751's pathkey code reads the mark and claims an
+# ordering that does not hold: ORDER BY plans no Sort and returns unordered rows.
+
+# ---- declarative partition -------------------------------------------------
+psql_run "CREATE TABLE prt (k int, j int) PARTITION BY RANGE (k);"
+psql_run "CREATE TABLE prt1 PARTITION OF prt FOR VALUES FROM (0) TO (100000) USING pgcolumnar;"
+psql_run "INSERT INTO prt SELECT (g*7919::bigint)%2000, (g*104729::bigint)%2000
+          FROM generate_series(1,20000) g;"
+check_num "premise: the partition holds every row" "$(q "SELECT count(*) FROM prt1;")" "20000"
+psql_run "SELECT pgcolumnar.vacuum_sorted('prt1','k');"
+check "premise: the partition is ordered by k and its mark says so" \
+	"$([ "$(descents prt1 k)" -eq 0 ] && echo ordered || echo unordered)/$(markof prt1)" \
+	"ordered/{k}/lexicographic"
+check "premise: the parent is NOT itself columnar, so gating on it would skip the child" \
+	"$(q "SELECT COALESCE((SELECT am.amname FROM pg_class c JOIN pg_am am ON am.oid=c.relam WHERE c.relname='prt'),'none');")" \
+	"none"
+# the rename can only be issued on the parent
+psql_run "ALTER TABLE prt RENAME COLUMN k TO tmp_swap;"
+psql_run "ALTER TABLE prt RENAME COLUMN j TO k;"
+psql_run "ALTER TABLE prt RENAME COLUMN tmp_swap TO j;"
+check "premise: after the swap the partition's ordered column is named j" \
+	"$([ "$(descents prt1 j)" -eq 0 ] && echo ordered || echo unordered)" "ordered"
+check "premise: and the column now named k is NOT ordered" \
+	"$([ "$(descents prt1 k)" -gt 0 ] && echo unordered || echo ordered)" "unordered"
+check "the PARTITION's mark follows a rename issued on the parent" "$(markof prt1)" "{j}/lexicographic"
+S="$(storid prt1)"
+psql_run "SELECT pgcolumnar.vacuum_sorted('prt1','k');"
+check "so vacuum_sorted on the partition does the work" \
+	"$([ "$S" = "$(storid prt1)" ] && echo "SKIPPED (gate fired wrongly)" || echo rewrote)" "rewrote"
+check_num "and the partition really is ordered by k afterwards" "$(descents prt1 k)" "0"
+
+# ---- INHERITS child --------------------------------------------------------
+psql_run "CREATE TABLE inp (k int, j int);"
+psql_run "CREATE TABLE inc (LIKE inp) INHERITS (inp) USING pgcolumnar;"
+psql_run "INSERT INTO inc SELECT (g*7919::bigint)%2000, (g*104729::bigint)%2000
+          FROM generate_series(1,20000) g;"
+psql_run "SELECT pgcolumnar.vacuum_sorted('inc','k');"
+check "premise: the inheritance child is ordered by k" \
+	"$([ "$(descents inc k)" -eq 0 ] && echo ordered || echo unordered)" "ordered"
+psql_run "ALTER TABLE inp RENAME COLUMN k TO tmp_swap;"
+psql_run "ALTER TABLE inp RENAME COLUMN j TO k;"
+psql_run "ALTER TABLE inp RENAME COLUMN tmp_swap TO j;"
+check "the CHILD's mark follows a rename issued on the parent" "$(markof inc)" "{j}/lexicographic"
+S="$(storid inc)"
+psql_run "SELECT pgcolumnar.vacuum_sorted('inc','k');"
+check "so vacuum_sorted on the child does the work" \
+	"$([ "$S" = "$(storid inc)" ] && echo "SKIPPED (gate fired wrongly)" || echo rewrote)" "rewrote"
+
+# ---- the WRONG-ANSWER shape: ORDER BY with no Sort over unordered rows ------
+# This is why the cascade is not a cosmetic gap. #751 reads the same mark to
+# claim a pathkey, so a stale mark makes the planner drop the Sort.
+sorts() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" -At \
+		-c "EXPLAIN (COSTS OFF) $1" 2>/dev/null \
+		| grep -qE '^ *(->)? *(Incremental )?Sort' && echo yes || echo no
+}
+psql_run "CREATE TABLE wp (k int, j int) PARTITION BY RANGE (k);"
+psql_run "CREATE TABLE wp1 PARTITION OF wp FOR VALUES FROM (0) TO (100000) USING pgcolumnar;"
+psql_run "INSERT INTO wp SELECT (g*7919::bigint)%2000, (g*104729::bigint)%2000
+          FROM generate_series(1,20000) g;"
+psql_run "SELECT pgcolumnar.vacuum_sorted('wp1','k');"
+check "premise: with the mark true, ORDER BY k needs no Sort" "$(sorts 'SELECT k FROM wp1 ORDER BY k')" "no"
+psql_run "ALTER TABLE wp RENAME COLUMN k TO tmp_swap;"
+psql_run "ALTER TABLE wp RENAME COLUMN j TO k;"
+psql_run "ALTER TABLE wp RENAME COLUMN tmp_swap TO j;"
+check "after the swap, ORDER BY on the now-unordered column plans a Sort" \
+	"$(sorts 'SELECT k FROM wp1 ORDER BY k')" "yes"
+check_num "THE WRONG-ANSWER ARM: and the rows really do come back ordered" \
+	"$(q "SELECT count(*) FROM (SELECT k < lag(k) OVER () AS d FROM (SELECT k FROM wp1 ORDER BY k) x) z WHERE d;")" \
+	"0"
+check "and ORDER BY on the column that IS ordered still needs no Sort" \
+	"$(sorts 'SELECT j FROM wp1 ORDER BY j')" "no"
+
+# ==================== the DECLARED key (options.sort_by) =====================
+# vacuum_sorted(t) with no columns resolves options.sort_by. Maintaining the
+# mark WITHOUT maintaining this would make the two catalogs name different
+# columns, so the same call with the same declared intent would silently rewrite
+# on a different physical key than it did yesterday.
+mk sb
+psql_run "SELECT pgcolumnar.set_options('sb', sort_by => ARRAY['a']);"
+psql_run "SELECT pgcolumnar.vacuum_sorted('sb');"
+check "premise: a bare vacuum_sorted() used the declared key" \
+	"$([ "$(descents sb a)" -eq 0 ] && echo ordered || echo unordered)" "ordered"
+swap sb
+check "the DECLARED key follows the rename too" \
+	"$(q "SELECT sort_by::text FROM pgcolumnar.options WHERE regclass = 'sb'::regclass;")" "{b}"
+check "so the two catalogs still agree after the rename" \
+	"$([ "$(q "SELECT sort_by::text FROM pgcolumnar.options WHERE regclass='sb'::regclass;")" \
+	    = "$(q "SELECT sorted_by::text FROM pgcolumnar.storage WHERE storage_id = pgcolumnar.get_storage_id('sb');")" ] \
+	  && echo agree || echo DISAGREE)" "agree"
+S="$(storid sb)"
+psql_run "SELECT pgcolumnar.vacuum_sorted('sb');"
+check "and a bare vacuum_sorted() is a no-op, not a rewrite on a different key" \
+	"$([ "$S" = "$(storid sb)" ] && echo noop || echo rewrote)" "noop"
+
 # ============================ recluster (#415) ===============================
 # The same comparison, character for character, in the online recluster gate.
 mkz() {

--- a/test/sorted_mark_rename.sh
+++ b/test/sorted_mark_rename.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+#
+# The ordering mark survives ALTER TABLE ... RENAME COLUMN (#778).
+#
+# pgcolumnar.storage records the applied sort key as a list of column NAMES
+# (sorted_by name[]), and both ordering self-gates compare that stored list
+# against the CURRENT attname of the requested columns -- vacuum_sorted's gate
+# (#774) and recluster's (#415), character for character.
+#
+# Column names are not stable. A three-statement swap moves a name from one
+# column to another, and if nothing maintains the mark, the stored name resolves
+# to a DIFFERENT column. The gate then reports "already in this order" about a
+# column that was never sorted, and skips work it must do. For vacuum_sorted
+# that is the exact failure #760 exists to prevent, reached through another door:
+# the table ends up neither sorted nor reclaimed, with no error.
+#
+# THE POSITIVE CONTROL IS LOAD-BEARING. A gate that never fires cannot fire
+# wrongly, so every arm below that asserts a gate misfiring is preceded by one
+# proving the same gate fires correctly on an untouched table. Without it a
+# broken gate and a fixed one look identical.
+#
+# Usage:  test/sorted_mark_rename.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+# Physical order as a DESCENT COUNT over the scan order: 0 means sorted
+# ascending. An ORDER BY subquery cannot be used as the oracle here -- the
+# planner is free to discard it, which makes both sides the same query and every
+# arm pass vacuously.
+descents() { q "SELECT count(*) FROM (SELECT $2 < lag($2) OVER () AS d FROM $1) z WHERE d;"; }
+markof()   { q "SELECT COALESCE(s.sorted_by::text,'-')||'/'||COALESCE(s.sorted_kind,'-')
+                FROM pgcolumnar.storage s WHERE s.storage_id = pgcolumnar.get_storage_id('$1');"; }
+layout()   { q "SELECT md5(string_agg(stripeid::text||':'||fileoffset::text, ',' ORDER BY stripeid)) FROM pgcolumnar.stats('$1');"; }
+storid()   { q "SELECT pgcolumnar.get_storage_id('$1');"; }
+
+mk() {
+	psql_run "DROP TABLE IF EXISTS $1;"
+	psql_run "CREATE TABLE $1 (a int, b int) USING pgcolumnar;"
+	psql_run "INSERT INTO $1 SELECT (g*7919::bigint)%2000, (g*104729::bigint)%2000
+	          FROM generate_series(1,20000) g;"
+	check_num "premise: $1 loaded every row (an overflowed INSERT would make an empty table look like a fired gate)" \
+		"$(q "SELECT count(*) FROM $1;")" "20000"
+}
+
+swap() {   # a <-> b, three ordinary statements
+	psql_run "ALTER TABLE $1 RENAME COLUMN a TO tmp_swap;"
+	psql_run "ALTER TABLE $1 RENAME COLUMN b TO a;"
+	psql_run "ALTER TABLE $1 RENAME COLUMN tmp_swap TO b;"
+}
+
+# ============================ vacuum_sorted ==================================
+# ---- positive control: the gate fires on an untouched table ------------------
+mk vr_ctl
+check "premise: before sorting, a is not in order" \
+	"$([ "$(descents vr_ctl a)" -gt 0 ] && echo unordered || echo ordered)" "unordered"
+psql_run "SELECT pgcolumnar.vacuum_sorted('vr_ctl','a');"
+check_num "premise: vacuum_sorted really ordered it by a" "$(descents vr_ctl a)" "0"
+S="$(storid vr_ctl)"
+psql_run "SELECT pgcolumnar.vacuum_sorted('vr_ctl','a');"
+check "CONTROL: a second identical call is a no-op, so the gate does fire" \
+	"$([ "$S" = "$(storid vr_ctl)" ] && echo noop || echo rewrote)" "noop"
+
+# ---- the defect: the same gate after a NAME SWAP ----------------------------
+mk vr_t
+psql_run "SELECT pgcolumnar.vacuum_sorted('vr_t','a');"
+check "premise: vr_t is ordered by a" "$([ "$(descents vr_t a)" -eq 0 ] && echo ordered || echo unordered)" "ordered"
+check "premise: and NOT by b" "$([ "$(descents vr_t b)" -gt 0 ] && echo unordered || echo ordered)" "unordered"
+check "premise: the mark records key {a}" "$(markof vr_t)" "{a}/lexicographic"
+swap vr_t
+check "premise: after the swap the ordered column is the one now named b" \
+	"$([ "$(descents vr_t b)" -eq 0 ] && echo ordered || echo unordered)" "ordered"
+check "premise: and the column now named a is NOT ordered" \
+	"$([ "$(descents vr_t a)" -gt 0 ] && echo unordered || echo ordered)" "unordered"
+
+check "the mark FOLLOWS the rename, so it still names the ordered column" \
+	"$(markof vr_t)" "{b}/lexicographic"
+
+S="$(storid vr_t)"
+psql_run "SELECT pgcolumnar.vacuum_sorted('vr_t','a');"
+check "THE POINT: vacuum_sorted('a') after the swap does the work" \
+	"$([ "$S" = "$(storid vr_t)" ] && echo "SKIPPED (gate fired wrongly)" || echo rewrote)" "rewrote"
+check_num "and the table really is ordered by a afterwards" "$(descents vr_t a)" "0"
+
+# and the gate is still armed for the column that IS now recorded
+S="$(storid vr_t)"
+psql_run "SELECT pgcolumnar.vacuum_sorted('vr_t','a');"
+check "the gate still fires for the right key after all that" \
+	"$([ "$S" = "$(storid vr_t)" ] && echo noop || echo rewrote)" "noop"
+
+# ---- a rename that touches no sort-key column leaves the mark alone ---------
+mk vr_o
+psql_run "ALTER TABLE vr_o ADD COLUMN spare int;"
+psql_run "SELECT pgcolumnar.vacuum_sorted('vr_o','a');"
+M="$(markof vr_o)"
+psql_run "ALTER TABLE vr_o RENAME COLUMN spare TO spare2;"
+check "renaming an unrelated column does not disturb the mark" "$(markof vr_o)" "$M"
+S="$(storid vr_o)"
+psql_run "SELECT pgcolumnar.vacuum_sorted('vr_o','a');"
+check "and the gate still fires" \
+	"$([ "$S" = "$(storid vr_o)" ] && echo noop || echo rewrote)" "noop"
+
+# ============================ recluster (#415) ===============================
+# The same comparison, character for character, in the online recluster gate.
+mkz() {
+	psql_run "DROP TABLE IF EXISTS $1;"
+	psql_run "CREATE TABLE $1 (a int, b int, c int) USING pgcolumnar;"
+	psql_run "SELECT pgcolumnar.set_options('$1', chunk_group_row_limit => 1000);"
+	psql_run "INSERT INTO $1 SELECT (g*7919::bigint)%2000, (g*104729::bigint)%2000, g
+	          FROM generate_series(1,20000) g;"
+	check_num "premise: $1 loaded every row" "$(q "SELECT count(*) FROM $1;")" "20000"
+}
+mkz rr_ctl
+FIRST="$(q "SELECT pgcolumnar.recluster('rr_ctl','a','b');")"
+check "premise: the first recluster does real work" \
+	"$([ "${FIRST:-0}" -gt 0 ] && echo yes || echo no)" "yes"
+check_num "CONTROL: a repeat recluster on the same key is a no-op, so the gate fires" \
+	"$(q "SELECT pgcolumnar.recluster('rr_ctl','a','b');")" "0"
+
+mkz rr_t
+psql_run "SELECT pgcolumnar.recluster('rr_t','a','b');"
+check "premise: the mark records {a,b} as zorder" "$(markof rr_t)" "{a,b}/zorder"
+# move an UNRELATED column onto the name 'b', so {a,b} would resolve to (a,c)
+psql_run "ALTER TABLE rr_t RENAME COLUMN b TO b_old;"
+psql_run "ALTER TABLE rr_t RENAME COLUMN c TO b;"
+check "the mark follows both renames" "$(markof rr_t)" "{a,b_old}/zorder"
+AFTER="$(q "SELECT pgcolumnar.recluster('rr_t','a','b');")"
+check "recluster on the NEW (a,b) is not skipped as already done" \
+	"$([ "${AFTER:-0}" -gt 0 ] && echo rewrote || echo "SKIPPED (gate fired wrongly)")" "rewrote"
+
+pgc_summary

--- a/test/sorted_mark_rename.sh
+++ b/test/sorted_mark_rename.sh
@@ -95,8 +95,21 @@ mk vr_o
 psql_run "ALTER TABLE vr_o ADD COLUMN spare int;"
 psql_run "SELECT pgcolumnar.vacuum_sorted('vr_o','a');"
 M="$(markof vr_o)"
+# The mark's CONTENT is unchanged either way, because rewriting it with the same
+# names produces the same names. So content alone cannot see whether the write
+# was skipped; xmin can. Without the early return this arm goes red while every
+# other arm in the file stays green.
+XMIN="$(q "SELECT xmin::text FROM pgcolumnar.storage WHERE storage_id = pgcolumnar.get_storage_id('vr_o');")"
 psql_run "ALTER TABLE vr_o RENAME COLUMN spare TO spare2;"
 check "renaming an unrelated column does not disturb the mark" "$(markof vr_o)" "$M"
+check "and does not rewrite the storage row at all (xmin unchanged)" \
+	"$(q "SELECT xmin::text FROM pgcolumnar.storage WHERE storage_id = pgcolumnar.get_storage_id('vr_o');")" \
+	"$XMIN"
+check "premise: xmin CAN move, so the arm above is not comparing two constants" \
+	"$(psql_run "ALTER TABLE vr_o RENAME COLUMN a TO a2;" >/dev/null 2>&1;
+	   NEW="$(q "SELECT xmin::text FROM pgcolumnar.storage WHERE storage_id = pgcolumnar.get_storage_id('vr_o');")";
+	   psql_run "ALTER TABLE vr_o RENAME COLUMN a2 TO a;" >/dev/null 2>&1;
+	   [ "$NEW" != "$XMIN" ] && echo moved || echo stuck)" "moved"
 S="$(storid vr_o)"
 psql_run "SELECT pgcolumnar.vacuum_sorted('vr_o','a');"
 check "and the gate still fires" \

--- a/test/sorted_pathkeys.sh
+++ b/test/sorted_pathkeys.sh
@@ -389,18 +389,55 @@ check "REFUSE: one updated row is a row outside the run" \
 check "and ORDER BY k LIMIT 1 finds the updated row" \
 	"$(q 'SELECT k FROM upc ORDER BY k LIMIT 1;')" "-1"
 
-# --- a column rename makes the recorded name stop resolving -----------------
+# --- a column rename: the mark follows it, so the claim survives (#778) ------
+#
+# This arm used to assert the opposite, and it was right to at the time: nothing
+# maintained the mark, so after a rename the recorded name stopped resolving and
+# the pathkey code refused to claim an ordering. #778 made the mark follow the
+# rename, because a rename does not move data -- the rows really are still
+# ordered by whichever column now carries the name -- so the claim is now both
+# available and TRUE, and the needless Sort goes away.
+#
+# The refusal still has to exist for a name that genuinely cannot be resolved,
+# which is the second half below.
 
 psql_run "CREATE TABLE rnc (LIKE c) USING pgcolumnar;"
 psql_run "SELECT pgcolumnar.set_options('rnc', stripe_row_limit => 2000, chunk_group_row_limit => 500);"
 psql_run "INSERT INTO rnc SELECT * FROM h;"
 psql_run "SELECT pgcolumnar.vacuum_sorted('rnc', 'k', 'j');"
+check "premise: the claim is live before the rename" \
+	"$(sorts 'SELECT k FROM rnc ORDER BY k')" "no"
 psql_run "ALTER TABLE rnc RENAME COLUMN k TO kk;"
-check "premise: the recorded key still names the old column" \
+check "the recorded key FOLLOWS the rename (#778)" \
 	"$(q "SELECT sorted_by::text FROM pgcolumnar.storage WHERE storage_id = pgcolumnar.get_storage_id('rnc');")" \
+	"{kk,j}"
+check "so the claim survives the rename instead of being refused" \
+	"$(sorts 'SELECT kk FROM rnc ORDER BY kk')" "no"
+# ...and the claim is not merely available, it is true: no Sort AND the rows
+# really do come out ordered. A plan with no Sort over unordered rows is the
+# wrong answer, which is the whole risk of claiming a pathkey.
+check "and the rows really are ordered by the renamed column (no Sort AND correct)" \
+	"$(q "SELECT count(*) FROM (SELECT kk < lag(kk) OVER () AS d FROM rnc) z WHERE d;")" "0"
+
+# a name that truly cannot be resolved must still refuse
+psql_run "CREATE TABLE rnd (LIKE c) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.set_options('rnd', stripe_row_limit => 2000, chunk_group_row_limit => 500);"
+psql_run "INSERT INTO rnd SELECT * FROM h;"
+psql_run "SELECT pgcolumnar.vacuum_sorted('rnd', 'k', 'j');"
+# Drop the FIRST key column, not the second. Dropping the second leaves {k} as a
+# resolvable prefix, and a prefix of a sort key is a sound claim -- ORDER BY k
+# legitimately needs no Sort, so that shape cannot test a refusal at all. With
+# the first column gone nothing about the remaining order can be claimed: j is
+# ordered only WITHIN equal k, so claiming j alone would be a wrong answer.
+psql_run "ALTER TABLE rnd DROP COLUMN k;"
+check "premise: the recorded key still names the dropped column" \
+	"$(q "SELECT sorted_by::text FROM pgcolumnar.storage WHERE storage_id = pgcolumnar.get_storage_id('rnd');")" \
 	"{k,j}"
+check "premise: and j alone really is NOT ordered, so a claim on it would be wrong" \
+	"$([ "$(q "SELECT count(*) FROM (SELECT j < lag(j) OVER () AS d FROM rnd) z WHERE d;")" -gt 0 ] && echo unordered || echo ordered)" \
+	"unordered"
 check "REFUSE: a recorded name that no longer resolves is not a claim" \
-	"$(sorts 'SELECT kk FROM rnc ORDER BY kk')" "yes"
+	"$(sorts 'SELECT j FROM rnd ORDER BY j')" "yes"
 
 # --- the GUC is the escape hatch and it works both ways ---------------------
 


### PR DESCRIPTION
Closes #778, which ChronicallyJD filed and reproduced.

## The defect

`pgcolumnar.storage` records the applied sort key as a list of column **names**, and both
ordering self-gates compare that stored list against the *current* `attname` — `vacuum_sorted`'s
gate (#760) and the online `recluster`'s (#415), character for character. Nothing maintained
the mark across `ALTER TABLE ... RENAME COLUMN`, and column names are not stable.

A three-statement swap made the stored name resolve to a **different column**:

```sql
ALTER TABLE t RENAME COLUMN a TO tmp;
ALTER TABLE t RENAME COLUMN b TO a;
ALTER TABLE t RENAME COLUMN tmp TO b;
SELECT pgcolumnar.vacuum_sorted('t','a');   -- reported success, did nothing
```

The gate said "already in this order" about a column that was never sorted. The table came out
neither ordered nor reclaimed, with no error — **the exact failure #760 exists to prevent,
reached through another door**. `recluster` returned 0, which a scheduler reads as "nothing to
do".

## Rename the mark, do not clear it

A rename does not move data. The rows really are still ordered by whichever column now carries
the name, so following the rename keeps a true fact instead of discarding a real optimisation
every time someone renames a column. It composes through the swap above: `{a}` → `{tmp}` →
`{tmp}` → `{b}`, which is the column the rows are actually ordered by.

Done in `ProcessUtility_hook` **after** the statement, so a rename that errors leaves the mark
untouched, and the relation already holds `AccessExclusiveLock` so the lookup cannot race.

## Removal proofs

**Disable the hook** — exactly the five defect arms redden, and `got [1990]` is the descent
count of a table left unsorted by a call that reported success:

```
FAIL  the mark FOLLOWS the rename, so it still names the ordered column: got [{a}/lexicographic]
FAIL  THE POINT: vacuum_sorted('a') after the swap does the work: got [SKIPPED (gate fired wrongly)]
FAIL  and the table really is ordered by a afterwards: got [1990] want [0]
FAIL  the mark follows both renames: got [{a,b}/zorder] want [{a,b_old}/zorder]
FAIL  recluster on the NEW (a,b) is not skipped as already done: got [SKIPPED (gate fired wrongly)]
```

**Remove the `!hit` early return** — exactly one arm reddens, the xmin one. That arm exists
because the mark's *content* is unchanged either way (rewriting it with the same names produces
the same names), so only `xmin` can see whether the write was skipped. Without it the guard
would have shipped as an untested optimisation:

```
FAIL  and does not rewrite the storage row at all (xmin unchanged): got [756] want [755]
```

## The positive controls are the load-bearing part

A gate that never fires cannot fire wrongly, so a broken gate and a fixed one look identical
without one. Every arm asserting a misfire is preceded by one proving the same gate fires
correctly on an untouched table. The fixture also asserts its own row count, because the
reviewer's first attempt at this issue was vacuous for exactly that reason — an `int4` overflow
killed the `INSERT`, and the empty table made `recluster` look like it declined the work.

## One behaviour improves, and `sorted_pathkeys.sh` is updated to say so

That suite had an arm asserting the OLD behaviour: after a rename the recorded name stopped
resolving, so the pathkey claim was refused. It now survives, and the claim is *sound* for the
same reason the mark is. The arm asserts the claim plus an oracle that the rows really do come
out ordered — a plan with no `Sort` over unordered rows is the wrong answer, which is the whole
risk of claiming a pathkey.

A separate arm keeps the refusal honest, and it took two tries: dropping the **second** key
column leaves `{k}` as a resolvable prefix, and a prefix of a sort key is a sound claim, so
that shape cannot test a refusal at all. Dropping the **first** can, since `j` is ordered only
within equal `k`.

## Not fixed here

`sort_status()` reports the stale key too, which is the reporter someone would use to check.
That is fixed by this change for the mark itself; the declared `pgcolumnar.options.sort_by` key
has the same name-stability problem and is not touched here. It fails differently — a wrong-key
rewrite rather than a silent skip — and it wants its own issue.

## Tests

`test/sorted_mark_rename.sh`, 26 checks, registered in its C-order slot. PG17 assert build:
`sorted_mark_rename` 26/26, `sorted_pathkeys` 113/113, `vacuum_sorted_gate` 34/34,
`recluster_gate` 13/13, `recluster_extent`, `native_recluster`, `eager_ordering_record`,
`sorted_projection`, `native_sort_by`, `sort_status`, `sort_status_privilege`,
`maintenance_due`, `autovacuum`, `reader_buffer_reuse`, `harness_selftest` 153/153,
`docs_style` — all PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaQ4vThXcmTCf3KRQpUDrE


---

## Update: the cascade case, which returns WRONG ROWS

The review found the gap, and it is the more serious half of #778.

**A column rename cascades to inheritance children and partitions**, which are separate
relations with their own storage and their own marks. The first version renamed only the
relation named in the statement. Worse: PostgreSQL refuses
`ALTER TABLE child RENAME COLUMN` with *"cannot rename inherited column"*, so **for a columnar
partition the parent is the only route a user has, and the hook never fired for the child at
all.** Every column rename on a partitioned columnar table missed it.

And because the stale name still *resolves*, this is the wrong-answer case rather than the
redundant-work one: #751 reads the same mark for pathkeys, so the planner claims an ordering
that does not hold. `SELECT k FROM par1 ORDER BY k` plans a bare Custom Scan with **no Sort
node** and returns **1,990 descents out of 2,000 rows**.

Fixed by walking `find_all_inheritors` and renaming on every columnar descendant. The block is
deliberately **not** gated on the relation named in the statement being columnar — a
partitioned parent is not itself a columnar relation, so testing it there closes the door
before the columnar children are reached. That decision has its own removal proof.

## Update: the declared key, folded in

`pgcolumnar.options.sort_by` is what `vacuum_sorted(t)` resolves when called with no columns,
and maintaining the mark **without** it is worse than maintaining neither. Before, both were
consistently stale. After, the two catalogs name **different** columns, so the same call with
the same declared intent silently rewrites on a different physical key than it did yesterday,
with no user change at all. It holds names deliberately — `options` is the catalog carried
through `pg_dump`, where attnums renumber and names do not — so a rename hook is the correct
maintenance for it rather than a workaround. Keyed by `regclass`, so the same walk covers it.

## Removal proofs for the new work

Each verified to have *applied* before its result was believed — one of these silently
no-matched first time and reported a clean pass, which is the same class of error as the
finding itself.

**Restrict the walk to the named relation** — the eight cascade arms redden:

```
FAIL  the PARTITION's mark follows a rename issued on the parent: got [{k}/lexicographic]
FAIL  so vacuum_sorted on the partition does the work: got [SKIPPED (gate fired wrongly)]
FAIL  and the partition really is ordered by k afterwards: got [1990] want [0]
FAIL  the CHILD's mark follows a rename issued on the parent: got [{k}/lexicographic]
FAIL  so vacuum_sorted on the child does the work: got [SKIPPED (gate fired wrongly)]
FAIL  after the swap, ORDER BY on the now-unordered column plans a Sort: got [no] want [yes]
FAIL  THE WRONG-ANSWER ARM: and the rows really do come back ordered: got [1990] want [0]
FAIL  and ORDER BY on the column that IS ordered still needs no Sort: got [yes] want [no]
```

**Gate early on the named relation being columnar** — the same eight, which is what makes that
a decision rather than an accident.

**Remove the declared-key call** — exactly three:

```
FAIL  the DECLARED key follows the rename too: got [{a}] want [{b}]
FAIL  so the two catalogs still agree after the rename: got [DISAGREE] want [agree]
FAIL  and a bare vacuum_sorted() is a no-op, not a rewrite on a different key: got [rewrote]
```

## Tests

`test/sorted_mark_rename.sh` is now **46 checks**. PG17 assert build, all PASSED:
`sorted_mark_rename`, `sorted_pathkeys` 113/113, `vacuum_sorted_gate`, `recluster_gate`,
`recluster_extent`, `native_recluster`, `eager_ordering_record`, `sorted_projection`,
`native_sort_by`, `sort_status`, `maintenance_due`, `autovacuum`, `native_index`,
`reader_buffer_reuse`, `docs_style`, `harness_selftest` 153/153.
