### PR TITLE
fix: charge columnar decode cost by column width, not column count (#768)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ### Fixed
 
+- The columnar scan's decode cost is now charged by projected column WIDTH, not
+  by column count (#768). #503 gave the scan a per-value decode term, which
+  fixed "nine columns are priced like one"; it counted columns, so a 324-byte
+  text column was charged exactly what a 4-byte int4 column was. Measured on
+  4,000,000 rows, four 324-byte text columns were priced at 163,422 while taking
+  5875 ms, against 206,524 and 335 ms for eight int columns: priced below, and
+  17.5x slower. Cost per millisecond across those projections spanned 22x before
+  the change and 1.7x after it, with an int-only projection priced exactly as
+  before.
+
 - The shared test cluster no longer sets `pgcolumnar.unique_lock_buckets`
   (#799). `test/lib.sh` wrote `100003` into the cluster nearly every suite runs
   against, where the shipped default is `128`, so the whole tree ran 781x above

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -1942,6 +1942,100 @@ pgcolumnar_full_scan_cost(RelOptInfo *rel, Path *seqpath)
 }
 
 /*
+ * pgcolumnar_projected_decode_units
+ *		The decode-CPU multiplier for a scan's projection, in units of one
+ *		narrow (4-byte) column.
+ *
+ *		#503 gave the scan a per-value decode term, which fixed "nine columns are
+ *		priced like one". It counted COLUMNS, so a 324-byte text column was charged
+ *		exactly what a 4-byte int4 column was. Measured on 4,000,000 rows, PG17
+ *		non-assert, with the metadata and fold paths off so the scan really decodes:
+ *
+ *			marginal cost of one more projected column
+ *			  int4           4 bytes     24.0 ms
+ *			  text (md5)    36 bytes    247.0 ms	10.29x, for 9.00x the bytes
+ *			  text (long)  324 bytes   1420.3 ms
+ *
+ *		and what the planner charged, after ANALYZE, for the whole projection:
+ *
+ *			8 int4                     206,524   at   335 ms
+ *			4 text (324 bytes)         163,422   at  5875 ms
+ *
+ *		Four long-text columns priced BELOW eight int columns while taking 17.5x
+ *		as long: a 22x under-charge, and in the direction that makes the planner
+ *		prefer the plan that is slower (#768).
+ *
+ *		Decode cost tracks BYTES. Per byte, text measured 1.14x an int4 on the md5
+ *		fixture, and across an 81x width range the per-byte figures span 0.45x to
+ *		1.36x -- within ~1.5x, against 59x for a per-column model. The profile says
+ *		the same thing: the text arm's self time is 15.60% __memmove_avx against
+ *		2.88% on the int arm, so the extra time is spent copying the extra bytes.
+ *
+ *		Width is divided by COLUMNAR_DECODE_REF_WIDTH so that a 4-byte column
+ *		contributes exactly 1.0 and an int-only projection is priced exactly as
+ *		#503 priced it. That is deliberate: it keeps the existing calibration for
+ *		the narrow case that #503 was tuned against, and changes only the wide
+ *		case that was wrong.
+ *
+ *		The per-column floor of 1.0 exists because decoding a value is not free
+ *		even when the value is one byte: a bool column still costs a validity
+ *		check, a rank, and a store. Without the floor this would REDUCE the charge
+ *		for narrow columns below what #503 measured, which nothing here justifies.
+ *
+ *		Width comes from ANALYZE's stored average, with get_typavgwidth as the
+ *		fallback, for the reason given on the width fraction below: a varlena
+ *		column's type width is "we do not know".
+ */
+#define COLUMNAR_DECODE_REF_WIDTH	4.0
+
+static double
+pgcolumnar_projected_decode_units(RelOptInfo *rel, Oid heapRelid)
+{
+	Bitmapset  *needed = NULL;
+	Relation	r;
+	TupleDesc	tupdesc;
+	ListCell   *lc;
+	double		units = 0.0;
+	int			i;
+
+	pull_varattnos((Node *) rel->reltarget->exprs, rel->relid, &needed);
+	foreach(lc, rel->baserestrictinfo)
+	{
+		RestrictInfo *rinfo = lfirst_node(RestrictInfo, lc);
+
+		pull_varattnos((Node *) rinfo->clause, rel->relid, &needed);
+	}
+
+	r = table_open(heapRelid, AccessShareLock);
+	tupdesc = RelationGetDescr(r);
+
+	for (i = 1; i <= tupdesc->natts; i++)
+	{
+		Form_pg_attribute att = TupleDescAttr(tupdesc, i - 1);
+		double		w;
+
+		if (att->attisdropped)
+			continue;
+		if (!bms_is_member(i - FirstLowInvalidHeapAttributeNumber, needed))
+			continue;
+
+		w = (double) get_attavgwidth(heapRelid, att->attnum);
+		if (w <= 0.0)
+			w = (double) get_typavgwidth(att->atttypid, att->atttypmod);
+		if (w <= 0.0)
+			w = 1.0;
+
+		w = w / COLUMNAR_DECODE_REF_WIDTH;
+		units += (w < 1.0) ? 1.0 : w;
+	}
+
+	table_close(r, AccessShareLock);
+	bms_free(needed);
+
+	return units;
+}
+
+/*
  * pgcolumnar_projected_width_fraction
  *		The share of a row's stored width this scan actually reads, in (0, 1].
  *		One means every column is referenced.
@@ -1967,40 +2061,6 @@ pgcolumnar_full_scan_cost(RelOptInfo *rel, Path *seqpath)
  *		Both the target list and the restriction clauses count: a qual on a
  *		column that is not selected still has to be decoded to be evaluated.
  */
-/*
- * pgcolumnar_projected_ncols
- *		How many distinct columns a scan decodes: the projected columns plus the
- *		columns any restriction reads. This is the multiplier for the per-value
- *		decode cost (#503); the inherited heap seqscan cost has no such term, so a
- *		wide projection is priced the same as a narrow one and the planner cannot
- *		see that decoding nine columns costs nine times the CPU of decoding one.
- *		Counted from the same "needed" set as the width fraction below, but as a
- *		count rather than a width, because decode cost is per value not per byte.
- */
-static int
-pgcolumnar_projected_ncols(RelOptInfo *rel)
-{
-	Bitmapset  *needed = NULL;
-	ListCell   *lc;
-	int			n = 0;
-	int			m = -1;
-
-	pull_varattnos((Node *) rel->reltarget->exprs, rel->relid, &needed);
-	foreach(lc, rel->baserestrictinfo)
-	{
-		RestrictInfo *rinfo = lfirst_node(RestrictInfo, lc);
-
-		pull_varattnos((Node *) rinfo->clause, rel->relid, &needed);
-	}
-
-	while ((m = bms_next_member(needed, m)) >= 0)
-		if (m + FirstLowInvalidHeapAttributeNumber >= 1)		/* a real column, not a system attr */
-			n++;
-
-	bms_free(needed);
-	return n;
-}
-
 static double
 pgcolumnar_projected_width_fraction(RelOptInfo *rel, Oid heapRelid)
 {
@@ -2369,8 +2429,14 @@ pgcolumnar_refined_scan_cost(RelOptInfo *rel, Oid relid, Path *seqpath,
 			saved = run;
 		run -= saved;
 	}
-	/* per-column decode CPU (#503), scaled by survival like the rest */
-	run += cpu_operator_cost * ntuples * (double) pgcolumnar_projected_ncols(rel);
+	/*
+	 * Per-value decode CPU (#503), now weighted by each column's width
+	 * (#768), and scaled by survival like the rest. An int-only projection
+	 * is priced exactly as before; a wide one is priced for the bytes it
+	 * actually copies.
+	 */
+	run += cpu_operator_cost * ntuples *
+		pgcolumnar_projected_decode_units(rel, relid);
 
 	*out_startup = startup;
 	*out_total = startup + run * survival;

--- a/test/scan_decode_cost.sh
+++ b/test/scan_decode_cost.sh
@@ -49,6 +49,59 @@ RATIO="$(awk -v w="$WIDE" -v n="$NARROW" 'BEGIN{ printf "%.3f", (n>0)?w/n:0 }')"
 check "a wide projection costs materially more than a narrow one (decode is priced)" \
 	"$(awk -v r="$RATIO" 'BEGIN{ print (r >= 1.5) ? "scaled" : "flat" }')" "scaled"
 
+# --- #768: the decode charge must scale with WIDTH, not just column count ------
+#
+# #503 above priced one cpu_operator_cost per decoded VALUE, which fixed "nine
+# columns cost the same as one". It left a second flatness: a 324-byte text
+# column is charged exactly what a 4-byte int4 column is. Measured on 4,000,000
+# rows, PG17 non-assert, metadata and fold paths off, min of interleaved reps:
+#
+#   marginal cost of one more projected column
+#     int4            4 bytes     24.0 ms
+#     text (md5)     36 bytes    247.0 ms      10.29x for 9.00x the bytes
+#     text (long)   324 bytes   1420.3 ms
+#
+#   and what the planner charged for the whole projection, after ANALYZE:
+#     8 int4                     206,524   at   335 ms
+#     4 text (324 bytes)         163,422   at  5875 ms
+#
+# Four long-text columns were priced BELOW eight int columns while taking 17.5
+# times as long -- a 22x under-charge. Decode cost tracks bytes to within ~1.5x
+# across an 81x width range; charging by column count is off by 59x across the
+# same range.
+#
+# The bound is deliberately weak. The measured time ratio is 17.5x and the fixed
+# model prices these ~40x apart on the decode term alone, but the assertion only
+# demands 2x, because the point is the SIGN of the comparison: the flat model
+# puts the text projection BELOW the int one at 0.79x, so 2x is unreachable
+# without width entering the charge, and the check does not encode one box's
+# calibration.
+TW=100000
+psql_run "CREATE TABLE cwide (a int4,b int4,c int4,d int4,e int4,f int4,g int4,h int4,
+	t1 text, t2 text, t3 text, t4 text) USING pgcolumnar;"
+psql_run "INSERT INTO cwide SELECT i,i,i,i,i,i,i,i,
+	repeat(md5(i::text),3), repeat(md5((i+1)::text),3),
+	repeat(md5((i+2)::text),3), repeat(md5((i+3)::text),3)
+	FROM generate_series(1,$TW) i;"
+psql_run "ANALYZE cwide;"
+
+# PREMISE: the fixture must actually be wide, and the planner must be able to SEE
+# that it is. A cost model that reads width from statistics is void as a subject
+# if the statistics are missing -- the arms would differ by nothing the model can
+# observe, and the check would be about ANALYZE rather than about costing.
+WT="$(q "SELECT avg_width FROM pg_stats WHERE tablename='cwide' AND attname='t1'")"
+WA="$(q "SELECT avg_width FROM pg_stats WHERE tablename='cwide' AND attname='a'")"
+check "premise: the wide column's width is in the statistics" 	"$([ "${WT:-0}" -ge 64 ] && echo "wide ($WT)" || echo "NOT WIDE (${WT:-none})")" "wide ($WT)"
+check "premise: and the narrow column's width is too, and is smaller" 	"$([ "${WA:-0}" -gt 0 ] && [ "${WA:-0}" -lt "${WT:-0}" ] && echo yes || echo "no (a=${WA:-none} t1=$WT)")" "yes"
+
+CTEXT="$(topcost 'SELECT t1,t2,t3,t4 FROM cwide')"
+CINT="$(topcost 'SELECT a,b,c,d,e,f,g,h FROM cwide')"
+check "premise: both projections priced" 	"$([ -n "$CTEXT" ] && [ -n "$CINT" ] && echo yes || echo no)" "yes"
+
+WRATIO="$(awk -v t="$CTEXT" -v i="$CINT" 'BEGIN{ printf "%.3f", (i>0)?t/i:0 }')"
+echo "-- #768: 4 wide text columns cost $CTEXT, 8 narrow int columns cost $CINT (${WRATIO}x)"
+check "four wide text columns cost more than eight narrow int ones (#768)" 	"$(awk -v r="$WRATIO" 'BEGIN{ print (r >= 2.0) ? "scaled" : "flat" }')" "scaled"
+
 # #171 guard: a point lookup on an indexed column must still choose the index,
 # not a full columnar scan. Raising the scan cost is the safe direction, but pin
 # it so a too-large term cannot push the planner off the index either.


### PR DESCRIPTION
Addresses the costing half of #768. The execution half is answered in
[this comment](https://github.com/commandprompt/pgcolumnar/issues/768#issuecomment-5448270117)
and is **not** a defect; this PR fixes the part that is.

## The defect

`src/columnar_customscan.c` charged decode CPU per **column count**:

```c
run += cpu_operator_cost * ntuples * (double) pgcolumnar_projected_ncols(rel);
```

#503 added that term to fix "nine columns are priced like one". It counts
columns, so a 324-byte text column is charged exactly what a 4-byte int4 column
is.

After `ANALYZE` (widths correctly 4 / 33 / 324 in `pg_stats`):

| projection | cost | measured | cost per ms |
|---|---:|---:|---:|
| 8 int4 | 206,524 | 335 ms | 617 |
| 4 text md5 | 146,911 | ~1200 ms | 122 |
| 4 text (324 B) | 163,422 | 5875 ms | **27.8** |

**Four long-text columns are priced below eight int columns while taking 17.5x
as long** — a 22x under-charge, in the direction that makes the planner prefer
the slower plan.

## Why width is the right variable

Marginal cost of one more projected column, 4,000,000 rows, PG17 non-assert,
metadata and fold paths off so the scan really decodes, min of interleaved reps:

| | ms/column | bytes/value | per byte |
|---|---:|---:|---:|
| int4 | 24.0 | 4 | — |
| text (md5) | 247.0 | 36 | 1.14x |
| text (long) | 1420.3 | 324 | — |

Across an **81x width range** the per-byte figures span 0.45x to 1.36x — within
~1.5x. A per-column model is off by **59x** across the same range.

The profile says the same thing. Self time, text arm against int arm:

```
15.60% __memmove_avx_unaligned_erms     2.88% __memmove_avx_unaligned_erms
```

The extra time is spent copying the extra bytes.

## The change

`pgcolumnar_projected_decode_units()` sums `max(1.0, avgwidth / 4.0)` over the
projected and restriction columns.

- **4.0 is a reference width, not a tuning knob.** A 4-byte column contributes
  exactly 1.0, so an **int-only projection is priced exactly as #503 priced it**.
  This keeps the calibration #503 was tuned against and changes only the wide
  case that was wrong. Verified: the existing #503 arm reads 3080.46 before and
  after.

  **That invariance is the reason for the constant, not evidence that the model
  is right.** A constant chosen to make a change invisible in the covered case
  will always produce a clean-looking control, so the int-only arm cannot
  support the model. The width sweep below is the evidence.
- **The per-column floor of 1.0** is there because decoding a value is not free
  even when the value is one byte — a bool still costs a validity check, a rank
  and a store. Without it this would *reduce* the charge for narrow columns
  below what #503 measured, which nothing here justifies.
- `pgcolumnar_projected_ncols()` is removed; it had no other caller.

Result — cost per ms:

| | before | after |
|---|---:|---:|
| 8 int4 | 617 | 616 |
| 4 text md5 | 122 | 364 |
| 4 text long | 27.8 | 572 |

Spread falls from **22x to 1.7x**.


## Residual, and its direction

Measured independently by @OffgridwithJD on a different fixture — four columns
of each type, 400,000 rows, min of 3, across the three width cells #768's
scoping note demanded:

| | int4 (4B) | text (3B) | md5 (33B) | long (292B) | spread |
|---|---:|---:|---:|---:|---:|
| before | 312 cost/ms | 176 | 83 | 24 | **13.23x** |
| after | 323 cost/ms | 182 | 296 | 562 | **3.10x** |

Two corrections to what I wrote above, both from that run:

- **The residual is 3.10x, not 1.7x.** My 1.7x is across my own fixture; across
  the cells the issue insisted on, it is about twice that. 3.10x is the number
  to quote.
- **The sign has flipped at the wide end.** 292-byte text was under-charged 13x
  and is now **over-charged 1.74x**. That is much better than a 13x
  under-charge and it is not nothing, because over-charging loses a plan you
  wanted rather than picking one you did not.

**The floor of 1.0 under-charges narrow text by ~1.8x.** A 3-byte column is
charged 8029.00, identical to int4, because 3/4 floors to 1.0 — while taking
1.78x the time. My own low-cardinality cell measured 1.40x in the same
direction. That is the price of "decoding is never zero", stated here so
whoever tunes this next starts from the measurement rather than rediscovering
it.

Neither holds this PR: both are improvements on a 13x-22x under-charge.

## Removal proof

With the new arm in place and the fix absent:

```
-- #768: 4 wide text columns cost 2975.54, 8 narrow int columns cost 3080.46 (0.966x)
FAIL  four wide text columns cost more than eight narrow int ones (#768): got [flat] want [scaled]
```

With the fix: `26225.54` against `3080.46`, **8.514x**, PASS.

The bound is 2.0x deliberately. The measured time ratio is 17.5x and the fixed
model prices these ~40x apart on the decode term alone, but the flat model puts
text *below* int at 0.966x — the **sign** is the signal, so 2.0x is unreachable
without width entering the charge and the check does not encode one box's
calibration.

The suite also carries a premise that both widths are actually in `pg_stats`: a
cost model that reads width from statistics is void as a subject if the
statistics are missing, and the check would then be about `ANALYZE` rather than
about costing.

## Verification (PG17)

- `scan_decode_cost` 8/8, including the pre-existing #503 and #171 arms
- `planner_choice_quality` PASSED — chosen plans at 0.08x and 0.06x of their
  alternatives. This is the guard most exposed to a bad cost change and it is
  skipped by `PGC_SKIP_TIMING`, so I ran it explicitly.
- Full matrix: 216 ran, 214 PASS, with `logical_decoding_source` and
  `logical_decoding_cdc_recipe` failing only because `test_decoding.so` was not
  built into that prefix.

  **Those two are now verified properly rather than by the cross-prefix
  shortcut.** Since this PR touches `src/`, running them against a different
  prefix would have exercised a `.so` that is not this change. `test_decoding`
  is now built against `pg17_nc`'s own headers via PGXS and both suites pass in
  that lane, built from this branch (`.so c28fb64bd12c`): `logical_decoding_source`
  11/11, `logical_decoding_cdc_recipe` 35/35. **PG17 is 216/216 for this change.**

  Worth recording, because it nearly produced a false green: my first
  `test_decoding` build installed a **stale prebuilt object** that shipped in the
  source tree, giving a `.so` byte-identical to the assert lane's. An identical
  md5 across an assert and a non-assert prefix is what exposed it. The real
  build differs (`225cce54` against `9464fc17`).

## Scope

This does not touch the index-fetch penalty's own `nproj` term
(`columnar_customscan.c:1871`), which has the same flatness. Left deliberately:
it is a different code path with its own calibration and its own guard, and
bundling it would make this PR's removal proof ambiguous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaQ4vThXcmTCf3KRQpUDrE
