### PR TITLE
docs: base the style gate on ISO 24495-1:2023, not ASD-STE100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,32 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ## [Unreleased]
 
+### Changed
+
+- The documentation style gate is now based on ISO 24495-1:2023, *Plain language
+  - Part 1: Governing principles and guidelines*, in place of ASD-STE100. The
+  project's writing rules cite two standards and no others: ISO 24495-1:2023 for
+  language, and ISO 82079-1 for the structure of instructions.
+
+  **No check changed.** The gate enforces the same four rules over the same
+  files, and `docs_style` runs the same nine checks. What changed is the basis
+  each rule is attributed to, and the honesty of that attribution:
+
+  - the 25-word sentence limit and the idiom list come from the standard's
+    "understandable" principle;
+  - the two dash rules are this project's typographic house rules and are now
+    labelled as such, because ISO 24495-1 does not ask for them.
+
+  The 25-word figure is named as this project's measurable proxy rather than a
+  number quoted from the standard, which does not give one. `test/ste_check.py`
+  is renamed to `test/plain_language_check.py` so the file does not assert a
+  standard the project no longer cites.
+
+  Conformity is still not claimed, and the reason is now the accurate one. Only
+  one of the four governing principles has mechanically checkable content, and
+  the standard's own test for another is that a reader acts on the document
+  successfully, which no checker performs.
+
 ### Fixed
 
 - `ORDER BY` no longer returns unordered rows after a column rename, and neither

--- a/design/ROADMAP.md
+++ b/design/ROADMAP.md
@@ -87,11 +87,12 @@ is and where the current numbers are; follow the link for figures.
    dictionary-coded grouping on the high-cardinality text key. The shapes where
    pgColumnar is furthest behind, and the two where it is slower than heap, are
    q6 and q8 in #289's table; nothing in flight addresses either.
