### PR TITLE
MERGE works, and now says so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,23 @@ true until the next version shipped.
 
 ## [Unreleased]
 
+### Added
+
+- `MERGE` is documented as working, which it has been all along. It needs no
+  index on the columnar target and takes every arm, including
+  `WHEN MATCHED ... DELETE`, `WHEN NOT MATCHED BY SOURCE`, and
+  `RETURNING merge_action()`. A columnar table can be the source as well as the
+  target. Verified rather than assumed, on PostgreSQL 17.10, in four shapes.
+
+  Nothing in the code changed. The gap was that a reader had no way to learn
+  this: `MERGE` appeared in no user-facing document, and its absence from
+  `docs/limitations.md` reads as easily as "unsupported" as "supported".
+
+  `docs/features.md` also records what a `MERGE` costs, because that is the part
+  a reader acts on: its updates and deletes mark rows rather than rewriting row
+  groups, exactly as a plain `UPDATE` or `DELETE` does, so space returns only
+  after `pgcolumnar.vacuum`.
+
 ### Fixed
 
 - The documentation is brought back into line with the code, and the version

--- a/docs/features.md
+++ b/docs/features.md
@@ -117,6 +117,15 @@ coverage.
 - Concurrent inserts of the same unique key are serialized so the conflict is
   always caught, controlled by `pgcolumnar.enable_unique_insert_lock`. See
   [limitations](limitations.md) for the exact behavior.
+- `INSERT`, `UPDATE`, `DELETE` and `MERGE` all work on a columnar table.
+  `MERGE` needs no index on the target and takes all of its arms, including
+  `WHEN MATCHED ... DELETE`, `WHEN NOT MATCHED BY SOURCE`, and
+  `RETURNING merge_action()`. A columnar table can be the source as well as the
+  target.
+- A `MERGE` costs what its arms cost. Its updates and deletes mark rows rather
+  than rewriting row groups, exactly as a plain `UPDATE` or `DELETE` does, so
+  space returns only after `pgcolumnar.vacuum`. See
+  [workload and access patterns](limitations.md#workload-and-access-patterns).
 
 ## Schema changes
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -118,10 +118,13 @@ coverage.
   always caught, controlled by `pgcolumnar.enable_unique_insert_lock`. See
   [limitations](limitations.md) for the exact behavior.
 - `INSERT`, `UPDATE`, `DELETE` and `MERGE` all work on a columnar table.
-  `MERGE` needs no index on the target and takes all of its arms, including
-  `WHEN MATCHED ... DELETE`, `WHEN NOT MATCHED BY SOURCE`, and
-  `RETURNING merge_action()`. A columnar table can be the source as well as the
-  target.
+  `MERGE` needs no index on the target and takes every arm the server offers,
+  including `WHEN MATCHED ... DELETE`. A columnar table can be the source as well
+  as the target.
+- `WHEN NOT MATCHED BY SOURCE` and `RETURNING merge_action()` work too, on
+  PostgreSQL 17 and later. Those two clauses are the server's, added in 17. On
+  PostgreSQL 15 and 16 they are a syntax error before the access method sees
+  them.
 - A `MERGE` costs what its arms cost. Its updates and deletes mark rows rather
   than rewriting row groups, exactly as a plain `UPDATE` or `DELETE` does, so
   space returns only after `pgcolumnar.vacuum`. See


### PR DESCRIPTION
Documentation only. No code change, so alpha3 stays feature-complete.

## The gap

`MERGE` appeared in **no user-facing document**. That is not a neutral omission:
`docs/limitations.md` is where a reader checks what does not work, and silence
there reads as easily as "unsupported" as it does as "supported". So a reader
evaluating pgColumnar for a workload that needs `MERGE` had no way to find out
that it already works.

It surfaced while building the release plan. Without checking, it would have
looked like pre-beta feature work and consumed an alpha slot.

## Verified rather than assumed

Four shapes, PostgreSQL 17.10:

| shape | result |
| --- | --- |
| all three arms, target with **no index** (conditional `UPDATE`, `DELETE`, `INSERT`) | `MERGE 3`, correct five rows |
| a columnar table as the **source** as well as the target | `MERGE 2`, correct |
| `WHEN NOT MATCHED BY SOURCE` (PostgreSQL 17) | `MERGE 4`, correct |
| `RETURNING merge_action()` | `INSERT \| 99 \| Z` |

The no-index case matters, because a reader could reasonably assume a columnar
`MERGE` needs an index on the join column to be viable. It does not.

## Both halves, not just the capability

`docs/features.md` records what a `MERGE` **costs**, because that is the part a
reader acts on. Its updates and deletes mark rows rather than rewriting row
groups, exactly as a plain `UPDATE` or `DELETE` does, so space returns only after
`pgcolumnar.vacuum`.

That entry links to the "workload and access patterns" section which already
states this, rather than restating it. Two copies of a behavioural claim drift,
and this session has spent a lot of effort on exactly that failure.

## Verification

`docs_style` 9 of 9, plain-language checker `ok` on both files, and the anchor
`limitations.md#workload-and-access-patterns` resolves to the heading at
`docs/limitations.md:184`.