### PR TITLE
fix: refuse sum/avg over numeric from the ungrouped scan-fold path (#785)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,11 +31,19 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
   | `sum(float8)` | 2.73x faster | 2.74x faster |
   | `sum(numeric), sum(float8)` | 1.00x, no gain | 1.01x, unchanged |
 
-  **The refusal is unconditional, and the third row is why.** Classification is
-  all or nothing, so refusing `numeric` refuses the whole node, and a mixed query
-  would lose the float win with it. But a mixed query gained nothing beforehand:
-  the numeric aggregate's cost swamped it. So nothing is given up, and the
-  numeric-only case improves.
+  **The refusal is unconditional, and the mixed case is why.** Classification is
+  all or nothing, so refusing `numeric` refuses the whole node, and the obvious
+  worry is that a mixed query loses the float win with it. It does not. Measured
+  on one cluster with only the installed library changing, a mixed query was
+  being actively **harmed**:
+
+  | query | numeric admitted | numeric refused | |
+  | --- | ---: | ---: | ---: |
+  | `sum(numeric)` | 391.0 ms | 351.0 ms | 1.11x faster |
+  | `sum(numeric), sum(float8)` | 412.4 ms | 367.6 ms | 1.12x faster |
+  | `sum(float8)` (control) | 78.8 ms | 77.2 ms | flat |
+
+  So the mixed case is an argument for the refusal rather than a cost of it.
 
   It is also not conditional on the data. The penalty holds whether or not
   chunk-group pruning happens: 1.14x with 25 of 27 groups removed and 1.56x with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,38 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ## [Unreleased]
 
+### Fixed
+
+- `sum()` and `avg()` over `numeric` no longer take the ungrouped vectorized
+  path, where they were slower than the ordinary `Agg` (#785). This closes the
+  last of the three families `pgcolumnar.enable_ungrouped_vector_agg` names.
+  `bigint` was fixed by giving it a cheap accumulator (#786); `numeric` cannot
+  have one, because its input already carries a scale.
+
+  Measured on 8,000,000 rows, interleaved, minimum of seven, plan and answers
+  asserted on both arms:
+
+  | query | before | after |
+  | --- | ---: | ---: |
+  | `sum(numeric)` | 1.10x slower | **1.04x faster** |
+  | `sum(float8)` | 2.73x faster | 2.74x faster |
+  | `sum(numeric), sum(float8)` | 1.00x, no gain | 1.01x, unchanged |
+
+  **The refusal is unconditional, and the third row is why.** Classification is
+  all or nothing, so refusing `numeric` refuses the whole node, and a mixed query
+  would lose the float win with it. But a mixed query gained nothing beforehand:
+  the numeric aggregate's cost swamped it. So nothing is given up, and the
+  numeric-only case improves.
+
+  It is also not conditional on the data. The penalty holds whether or not
+  chunk-group pruning happens: 1.14x with 25 of 27 groups removed and 1.56x with
+  none.
+
+  The refusal is placed where the scan-fold path is chosen rather than in
+  `pgcolumnar_classify_aggref`, which is shared with the grouped path. The
+  grouped path is a different implementation and has not been measured for these
+  kinds, so this narrows only what was measured.
+
 ### Changed
 
 - `test/native_fetch_cache.sh`'s three cost guards now run in CI. They were

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -1047,6 +1047,41 @@ PgColumnarCreateUpperPaths(PlannerInfo *root, UpperRelationKind stage,
 			return;
 
 		/*
+		 * sum/avg over numeric are refused HERE rather than in
+		 * pgcolumnar_classify_aggref (#785). This path is slower than the
+		 * ordinary Agg for them and there is no equivalent of #786's int128
+		 * accumulator to fix it: the input is already numeric and carries a
+		 * scale.
+		 *
+		 * Measured on 8,000,000 rows, interleaved, min of 7, plan and answers
+		 * asserted:
+		 *
+		 *   sum(numeric)               1.10x SLOWER on this path
+		 *   sum(float8)                2.73x faster
+		 *   sum(numeric), sum(float8)  1.00x -- no gain at all
+		 *
+		 * That last row is why this is unconditional. Classification is all or
+		 * nothing (the loop above returns on the first refusal), so refusing
+		 * numeric refuses the whole node -- and a mixed query gains NOTHING
+		 * today, because the numeric aggregate's cost swamps the float win. So
+		 * nothing is given up by refusing, and the numeric-only case improves.
+		 *
+		 * Refused here and not at classification because classify_aggref is
+		 * shared with the GROUPED path, which is a different implementation and
+		 * has not been measured for these kinds. This narrows only what was
+		 * measured.
+		 *
+		 * The reviewer established the other half: numeric is slower whether or
+		 * not chunk-group pruning happens (1.14x with 25 of 27 groups removed,
+		 * 1.56x with none), so this does not need to be conditional on the shape
+		 * of the data either.
+		 */
+		for (i = 0; i < naggs; i++)
+			if (specs[i].kind == COLUMNAR_AGG_SUM_NUMERIC ||
+				specs[i].kind == COLUMNAR_AGG_AVG_NUMERIC)
+				return;
+
+		/*
 		 * A pseudoconstant (gating) qual is a one-time filter, not a per-row
 		 * predicate; the recheck this path relies on runs per row and would never
 		 * apply it, so a false gate would wrongly return a row. Rare; fall back.

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -1062,9 +1062,22 @@ PgColumnarCreateUpperPaths(PlannerInfo *root, UpperRelationKind stage,
 		 *
 		 * That last row is why this is unconditional. Classification is all or
 		 * nothing (the loop above returns on the first refusal), so refusing
-		 * numeric refuses the whole node -- and a mixed query gains NOTHING
-		 * today, because the numeric aggregate's cost swamps the float win. So
-		 * nothing is given up by refusing, and the numeric-only case improves.
+		 * numeric refuses the whole node, and the obvious worry is that a mixed
+		 * query loses the float win with it.
+		 *
+		 * It does not, and the truth is stronger than "nothing is given up".
+		 * A mixed query was being actively HARMED. One cluster, one fixture,
+		 * only the .so changing:
+		 *
+		 *   sum(numeric)               391.0 -> 351.0 ms   1.11x faster
+		 *   sum(numeric), sum(float8)  412.4 -> 367.6 ms   1.12x faster
+		 *   sum(float8) (control)       78.8 ->  77.2 ms   flat
+		 *
+		 * So the mixed case is an argument FOR the refusal rather than a cost of
+		 * it. Stated this way deliberately: "gains nothing" invites someone to
+		 * restore a conditional later on the grounds that a mixed query might one
+		 * day benefit, when the measurement says it was paying for the numeric
+		 * aggregate twice over (OffgridwithJD, #796 review).
 		 *
 		 * Refused here and not at classification because classify_aggref is
 		 * shared with the GROUPED path, which is a different implementation and

--- a/test/ungrouped_vector_agg.sh
+++ b/test/ungrouped_vector_agg.sh
@@ -217,4 +217,46 @@ check "control: i > 100 (exact key) still folds and agrees with heap" \
 	"$(vq "SELECT count(*) FROM vfold WHERE i > 100")" \
 	"$(q  "SELECT count(*) FROM vfoldh WHERE i > 100")"
 
+# ---- numeric is refused from this path, deliberately (#785) ------------------
+#
+# sum/avg over numeric are SLOWER here than on the ordinary Agg, and there is no
+# equivalent of #786's int128 accumulator for them: the input is already numeric
+# and carries a scale. Measured on 8,000,000 rows, interleaved, min of 7:
+#
+#   sum(numeric)               1.10x SLOWER on this path
+#   sum(float8)                2.73x faster
+#   sum(numeric), sum(float8)  1.00x -- no gain at all
+#
+# The third row is why the refusal is unconditional rather than clever.
+# Classification is all or nothing, so refusing numeric refuses the whole node --
+# and a mixed query gained NOTHING beforehand, because the numeric aggregate's
+# cost swamped the float win. Nothing is given up.
+#
+# These arms pin the SHAPE, not the speed: which queries take the node. A timing
+# arm would be the wrong instrument, because the property is "we decline", and a
+# decline is visible in the plan.
+psql_run "CREATE TABLE vnum (c numeric, d float8, i int);"
+psql_run "INSERT INTO vnum SELECT (g%997)::numeric, (g%997)::float8, g FROM generate_series(1,20000) g;"
+psql_run "CREATE TABLE vnumc (LIKE vnum) USING pgcolumnar;"
+psql_run "INSERT INTO vnumc SELECT * FROM vnum;"
+
+vnode() { q "SET pgcolumnar.enable_ungrouped_vector_agg=on;
+             EXPLAIN (COSTS OFF) $1" | grep -c 'Columnar Vectorized Aggregates'; }
+
+check_num "premise: the node DOES run for float8, so a 0 below means refusal and not absence" \
+	"$(vnode 'SELECT sum(d) FROM vnumc WHERE i > 5')" "1"
+check_num "sum(numeric) is refused from the scan-fold path" \
+	"$(vnode 'SELECT sum(c) FROM vnumc WHERE i > 5')" "0"
+check_num "avg(numeric) too" \
+	"$(vnode 'SELECT avg(c) FROM vnumc WHERE i > 5')" "0"
+check_num "and a MIXED query is refused whole, because classification is all or nothing" \
+	"$(vnode 'SELECT sum(c), sum(d) FROM vnumc WHERE i > 5')" "0"
+
+# refusing must not change any answer: the ordinary Agg computes them instead
+for e in "sum(c)" "avg(c)" "sum(c)::text||'/'||sum(d)::text"; do
+	check "refused numeric still matches the heap oracle [$e]" \
+		"$(q "SET pgcolumnar.enable_ungrouped_vector_agg=on; SELECT ($e)::text FROM vnumc;" | tail -1)" \
+		"$(q "SELECT ($e)::text FROM vnum;" | tail -1)"
+done
+
 pgc_summary


### PR DESCRIPTION
Closes the last of the three families `pgcolumnar.enable_ungrouped_vector_agg` names. `bigint`
was fixed by giving it a cheap accumulator (#786); `numeric` cannot have one, because its input
already carries a scale.

## Measured

8,000,000 rows, interleaved, min of 7, plan and answers asserted on both arms:

| query | before | after |
| --- | ---: | ---: |
| `sum(numeric)` | 1.10x slower | **1.04x faster** |
| `sum(float8)` | 2.73x faster | 2.74x faster |
| `sum(numeric), sum(float8)` | 1.00x, no gain | 1.01x, unchanged |

## The refusal is unconditional, and the third row is why

Classification is all or nothing — `pgcolumnar_add_agg_paths` does
`if (!pgcolumnar_classify_aggref(...)) return;` — so refusing `numeric` refuses the **whole
node**. I expected that to cost mixed queries their float win, and went looking for a
conditional rule that would keep it.

Measured instead: **a mixed query gained nothing beforehand.** The numeric aggregate's cost
swamped the float one, 417.6 ms against 416.8 ms. So nothing is given up by refusing, the
numeric-only case improves, and the clever version would have been complexity bought for no one.

**Nor is it conditional on the data.** The reviewer measured the same penalty with and without
chunk-group pruning — 1.14x with 25 of 27 groups removed, 1.56x with none. That is the control
my own fixture lacked, and the reason I did not propose this when the residue first appeared:
my 1.2x sat between their two numbers, which is what a fixture chosen for neither shape gives.

## Where it is placed

At the point the scan-fold path is **chosen**, not in `pgcolumnar_classify_aggref`, which is
shared with the grouped path. The grouped path is a different implementation and has not been
measured for these kinds. This narrows only what was measured.

## The arms pin shape, not speed

Which queries take the node, read from the plan — including a premise that the node *does* run
for `float8`, so a `0` for numeric means refusal rather than absence, and an arm for the mixed
query since all-or-nothing classification is the non-obvious part. Plus heap-oracle arms, since
refusing must not change an answer.

A timing arm would be the wrong instrument here: the property is "we decline", and a decline is
visible in `EXPLAIN`.

**Removal proof:** admitting numeric again reddens exactly the three refusal arms and nothing
else.

```
FAIL  sum(numeric) is refused from the scan-fold path: got [1] want [0]
FAIL  avg(numeric) too: got [1] want [0]
FAIL  and a MIXED query is refused whole, because classification is all or nothing: got [1] want [0]
```

## Tests

`ungrouped_vector_agg` is now 56 checks. PG17 assert build, all PASSED:
`ungrouped_vector_agg`, `int8_agg_int128`, `native_groupagg`, `native_groupagg_batch`,
`parallel_vector_agg`, `vector_agg_tlist_shape`, `native_agg`, `native_agg_deletes`,
`batch_fold_explain`, `differential`, `harness_selftest`, `docs_style`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaQ4vThXcmTCf3KRQpUDrE