### PR TITLE
fix: pgcolumnar_agg_specs_reset did not clear the int128 accumulator

### DIFF
--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -3232,6 +3232,11 @@ pgcolumnar_batch_agg_ok(PgColumnarAggKind kind)
 	 * uses is cleared there before adding one. The int8 kinds accumulate in
 	 * spec->i128sum (#786), which that function did not clear until the omission
 	 * was found while scoping #755 question 3.
+	 *
+	 * Admitting a kind here does NOT by itself make a stale accumulator
+	 * observable -- see the note on that function for why the one known
+	 * fall-back trigger cannot reach it -- so do not rely on a test to catch a
+	 * missing reset. Read it.
 	 */
 	switch (kind)
 	{
@@ -3413,16 +3418,30 @@ pgcolumnar_batch_shape_eligible(PgColumnarAggScanState *state, TupleDesc tupdesc
  * Every accumulating field of PgColumnarAggSpec belongs here, and i128sum is
  * one -- it was added by #786 and this function was not updated with it.
  *
- * UNREACHABLE TODAY, and said plainly rather than left to look tested: the only
- * caller is the batch fold's fall-back, and pgcolumnar_batch_agg_ok does not
- * admit COLUMNAR_AGG_SUM_INT8 or COLUMNAR_AGG_AVG_INT8, so the fold is never
- * entered with an int8 spec and the stale accumulator can never be observed. No
- * test here can fail without that gate changing first.
+ * NO TEST CAN FAIL ON THIS, and the reason is stronger than it first looked.
  *
- * It is fixed now anyway, because the gate changing is exactly the open work on
- * #755 question 3, and a reset that silently keeps one accumulator is a
- * wrong-answer bug the moment it becomes reachable. pgcolumnar_batch_agg_ok
- * carries a note pointing back here for whoever makes that change.
+ * The only caller is the batch fold's fall-back, taken when a row group predates
+ * an ADD COLUMN. I first wrote that the stale accumulator becomes a wrong answer
+ * once the int8 kinds are admitted to pgcolumnar_batch_agg_ok. That was
+ * reasoning, and it is wrong. Instrumented by OffgridwithJD with the int8 kinds
+ * admitted: the fall-back is reached, once, with count = 0 and nothing
+ * accumulated, so the reset is a no-op and reverting this line changes no
+ * answer.
+ *
+ * The order looks structural rather than lucky. The groups lacking the column
+ * are exactly those written BEFORE the ADD COLUMN, so they carry the lowest
+ * group numbers and are scanned first; the fold trips the missing column on the
+ * first group it reads. Observing a stale accumulator needs a group folded
+ * successfully and THEN a group that trips the fall-back, which ADD COLUMN
+ * orders the wrong way round by construction.
+ *
+ * That is one route shown not to reach it, not a proof that none does, and it
+ * is not claimed as one.
+ *
+ * Fixed regardless. A function whose job is to reset every accumulator, that
+ * silently keeps one, is wrong whether or not today's callers can observe it,
+ * and it is one line. pgcolumnar_batch_agg_ok carries a note pointing back here
+ * so the next kind admitted gets checked against it.
  */
 static void
 pgcolumnar_agg_specs_reset(PgColumnarAggScanState *state)

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -3226,6 +3226,13 @@ pgcolumnar_batch_type_ok(Oid typ)
 static bool
 pgcolumnar_batch_agg_ok(PgColumnarAggKind kind)
 {
+	/*
+	 * Admitting a kind here makes pgcolumnar_agg_specs_reset reachable for it,
+	 * on the batch fold's fall-back path. Check that every accumulator the kind
+	 * uses is cleared there before adding one. The int8 kinds accumulate in
+	 * spec->i128sum (#786), which that function did not clear until the omission
+	 * was found while scoping #755 question 3.
+	 */
 	switch (kind)
 	{
 		case COLUMNAR_AGG_COUNT_STAR:
@@ -3400,7 +3407,23 @@ pgcolumnar_batch_shape_eligible(PgColumnarAggScanState *state, TupleDesc tupdesc
 								   keysOut, nkeysOut);
 }
 
-/* Reset the accumulators to their initial state (for a clean fall-back). */
+/*
+ * Reset the accumulators to their initial state (for a clean fall-back).
+ *
+ * Every accumulating field of PgColumnarAggSpec belongs here, and i128sum is
+ * one -- it was added by #786 and this function was not updated with it.
+ *
+ * UNREACHABLE TODAY, and said plainly rather than left to look tested: the only
+ * caller is the batch fold's fall-back, and pgcolumnar_batch_agg_ok does not
+ * admit COLUMNAR_AGG_SUM_INT8 or COLUMNAR_AGG_AVG_INT8, so the fold is never
+ * entered with an int8 spec and the stale accumulator can never be observed. No
+ * test here can fail without that gate changing first.
+ *
+ * It is fixed now anyway, because the gate changing is exactly the open work on
+ * #755 question 3, and a reset that silently keeps one accumulator is a
+ * wrong-answer bug the moment it becomes reachable. pgcolumnar_batch_agg_ok
+ * carries a note pointing back here for whoever makes that change.
+ */
 static void
 pgcolumnar_agg_specs_reset(PgColumnarAggScanState *state)
 {
@@ -3419,6 +3442,9 @@ pgcolumnar_agg_specs_reset(PgColumnarAggScanState *state)
 		spec->fsxx = 0;
 		spec->nsum = (Datum) 0;
 		spec->nsumSet = false;
+#ifdef HAVE_INT128
+		spec->i128sum = 0;
+#endif
 	}
 }
 


### PR DESCRIPTION
#786 added `spec->i128sum` and did not add it to the function whose job is to reset every
accumulator. Found while scoping #755 question 3, by reading the reset before building on top
of it, not by a test.

## It is unreachable today, and this says so rather than looking tested

The only caller of `pgcolumnar_agg_specs_reset` is the batch fold's fall-back path, and
`pgcolumnar_batch_agg_ok` admits only `COUNT_STAR`, `COUNT_COL`, `SUM_INT`, `AVG_INT`,
`SUM_FLOAT` and `AVG_FLOAT`. It does **not** admit the int8 kinds, so the fold is never entered
with an int8 spec and a stale accumulator cannot be observed.

**No test in this tree can fail without that gate changing first, so none is added.** An arm
that cannot fail is worse than an honest note — it reads as protection.

## Fixed now anyway

The gate changing is exactly the open work on #755 question 3. A reset that silently keeps one
accumulator was described as becoming a wrong-answer bug once the kind was admitted; see the correction below, and a fix that lands in
the same change as the feature is how it gets overlooked a second time.

`pgcolumnar_batch_agg_ok` now carries a note pointing back at the reset: admitting a kind there
makes the reset reachable for it, so check that every accumulator that kind uses is cleared
first. That puts the coupling where someone would break it rather than where it breaks.

## Scope

`i128sum` is the only gap. The other spec fields the reset leaves alone (`kind`, `attidx`,
`inputType`, `cmpFn`, `collation`, `byval`, `typlen`) are configuration rather than
accumulators, and correctly persist.

## Tests

PG17 assert build, all PASSED: `int8_agg_int128`, `ungrouped_vector_agg`, `native_groupagg_batch`,
`native_batch_fold_projection`, `parallel_vector_agg`, `native_agg`, `differential`. None of
them can fail on this change, for the reason above; they are run to show it breaks nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaQ4vThXcmTCf3KRQpUDrE


---

## Correction: it is not reachable when #789 lands either

This PR originally said the stale accumulator "becomes a wrong-answer bug the moment the kind is
admitted". That was reasoning, and the reviewer refuted it by instrumenting the path with the
int8 kinds admitted:

```
WARNING:  FALLBACK reached: agg 0 kind=6 count=0 i128sum_nonzero=0
```

The fall-back **is** reached, once, with nothing accumulated, so the reset is a no-op and
reverting the line changes no answer. All four value arms agree with the heap twin either way.

The order looks structural rather than lucky. The groups lacking the column are exactly those
written **before** the `ADD COLUMN`, so they hold the lowest group numbers and are scanned
first; the fold trips the missing column on the first group it reads. Observing a stale
accumulator needs a successfully folded group followed by one that trips the fall-back, and
`ADD COLUMN` orders the two sets the wrong way round by construction.

That is one route shown not to reach it, **not** a proof that none does, and neither the comment
nor this body claims otherwise.

**This makes the no-test decision better founded than the argument I gave for it.** I said no
test could fail until the gate changed. The gate has now changed, in #789, and still no test can
be written. That is a stronger reason for its absence than the one I originally offered.

The fix stands on its own: a function whose job is to reset every accumulator, that silently
keeps one, is wrong whether or not today's callers can observe it, and it is one line.
