### PR TITLE
test: rebuild the one/many fetch fixture between readings (#801)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,29 @@ pinned at `1.0-dev` or `1.0-alpha`, each true until the next version shipped.
   is not one. A new harness selftest keeps the shared cluster config free of
   `pgcolumnar.*` GUCs; `PGC_EXTRA_CONF` remains the per-suite mechanism.
 
+- The `one/many` fetch cost guard in `test/native_fetch_cache.sh` now rebuilds
+  its fixture before every reading, and asserts the group geometry at each one
+  (#801). The guard could not fail. The `UPDATE` it times does not rewrite the
+  row group it reads: it marks the rows deleted and appends them as a new group,
+  so `fc_one` goes from one group of 20,000 rows to that group plus one of
+  2,000, and from the second reading on the rows it targets sit in the small
+  appended group. That is the geometry the `fc_many` control has, so the arms
+  stop differing after one reading, and `min3` returned one of the cheap
+  post-rewrite readings every run. Measured against a build whose fetch cache
+  retains nothing, so every fetch re-decodes: the guard read 0.98x and PASSED,
+  where rebuilding reads 5.89x and 6.13x on two runs and fails as it should. The
+  `#353` guard in the same file fails correctly on that build, which is what
+  shows the ablation was real. A per-fetch decode counter says it in rows rather
+  than milliseconds: `fc_one` decodes 40,000,000 rows on the first reading and
+  4,000,000 on the next two, and 40,000,000 on all three once the fixture is
+  rebuilt.
+
+  The new premise records the group count at each reading. Both faults it
+  covers were proved by mutation, each changing one thing: dropping the rebuild
+  records `1 2 3`, and an `INSERT` that populates nothing records `0 0 0`. The
+  timing check passed in both mutants, at 0.77x and 1.14x, so the premise is
+  what separates either fault from a green suite.
+
 - The fetch cache cost guards in `test/native_fetch_cache.sh` now assert that
   they reach the per-row fetch path, and set
   `pgcolumnar.enable_index_fetch_penalty = off` so that they do (#797). They had

--- a/test/native_fetch_cache.sh
+++ b/test/native_fetch_cache.sh
@@ -100,15 +100,88 @@ min3() {  # min3 FUNC ARG...
 	printf '%s\n' "$a" "$b" "$c" | sort -n | head -1
 }
 
-build fc_one "$ROWS"          # every row in a single row group
-build fc_many $((ROWS / 10))  # the same rows across ten
+# THE FIXTURE HAS TO BE REBUILT BETWEEN READINGS, because the measured statement
+# destroys the geometry it measures (#801).
+#
+# An UPDATE on a columnar table does not rewrite the group it read. It marks the
+# rows deleted and appends them as a NEW group. So the first reading of fc_one
+# leaves groups 1:20000 and 2:2000, and every later reading finds the rows it
+# targets in the small appended group -- exactly the geometry fc_many has. The
+# two arms stop differing after one reading.
+#
+# min3 then takes a minimum across two different fixtures, and the post-rewrite
+# readings are the fast ones, so it returns one of them every time. That is why
+# the guard could not fail. Measured with a per-fetch decode counter, against a
+# build whose fetch cache retains nothing so every fetch re-decodes:
+#
+#              reading 1   reading 2   reading 3     this suite's verdict
+#   reused      629 ms       81 ms       96 ms        PASS 0.98x   <- false
+#   rebuilt     617 ms      623 ms      620 ms        FAIL 6.13x   <- correct
+#
+# The per-reading times come from a standalone probe, which prints them. The
+# verdicts come from running this suite whole against that same .so, once with
+# each form of the fixture handling, so they are two runs and not one. The
+# rebuilt figure was 5.89x and 6.13x on the two runs of it.
+#
+# The #353 guard below fails on that .so as well, at 6.48x against its 5x
+# bound, which is what shows the ablation was real rather than a build that did
+# nothing. On a stock .so this ratio has read 0.63x, 0.76x, 0.77x, 0.92x and
+# 1.00x, the 0.76x under the matrix running six suites at once. So the bound of
+# 3 sits about three times above the worst passing reading and about half the
+# smallest failing one.
+#
+# The decode counter says the same thing in rows rather than milliseconds:
+# reused, fc_one decodes 40,000,000 rows on the first reading and 4,000,000 on
+# the next two; rebuilt, it decodes 40,000,000 on all three.
+min3_fresh() {  # table, rows-per-group -- rebuild before every reading
+	local a b c
+	build "$1" "$2" >/dev/null; geom_seen "$1"; a="$(upd_ms "$1")"
+	build "$1" "$2" >/dev/null; geom_seen "$1"; b="$(upd_ms "$1")"
+	build "$1" "$2" >/dev/null; geom_seen "$1"; c="$(upd_ms "$1")"
+	printf '%s\n' "$a" "$b" "$c" | sort -n | head -1
+}
 
-one="$(min3 upd_ms fc_one)"
-many="$(min3 upd_ms fc_many)"
+# The premise the ratio rests on, recorded at the moment of each reading rather
+# than once at the start: the number of row groups the table is laid out in.
+# A rebuild that stopped happening, or a stripe limit that stopped being
+# honoured, shows up here as "1 2 3" instead of "1 1 1" -- which is precisely
+# the state that produced the false green above.
+#
+# It doubles as the fixture's row-count premise. build's output is discarded so
+# that three rebuilds do not print three copies of its notices, so an INSERT
+# that died would otherwise be silent; an empty table has no row groups at all
+# and records "0 0 0" here.
+#
+# Both halves were proved by mutation, each changing one thing and nothing else.
+# Dropping the rebuild records "1 2 3" for fc_one and "10 11 12" for fc_many;
+# making the INSERT populate nothing records "0 0 0" for both. In BOTH mutants
+# the ratio check below still passed -- at 0.77x and at 1.14x -- so this premise
+# is the only thing standing between either fault and a green suite.
+#
+# A record accumulates in a file rather than a variable because each reading
+# runs inside the command substitution that captures the timing, so an
+# assignment would not survive it. xargs normalises the separators, so the
+# expected value below is not carrying an invisible trailing space.
+geom_seen() {  # table -- append this reading's group count to its record
+	q "SELECT count(*) FROM pgcolumnar.row_group r
+		JOIN pgcolumnar.storage s USING (storage_id)
+		WHERE s.relation_oid = '$1'::regclass" >> "$PGC_WORKDIR/geom.$1"
+}
+
+: > "$PGC_WORKDIR/geom.fc_one"
+: > "$PGC_WORKDIR/geom.fc_many"
+one="$(min3_fresh fc_one "$ROWS")"          # every row in a single row group
+many="$(min3_fresh fc_many $((ROWS / 10)))" # the same rows across ten
 echo "-- $UPD fetches: one group of $ROWS took ${one} ms; ten groups took ${many} ms"
 
-# Without the cache the single-group case decodes ten times as much per fetch and
-# lands near 10x. With it, both are dominated by the fetches and sit near 1x.
+check "every fc_one reading measured one row group (#801)" \
+	"$(xargs < "$PGC_WORKDIR/geom.fc_one")" "1 1 1"
+check "every fc_many reading measured ten row groups (#801)" \
+	"$(xargs < "$PGC_WORKDIR/geom.fc_many")" "10 10 10"
+
+# Without the cache the single-group case decodes ten times as much per fetch.
+# Measured at 6.13x on the build described above; with the cache both are
+# dominated by the fetches themselves and the ratio sits at or below 1x.
 check_ratio "fetching from one big group is not far dearer than from ten small ones" \
 	"$one" "$many" "3"
 


### PR DESCRIPTION
Closes #801.

The `one/many` fetch cost guard could not fail. It passes on a build with no
fetch cache at all. This rebuilds its fixture before every reading and asserts
the geometry the ratio depends on at each one.

## What was wrong

The arms differ exactly as the guard's comment says they do -- 10:1 in decode
work -- for one reading. Then the measured statement destroys the geometry it is
measuring.

A columnar `UPDATE` does not rewrite the row group it read. It marks the rows
deleted and appends them as a **new** group. Read straight out of
`pgcolumnar.row_group`:

```
fc_one   before any UPDATE : 1 groups  | 1:20000
  reading 1: 629 ms   after: 2 groups  | 1:20000, 2:2000
  reading 2:  81 ms   after: 3 groups  | 1:20000, 2:2000, 3:2000
  reading 3:  96 ms   after: 4 groups  | 1:20000, 2:2000, 3:2000, 4:2000
```

From reading 2 on, the rows `id <= 2000` live in an appended 2,000-row group --
the geometry the `fc_many` control has. The arms stop differing, and `min3`
takes its minimum across two different fixtures. The post-rewrite readings are
the cheap ones, so it returns one of them every run.

An instrumented build counting decodes per statement says the same thing in
rows. `fc_one`, cache ablated so every fetch re-decodes:

```
reused fixture    reading 1  decoded_rows=40,000,000
                  reading 2  decoded_rows= 4,000,000
                  reading 3  decoded_rows= 4,000,000
rebuilt fixture   readings 1-3 all       40,000,000
```

The suite had already met the value half of this problem -- its own comment
records that `upd_ms` once updated with `v = v + 1`, "fine once and wrong three
times" -- and fixed the arithmetic. The physical layout kept drifting.

## Removal proof

One `.so` with the fetch cache ablated to retain nothing (every lookup misses),
built from the same tree. The counters prove the ablation took: `hit=0
miss=2000` against `hit=1999 miss=1`.

Three full runs of the suite. **Arms 2 and 3 are the same `.so`; only the test
file differs**, so nothing but the fixture handling separates them:

```
arm  suite     .so                     one/many verdict                suite
 1   fixed     e18bafcb2ee3 stock      PASS  1.00x  (48 / 48)          18 PASS 0 FAIL
 2   shipped   3edded559008 ABLATED    PASS  0.98x  (83 / 85)  <- FALSE 15 PASS 1 FAIL
 3   fixed     3edded559008 ABLATED    FAIL  6.13x  (601 /  98)        16 PASS 2 FAIL
```

The positive control is in the same file: in both ablated arms the `#353` guard
fails correctly, at 7.74x and 7.99x against its 5x bound. `one/many` was the one
guard that sat through it.

## The premise, and why it is not decorative

`pgc_uses_row_fetch` is the wrong premise here and stays unused -- the plan is a
`Custom Scan` either way, so asserting an index scan would be a false red, as
#798 documented. The premise that does discriminate is the group geometry,
recorded **at each reading** rather than once at the start:

```
PASS  every fc_one reading measured one row group (#801)      1 1 1
PASS  every fc_many reading measured ten row groups (#801)   10 10 10
```

It passes in all three arms above, including the ablated ones, because it
asserts the fixture and not the cache. Both faults it covers were proved by
mutation, each changing one thing and nothing else, on a stock `.so`:

```
mutation                          fc_one     fc_many      the ratio check
rebuild removed                   1 2 3      10 11 12     PASS 0.77x
INSERT populates nothing          0 0 0      0 0 0        PASS 1.14x
```

**The ratio check passed in both mutants.** That is the point of the premise: it
is not a second opinion alongside the timing, it is the only thing between
either fault and a green suite. The first mutation is the shipped behaviour, so
its `1 2 3` is the state that produced the false green. The second is why
`build`'s output can be discarded without the fixture failing silently.

## Two figures I could not confirm

* The guard's comment predicted "near 10x" without the cache. The decode work is
  10:1, but the `UPDATE` also scans, writes, maintains the index and makes 6,902
  zero-decode liveness calls, so the measured ratio is 5.89x. The comment now
  carries the measured figure.
* `pgc_uses_row_fetch`'s comment in `lib.sh` cites 20,366 fetch calls for a
  2,000-row `UPDATE`. That is a total across entry points, and most of it does
  not decode: I measure 2,000 decoding calls to 6,902 that return at the
  `!wantValues` early exit. **I have not changed that comment** -- its
  conclusion is right and the number is not load-bearing for it -- but it should
  not be read as a decode count.

## Scope

Test and CHANGELOG only. No `src/` change, so `PGC_SKIP_BUILD` is not in play
anywhere here. The `#353` and `#359` guards in the same file are untouched and
unaffected: both are `SELECT`s, and neither writes.

## Gate

```
run_all_versions.sh, PG18 and PG19, assert builds:
  PASS  PG18  223 ran, 2 skipped (native_repack, pg19_vacuum_options)
  PASS  PG19  225 ran, 0 skipped
  ALL VERSIONS PASSED, exit 0
  native_fetch_cache=PASS on both

build_all_versions.sh across five majors, explicit pg_config paths:
  OK  15.18  0 warnings     OK  16.14  0 warnings     OK  17.6   0 warnings
  OK  18.4   0 warnings     OK  19beta2 0 warnings
```

The preflight needs those paths spelled out on this box. Run with no arguments
it takes the default `/usr/local/pg15..pg19`, every one of which is absent here,
and prints `PASSED` with exit 0 having built nothing. I nearly reported that as
a five-major pass.

**Composed against everything else in flight.** `main` + #804 + #805 + #807 +
this branch merges with one conflict, in `CHANGELOG.md`, resolved by keeping
both entries. No source or test conflict. The full matrix on that composed tree:
PG18 224 ran 2 skipped, PG19 226 ran, exit 0, with `native_fetch_cache`,
`index_fetch_penalty_width`, `scan_decode_cost`,
`native_index_fetch_stripe_cost`, `harness_selftest` and `docs_style` all
passing on both majors.
