### PR TITLE
opt: decode FSST symbols with one 8-byte store, not a variable-length memcpy (#768)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,37 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ## [Unreleased]
 
+### Changed
+
+- FSST decoding is between 1.5 and 2.9 times faster, which makes a scan of an
+  FSST-encoded text column that much faster overall (#768). `encode_effort` is
+  `full` by default, so this applies to text columns generally rather than to an
+  opt-in.
+
+  A profile of a scan over a repetitive text column put **68.8% of the whole
+  query in `decode_fsst_shared`**, 147.4 ms of 230.3 ms. The loop copied each
+  symbol out of the table with a `memcpy` whose length is only known at run
+  time, which cannot become a single instruction. It now packs each symbol into
+  a `uint64` once when the table is parsed, and stores it with one fixed 8-byte
+  write, keeping only the symbol's own length by advancing the output cursor by
+  that much. The buffer is allocated with 8 bytes of headroom so the tail of
+  that write stays inside the allocation.
+
+  Measured on one cluster with only the installed library changing, 1,000,000
+  rows in one text column, `SELECT count(v)`, vectorized paths off so the scan
+  decodes every value, minimum of seven runs, and the column's `md5` identical
+  across both builds:
+
+  | Text shape | Before | After | |
+  | --- | ---: | ---: | ---: |
+  | Repeating host and path strings | 221.4 ms | 77.7 ms | 2.85x |
+  | 128-char hex | 302.0 ms | 200.9 ms | 1.50x |
+
+  The shape with more repeated substrings gains more, which is the shape FSST
+  is for. The transform is byte-identical in both directions and the on-disk
+  format does not change, so a table written by any earlier version reads the
+  same.
+
 ### Fixed
 
 - `ORDER BY` no longer returns unordered rows after a column rename, and neither

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,11 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
   `full` by default, so this applies to text columns generally rather than to an
   opt-in.
 
-  A profile of a scan over a repetitive text column put **68.8% of the whole
-  query in `decode_fsst_shared`**, 147.4 ms of 230.3 ms. The loop copied each
+  A profile of a scan over a repetitive text column put **68.8% of the query's
+  CPU in `decode_fsst_shared`**, 147.4 ms of the 214.1 ms per query that the
+  profile measured. (The wall-clock minimum for the same query was 230.3 ms.
+  Those are two different quantities and an earlier draft of this entry divided
+  one by the other, which gives 64.0% and reconciles with nothing.) The loop copied each
   symbol out of the table with a `memcpy` whose length is only known at run
   time, which cannot become a single instruction. It now packs each symbol into
   a `uint64` once when the table is parsed, and stores it with one fixed 8-byte

--- a/src/columnar_encoding.c
+++ b/src/columnar_encoding.c
@@ -2047,7 +2047,7 @@ decode_fsst_shared(const char *enc, uint32 encLen, const char *table,
 	const char *end = enc + encLen;
 	const char *tp;
 	const char *tend;
-	uint64		symVal[FSST_MAX_SYMBOLS];	/* symbol bytes packed low-first */
+	uint64		symVal[FSST_MAX_SYMBOLS];	/* symbol bytes, memcpy'd in and out */
 	uint8		symLen[FSST_MAX_SYMBOLS];
 	uint32		nSym;
 	uint32		outPos = 0;
@@ -2078,6 +2078,16 @@ decode_fsst_shared(const char *enc, uint32 encLen, const char *table,
 		 * Pack the symbol into a uint64 once, here, rather than copying L bytes
 		 * out of the table on every occurrence in the loop. nSym is at most 255
 		 * and this runs once per chunk.
+		 *
+		 * ENDIANNESS. This is safe on any byte order for one reason only: both
+		 * ends are a byte-wise memcpy, so the bytes round-trip, and symVal[i] is
+		 * NEVER INTERPRETED AS A NUMBER. Do not "clarify" this into
+		 * `v |= (uint64) tp[j] << (8 * j)`. That builds a little-endian integer,
+		 * is identical on x86, and is wrong on a big-endian machine, where the
+		 * store below would write the symbol reversed.
+		 *
+		 * The L < 1 || L > FSST_MAX_SYMLEN check above is load-bearing here in a
+		 * way it was not before: it is what keeps this memcpy inside the uint64.
 		 */
 		{
 			uint64		v = 0;

--- a/src/columnar_encoding.c
+++ b/src/columnar_encoding.c
@@ -1464,6 +1464,7 @@ decode_dict(const char *enc, uint32 encLen, Form_pg_attribute att, uint32 n,
 								 * codes) at negligible amortized cost. */
 #define FSST_MIN_RAWLEN 64		/* below this, table overhead cannot pay off */
 #define FSST_COUNT_SLOTS (1u << 17)	/* candidate-counting hash capacity */
+#define FSST_DECODE_SLACK 8		/* headroom so a symbol is one 8-byte store (#768) */
 
 typedef struct FsstTable
 {
@@ -2034,12 +2035,19 @@ static char *
 decode_fsst_shared(const char *enc, uint32 encLen, const char *table,
 				   uint32 tableLen, uint32 rawLen, MemoryContext cx)
 {
-	char	   *raw = MemoryContextAlloc(cx, rawLen > 0 ? rawLen : 1);
+	/*
+	 * FSST_DECODE_SLACK bytes of headroom past rawLen, so the decode loop can
+	 * store a symbol as one unaligned 8-byte write whatever its length. The
+	 * write starts at outPos, which the bounds check in the loop holds at
+	 * rawLen - L or less, so it reaches at most rawLen + 7.
+	 */
+	char	   *raw = MemoryContextAlloc(cx, (rawLen > 0 ? rawLen : 1) +
+										 FSST_DECODE_SLACK);
 	const char *p = enc;
 	const char *end = enc + encLen;
 	const char *tp;
 	const char *tend;
-	const char *symPtr[FSST_MAX_SYMBOLS];
+	uint64		symVal[FSST_MAX_SYMBOLS];	/* symbol bytes packed low-first */
 	uint8		symLen[FSST_MAX_SYMBOLS];
 	uint32		nSym;
 	uint32		outPos = 0;
@@ -2066,7 +2074,17 @@ decode_fsst_shared(const char *enc, uint32 encLen, const char *table,
 		if ((uint32) (tend - tp) < L)
 			DECODE_CORRUPT("FSST shared table symbol bytes past end");
 		symLen[i] = L;
-		symPtr[i] = tp;
+		/*
+		 * Pack the symbol into a uint64 once, here, rather than copying L bytes
+		 * out of the table on every occurrence in the loop. nSym is at most 255
+		 * and this runs once per chunk.
+		 */
+		{
+			uint64		v = 0;
+
+			memcpy(&v, tp, L);
+			symVal[i] = v;
+		}
 		tp += L;
 	}
 
@@ -2107,7 +2125,14 @@ decode_fsst_shared(const char *enc, uint32 encLen, const char *table,
 			L = symLen[c];
 			if (L > rawLen - outPos)	/* outPos <= rawLen invariant */
 				DECODE_CORRUPT("FSST output exceeds raw length");
-			memcpy(raw + outPos, symPtr[c], L);
+			/*
+			 * One fixed 8-byte store rather than a variable-length memcpy. A
+			 * memcpy whose length is only known at run time cannot become a
+			 * single store; this can, and the slack allocated above makes the
+			 * over-write safe. Only symLen[c] bytes are kept: outPos advances
+			 * by L, so the next store overwrites the remainder.
+			 */
+			memcpy(raw + outPos, &symVal[c], sizeof(uint64));
 			outPos += L;
 		}
 	}

--- a/test/selftest/130-the-sanitizer-subset-must-cover-the.sh
+++ b/test/selftest/130-the-sanitizer-subset-must-cover-the.sh
@@ -56,31 +56,24 @@ check "the sanitizer subset runs every suite that drives the encoding selftest" 
 	"$(printf '%s' "$_san_missing" | sed 's/^ //')" ""
 
 
-# ---- and every suite that is the ONLY guard on a deliberate over-write -------
+# ---- NOT a check: FSST slack coverage, and why there is no arm for it --------
 #
 # decode_fsst_shared stores each symbol as one fixed 8-byte write and allocates
-# FSST_DECODE_SLACK bytes past rawLen so the tail of that write is inside the
+# FSST_DECODE_SLACK bytes past rawLen so the tail of that write stays inside the
 # allocation (#768). Nothing in the ordinary matrix can see the slack removed:
 # the over-write lands 1 to 7 bytes past a palloc'd chunk, which does not fault
-# and does not change any answer. **The sanitizer is the only thing that
-# catches it**, and it does so precisely -- with the slack deleted,
-# write_fsst_compressed reports
+# and changes no answer. The sanitizer catches it precisely -- with the slack
+# deleted, write_fsst_compressed reports
 # `heap-buffer-overflow ... columnar_encoding.c in decode_fsst_shared`.
 #
-# So a suite that exercises FSST decoding must stay in the subset. Dropping one
-# would not fail anything; it would silently remove the only guard there is.
-# Asked by which suites DRIVE FSST rather than by name, so moving the coverage
-# to another suite cannot quietly narrow it.
-_fsst_missing=""
-_fsst_drivers=0
-for _f in "$PGC_SRCDIR"/test/*.sh; do
-	grep -qE "encode_effort *=> *'full'|fsst" "$_f" || continue
-	_fsst_drivers=$((_fsst_drivers + 1))
-	_b="$(basename "$_f" .sh)"
-	grep -qw "$_b" <<<"$_san_suites" || _fsst_missing="$_fsst_missing $_b"
-done
-check "premise: at least one suite drives FSST encoding" \
-	"$([ "$_fsst_drivers" -ge 1 ] && echo yes || echo "no ($_fsst_drivers)")" "yes"
-check "the sanitizer subset runs at least one suite that drives FSST decoding" \
-	"$([ "$_fsst_drivers" -gt "$(printf '%s' "$_fsst_missing" | wc -w)" ] && echo covered || echo "none covered")" \
-	"covered"
+# I wrote an arm here requiring the subset to keep a suite that drives FSST, and
+# then removed it, because it cannot fail. `encode_effort = full` is the DEFAULT,
+# so FSST decoding is exercised by essentially every suite that stores text, and
+# the subset holds many: native_encoding, write_fsst_compressed, differential,
+# arrow_export among them. Measured: deleting all three of the suites I first
+# named from the subset left the check green, because others still matched.
+#
+# So the coverage is not at risk in the way an arm here would guard, and a check
+# that cannot go red is worse than none -- it reads as protection. The comment
+# stays because the REASON matters: if the sanitizer subset ever narrowed to
+# suites that store no varlena data, the slack would lose its only detector.

--- a/test/selftest/130-the-sanitizer-subset-must-cover-the.sh
+++ b/test/selftest/130-the-sanitizer-subset-must-cover-the.sh
@@ -55,3 +55,32 @@ check "premise: at least one suite drives the C-level encoding selftest" \
 check "the sanitizer subset runs every suite that drives the encoding selftest" \
 	"$(printf '%s' "$_san_missing" | sed 's/^ //')" ""
 
+
+# ---- and every suite that is the ONLY guard on a deliberate over-write -------
+#
+# decode_fsst_shared stores each symbol as one fixed 8-byte write and allocates
+# FSST_DECODE_SLACK bytes past rawLen so the tail of that write is inside the
+# allocation (#768). Nothing in the ordinary matrix can see the slack removed:
+# the over-write lands 1 to 7 bytes past a palloc'd chunk, which does not fault
+# and does not change any answer. **The sanitizer is the only thing that
+# catches it**, and it does so precisely -- with the slack deleted,
+# write_fsst_compressed reports
+# `heap-buffer-overflow ... columnar_encoding.c in decode_fsst_shared`.
+#
+# So a suite that exercises FSST decoding must stay in the subset. Dropping one
+# would not fail anything; it would silently remove the only guard there is.
+# Asked by which suites DRIVE FSST rather than by name, so moving the coverage
+# to another suite cannot quietly narrow it.
+_fsst_missing=""
+_fsst_drivers=0
+for _f in "$PGC_SRCDIR"/test/*.sh; do
+	grep -qE "encode_effort *=> *'full'|fsst" "$_f" || continue
+	_fsst_drivers=$((_fsst_drivers + 1))
+	_b="$(basename "$_f" .sh)"
+	grep -qw "$_b" <<<"$_san_suites" || _fsst_missing="$_fsst_missing $_b"
+done
+check "premise: at least one suite drives FSST encoding" \
+	"$([ "$_fsst_drivers" -ge 1 ] && echo yes || echo "no ($_fsst_drivers)")" "yes"
+check "the sanitizer subset runs at least one suite that drives FSST decoding" \
+	"$([ "$_fsst_drivers" -gt "$(printf '%s' "$_fsst_missing" | wc -w)" ] && echo covered || echo "none covered")" \
+	"covered"


### PR DESCRIPTION
Part of #768, and the largest term measured in it.

## Where the time was

A leaf profile of a scan over a repetitive text column, shares converted to absolute ms:

```
   147.4 ms   68.8%  [.] decode_fsst_shared
    17.5 ms    8.2%  [.] __memmove_avx_unaligned_erms
     5.9 ms    2.8%  [.] ExecInterpExpr
```

**68.8% of the query's CPU in one function.**

**Correction, from the review.** An earlier version of this line said "68.8% of a 230.3 ms
query, 147.4 ms of 230.3 ms". Those do not reconcile -- 147.4 / 230.3 is 64.0%. The percentages
and the absolute ms are both against the **profile's per-query CPU of 214.1 ms** (2348 samples
at 997 Hz over 11 queries); the 230.3 ms is a separately measured wall-clock minimum of 5. Two
quantities, and I divided one by the other. The conclusion is unaffected and the wall clock
corroborates it independently: 221.4 -> 77.7 ms saves 143.7 ms against 147.4 ms attributed. And `encode_effort` is `full` by default, so this
is text columns generally, not an opt-in path.

The loop copied each symbol out of the symbol table with a `memcpy` whose length is only known
at run time. A compiler cannot turn that into a single store, so every symbol occurrence paid
a call.

## The change

Pack each symbol into a `uint64` once when the table is parsed — `nSym` is at most 255 and this
runs once per chunk — then in the loop do one fixed 8-byte store and advance the output cursor
by the symbol's own length, so the next store overwrites the remainder. The output buffer gets
`FSST_DECODE_SLACK` (8) bytes of headroom so the tail of that write stays inside the
allocation.

**Endianness-safe**: the symbol is packed by `memcpy` from the table and written back by
`memcpy` of the same `uint64`, so byte order round-trips either way. **The on-disk format does
not change** and the transform is byte-identical in both directions, so a table written by any
earlier version reads the same.

## Measured

One cluster, one fixture, **only the installed `.so` changing** (md5 printed on both arms).
1,000,000 rows in one text column, `SELECT count(v)`, vectorized paths off so the scan decodes
every value, minimum of 7, and **the column's `md5` identical across both builds**:

| Text shape | Before | After | |
| --- | ---: | ---: | ---: |
| Repeating host and path strings | 221.4 ms | 77.7 ms | **2.85x** |
| 128-char hex | 302.0 ms | 200.9 ms | **1.50x** |

Both shapes gain; the one with more repeated substrings gains more, which is the shape FSST is
for. The second shape is included precisely because it is where FSST does least, so it bounds
the gain from below rather than showcasing it.

**Verified rather than assumed.** My own note on #705 records this exact word-at-a-time
technique failing to transfer to Gorilla (+0.05%, and a threshold variant 14% *worse*). It
transfers here, but that had to be measured, not reasoned.

## The slack is the part with a correctness cost, and it has a removal proof

Deleting `FSST_DECODE_SLACK` makes ASAN report, from `write_fsst_compressed`:

```
ERROR: AddressSanitizer: heap-buffer-overflow on address 0x778db1176379
SUMMARY: heap-buffer-overflow src/columnar_encoding.c:2134 in decode_fsst_shared
```

**The sanitizer is the only thing that catches it.** The over-write lands 1 to 7 bytes past a
palloc'd chunk, which does not fault and changes no answer, so the ordinary matrix cannot see
it. `test/selftest/130` now records that reasoning.

It does **not** gain an arm for it. I wrote one, then measured that it cannot fail — deleting
the three suites I first named from the sanitizer subset left it green, because
`encode_effort` defaults to `full` and so nearly every text-storing suite drives FSST and the
subset holds several. Removed rather than shipped, since a check that cannot go red reads as
protection.

## Tests

**Sanitizer gate**, which this change earns twice over (decode path, and a deliberate
over-write): `write_fsst_compressed`, `native_encdesc_golden`, `native_encoding`,
`native_roundtrip`, `encode_invariants`, `native_vecdecode`, `differential`,
`native_varlena_bound` — 8/8, `SANITIZER GATE PASSED`.

**PG17 assert build**, 21 suites all PASSED, including the byte-level `native_encdesc_golden`
and the heap-mirror `differential`: `write_fsst_compressed`, `encode_invariants`,
`encode_effort`, `native_encoding`, `native_roundtrip`, `native_vecdecode`, `native_vecskip`,
`native_fastdecode`, `native_varlena_bound`, `native_toasted_write`, `native_dict_underfill`,
`native_format`, `column_projection`, `native_projection`, `arrow_export`, `parquet_export`,
`native_skip`, `harness_selftest`, `docs_style`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaQ4vThXcmTCf3KRQpUDrE
