### PR TITLE
test: refuse a set_options call with a value the function will reject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,29 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ### Changed
 
+- The harness now refuses a `pgcolumnar.set_options` call whose value the
+  function will reject. `set_options` raises on an out-of-range limit, so a
+  suite that calls it and discards the output runs on **default** limits while
+  the script reads as configured, and every later assertion is about a fixture
+  that was never built. Found in review probes that passed
+  `stripe_row_limit => 500`, which errors with "must be at least 1000".
+
+  The naive form of that guard would be wrong. Measured on this tree before
+  writing it: 182 `set_options` calls and exactly three out-of-range literals,
+  all in `test/audit.sh`, all deliberate, all wrapped in `expect_error` because
+  rejecting them is what that suite tests. A guard flagging every out-of-range
+  value is wrong on three of three. The discriminator is whether the call's
+  result is inspected or discarded, so calls passed to `expect_error` are
+  skipped and exactly the silent class remains.
+
+  Line continuations are joined before matching, because two of those three
+  calls are backslash-continued and a line-based scan sees neither the value nor
+  the `expect_error`. That direction fails safe; the same blindness fails open
+  on a real multi-line offender. Proved: without the join, those three become
+  false positives.
+
+### Changed
+
 - `docs/configuration.md` now says why `pgcolumnar.enable_group_vectorization`
   is off by default, which #755 records as not visible from outside the code.
   Measured rather than reasoned: on 4,000,000 rows in 200,000 groups the setting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,14 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
   on a real multi-line offender. Proved: without the join, those three become
   false positives.
 
