### PR TITLE
test: stop overriding unique_lock_buckets for the whole tree (#799)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ### Fixed
 
+- The shared test cluster no longer sets `pgcolumnar.unique_lock_buckets`
+  (#799). `test/lib.sh` wrote `100003` into the cluster nearly every suite runs
+  against, where the shipped default is `128`, so the whole tree ran 781x above
+  shipped behaviour to serve one suite that already sets the value on the
+  cluster it builds itself. The visible symptom was a 20,000-row insert into a
+  columnar table with a unique index failing with `out of shared memory` and a
+  hint to raise `max_locks_per_transaction`, which reads as a product defect and
+  is not one. A new harness selftest keeps the shared cluster config free of
+  `pgcolumnar.*` GUCs; `PGC_EXTRA_CONF` remains the per-suite mechanism.
+
 - The fetch cache cost guards in `test/native_fetch_cache.sh` now assert that
   they reach the per-row fetch path, and set
   `pgcolumnar.enable_index_fetch_penalty = off` so that they do (#797). They had

--- a/test/advisory_lock_class.sh
+++ b/test/advisory_lock_class.sh
@@ -17,11 +17,13 @@
 # which is not the property. Reading the tag the running system actually took, then
 # trying to grab that exact tag through the SQL function, is.
 #
-# It also avoids a trap the first version of this file walked into: lib.sh sets
-# pgcolumnar.unique_lock_buckets=100003, so "hold every bucket" needs 100,003
-# advisory locks against a max_locks_per_transaction of 64. The holder failed, the
-# check passed with nobody holding anything, and the suite reported the same result
-# with and without the fix.
+# It also avoids a trap the first version of this file walked into: "hold every
+# bucket" needs one advisory lock per bucket against a max_locks_per_transaction
+# of 64, so the holder failed, the check passed with nobody holding anything, and
+# the suite reported the same result with and without the fix. That was found
+# when lib.sh globally set unique_lock_buckets=100003; the global is gone (#799)
+# and the shipped default is 128, but 128 still exceeds 64, so discovering the
+# tag rather than enumerating buckets remains the right shape.
 #
 # Usage:  test/advisory_lock_class.sh [PG_CONFIG]
 # Written fresh for pgColumnar.

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -223,10 +223,16 @@ pgc_setup() {
 		echo "bytea_output='hex'"
 		# Keep planner honest but let small tables use the custom scan.
 		echo "max_parallel_workers_per_gather=0"
-		# The unique-insert lock bucket count is fixed at server start (it is part
-		# of the advisory lock tag, so backends must agree on it). A large prime
-		# keeps unrelated keys out of the same bucket in unique_conc.
-		echo "pgcolumnar.unique_lock_buckets=100003"
+		# No pgcolumnar.* GUC is set here. A global override makes every suite
+		# in the tree measure something other than the shipped default, and the
+		# divergence is invisible from inside the suite that trips over it: this
+		# line used to read unique_lock_buckets=100003 against a shipped default
+		# of 128, so a 20,000-row insert into a table with a unique index
+		# exhausted max_locks_per_transaction and failed with "out of shared
+		# memory" -- an error that reads as a product defect and is not one
+		# (#799). unique_conc.sh sets the value on its own cluster, where it
+		# belongs; anything else that needs a non-default GUC has PGC_EXTRA_CONF
+		# below. Selftest 280 keeps this section free of them.
 		# Per-suite extra GUCs, set before the cluster starts (some, like
 		# max_prepared_transactions, are PGC_POSTMASTER and cannot be changed
 		# later). parallel_copy.sh uses this for 2PC capacity + worker slots.

--- a/test/selftest/280-the-shared-cluster-config-must-not.sh
+++ b/test/selftest/280-the-shared-cluster-config-must-not.sh
@@ -1,0 +1,84 @@
+# The shared cluster config must not set a pgcolumnar.* GUC.
+#
+# lib.sh builds the cluster nearly every suite runs against. A pgcolumnar.* GUC
+# set in that block applies to ALL of them, so the whole tree measures something
+# other than what ships, and no suite can see it: the value is correct in SHOW,
+# nothing in the suite mentions it, and the divergence is a property of the
+# harness rather than of the test being read.
+#
+# FOUND THE EXPENSIVE WAY, 2026-08-28 (#799). The block set
+# pgcolumnar.unique_lock_buckets=100003 against a shipped default of 128 -- 781
+# times higher -- to serve one suite. The bucket count bounds the advisory locks
+# a transaction holds per unique index, so a 20,000-row insert into a columnar
+# table with a PRIMARY KEY exhausted max_locks_per_transaction and failed with
+#
+#   ERROR:  out of shared memory
+#   HINT:  You might need to increase "max_locks_per_transaction".
+#
+# which reads as a product defect and is not one. OffgridwithJD spent an hour
+# reproducing it with clean controls -- heap+PK fine, columnar+plain-index fine,
+# threshold between 10,000 and 20,000 rows -- all of which correctly implicated
+# the unique-insert lock path and none of which could see the cause, because
+# every control ran on the same overridden cluster. It was caught by reading
+# lib.sh rather than by any measurement on the cluster it was handed.
+#
+# WHY THE RULE IS "NONE" RATHER THAN "NOT THAT ONE". The failure was not that
+# 100003 is a bad number; it is the right number for unique_conc, which sets it
+# on its own cluster. The failure is that a whole-tree default was used to
+# configure one suite. PGC_EXTRA_CONF exists for the per-suite case and is
+# checked below to still be reachable, since a guard that forbade the global
+# without leaving the alternative open would just be reverted.
+#
+# SCOPE. This checks the cluster-config block in lib.sh only. A suite setting a
+# GUC on its own cluster, in its own session, or through PGC_EXTRA_CONF is the
+# supported shape and is not flagged. Core PostgreSQL GUCs in the block are
+# deliberately allowed: they are there to make heap and columnar output
+# comparable, which is the harness's job.
+
+_cc_lib="$PGC_TESTDIR/lib.sh"
+
+# The block is delimited by the initdb call above it and the redirection into
+# postgresql.conf below it, both of which are load-bearing lines that cannot be
+# renamed without someone noticing.
+_cc_block() {
+	awk '/^[[:space:]]*echo "port=\$PGC_PORT"/ {inb=1}
+	     inb {print}
+	     /postgresql.conf.\"$/ && inb {exit}' "${1:-$_cc_lib}"
+}
+
+_cc_offenders() { _cc_block "${1:-}" | grep -nE '^[[:space:]]*echo "pgcolumnar\.' ; }
+
+_CC_LINES="$(_cc_block | wc -l)"
+
+# The extractor must have FOUND the block. If either delimiter is renamed this
+# returns nothing, every check below passes on an empty string, and the guard
+# reports a clean cluster config forever. This is the fail-open half.
+check "premise: the cluster-config block was located in lib.sh" \
+	"$([ "${_CC_LINES:-0}" -ge 8 ] && echo "found ($_CC_LINES lines)" || echo "NOT FOUND ($_CC_LINES)")" \
+	"found ($_CC_LINES lines)"
+check "premise: and it is the right block (it sets the port and the preload)" \
+	"$(_cc_block | grep -cE 'PGC_PORT|shared_preload_libraries')" "2"
+
+# POSITIVE CONTROL. An empty offender list is what a working guard and a blind
+# one both report, so make the detector fire on a synthetic copy carrying the
+# exact line this file exists to prevent.
+_cc_tmp="$(mktemp)"
+_cc_block > "$_cc_tmp"
+sed -i 's|^\([[:space:]]*\)echo "max_parallel_workers_per_gather=0"|\1echo "max_parallel_workers_per_gather=0"\n\1echo "pgcolumnar.unique_lock_buckets=100003"|' "$_cc_tmp"
+check "premise: the detector fires on the line that caused #799" \
+	"$([ -n "$(_cc_offenders "$_cc_tmp")" ] && echo fires || echo BLIND)" "fires"
+rm -f "$_cc_tmp"
+
+# PGC_EXTRA_CONF is the sanctioned alternative. If it stopped being applied,
+# this guard would be forbidding the global with nothing left in its place, and
+# the next person needing a non-default GUC would put it back.
+# Counted on NON-COMMENT lines only: the block's own comment explains the hatch
+# and would otherwise be counted as a use of it, which is the same
+# assert-the-code-not-the-prose mistake this suite catches elsewhere.
+check "the per-suite escape hatch PGC_EXTRA_CONF is still applied to the config" \
+	"$(_cc_block | grep -v '^[[:space:]]*#' | grep -c 'PGC_EXTRA_CONF')" "1"
+
+_CC_BAD="$(_cc_offenders)"
+[ -n "$_CC_BAD" ] && printf '%s\n' "$_CC_BAD" | sed 's/^/    /'
+check "the shared cluster config sets no pgcolumnar.* GUC" \
+	"$([ -z "$_CC_BAD" ] && echo clean || echo "$(printf '%s\n' "$_CC_BAD" | wc -l) offender(s)")" "clean"


### PR DESCRIPTION
Fixes #799.

`test/lib.sh` set `pgcolumnar.unique_lock_buckets=100003` into the cluster nearly
every suite runs against. The shipped default is `128`, so the whole tree ran
**781x above shipped behaviour** to serve one suite that already sets the value
on the cluster it builds itself.

## Before / after, same cluster, nothing else changed

```
-- SHOW unique_lock_buckets = 100003  (shipped default is 128)
-- max_locks_per_transaction = 64
-- 20,000-row insert into a PK columnar table: ERROR:  out of shared memory
   HINT:  You might need to increase "max_locks_per_transaction".
-- rows now present: 0
```

```
-- SHOW unique_lock_buckets = 128  (shipped default is 128)
-- 20,000-row insert into a PK columnar table: INSERT 0 20000
-- rows now present: 20000
```

The bucket count bounds the advisory locks a transaction holds per unique index,
so the override was spending the lock table. The resulting error reads as a
product defect and is not one.

## Nothing needed the global

- `unique_conc.sh:144` sets the value on the cluster it builds itself.
- `advisory_lock_class.sh` only *referenced* it in a comment; it discovers the
  lock tag from `pg_locks` precisely so it never enumerates buckets. That comment
  is corrected here rather than left describing a global that is gone — 128 still
  exceeds `max_locks_per_transaction` of 64, so the reasoning it records is
  unchanged and only its number was wrong.

Both suites pass without it.

## The guard

`test/selftest/280-the-shared-cluster-config-must-not.sh`: the shared cluster
config sets no `pgcolumnar.*` GUC.

The rule is **"none" rather than "not that one"** on purpose. 100003 is the right
number for `unique_conc`; the defect was configuring one suite through a
whole-tree default.

It carries the premises this file's own subject demands:

- the config block was **located at all** — a renamed delimiter would otherwise
  make every check below pass on an empty string forever;
- it is the **right block** (it sets the port and the preload);
- a **positive control**: the detector fires on the exact line that caused this,
  injected into a synthetic copy. An empty offender list is what a working guard
  and a blind one both report;
- `PGC_EXTRA_CONF` is **still applied**, since a guard that forbids the global
  without leaving the sanctioned alternative open would simply be reverted. Counted
  on non-comment lines, because the block's own comment explains the hatch and
  would otherwise be counted as a use of it.

## Verification (PG17)

- `harness_selftest` 163/163
- `advisory_lock_class` 7/7, `unique_conc` PASSED
- full suite matrix: 216 ran, **214 PASS**

The two failures are `logical_decoding_source` and `logical_decoding_cdc_recipe`,
failing in this lane only because `test_decoding.so` is not built into that
prefix (`FAIL test_decoding.so is not in /usr/local/pg17_nc/lib/postgresql`).
Both **PASS** with this tree against a prefix that has it.

## Credit

Observed by `OffgridwithJD`, who also retracted the product-bug reading of it
after checking the `DefineCustom` default against `SHOW`. There is no product
defect here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaQ4vThXcmTCf3KRQpUDrE
