### PR TITLE
Charge the index-fetch penalty by decoded width, not column count (#803)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,48 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
 
 ### Fixed
 
+- The index-fetch penalty now charges decode CPU by projected column WIDTH, not by
+  column count (#803). This is the same flatness #768 fixed for the sequential
+  scan, in the other cost site. `pgcolumnar_index_fetch_penalty`'s CPU term was
+  `cpu_operator_cost * R * nproj`, a count, so a 68-byte text column was charged
+  exactly what a 4-byte int4 column was.
+
+  Measured on two tables of identical shape whose columns differ only in type, so
+  the decoded prefix is four columns on both arms and only the bytes move. Read
+  out of an instrumented build, the decode CPU term was **200.00 on both arms**
+  across an 8.6x difference in decoded width (16 B against 138 B). The same
+  ~39,000-row index fetch took 4,385 ms on the narrow table and 88,352 ms on the
+  wide one, a 20.15x difference against a modelled 1.49x. Cost per millisecond
+  spanned 13.4x, inside the 13x-22x #768 measured for the scan path.
+
+  The consequence was an inverted ordering rather than a uniform under-charge. A
+  wider decoded prefix makes every row-group decode dearer, so a wide table should
+  abandon per-row fetches sooner; priced by count it did the opposite. The model
+  kept the index up to 120-161 rows on the wide table and only 40-60 on the narrow
+  one, while the measured crossovers are 40-120 wide and 120-279 narrow. At 120
+  rows the wide table's chosen index plan measured 239.6 ms against an 82.9 ms
+  scan.
+
+  `pgcolumnar_scan_decode_shape` now accumulates decode units over the prefix it
+  already walks, using the same reference width as the scan's
+  `pgcolumnar_projected_decode_units`, and the penalty charges those units.
+  Substituting `pgcolumnar_projected_decode_units` itself would have been wrong:
+  it sums the columns a query *references*, while the fetch decodes the *prefix*
+  up to the highest referenced column (#363), and the two differ on exactly the
+  shape #363 exists for.
+
+  An all-int prefix is priced exactly as before, because a 4-byte column is one
+  unit: the narrow arm's flip point is unchanged at 40-60 rows. The wide arm moves
+  to 7-15. Both arms now stop earlier than the measured crossover, which is the
+  direction the model already erred on the narrow arm before this change; the
+  #376 bound and the clustered-index and point-lookup guards in
+  `test/analyze_stats.sh` are unaffected and still pass.
+
+  `test/index_fetch_penalty_width.sh` pins the ordering from the plan rather than
+  the clock, so `PGC_SKIP_TIMING` does not apply to it. On the unfixed build its
+  seven premises pass and the ordering check fails with
+  `INVERTED (wide 138B fetches to 120 rows, narrow 16B only to 40)`.
+
 - The columnar scan's decode cost is now charged by projected column WIDTH, not
   by column count (#768). #503 gave the scan a per-value decode term, which
   fixed "nine columns are priced like one"; it counted columns, so a 324-byte

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -200,6 +200,11 @@ check that could refuse such a move. See
   conditions. One measurement shows the effect. On a table of ten text columns,
   with the same rows and the same plan, a query on the first column took 975 ms.
   A query on the tenth column took 194,798 ms.
+
+  The planner accounts for this. It charges the decode by the width of the columns
+  it must decode, not by their number. A wide table therefore moves to a full scan
+  at a lower row count than a narrow one. That is the order the measured times
+  follow.
 - A bulk `UPDATE` or `DELETE` through an index no longer costs the number of rows
   multiplied by the row group size. It still costs several times more than heap.
   The reason is that each changed row is marked and written again, and not

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -1730,6 +1730,16 @@ pgcolumnar_index_correlation(IndexOptInfo *index, Oid heapRelid)
 }
 
 /*
+ * A decode unit is one reference-width column. Width is divided by
+ * COLUMNAR_DECODE_REF_WIDTH so that a 4-byte column counts as exactly one and the
+ * cost of an int-only prefix is unchanged, and each unit is floored at one so a
+ * narrow column is never cheaper than the per-value work it still costs. Shared
+ * by the scan cost (pgcolumnar_projected_decode_units) and the index-fetch
+ * penalty, so the two cannot drift apart.
+ */
+#define COLUMNAR_DECODE_REF_WIDTH	4.0
+
+/*
  * pgcolumnar_scan_decode_shape
  *		How much a by-row-number fetch of this rel actually decodes: the number of
  *		columns and their summed width.
@@ -1753,13 +1763,14 @@ pgcolumnar_index_correlation(IndexOptInfo *index, Oid heapRelid)
  */
 static void
 pgcolumnar_scan_decode_shape(RelOptInfo *rel, Index rti, Oid relid,
-						   int *nprefix, double *prefixWidth)
+						   double *prefixUnits, double *prefixWidth)
 {
 	Bitmapset  *attrs = NULL;
 	ListCell   *lc;
 	int			maxatt = 0;
 	int			x;
 	double		width = 0.0;
+	double		units = 0.0;
 	int			i;
 
 	pull_varattnos((Node *) rel->reltarget->exprs, rti, &attrs);
@@ -1787,7 +1798,7 @@ pgcolumnar_scan_decode_shape(RelOptInfo *rel, Index rti, Oid relid,
 
 	if (maxatt < 1)
 	{
-		*nprefix = 1;
+		*prefixUnits = 1.0;
 		*prefixWidth = (rel->reltarget->width > 0) ? rel->reltarget->width : 1.0;
 		return;
 	}
@@ -1810,9 +1821,11 @@ pgcolumnar_scan_decode_shape(RelOptInfo *rel, Index rti, Oid relid,
 			w = get_typavgwidth(typid, typmod);
 		}
 		width += (double) w;
+		units += ((double) w / COLUMNAR_DECODE_REF_WIDTH < 1.0)
+			? 1.0 : (double) w / COLUMNAR_DECODE_REF_WIDTH;
 	}
 
-	*nprefix = maxatt;
+	*prefixUnits = (units > 0.0) ? units : 1.0;
 	*prefixWidth = (width > 0.0) ? width : 1.0;
 }
 
@@ -1845,7 +1858,7 @@ pgcolumnar_scan_decode_shape(RelOptInfo *rel, Index rti, Oid relid,
  */
 static Cost
 pgcolumnar_index_fetch_penalty(RelOptInfo *rel, Oid relid, double rows, double rho,
-							 int nproj, double decodedWidth, bool tid_ordered)
+							 double decodeUnits, double decodedWidth, bool tid_ordered)
 {
 	double		R = (double) pgcolumnar_effective_stripe_row_limit(relid);
 	double		N = (rel->tuples > 0) ? rel->tuples : rows;
@@ -1868,7 +1881,7 @@ pgcolumnar_index_fetch_penalty(RelOptInfo *rel, Oid relid, double rows, double r
 	if (pages_per_stripe < 1)
 		pages_per_stripe = 1;
 	decode_per_group = seq_page_cost * pages_per_stripe
-		+ cpu_operator_cost * R * (double) nproj;
+		+ cpu_operator_cost * R * decodeUnits;
 
 	groups_min = ceil(rows / R);
 	groups_max = rows;
@@ -1986,8 +1999,6 @@ pgcolumnar_full_scan_cost(RelOptInfo *rel, Path *seqpath)
  *		fallback, for the reason given on the width fraction below: a varlena
  *		column's type width is "we do not know".
  */
-#define COLUMNAR_DECODE_REF_WIDTH	4.0
-
 static double
 pgcolumnar_projected_decode_units(RelOptInfo *rel, Oid heapRelid)
 {
@@ -2307,7 +2318,7 @@ static void
 pgcolumnar_penalize_index_fetches(RelOptInfo *rel, Index rti, Oid relid,
 								Cost fullScanCost)
 {
-	int			nproj;
+	double		decodeUnits;
 	double		decodedWidth;
 	Cost		cap;
 	bool		mutated = false;
@@ -2316,7 +2327,7 @@ pgcolumnar_penalize_index_fetches(RelOptInfo *rel, Index rti, Oid relid,
 	if (!pgcolumnar_enable_index_fetch_penalty)
 		return;
 
-	pgcolumnar_scan_decode_shape(rel, rti, relid, &nproj, &decodedWidth);
+	pgcolumnar_scan_decode_shape(rel, rti, relid, &decodeUnits, &decodedWidth);
 
 	/*
 	 * The penalty is bounded by a multiple of one full scan (issue #376).
@@ -2363,13 +2374,13 @@ pgcolumnar_penalize_index_fetches(RelOptInfo *rel, Index rti, Oid relid,
 			IndexPath  *ip = castNode(IndexPath, p);
 			double		rho = pgcolumnar_index_correlation(ip->indexinfo, relid);
 
-			add = pgcolumnar_index_fetch_penalty(rel, relid, p->rows, rho, nproj,
+			add = pgcolumnar_index_fetch_penalty(rel, relid, p->rows, rho, decodeUnits,
 											   decodedWidth, false);
 		}
 		else if (p->pathtype == T_BitmapHeapScan)
 		{
 			/* a bitmap heap scan fetches in TID (row-number) order */
-			add = pgcolumnar_index_fetch_penalty(rel, relid, p->rows, 1.0, nproj,
+			add = pgcolumnar_index_fetch_penalty(rel, relid, p->rows, 1.0, decodeUnits,
 											   decodedWidth, true);
 		}
 		/* T_IndexOnlyScan and the custom scans do no heap fetch */

--- a/test/index_fetch_penalty_width.sh
+++ b/test/index_fetch_penalty_width.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+#
+# pgColumnar: the index-fetch penalty charges decode CPU by column WIDTH, not by a
+# bare column count (#803).
+#
+# pgcolumnar_index_fetch_penalty prices the row-group decode a per-row fetch forces.
+# Its CPU term was cpu_operator_cost * R * nproj, where nproj is a count of the
+# decoded prefix's columns, so a 68-byte text column was charged exactly what a
+# 4-byte int4 column was -- the same flatness #768 fixed for the sequential scan.
+#
+# Measured before the fix, on the two tables this suite builds: the decode CPU term
+# was 200.00 on both arms across an 8.6x difference in decoded bytes, while the same
+# ~39k-row fetch took 4,385 ms narrow against 88,352 ms wide. The consequence was not
+# merely under-pricing but an inverted ordering -- the model let the WIDE table fetch
+# about 3x more rows than the narrow one before switching to a scan, when in reality
+# the wide table can afford about 3x FEWER. At 120 rows the wide table's chosen index
+# plan measured 239.6 ms against an 82.9 ms scan.
+#
+# This suite pins the ordering, which is the part that changes a plan, and does it
+# from the PLAN rather than the clock so it is not a timing check and PGC_SKIP_TIMING
+# never applies to it. The absolute row counts are deliberately not asserted: they
+# move with the cost constants, and the defect is the direction.
+#
+# nproj is the decoded PREFIX length (pgcolumnar_scan_decode_shape sets *nprefix =
+# maxatt, per #363), so width cannot be varied at a fixed prefix inside one table.
+# Hence two tables of identical shape whose columns differ only in TYPE at each
+# position: the prefix is four columns on both arms by construction.
+#
+# Both prefixes are kept far below COLUMNAR_FETCH_CACHE_MAX_BYTES so the width-aware
+# cache-overflow blend is inactive on both arms and cannot be what the check measures;
+# that is asserted, not assumed. That the penalty must still not over-fire on a
+# clustered index or a point lookup is pinned by test/analyze_stats.sh (#355, #376).
+#
+# Usage:  test/index_fetch_penalty_width.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+# The row-group limit is pinned in the cluster config rather than by SET so the
+# writing and planning sessions cannot disagree about it (see #806).
+PGC_EXTRA_CONF="${PGC_EXTRA_CONF:-}
+pgcolumnar.stripe_row_limit=20000"
+export PGC_EXTRA_CONF
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+N=400000
+R=20000
+CAP=$((32 * 1024 * 1024))
+
+psql_run "CREATE TABLE ifw_n (id int, scat int, c1 int,  c2 int)  USING pgcolumnar;"
+psql_run "CREATE TABLE ifw_w (id int, scat int, c1 text, c2 text) USING pgcolumnar;"
+psql_run "INSERT INTO ifw_n SELECT g, (g * 2654435761::bigint % 1000000)::int, g, g + 1
+          FROM generate_series(1,$N) g;"
+psql_run "INSERT INTO ifw_w SELECT g, (g * 2654435761::bigint % 1000000)::int,
+            repeat(md5(g::text),2), repeat(md5((g+1)::text),2)
+          FROM generate_series(1,$N) g;"
+psql_run "CREATE INDEX ifw_n_scat ON ifw_n(scat);"
+psql_run "CREATE INDEX ifw_w_scat ON ifw_w(scat);"
+psql_run "ANALYZE ifw_n;"
+psql_run "ANALYZE ifw_w;"
+
+q1() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" -Atq \
+		-c "$1" 2>&1 | tail -1
+}
+SETS="SET enable_seqscan=off; SET max_parallel_workers_per_gather=0; SET random_page_cost=1.1;"
+plan_of() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" -Atq \
+		-c "$SETS $1" 2>&1
+}
+
+# ---- premises -------------------------------------------------------------
+for t in ifw_n ifw_w; do
+	check "premise: $t holds all $N rows" "$(q1 "SELECT count(*) FROM $t")" "$N"
+done
+
+GN="$(q1 "SELECT count(*) FROM pgcolumnar.storage s JOIN pgcolumnar.row_group rg USING (storage_id) WHERE s.relation_oid = 'ifw_n'::regclass")"
+GW="$(q1 "SELECT count(*) FROM pgcolumnar.storage s JOIN pgcolumnar.row_group rg USING (storage_id) WHERE s.relation_oid = 'ifw_w'::regclass")"
+check "premise: both tables have the same row-group count, and more than the fetch cache holds" \
+	"$([ "$GN" = "$GW" ] && [ "${GN:-0}" -gt 4 ] && echo "yes ($GN)" || echo "no (n=$GN w=$GW)")" "yes ($GN)"
+
+WN="$(q1 "SELECT sum(avg_width) FROM pg_stats WHERE tablename = 'ifw_n'")"
+WW="$(q1 "SELECT sum(avg_width) FROM pg_stats WHERE tablename = 'ifw_w'")"
+check "premise: the wide table's prefix really is wider, by a large factor" \
+	"$(awk -v a="${WN:-0}" -v b="${WW:-0}" 'BEGIN { print (a > 0 && b >= 4 * a) ? "wider" : "NOT WIDER (n=" a " w=" b ")" }')" "wider"
+check "premise: both prefixes decode well under the fetch cache cap, so the overflow blend is inactive on both arms" \
+	"$([ $(( ${WN:-0} * R )) -lt $CAP ] && [ $(( ${WW:-0} * R )) -lt $CAP ] && echo "under" \
+	   || echo "OVER (n=$(( ${WN:-0} * R )) w=$(( ${WW:-0} * R )) cap=$CAP)")" "under"
+
+# The check below reads a plan flip. If the penalty never moves a plan there is
+# nothing to order and the whole suite would pass vacuously.
+PEN_ON="$(plan_of "SET pgcolumnar.enable_index_fetch_penalty=on;  EXPLAIN (COSTS OFF) SELECT c1,c2 FROM ifw_w WHERE scat BETWEEN 1 AND 400")"
+PEN_OFF="$(plan_of "SET pgcolumnar.enable_index_fetch_penalty=off; EXPLAIN (COSTS OFF) SELECT c1,c2 FROM ifw_w WHERE scat BETWEEN 1 AND 400")"
+check "premise: the penalty is what moves this plan (index without it, not with it)" \
+	"$(grep -q 'Index Scan' <<<"$PEN_OFF" && ! grep -q 'Index Scan' <<<"$PEN_ON" && echo yes \
+	   || echo "no (off=$(grep -m1 -oE 'Index Scan|Custom Scan' <<<"$PEN_OFF") on=$(grep -m1 -oE 'Index Scan|Custom Scan' <<<"$PEN_ON"))")" "yes"
+
+# ---- the check ------------------------------------------------------------
+# The largest fetched-row count at which the table still plans a per-row index
+# fetch. Ladder rather than a bisection so a failure prints where it turned over.
+flip_rows() {
+	local t="$1" k last=0
+	for k in 20 40 60 80 100 150 200 300 400 600 900; do
+		if grep -q 'Index Scan' <<<"$(plan_of "SET pgcolumnar.enable_index_fetch_penalty=on;
+			EXPLAIN (COSTS OFF) SELECT c1,c2 FROM $t WHERE scat BETWEEN 1 AND $k")"; then
+			last="$(q1 "SELECT count(*) FROM $t WHERE scat BETWEEN 1 AND $k")"
+		else
+			break
+		fi
+	done
+	echo "$last"
+}
+FN="$(flip_rows ifw_n)"
+FW="$(flip_rows ifw_w)"
+echo "-- last row count still fetched by index:  narrow prefix ${WN}B = $FN rows,  wide prefix ${WW}B = $FW rows"
+
+check "premise: the narrow table does fetch by index somewhere on the ladder" \
+	"$([ "${FN:-0}" -gt 0 ] && echo yes || echo "no -- nothing to order")" "yes"
+
+# A wider decoded prefix makes every row-group decode dearer, so the wide table must
+# abandon per-row fetches no later than the narrow one. Priced by column COUNT the two
+# arms charge the same decode CPU and the wide table's larger page term pushes its
+# flip point HIGHER, which is the inversion #803 reports.
+check "a wider decoded prefix gives up on per-row fetches no later than a narrow one (#803)" \
+	"$([ "${FW:-0}" -le "${FN:-0}" ] && echo "ordered" \
+	   || echo "INVERTED (wide ${WW}B fetches to $FW rows, narrow ${WN}B only to $FN)")" "ordered"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -105,6 +105,7 @@ SUITES=(
 	import_deferred
 	import_exclusion
 	import_export_privilege
+	index_fetch_penalty_width
 	index_only
 	int8_agg_int128
 	isolation


### PR DESCRIPTION
Closes the flatness #803 reports, in the direction the measurement pointed rather than the one the issue assumed. Full measurement is in [#803](https://github.com/commandprompt/pgcolumnar/issues/803#issuecomment-5449266795); the short version is below.

I offered to let you call the shape before implementing. Taking it as far as a measured before/after seemed more useful than waiting on the question — if you want a different shape, say so and I will redo or drop it.

## The defect

`pgcolumnar_index_fetch_penalty` prices the row-group decode a per-row fetch forces:

```c
decode_per_group = seq_page_cost * pages_per_stripe
    + cpu_operator_cost * R * (double) nproj;      /* nproj is a COUNT */
```

A 68-byte text column is charged exactly what a 4-byte int4 column is.

## It is not a uniform under-charge — the ordering is inverted

That is the part worth the change. A wider decoded prefix makes every row-group decode dearer, so a wide table should abandon per-row fetches **sooner** than a narrow one. Priced by count it does the opposite, because the only term representing decode work is width-blind and the wide table's larger page term then pushes its flip point *higher*.

Two tables of identical shape whose columns differ only in type, so the decoded prefix is four columns on both arms and only bytes move:

```
                    model flips at      truly flips at
narrow (16 B)         40 - 60 rows      120 - 279 rows
wide   (138 B)       120 - 161 rows       40 - 120 rows
```

At 120 rows on the wide table the planner plans an index scan, and that plan measures **239.6 ms against an 82.9 ms scan** — 2.9x slower, on a stock build.

Read out of an instrumented build (`up/main` plus one `elog`), the CPU term is **200.00 on both arms** across an 8.6x width difference, while the same ~39,000-row fetch takes 4,385 ms narrow and 88,352 ms wide — 20.15x measured against 1.49x modelled. Cost per millisecond spans 13.4x, inside the 13x–22x #768 measured for the same flatness on the scan.

## The change

`pgcolumnar_scan_decode_shape` already walks the prefix `1..maxatt` summing `get_attavgwidth`. It now accumulates decode units in that same loop and returns them in place of the bare count; the penalty charges units.

**`pgcolumnar_projected_decode_units()` could not be substituted directly**, which is the one correction to the issue's guess. It sums the columns a query *references* (`pull_varattnos` over `reltarget->exprs` plus `baserestrictinfo`), while the fetch decodes the *prefix* up to the highest referenced column — that is the whole point of #363, where a query touching one late column decodes every column before it. On my fixture the two coincide, so a drop-in would have looked correct here and been wrong on exactly the shape #363 exists for. The reference-width macro moves up so both sites share one definition of a decode unit.

## After

```
                    before          after           measured truth
narrow flip       40 - 60 rows    40 - 60 rows      120 - 279 rows
wide   flip      120 - 161 rows    7 - 15 rows       40 - 120 rows
```

**The narrow arm does not move at all.** A 4-byte column is exactly one unit, so an all-int prefix is priced as before — that is the control that this is a width term and not a general inflation.

The wide arm's ordering is now right. It is also conservative: it gives up at 7–15 rows where the crossover is 40–120. I am not going to present that as a win it is not. But the narrow arm has been conservative by a similar factor all along (40–60 against 120–279), so after this change both widths err in the same direction and by a comparable factor, where before one was conservative and the other permissive. Trading a modest conservative loss on a narrow band for removing a demonstrated 2.9x wrong plan looks like the right side of that trade to me; if you would rather calibrate the absolute level too, that is a separate change and I would want a fixture ladder for it rather than a constant chosen from these two points.

The #376 bound is untouched, and `test/analyze_stats.sh` — which pins that the penalty must not over-fire on a clustered `ORDER BY` or a point lookup (#355, #362, #376) — passes unchanged.

## The guard, and its removal proof

`test/index_fetch_penalty_width.sh` pins the **ordering**, not the absolute row counts, which move with the cost constants. It reads plans, never the clock, so it is not a timing suite and `PGC_SKIP_TIMING` cannot drop it. Registered in `run_all_versions.sh`.

On this branch: 8 checks, all pass. On unfixed `main`, **all seven premises still pass** and only the ordering check fails:

```
-- last row count still fetched by index:  narrow prefix 16B = 40 rows,  wide prefix 138B = 120 rows
FAIL  a wider decoded prefix gives up on per-row fetches no later than a narrow one (#803):
      got [INVERTED (wide 138B fetches to 120 rows, narrow 16B only to 40)] want [ordered]
```

The premises passing on the failing build is the point: the failure is the ordering, not a fixture that fell over.

Premises asserted rather than assumed: both tables hold all 400,000 rows; both have the same row-group count and more groups than the fetch cache holds; the wide prefix really is wider by at least 4x; **both prefixes decode well under `COLUMNAR_FETCH_CACHE_MAX_BYTES`, so the width-aware overflow blend is inactive on both arms** and cannot be what the check is measuring; and the penalty is what moves the plan (index without it, not with it), so the check cannot pass vacuously.

The suite pins `pgcolumnar.stripe_row_limit` through the cluster config rather than `SET`, because the writing and planning sessions otherwise disagree about it — that is #806, filed out of this work, and this suite is written not to depend on it either way.

## Gate

- `test/run_all_versions.sh` on PostgreSQL 18.4 and 19beta2 assert builds, from base `35846a1`: **PG18 224 ran all PASS** (2 skipped: `native_repack`, `pg19_vacuum_options`), **PG19 226 ran all PASS**, exit 0. `harness_selftest` and `docs_style` both pass, and this PR edits `SUITES`, so the first one matters.
- Five-major build preflight `pg15a`–`pg19a`, each after `make clean`: all OK, **zero warnings**.
- An earlier gate on this branch failed `docs_style` on one 26-word sentence in my `docs/limitations.md` addition. Split into two; the run above is the fixed tree.

Closes #803.