+  The guard also asserts that it swept **every** file containing such a call,
+  not merely that it swept something. Its globs are `test/*.sh` and `bench/*.sh`,
+  which do not match `test/selftest/*.sh` or `test/pbt/*.sh`, so it was complete
+  by accident of the tree's current shape rather than by construction. Comparing
+  the files that contain a call against the files actually read fails loudly the
+  day one appears anywhere new, including a directory nobody predicted, which a
+  wider glob cannot do.
+
 ### Changed
 
 - `docs/configuration.md` now says why `pgcolumnar.enable_group_vectorization`

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -2368,7 +2368,7 @@ pgcolumnar_process_utility(PlannedStmt *pstmt, const char *queryString,
 				 *
 				 * That is the argument to keep. Without it the walk reads as
 				 * over-broad and invites a later condition that reintroduces
-				 * the bug (ChronicallyJD, #779 review).
+				 * the bug (OffgridwithJD, #779 review).
 				 *
 				 * The rename already holds the locks it needs on the whole
 				 * hierarchy, so NoLock here takes no new lock and cannot race.

--- a/test/native_parquet_fieldid.sh
+++ b/test/native_parquet_fieldid.sh
@@ -88,7 +88,7 @@ check "a file with no field ids is refused (22023)" \
 	"$(sqlstate_of "SELECT * FROM pgcolumnar.read_parquet('$NOID', ARRAY[1]) AS t(x int)")" "22023"
 # a duplicate REQUESTED id (two output columns asking for one file column) is
 # refused up front with a clear cause, not left to fail deep in the decode with a
-# message that wrongly blames the file (ChronicallyJD's #638 note).
+# message that wrongly blames the file (OffgridwithJD's #638 note).
 check "a duplicate requested field id is refused (22023)" \
 	"$(sqlstate_of "SELECT * FROM pgcolumnar.read_parquet('$FID', ARRAY[7,7]) AS t(a1 int, a2 int)")" "22023"
 check "the duplicate-requested-id error names the id, not the file" \

--- a/test/selftest/270-a-set-options-call-must-use-values.sh
+++ b/test/selftest/270-a-set-options-call-must-use-values.sh
@@ -89,10 +89,19 @@ check "premise: the set_options sweep read a substantial number of calls" \
 # data (the positive control writes an out-of-range call that is deliberately
 # not wrapped in expect_error), so sweeping it would flag the probe that proves
 # the sweep works. Keyed on BASH_SOURCE so it cannot drift into a
-# hand-maintained list of exceptions.
+# hand-maintained list of exceptions. Matched with grep -vxF against the FULL
+# path: -vF on the basename would be a substring match against the whole path,
+# which is still a name match and not what this comment promises.
+#
+# LATENT, and named rather than fixed: --include='*.sh' bounds BOTH sides of the
+# premise, so a .sql calling set_options would be invisible to the sweep and to
+# the completeness check alike -- the same accidental-completeness argument one
+# level over. Checked on 011389f: the only .sql mentioning set_options is
+# test/fixtures/pgcolumnar--1.0-alpha.sql, which DEFINES the function rather
+# than calling it (OffgridwithJD, #780 review).
 _so_self="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
 _so_have="$(grep -rl 'set_options(' --include='*.sh' "$PGC_SRCDIR" 2>/dev/null \
-	| grep -vF "$(basename "$_so_self")" | LC_ALL=C sort -u)"
+	| grep -vxF "$_so_self" | LC_ALL=C sort -u)"
 _so_read="$(_so_calls | cut -d: -f1 | LC_ALL=C sort -u)"
 _so_missed="$(LC_ALL=C comm -23 <(printf '%s\n' "$_so_have") <(printf '%s\n' "$_so_read"))"
 [ -n "$_so_missed" ] && printf '%s\n' "$_so_missed" | sed 's/^/    unswept: /'

--- a/test/selftest/270-a-set-options-call-must-use-values.sh
+++ b/test/selftest/270-a-set-options-call-must-use-values.sh
@@ -3,9 +3,16 @@
 # pgcolumnar.set_options RAISES on an out-of-range limit. A suite that calls it
 # and discards the output therefore runs on DEFAULT limits while the script
 # reads as though it were configured, and every later assertion is about a
-# fixture that was never built. Found by ChronicallyJD on 2026-08-27: several
+# fixture that was never built. Found by OffgridwithJD on 2026-08-27: several
 # probes passed stripe_row_limit => 500, which errors with "must be at least
 # 1000", and the fixtures silently ran on defaults.
+#
+# SCOPE. This checks NUMERIC BOUNDS only. set_options also raises on an unknown
+# compression or encode_effort, and on a sort_by naming a column that does not
+# exist or is virtual -- silent in exactly the same way, and not checkable from
+# a literal without resolving the relation. Those are deliberately not covered,
+# so the title of this file is narrower than "every value set_options will
+# reject".
 #
 # WHY THE NAIVE FORM OF THIS GUARD WOULD BE REVERTED IN A WEEK. Measured on this
 # tree before writing it: 182 set_options calls, and exactly THREE out-of-range

--- a/test/selftest/270-a-set-options-call-must-use-values.sh
+++ b/test/selftest/270-a-set-options-call-must-use-values.sh
@@ -1,0 +1,87 @@
+# A set_options call must use IN-RANGE values, unless its error is the point.
+#
+# pgcolumnar.set_options RAISES on an out-of-range limit. A suite that calls it
+# and discards the output therefore runs on DEFAULT limits while the script
+# reads as though it were configured, and every later assertion is about a
+# fixture that was never built. Found by ChronicallyJD on 2026-08-27: several
+# probes passed stripe_row_limit => 500, which errors with "must be at least
+# 1000", and the fixtures silently ran on defaults.
+#
+# WHY THE NAIVE FORM OF THIS GUARD WOULD BE REVERTED IN A WEEK. Measured on this
+# tree before writing it: 182 set_options calls, and exactly THREE out-of-range
+# literals -- all in audit.sh, all deliberate, all wrapped in expect_error,
+# because rejecting them is what that suite tests. A guard that flags every
+# out-of-range value is wrong on 3 of 3 and gets deleted. The discriminator is
+# already the house vocabulary: a call whose result is INSPECTED is fine, one
+# whose output is DISCARDED is the one that fails silently.
+#
+# LINE CONTINUATIONS ARE JOINED FIRST. audit.sh:208 and :210 are backslash
+# continued, so a line-based grep sees neither the expect_error nor the value.
+# Here that would fail SAFE, but the same blindness fails OPEN on a real
+# multi-line offender, and multi-line set_options calls are common.
+#
+# Bounds are set_options' own: stripe >= 1000, chunk_group >= 100,
+# compression_level 1..22.
+
+_so_scan() {
+	# $1: extra files to include (used by the positive control)
+	local extra="${1:-}"
+	local f
+	for f in "$PGC_SRCDIR"/test/*.sh "$PGC_SRCDIR"/bench/*.sh $extra; do
+		[ -f "$f" ] || continue
+		awk -v F="$f" '{
+			line = $0; n = NR
+			while (sub(/\\$/, "", line)) { if ((getline nxt) > 0) line = line nxt; else break }
+			print F ":" n ":" line
+		}' "$f"
+	done
+}
+
+# every joined line that calls set_options, minus the ones whose error is the point
+_so_calls() { _so_scan "${1:-}" | grep 'set_options(' ; }
+_so_offenders() {
+	_so_calls "${1:-}" | grep -v 'expect_error' | while IFS= read -r L; do
+		_so_check "$L" stripe_row_limit 1000 2147483647
+		_so_check "$L" chunk_group_row_limit 100 2147483647
+		_so_check "$L" compression_level 1 22
+	done
+}
+_so_check() {
+	local L="$1" name="$2" lo="$3" hi="$4" v
+	printf '%s\n' "$L" | grep -oE "$name *=> *[0-9]+" | grep -oE '[0-9]+$' | while read -r v; do
+		if [ "$v" -lt "$lo" ] || [ "$v" -gt "$hi" ]; then
+			printf '%s %s => %s (allowed %s..%s)\n' "$(printf '%s' "$L" | cut -d: -f1,2)" "$name" "$v" "$lo" "$hi"
+		fi
+	done
+}
+
+_SO_CALLS="$(_so_calls | grep -c 'set_options(')"
+
+# The sweep must have READ something. A path typo makes every check below
+# vacuously green forever, which is the failure this file exists to prevent in
+# other people's suites.
+check "premise: the set_options sweep read a substantial number of calls" \
+	"$([ "${_SO_CALLS:-0}" -ge 100 ] && echo yes || echo "no ($_SO_CALLS)")" "yes"
+
+# POSITIVE CONTROL. The three known out-of-range values in audit.sh are skipped
+# because they are expect_error, so their absence from the report proves nothing
+# on its own -- a detector that finds NOTHING would also pass. Run it over a
+# synthetic file carrying one of the same values NOT wrapped in expect_error.
+_so_tmp="$(mktemp)"
+cat > "$_so_tmp" <<'PROBE'
+psql_run "SELECT pgcolumnar.set_options('t', stripe_row_limit => 500);"
+PROBE
+check "premise: the detector fires on an out-of-range value that is NOT expect_error" \
+	"$([ -n "$(_so_offenders "$_so_tmp" | grep "$_so_tmp")" ] && echo fires || echo BLIND)" "fires"
+cat > "$_so_tmp" <<'PROBE'
+expect_error "reject it" \
+	"SELECT pgcolumnar.set_options('t', stripe_row_limit => 500);"
+PROBE
+check "premise: and does NOT fire when the error is the point, across a continuation" \
+	"$([ -z "$(_so_offenders "$_so_tmp" | grep "$_so_tmp")" ] && echo quiet || echo "fired")" "quiet"
+rm -f "$_so_tmp"
+
+_SO_BAD="$(_so_offenders)"
+[ -n "$_SO_BAD" ] && printf '%s\n' "$_SO_BAD" | sed 's/^/    /'
+check "no suite calls set_options with a value it will reject" \
+	"$([ -z "$_SO_BAD" ] && echo clean || echo "$(printf '%s\n' "$_SO_BAD" | wc -l) offender(s)")" "clean"

--- a/test/selftest/270-a-set-options-call-must-use-values.sh
+++ b/test/selftest/270-a-set-options-call-must-use-values.sh
@@ -78,6 +78,15 @@ check "premise: the set_options sweep read a substantial number of calls" \
 # tree has no set_options call outside the globs, so the guard is complete by
 # accident of its current shape rather than by construction.
 #
+# WHAT THE PREMISE IS FOR, which is not obvious from the premise. In every
+# unswept-file case the OFFENDER check still reports clean, because a file the
+# sweep never read cannot be examined -- so without this premise the guard would
+# assert "no suite calls set_options with a value it will reject" about a tree
+# containing exactly that. The generalisation is worth more than this file: any
+# content check over a swept set needs a companion premise that the sweep
+# covered the set, or its clean result means "found nothing" rather than "there
+# is nothing".
+#
 # Fixed with a premise rather than a wider glob, because a wider glob only ever
 # covers the directories someone thought of. Comparing the files that CONTAIN a
 # call against the files the sweep actually READ fails loudly the day one

--- a/test/selftest/270-a-set-options-call-must-use-values.sh
+++ b/test/selftest/270-a-set-options-call-must-use-values.sh
@@ -63,6 +63,36 @@ _SO_CALLS="$(_so_calls | grep -c 'set_options(')"
 check "premise: the set_options sweep read a substantial number of calls" \
 	"$([ "${_SO_CALLS:-0}" -ge 100 ] && echo yes || echo "no ($_SO_CALLS)")" "yes"
 
+# ...and it must have read EVERYTHING. The premise above proves the sweep read
+# something; it cannot see a whole directory the glob does not reach. The globs
+# are test/*.sh and bench/*.sh, which do NOT match test/selftest/*.sh or
+# test/pbt/*.sh, so a suite added under either would be silently unguarded --
+# the exact fail-open class this file exists to prevent elsewhere. Today the
+# tree has no set_options call outside the globs, so the guard is complete by
+# accident of its current shape rather than by construction.
+#
+# Fixed with a premise rather than a wider glob, because a wider glob only ever
+# covers the directories someone thought of. Comparing the files that CONTAIN a
+# call against the files the sweep actually READ fails loudly the day one
+# appears anywhere new, with nobody having to predict where (OffgridwithJD,
+# #780 review).
+#
+# This file is the one legitimate exclusion, and it excludes ITSELF by path
+# rather than by name: it necessarily contains the bad pattern as its own test
+# data (the positive control writes an out-of-range call that is deliberately
+# not wrapped in expect_error), so sweeping it would flag the probe that proves
+# the sweep works. Keyed on BASH_SOURCE so it cannot drift into a
+# hand-maintained list of exceptions.
+_so_self="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+_so_have="$(grep -rl 'set_options(' --include='*.sh' "$PGC_SRCDIR" 2>/dev/null \
+	| grep -vF "$(basename "$_so_self")" | LC_ALL=C sort -u)"
+_so_read="$(_so_calls | cut -d: -f1 | LC_ALL=C sort -u)"
+_so_missed="$(LC_ALL=C comm -23 <(printf '%s\n' "$_so_have") <(printf '%s\n' "$_so_read"))"
+[ -n "$_so_missed" ] && printf '%s\n' "$_so_missed" | sed 's/^/    unswept: /'
+check "premise: every file containing a set_options call is in the sweep" \
+	"$([ -z "$_so_missed" ] && echo complete || echo "$(printf '%s\n' "$_so_missed" | wc -l) unswept")" \
+	"complete"
+
 # POSITIVE CONTROL. The three known out-of-range values in audit.sh are skipped
 # because they are expect_error, so their absence from the report proves nothing
 # on its own -- a detector that finds NOTHING would also pass. Run it over a


### PR DESCRIPTION
A harness guard, from a finding in the #779 review.

## The failure

`pgcolumnar.set_options` **raises** on an out-of-range limit. A suite that calls it and
discards the output therefore runs on **default** limits while the script reads as though it
were configured, and every later assertion is about a fixture that was never built.
ChronicallyJD hit it while attacking #779: several probes passed `stripe_row_limit => 500`,
which errors with *"must be at least 1000"*.

## The naive guard would be reverted in a week, and the tree says so

Measured before writing it, not after: **182 `set_options` calls, and exactly three
out-of-range literals** — all in `test/audit.sh`, all deliberate, all wrapped in
`expect_error`, because rejecting them is what that suite tests.

```
test/audit.sh:208  chunk_group_row_limit => 0   (allowed 100..)
test/audit.sh:210  stripe_row_limit => 5        (allowed 1000..)
test/audit.sh:212  compression_level => 99      (allowed 1..22)
```

A guard flagging every out-of-range value is wrong on **three of three**. The discriminator is
already the house vocabulary: a call whose result is **inspected** is fine, one whose output is
**discarded** is the one that fails silently. So `expect_error` calls are skipped, and exactly
the real class remains.

## Line continuations are joined first

Two of those three calls are backslash-continued, so a line-based scan sees neither the value
nor the `expect_error`. In that direction it fails *safe* — but the same blindness fails
**open** on a real multi-line offender, and multi-line `set_options` calls are common.

## Two premises on the guard itself

**It asserts the sweep read something** (>= 100 calls). A path typo would make it vacuously
green forever, which is the exact failure this file exists to catch in other people's suites.

**It carries a positive control**, because the three real out-of-range values are *skipped* —
so their absence from the report would equally be produced by a detector that finds nothing.
The control runs it over a synthetic file with the same value not wrapped in `expect_error`
(must fire), then over one that is (must stay quiet, across a continuation).

## Removal proofs

**Inject a real offender** into `test/native_sort_by.sh`:

```
FAIL  no suite calls set_options with a value it will reject: got [1 offender(s)] want [clean]
```

**Remove the continuation join** — the continuation premise reddens *and* `audit.sh`'s three
deliberate values become false positives, which is the failure mode the join exists to prevent:

```
FAIL  premise: and does NOT fire when the error is the point, across a continuation: got [fired]
FAIL  no suite calls set_options with a value it will reject: got [3 offender(s)] want [clean]
```

## Not done here

Making `psql_run` fatal looks like the general fix and is not: `alter_column_type.sh`,
`analyze_differential.sh` and others capture its errors deliberately, and only 8 of 237 suites
run `set -e` at all. That is a large risky sweep for a narrow problem. Separately,
`expect_error` is defined independently in at least four suites rather than in `lib.sh`, which
is a candidate for a later tidy. Both observations are ChronicallyJD's.

## Tests

`harness_selftest` 157/157 on PG17 (was 153; this adds four checks).

Design credit to ChronicallyJD, who scanned the tree before answering rather than proposing the
naive form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaQ4vThXcmTCf3KRQpUDrE