### PR TITLE
Anchor the cost read on the scan node, not on the first plan line (#753)

### DIFF
--- a/test/doc_parallel_premise.sh
+++ b/test/doc_parallel_premise.sh
@@ -98,11 +98,20 @@ total_groups() { explain_of "$1" | sed -n 's/.*Chunk Groups Total: \([0-9]*\).*/
 # The post-#821 figure is 4212 x 3/10, and EXPLAIN ANALYZE reports "Chunk Groups
 # Read: 3 of 10", so the estimate now agrees with the scan it prices. The check
 # below asserts the ORDERING of the two costs, which holds on either side.
-serial_cost() {
+# Anchored on the scan node rather than on the first cost= in the plan.
+# `grep -m1` returns whatever node comes first, so the moment the plan gains a
+# node above the scan it reports that node's cost instead, silently and with the
+# right shape. That is the same class of defect this suite exists to catch, so
+# the suite should not contain one.
+plan_of() {
 	q "SET max_parallel_workers_per_gather = 0;
 	   SET pgcolumnar.stripe_row_limit = 20000;
-	   EXPLAIN SELECT sel, a, b FROM c753 WHERE $1 <= $(p25 "$1")" \
-	  | grep -m1 -oE 'cost=[0-9.]+\.\.[0-9.]+' | sed 's/.*\.\.//'
+	   EXPLAIN SELECT sel, a, b FROM c753 WHERE $1 <= $(p25 "$1")"
+}
+scan_lines() { plan_of "$1" | grep -c 'PgColumnarScan'; }
+serial_cost() {
+	plan_of "$1" | grep 'PgColumnarScan' \
+	  | grep -oE 'cost=[0-9.]+\.\.[0-9.]+' | sed 's/.*\.\.//' | head -1
 }
 
 doc_read=$(read_groups "$doc_col"); doc_tot=$(total_groups "$doc_col")
@@ -132,6 +141,10 @@ check "the documented column is not the one stored in order" \
 # Exact rather than bounded: reading more groups must cost more. A bound here
 # would need calibrating and the direction does not.
 if [ "$doc_col" != "sel" ]; then
+	for _c in "$doc_col" sel; do
+		check "premise: the $_c plan is exactly one columnar scan node" \
+			"$(scan_lines "$_c")" "1"
+	done
 	dc=$(serial_cost "$doc_col"); sc=$(serial_cost sel)
 	echo "-- serial cost: $doc_col $dc, sel $sc"
 	check "and the documented column is costed above the ordered one" \


### PR DESCRIPTION
The review nit from #820, folded in as promised. Test only, no `src/` change.

## The defect is LATENT, not live, and that is the case for fixing it

Correcting my own framing, after @OffgridwithJD printed the raw plan for both
arms. **This suite is not misreporting anything today.** Its query produces a
bare scan with no node above it:

```
Custom Scan (PgColumnarScan) on c753  (cost=0.00..4212.00 rows=51209 width=12)
Custom Scan (PgColumnarScan) on c753  (cost=0.00..1404.00 rows=49184 width=12)
```

So `grep -m1` and the anchored form return the same number, and the suite still
reports `a 4212.00, sel 1404.00` either way.

That is the whole point. `serial_cost` read the cost with `grep -m1`, which
returns whatever node comes first. It is correct here by luck rather than by
construction: the first node happens to be the scan. It stays correct right up
until the plan gains a node above the scan, and then it reports a different
node's cost, silently and with a plausible value.

The mechanism, shown on a query that DOES have a node above the scan, which is
not this suite's query:

```
 Aggregate                                   (cost=66119.86..66119.87 rows=1 width=8)
   ->  Custom Scan (PgColumnarScan) on c753  (cost=0.00..61101.78 rows=2007235 width=0)

grep -m1 form   66119.87   <- the aggregate's cost
anchored form   61101.78   <- the scan's cost
```

Latent is the state worth fixing. This suite exists because a published number
outlived the fixture it described, and a helper that reads a plausible number
from the wrong place is the same failure one level down.

## The change

`serial_cost` selects the `PgColumnarScan` line before extracting the cost. Two
premises assert the anchor found **exactly one** such node on each arm, ordered
before the check that relies on them.

```
PASS  premise: the a plan is exactly one columnar scan node
PASS  premise: the sel plan is exactly one columnar scan node
-- serial cost: a 4212.00, sel 1404.00
PASS  and the documented column is costed above the ordered one
checks run: 9
doc_parallel_premise.sh: PASSED
```

9 of 9, up from 7. Both new checks are premises rather than new assertions about
the product, so this does not widen what the suite claims.

The `scan_lines == 1` premise turned out to defend more than the nit asked for.
It also catches a node name matching inside another node's property line, which
@OffgridwithJD reports having been bitten by twice in one day: "Aggregate" inside
`Columnar Vectorized Aggregates`, and "Sort" inside a Merge Append's `Sort Key:`.
A bare `grep 'Aggregate'` on a plan is not a node test.

Reported by @OffgridwithJD in review of #820.