### PR TITLE
fix: decline the equality preimage when the interval degenerates (#836)

### DIFF
--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -586,6 +586,26 @@ pgcolumnar_preimage_range_scankey(OpExpr *op, Index scanrelid, TupleDesc tupdesc
 			break;				/* equality: the bounded interval below */
 	}
 
+	/*
+	 * Equality needs the interval to be non-empty, and at an infinity it is not.
+	 * The near-maximum decline above deliberately exempts infinities because
+	 * interval arithmetic saturates there instead of raising -- but saturating
+	 * is exactly the problem here: hi = lo + step returns lo again, so the
+	 * bounded interval becomes `k >= lo AND k < lo` and excludes the row it was
+	 * built to select. `date_trunc('day', ts) = 'infinity'` returned no rows
+	 * while the heap returned one.
+	 *
+	 * The ordered operators are unaffected and keep their exemption: each emits
+	 * ONE key, so lo == hi costs them nothing. That is why the two infinity arms
+	 * in preimage_rewrite.sh stayed green while equality was wrong.
+	 *
+	 * Declining rather than special-casing the value: this file's rule is that
+	 * anything it cannot inarguably invert returns 0, and a decline costs a scan
+	 * rather than an answer.
+	 */
+	if (DatumGetTimestamp(hi) <= DatumGetTimestamp(lo))
+		return 0;
+
 	key[0].sk_strategy = BTGreaterEqualStrategyNumber;
 	key[0].sk_argument = lo;
 

--- a/test/preimage_rewrite.sh
+++ b/test/preimage_rewrite.sh
@@ -170,7 +170,8 @@ ord_arm "ts_trunc < c, c not truncated"  "date_trunc('day', ts) < $HALF"  "ts < 
 psql_run "CREATE TABLE pre_edge(ts timestamp, v int) USING pgcolumnar;"
 psql_run "INSERT INTO pre_edge SELECT timestamp '2024-01-01' + g * interval '1 day', g
           FROM generate_series(1,1000) g;"
-psql_run "INSERT INTO pre_edge VALUES ('294276-12-31 23:00', -1), ('infinity', -2);"
+psql_run "INSERT INTO pre_edge VALUES ('294276-12-31 23:00', -1), ('infinity', -2),
+          ('-infinity', -3);"
 psql_run "CREATE TABLE pre_edgeh(ts timestamp, v int);"
 psql_run "INSERT INTO pre_edgeh SELECT * FROM pre_edge;"
 MAXY="timestamp '294276-01-01'"
@@ -187,10 +188,27 @@ edge_arm "year >= max" "date_trunc('year', ts) >= $MAXY"
 edge_arm "year > max"  "date_trunc('year', ts) > $MAXY"
 edge_arm "year <= max" "date_trunc('year', ts) <= $MAXY"
 edge_arm "year < max"  "date_trunc('year', ts) < $MAXY"
-# Infinity is exempt: interval arithmetic saturates there rather than
-# overflowing, so those predicates still rewrite and still prune.
+# Infinity is exempt from the near-maximum decline: interval arithmetic saturates
+# there rather than overflowing, so those predicates still rewrite and still
+# prune.
 edge_arm "day >= infinity" "date_trunc('day', ts) >= timestamp 'infinity'"
 edge_arm "day < infinity"  "date_trunc('day', ts) < timestamp 'infinity'"
+# EQUALITY on an infinity is the case that exemption did not cover. The ordered
+# operators emit ONE key, so lo == hi is harmless to them and the two arms above
+# stayed green. Equality emits the bounded interval `k >= lo AND k < hi`, and
+# saturation makes hi equal lo, so the interval is empty and excludes the very
+# row that matches. The suite carried infinity arms, and carried equality arms,
+# and never their intersection.
+edge_arm "day = infinity"  "date_trunc('day', ts) = timestamp 'infinity'"
+edge_arm "day = -infinity" "date_trunc('day', ts) = timestamp '-infinity'"
+edge_arm "hour = infinity" "date_trunc('hour', ts) = timestamp 'infinity'"
+edge_arm "year = -infinity" "date_trunc('year', ts) = timestamp '-infinity'"
+# The premise those four rest on: both infinities are in the fixture, so a
+# columnar count of 0 is a lost row rather than an empty fixture.
+check_num "premise: the fixture holds one +infinity row" \
+	"$(q1 "SELECT count(*) FROM pre_edgeh WHERE ts = timestamp 'infinity';")" 1
+check_num "premise: the fixture holds one -infinity row" \
+	"$(q1 "SELECT count(*) FROM pre_edgeh WHERE ts = timestamp '-infinity';")" 1
 
 # ---- the shapes that must DECLINE ------------------------------------------
 # A non-truncated constant is unsatisfiable, and these arms assert the ANSWER,


### PR DESCRIPTION
Closes #836.

`date_trunc(unit, ts) = 'infinity'` returned 0 rows where the heap returned 1, in the **default configuration** (`enable_qual_pushdown` ships on).

## Cause

The near-maximum decline correctly exempts infinities, because interval arithmetic saturates there instead of raising. Saturating is the problem: `hi = lo + step` returns `lo` again, so equality's bounded interval `k >= lo AND k < hi` is empty.

Ordered operators are unaffected and keep the exemption: each emits ONE key, so `lo == hi` costs them nothing. That is precisely why the two infinity arms already in the suite stayed green while equality was wrong.

## Fix

Equality declines when `hi` is not strictly greater than `lo`. Declining rather than special-casing the value follows the file's stated rule: anything it cannot inarguably invert returns 0, and a decline costs a scan rather than an answer.

## Test

The suite carried infinity rows and exercised them with `>=` and `<`; it carried equality arms on finite constants; it never carried their intersection. Four equality-on-infinity arms are added over both infinities and three units, with the fixture premises asserted beside them so a columnar 0 reads as a lost row rather than an empty fixture.

## Removal proof

| | fixed | guard deleted |
| --- | --- | --- |
| installed `.so` | `5e24d9d61555` | `964834b893cd` |
| the four new arms | PASSED | **FAIL** `got [0] want [1]` |

The mutation was asserted applied (guard occurrences 0) before the run, and the `.so` differed, so the before run was not the fixed binary.

## Pruning is unaffected

The risk a decline always carries is that it buys correctness by disabling the optimisation. It does not here:

- `date_trunc('day', ts) = const prunes chunk groups (#403)` PASSES
- `...and prunes as well as the equivalent explicit range` PASSES

`qual_order_selectivity`, `native_saop_pushdown`, `pushdown_report`, `zonemap_cost`, `native_param_pushdown`, `temporal` and `ttl_expire` all pass unchanged.

Reproduced on PG 17.10 and PG 18.4.