### PR TITLE
opt: admit the int8 kinds to the batch fold (#755 question 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,41 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ### Changed
 
+- `sum()` and `avg()` over `bigint` now take the batch fold, which closes the
+  filtered case that #786 left behind (#755 question 3). Before this, a filtered
+  `sum(bigint)` on the vectorized path was **slower** than not using it, while
+  `sum(float8)` on the same fixture was more than twice as fast. That asymmetry
+  was the whole evidence for the question, and it was the batch fold rather than
+  the aggregate: the int8 kinds folded row at a time while the float kinds folded
+  column at a time.
+
+  Measured on one cluster with only the installed library changing, 8,000,000
+  rows, values chosen to defeat run-length and dictionary encoding so the fold is
+  not answered from encoded runs, minimum of seven, answers identical:
+
+  | | Before | After |
+  | --- | ---: | ---: |
+  | `sum(bigint)` | 133.5 ms | **92.0 ms** |
+  | `sum(bigint) WHERE ...` | 228.2 ms | **99.4 ms** |
+  | `avg(bigint) WHERE ...` | 226.2 ms | **98.7 ms** |
+  | `sum(float8) WHERE ...` (control) | 85.2 ms | 86.6 ms |
+
+  The float control does not move, which is what says the change is specific to
+  the int8 kinds.
+
+  It is a two-line change because #786 did the work: the fold reads a column at a
+  time and then accumulates per value, so a kind is foldable when its accumulate
+  is cheap, and since #786 the int8 kinds accumulate into an `int128` and
+  allocate nothing. This does **not** make them parallel-eligible.
+  `pgcolumnar_parallel_agg_ok` is a separate predicate with its own callers, and
+  the int8 kinds stay out of it: an `int128` running total is not a partial state
+  a core `Finalize` can combine.
+
+  `sum`/`avg` over `numeric` are unchanged and still slower on this path. They
+  cannot use an integer accumulator, and that residue stays on #785.
+
+### Changed
+
 - The documentation style gate is now based on ISO 24495-1:2023, *Plain language
   - Part 1: Governing principles and guidelines*, in place of ASD-STE100. The
   project's writing rules cite two standards and no others: ISO 24495-1:2023 for

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -830,9 +830,17 @@ pgcolumnar_agg_metadata_answerable(PgColumnarAggKind kind)
  *		already holds and a core Finalize can combine (#289 phase 5/6): count(*),
  *		count(col), and sum/avg over int2/int4/float4/float8. The transition types:
  *		count/sum(int) -> int8, sum(float) -> the identity float, avg(int) -> the
- *		int8[2] {N,sum} array, avg(float) -> the _float8 {N,Sx,Sxx} array. The
- *		internal-transtype kinds (sum/avg over int8/numeric) are not batch-eligible
- *		and stay on the serial node or the ordinary core Agg.
+ *		int8[2] {N,sum} array, avg(float) -> the _float8 {N,Sx,Sxx} array.
+ *
+ *		The internal-transtype kinds (sum/avg over int8/numeric) stay OUT OF THIS
+ *		PREDICATE, and still should: an int128 running total is not a partial
+ *		state a core Finalize can combine, whatever else changes.
+ *
+ *		This header used to add "and are not batch-eligible", which was a claim
+ *		about a DIFFERENT predicate asserted inside this one. Batch eligibility
+ *		is pgcolumnar_batch_agg_ok, which has its own callers, and since #755 q3
+ *		it admits the int8 kinds while this one does not. Two predicates, two
+ *		answers; one sentence used to give both (OffgridwithJD, #755 review).
  */
 static bool
 pgcolumnar_parallel_agg_ok(PgColumnarAggKind kind)
@@ -3242,6 +3250,28 @@ pgcolumnar_batch_agg_ok(PgColumnarAggKind kind)
 		case COLUMNAR_AGG_SUM_FLOAT:
 		case COLUMNAR_AGG_AVG_FLOAT:
 			return true;
+#ifdef HAVE_INT128
+		case COLUMNAR_AGG_SUM_INT8:
+		case COLUMNAR_AGG_AVG_INT8:
+			/*
+			 * #755 q3. The fold reads a column at a time and then calls
+			 * pgcolumnar_apply_one per value, so a kind is foldable when its
+			 * accumulate is cheap, not when it has a combinable transtype. Since
+			 * #786 the int8 kinds accumulate into an int128 and allocate
+			 * nothing, which is what makes them eligible here.
+			 *
+			 * This is NOT parallel eligibility. pgcolumnar_parallel_agg_ok is a
+			 * separate predicate with its own callers, and int8 stays out of it
+			 * on its own merits: an int128 running total is not a partial state
+			 * a core Finalize can combine.
+			 *
+			 * Guarded on HAVE_INT128 because without it apply_one takes the
+			 * per-row numeric path, which allocates twice per value, and the
+			 * fold would be folding the expensive accumulate faster rather than
+			 * making it cheap.
+			 */
+			return true;
+#endif
 		default:
 			return false;
 	}

--- a/test/int8_agg_int128.sh
+++ b/test/int8_agg_int128.sh
@@ -188,4 +188,43 @@ done
 echo "-- sum(bigint): vectorized $BON ms, scalar $BOFF ms"
 check_ratio "the vectorized path is not slower than the scalar one" "$BON" "$BOFF" "1.10"
 
+# ---- the FILTERED case, which is what #755 question 3 fixed -----------------
+#
+# Before the int8 kinds were admitted to the batch fold this was the arm that
+# lost: 1.13x to 1.21x SLOWER with the path on, while sum(float8) on the same
+# fixture was 2.4x faster. The asymmetry was the whole evidence for q3, so it
+# gets its own arm rather than riding on the unfiltered one.
+#
+# The fixture deliberately defeats run-length and dictionary encoding. A column
+# of `g % 1000` is answered from encoded runs in about a millisecond, and a fold
+# measured on that measures nothing -- the same trap as an FSST fixture that the
+# dictionary collapses before the encoder ever runs.
+psql_run "DROP TABLE IF EXISTS perf8f;"
+psql_run "CREATE TABLE perf8f (k int, v bigint) USING pgcolumnar;"
+psql_run "INSERT INTO perf8f SELECT g % 1000, ((g*2654435761)::bigint % 1000000007)
+          FROM generate_series(1,4000000) g;"
+check_num "premise: the filtered fixture loaded every row" \
+	"$(q 'SELECT count(*) FROM perf8f;')" "4000000"
+check "premise: its values are NOT low-cardinality, so the fold is not answered from runs" \
+	"$([ "$(q 'SELECT count(DISTINCT v) FROM perf8f;')" -gt 1000000 ] && echo varied || echo "collapsed")" \
+	"varied"
+check_num "premise: the vectorized node runs on the FILTERED query too" \
+	"$(q "$ON; EXPLAIN (COSTS OFF) SELECT sum(v) FROM perf8f WHERE k < 50;" | grep -c 'Columnar Vectorized Aggregates')" "1"
+
+msf() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" -q \
+		-c "SET pgcolumnar.enable_ungrouped_vector_agg=$1" -c '\timing on' \
+		-c "SELECT sum(v) FROM perf8f WHERE k < 50" 2>/dev/null \
+	| grep -o 'Time: [0-9.]*' | tail -1 | cut -d' ' -f2
+}
+FON=""; FOFF=""
+for _ in 1 2 3 4 5; do
+	x="$(msf on)"; y="$(msf off)"
+	[ -z "$FON" ] && FON="$x"; [ -z "$FOFF" ] && FOFF="$y"
+	FON="$(awk -v a="$FON" -v b="$x" 'BEGIN{print (b<a)?b:a}')"
+	FOFF="$(awk -v a="$FOFF" -v b="$y" 'BEGIN{print (b<a)?b:a}')"
+done
+echo "-- sum(bigint) WHERE k < 50: vectorized $FON ms, scalar $FOFF ms"
+check_ratio "the FILTERED vectorized path is not slower than the scalar one" "$FON" "$FOFF" "1.10"
+
 pgc_summary


### PR DESCRIPTION
Answers question 3 of #755. **Stacked on #788**, which fixes the reset this makes reachable —
base that first.

## The evidence, and what it turned out to mean

After #786, `sum(bigint)` was a 1.65x win unfiltered and **1.13x to 1.21x slower filtered**,
while `sum(float8)` on the same fixture was 2.4x faster filtered and gained *more* as the
filter loosened. `sum(int)` filtered was 2.70x faster.

So it was not the filter, and it was not the arithmetic. It was the fold: the int8 kinds folded
**row at a time** while the float kinds folded **column at a time**, because
`pgcolumnar_batch_agg_ok` did not admit them.

## Two lines, because #786 did the work

The fold reads a column at a time and then calls `pgcolumnar_apply_one` per value. So a kind is
foldable when its **accumulate is cheap**, not when it has a combinable transtype — and since
#786 the int8 kinds accumulate into an `int128` and allocate nothing.

Guarded on `HAVE_INT128`: without it `apply_one` takes the per-row numeric path, and the fold
would be folding an expensive accumulate faster rather than making it cheap.

## Measured

One cluster, one fixture, **only the `.so` changing**, answers identical:

| | Before | After |
| --- | ---: | ---: |
| `sum(b)` | 133.5 ms | **92.0 ms** |
| `sum(b) WHERE k < 50` | 228.2 ms | **99.4 ms** |
| `avg(b) WHERE k < 50` | 226.2 ms | **98.7 ms** |
| `sum(f) WHERE k < 50` (control) | 85.2 ms | 86.6 ms |

**The float control does not move**, which is what says this is specific to the int8 kinds
rather than a general shift.

## The fixture defeats run-length and dictionary encoding, deliberately

A column of `g % 1000` is answered from encoded runs in about a millisecond, so a fold measured
on it measures nothing. That is the same trap as an FSST fixture the dictionary collapses
before the encoder ever runs, which the reviewer hit today on a different suite. The new arm
**asserts the cardinality** rather than assuming it.

## This is not parallel eligibility, and a comment said otherwise

`pgcolumnar_parallel_agg_ok` is a separate predicate with its own callers at two entry points.
The int8 kinds stay out of it on their own merits: an `int128` running total is not a partial
state a core `Finalize` can combine.

Its header claimed "the internal-transtype kinds ... are not batch-eligible", which is a
statement about a **different** predicate asserted inside this one — the exact conflation I
suspected I would have to untangle in the code, living in the documentation instead. Corrected
and credited to the review that found it.

## Removal proof

Taking the int8 kinds back out reddens **exactly** the new filtered arm:

```
FAIL  the FILTERED vectorized path is not slower than the scalar one: 1.20x exceeds the 1.10x bound
```

The unfiltered arm stays green, because #786 already wins there without the fold. The two
changes guard different halves and the suite now says which.

## What is still open on #785

`sum`/`avg` over `numeric` are unchanged and still slower on this path (1.50x filtered on this
fixture). They cannot use an integer accumulator. The reviewer is measuring the case my fixture
could not reach — a clustered key where a `WHERE` prunes real chunk groups — before anyone
decides whether to exclude them.

## Tests

`int8_agg_int128.sh` is now 27 checks. PG17 assert build, all PASSED: `int8_agg_int128`,
`ungrouped_vector_agg`, `native_groupagg`, `native_groupagg_batch`,
`native_batch_fold_projection`, `parallel_vector_agg`, `vector_agg_tlist_shape`, `native_agg`,
`native_agg_deletes`, `native_agg_addcolumn`, `batch_fold_explain`, `differential`,
`harness_selftest`, `docs_style`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaQ4vThXcmTCf3KRQpUDrE


---

## Correction: it is not reachable when #789 lands either

This PR originally said the stale accumulator "becomes a wrong-answer bug the moment the kind is
admitted". That was reasoning, and the reviewer refuted it by instrumenting the path with the
int8 kinds admitted:

```
WARNING:  FALLBACK reached: agg 0 kind=6 count=0 i128sum_nonzero=0
```

The fall-back **is** reached, once, with nothing accumulated, so the reset is a no-op and
reverting the line changes no answer. All four value arms agree with the heap twin either way.

The order looks structural rather than lucky. The groups lacking the column are exactly those
written **before** the `ADD COLUMN`, so they hold the lowest group numbers and are scanned
first; the fold trips the missing column on the first group it reads. Observing a stale
accumulator needs a successfully folded group followed by one that trips the fall-back, and
`ADD COLUMN` orders the two sets the wrong way round by construction.

That is one route shown not to reach it, **not** a proof that none does, and neither the comment
nor this body claims otherwise.

**This makes the no-test decision better founded than the argument I gave for it.** I said no
test could fail until the gate changed. The gate has now changed, in #789, and still no test can
be written. That is a stronger reason for its absence than the one I originally offered.

The fix stands on its own: a function whose job is to reset every accumulator, that silently
keeps one, is wrong whether or not today's callers can observe it, and it is one line.
