### PR TITLE
test: name the ratio helper for what it does, not what it measures (#787)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,30 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ### Changed
 
+- `check_ratio_timing` is renamed to `check_ratio_needs_quiet_machine`, and the
+  distinction it encodes is now written where it is decided (#787). The helper was
+  named for what it measures, a ratio of timings, rather than for what it does:
+  both `ci.yml` and `nightly.yml` set `PGC_SKIP_TIMING`, so a check written with it
+  runs in no automated gate at all.
+
+  Two kinds of timing assertion need different treatment and only one needs that.
+  A ratio against an absolute or cross-run baseline can be distorted by a loaded
+  machine. A ratio whose two arms are measured back to back in the same run and
+  compared by minimum cannot, because both readings move together under load, and
+  `test/cancel_decode.sh` had argued exactly that for its own ratio and run in CI
+  on the strength of it. An author holding the safe shape reached for the name
+  that matched their units and lost the check silently, which is how #786's guard
+  came to be skipped everywhere until it was moved to `check_ratio`.
+
+  No behaviour changed. The two call sites, both in
+  `test/planner_choice_quality.sh`, keep the guard they had; that suite is in
+  `is_timing_suite`, so the driver already names it as skipped rather than
+  reporting a pass over a dropped subject. What changed is that the reasoning now
+  sits beside the helper rather than being re-derived in three suite headers --
+  `bloom_sizing` for a size, `native_fetch_bigcap` for buffers, `cancel_decode`
+  for a same-run ratio -- which is the recurrence #253, #254 and #764 each fixed
+  for one suite.
+
 - The documentation style gate is now based on ISO 24495-1:2023, *Plain language
   - Part 1: Governing principles and guidelines*, in place of ASD-STE100. The
   project's writing rules cite two standards and no others: ISO 24495-1:2023 for

--- a/test/int8_agg_int128.sh
+++ b/test/int8_agg_int128.sh
@@ -147,7 +147,7 @@ check "avg(numeric) too" "$(trio d8 'avg(v)')" \
 # green. The defect #785 records was speed, so the arm that guards it has to
 # measure speed.
 #
-# It uses check_ratio and NOT check_ratio_timing, and that distinction is the
+# It uses check_ratio and NOT check_ratio_needs_quiet_machine, and that distinction is the
 # whole reason this arm runs at all: PGC_SKIP_TIMING=1 is set in ci.yml and in
 # nightly.yml, so the _timing form would run in no automated gate while these 22
 # arms still reported PASSED. That is a suite passing with its subject dropped.

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -646,6 +646,10 @@ check_num() {
 # A zero numerator is "the thing we measured cost nothing", which is nearly
 # always "the thing we measured did not happen". A call site that genuinely needs
 # to permit zero should say so under its own name rather than get it by default.
+# Runs everywhere, including CI. For a ratio whose arms move together under
+# load -- measured back to back in the same run, compared by minimum. If the
+# ratio needs an idle machine to mean anything, use
+# check_ratio_needs_quiet_machine instead and read why there.
 check_ratio() {	# $1 label, $2 a, $3 b, $4 max
 	local name="$1" a="$2" b="$3" max="$4" ratio
 
@@ -727,7 +731,29 @@ check_timing() {
 # the suite's copy of the condition agreed with this file's, which is exactly the
 # coupling this helper removes. Deciding whether to MEASURE is still the suite's
 # business; deciding whether to assert is this file's.
-check_ratio_timing() {  # check_ratio_timing <name> <a> <b> <bound>
+# A wall-clock ratio that is only meaningful on an unloaded machine.
+#
+# THIS HELPER REMOVES THE CHECK FROM EVERY AUTOMATED GATE. Both .github/workflows/
+# ci.yml and .github/workflows/nightly.yml set PGC_SKIP_TIMING, so a check written
+# with it runs only when someone runs the suite by hand. That is correct for a
+# ratio a shared runner can distort, and it is the whole cost of using it.
+#
+# USE IT when the ratio compares against an absolute or cross-run baseline, where
+# a loaded machine can move one side and not the other.
+#
+# DO NOT USE IT when the two arms are measured back to back in the same run and
+# compared by minimum. Both readings then move together under load, which is what
+# makes that shape safe on shared hardware -- use check_ratio, which runs
+# everywhere. test/cancel_decode.sh carries the worked argument for its own ratio
+# and test/int8_agg_int128.sh is a second instance.
+#
+# The name says what the helper DOES rather than what it measures. It was
+# check_ratio_timing, which read as "the helper for ratios of timings" -- so an
+# author holding the safe shape picked it by matching units and lost the check in
+# CI silently. Three suites had each derived the exemption for themselves in their
+# own headers (bloom_sizing a size, native_fetch_bigcap buffers, cancel_decode a
+# same-run ratio) and nothing said it here, where it is decided (#787).
+check_ratio_needs_quiet_machine() {  # <name> <a> <b> <bound>
 	if [ "${PGC_SKIP_TIMING:-0}" = 1 ]; then
 		echo "SKIP  $1 (PGC_SKIP_TIMING: wall-clock ratio)"
 		return 0

--- a/test/planner_choice_quality.sh
+++ b/test/planner_choice_quality.sh
@@ -32,7 +32,7 @@
 #
 # PGC_SKIP_TIMING
 #
-# The ratio goes through check_ratio_timing, which lives in lib.sh and owns the
+# The ratio goes through check_ratio_needs_quiet_machine, which lives in lib.sh and owns the
 # decision. This file does NOT branch on the flag to decide whether to assert.
 #
 # Two earlier versions got this wrong in the same way. The first only SAID the
@@ -54,7 +54,7 @@ pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
 PLAN_BOUND=${PGC_PLAN_BOUND:-3}
 # The only read of PGC_SKIP_TIMING in this file, and it governs COST alone: how
 # big a fixture to build, and whether to execute the timed queries. Whether to
-# assert a ratio is check_ratio_timing's decision, in lib.sh.
+# assert a ratio is check_ratio_needs_quiet_machine's decision, in lib.sh.
 PGC_MEASURING=1
 [ "${PGC_SKIP_TIMING:-0}" = 1 ] && PGC_MEASURING=0
 ROWS=${PGC_PLAN_ROWS:-200000}
@@ -146,11 +146,11 @@ choice_vs_best() {  # choice_vs_best <label> <sql>
 
 	# Everything below this line has a wall clock in it. An absent timing is the
 	# signal, not a second reading of the flag: when nothing was executed there is
-	# no ratio to judge, and check_ratio_timing decides whether that is a skip or a
+	# no ratio to judge, and check_ratio_needs_quiet_machine decides whether that is a skip or a
 	# failure. If the flag is set it announces a skip; if it is not, check_ratio
 	# rejects the empty side loudly. Either way this suite never asserts "" == "".
 	if [ -z "$cms" ]; then
-		check_ratio_timing "[$label] the chosen plan is within ${PLAN_BOUND}x of the best alternative" \
+		check_ratio_needs_quiet_machine "[$label] the chosen plan is within ${PLAN_BOUND}x of the best alternative" \
 			"$cms" "" "$PLAN_BOUND"
 		return
 	fi
@@ -213,7 +213,7 @@ choice_vs_best() {  # choice_vs_best <label> <sql>
 		check "[$label] the chosen plan finished within ${PLAN_TIMEOUT}s" "no" "yes"
 		return
 	fi
-	check_ratio_timing "[$label] the chosen plan is within ${PLAN_BOUND}x of the best alternative ($bnode)" \
+	check_ratio_needs_quiet_machine "[$label] the chosen plan is within ${PLAN_BOUND}x of the best alternative ($bnode)" \
 		"$cms" "$best" "$PLAN_BOUND"
 }
 


### PR DESCRIPTION
Closes #787.

`check_ratio_timing` removed a check from **every automated gate**. Both `ci.yml` and
`nightly.yml` set `PGC_SKIP_TIMING`, so a check written with it ran only when someone ran the
suite by hand. The name did not say that — it read as "the helper for ratios of timings", which
is the units, and an author holding a ratio of timings picked it by matching them.

## Two kinds of timing assertion, and only one needs the guard

- **Needs an idle machine:** a ratio against an absolute or cross-run baseline, where load can
  move one side and not the other.
- **Does not:** a ratio whose two arms are measured back to back in the same run and compared by
  minimum. Both readings move together under load.

`test/cancel_decode.sh` had already argued the second case for its own ratio and runs in CI on
the strength of it. #786's guard was the same shape, was written with the guarded helper, was
skipped everywhere, and moved to `check_ratio` once that was noticed — which is what this issue
came from.

## Fixed where the choice is made

The reasoning existed in three suite headers and nowhere near the helper: `bloom_sizing` for a
size, `native_fetch_bigcap` for buffers, `cancel_decode` for a same-run ratio. Three authors
deriving one rule from scratch is the defect, and #253, #254 and #764 each fixed one instance of
its consequence. `check_ratio` gains a pointer too, so the choice is visible from either side.

The old name is kept in the comment as the record of why the rename happened, so the next reader
who searches for it lands on the explanation rather than nothing.

## No behaviour changed, verified in both directions

The two call sites are both in `test/planner_choice_quality.sh` and keep the guard they had;
that suite is in `is_timing_suite`, so the driver already names it as skipped rather than
reporting a pass over a dropped subject.

```
without PGC_SKIP_TIMING   PASS  [range scan with aggregate] ... (0.07x, bound 3x, from a=8.721 b=124.410)
                          PASS  [wide range, narrow projection] ... (0.05x, bound 3x, from a=7.023 b=134.341)
                          checks run: 9

with PGC_SKIP_TIMING=1    SKIP  [range scan with aggregate] ... (PGC_SKIP_TIMING: wall-clock ratio)
                          SKIP  [wide range, narrow projection] ... (PGC_SKIP_TIMING: wall-clock ratio)
                          checks run: 7
```

The renamed helper runs and evaluates real ratios without the flag, and skips visibly with it.
`docs_style` 9/9, `harness_selftest` 158/158, `int8_agg_int128` 23/23.

## What this deliberately does not add

A selftest asserting that no suite outside `is_timing_suite` calls the guarded helper. I proposed
one on the issue and withdrew it: it forbids a legitimate arrangement — a suite with several
independent subjects, one of them genuinely load-sensitive — and the property that actually
matters, *a suite must not report PASS when the only arm that can detect its subject was
skipped*, is not statically checkable, because it turns on whether the remaining arms can see the
defect. "Zero false positives on today's tree" is also true of a rule that is simply wrong and
has not met its counterexample.
