### PR TITLE
cluster() is not numeric-only, and the error already said so (#827 follow-up)

### DIFF
--- a/pgcolumnar--1.0-alpha2--1.0-alpha3.sql
+++ b/pgcolumnar--1.0-alpha2--1.0-alpha3.sql
@@ -293,3 +293,6 @@ $sort_status$;
 
 COMMENT ON FUNCTION pgcolumnar.sort_status(regclass)
 	IS 'how much of an ordered columnar table is still in its ordered run, and by what kind of ordering (#301, #761)';
+
+COMMENT ON FUNCTION pgcolumnar.vacuum_sorted(regclass, name[])
+	IS 'compact a columnar table, storing rows sorted ascending (NULLS LAST) on the given columns. With no columns, applies the table''s declared sort_by key from set_options (#288), like a bare CLUSTER re-applying a remembered index; errors if none is declared. Supports any btree-orderable column including text and numeric, unlike Z-order cluster(), which takes integer, date/time, boolean and floating-point columns only. One-shot: not auto-maintained.';

--- a/pgcolumnar--1.0-alpha3.sql
+++ b/pgcolumnar--1.0-alpha3.sql
@@ -895,7 +895,7 @@ CREATE FUNCTION pgcolumnar.vacuum_sorted(
 	AS 'MODULE_PATHNAME', 'pgcolumnar_vacuum_sorted';
 
 COMMENT ON FUNCTION pgcolumnar.vacuum_sorted(regclass, name[])
-	IS 'compact a columnar table, storing rows sorted ascending (NULLS LAST) on the given columns. With no columns, applies the table''s declared sort_by key from set_options (#288), like a bare CLUSTER re-applying a remembered index; errors if none is declared. Supports any btree-orderable column including text (unlike the numeric-only Z-order cluster()). One-shot: not auto-maintained.';
+	IS 'compact a columnar table, storing rows sorted ascending (NULLS LAST) on the given columns. With no columns, applies the table''s declared sort_by key from set_options (#288), like a bare CLUSTER re-applying a remembered index; errors if none is declared. Supports any btree-orderable column including text and numeric, unlike Z-order cluster(), which takes integer, date/time, boolean and floating-point columns only. One-shot: not auto-maintained.';
 
 /*
  * One-argument form: apply the declared sort_by key (#288). A VARIADIC function

--- a/src/columnar_vacuum.c
+++ b/src/columnar_vacuum.c
@@ -1740,7 +1740,8 @@ vacuum_sorted_gate_is_noop(Relation rel, int ncols, AttrNumber *atts)
  *		declared sort_by key from pgcolumnar.options (#288), like a bare
  *		"CLUSTER t" re-applying a remembered index; it errors if none is set.
  *		Sorting supports any btree-orderable column, text included; the Z-order
- *		cluster() path is numeric-only.
+ *		cluster() path takes integer, date/time, boolean and floating-point
+ *		columns.
  */
 Datum
 pgcolumnar_vacuum_sorted(PG_FUNCTION_ARGS)


### PR DESCRIPTION
Documentation only. Nothing executes differently. Follow-up to the finding I left on
#827, which I had not filed.

**Claiming this so it cannot collide with your bug sweep** — it touches only the two
extension scripts, one code comment, and the CHANGELOG.

## The defect

`COMMENT ON FUNCTION pgcolumnar.vacuum_sorted` calls the alternative "the
**numeric-only** Z-order `cluster()`". Wrong in both directions.

`cluster_type_supported()` (`src/columnar_vacuum.c`) takes `boolean`, `smallint`,
`integer`, `bigint`, `real`, `double precision`, `date`, `timestamp` and
`timestamptz`. Several are not numeric. And `numeric` itself is absent — `NUMERICOID`
appears nowhere in the file — so the one type the sentence names is precisely the one
`cluster()` refuses.

**The extension already contradicted it.** A rejected column raises:

> `errhint`: Z-order clustering supports integer, date/time, boolean, and
> floating-point columns.

A user who trips the gate is told the truth. A user who reads the catalog first is
not. The comment now uses the errhint's own wording, so there is one description of
this rule instead of two that disagree.

This is user-facing: `COMMENT ON FUNCTION` lands in `pg_description` and is what
`\df+` prints — exactly where someone choosing between `vacuum_sorted` and
`cluster()` looks.

## Measured, not read

A positive control is included so the deny arms are not vacuous. 20,000-row table,
PG 18:

| call | result |
| --- | --- |
| `vacuum_sorted('np','n')` numeric | accepted |
| `vacuum_sorted('np','t')` text | accepted |
| `cluster('np','i')` int | accepted — **control** |
| `cluster('np','n')` numeric | rejected: `column "n" of type numeric cannot be used as a clustering key` |
| `cluster('np','t')` text | rejected |

The error a user gets for `numeric` refutes the word "numeric-only" on its own.

## Why the upgrade script is half the fix, and not optional

`native_upgrade_converge` hashes `obj_description(p.oid,'pg_proc')` for every
function in the schema. The `1.0-alpha2` -> `1.0-alpha3` script did not re-issue this
comment, so correcting only the full script makes a fresh install and an upgraded one
disagree — and the suite says so. Run in this order:

| arm | `native_upgrade_converge` |
| --- | --- |
| unmodified `main` | **8 of 8 PASSED** |
| full script corrected only | **FAILED** — both the `1.0-alpha` and `1.0-alpha2` paths |
| + upgrade script re-issues | **8 of 8 PASSED** |

The middle row is the point: the gate catches the half-fix. Re-issuing in that script
is the established pattern — `set_options`, `expire`, `parallel_copy` and
`sort_status` already do it there. The upgrade copies the literal verbatim from the
full script, so the two cannot drift.

## The third site

The same sentence sat in `src/columnar_vacuum.c` above `pgcolumnar_vacuum_sorted`.
That is where the catalog string came from, so it is corrected too. Leaving it would
leave the input to the defect in place.

**Left alone deliberately:** `test/fixtures/pgcolumnar--1.0-alpha{,2}.sql` and
`pgcolumnar--1.0-alpha--1.0-alpha2.sql` are faithful snapshots of what shipped, and
the alpha2->alpha3 re-issue corrects the upgrade path anyway. `CHANGELOG.md:2422` is
a historical entry.

## Gate

| arm | result |
| --- | --- |
| preflight, PG 15/16/17/18/19 | built 5 of 5, 0 warnings each |
| matrix PG18 | 231 ran, 2 skipped, ALL PASSED |
| matrix PG19 | 233 ran, 0 skipped, ALL PASSED |
| `docs_style` | 9 of 9 |
| `native_upgrade_converge` | 8 of 8 |
| `harness_selftest` | PASS on both arms |

Those tallies are identical to `main` at `808cd46` measured on the same box today,
which is how I know the change is inert.

**The first gate run failed**, and it is worth recording rather than quietly
re-running: `docs_style` reported
`CHANGELOG.md carries no em or en dash: got [2] want [0]`. Both dashes were mine, in
the entry above. The house rule is deliberate and documented in the suite. Fixed
before pushing, so this branch has never been red, but it would have been the first
thing CI told you.
