### PR TITLE
parallel_copy can refuse a load it has already taken (#403 item 7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,40 @@ true until the next version shipped.
 
 ## [Unreleased]
 
+### Added
+
+- `pgcolumnar.parallel_copy` can refuse a load it has already taken, with
+  `dedup => true` (#403 item 7). A load that commits, whose acknowledgement the
+  client never receives, is retried and the rows go in twice: measured, the same
+  file loaded twice gives 100,000 rows and then 200,000.
+
+  With `dedup`, the SHA-256 of the file is recorded in the new
+  `pgcolumnar.load_fingerprint` catalog after a successful load. A later load of
+  the same contents into the same table stores nothing, returns 0, and raises a
+  `NOTICE` rather than failing. A file whose contents changed is a different load
+  and is stored, even at the same path.
+
+  It is off by default, because discarding rows a caller asked to store is not
+  ordinary `INSERT` behavior.
+
+  The unit is the whole load rather than a "part". `parallel_copy` is atomic
+  through 2PC, proved by a malformed row at line 50,001 leaving 0 rows and 0
+  prepared transactions, so parts never commit independently and a part hash
+  would deduplicate nothing that is not already all-or-nothing.
+
+  The check runs after every worker has prepared and before anything commits,
+  which is the only point at which a repeat can be refused without charging every
+  load for it. A refused load therefore does its work and discards it. The
+  alternative, hashing before dispatch, costs 42% of a 264 MiB load; as
+  implemented the fingerprint has no measurable cost, because the coordinator
+  computes it while the loaders are already reading the same file.
+
+  Three limits, all stated in `docs/sql-reference.md`: the fingerprint is
+  recorded after the data commits, so a crash between them leaves data that a
+  retry will store again; two identical loads running at once both store, because
+  each checks the record before either writes it; and a refused load still reads
+  and parses the file.
+
 ### Changed
 
 - Chunk-group skip predicates are now evaluated most-selective-first, so a group

--- a/docs/sql-reference.md
+++ b/docs/sql-reference.md
@@ -457,7 +457,7 @@ SELECT pgcolumnar.import_parquet('events_copy', '/tmp/events.parquet');
 SELECT pgcolumnar.import_parquet('events_copy', '/data/events/');
 ```
 
-### pgcolumnar.parallel_copy(target regclass, filename text, workers int DEFAULT NULL) returns bigint
+### pgcolumnar.parallel_copy(target regclass, filename text, workers int DEFAULT NULL, dedup boolean DEFAULT false) returns bigint
 
 Loads a text file into a columnar table with several background workers at once,
 as one atomic operation. Returns the number of rows loaded. The caller needs
@@ -485,6 +485,42 @@ count, because the load prepares one transaction per worker.
 When `workers` is omitted the function derives a value from the target. For a
 partitioned target it lowers `workers` to the partition count when the count is
 smaller.
+
+#### Refusing a load this table has already taken
+
+A load that commits, whose acknowledgement the client never receives, is retried,
+and the rows go in twice. Pass `dedup => true` to refuse the repeat.
+
+With `dedup`, the function records the SHA-256 of the file after a successful
+load, in `pgcolumnar.load_fingerprint`. A later load of a file with the same
+contents into the same table stores nothing, returns 0, and raises a `NOTICE`
+saying why. It does not fail. A file whose contents changed is a different load
+and is stored, even at the same path.
+
+`dedup` is off by default. Discarding rows a caller asked to store is not
+ordinary `INSERT` behavior, so it happens only when asked for, and only on this
+function.
+
+Three limits apply.
+
+The fingerprint is recorded after the data commits. A crash between the two
+leaves the data stored and unrecorded, so a later retry stores it again. That is
+the behavior without `dedup` and is the safe direction.
+
+Two identical loads running at the same time both store their rows. Each checks
+the record before either writes it. `dedup` refuses a load that follows a
+completed one; it does not serialize concurrent loads.
+
+A refused load still does the work. The rows are read, parsed and written, and
+then discarded without being made visible, because the check happens after every
+worker has prepared. The alternative costs every load a serial pass over the file
+before any worker starts. Measured on a 264 MiB file, that pass takes 42% of the
+load, while the fingerprint as implemented has no measurable cost.
+
+```sql
+-- refuse a repeat of a load this table has already taken
+SELECT pgcolumnar.parallel_copy('events', '/data/events.txt', 8, true);
+```
 
 ```sql
 -- single columnar table, any row order

--- a/pgcolumnar--1.0-alpha2--1.0-alpha3.sql
+++ b/pgcolumnar--1.0-alpha2--1.0-alpha3.sql
@@ -33,7 +33,7 @@ CREATE TABLE pgcolumnar.load_fingerprint (
 -- check before either records, both commit, and the loser's record insert would
 -- fail, reporting failure for a load that succeeded. A duplicate record is
 -- harmless; a false failure is not.
-CREATE INDEX load_fingerprint_pkey
+CREATE INDEX load_fingerprint_idx
 	ON pgcolumnar.load_fingerprint USING btree (relation_oid, fingerprint);
 
 -- Two functions gain a parameter, which changes their signatures, so neither can

--- a/pgcolumnar--1.0-alpha2--1.0-alpha3.sql
+++ b/pgcolumnar--1.0-alpha2--1.0-alpha3.sql
@@ -9,9 +9,47 @@
  */
 \echo Use "ALTER EXTENSION pgcolumnar UPDATE" to load this file. \quit
 
--- sort_status gains an OUT parameter (#761), which changes its signature, so it
--- cannot be a CREATE OR REPLACE.
+-- New catalog for pgcolumnar.parallel_copy's opt-in load dedup (#403 item 7).
+-- Loads pgcolumnar.parallel_copy has already performed, for its opt-in dedup
+-- (#403 item 7). One row per (table, file fingerprint) that committed.
+--
+-- The fingerprint is the SHA-256 of the loaded file's bytes, so a file that
+-- changed at the same path is a different load. Path, size and mtime would all
+-- call that the same file.
+--
+-- The row is written AFTER the data commits, never before. A crash between the
+-- two leaves data with no fingerprint, so a retry loads again, which is the
+-- behaviour without this feature and is the safe direction. The reverse order
+-- would leave a fingerprint with no data and refuse rows that were never stored.
+CREATE TABLE pgcolumnar.load_fingerprint (
+	relation_oid oid NOT NULL,
+	fingerprint bytea NOT NULL,       -- SHA-256 of the file's bytes
+	rows bigint NOT NULL,
+	loaded_at timestamptz NOT NULL DEFAULT now()
+);
+-- NOT unique, deliberately. The lookup is an existence test, and a unique
+-- index would turn the one case that can produce a second row into an ERROR
+-- raised AFTER the data committed: two concurrent loads of the same file both
+-- check before either records, both commit, and the loser's record insert would
+-- fail, reporting failure for a load that succeeded. A duplicate record is
+-- harmless; a false failure is not.
+CREATE INDEX load_fingerprint_pkey
+	ON pgcolumnar.load_fingerprint USING btree (relation_oid, fingerprint);
+
+-- Two functions gain a parameter, which changes their signatures, so neither can
+-- be a CREATE OR REPLACE: sort_status (#761) and parallel_copy (#403 item 7).
 DROP FUNCTION IF EXISTS pgcolumnar.sort_status(regclass);
+DROP FUNCTION IF EXISTS pgcolumnar.parallel_copy(regclass, text, int);
+
+CREATE FUNCTION pgcolumnar.parallel_copy(target regclass, filename text,
+										 workers int DEFAULT NULL,
+										 dedup boolean DEFAULT false)
+	RETURNS bigint
+	LANGUAGE C
+	AS 'MODULE_PATHNAME', 'pgcolumnar_parallel_copy';
+
+COMMENT ON FUNCTION pgcolumnar.parallel_copy(regclass, text, int, boolean)
+	IS 'atomic parallel bulk load of a COPY text file into a columnar table using background workers: a single columnar table (any row order), or a RANGE-partitioned columnar table sorted by the partition key with one distinct partition set per worker (#300). With dedup, a file already loaded into this table is refused rather than loaded twice (#403)';
 
 CREATE FUNCTION pgcolumnar.sort_status(
 	rel regclass,

--- a/pgcolumnar--1.0-alpha3.sql
+++ b/pgcolumnar--1.0-alpha3.sql
@@ -258,6 +258,32 @@ CREATE TABLE pgcolumnar.bloom (
 CREATE UNIQUE INDEX bloom_pkey
 	ON pgcolumnar.bloom USING btree (storage_id, group_number, column_index);
 
+-- Loads pgcolumnar.parallel_copy has already performed, for its opt-in dedup
+-- (#403 item 7). One row per (table, file fingerprint) that committed.
+--
+-- The fingerprint is the SHA-256 of the loaded file's bytes, so a file that
+-- changed at the same path is a different load. Path, size and mtime would all
+-- call that the same file.
+--
+-- The row is written AFTER the data commits, never before. A crash between the
+-- two leaves data with no fingerprint, so a retry loads again, which is the
+-- behaviour without this feature and is the safe direction. The reverse order
+-- would leave a fingerprint with no data and refuse rows that were never stored.
+CREATE TABLE pgcolumnar.load_fingerprint (
+	relation_oid oid NOT NULL,
+	fingerprint bytea NOT NULL,       -- SHA-256 of the file's bytes
+	rows bigint NOT NULL,
+	loaded_at timestamptz NOT NULL DEFAULT now()
+);
+-- NOT unique, deliberately. The lookup is an existence test, and a unique
+-- index would turn the one case that can produce a second row into an ERROR
+-- raised AFTER the data committed: two concurrent loads of the same file both
+-- check before either records, both commit, and the loser's record insert would
+-- fail, reporting failure for a load that succeeded. A duplicate record is
+-- harmless; a false failure is not.
+CREATE INDEX load_fingerprint_pkey
+	ON pgcolumnar.load_fingerprint USING btree (relation_oid, fingerprint);
+
 /* ---------------------------------------------------------------------------
  * pgcolumnar.free_space (Phase F physical reclaim)
  *
@@ -1205,13 +1231,14 @@ COMMENT ON FUNCTION pgcolumnar.file_split_offsets(text, int)
 -- the loaders would block on that lock and the wait is invisible to the deadlock
 -- detector. See design/PARALLEL_COPY_PLAN.md.
 CREATE FUNCTION pgcolumnar.parallel_copy(target regclass, filename text,
-										 workers int DEFAULT NULL)
+										 workers int DEFAULT NULL,
+										 dedup boolean DEFAULT false)
 	RETURNS bigint
 	LANGUAGE C
 	AS 'MODULE_PATHNAME', 'pgcolumnar_parallel_copy';
 
-COMMENT ON FUNCTION pgcolumnar.parallel_copy(regclass, text, int)
-	IS 'atomic parallel bulk load of a COPY text file into a columnar table using background workers: a single columnar table (any row order), or a RANGE-partitioned columnar table sorted by the partition key with one distinct partition set per worker (#300)';
+COMMENT ON FUNCTION pgcolumnar.parallel_copy(regclass, text, int, boolean)
+	IS 'atomic parallel bulk load of a COPY text file into a columnar table using background workers: a single columnar table (any row order), or a RANGE-partitioned columnar table sorted by the partition key with one distinct partition set per worker (#300). With dedup, a file already loaded into this table is refused rather than loaded twice (#403)';
 
 /*
  * Per-column statistics without reading the whole table (#414).

--- a/pgcolumnar--1.0-alpha3.sql
+++ b/pgcolumnar--1.0-alpha3.sql
@@ -281,7 +281,7 @@ CREATE TABLE pgcolumnar.load_fingerprint (
 -- check before either records, both commit, and the loser's record insert would
 -- fail, reporting failure for a load that succeeded. A duplicate record is
 -- harmless; a false failure is not.
-CREATE INDEX load_fingerprint_pkey
+CREATE INDEX load_fingerprint_idx
 	ON pgcolumnar.load_fingerprint USING btree (relation_oid, fingerprint);
 
 /* ---------------------------------------------------------------------------

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -644,6 +644,15 @@ extern uint64 PgColumnarVectorDecodes(PgColumnarReadState *readState);
 extern uint64 PgColumnarVectorsRuledOutByValue(PgColumnarReadState *readState);
 extern uint64 PgColumnarZoneMapProbes(PgColumnarReadState *readState);
 
+/* pgcolumnar.parallel_copy load dedup (#403 item 7) */
+extern bool PgColumnarLoadFingerprintSeen(Oid relationOid,
+										  const uint8 *fingerprint,
+										  int fingerprintLen,
+										  Snapshot snapshot);
+extern void PgColumnarRecordLoadFingerprint(Oid relationOid,
+											const uint8 *fingerprint,
+											int fingerprintLen, int64 rows);
+
 /*
  * How many of the scan keys the reader was handed became skip predicates it can
  * actually exclude a chunk group with (#479). Never larger than the scan-key

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -2427,7 +2427,7 @@ PgColumnarInsertBloomRow(const NativeBloomMetadata *b)
  *		Has this exact file already been loaded into this table by a committed
  *		pgcolumnar.parallel_copy (#403 item 7)?
  *
- *		Keyed by (relation_oid, fingerprint), which is load_fingerprint_pkey, so
+ *		Keyed by (relation_oid, fingerprint), which is load_fingerprint_idx, so
  *		this is an exact index lookup. The fingerprint is the SHA-256 of the
  *		file's bytes: a file that changed at the same path is a different load.
  */
@@ -2452,7 +2452,7 @@ PgColumnarLoadFingerprintSeen(Oid relationOid, const uint8 *fingerprint,
 	ScanKeyInit(&key[1], Anum_load_fingerprint_fingerprint, BTEqualStrategyNumber,
 				F_BYTEAEQ, PointerGetDatum(fp));
 
-	idxOid = pgcolumnar_index_oid("load_fingerprint_pkey");
+	idxOid = pgcolumnar_index_oid("load_fingerprint_idx");
 	scan = systable_beginscan(rel, idxOid, OidIsValid(idxOid), snapshot, 2, key);
 	tuple = systable_getnext(scan);
 	found = HeapTupleIsValid(tuple);

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -109,6 +109,13 @@
 #define Anum_bloom_filter 4
 #define Natts_bloom 4
 
+/* pgcolumnar.load_fingerprint (#403 item 7) */
+#define Anum_load_fingerprint_relation_oid 1
+#define Anum_load_fingerprint_fingerprint 2
+#define Anum_load_fingerprint_rows 3
+#define Anum_load_fingerprint_loaded_at 4
+#define Natts_load_fingerprint 4
+
 /* attribute numbers for columnar.free_space (Phase F physical reclaim) */
 #define Anum_free_space_storage_id 1
 #define Anum_free_space_file_offset 2
@@ -2408,6 +2415,84 @@ PgColumnarInsertBloomRow(const NativeBloomMetadata *b)
 	values[Anum_bloom_group_number - 1] = Int64GetDatum((int64) b->groupNumber);
 	values[Anum_bloom_column_index - 1] = Int16GetDatum((int16) b->columnIndex);
 	values[Anum_bloom_filter - 1] = PointerGetDatum(filt);
+
+	tuple = heap_form_tuple(tupdesc, values, nulls);
+	metadata_flush_insert(rel, tuple);
+	heap_freetuple(tuple);
+	metadata_flush_close(rel, RowExclusiveLock);
+}
+
+/*
+ * PgColumnarLoadFingerprintSeen
+ *		Has this exact file already been loaded into this table by a committed
+ *		pgcolumnar.parallel_copy (#403 item 7)?
+ *
+ *		Keyed by (relation_oid, fingerprint), which is load_fingerprint_pkey, so
+ *		this is an exact index lookup. The fingerprint is the SHA-256 of the
+ *		file's bytes: a file that changed at the same path is a different load.
+ */
+bool
+PgColumnarLoadFingerprintSeen(Oid relationOid, const uint8 *fingerprint,
+							  int fingerprintLen, Snapshot snapshot)
+{
+	Relation	rel = open_columnar_table("load_fingerprint", AccessShareLock);
+	ScanKeyData key[2];
+	SysScanDesc scan;
+	Oid			idxOid;
+	HeapTuple	tuple;
+	bytea	   *fp;
+	bool		found;
+
+	fp = (bytea *) palloc(VARHDRSZ + fingerprintLen);
+	SET_VARSIZE(fp, VARHDRSZ + fingerprintLen);
+	memcpy(VARDATA(fp), fingerprint, fingerprintLen);
+
+	ScanKeyInit(&key[0], Anum_load_fingerprint_relation_oid, BTEqualStrategyNumber,
+				F_OIDEQ, ObjectIdGetDatum(relationOid));
+	ScanKeyInit(&key[1], Anum_load_fingerprint_fingerprint, BTEqualStrategyNumber,
+				F_BYTEAEQ, PointerGetDatum(fp));
+
+	idxOid = pgcolumnar_index_oid("load_fingerprint_pkey");
+	scan = systable_beginscan(rel, idxOid, OidIsValid(idxOid), snapshot, 2, key);
+	tuple = systable_getnext(scan);
+	found = HeapTupleIsValid(tuple);
+	systable_endscan(scan);
+	table_close(rel, AccessShareLock);
+	pfree(fp);
+
+	return found;
+}
+
+/*
+ * PgColumnarRecordLoadFingerprint
+ *		Record that this file has been loaded into this table (#403 item 7).
+ *
+ *		Called AFTER the data commits, never before. A crash between the two
+ *		leaves data with no fingerprint, so a retry loads again -- the behaviour
+ *		without this feature, and the safe direction. The reverse order would
+ *		leave a fingerprint with no data and refuse rows that were never stored.
+ */
+void
+PgColumnarRecordLoadFingerprint(Oid relationOid, const uint8 *fingerprint,
+								int fingerprintLen, int64 rows)
+{
+	Relation	rel = open_columnar_table("load_fingerprint", RowExclusiveLock);
+	TupleDesc	tupdesc = RelationGetDescr(rel);
+	Datum		values[Natts_load_fingerprint];
+	bool		nulls[Natts_load_fingerprint];
+	HeapTuple	tuple;
+	bytea	   *fp;
+
+	memset(nulls, false, sizeof(nulls));
+	fp = (bytea *) palloc(VARHDRSZ + fingerprintLen);
+	SET_VARSIZE(fp, VARHDRSZ + fingerprintLen);
+	memcpy(VARDATA(fp), fingerprint, fingerprintLen);
+
+	values[Anum_load_fingerprint_relation_oid - 1] = ObjectIdGetDatum(relationOid);
+	values[Anum_load_fingerprint_fingerprint - 1] = PointerGetDatum(fp);
+	values[Anum_load_fingerprint_rows - 1] = Int64GetDatum(rows);
+	values[Anum_load_fingerprint_loaded_at - 1] =
+		TimestampTzGetDatum(GetCurrentTimestamp());
 
 	tuple = heap_form_tuple(tupdesc, values, nulls);
 	metadata_flush_insert(rel, tuple);

--- a/src/columnar_parallel_copy.c
+++ b/src/columnar_parallel_copy.c
@@ -1260,10 +1260,19 @@ pgcolumnar_parallel_copy_coordinator(Datum main_arg)
 			 * the pass overlaps the loaders instead of delaying them (#403
 			 * item 7). The decision it feeds is taken below, after every loader
 			 * has PREPAREd and before anything commits.
+			 *
+			 * INSIDE A TRANSACTION, which is not optional. On a build with
+			 * --with-openssl, pg_cryptohash_create registers the context with
+			 * CurrentResourceOwner, and outside a transaction that pointer is
+			 * NULL: the coordinator segfaults. A build without OpenSSL uses the
+			 * in-core SHA-2, which touches no resource owner and does not care,
+			 * which is why this passed on one build and crashed on another.
 			 */
 			if (hdr->dedup && !fingerprinted)
 			{
+				StartTransactionCommand();
 				pcopy_fingerprint_file(hdr->filename, hdr->fingerprint);
+				CommitTransactionCommand();
 				fingerprinted = true;
 			}
 			(void) WaitLatch(MyLatch, WL_LATCH_SET | WL_TIMEOUT | WL_EXIT_ON_PM_DEATH,
@@ -1328,13 +1337,14 @@ pgcolumnar_parallel_copy_coordinator(Datum main_arg)
 			 */
 			if (hdr->dedup)
 			{
+				StartTransactionCommand();
+				PushActiveSnapshot(GetTransactionSnapshot());
+				/* inside the transaction, for the resource-owner reason above */
 				if (!fingerprinted)
 				{
 					pcopy_fingerprint_file(hdr->filename, hdr->fingerprint);
 					fingerprinted = true;
 				}
-				StartTransactionCommand();
-				PushActiveSnapshot(GetTransactionSnapshot());
 				duplicate = PgColumnarLoadFingerprintSeen(hdr->relid,
 														  hdr->fingerprint,
 														  PG_SHA256_DIGEST_LENGTH,

--- a/src/columnar_parallel_copy.c
+++ b/src/columnar_parallel_copy.c
@@ -41,6 +41,12 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include "common/cryptohash.h"
+#include "common/sha2.h"
+
+/* read size for the dedup fingerprint pass */
+#define PCOPY_FINGERPRINT_BUFSZ	(256 * 1024)
+
 #include "columnar.h"
 
 #include "columnar_write_state.h"
@@ -395,6 +401,16 @@ typedef struct PcopyHeader
 	int			failed_worker;	/* index of the first failed loader, or -1 */
 	int			coord_sqlerrcode;
 	char		coord_errmsg[512];
+
+	/*
+	 * Opt-in load dedup (#403 item 7). dedup is what the caller asked for;
+	 * fingerprint is the SHA-256 of the file, computed by the coordinator while
+	 * the loaders run; skipped_duplicate reports back that the load was refused
+	 * because this table has already taken this file.
+	 */
+	bool		dedup;
+	uint8		fingerprint[PG_SHA256_DIGEST_LENGTH];
+	bool		skipped_duplicate;
 } PcopyHeader;
 
 /*
@@ -973,6 +989,88 @@ pgcolumnar_parallel_copy_worker(Datum main_arg)
 }
 
 /*
+ * pcopy_fingerprint_file
+ *		SHA-256 of a file's bytes, for the opt-in load dedup (#403 item 7).
+ *
+ *		The whole file rather than its path, size or mtime, because all three of
+ *		those call a changed file the same file, and being wrong in that
+ *		direction discards rows the caller meant to load.
+ *
+ *		The coordinator runs this while the loaders are already reading the same
+ *		file, so it overlaps their work rather than adding a serial pass in front
+ *		of it. Measured on 264 MiB: the load takes 1.13 s across four workers and
+ *		a single-threaded SHA-256 of the same bytes takes 0.48 s, so doing it
+ *		before dispatch would have cost 42%.
+ *
+ *		A file that cannot be read is an error, not a reason to load without
+ *		checking: the caller asked for the load to be refused if it was a repeat,
+ *		and silently loading it again is the answer they excluded.
+ */
+static void
+pcopy_fingerprint_file(const char *path, uint8 *out)
+{
+	pg_cryptohash_ctx *ctx;
+	char	   *buf;
+	int			fd;
+	int			nread;
+
+	fd = OpenTransientFile(path, O_RDONLY | PG_BINARY);
+	if (fd < 0)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not open \"%s\" to fingerprint it for dedup: %m",
+						path)));
+
+	ctx = pg_cryptohash_create(PG_SHA256);
+	if (ctx == NULL || pg_cryptohash_init(ctx) < 0)
+	{
+		CloseTransientFile(fd);
+		ereport(ERROR,
+				(errcode(ERRCODE_INTERNAL_ERROR),
+				 errmsg("could not initialise SHA-256 for the dedup fingerprint")));
+	}
+
+	buf = palloc(PCOPY_FINGERPRINT_BUFSZ);
+	while ((nread = read(fd, buf, PCOPY_FINGERPRINT_BUFSZ)) > 0)
+	{
+		if (pg_cryptohash_update(ctx, (const uint8 *) buf, (size_t) nread) < 0)
+		{
+			CloseTransientFile(fd);
+			pg_cryptohash_free(ctx);
+			ereport(ERROR,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 errmsg("could not compute the dedup fingerprint of \"%s\"",
+							path)));
+		}
+	}
+
+	if (nread < 0)
+	{
+		int			saved = errno;
+
+		CloseTransientFile(fd);
+		pg_cryptohash_free(ctx);
+		errno = saved;
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not read \"%s\" to fingerprint it for dedup: %m",
+						path)));
+	}
+	CloseTransientFile(fd);
+
+	if (pg_cryptohash_final(ctx, out, PG_SHA256_DIGEST_LENGTH) < 0)
+	{
+		pg_cryptohash_free(ctx);
+		ereport(ERROR,
+				(errcode(ERRCODE_INTERNAL_ERROR),
+				 errmsg("could not finalise the dedup fingerprint of \"%s\"",
+						path)));
+	}
+	pg_cryptohash_free(ctx);
+	pfree(buf);
+}
+
+/*
  * pcopy_finish_prepared
  *		COMMIT PREPARED (isCommit) or ROLLBACK PREPARED a gid from this (coordinator)
  *		session. FinishPreparedTransaction is what the COMMIT/ROLLBACK PREPARED
@@ -1048,6 +1146,7 @@ pgcolumnar_parallel_copy_coordinator(Datum main_arg)
 	BackgroundWorker bw;
 	BackgroundWorkerHandle **handles;
 	int			i;
+	bool		fingerprinted = false;
 
 	pqsignal(SIGTERM, pcopy_coord_sigterm);
 	BackgroundWorkerUnblockSignals();
@@ -1155,6 +1254,18 @@ pgcolumnar_parallel_copy_coordinator(Datum main_arg)
 			}
 			if (running == 0 || pcopy_coord_got_sigterm)
 				break;
+
+			/*
+			 * Fingerprint the file once, here rather than before dispatch, so
+			 * the pass overlaps the loaders instead of delaying them (#403
+			 * item 7). The decision it feeds is taken below, after every loader
+			 * has PREPAREd and before anything commits.
+			 */
+			if (hdr->dedup && !fingerprinted)
+			{
+				pcopy_fingerprint_file(hdr->filename, hdr->fingerprint);
+				fingerprinted = true;
+			}
 			(void) WaitLatch(MyLatch, WL_LATCH_SET | WL_TIMEOUT | WL_EXIT_ON_PM_DEATH,
 							 1000L, PG_WAIT_EXTENSION);
 			ResetLatch(MyLatch);
@@ -1194,6 +1305,55 @@ pgcolumnar_parallel_copy_coordinator(Datum main_arg)
 
 		if (all_prepared)
 		{
+			bool		duplicate = false;
+
+			/*
+			 * The load is done and prepared; nothing is visible yet. This is the
+			 * only point at which a repeat can be refused for free, because 2PC
+			 * lets the whole thing be thrown away after the work rather than
+			 * before it (#403 item 7). A duplicate therefore costs a full load
+			 * that is discarded, which is the right trade: the duplicate is the
+			 * exceptional case, and checking before the load would mean either a
+			 * serial hash pass in front of every load or a fingerprint that
+			 * depends on the worker count.
+			 *
+			 * NOT serialized against a CONCURRENT identical load. Two loads of
+			 * the same file running at once both check before either records,
+			 * so both commit -- which is the behaviour without dedup, and is the
+			 * safe direction. What this refuses is the case it was built for: a
+			 * committed load whose acknowledgement the client never saw, retried
+			 * afterwards. Serializing the concurrent case needs a lock held
+			 * across the check, the COMMIT PREPAREDs and the record, and
+			 * COMMIT PREPARED cannot run inside a transaction block.
+			 */
+			if (hdr->dedup)
+			{
+				if (!fingerprinted)
+				{
+					pcopy_fingerprint_file(hdr->filename, hdr->fingerprint);
+					fingerprinted = true;
+				}
+				StartTransactionCommand();
+				PushActiveSnapshot(GetTransactionSnapshot());
+				duplicate = PgColumnarLoadFingerprintSeen(hdr->relid,
+														  hdr->fingerprint,
+														  PG_SHA256_DIGEST_LENGTH,
+														  GetActiveSnapshot());
+				PopActiveSnapshot();
+				CommitTransactionCommand();
+			}
+
+			if (duplicate)
+			{
+				/* refuse it: roll every range back, so nothing becomes visible */
+				for (i = 0; i < nworkers; i++)
+					pcopy_rollback_prepared_quietly(slots[i].gid);
+				hdr->total_rows = 0;
+				hdr->skipped_duplicate = true;
+				pg_atomic_write_u32(&hdr->coord_state, PCOPY_COORD_DONE);
+			}
+			else
+			{
 			/*
 			 * Decision: commit. Committing N prepared transactions is not itself
 			 * one atomic step -- a coordinator crash mid-loop leaves the standard
@@ -1207,7 +1367,26 @@ pgcolumnar_parallel_copy_coordinator(Datum main_arg)
 				total += slots[i].rows;
 			}
 			hdr->total_rows = total;
+
+			/*
+			 * Recorded AFTER the data commits, never before. A crash between the
+			 * two leaves data with no fingerprint, so a retry loads again, which
+			 * is the behaviour without this feature and is the safe direction.
+			 * The reverse order would leave a fingerprint with no data and refuse
+			 * rows that were never stored.
+			 */
+			if (hdr->dedup)
+			{
+				StartTransactionCommand();
+				PushActiveSnapshot(GetTransactionSnapshot());
+				PgColumnarRecordLoadFingerprint(hdr->relid, hdr->fingerprint,
+												PG_SHA256_DIGEST_LENGTH, total);
+				PopActiveSnapshot();
+				CommitTransactionCommand();
+			}
+
 			pg_atomic_write_u32(&hdr->coord_state, PCOPY_COORD_DONE);
+			}
 		}
 		else
 		{
@@ -1287,6 +1466,7 @@ pgcolumnar_parallel_copy(PG_FUNCTION_ARGS)
 	char	   *path;
 	int			workers;
 	int			max_prepared;
+	bool		dedup;
 	bool		single_table = false;
 	int64	   *offs;
 	shm_toc_estimator est;
@@ -1309,6 +1489,7 @@ pgcolumnar_parallel_copy(PG_FUNCTION_ARGS)
 	relid = PG_GETARG_OID(0);
 	path = text_to_cstring(PG_GETARG_TEXT_PP(1));
 	workers = PG_ARGISNULL(2) ? pcopy_auto_workers() : PG_GETARG_INT32(2);
+	dedup = PG_ARGISNULL(3) ? false : PG_GETARG_BOOL(3);
 
 	if (!has_privs_of_role(GetUserId(), ROLE_PG_READ_SERVER_FILES))
 		ereport(ERROR,
@@ -1441,6 +1622,9 @@ pgcolumnar_parallel_copy(PG_FUNCTION_ARGS)
 	hdr->failed_worker = -1;
 	hdr->coord_sqlerrcode = 0;
 	hdr->coord_errmsg[0] = '\0';
+	hdr->dedup = dedup;
+	hdr->skipped_duplicate = false;
+	memset(hdr->fingerprint, 0, sizeof(hdr->fingerprint));
 	pg_atomic_init_u32(&hdr->coord_state, PCOPY_COORD_PENDING);
 
 	for (i = 0; i < workers; i++)
@@ -1495,8 +1679,22 @@ pgcolumnar_parallel_copy(PG_FUNCTION_ARGS)
 	if (cstate == PCOPY_COORD_DONE)
 	{
 		int64		total = hdr->total_rows;
+		bool		skipped = hdr->skipped_duplicate;
 
 		dsm_detach(seg);
+
+		/*
+		 * Say what happened rather than returning a silent 0. Discarding rows a
+		 * caller asked to insert is not ordinary INSERT behaviour, so a caller
+		 * that gets 0 back is owed the reason (#403 item 7).
+		 */
+		if (skipped)
+			ereport(NOTICE,
+					(errmsg("pgcolumnar.parallel_copy skipped a load already applied to \"%s\"",
+							get_rel_name(relid)),
+					 errdetail("The file has the same contents as a load this table already took."),
+					 errhint("Pass dedup => false to load it again.")));
+
 		PG_RETURN_INT64(total);
 	}
 	else

--- a/test/parallel_copy_dedup.sh
+++ b/test/parallel_copy_dedup.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# pgColumnar: pgcolumnar.parallel_copy can refuse a load it has already done
+# (#403 item 7).
+#
+# THE DEFECT. A committed load whose acknowledgement the client never sees is
+# retried, and the rows go in twice. Measured before this change: the same file
+# loaded twice into the same table gives 100,000 rows and then 200,000.
+#
+# WHY THE UNIT IS THE WHOLE LOAD, not a "part". The paper this comes from keeps
+# hashes of the last N inserted PARTS, because there each part commits on its
+# own. pgcolumnar.parallel_copy is atomic through 2PC: the loaders PREPARE and a
+# coordinator commits all or none, proved by a malformed row at line 50,001
+# leaving 0 rows and 0 prepared transactions. Parts never commit independently
+# here, so a part hash would deduplicate nothing that is not already
+# all-or-nothing. The load is the unit.
+#
+# WHY IT IS OPT-IN. Discarding rows a client asked to insert is not SQL INSERT
+# behaviour. It is off unless asked for, it is scoped to the bulk-load path, and
+# it says what it skipped rather than returning a silent 0.
+#
+# WHAT MAKES TWO LOADS "THE SAME". The SHA-256 of the file's bytes, so a file
+# that changed at the same path is a different load and is loaded. Path, size
+# and mtime would all call that file the same one.
+#
+# THE ORDER OF THE TWO WRITES IS THE SAFETY ARGUMENT. The data commits first and
+# the fingerprint is recorded after. A crash between them leaves data with no
+# fingerprint, so a retry loads again -- which is exactly today's behaviour and
+# is the safe direction. The reverse order would leave a fingerprint with no
+# data, and a later load would be refused for rows that were never stored.
+#
+# Usage:  test/parallel_copy_dedup.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+export PGC_EXTRA_CONF=$'max_prepared_transactions=8\nmax_worker_processes=16'
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+DATADIR="$PGC_WORKDIR/pcdedup"
+mkdir -p "$DATADIR"; chmod 777 "$DATADIR"
+if [ "$(id -u)" = "0" ]; then chown postgres "$DATADIR"; fi
+
+ROWS=20000
+F="$DATADIR/load.txt"
+G="$DATADIR/other.txt"
+
+psql_run "COPY (SELECT g AS id, 'v'||g AS txt FROM generate_series(1,$ROWS) g)
+          TO '$F' WITH (FORMAT text);" >/dev/null
+psql_run "COPY (SELECT g AS id, 'w'||g AS txt FROM generate_series(1,$ROWS) g)
+          TO '$G' WITH (FORMAT text);" >/dev/null
+
+q() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" -Atq \
+		-c "$1" 2>&1 | tail -1
+}
+
+mk() { psql_run "DROP TABLE IF EXISTS $1; CREATE TABLE $1 (id int, txt text) USING pgcolumnar;" >/dev/null; }
+
+# ---- the control: without dedup the retry doubles the table ----------------
+mk pcd_plain
+r1="$(q "SELECT pgcolumnar.parallel_copy('pcd_plain','$F',4)")"
+r2="$(q "SELECT pgcolumnar.parallel_copy('pcd_plain','$F',4)")"
+check "premise: without dedup a repeated load doubles the table, which is the defect" \
+	"$(q "SELECT count(*) FROM pcd_plain")" "$(( ROWS * 2 ))"
+check "premise: and each of those loads reported its rows" "$r1/$r2" "$ROWS/$ROWS"
+
+# ---- the same load twice, with dedup --------------------------------------
+mk pcd
+d1="$(q "SELECT pgcolumnar.parallel_copy('pcd','$F',4,true)")"
+c1="$(q "SELECT count(*) FROM pcd")"
+d2="$(q "SELECT pgcolumnar.parallel_copy('pcd','$F',4,true)")"
+c2="$(q "SELECT count(*) FROM pcd")"
+echo "-- dedup on: load 1 returned $d1 (table $c1), load 2 returned $d2 (table $c2)"
+
+check "the first load stores its rows normally (#403 item 7)" "$c1" "$ROWS"
+check "and reports them" "$d1" "$ROWS"
+check "the second load of the same file stores nothing (#403 item 7)" "$c2" "$ROWS"
+check "and reports 0 rather than claiming it loaded them" "$d2" "0"
+
+# ---- a changed file at the same path is a different load -------------------
+cp "$G" "$F"
+d3="$(q "SELECT pgcolumnar.parallel_copy('pcd','$F',4,true)")"
+c3="$(q "SELECT count(*) FROM pcd")"
+echo "-- after replacing the file at the same path: returned $d3, table $c3"
+check "a changed file at the same path is loaded, not skipped (#403 item 7)" "$c3" "$(( ROWS * 2 ))"
+check "and reports the rows it loaded" "$d3" "$ROWS"
+
+# ---- the fingerprint is per table -----------------------------------------
+mk pcd_other
+d4="$(q "SELECT pgcolumnar.parallel_copy('pcd_other','$F',4,true)")"
+check "the same file loads into a DIFFERENT table (the record is per table)" \
+	"$(q "SELECT count(*) FROM pcd_other")" "$ROWS"
+check "and reports its rows" "$d4" "$ROWS"
+
+# ---- dedup off still loads twice, on the same table ------------------------
+d5="$(q "SELECT pgcolumnar.parallel_copy('pcd_other','$F',4,false)")"
+check "asking for no dedup loads again even though the file is on record" \
+	"$(q "SELECT count(*) FROM pcd_other")" "$(( ROWS * 2 ))"
+check "and reports those rows too" "$d5" "$ROWS"
+
+# ---- the record itself -----------------------------------------------------
+check "the skipped load left exactly one record for that table and file" \
+	"$(q "SELECT count(*) FROM pgcolumnar.load_fingerprint
+	      WHERE relation_oid = 'pcd'::regclass")" "2"
+
+check "no prepared transaction leaked through any of it" \
+	"$(q "SELECT count(*) FROM pg_prepared_xacts")" "0"
+
+pgc_summary

--- a/test/parallel_copy_dedup.sh
+++ b/test/parallel_copy_dedup.sh
@@ -29,6 +29,14 @@
 # is the safe direction. The reverse order would leave a fingerprint with no
 # data, and a later load would be refused for rows that were never stored.
 #
+# RUN THIS AGAINST A BUILD WITH OpenSSL. The coordinator fingerprints the file
+# from inside a transaction, and that is not tidiness: on a --with-openssl build
+# pg_cryptohash_create registers the hash context with CurrentResourceOwner,
+# which is NULL outside a transaction, and the coordinator segfaults. A build
+# without OpenSSL uses the in-core SHA-2, touches no resource owner, and passes.
+# This suite therefore passed on the local source builds and crashed on CI's
+# packaged PostgreSQL until the transaction was added.
+#
 # Usage:  test/parallel_copy_dedup.sh [PG_CONFIG]
 # Written fresh for pgColumnar.
 

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -212,6 +212,7 @@ SUITES=(
 	objstore_userinfo
 	parallel
 	parallel_copy
+	parallel_copy_dedup
 	parallel_degree
 	parallel_export_parquet
 	parallel_flush_optin


### PR DESCRIPTION
Item 7 of #403. Uses the alpha3 upgrade script #812 opened.

## The defect, measured first

```
load 1 returned 100000, table holds 100000
load 2 returned 100000, table holds 200000
```

A load that commits, whose acknowledgement the client never receives, is retried and the rows go in twice.

## The unit is the whole load, not a "part"

The paper keeps hashes of the last N inserted **parts**, because there each part commits on its own. `parallel_copy` is atomic through 2PC — proved, not assumed, with a malformed integer at line 50,001:

```
rows before = 0
ERROR: worker 1 failed: invalid input syntax for type integer: "not-an-int"
rows after  = 0        prepared transactions left: 0
```

Parts never commit independently here, so a part hash would deduplicate nothing that is not already all-or-nothing.

**My first attempt to prove that failed to fire.** I set `pgcolumnar.sink_fail_after` and the load succeeded anyway, because the injection GUC never reaches the background workers. That would have been a clean-looking pass proving nothing.

## Where the check goes, and what it costs

After every loader has PREPAREd and **before anything commits**. That is the only point at which a repeat can be refused without charging every load for it, and 2PC is what makes it possible: the work can be thrown away after it is done.

So a refused load does its work and discards it. The alternative — hashing before dispatch — costs **42%** of the load on a 264 MiB file (1.13 s across four workers against 0.48 s single-threaded SHA-256). As implemented the coordinator hashes while the loaders are already reading the same file:

```
min-of-8, 5,000,000 rows asserted per rep
dedup off  1.09 s
dedup on   1.08 s
```

No measurable cost. The arms' ranges overlap almost entirely on this contended box, so the honest claim is that the overhead is not resolvable here — which is the result, given the 42% alternative *is* resolvable.

## The order of the two writes is the safety argument

Data commits first; the fingerprint is recorded after. A crash between them leaves data with no fingerprint, so a retry loads again — the behaviour without this feature, and the safe direction. The reverse would leave a fingerprint with no data and refuse rows that were never stored.

## A defect my own removal proof found

Running the mutation, the record insert hit `duplicate key value violates unique constraint` **after the data had committed** — reporting failure for a load that succeeded. Two concurrent loads of one file reach that state with no mutation at all: both check before either records.

So the index is **not** unique. The lookup is an existence test, a duplicate record is harmless, and a false failure is not. Concurrent identical loads both store, which is the behaviour without dedup and the safe direction; serializing them needs a lock held across the check, the COMMIT PREPAREDs and the record, and COMMIT PREPARED cannot run inside a transaction block. Stated in the code and in the docs rather than left to be found.

## Gate

`test/parallel_copy_dedup.sh`, 14 checks, registered. Its **two premises measure the defect itself**, so the suite fails if the double-insert ever stops happening for an unrelated reason.

Removal proof, mutation asserted applied (`real check sites left: 0`): the repeat stores 40,000 rows and three checks go red.

`native_upgrade_converge` **passes** — the proof that the new catalog and the changed function signature reach an upgraded catalog identically to a fresh `1.0-alpha3` install, in definition, ACL and comment. `parallel_copy`, `entry_point_privilege`, `harness_selftest`, `docs_style`, `eager_ordering_record` all pass on PG 18.4. Built with `COPT=-Werror`, 0 warnings — I am not repeating #810's C90 miss.

Refs #403.