### PR TITLE
fix: cost zone-map survival from the written geometry, not the session GUC (#817)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,46 @@ true until the next version shipped.
 
 ### Fixed
 
+- The zone-map survival estimate reads the row-group geometry a table was
+  **written** with, so a plan's cost no longer moves with the planning session's
+  `pgcolumnar.stripe_row_limit` (#817). This is the half #806 left open; it fixed
+  the index-fetch penalty and deliberately declined the same substitution here.
+
+  `pgcolumnar_zonemap_survival` asked `pgcolumnar_effective_stripe_row_limit`,
+  which answers "what limit would a write in THIS session use". For a table with
+  no per-table option, that is the session GUC. A table written at 2,000 rows per
+  group and planned from a session at the 150,000 default was therefore modelled
+  as holding `ceil(20000/150000) = 1` group, the one sampled group survived, and
+  the discount vanished. Measured on one unchanged table, varying only the
+  plan-time GUC:
+
+  | plan-time `stripe_row_limit` | before | after |
+  | --- | ---: | ---: |
+  | 150000, the default | 306.00 | 61.20 |
+  | 2000, the written value | 61.20 | 61.20 |
+
+  A 5x swing on a table that did not change, and at the default the pruning
+  predicate was priced identically to a full scan of the same table -- pruning had
+  left the cost model entirely rather than merely drifting.
+
+  **Why this is now safe, and was not before.** #806 declined it because the
+  substitution then moved `native_zonemap_narrow` from wide=30/narrow=30 to
+  wide=570/narrow=66, zone-map reads that scale with table width. That was the
+  width-blind whole-group probe in the estimator, which #821 replaced with a
+  per-column probe. The same substitution now measures **wide=40/narrow=40**,
+  exactly width-independent.
+
+  Planning-time zone-map fetches go from 1 to 10 on that fixture. The 1 was never
+  a saving: it was the estimator examining a single group because it believed a
+  20,000-row table held one. Ten is the estimator sampling the ten groups that
+  exist, bounded by `PGCOLUMNAR_PRUNE_SAMPLE_GROUPS` and charged per predicate
+  column rather than per table column.
+
+  `test/doc_parallel_premise.sh` carried `SET pgcolumnar.stripe_row_limit = 20000`
+  as a workaround for exactly this. It is **removed**, which makes that suite a
+  removal proof: its cost-ordering check now holds only because the estimator
+  reads the written geometry.
+
 - `pgcolumnar.row_group.group_number` is documented as **one-based**, which is what
   it has always been (#817). The column comment said "0-based row group ordinal".
   A group number is the stripe id reserved from the metapage when the group began

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -2194,22 +2194,33 @@ pgcolumnar_zonemap_survival(RelOptInfo *rel, Oid heapRelid)
 	 */
 	{
 		/*
-		 * NOT pgcolumnar_written_stripe_row_limit here, deliberately (#806).
+		 * The WRITTEN geometry, like the index-fetch penalty above (#806, #817).
 		 *
-		 * #806 measured the session GUC leaking into the index-fetch penalty and
-		 * fixed it there. Making the same substitution at this site is not the
-		 * same change: this one feeds the zone-map survival estimate, and
-		 * switching it moved native_zonemap_narrow's zone-map reads from
-		 * wide=30/narrow=30 to wide=570/narrow=66 -- reads that scale with table
-		 * width, which is the property that suite exists to hold.
+		 * This asked pgcolumnar_effective_stripe_row_limit, which answers "what
+		 * limit would a write in THIS session use" -- the right question for the
+		 * writer and the wrong one for a cost model describing geometry that
+		 * already exists. A table written at 20,000 rows per group and planned
+		 * from a session at the 150,000 default was modelled as holding
+		 * ceil(200000/150000) = 2 groups. A fraction-of-groups-surviving term
+		 * over two groups cannot express pruning at all, so zone-map pruning
+		 * left the cost entirely: two predicates that EXPLAIN ANALYZE shows
+		 * reading 10 of 10 and 3 of 10 chunk groups were both priced 4212.00.
 		 *
-		 * The written geometry is arguably the more correct input here too, and
-		 * the comment above says as much about which limit decides the group
-		 * count. But there is no measured defect at this site, there is a
-		 * measured regression from changing it, and #806's evidence is entirely
-		 * about the penalty. Left alone until someone has the measurement.
+		 * #806 declined this substitution, and was right to at the time: it then
+		 * moved native_zonemap_narrow from wide=30/narrow=30 to wide=570/
+		 * narrow=66, reads that scale with table width. That was the width-blind
+		 * whole-group probe, and #821 replaced it with a per-column probe. The
+		 * same substitution now measures wide=40/narrow=40 -- exactly
+		 * width-independent -- so the reason to decline is gone.
+		 *
+		 * Planning-time zone-map fetches on that fixture go from 1 to 10. The 1
+		 * was never a saving: it was this function examining a single group
+		 * because it believed a 200,000-row table held two. Ten is the estimator
+		 * sampling the ten groups that exist, bounded by
+		 * PGCOLUMNAR_PRUNE_SAMPLE_GROUPS and charged per predicate column rather
+		 * than per table column.
 		 */
-		int			limit = pgcolumnar_effective_stripe_row_limit(heapRelid);
+		int			limit = pgcolumnar_written_stripe_row_limit(heapRelid);
 
 		if (limit <= 0)
 			return 1.0;

--- a/test/doc_parallel_premise.sh
+++ b/test/doc_parallel_premise.sh
@@ -77,27 +77,22 @@ explain_of() {  # column -> the EXPLAIN ANALYZE text for a 25% scan on it
 }
 read_groups() { explain_of "$1" | sed -n 's/.*Chunk Groups Read: \([0-9]*\).*/\1/p' | head -1; }
 total_groups() { explain_of "$1" | sed -n 's/.*Chunk Groups Total: \([0-9]*\).*/\1/p' | head -1; }
-# The plan-time stripe_row_limit is set to the value this table was WRITTEN at.
+# No plan-time stripe_row_limit here, and that is now load-bearing.
 #
-# This is a workaround for the half of #817 that is still open: that
-# pgcolumnar_zonemap_survival sizes the group count from the planning SESSION's
-# GUC rather than from the written geometry. PR #821 fixed that estimator's
-# sample, NOT this. Do not delete this line on the strength of #817 being
-# referenced as fixed somewhere.
+# This carried `SET pgcolumnar.stripe_row_limit = 20000` as a workaround for the
+# half of #817 that was still open: pgcolumnar_zonemap_survival sized the group
+# count from the planning SESSION's GUC, so at the 150,000 default it modelled
+# this 10-group table as a 2-group one and zone-map pruning left the cost
+# entirely -- both columns priced 4212.00. The survival site now reads the
+# WRITTEN geometry, so the session GUC no longer reaches this estimate and the
+# workaround is redundant.
 #
-# ceil(200000/150000) is 2, so at the default the estimator models a 10-group
-# table as a 2-group one, and both groups it examines survive. Zone map pruning
-# then leaves the cost entirely: both columns cost 4212.00, where the written
-# limit prices the pruning. Measured on both sides of #821, which moved the
-# written-limit figure and left the default one untouched:
+# Leaving it out is deliberate: it makes this suite a removal proof for that fix.
+# The check below asserts the documented column is costed ABOVE the ordered one,
+# and without the SET that only holds because the estimator reads the geometry
+# the table was written with. Put the SET back and the check passes for the wrong
+# reason; revert the fix and it fails here.
 #
-#                       plan-time 150000     plan-time 20000
-#   before #821         4212.00 / 4212.00    4212.00 / 1404.00
-#   after  #821         4212.00 / 4212.00    4212.00 / 1263.60
-#
-# The post-#821 figure is 4212 x 3/10, and EXPLAIN ANALYZE reports "Chunk Groups
-# Read: 3 of 10", so the estimate now agrees with the scan it prices. The check
-# below asserts the ORDERING of the two costs, which holds on either side.
 # Anchored on the scan node rather than on the first cost= in the plan.
 # `grep -m1` returns whatever node comes first, so the moment the plan gains a
 # node above the scan it reports that node's cost instead, silently and with the
@@ -105,7 +100,6 @@ total_groups() { explain_of "$1" | sed -n 's/.*Chunk Groups Total: \([0-9]*\).*/
 # the suite should not contain one.
 plan_of() {
 	q "SET max_parallel_workers_per_gather = 0;
-	   SET pgcolumnar.stripe_row_limit = 20000;
 	   EXPLAIN SELECT sel, a, b FROM c753 WHERE $1 <= $(p25 "$1")"
 }
 scan_lines() { plan_of "$1" | grep -c 'PgColumnarScan'; }

--- a/test/zonemap_estimate_sample.sh
+++ b/test/zonemap_estimate_sample.sh
@@ -171,4 +171,50 @@ check "a pruning predicate still returns the right rows" \
 check "a predicate matching nothing still returns no rows" \
 	"$(q 'SELECT count(*) FROM w WHERE c1 > 99999;')" "0"
 
+# ---- the estimate must not move with the planning session's GUC (#817) ------
+#
+# The two tables above carry an explicit per-table stripe_row_limit, so
+# pgcolumnar_effective_stripe_row_limit would return the option and the session
+# GUC could never have reached them. This one deliberately sets NO option and is
+# written under a session GUC instead, which is the only shape where the two
+# readings differ -- and it is the shape a user produces by setting the GUC before
+# a bulk load.
+#
+# Before #817's fix the survival site asked what limit a write in the PLANNING
+# session would use. At the 150,000 default that made this 10-group table a
+# ceil(20000/150000) = 1 group one, the single sampled group survived, and the
+# discount vanished: the same unchanged table was priced differently by two
+# sessions that had done nothing but SET a GUC.
+q "CREATE TABLE gsess (c1 int, c2 int) USING pgcolumnar;" >/dev/null
+q "SET pgcolumnar.stripe_row_limit = 2000;
+   INSERT INTO gsess SELECT g, g FROM generate_series(1,20000) g;" >/dev/null
+
+check "PREMISE: gsess carries NO per-table option, so the GUC is the only other input" \
+	"$(q "SELECT count(*) FROM pgcolumnar.options WHERE regclass='gsess'::regclass AND stripe_row_limit IS NOT NULL;")" "0"
+check "PREMISE: and it really was written at 2000, so it holds 10 groups" \
+	"$(q "SELECT count(*) FROM pgcolumnar.row_group WHERE storage_id = $(sid gsess);")" "10"
+
+# The SET and the EXPLAIN must share a session, so they go in one call.
+gcost() {
+	q "SET max_parallel_workers_per_gather = 0;
+	   SET pgcolumnar.stripe_row_limit = $1;
+	   EXPLAIN SELECT count(*) FROM gsess WHERE c1 <= 4000;" |
+	  sed -n 's/.*Custom Scan (PgColumnarScan) on gsess  (cost=[0-9.]*\.\.\([0-9.]*\) .*/\1/p'
+}
+DEF="$(gcost 150000)"   # the shipped default
+WRT="$(gcost 2000)"     # the value the table was written at
+echo "-- gsess cost, planned at the default GUC=$DEF ; at the written 2000=$WRT"
+check "a cost was extracted from both arms" \
+	"$([ -n "$DEF" ] && [ -n "$WRT" ] && echo yes || echo "def=$DEF wrt=$WRT")" "yes"
+check "the estimate does not move with the planning session's GUC (#817)" "$DEF" "$WRT"
+check "and the discount is real, not just stable (2 of 10 groups priced below a full scan)" \
+	"$(q "SET max_parallel_workers_per_gather = 0;
+	      EXPLAIN SELECT count(*) FROM gsess WHERE c1 <= 4000;" |
+	   sed -n 's/.*Custom Scan (PgColumnarScan) on gsess  (cost=[0-9.]*\.\.\([0-9.]*\) .*/\1/p' |
+	   awk -v f="$(q "SET max_parallel_workers_per_gather = 0;
+	                  EXPLAIN SELECT count(*) FROM gsess WHERE c1 >= 0;" |
+	               sed -n 's/.*Custom Scan (PgColumnarScan) on gsess  (cost=[0-9.]*\.\.\([0-9.]*\) .*/\1/p')" \
+	       '{ print ($1 < f) ? "yes" : "no (" $1 " vs full " f ")" }')" "yes"
+check "gsess reads back correctly" "$(q 'SELECT count(*) FROM gsess WHERE c1 <= 4000;')" "4000"
+
 pgc_summary


### PR DESCRIPTION
Closes the half of #817 that #806 left open. The site's own comment said *"left
alone until someone has the measurement"* — this is that measurement, and the
reason it was declined has since been removed by #821.

## The defect

`pgcolumnar_zonemap_survival` asked `pgcolumnar_effective_stripe_row_limit`, which
answers "what limit would a write in **this session** use". For a table carrying no
per-table option that is the session GUC, so the same unchanged table was priced
differently by two sessions that had done nothing but `SET` one.

A table written at 2,000 rows per group, planned from a session at the 150,000
default, was modelled as holding `ceil(20000/150000) = 1` group. The one sampled
group survived and the discount vanished:

| plan-time `stripe_row_limit` | before | after |
| --- | ---: | ---: |
| 150000, the default | **306.00** | 61.20 |
| 2000, the written value | 61.20 | 61.20 |

A 5x swing on a table that did not change. And 306.00 is not a drifted number — it
is what a **full scan of the same table** costs, so zone-map pruning had left the
cost model entirely rather than being mis-sized.

## Why this is safe now and was not before

#806 declined this substitution and was right to. It then moved
`native_zonemap_narrow` from wide=30/narrow=30 to wide=570/narrow=66, zone-map
reads scaling with table width, which is the property that suite exists to hold.

That was the width-blind whole-group probe in the estimator. #821 replaced it with
a per-column probe, so a more accurate group count no longer switches on a loop
that scales with width:

```
                              wide (30 col)   narrow (2 col)
  main today                        31              31        PASS
  with this change                  40              40        PASS
  #806 measured, pre-#821          570              66        FAIL
```

Exactly equal on 30 columns and 2.

**The honest cost.** Planning-time zone-map fetches on that fixture go from 1 to
10. The 1 was never a saving: it was the estimator examining a single group because
it believed the table held one. Ten is the estimator sampling the ten groups that
exist, bounded by `PGCOLUMNAR_PRUNE_SAMPLE_GROUPS` and charged per predicate column
rather than per table column.

## Tests

**`test/doc_parallel_premise.sh` loses its workaround, and that is the removal
proof.** It carried `SET pgcolumnar.stripe_row_limit = 20000` in `plan_of`
specifically for this defect, with a comment saying so. Removing it means the
suite's cost-ordering check holds only because the estimator reads the written
geometry. The write-time `SET` that gives the fixture its geometry stays; only the
plan-time one goes.

**`test/zonemap_estimate_sample.sh` gains a direct arm** on a table with **no**
per-table option — the only shape where the two readings differ, and the shape a
user produces by setting the GUC before a bulk load. The premise that the table
carries no option is load-bearing: with one, `effective()` returns the option and
the GUC could never have mattered, so the check would pass for the wrong reason.

Red/green, reverting only the `src` line and keeping both tests:

```
GREEN  zonemap_estimate_sample  PASSED   gsess: default=61.20  written=61.20
       doc_parallel_premise     11/11    a 4212.00, sel 1263.60
       native_zonemap_narrow    PASSED   40 / 40

RED    zonemap_estimate_sample  FAILED
         FAIL the estimate does not move with the planning session's GUC (#817):
              got [306.00] want [61.20]
         FAIL and the discount is real, not just stable:
              got [no (306.00 vs full 306.00)] want [yes]
       doc_parallel_premise     FAILED
         FAIL and the documented column is costed above the ordered one:
              got [no (4212.00 vs 4212.00)] want [yes]
       native_zonemap_narrow    PASSED   31 / 31   (unaffected either way)
```

## Gate

| | |
| --- | --- |
| `harness_selftest` | 168 checks, PASSED |
| `docs_style` | 9 checks, PASSED |
| five-major preflight | built 5 of 5, 0 warnings |
| full matrix PG18 | 231 of 233 ran, 2 skipped, ALL VERSIONS PASSED |
| full matrix PG19 | **233 of 233 ran, 0 skipped**, ALL VERSIONS PASSED |

`zonemap_estimate_sample`, `doc_parallel_premise`, `native_zonemap_narrow` and
`zonemap_cost` each report `=PASS` explicitly on both majors, so they ran rather
than skipped.

The gate asserts its own premise before running: it aborts unless the survival site
reads `written()`, `effective()` is gone from it, `plan_of` has no plan-time `SET`,
and the new arm is present. I added that after starting an earlier run on a tree
whose `src` change a cleanup step had reverted.

The fixture and the 4212-vs-4212 measurement are jdatcmd's, from #752 and #820.

acting as: OffgridwithJD
