### PR TITLE
fix: .mailmap missed the bare noreply forms, so 49 commits showed separately

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,6 +1,19 @@
 # Canonical author identity for pgColumnar.
 # Maps earlier commit identities to the jdatcmd account so git log, git shortlog,
 # and the GitHub contributor view show one author, without rewriting history.
+# The bare noreply forms too. The 136637981+ form below is the one GitHub uses
+# for web commits; the two without the id prefix come from other clients and are
+# what 49 commits were still authored under, showing as a separate contributor
+# despite the goal stated above. Verified with git shortlog -sne, which had
+# 1609 under the canonical identity plus 40 and 9 under these.
+#
+# The ChronicallyJD spellings stay HERE even though that account was renamed to
+# OffgridwithJD and the name now 404s on GitHub. These are historical commit
+# ADDRESSES baked into existing commits, not pointers to a live account: this is
+# the one place the old name is correct and load-bearing, and renaming it would
+# split the contributor view rather than repair it.
+Joshua D. Drake <jd@commandprompt.com> <ChronicallyJD@users.noreply.github.com>
+Joshua D. Drake <jd@commandprompt.com> <chronicallyjd@users.noreply.github.com>
 Joshua D. Drake <jd@commandprompt.com> <136637981+ChronicallyJD@users.noreply.github.com>
 Joshua D. Drake <jd@commandprompt.com> Joshua (D) Drake <136637981+ChronicallyJD@users.noreply.github.com>
 Joshua D. Drake <jd@commandprompt.com> <offgridwithjd@gmail.com>


### PR DESCRIPTION
Found by OffgridwithJD while checking that #780's account-name sweep had not gone too far. It
had not — but looking at `.mailmap` turned up a real defect in it.

## The file states a goal it does not reach

Its own header says it maps earlier commit identities *"so git log, git shortlog, and the
GitHub contributor view show one author"*. It mapped the `136637981+ChronicallyJD` noreply form
that GitHub uses for web commits, but not the two forms other clients produce.

```
before:  1604  Joshua D. Drake <jd@commandprompt.com>
           40  ChronicallyJD <ChronicallyJD@users.noreply.github.com>
            9  ChronicallyJD <chronicallyjd@users.noreply.github.com>

after:   1653  Joshua D. Drake <jd@commandprompt.com>
```

**1604 + 40 + 9 = 1653**, so the fix accounts for every commit rather than dropping some
through a mapping that is too greedy. Removal proof is the `before` block: dropping the two new
lines restores the split exactly.

## Why the old name stays in this file

The `ChronicallyJD` spellings remain here even though the account was renamed to
`OffgridwithJD` and the old name now 404s (`gh api users/ChronicallyJD` → 404, while
`users/OffgridwithJD` resolves to id 136637981).

These are historical commit **addresses** baked into existing commits, not pointers to a live
account. **This is the one place the old name is correct and load-bearing**, and renaming it
would split the contributor view rather than repair it — which is exactly why #780's
source-comment repairs stopped short of it.

The 8 `design/*.md` files that also carry the name are historical narrative ("Measured by
ChronicallyJD on hits_col"), so a blanket rename there edits the record of who said what. Left
alone deliberately; that is the owner's call rather than something to settle in a PR.

## Verification

`git shortlog -sne HEAD` before and after, shown above. No code, no tests, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaQ4vThXcmTCf3KRQpUDrE