-2. **Code comment audit** (#291) to the ASD-STE100 standard. The documentation
-   half landed in #298, which added `test/docs_style.sh` to the matrix as a
-   durable gate. The code comments remain, and no gate covers them: the licensed
-   ASD-STE100 vocabulary list cannot be checked mechanically, so any claim of
-   compliance there is unverifiable by construction.
+2. **Code comment audit** (#291) to ISO 24495-1:2023, the plain-language
+   standard the project's documentation follows. The documentation half landed
+   in #298, which added `test/docs_style.sh` to the matrix as a durable gate.
+   The code comments remain, and no gate covers them: most of ISO 24495-1 is not
+   mechanical (whether a reader got what they needed, whether they could act on
+   it), so any claim of conformity there is unverifiable by construction.
 
 Bulk ingest is done and #300 is closed. `pgcolumnar.parallel_copy` fans core COPY,
 unchanged, across background workers: partition-parallel in #323, single-table in

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -417,39 +417,55 @@ longer alive. Interrupting a run with Ctrl-C does the same cleanup.
 
 ## Documentation style
 
-The user-facing documentation follows the ASD-STE100 writing rules. These are:
+The user-facing documentation follows ISO 24495-1:2023, *Plain language - Part 1:
+Governing principles and guidelines*. The standard gives four governing
+principles. Readers get what they need. Readers can easily find what they need.
+Readers can easily understand what they find. Readers can easily use what they
+find.
 
-- one topic to a sentence
-- active voice
+Under the third principle, the project writes to these practices:
+
+- one main idea to a sentence
+- short sentences
+- familiar words, and a necessary term defined at first use
+- active voice, with the actor named
 - present tense
 - articles kept
-- no gerund used as a noun
+- a real verb rather than a noun built from one
 - one term for one thing
-- no idiom
- `test/docs_style.sh` checks
-the rules that a machine can check. It runs in the matrix, so a document that
-drifts goes red.
+- no idiom and no figurative language
+
+`test/docs_style.sh` checks the rules that a machine can check. It runs in the
+matrix, so a document that drifts goes red.
 
 ```sh
 test/docs_style.sh
 ```
 
-It enforces four rules over `docs/*.md` and `README.md`:
+It enforces four rules over `docs/*.md` and `README.md`. Two come from the
+standard and two are house rules:
 
-- no em dash and no en dash
-- no double hyphen used as a dash in prose
-- a maximum of 25 words to a sentence
-- no phrase from an idiom list
+- a maximum of 25 words to a sentence (from the standard)
+- no phrase from an idiom list (from the standard)
+- no em dash and no en dash (house rule)
+- no double hyphen used as a dash in prose (house rule)
+
+The standard asks for short sentences. It does not give a number. The 25-word
+limit is this project's measurable proxy for that principle, not a figure quoted
+from ISO 24495-1. The two dash rules are typographic preferences of this project.
+They are named as house rules so that nobody mistakes a preference for a
+requirement.
 
 `CHANGELOG.md` is a record of what happened at the time it happened. To rewrite a
 landed entry would edit history. The gate therefore checks it for dash characters
 only.
 
-**Full ASD-STE100 compliance is not claimed.** Compliance is defined against the
-licensed ASD Dictionary. That dictionary holds approximately 900 approved words.
-Each word has one approved meaning and one part of speech. That dictionary is not available to this
-project, so the approved-vocabulary rule is not enforced and is not claimed. An
-unverifiable claim of compliance would be worse than an honest partial one.
+**Conformity to ISO 24495-1 is not claimed.** Only one of the four principles has
+any mechanically checkable content, and only in part. The standard's own test for
+the fourth principle is that a reader acts on the document successfully. No
+checker can perform that test. A green run means the measurable subset holds. It
+does not mean the documentation is plain. An unverifiable claim of conformity
+would be worse than an honest partial one.
 
 `design/` holds internal engineering records and is not checked. Code comments
 are not checked either. Both exist to explain why a thing is the way it is, and

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -445,16 +445,21 @@ test/docs_style.sh
 It enforces four rules over `docs/*.md` and `README.md`. Two come from the
 standard and two are house rules:
 
-- a maximum of 25 words to a sentence (from the standard)
-- no phrase from an idiom list (from the standard)
+- a maximum of 25 words to a sentence (a proxy for a principle of the standard)
+- no phrase from an idiom list (a proxy for a principle of the standard)
 - no em dash and no en dash (house rule)
 - no double hyphen used as a dash in prose (house rule)
 
-The standard asks for short sentences. It does not give a number. The 25-word
-limit is this project's measurable proxy for that principle, not a figure quoted
-from ISO 24495-1. The two dash rules are typographic preferences of this project.
-They are named as house rules so that nobody mistakes a preference for a
-requirement.
+Two of those four rules take a principle from the standard and measure it with
+something this project chose. The standard asks for short sentences and does not
+give a number, so the 25-word limit is the proxy. The standard warns against
+figurative language and publishes no list, so the idiom list is the proxy too.
+That list is short and it is curated from the phrases these authors write, such
+as `fall back`, `hand-rolled` and `in flight`. Neither figure comes from ISO
+24495-1.
+
+The two dash rules are typographic preferences of this project. They are named
+as house rules so that nobody mistakes a preference for a requirement.
 
 `CHANGELOG.md` is a record of what happened at the time it happened. To rewrite a
 landed entry would edit history. The gate therefore checks it for dash characters

--- a/test/docs_style.sh
+++ b/test/docs_style.sh
@@ -1,20 +1,26 @@
 #!/usr/bin/env bash
 #
-# Documentation style gate: the measurable ASD-STE100 rules (issue #291).
+# Documentation style gate: the measurable plain-language rules (issue #291).
 #
-# The project writes its user-facing documentation to the ASD-STE100 writing
-# rules. A rule that nothing checks is a rule the next writer does not know
-# about, and this project has been bitten by that shape before: an empty REGRESS
-# made `make installcheck` report success while running nothing. So the rules
-# that a machine can check are checked here, and a document that drifts goes red.
+# The project writes its user-facing documentation to ISO 24495-1:2023, Plain
+# language - Part 1: Governing principles and guidelines. A rule that nothing
+# checks is a rule the next writer does not know about, and this project has been
+# bitten by that shape before: an empty REGRESS made `make installcheck` report
+# success while running nothing. So the rules that a machine can check are
+# checked here, and a document that drifts goes red.
 #
-# WHAT IS NOT CLAIMED. Full ASD-STE100 compliance is defined against the licensed
-# ASD Dictionary of approximately 900 approved words, each with one approved
-# meaning and one part of speech. That dictionary is not available to this
-# project. The approved-vocabulary rule is therefore not enforced and is not
-# claimed, here or in the documentation. What is enforced is sentence length,
-# idiom, and dash characters. Saying so is the point: an unverifiable claim of
-# compliance would be worse than an honest partial one.
+# WHAT IS NOT CLAIMED. ISO 24495-1 gives four governing principles -- relevant,
+# findable, understandable, usable -- and only the third has any mechanically
+# checkable content, and only in part. Its own test for "usable" is that a reader
+# acts on the document successfully, which no checker performs. So a green run
+# means the measurable subset holds, NOT that the documentation is plain. Saying
+# so is the point: an unverifiable claim of conformity would be worse than an
+# honest partial one.
+#
+# Two of the four checks are this project's typographic house rules rather than
+# anything the standard requires: no em or en dash, and no double hyphen as a
+# dash in prose. They are named as house rules wherever they appear so nobody
+# mistakes a preference for a requirement.
 #
 # SCOPE, which is a decision rather than an oversight:
 #
@@ -54,10 +60,10 @@ echo "== pgColumnar test: docs_style.sh =="
 
 # The full rules over every user-facing document.
 docs=$(ls "$SRCDIR"/docs/*.md "$SRCDIR"/README.md 2>/dev/null)
-out="$(python3 "$SRCDIR/test/ste_check.py" $docs 2>&1)"
+out="$(python3 "$SRCDIR/test/plain_language_check.py" $docs 2>&1)"
 rc=$?
 echo "$out" | sed 's/^/  /'
-check "every user-facing document meets the measurable STE rules" "$rc" "0"
+check "every user-facing document meets the measurable plain-language rules" "$rc" "0"
 
 # The control. A checker that examines nothing reports nothing, and this suite
 # would then pass on an empty docs/ directory or a broken glob.
@@ -83,7 +89,7 @@ check "and the page that nav entry points at exists" \
 # in docs/limitations.md under "Vacuum and compaction", and every other check in
 # this file passed with them there, because they are valid Markdown text.
 #
-# The STE checker reads prose and the nav check reads mkdocs.yml. Neither asks
+# The prose checker reads prose and the nav check reads mkdocs.yml. Neither asks
 # whether the page is a coherent document. This does.
 conflicts=$(grep -rlE '^(<<<<<<< |>>>>>>> )' "$SRCDIR/docs" "$SRCDIR"/*.md 2>/dev/null | tr '\n' ' ')
 check "no document carries a merge conflict marker" \

--- a/test/plain_language_check.py
+++ b/test/plain_language_check.py
@@ -1,29 +1,47 @@
 #!/usr/bin/env python3
 """
-Measurable ASD-STE100 rules for the pgColumnar documentation (issue #291).
+Measurable plain-language rules for the pgColumnar documentation.
 
-This checks the rules that a machine can check: sentence length, idiom, and dash
-characters. It deliberately does NOT claim ASD-STE100 compliance. Compliance is
-defined against the licensed ASD Dictionary of approximately 900 approved words,
-each with one approved meaning and one part of speech. That dictionary is not
-available to this project, so the approved-vocabulary rule is neither enforced
-here nor claimed anywhere in the documentation.
+The project writes its user-facing documentation to ISO 24495-1:2023, Plain
+language - Part 1: Governing principles and guidelines. This file checks the
+part of that standard a machine can check.
 
-What is enforced:
+ISO 24495-1 states four governing principles: readers get what they need
+(relevant), can easily find it (findable), can easily understand it
+(understandable), and can easily use it (usable). Only the third has any
+mechanically checkable content, and only in part. What is enforced here is that
+subset, and nothing is claimed beyond it.
+
+From the standard, under "understandable":
+
+  * A sentence carries at most 25 words. The standard asks for short sentences
+    that each carry one main idea. It does not give a number, so 25 is this
+    project's measurable proxy for that principle and not a figure quoted from
+    ISO 24495-1.
+  * No phrase from the idiom list below. The standard asks for familiar words
+    and warns against figurative language, which a reader without fluent English
+    cannot resolve. Idiom is the part a fluent reader does not notice, which
+    makes it the rule with the most value and the least visibility.
+
+House rules, which are this project's typographic choices and are NOT from the
+standard. They are listed separately so nobody mistakes a preference for a
+requirement:
 
   * No em dash or en dash, anywhere in the checked files.
   * No double hyphen used as a dash in prose. A double hyphen inside a fenced
     code block is a SQL comment and is left alone.
-  * A sentence carries at most 25 words, the STE limit for descriptive writing.
-  * No phrase from the idiom list below. Idiom is the part a fluent reader does
-    not notice and a reader without fluent English cannot resolve, which makes it
-    the rule with the most value and the least visibility.
+
+WHAT IS NOT CHECKED. Most of ISO 24495-1 is not mechanical: whether the reader
+got what they needed, whether the order suits their task, whether the document
+works when someone uses it. The standard's own test for "usable" is that a
+reader acts on the document successfully, which no checker can perform. A green
+run here means the measurable subset holds, not that the documentation is plain.
 
 Code blocks, tables, headings and link targets are excluded from the sentence
 measurement, because none of them is prose. A list item counts as its own
 sentence: joining the items of a list reports a long sentence that nobody wrote.
 
-Usage:  test/ste_check.py FILE [FILE ...]
+Usage:  test/plain_language_check.py FILE [FILE ...]
 Exit status is the number of violations, so a caller can test it directly.
 
 Written fresh for pgColumnar.

--- a/test/plain_language_check.py
+++ b/test/plain_language_check.py
@@ -23,6 +23,13 @@ From the standard, under "understandable":
     cannot resolve. Idiom is the part a fluent reader does not notice, which
     makes it the rule with the most value and the least visibility.
 
+    The PRINCIPLE is the standard's; the LIST is this project's, in the same way
+    the 25-word limit is. ISO 24495-1 publishes no vocabulary, and the entries
+    below are curated from the phrases these authors actually write. So the
+    rule's name matters: it is "no phrase from an idiom list", not "no idiom",
+    and a mutation that reaches for an idiom which is not on the list gets a
+    green run and proves nothing.
+
 House rules, which are this project's typographic choices and are NOT from the
 standard. They are listed separately so nobody mistakes a preference for a
 requirement:


### PR DESCRIPTION
The project's writing rules now cite **two standards and no others**: ISO 24495-1:2023 for
language, and ISO 82079-1 for the structure of instructions. ASD-STE100 was a third, and the
documentation gate was written against it.

## No check changed

The same four rules run over the same files, and `docs_style` still reports its nine checks,
all passing. This is a re-attribution, not a behaviour change — deliberately, so that no
document's pass or fail status moves and the change is reviewable as documentation.

What changed is what each rule is attributed to, and the honesty of that attribution:

| Rule | Basis before | Basis now |
| --- | --- | --- |
| 25 words to a sentence | "the STE limit" | ISO 24495-1 "understandable"; **25 is this project's proxy** |
| no idiom | ASD-STE100 | ISO 24495-1 "understandable" |
| no em or en dash | implied ASD-STE100 | **house rule**, from neither standard |
| no double hyphen as a dash | implied ASD-STE100 | **house rule**, from neither standard |

The two dash rules were sitting inside a block headed by a standard that does not ask for them.
They are now labelled as house rules wherever they appear, so nobody mistakes a preference for
a requirement. And ISO 24495-1 asks for short sentences carrying one main idea without giving a
number, so 25 is named as this project's measurable proxy rather than quoted as if the standard
said it.

## The "not claimed" statement gets more accurate, not less

Under ASD-STE100 the unverifiable part was one thing: the licensed ~900-word dictionary.

Under ISO 24495-1 it is broader and worth stating plainly. Only one of the four governing
principles (*relevant, findable, understandable, usable*) has any mechanically checkable
content, and only in part. The standard's own test for **usable** is that a reader acts on the
document successfully, which no checker can perform. So a green run means the measurable subset
holds; it does not mean the documentation is plain.

## Rename

`test/ste_check.py` → `test/plain_language_check.py`. A file named for a standard the project
does not cite is a claim in the wrong direction. Nothing but `docs_style.sh` referenced it,
checked before the move.

## What is deliberately left alone

`design/ISSUE_*.md` keep their "STE clean" notes. Those are records of what was done at the
time, not live pointers, and rewriting them would edit the record — the same distinction drawn
for `.mailmap` in #781. `design/ROADMAP.md` **is** updated, because its item 2 is planned work
rather than a record, and planning to audit against a standard the project no longer follows
would send someone in the wrong direction.

## Tests

`docs_style` 9/9 and `harness_selftest` 158/158 on PG17. The checker was also run directly over
the rewritten `docs/testing.md`, since that file now describes the rules it must itself obey.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaQ4vThXcmTCf3KRQpUDrE