### PR TITLE
docs: pgcolumnar.expire has merged, so stop calling it pending

### DIFF
--- a/design/OBJECT_STORAGE_TIERING.md
+++ b/design/OBJECT_STORAGE_TIERING.md
@@ -101,8 +101,8 @@ invariants above touched:
 
 1. Export the cold range to Parquet in object storage, with
    `pgcolumnar.export_parquet` or `pgcolumnar.parallel_export_parquet` (#394).
-2. Drop the local rows, with `pgcolumnar.expire` (#403 item 5a, PR #815, not yet
-   merged) or an ordinary `DELETE` plus `pgcolumnar.compact`.
+2. Drop the local rows, with `pgcolumnar.expire` (#403 item 5a) or an ordinary
+   `DELETE` plus `pgcolumnar.compact`.
 3. Read the exported data when it is needed, through the external Parquet reader
    or `iceberg_scan` (#388, #393).
 


### PR DESCRIPTION
`design/OBJECT_STORAGE_TIERING.md` from #818 recommends composing
`export_parquet`, `expire` and the external Parquet reader as the supported
alternative to object-storage tiering. It marked the middle step as
"#403 item 5a, PR #815, not yet merged".

#815 merged in `554d136`, so `pgcolumnar.expire` ships in
`pgcolumnar--1.0-alpha3.sql` now and the document tells a reader that part of its
own recommendation is unavailable when it is not.

I flagged this in the #815 approval as the sentence that would go stale on
merge, so this is the follow-up rather than a new finding.

**Checked while here.** All six functions the recommendation names are present
in the shipped alpha3 script:

```
  export_parquet            2      compact         4
  parallel_export_parquet   2      iceberg_scan    2
  expire                    2      read_parquet    4
```

The other `PR #8xx` strings under `design/` are outcome-table attributions
recording where an item landed, not availability claims, so they are correct as
they stand and are left alone.

`docs_style` passes. Docs only, one sentence.