### PR TITLE
Correct fetch_group_slot's NULL contract and enforce it (#795)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,33 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ### Fixed
 
+- `pgcolumnar_fetch_group_slot`'s header promised a NULL return that neither the
+  function nor its callers implement, and following it segfaults (#795). The
+  comment read "Returns NULL when nothing should be cached, in which case the
+  caller decodes into its own scratch context exactly as before". There is no
+  such path. The function has two returns, `return e` on a hit and
+  `return victim` on a miss, and `victim` cannot be NULL: the branch that runs
+  when every slot is live picks a least-recently-used entry. Both callers
+  dereference the result immediately, one through `entry->firstRowNumber` in the
+  geometry check and one through `MemoryContextSwitchTo(entry->cx)`, neither
+  guarded.
+
+  So the sentence did not describe an unimplemented option, it described a trap.
+  Forcing the documented return on an assert build of PostgreSQL 18.4 produced
+  `signal 11: Segmentation fault` in a backend. Nothing in `main` reaches it --
+  the function never returns NULL today, and the same fixture on a clean build is
+  correct -- but the comment invites the change that does.
+
+  The comment now states the guarantee the code makes, that a slot always comes
+  back and a miss returns a reset entry for the caller to fill, and records that
+  a "do not cache this one" policy needs a scratch-context path in the callers
+  before it can be expressed as a NULL. An `Assert(entry != NULL)` at each call
+  site holds that to be true rather than leaving it to the comment, which is what
+  rotted. With the Assert in place the same injected NULL return reports
+  `TRAP: failed Assert("entry != NULL"), File: "src/columnar_reader.c", Line:
+  3888` instead of faulting, so the next person to try it gets the line rather
+  than a core file.
+
 - The columnar scan's decode cost is now charged by projected column WIDTH, not
   by column count (#768). #503 gave the scan a per-value decode term, which
   fixed "nine columns are priced like one"; it counted columns, so a 324-byte

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -3658,8 +3658,13 @@ pgcolumnar_lookup_row_group(uint64 storageId, Snapshot metaSnapshot,
 
 /*
  * Find the entry for this group in this command, or prepare an empty one.
- * Returns NULL when nothing should be cached, in which case the caller decodes
- * into its own scratch context exactly as before.
+ *
+ * Always returns a usable slot, never NULL. A hit returns the live entry and
+ * sets *hit; a miss returns a reset entry with a fresh context for the caller
+ * to fill. Every caller dereferences the result unconditionally, so returning
+ * NULL here to mean "do not cache this one" would fault rather than fall back:
+ * expressing such a policy needs a scratch-context path in the callers first.
+ * The Asserts at the call sites hold this to be true.
  */
 static PgColumnarFetchGroup *
 pgcolumnar_fetch_group_slot(uint64 storageId, uint64 groupNumber, bool *hit)
@@ -3880,6 +3885,7 @@ pgcolumnar_fetch_row(Relation rel, Snapshot snapshot, uint64 rowNumber,
 	 * and the decode entirely.
 	 */
 	entry = pgcolumnar_fetch_group_slot(storageId, rg->groupNumber, &hit);
+	Assert(entry != NULL);
 
 	/*
 	 * The geometry the entry was filled with has to match the group just read
@@ -3899,6 +3905,7 @@ pgcolumnar_fetch_row(Relation rel, Snapshot snapshot, uint64 rowNumber,
 	{
 		pgcolumnar_fetch_entry_reset(entry);
 		entry = pgcolumnar_fetch_group_slot(storageId, rg->groupNumber, &hit);
+		Assert(entry != NULL);
 		Assert(!hit);
 	}
 


### PR DESCRIPTION
`pgcolumnar_fetch_group_slot`'s header promises a NULL return that neither the function nor its callers implement. Following it segfaults. Nothing in `main` reaches it, so this is not a live defect — it is a comment that invites one, and it cost me an hour inside #795 before I read the code rather than the contract.

## The claim, and why it is false

```c
/*
 * Find the entry for this group in this command, or prepare an empty one.
 * Returns NULL when nothing should be cached, in which case the caller decodes
 * into its own scratch context exactly as before.
 */
```

There is no such path.

The function has exactly two returns — `return e` on a hit and `return victim` on a miss — and **`victim` cannot be NULL**. The branch that runs when every slot is live picks a least-recently-used entry and resets it:

```c
	if (victim == NULL)
	{
		/* every slot is live in this command: take the least recently used */
		...
		pgcolumnar_fetch_entry_reset(victim);
	}
```

Both callers dereference the result immediately and neither is guarded — `entry->firstRowNumber` in the geometry check, and `MemoryContextSwitchTo(entry->cx)` in the fill.

So the sentence does not describe an unimplemented option. It describes a trap: the one change it invites is the one that faults.

## Proof

Three arms on the same fixture, PostgreSQL 18.4 assert build, each `.so` fingerprinted separately so no arm can be read off a stale build:

| arm | `.so` | outcome |
| --- | --- | --- |
| `main` + the comment's promise (`return NULL` on the miss path) | `0f945d3e19ff` | `LOG: client backend (PID 1544479) was terminated by signal 11: Segmentation fault` |
| this branch + the same injection | `a9a11e52003d` | `TRAP: failed Assert("entry != NULL"), File: "src/columnar_reader.c", Line: 3888` |
| this branch as proposed, no injection | `21a5cff75da9` | `updated=2000`, server log clean |

The first arm is the trap. The second is the same trap with this change in place. The third is the positive control that the change costs nothing when the invariant holds.

**The second arm is also the removal proof for the `Assert` itself.** An `Assert` that is never reached is decoration; this one fires, at the exact line, on the exact mutation the stale comment recommends. I did not assume it was reached — I made it fire.

## What this changes

Not the behaviour. `main` never returns NULL, and the third arm is byte-for-byte the same result as before.

The comment now states the guarantee the code actually makes — a slot always comes back, a miss returns a reset entry for the caller to fill — and records what a future "do not cache this one" policy would need first, which is a scratch-context path in the callers. The `Assert(entry != NULL)` at each call site holds that to be true rather than leaving it to a comment, since leaving it to a comment is what rotted.

That shape is deliberate. I argued in #795 for deleting the sentence outright, and I still think the NULL path should not be implemented — nothing asks for a no-cache switch. But deleting it alone leaves the invariant unstated *and* unenforced, which is the state that produced this. Correcting the comment and making it executable costs two lines and one branch on an assert build only.

## Scope

`src/columnar_reader.c` and `CHANGELOG.md`. No `docs/` change: nothing here is user-visible — no GUC, no SQL surface, no plan or output difference.

This is one of the three answers #795 reached, and the only one that was fully settled. **The two fixture questions stay open on that issue** and this PR does not touch them: the three cost bounds are unchanged, `wide/small` still cannot reach the 32 MB cap, and `over/under`'s 6.6% straddle margin is still worth checking before anyone tightens it.

## Gate

`test/run_all_versions.sh` on PostgreSQL 18.4 and 19beta2 assert builds, from `up/main` `35846a1`, which is this branch's base.

- **PG18 — 223 ran, all PASS**, 2 skipped (`native_repack`, and `pg19_vacuum_options`, which is PG19-only). Naming the skips rather than reporting "PASS" alone: a green summary reports PASS and SKIP identically.
- **PG19 — 225 ran, all PASS.** Two of them needed the box fixed first, see below.
- **Five-major build preflight**, `pg15a` through `pg19a`, each after `make clean`: all build, **zero warnings**.

Suite list derived rather than guessed. Every suite in `test/` naming the fetch cache or the row-fetch path is `analyze_stats`, `native_fetch_bigcap`, `native_fetch_cache`, `native_lazy_slot`, `native_rewrite`, `planner_choice_quality`, `rewrite_group_scan` — seven, all confirmed present in `run_all_versions.sh`'s `SUITES`, and all seven inside the full runs above.

### The PG19 run was red first, and it was my box

`logical_decoding_source` and `logical_decoding_cdc_recipe` both failed on PG19 with

```
FAIL  test_decoding.so is not in /usr/local/pg19a/lib/postgresql; build contrib/test_decoding
```

I did not assume that was unrelated to a patch touching the fetch path. Control: the same two suites on **unmodified `up/main` `35846a1`**, same `pg19a`, fail identically. It is the box — `test_decoding.so` was present for `pg16a` and `pg18a` and absent for `pg15a`, `pg17a` and `pg19a`, which is why PG18 was green on the same two suites.

Rather than caveat it, I built `contrib/test_decoding` for all three missing majors from the already-configured source trees and verified the artifact rather than the exit status (`/usr/local/pg19a/lib/postgresql/test_decoding.so`, 108,784 bytes). Both suites then **PASS** on this branch on `pg19a`, `.so 1c24f3bffb43`, which is what makes the 225/225 above complete rather than 223 plus an excuse.

Worth knowing for anyone else gating locally: **a local PG15, PG17 or PG19 gate has been silently failing those two suites**, and on majors where they had been failing all along they say nothing about the patch under test.

Refs #795.
