### PR TITLE
test: run native_fetch_cache's three cost guards in CI (#792)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,37 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ### Changed
 
+- `test/native_fetch_cache.sh`'s three cost guards now run in CI. They were
+  written with `check_timing`, which `PGC_SKIP_TIMING` drops, and that suite is
+  not in `is_timing_suite` -- so the suite ran, reported `PASSED`, and skipped all
+  three, including the two that guard named regressions (#353, #359). Three cost
+  guards in no automated gate (#792).
+
+  They were already the exempt shape by `test/cancel_decode.sh`'s argument: two
+  readings taken back to back in the same run, which move together under load.
+  But that argument has a second half -- *"the best of three readings, not the
+  average ... an average would let one descheduled run widen the ratio on its
+  own"* -- and these took a single reading per side. Measured on six busy cores
+  of an eight-core box before the change, the `one/many` ratio reached **2.39
+  against its bound of 3** on one run. Unguarding them as they stood would have
+  traded a check that is skipped everywhere for one that is flaky somewhere.
+
+  So each side is now the minimum of three, and then they are ordinary checks.
+  Under the same load afterwards, four runs: `one/many` 0.84 to 0.93, `wide/small`
+  0.98 to 1.00, `over/under` 1.18 to 1.23, against bounds of 3, 5 and 12. The
+  suite costs about 0.9 s more (4.4 s to 5.3 s, build excluded).
+
+  A repeated measurement must be idempotent, and this one was not: `upd_ms`
+  updated with `v = v + 1`, which is correct once and wrong three times. The
+  suite's own correctness arms caught it -- they assert `v = id + 1` -- so the
+  update now sets `v = id + 1`, which is the same work per row and true after any
+  number of runs.
+
+  `check_timing`'s skip message said "wall-clock ratio" on a helper that takes a
+  scalar, so it misdescribed every skip it printed. Its one remaining caller,
+  `test/native_cancel.sh`, is in `is_timing_suite`, so the driver names that suite
+  as skipped rather than reporting a pass over a dropped subject.
+
 - `sum()` and `avg()` over `bigint` now take the batch fold, which closes the
   filtered case that #786 left behind (#755 question 3). Before this, a filtered
   `sum(bigint)` on the vectorized path was **slower** than not using it, while

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -709,7 +709,7 @@ check_timing() {
 	local name="$1" got="$2" want="$3"
 
 	if [ "${PGC_SKIP_TIMING:-0}" = 1 ]; then
-		echo "SKIP  $name (PGC_SKIP_TIMING: wall-clock ratio)"
+		echo "SKIP  $name (PGC_SKIP_TIMING: wall-clock measurement)"
 		return 0
 	fi
 	check "$name" "$got" "$want"

--- a/test/native_fetch_cache.sh
+++ b/test/native_fetch_cache.sh
@@ -55,21 +55,43 @@ upd_ms() {
 	psql_run "SET max_parallel_workers_per_gather = 0;
 		SET enable_seqscan = off;
 		SET enable_bitmapscan = off;
-		UPDATE $1 SET v = v + 1 WHERE id <= $UPD;" >/dev/null 2>&1
+		UPDATE $1 SET v = id + 1 WHERE id <= $UPD;" >/dev/null 2>&1
 	end=$(date +%s%N)
 	echo $(( (end - start) / 1000000 ))
+}
+
+# Best of three readings, not one and not the average.
+#
+# Scheduling noise on a shared runner only ever ADDS latency, so the minimum is
+# the reading least polluted by it, and a single descheduled run cannot widen the
+# ratio on its own. test/cancel_decode.sh makes this argument for its own ratio
+# and runs in CI on the strength of it; these three had the same-run half and not
+# this half, which is why they were guarded instead (#792).
+#
+# Measured before the change, six busy cores on an eight-core box: the one/many
+# ratio reached 2.39 against its bound of 3 on a single reading, where the best of
+# three across the same runs was 0.89 -- which is where the idle readings sit.
+#
+# A REPEATED MEASUREMENT MUST BE IDEMPOTENT. upd_ms updated with "v = v + 1",
+# which is fine once and wrong three times: the suite's own correctness arms below
+# assert v = id + 1, and they caught it. It sets "v = id + 1" now, which is the
+# same work per row and true after any number of runs.
+min3() {  # min3 FUNC ARG...
+	local a b c
+	a="$("$@")"; b="$("$@")"; c="$("$@")"
+	printf '%s\n' "$a" "$b" "$c" | sort -n | head -1
 }
 
 build fc_one "$ROWS"          # every row in a single row group
 build fc_many $((ROWS / 10))  # the same rows across ten
 
-one="$(upd_ms fc_one)"
-many="$(upd_ms fc_many)"
+one="$(min3 upd_ms fc_one)"
+many="$(min3 upd_ms fc_many)"
 echo "-- $UPD fetches: one group of $ROWS took ${one} ms; ten groups took ${many} ms"
 
 # Without the cache the single-group case decodes ten times as much per fetch and
 # lands near 10x. With it, both are dominated by the fetches and sit near 1x.
-check_timing "fetching from one big group is not far dearer than from ten small ones" \
+check "fetching from one big group is not far dearer than from ten small ones" \
 	"$( [ "$many" -gt 0 ] && [ $(( one / (many > 0 ? many : 1) )) -lt 3 ] && echo yes ||
 		echo "no (one=${one}ms ten=${many}ms)")" \
 	"yes"
@@ -125,9 +147,9 @@ w_ms() {  # index-driven point query over one host: many fetches into few groups
 }
 wbuild fc_wide 150000      # default stripe: one/two big groups, wide decoded prefix
 wbuild fc_wnarrow 20000    # smaller groups that fit under the cap regardless
-bigw="$(w_ms fc_wide)"; smallw="$(w_ms fc_wnarrow)"
+bigw="$(min3 w_ms fc_wide)"; smallw="$(min3 w_ms fc_wnarrow)"
 echo "-- #353 wide point query: default-stripe ${bigw} ms, small-stripe ${smallw} ms"
-check_timing "a wide group's fetch is not far dearer than a small group's (#353)" \
+check "a wide group's fetch is not far dearer than a small group's (#353)" \
 	"$( [ "$smallw" -gt 0 ] && [ $(( bigw / (smallw > 0 ? smallw : 1) )) -lt 5 ] && echo yes ||
 		echo "no (wide=${bigw}ms small=${smallw}ms)")" \
 	"yes"
@@ -182,10 +204,10 @@ w359_ms() {  # number of projected text columns
 	end=$(date +%s%N); echo $(( (end - start) / 1000000 ))
 }
 
-under="$(w359_ms 4)"   # ~30 MB decoded: fits
-over="$(w359_ms 5)"    # ~38 MB decoded: does not
+under="$(min3 w359_ms 4)"   # ~30 MB decoded: fits
+over="$(min3 w359_ms 5)"    # ~38 MB decoded: does not
 echo "-- #359 projection width: four columns ${under} ms, five columns ${over} ms"
-check_timing "crossing the fetch cache cap costs proportionally, not totally (#359)" \
+check "crossing the fetch cache cap costs proportionally, not totally (#359)" \
 	"$( [ "$under" -gt 0 ] && [ $(( over / (under > 0 ? under : 1) )) -lt 12 ] && echo yes ||
 		echo "no (four=${under}ms five=${over}ms)")" \
 	"yes"


