### PR TITLE
docs: row_group.group_number is one-based, not zero-based (#817)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,20 @@ true until the next version shipped.
 
 ### Fixed
 
+- `pgcolumnar.row_group.group_number` is documented as **one-based**, which is what
+  it has always been (#817). The column comment said "0-based row group ordinal".
+  A group number is the stripe id reserved from the metapage when the group began
+  buffering, and `PgColumnarInitMetapage` starts `reservedStripeId` at 1, so there
+  is no group 0 on any storage. Verified rather than reasoned: on a 27-group table,
+  `row_group` and `zone_map` both report `min = 1, max = 27` over 27 distinct
+  numbers.
+
+  This is a source comment, not a catalog one -- there is no `COMMENT ON` for the
+  table, so nothing reads it at runtime and `native_upgrade_converge`, which
+  compares `col_description`, cannot see it. It is corrected because a reader
+  believed it: the planner's zone-map sample walked `[0, ngroups)` and paid for it
+  in the defect fixed immediately below.
+
 - The planner's zone-map sample is one-based, so it no longer under-prices a
   scan for matching the **newest** rows (#817).
 

--- a/pgcolumnar--1.0-alpha3.sql
+++ b/pgcolumnar--1.0-alpha3.sql
@@ -214,7 +214,17 @@ CREATE UNIQUE INDEX storage_pkey
 
 CREATE TABLE pgcolumnar.row_group (
 	storage_id bigint NOT NULL,
-	group_number bigint NOT NULL,     -- 0-based row group ordinal
+	-- ONE-BASED. group_number is the stripe id reserved from the metapage when
+	-- the group began buffering, and PgColumnarInitMetapage starts
+	-- reservedStripeId at 1, so there is no group 0 on any storage. The same
+	-- numbering is used by column_chunk, zone_map, bloom and delete_vector.
+	--
+	-- This said "0-based row group ordinal" until #817. Nothing read the comment
+	-- at runtime, but a reader did: the planner's zone-map sample walked
+	-- [0, ngroups), so it spent its first probe on a number that cannot exist and
+	-- never probed the highest group at all, which priced a predicate differently
+	-- according to where in the table its groups sat.
+	group_number bigint NOT NULL,
 	file_offset bigint NOT NULL,      -- logical byte offset of the group
 	row_count bigint NOT NULL,
 	byte_length bigint NOT NULL,


### PR DESCRIPTION
The column comment on `pgcolumnar.row_group` says `-- 0-based row group ordinal`.
It is not zero-based, and the sampler that believed it is the defect #821 just
fixed.

## The claim, measured

A group number is the stripe id reserved from the metapage when the group began
buffering (`columnar_write_state.c`: `groupNumber = writeState->stripeId`), and
`PgColumnarInitMetapage` starts `reservedStripeId` at 1. So there is no group 0 on
any storage. On a 540,000-row table written at `stripe_row_limit = 20000`:

```
row_group  min=1 max=27 n=27
zone_map   min=1 max=27 distinct=27
```

Confirmed on two catalogs, not inferred from the writer.

## Why a comment is worth a PR

Because a reader acted on it. `PgColumnarEstimatePruneSurvival` walked
`[0, ngroups)`, so it spent its first probe on a number that cannot exist and
never probed group `ngroups` at all — which priced the same predicate differently
according to where in the table its groups sat, by exactly a factor of two on a
two-group-of-ten predicate. #821 fixed the loop. This is the sentence that taught
it, still sitting in the schema for the next person to read.

Fixing the code and leaving the statement that produced it is half a fix.

## Scope, and what is deliberately untouched

**This cannot change behaviour.** It is a source comment, not a catalog one: there
is no `COMMENT ON` for the table, so it never reaches `pg_description`, and
`native_upgrade_converge` compares `col_description`, so no suite can observe it.

**`test/fixtures/pgcolumnar--1.0-alpha.sql` and `--1.0-alpha2.sql` carry the same
wrong line and are left alone.** They are faithful snapshots of shipped versions;
editing them would defeat exactly what the upgrade tests exist to check.

**The neighbour three lines down is correct and unchanged.**
`column_index smallint NOT NULL, -- 0-based attribute position` really is
0-based — the reader bounds-checks `columnIndex >= 0 && < natts` and indexes
`byCol[]` with it directly. Only the `group_number` line was wrong.

The replacement states the numbering, names where it comes from, notes that
`column_chunk`, `zone_map`, `bloom` and `delete_vector` share it, and records what
believing the old text cost.

## Gate

Full bar, even though the change is provably inert.

| | |
| --- | --- |
| `harness_selftest` | 168 checks, PASSED |
| `docs_style` | 9 checks, PASSED |
| `native_upgrade_converge` | 8 checks, PASSED |
| five-major preflight | built 5 of 5, 0 warnings |
| full matrix PG18 | 231 ran, 2 skipped, ALL VERSIONS PASSED |
| full matrix PG19 | ALL VERSIONS PASSED |

One note on that PG18 line, since the first attempt at it was red. I ran an
unrelated review probe in parallel, and `pgc_setup` build-and-installs into the
same prefix the matrix had already installed into and was running with
`PGC_SKIP_BUILD=1`. `harness_selftest` caught it exactly as designed --
`the installed .so is the one this run built: got [no (installed 72997ef7292f,
built 812c45ae4df4)]` -- and that stale-fingerprint check was the only failure of
231 suites. The gate was invalid rather than red, the concurrent matrix on PG19
passed ALL VERSIONS on the same tree throughout, and the figure above is from a
clean uncontended re-run.

acting as: OffgridwithJD
