### PR TITLE
fix: size the options arrays from the catalog, not a stale constant (#834)

### DIFF
--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -46,7 +46,12 @@
 #define Anum_options_sort_by 7
 #define Anum_options_ttl_column 8
 #define Anum_options_ttl_interval 9
-#define Natts_options 7
+/* Nine, not seven: ttl_column and ttl_interval (#403 item 5a) widened the table
+ * and this constant was left behind. It sizes the values/nulls/replace arrays
+ * handed to heap_modify_tuple, which iterates tupdesc->natts, so a short value
+ * here reads past three stack arrays at once. test/catalog_natts.sh pins every
+ * Natts_* against the width the server reports. */
+#define Natts_options 9
 
 /* attribute numbers for columnar.projection (gap 26, format 2.2) */
 #define Anum_projection_declaration_rel 1

--- a/test/catalog_natts.sh
+++ b/test/catalog_natts.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# Every Natts_* constant must equal the width of the catalog it addresses.
+#
+# The constants in src/columnar_metadata.c size the stack arrays handed to
+# heap_modify_tuple, which iterates tupdesc->natts. A constant smaller than its
+# table is a stack buffer overflow, not a cosmetic drift: it reads
+# (natts - Natts) slots past the end of three arrays at once.
+#
+# That is not hypothetical. pgcolumnar.options grew ttl_column and ttl_interval
+# for retention (#403 item 5a) and the Anum_options_* constants were extended to
+# 9, but Natts_options was left at 7. ALTER TABLE ... RENAME COLUMN on a table
+# with a declared sort_by then overflowed three arrays in
+# PgColumnarRenameDeclaredSortByColumn and aborted the backend, taking the
+# cluster into crash recovery with it.
+#
+# Why the whole matrix never saw it: on an ordinary build the overflow lands in
+# adjacent stack slots and is silent, so sorted_mark_rename passed on every
+# major. Only the sanitizer build diagnoses it, and sorted_mark_rename was not in
+# the sanitizer subset. So this suite checks the INVARIANT rather than waiting
+# for the crash, which makes it a matrix check on every major rather than a
+# sanitizer-only one.
+#
+# The widths come from the LIVE SERVER, not from the shipped .sql: the server is
+# what heap_modify_tuple will actually iterate, and an upgrade script that adds a
+# column changes the server without changing any CREATE TABLE text.
+#
+# Usage:  test/catalog_natts.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+META="$PGC_SRCDIR/src/columnar_metadata.c"
+check "premise: the metadata source is where we think it is" \
+	"$([ -f "$META" ] && echo found || echo missing)" "found"
+
+# The constant name is not always the table name: Anum_native_storage_* address
+# pgcolumnar.storage. Everything else is identity. Kept as an explicit map so a
+# renamed catalog fails loudly here instead of silently skipping.
+map_table() {
+	case "$1" in
+		native_storage) echo storage ;;
+		*)              echo "$1" ;;
+	esac
+}
+
+# --- premise: the constants exist and are actually LOAD-BEARING --------------
+# A grep over source text is the weaker kind of check. Premise it on the call
+# site, or this suite would approve a file that no longer sizes anything with
+# these constants.
+nconst=$(grep -cE '^#define Natts_[a-z_]+[[:space:]]+[0-9]+' "$META")
+check "premise: the source defines Natts_* constants at all" \
+	"$([ "$nconst" -gt 0 ] && echo yes || echo no)" "yes"
+
+nuse=$(grep -cE '\[Natts_[a-z_]+\]' "$META")
+check "premise: those constants SIZE arrays, so a wrong one is a real overflow" \
+	"$([ "$nuse" -gt 0 ] && echo yes || echo no)" "yes"
+
+nmod=$(grep -c 'heap_modify_tuple' "$META")
+check "premise: heap_modify_tuple is still called here (the consumer of those arrays)" \
+	"$([ "$nmod" -gt 0 ] && echo yes || echo no)" "yes"
+echo "-- constants defined: $nconst   array declarations using them: $nuse   heap_modify_tuple calls: $nmod"
+
+# --- the sweep --------------------------------------------------------------
+checked=0
+missing=0
+while read -r name value; do
+	tbl="$(map_table "$name")"
+	# Ask the server, never the .sql file.
+	width="$(q "SELECT count(*) FROM pg_attribute a
+	            JOIN pg_class c ON c.oid = a.attrelid
+	            JOIN pg_namespace n ON n.oid = c.relnamespace
+	            WHERE n.nspname = 'pgcolumnar' AND c.relname = '$tbl'
+	              AND a.attnum > 0 AND NOT a.attisdropped;")"
+	if [ -z "$width" ] || [ "$width" = 0 ]; then
+		missing=$((missing + 1))
+		check "premise: pgcolumnar.$tbl exists on the server (for Natts_$name)" \
+			"absent" "present"
+		continue
+	fi
+	checked=$((checked + 1))
+	check_num "Natts_$name matches the width of pgcolumnar.$tbl" "$value" "$width"
+done < <(grep -oE '^#define Natts_[a-z_]+[[:space:]]+[0-9]+' "$META" \
+         | sed -E 's/^#define Natts_//; s/[[:space:]]+/ /')
+
+# inputs == sum(buckets), printed from the data rather than retyped.
+echo "-- constants swept: $nconst = checked $checked + unmapped $missing"
+check_num "premise: every constant found was swept" "$((checked + missing))" "$nconst"
+
+# --- the other direction: a catalog with no constant ------------------------
+# Not a failure on its own -- not every catalog is written through
+# heap_modify_tuple -- but it is printed so a new catalog that needs a constant
+# is visible rather than silently uncovered.
+echo "-- pgcolumnar catalogs on the server, and whether a Natts_* names them:"
+for t in $(q "SELECT c.relname FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+              WHERE n.nspname = 'pgcolumnar' AND c.relkind = 'r' ORDER BY c.relname;"); do
+	cname="$t"
+	[ "$t" = storage ] && cname=native_storage
+	if grep -qE "^#define Natts_${cname}[[:space:]]" "$META"; then
+		echo "     $t: Natts_$cname"
+	else
+		echo "     $t: (no Natts_ constant)"
+	fi
+done
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -59,6 +59,7 @@ SUITES=(
 	bloom_setting
 	bloom_sizing
 	cancel_decode
+	catalog_natts
 	column_projection
 	concurrency
 	concurrent_diff


### PR DESCRIPTION
Closes #834.

`pgcolumnar.options` has nine columns and `src/columnar_metadata.c:49` said
seven, so `PgColumnarRenameDeclaredSortByColumn` handed `heap_modify_tuple`
three stack arrays that were two slots short of what it iterates.

`ALTER TABLE ... RENAME COLUMN` on a columnar table with a declared `sort_by` is
enough to reach it. On the sanitizer build the backend aborts and the postmaster
takes every other session into crash recovery.

## How it was found

A full-matrix sanitizer sweep. The shipped gate runs 24 of the 233 registered
suites under ASAN; this ran all of them. One suite produced a genuine report:

```
logs examined              232
with a genuine report        1   (sorted_mark_rename)
clean                      231
```

`sorted_mark_rename` performs exactly this rename and passes on an ordinary
build, on both PG18 and PG19, because the overflow lands in adjacent stack slots
and has no symptom there.

## The fix

`Natts_options` becomes 9, with a comment saying why the number is what it is.

## The test

`test/catalog_natts.sh` checks the invariant rather than waiting for the crash,
so it runs on every major rather than only where a sanitizer does. For each
`Natts_*` constant it compares the value against the width the **server** reports
for the catalog it addresses. The server is what `heap_modify_tuple` iterates,
and an upgrade script can widen a table without changing any `CREATE TABLE` text.

It asserts its own premises before sweeping: that the constants exist, that they
still size arrays (`[Natts_...]`), and that `heap_modify_tuple` is still the
consumer. Without those, the suite would keep passing after the constants stopped
being load-bearing, which is the failure mode a text-grep check invites.

Eleven catalogs audited; ten were already correct.

## Removal proof

With `Natts_options` put back to 7, and the mutation asserted applied:

| | fixed | mutated |
| --- | --- | --- |
| installed `.so` | `9496bf09f2643178` | `cb74c148fa3d55cc` |
| `catalog_natts` | PASSED | **FAIL** `got [7] want [9]` |
| `sorted_mark_rename` under ASAN | rc=0, 0 reports | **rc=1, 2 reports**, `stack-buffer-overflow heaptuple.c:1240` |

The `.so` differed between the runs, so the before run was not the fixed binary.

## Verification

- `catalog_natts` RED before the fix for the stated reason, GREEN after.
- The minimal reproducer no longer aborts; `ALTER TABLE` returns normally.
- `sorted_mark_rename` under the sanitizer: was rc=1 with 2 reports, now rc=0
  with none.
- `harness_selftest`: 168 checks, PASSED, so the new suite is registered in
  sorted position and the array still parses the way bash reads it.
- `shellcheck -S error`: clean.

## Not claimed

Pre-fix, `replace[7]` and `replace[8]` were uninitialised stack, so replacing
`ttl_column` or `ttl_interval` with a garbage Datum was possible in principle. I
tried to demonstrate that on a non-sanitizer build and could not: both fields
survived the rename intact. The defect here is the out-of-bounds read and the
abort it causes, not a demonstrated corruption.

## Follow-up, deliberately not in this PR

`sorted_mark_rename` is still outside the sanitizer subset. This PR makes the
class visible to the ordinary matrix, which is the stronger fix; widening the
sanitizer subset is a separate change.
