### PR TITLE
test: make the preflight report what it built, and refuse zero (#809)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,27 @@ true until the next version shipped.
   rather than resizes because the two disagree: the first instrument counted
   resizes and reported that sizing removed 7 of 10 while it removed about a
   quarter of the rehashing, the work being dominated by the last two steps.
+### Fixed
+
+- `test/build_all_versions.sh` now reports how many majors it built and refuses
+  a run that built none (#809). Its verdict read only the `failed` flag, which
+  only a build that RUNS and FAILS sets, so a `pg_config` that is not executable
+  was skipped without touching it. A run where every major was skipped reached
+  the end with `failed=0` and printed `PASSED` with exit 0, having invoked no
+  compiler.
+
+  That is not hypothetical: the default list is `/usr/local/pg15`, `pg16`,
+  `pg17`, `pgsql` and `pg19`, and a machine whose builds live elsewhere skips
+  all five. It was recorded as a green five-major preflight for a pull request
+  and caught by reading the body above the verdict rather than by any check.
+
+  The script now prints `built N of M` before its verdict, in the same shape
+  `test/run_all_versions.sh` already uses for `versions run: N of M configured`,
+  and fails on zero with the invocation that names the paths. A PARTIAL run is
+  deliberately left passing: whether three of five present should fail or warn
+  is a judgement about how people run this, and the count makes it visible
+  either way. A new `harness_selftest` case pins all three behaviours, since
+  nothing covered this script before.
 
 ### Added
 

--- a/test/build_all_versions.sh
+++ b/test/build_all_versions.sh
@@ -41,6 +41,7 @@ fi
 echo "== pgColumnar build check across majors =="
 
 failed=0
+built=0
 for pgc in "${CONFIGS[@]}"; do
 	if [ ! -x "$pgc" ]; then
 		printf '  SKIP  %-34s (not executable)\n' "$pgc"
@@ -55,6 +56,7 @@ for pgc in "${CONFIGS[@]}"; do
 		# -Werror is not set, so a warning still builds; report it rather than
 		# let a new one accumulate unnoticed across majors.
 		warns="$(grep -cE '^[^ ].*\bwarning:' "$log")"
+		built=$((built + 1))
 		printf '  OK    %-34s %s warning(s)\n' "$ver" "$warns"
 		[ "$warns" != "0" ] && grep -E '^[^ ].*\bwarning:' "$log" | head -5 | sed 's/^/          /'
 	else
@@ -69,8 +71,30 @@ done
 # build against a different major would link objects compiled for this one.
 make -C "$SRCDIR" clean >/dev/null 2>&1 || true
 
+# What was actually compiled, next to what was asked for. Without this line the
+# verdict below collapses "built five" and "built none" into the same word: a
+# pg_config that is not executable is skipped above without touching `failed`,
+# so a run that invoked no compiler at all reached PASSED and exit 0 (#809). The
+# sibling run_all_versions.sh prints the same shape, `versions run: N of M`.
+echo "  built $built of ${#CONFIGS[@]}"
+
 if [ "$failed" != "0" ]; then
 	echo "build_all_versions.sh: FAILED"
+	exit 1
+fi
+
+# Zero is refused rather than reported. A preflight that compiled nothing has
+# not answered the question it was run to answer, and the most likely cause is
+# that this machine keeps its builds somewhere other than the default list --
+# which is a reason to name the paths, not a reason to call the run clean.
+#
+# A PARTIAL run is deliberately left passing. Whether three of five present
+# should fail or warn is a judgement about how people run this; the count above
+# makes it visible either way, and only the zero case is unambiguously wrong.
+if [ "$built" = "0" ]; then
+	echo "build_all_versions.sh: FAILED (built nothing: every pg_config was skipped)"
+	echo "       name the pg_config paths explicitly, e.g."
+	echo "       test/build_all_versions.sh /usr/local/pg15a/bin/pg_config ..."
 	exit 1
 fi
 echo "build_all_versions.sh: PASSED"

--- a/test/selftest/290-a-preflight-that-built-nothing.sh
+++ b/test/selftest/290-a-preflight-that-built-nothing.sh
@@ -1,0 +1,61 @@
+# A preflight that built nothing must not report PASSED.
+#
+# test/build_all_versions.sh answers "does this compile on every major". Its
+# verdict reads only `failed`, and only a build that RUNS and FAILS sets it. A
+# pg_config that is not executable takes the `continue` above that, so a run
+# where every major was skipped reaches the end with failed=0 and prints
+# PASSED, exit 0, having invoked no compiler at all.
+#
+# FOUND THE EXPENSIVE WAY, 2026-08-28 (#809). The defaults are /usr/local/pg15,
+# pg16, pg17, pgsql and pg19. The audit container has none of them -- every
+# assert build there is a-suffixed, pg15a through pg19a -- so the no-argument
+# form can never build anything on that machine. It was recorded as a green
+# five-major preflight for a pull request and caught only by reading the body
+# above the verdict:
+#
+#   SKIP  /usr/local/pg15/bin/pg_config      (not executable)     [x5]
+#   build_all_versions.sh: PASSED
+#
+# WHY A COUNT RATHER THAN A STRICTER DEFAULT LIST. Hard-coding this box's paths
+# would move the problem to the next machine. The verdict is what is wrong: it
+# collapses "built five" and "built none" into one word. Its sibling
+# run_all_versions.sh already prints `versions run: N of M configured`, and that
+# line is the whole fix -- a reader sees the denominator, and zero is refused.
+#
+# SCOPE. This pins the all-skip case only. Whether a PARTIAL run (three of five
+# present) should fail or warn is a judgement about how people run this, and is
+# deliberately not decided here.
+
+_bav_src="$PGC_TESTDIR/build_all_versions.sh"
+
+# Run a COPY, in a scratch tree, because the real script ends with
+# `make -C "$SRCDIR" clean` and SRCDIR is derived from the script's own
+# location. Run in place, this selftest would wipe the object tree of the very
+# build the surrounding suite is testing. In the scratch tree that make has no
+# Makefile to find and fails into the script's own `|| true`.
+_bav_dir="$(mktemp -d)"
+mkdir -p "$_bav_dir/test"
+cp "$_bav_src" "$_bav_dir/test/build_all_versions.sh"
+
+# Three pg_config paths that certainly do not exist, so every major skips.
+_bav_out="$(bash "$_bav_dir/test/build_all_versions.sh" \
+	/nonexistent-a/bin/pg_config /nonexistent-b/bin/pg_config \
+	/nonexistent-c/bin/pg_config 2>&1)"
+_bav_rc=$?
+rm -rf "$_bav_dir"
+
+# PREMISE. The arm has to actually be the all-skip case. If a path above ever
+# existed, or the skip line were reworded, every assertion below would be
+# testing a run that did something, and would pass or fail for the wrong reason.
+check "premise: the probe run skipped every major" \
+	"$(printf '%s\n' "$_bav_out" | grep -c 'SKIP')" "3"
+check "premise: and it built none of them" \
+	"$(printf '%s\n' "$_bav_out" | grep -cE '^[[:space:]]*OK')" "0"
+
+# The three things a verdict on zero builds must do.
+check "a preflight that built nothing says how many it built" \
+	"$(printf '%s\n' "$_bav_out" | grep -cE 'built 0 of 3')" "1"
+check "a preflight that built nothing does not report PASSED" \
+	"$(printf '%s\n' "$_bav_out" | grep -c 'build_all_versions.sh: PASSED')" "0"
+check "a preflight that built nothing exits non-zero" \
+	"$([ "$_bav_rc" -ne 0 ] && echo nonzero || echo "zero")" "nonzero"


### PR DESCRIPTION
Closes #809.

`test/build_all_versions.sh` reported `PASSED` and exited 0 when it had built
nothing.

## The verdict could not see it

`failed` is the only thing the verdict reads, and only a build that *runs and
fails* sets it. The skip branch `continue`s before that, so a run where every
major was skipped reached the end with `failed=0`:

```
== pgColumnar build check across majors ==
  SKIP  /usr/local/pg15/bin/pg_config      (not executable)
  SKIP  /usr/local/pg16/bin/pg_config      (not executable)
  SKIP  /usr/local/pg17/bin/pg_config      (not executable)
  SKIP  /usr/local/pgsql/bin/pg_config     (not executable)
  SKIP  /usr/local/pg19/bin/pg_config      (not executable)
build_all_versions.sh: PASSED
exit=0
```

Zero compilers invoked, green. **I recorded that as the five-major preflight for
a pull request** and caught it only by reading the body above the verdict. The
defaults are `/usr/local/pg15`, `pg16`, `pg17`, `pgsql`, `pg19`; any machine
whose builds live elsewhere gets this, and on the audit container -- where every
assert build is `a`-suffixed -- the no-argument form can never build anything.

## The fix is the line the sibling already prints

`test/run_all_versions.sh` ends with `versions run: 2 of 2 configured`. This now
prints the same shape before its verdict, and refuses zero:

```
  built 5 of 5                     <- the real run, five majors named explicitly
  built 0 of 1                     <- and this now FAILS, exit 1, with the
                                      invocation that names the paths
```

**A partial run is deliberately left passing.** Whether three of five present
should fail or warn is a judgement about how people run this, and I would rather
you make it than have me make it silently. The count makes the situation visible
either way; only zero is unambiguously wrong.

## Red first

`test/selftest/290-a-preflight-that-built-nothing.sh`, run against unmodified
`main`:

```
FAIL  a preflight that built nothing says how many it built: got [0] want [1]
FAIL  a preflight that built nothing does not report PASSED: got [1] want [0]
FAIL  a preflight that built nothing exits non-zero: got [zero] want [nonzero]
                                                       165 PASS / 3 FAIL
```

With the fix, **168 PASS / 0 FAIL** -- the same three flipped and nothing else
moved. That red run against `main` is the removal proof: the mutation is the fix
being absent.

Both premises pass in the red arm too (`skipped every major` = 3,
`built none of them` = 0), so the red is the verdict and not a collapsed
fixture.

## One thing the selftest has to do carefully

It runs a **copy** of the script in a scratch tree. The real one ends with
`make -C "$SRCDIR" clean`, and `SRCDIR` is derived from the script's own
location -- so run in place, this selftest would wipe the object tree of the
very build the surrounding suite is testing. In the scratch tree that `make`
finds no Makefile and falls into the script's own `|| true`.

## Gate

```
run_all_versions.sh   PG18  224 ran, 2 skipped (native_repack, pg19_vacuum_options)
                      PG19  226 ran, 0 skipped        ALL VERSIONS PASSED, exit 0
build_all_versions.sh 15.18 / 16.14 / 17.6 / 18.4 / 19beta2, 0 warnings each
                      built 5 of 5
```

That preflight line is the first run of it on this box that was incapable of
reporting green having built nothing.

`docs_style` passes. No `src/` change, so `PGC_SKIP_BUILD` is not in play.