### PR DESCRIPTION
Closes #792.

`test/native_fetch_cache.sh`'s three cost guards were written with `check_timing`, which
`PGC_SKIP_TIMING` drops, and that suite is **not** in `is_timing_suite`. So it ran in CI,
reported `PASSED`, and skipped all three — including the two that guard named regressions:

```
SKIP  fetching from one big group is not far dearer than from ten small ones
SKIP  a wide group's fetch is not far dearer than a small group's (#353)
SKIP  crossing the fetch cache cap costs proportionally, not totally (#359)
checks run: 9
native_fetch_cache.sh: PASSED
```

## Why they could not simply be unguarded

They are already the exempt shape by `test/cancel_decode.sh`'s argument — `one`/`many`,
`bigw`/`smallw`, `over`/`under` are each two readings taken back to back in the same run, which
move together under load. But that argument has a **second half**:

> The best of three readings, not the average ... an average would let one descheduled run widen
> the ratio on its own.

These took a single reading per side. Measured before the change, five runs with six busy cores
on an eight-core box:

```
            IDLE                          UNDER LOAD                    bound
one/many    0.64 0.94 0.94 0.95 0.98      0.89 0.91 0.91 0.96 2.39        3
wide/small  0.83 0.83 0.97 1.04 1.16      0.83 1.00 1.04 1.06 2.05        5
over/under  1.05 1.08 1.11 1.21 1.25      1.13 1.14 1.16 1.20 1.23       12
```

`one/many` reached **2.39 against a bound of 3** — within 20% of a red, from one unrepeated
reading. Unguarding them as they stood would have traded a check that is skipped everywhere for
one that is flaky somewhere.

## So: sample first, then unguard

Each side is the minimum of three, then they become ordinary `check` calls. Under the same load
afterwards, four runs:

```
one/many    0.89  0.88  0.93  0.84     bound 3
wide/small  1.00  1.00  1.00  0.98     bound 5
over/under  1.19  1.23  1.20  1.18     bound 12
```

The excursions are gone; the worst reading is 1.23 where it was 2.39. The suite costs about
**0.9 s** more, 4.4 s to 5.3 s with the build excluded.

## A repeated measurement must be idempotent, and this one was not

`upd_ms` updated with `v = v + 1` — correct once and wrong three times. **The suite's own
correctness arms caught it**: they assert `v = id + 1`, and my first attempt turned a `PASSED`
suite into a `FAILED` one with all three timing checks still green. It sets `v = id + 1` now,
which is the same work per row and true after any number of runs. That is recorded in the
comment beside `min3`, because it is the trap for whoever repeats the next measurement.

## The message fix

`check_timing`'s skip line said `wall-clock ratio` on a helper that takes a scalar, so it
misdescribed every skip it printed. Its one remaining caller, `test/native_cancel.sh`, is in
`is_timing_suite`, so the driver names that suite as skipped rather than reporting a pass over a
dropped subject — which is the arrangement #764 established and the one this suite was missing.

## Verified

12/12 idle; 12/12 with `PGC_SKIP_TIMING=1`, where the three now **run** rather than skip; 12/12
on each of four loaded runs; and the checks still go red when a bound is forced.

Not addressed here: `over/under` sits at 1.18–1.25 against a bound of **12** and did not move
under load at all. That is very loose for a guard on a named regression and worth its own look at
whether it would still catch #359 — I would not change a bound while moving the check.
