### PR TITLE
A check that passes on blank counters is worse than no check (#753)

### DIFF
--- a/test/doc_parallel_premise.sh
+++ b/test/doc_parallel_premise.sh
@@ -137,8 +137,12 @@ echo "-- sel (stored in order):            $sel_read of $sel_tot groups read"
 # --- 1. the defect this suite exists for ------------------------------------
 # The published speedup numbers were taken with every group read. If the page's
 # query prunes, the numbers beside it describe a different amount of work.
+# Defaults that CANNOT collide, so blank-versus-blank fails on its own rather
+# than relying on the premise above to catch it. `check "" ""` passes, so a check
+# fed by two extracted values must never be able to compare one blank with
+# another.
 check "the documented narrow query reads every chunk group" \
-	"$doc_read" "$doc_tot"
+	"${doc_read:-<no-read-counter>}" "${doc_tot:-<no-total-counter>}"
 
 # --- 2. the contrast the page now documents is real -------------------------
 check "and filtering the ordered column instead prunes some away" \

--- a/test/doc_parallel_premise.sh
+++ b/test/doc_parallel_premise.sh
@@ -114,8 +114,23 @@ serial_cost() {
 	  | grep -oE 'cost=[0-9.]+\.\.[0-9.]+' | sed 's/.*\.\.//' | head -1
 }
 
+# The scan-node premise comes FIRST, because every counter below is read out of
+# a columnar scan's EXPLAIN output and does not exist without one.
+for _c in "$doc_col" sel; do
+	check "premise: the $_c plan is exactly one columnar scan node" \
+		"$(scan_lines "$_c")" "1"
+done
+
 doc_read=$(read_groups "$doc_col"); doc_tot=$(total_groups "$doc_col")
 sel_read=$(read_groups sel);        sel_tot=$(total_groups sel)
+
+# A counter that was not printed is an EMPTY string, and `check "" ""` PASSES.
+# That is not hypothetical: with pgcolumnar.enable_custom_scan=off the plan is a
+# seq scan, every counter below is blank, and check 1 passed comparing one blank
+# with another. A check that passes on nothing is worse than no check.
+check "premise: the group counters were read, not blank" \
+	"$([ -n "$doc_read" ] && [ -n "$doc_tot" ] && [ -n "$sel_read" ] && [ -n "$sel_tot" ] \
+		&& echo yes || echo "doc=$doc_read/$doc_tot sel=$sel_read/$sel_tot")" "yes"
 echo "-- $doc_col (the documented column): $doc_read of $doc_tot groups read"
 echo "-- sel (stored in order):            $sel_read of $sel_tot groups read"
 
@@ -141,11 +156,9 @@ check "the documented column is not the one stored in order" \
 # Exact rather than bounded: reading more groups must cost more. A bound here
 # would need calibrating and the direction does not.
 if [ "$doc_col" != "sel" ]; then
-	for _c in "$doc_col" sel; do
-		check "premise: the $_c plan is exactly one columnar scan node" \
-			"$(scan_lines "$_c")" "1"
-	done
 	dc=$(serial_cost "$doc_col"); sc=$(serial_cost sel)
+	check "premise: both costs were extracted, not blank" \
+		"$([ -n "$dc" ] && [ -n "$sc" ] && echo yes || echo "dc=$dc sc=$sc")" "yes"
 	echo "-- serial cost: $doc_col $dc, sel $sc"
 	check "and the documented column is costed above the ordered one" \
 		"$(awk -v a="$dc" -v b="$sc" 'BEGIN { print (a > b) ? "yes" : "no (" a " vs " b ")" }')" "yes"


### PR DESCRIPTION
Test only, no `src/` change. Found by running a removal proof I owed and had not
done.

## The debt

#822 added two `scan_lines == 1` premises. I demonstrated the **mechanism** on a
different query and never reddened the premises themselves. That is the shape
this suite exists to catch, in the suite itself.

Doing it properly, with `pgcolumnar.enable_custom_scan = off`, reddens them at
`got [0] want [1]`. So they are not vacuous.

## But it exposed a real defect

With no columnar scan in the plan, every counter is an empty string, and
`check "" ""` **passes**:

```
-- a (the documented column):  of  groups read
PASS  the documented narrow query reads every chunk group
```

That check reported success having compared one blank with another. It would have
stayed hidden indefinitely, because the mutation that produces it is not one the
suite ever ran.

## The change

**The scan-node premise now runs before anything reads a counter**, rather than
inside the cost block. Every counter in this suite comes out of a columnar scan's
`EXPLAIN` output and does not exist without one, so that premise guards the whole
suite rather than the two checks that happened to follow it.

**Two premises refuse blanks explicitly**, one for the group counters and one for
the two costs, and they print what they got so a failure reads
`doc=/ sel=/` instead of leaving the reader to infer emptiness from a strange
comparison.

## Removal proof

`pgcolumnar.enable_custom_scan = off`, which is the mutation that produced the
vacuous pass:

```
FAIL  premise: the a plan is exactly one columnar scan node: got [0] want [1]
FAIL  premise: the sel plan is exactly one columnar scan node: got [0] want [1]
FAIL  premise: the group counters were read, not blank: got [doc=/ sel=/] want [yes]
FAIL  premise: both costs were extracted, not blank: got [dc= sc=] want [yes]
```

Before this commit the same mutation left check 1 reporting PASS. Stock is **11
of 11**, up from 9.

## What this does not claim

The premises guard the checks; check 1 itself is still a comparison of two values
that are equal when both are blank. The suite now fails loudly and names the
cause before reaching it, which is the house pattern (`cost_written_geometry`
orders its premises the same way), rather than making every individual check
self-defending.