### PR TITLE
test: make the fetch cache guards reach the fetch path (#797)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ### Fixed
 
+- The fetch cache cost guards in `test/native_fetch_cache.sh` now assert that
+  they reach the per-row fetch path, and set
+  `pgcolumnar.enable_index_fetch_penalty = off` so that they do (#797). They had
+  not exercised the cache since the penalty landed: `enable_seqscan = off` and
+  `enable_bitmapscan = off` do not disable the columnar custom scan, so the
+  planner answered these queries with a group scan and the guards timed a
+  different mechanism while staying green. The #353 guard was written 83 minutes
+  before the penalty existed. With the path restored the two guards read 2.00x
+  and 6.42x, against 0.98x and 1.21x before, and the 6.42x reproduces the 5.8x
+  recorded in the suite's own comment when the guard was written.
+
 - `sum()` and `avg()` over `numeric` no longer take the ungrouped vectorized
   path, where they were slower than the ordinary `Agg` (#785). This closes the
   last of the three families `pgcolumnar.enable_ungrouped_vector_agg` names.

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -782,6 +782,35 @@ pgc_is_columnar_scan() {	# query -> yes|no
 		| grep -q 'Columnar Projected Columns' && echo yes || echo no
 }
 
+# Does this query's plan drive the per-row fetch path?
+#
+# The fetch cache and its cap live in pgcolumnar_fetch_row(), which is reached
+# only from the index fetch. A cost guard that means to measure the cache must
+# assert this, because enable_seqscan=off and enable_bitmapscan=off do NOT
+# disable the columnar custom scan: the planner is free to answer the same query
+# with a group scan that never fetches a row, and the guard then times a
+# different mechanism and stays green forever (#797).
+#
+# The setup argument carries the SET statements the guard runs under, because
+# the plan depends on them -- pgcolumnar.enable_index_fetch_penalty in
+# particular decides this very choice. Passing them separately keeps them out of
+# the EXPLAIN target.
+#
+# A positive grep for "Index Scan using" rather than an absence test, for the
+# same reason as pgc_is_columnar_scan above: a plan that fell back has no line
+# to be absent, so an absence test passes for exactly the case worth catching.
+#
+# This asks about a SELECT that reaches the fetch path THROUGH AN INDEX SCAN. It
+# is the wrong premise for a DML guard: an UPDATE reaches pgcolumnar_fetch_row()
+# for every row it modifies while still planning as a custom scan, so this would
+# report "no" for a query that does exercise the cache. Measured: an UPDATE over
+# 2,000 rows made 20,366 fetch_row calls under a Custom Scan plan (#797).
+pgc_uses_row_fetch() {	# setup query -> yes|no
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -At -c "$1" -c "EXPLAIN (COSTS OFF) $2" 2>/dev/null \
+		| grep -q 'Index Scan using' && echo yes || echo no
+}
+
 # Order-independent set hash of an arbitrary query's result. The row is cast to
 # text as a whole composite so any column list works. No single quotes are used
 # in the wrapper (dollar-quoting + chr(10)) so the inner query may contain its

--- a/test/native_fetch_cache.sh
+++ b/test/native_fetch_cache.sh
@@ -134,6 +134,16 @@ check "a hit re-checks the group geometry it was filled with" \
 check "the cache is released at executor end, not only at transaction end" \
 	"$(grep -c 'PgColumnarDiscardFetchCache' "$SRC/columnar_tableam.c")" "2"
 
+# The SETs every fetch-path guard below runs under, defined once because the
+# premise that asserts the plan and the measurement that depends on it must not
+# drift apart (#797). enable_seqscan/enable_bitmapscan alone are not enough:
+# neither disables the columnar custom scan, and pgcolumnar.enable_index_fetch_penalty
+# (on by default since #355) costs the per-row fetch highly enough that the
+# planner answers these queries with a group scan instead -- which is how these
+# guards spent months timing a mechanism they do not exercise.
+FETCH_PATH_SETS="SET max_parallel_workers_per_gather=0; SET enable_seqscan=off;
+	SET enable_bitmapscan=off; SET pgcolumnar.enable_index_fetch_penalty=off;"
+
 # --- #353: a wide group's decode scratch must not blow the fetch cap ----------
 # The by-row-number decode allocated its intermediates -- the decompressed region
 # and each vector's decoded buffer -- in the cached entry, ~3x the result. A wide
@@ -157,12 +167,17 @@ wbuild() {  # table, stripe
 w_ms() {  # index-driven point query over one host: many fetches into few groups
 	local start end
 	start=$(date +%s%N)
-	psql_run "SET max_parallel_workers_per_gather=0; SET enable_seqscan=off; SET enable_bitmapscan=off;
+	psql_run "$FETCH_PATH_SETS
 		SELECT count(*), max(u) FROM $1 WHERE h='h1';" >/dev/null 2>&1
 	end=$(date +%s%N); echo $(( (end - start) / 1000000 ))
 }
 wbuild fc_wide 150000      # default stripe: one/two big groups, wide decoded prefix
 wbuild fc_wnarrow 20000    # smaller groups that fit under the cap regardless
+for _t in fc_wide fc_wnarrow; do
+	check "the $_t point query really drives the fetch path (#797)" \
+		"$(pgc_uses_row_fetch "$FETCH_PATH_SETS" \
+			"SELECT count(*), max(u) FROM $_t WHERE h='h1'")" yes
+done
 bigw="$(min3 w_ms fc_wide)"; smallw="$(min3 w_ms fc_wnarrow)"
 echo "-- #353 wide point query: default-stripe ${bigw} ms, small-stripe ${smallw} ms"
 check_ratio "a wide group's fetch is not far dearer than a small group's (#353)" \
@@ -208,16 +223,20 @@ w359_ms() {  # number of projected text columns
 	local n=$1 sel="count(*)" i start end
 	for i in $(seq 1 "$n"); do sel="$sel, max(t$i)"; done
 	# warm, so the comparison is decode cost rather than first-touch I/O
-	psql_run "SET max_parallel_workers_per_gather=0; SET enable_seqscan=off;
-		SET enable_bitmapscan=off;
+	psql_run "$FETCH_PATH_SETS
 		SELECT $sel FROM fc_w359 WHERE h='h7';" >/dev/null 2>&1
 	start=$(date +%s%N)
-	psql_run "SET max_parallel_workers_per_gather=0; SET enable_seqscan=off;
-		SET enable_bitmapscan=off;
+	psql_run "$FETCH_PATH_SETS
 		SELECT $sel FROM fc_w359 WHERE h='h7';" >/dev/null 2>&1
 	end=$(date +%s%N); echo $(( (end - start) / 1000000 ))
 }
 
+for _n in 4 5; do
+	_sel="count(*)"; for _i in $(seq 1 "$_n"); do _sel="$_sel, max(t$_i)"; done
+	check "the $_n-column projection really drives the fetch path (#797)" \
+		"$(pgc_uses_row_fetch "$FETCH_PATH_SETS" \
+			"SELECT $_sel FROM fc_w359 WHERE h='h7'")" yes
+done
 under="$(min3 w359_ms 4)"   # ~30 MB decoded: fits
 over="$(min3 w359_ms 5)"    # ~38 MB decoded: does not
 echo "-- #359 projection width: four columns ${under} ms, five columns ${over} ms"


### PR DESCRIPTION
Fixes #797.

The three cost guards in `test/native_fetch_cache.sh` did not execute the fetch
cache. On `main` all three plan as `Custom Scan (PgColumnarScan)`, so
`pgcolumnar_fetch_row()` -- where the cache and its 32 MB cap live -- is never
entered. They were green throughout without touching the mechanism they name.

## Why

`enable_seqscan=off` and `enable_bitmapscan=off`, which is all they set, do not
disable a columnar custom scan. `pgcolumnar.enable_index_fetch_penalty` (on by
default since #355) costs the per-row fetch so the planner prefers the group
scan.

All on 2026-08-03: the #353 guard landed 11:25, the penalty 12:48, the #359
guard 13:36. The #353 guard measured a real index scan when it was written and
was defused 83 minutes later by an unrelated cost-model change. Nothing about
the guard changed; the world moved under it.

## Evidence

`LOG`-only probe at the top of `pgcolumnar_fetch_row()` and at the cap
comparison, PG17. The UPDATE is the positive control, without which a zero count
is indistinguishable from a dead instrument.

| arm | `fetch_row` | cap checks | plan |
|---|---|---|---|
| **control** `UPDATE fc_wide` | 20366 | 12600 | (reached) |
| #353 `fc_wide` | **0** | **0** | Custom Scan |
| #359 n=4 | **0** | **0** | Custom Scan |
| #359 n=5 | **0** | **0** | Custom Scan |
| same three, penalty off | 590/200/200 | 81/601/700 | Index Scan |

Plans were read from the real suite, not a replica, with literals supplied from
a file -- my first attempt turned `'h1'` into `'"h1"'` through nested shell
quoting.

## The change

- `pgc_uses_row_fetch()` in `lib.sh`: a **positive** grep for `Index Scan using`
  rather than an absence test, for the same reason `pgc_is_columnar_scan` is one
  -- a plan that fell back has no line to be absent, so an absence test passes
  for exactly the case worth catching. Takes the SETs separately because the
  plan depends on them.
- Documented as the **wrong premise for a DML guard**: an UPDATE reaches the
  fetch path under a custom scan plan (the control above, 20,366 calls that
  way), so `upd_ms` is deliberately left alone. Applying the assertion there
  would have been a false red.
- `FETCH_PATH_SETS` defined once and used by both the premise and the
  measurement it is a premise about, so a later edit cannot make the assertion
  describe a different plan than the one timed.

## Removal proof

With the premises added but the penalty left on, all four go red for the
intended reason:

```
FAIL  the fc_wide point query really drives the fetch path (#797): got [no] want [yes]
FAIL  the fc_wnarrow point query really drives the fetch path (#797): got [no] want [yes]
FAIL  the 4-column projection really drives the fetch path (#797): got [no] want [yes]
FAIL  the 5-column projection really drives the fetch path (#797): got [no] want [yes]
```

The measurements move with the fix as well: #353 from 0.98x to **2.00x**, #359
from 1.21x to **6.42x** (59 ms -> 379 ms). The 6.42x reproduces the
`after 64 ms -> 368 ms (5.8x)` this suite's own comment recorded when the guard
was written, which is the strongest evidence available that the guard is back on
the mechanism it was built for.

## What I did not prove

I attempted a second removal proof by crippling the cache so every lookup
misses. That build broke correctness (`the updated rows are correct: got []
want [2000]`), so its numbers are not evidence in either direction and I have
not used them. This is recorded in #797 as a failed attempt.

## Not in scope

#797 originally suggested resizing the fixture against the measured cap
quantity. The GREEN run refutes the premise for that -- the arms do behave as
either side of the cap -- and I have withdrawn it in a comment on the issue.

## Verification

`harness_selftest` 158/158 (it owns `lib.sh`) and `native_fetch_cache` 16/16 on
PG17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaQ4vThXcmTCf3KRQpUDrE
