### PR TITLE
fix: cost the index-fetch penalty from written geometry, not the session GUC (#806)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,60 @@ true until the next version shipped.
 
 ## [Unreleased]
 
+### Fixed
+
+- The cost model reads the row-group geometry a table was **written** with,
+  not the geometry a write in the planning session would produce (#806).
+  `pgcolumnar.storage.row_group_limit` records what the writer used and nothing
+  read it back; the index-fetch penalty called
+  `pgcolumnar_effective_stripe_row_limit()`, which returns the per-table option
+  or else the planning session's `pgcolumnar.stripe_row_limit`.
+
+  The consequence is larger than a mis-costed table. A session that sets that
+  GUC -- before a bulk load, say -- repriced every columnar table it then
+  planned against, including tables it never touched. Measured on one unchanged
+  table of three row groups, varying only the GUC at plan time:
+
+  | plan-time `stripe_row_limit` | before | after |
+  | --- | ---: | ---: |
+  | 150000 | 775.26 | 775.28 |
+  | 20000 | 113.26 | 775.28 |
+  | 5000 | 36.26 | 775.28 |
+
+  A 21x swing on a table that did not change. `R` is not a minor term: it sets
+  the group count, the pages per group, the per-group decode CPU, and the
+  `decodedWidth * R` test against the 32 MB fetch-cache cap, so it can be wrong
+  in either direction there.
+
+  **One call site changed**, the index-fetch penalty, which is where the defect
+  was measured. Two others deliberately did not:
+
+  - `columnar_write_state.c` still asks `pgcolumnar_effective_stripe_row_limit()`,
+    because a writer deciding the geometry it is about to lay down is exactly
+    what that function answers;
+  - `pgcolumnar_zonemap_survival()` also still asks it. Substituting the written
+    geometry there moved `native_zonemap_narrow` from 30/30 zone-map reads on a
+    wide and a narrow table to 570/66 -- reads that scale with table width,
+    which is the property that suite exists to hold. There is no measured defect
+    at that site and there is a measured regression from changing it.
+
+  An explicit per-table `stripe_row_limit` still wins over the written geometry.
+  This is about the planning session's GUC, which has nothing to do with the
+  table; a per-table option is a durable statement by its owner, and
+  `native_index_fetch_stripe_cost` asserts the cost model can see it.
+
+  Two things this leaves, stated rather than hidden. Because the survival
+  estimate still reads the session GUC, a plan-time limit far enough below the
+  written one can still flip a plan through that path: at 5000 the table above
+  costs 87.79 rather than 775.07, because it stops being an index scan. And the
+  recorded limit is one number, the last writer's, so a table whose groups were
+  written under changing limits is still approximated -- the exact quantity is
+  the real group count, which would be a catalog scan proportional to the number
+  of groups on every plan.
+
+  New suite `test/cost_written_geometry.sh`. It asserts planner costs rather
+  than timings, so `PGC_SKIP_TIMING` does not drop it.
+
 ### Changed
 
 - Chunk-group skip predicates are now evaluated most-selective-first, so a group

--- a/src/columnar.h
+++ b/src/columnar.h
@@ -506,6 +506,7 @@ extern void PgColumnarDeleteMetadata(uint64 storageId);
 /* per-table options catalog (spec 7.4) */
 extern bool PgColumnarReadOptions(Oid relid, PgColumnarOptions *opts);
 extern int pgcolumnar_effective_stripe_row_limit(Oid relid);
+extern int pgcolumnar_written_stripe_row_limit(Oid relid);
 
 /* declared physical sort key (#288); List of pstrdup'd column names, NIL if
  * none is declared. Names (not attnums) so the value survives dump/restore. */

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -1860,7 +1860,7 @@ static Cost
 pgcolumnar_index_fetch_penalty(RelOptInfo *rel, Oid relid, double rows, double rho,
 							 double decodeUnits, double decodedWidth, bool tid_ordered)
 {
-	double		R = (double) pgcolumnar_effective_stripe_row_limit(relid);
+	double		R = (double) pgcolumnar_written_stripe_row_limit(relid);
 	double		N = (rel->tuples > 0) ? rel->tuples : rows;
 	double		n_groups,
 				pages_per_stripe,
@@ -2193,6 +2193,22 @@ pgcolumnar_zonemap_survival(RelOptInfo *rel, Oid heapRelid)
 	 * cost model that is otherwise wrong by an order of magnitude.
 	 */
 	{
+		/*
+		 * NOT pgcolumnar_written_stripe_row_limit here, deliberately (#806).
+		 *
+		 * #806 measured the session GUC leaking into the index-fetch penalty and
+		 * fixed it there. Making the same substitution at this site is not the
+		 * same change: this one feeds the zone-map survival estimate, and
+		 * switching it moved native_zonemap_narrow's zone-map reads from
+		 * wide=30/narrow=30 to wide=570/narrow=66 -- reads that scale with table
+		 * width, which is the property that suite exists to hold.
+		 *
+		 * The written geometry is arguably the more correct input here too, and
+		 * the comment above says as much about which limit decides the group
+		 * count. But there is no measured defect at this site, there is a
+		 * measured regression from changing it, and #806's evidence is entirely
+		 * about the penalty. Left alone until someone has the measurement.
+		 */
 		int			limit = pgcolumnar_effective_stripe_row_limit(heapRelid);
 
 		if (limit <= 0)

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -3011,6 +3011,89 @@ pgcolumnar_effective_stripe_row_limit(Oid relid)
 	return pgcolumnar_stripe_row_limit;
 }
 
+/*
+ * pgcolumnar_written_stripe_row_limit
+ *		The row-group limit the table was actually WRITTEN with, read back from
+ *		pgcolumnar.storage.row_group_limit (#806).
+ *
+ *		The planner must ask this and not pgcolumnar_effective_stripe_row_limit.
+ *		That function answers "what limit would a write in THIS session use",
+ *		which is the right question for the writer -- columnar_write_state.c is
+ *		deciding the geometry it is about to lay down -- and the wrong one for a
+ *		cost model, which is describing geometry that already exists. A table
+ *		written while pgcolumnar.stripe_row_limit differed from the planning
+ *		session's value is otherwise costed against a shape it does not have:
+ *		measured at 20 groups of 20,000 rows being costed as 3 of 150,000.
+ *
+ *		Falls back to the session answer only when there is neither an explicit
+ *		per-table option nor a storage row -- a table that has never been
+ *		written. There is no written geometry to prefer then, and the next write
+ *		will use the session value anyway.
+ *
+ *		This is ONE number, the last writer's. A table whose groups were laid
+ *		down under changing limits is still approximated. The exact quantity is
+ *		the real group count, and reading it is a scan proportional to the number
+ *		of groups on every plan, which is too much to spend refining a term that
+ *		is approximate by construction.
+ *
+ *		Scanned without an index, like PgColumnarReadOptions immediately above:
+ *		the storage index is on storage_id and this looks up by relation_oid.
+ */
+int
+pgcolumnar_written_stripe_row_limit(Oid relid)
+{
+	PgColumnarOptions opts;
+	Relation	rel;
+	TupleDesc	tupdesc;
+	ScanKeyData key[1];
+	SysScanDesc scan;
+	HeapTuple	tuple;
+	int32		limit = 0;
+
+	/*
+	 * An explicit per-table option still wins, and deliberately so. #806 is
+	 * about the PLANNING SESSION's GUC leaking into the cost of a table it has
+	 * nothing to do with. A per-table stripe_row_limit is the opposite: a
+	 * durable statement by the table's owner about that table, which
+	 * native_index_fetch_stripe_cost asserts the cost model can see.
+	 *
+	 * It is worth naming what this leaves unresolved. Setting the option does
+	 * not rewrite the table, so between the option and the next rewrite the
+	 * model describes the geometry the owner asked for rather than the one on
+	 * disk. That is a real gap, it predates this change, and narrowing #806 to
+	 * the session GUC is not the place to decide it.
+	 */
+	if (PgColumnarReadOptions(relid, &opts) &&
+		opts.stripeRowLimitSet && opts.stripeRowLimit > 0)
+		return opts.stripeRowLimit;
+
+	rel = open_columnar_table("storage", AccessShareLock);
+	tupdesc = RelationGetDescr(rel);
+
+	ScanKeyInit(&key[0], Anum_native_storage_relation_oid, BTEqualStrategyNumber,
+				F_OIDEQ, ObjectIdGetDatum(relid));
+	scan = systable_beginscan(rel, InvalidOid, false, NULL, 1, key);
+
+	if (HeapTupleIsValid(tuple = systable_getnext(scan)))
+	{
+		bool		isnull;
+		Datum		d = heap_getattr(tuple, Anum_native_storage_row_group_limit,
+									 tupdesc, &isnull);
+
+		if (!isnull)
+			limit = DatumGetInt32(d);
+	}
+
+	systable_endscan(scan);
+	table_close(rel, AccessShareLock);
+
+	if (limit > 0)
+		return (int) limit;
+
+	/* never written and no option: the session's value is all there is */
+	return pgcolumnar_stripe_row_limit;
+}
+
 
 /*
  * PgColumnarReadSortBy

--- a/test/cost_written_geometry.sh
+++ b/test/cost_written_geometry.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+#
+# The cost model must describe the geometry a table WAS WRITTEN WITH, not the
+# geometry a write in the planning session would produce (#806).
+#
+# pgcolumnar.storage.row_group_limit records what the writer used. Nothing read
+# it: the index-fetch penalty called pgcolumnar_effective_stripe_row_limit(),
+# which returns the per-table option or else the PLANNING SESSION's GUC. So a
+# session that set pgcolumnar.stripe_row_limit -- before a bulk load, say --
+# repriced every columnar table it then planned against, including tables it had
+# never touched.
+#
+# Measured on the same unchanged table, three row groups, written at the
+# default, varying only the GUC at plan time:
+#
+#     plan-time stripe_row_limit    before      after
+#              150000               775.26     775.28
+#               20000               113.26     775.28
+#                5000                36.26     775.28
+#
+# A 21x swing on a table that did not change. That is the shape of this suite's
+# first check, and it needs no bound: the costs must be EQUAL.
+#
+# WHY THE SWEEP STOPS AT 20000 AND NOT LOWER. The penalty is one of two places
+# the session GUC reached. The other is pgcolumnar_zonemap_survival, which uses
+# it to guess how many groups exist and is NOT changed here -- substituting the
+# written geometry there moved native_zonemap_narrow from wide=30/narrow=30 zone
+# map reads to wide=570/narrow=66, reads that scale with table width, which is
+# the property that suite exists to hold. So this change fixes the penalty and
+# leaves the survival estimate, and a plan-time limit far enough below the
+# written one still flips the plan through that second path: at 5000 the same
+# table costs 87.79 rather than 775.07, because it stops being an index scan.
+#
+# That residual is real and is filed rather than hidden. This suite asserts what
+# this change actually fixes; it would be dishonest to sweep a range the change
+# does not cover and dishonest to pretend the range it does cover is the whole
+# defect.
+#
+# These are planner costs, not timings, so this suite is not a timing suite and
+# PGC_SKIP_TIMING does not apply to it (#787).
+#
+# Usage:  test/cost_written_geometry.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+ROWS=${PGC_CWG_ROWS:-400000}
+
+# gb: written at the default limit.  ga: written at a much smaller one, in the
+# session that does the writing, which is where the limit legitimately applies.
+psql_run "DROP TABLE IF EXISTS gb;
+	CREATE TABLE gb (id int, v int, t text) USING pgcolumnar;
+	INSERT INTO gb SELECT g, g, 'r' || g FROM generate_series(1, $ROWS) g;
+	CREATE INDEX gb_id ON gb (id);"
+psql_run "DROP TABLE IF EXISTS ga;
+	SET pgcolumnar.stripe_row_limit = 20000;
+	SET pgcolumnar.chunk_group_row_limit = 20000;
+	CREATE TABLE ga (id int, v int, t text) USING pgcolumnar;
+	INSERT INTO ga SELECT g, g, 'r' || g FROM generate_series(1, $ROWS) g;
+	CREATE INDEX ga_id ON ga (id);"
+psql_run "ANALYZE ga; ANALYZE gb;"
+
+groups() {  # table -> row groups actually written
+	q "SELECT count(*) FROM pgcolumnar.row_group r
+	   JOIN pgcolumnar.storage s USING (storage_id)
+	   WHERE s.relation_oid = '$1'::regclass"
+}
+written_limit() {
+	q "SELECT row_group_limit FROM pgcolumnar.storage WHERE relation_oid = '$1'::regclass"
+}
+# The costed plan for an index-driven fetch, under a stated plan-time GUC.
+plan_line() {  # table, plan-time stripe_row_limit
+	q "SET pgcolumnar.stripe_row_limit = $2; SET enable_seqscan = off;
+	   SET max_parallel_workers_per_gather = 0;
+	   EXPLAIN SELECT id, v FROM $1 WHERE id <= 100" | grep -m1 'cost='
+}
+cost_at() { plan_line "$1" "$2" | grep -oE 'cost=[0-9.]+\.\.[0-9.]+' | sed 's/.*\.\.//'; }
+
+# --- premises: the fixture is the shape the checks assume -------------------
+check "premise: both tables hold the same number of rows" \
+	"$(q "SELECT count(*) FROM ga")" "$(q "SELECT count(*) FROM gb")"
+check "premise: gb was written at the default limit, in few groups" \
+	"$([ "$(groups gb)" -le 5 ] && echo few || echo "$(groups gb)")" "few"
+check "premise: ga was written at 20000, in many more groups" \
+	"$([ "$(groups ga)" -ge 15 ] && echo many || echo "$(groups ga)")" "many"
+check "premise: and the catalog recorded both limits" \
+	"$(written_limit ga)|$(written_limit gb)" "20000|$(q "SHOW pgcolumnar.stripe_row_limit" | tr -d ' ')"
+
+# The comparison is only meaningful against one plan shape.
+for _g in 150000 20000; do
+	check "premise: gb is costed as an index scan at plan-time limit $_g" \
+		"$(plan_line gb "$_g" | grep -c 'Index Scan')" "1"
+done
+
+# --- 1. the planning session must not reprice an existing table -------------
+# The table is not touched between these three readings. Only a session GUC
+# moves, and it describes what a WRITE would do, so it cannot legitimately
+# change what an existing table costs to read.
+c1="$(cost_at gb 150000)"
+c2="$(cost_at gb 20000)"
+echo "-- gb costed at plan-time limits 150000 / 20000: $c1 / $c2"
+check "the planning session's stripe_row_limit does not reprice a written table" \
+	"$c1|$c2" "$c1|$c1"
+
+# --- 2. and the model can still see real geometry ---------------------------
+# The converse failure would be a model that ignores the session GUC by ignoring
+# geometry altogether. ga really is laid out in many small groups, so its
+# per-group decode is genuinely cheaper, and the cost must reflect that.
+ca="$(cost_at ga 150000)"
+cb="$(cost_at gb 150000)"
+echo "-- ga (many small groups) $ca vs gb (few large) $cb, same rows, same plan-time GUC"
+check "a table written in smaller groups is costed cheaper than one in larger" \
+	"$(awk -v a="$ca" -v b="$cb" 'BEGIN{print (a < b) ? "cheaper" : "not cheaper"}')" "cheaper"
+
+# --- 3. a table that was never written still plans ---------------------------
+# There is no storage row before the first write, so the reader falls back to the
+# session answer. That path has to work rather than error or return zero.
+psql_run "DROP TABLE IF EXISTS gempty;
+	CREATE TABLE gempty (id int, v int) USING pgcolumnar;
+	CREATE INDEX gempty_id ON gempty (id);"
+check "a never-written table still produces a plan" \
+	"$(q "SET enable_seqscan=off; EXPLAIN SELECT id, v FROM gempty WHERE id <= 100" \
+	   | grep -c 'cost=' | awk '{print ($1 >= 1) ? "yes" : "no"}')" "yes"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -63,6 +63,7 @@ SUITES=(
 	concurrency
 	concurrent_diff
 	corruption
+	cost_written_geometry
 	debug_hook_privilege
 	decode_interrupts
 	decode_skip_interrupts


### PR DESCRIPTION
Closes #806.

`pgcolumnar.storage.row_group_limit` records the geometry a table was written
with. Nothing read it back. `pgcolumnar_index_fetch_penalty` asked
`pgcolumnar_effective_stripe_row_limit()`, which returns the per-table option or
else **the planning session's** `pgcolumnar.stripe_row_limit`.

## The defect is bigger than a mis-costed table

The same unchanged table, three row groups, written at the default. Only a
session GUC moves between these readings:

| plan-time `stripe_row_limit` | before | after |
| --- | ---: | ---: |
| 150000 | 775.26 | 775.28 |
| 20000 | 113.26 | 775.28 |
| 5000 | 36.26 | 775.28 |

**A 21x swing on a table that did not change.** Any session that sets that GUC
-- before a bulk load, say -- repriced every columnar table it then planned
against, including tables it never touched.

`R` is not a minor term. It sets the group count, the pages per group, the
per-group decode CPU, and the `decodedWidth * R` test against the 32 MB
fetch-cache cap, so it can be wrong in either direction there.

## Red first

`test/cost_written_geometry.sh`, on unmodified `main`:

```
FAIL  the planning session's stripe_row_limit does not reprice a written table:
      got [775.21|113.21] want [775.21|775.21]
FAIL  a table written in smaller groups is costed cheaper than one in larger:
      got [not cheaper] want [cheaper]
                                                          7 PASS / 2 FAIL
```

With the fix, **9 PASS / 0 FAIL**. The first check is an equality, not a bound:
the cost simply must not move when only the session GUC does.

## One call site changed. The gate caught me changing two more than I had proved

I first made written geometry beat everything and switched both planner sites.
The full matrix rejected both extensions, and it was right twice:

**The per-table option.** Broke `native_index_fetch_stripe_cost`, which asserts
`set_options(tbl, stripe_row_limit => X)` is visible in the cost. Re-reading my
own issue, the complaint is the fallback to the *session* GUC. A per-table
option is a durable statement by the table's owner; the session GUC is not about
the table at all. The option still wins.

**`pgcolumnar_zonemap_survival()`.** Broke `native_zonemap_narrow`, moving
zone-map reads from `wide=30 narrow=30` to `wide=570 narrow=66` -- reads that
scale with table width, the property that suite exists to hold. A control run on
unmodified `main` confirmed the regression was mine and not pre-existing. My
issue only said "the same call site pattern is at :2193"; I never measured a
defect there, and there is now a measured regression from changing it. Left
alone, with the reason in the code.

`columnar_write_state.c` is untouched throughout: a writer deciding the geometry
it is about to lay down is exactly what the effective limit answers.

## What this does not fix

Because the survival estimate still reads the session GUC, a plan-time limit far
enough below the written one can still flip a plan through that second path: at
5000 the table above costs 87.79 rather than 775.07, because it stops being an
index scan. The suite sweeps 150000 and 20000 -- the range this change covers --
and its header records why it stops there and what remains. Sweeping a range the
change does not cover, or implying the covered range is the whole defect, would
both be dishonest.

The recorded limit is also one number, the last writer's, so a table whose
groups were written under changing limits is still approximated. The exact
quantity is the real group count, which is a catalog scan proportional to the
number of groups on every plan.

I will file the survival-estimate half separately with the measurement above,
since fixing it needs the `native_zonemap_narrow` interaction understood rather
than a follow-on edit.

## Gate

```
run_all_versions.sh   PG18  227 ran, 2 skipped (native_repack, pg19_vacuum_options)
                      PG19  229 ran, 0 skipped      ALL VERSIONS PASSED, exit 0
  cost_written_geometry            PASS  PASS
  native_index_fetch_stripe_cost   PASS  PASS      (the one I broke, restored)
  native_zonemap_narrow            PASS  PASS      (likewise)

build_all_versions.sh  15.18 / 16.14 / 17.6 / 18.4 / 19beta2, 0 warnings each
                       built 5 of 5
```

Preflight run on this branch, not only on `main` -- #810 warned on all four
majors in a hunk I had approved, and that is the check that would have caught it.
