### PR TITLE
fix: vouch for no index entry we cannot prove dead to everyone (#838)

### DIFF
--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -1412,24 +1412,43 @@ pgcolumnar_compute_xid_horizon_for_tuples(Relation rel, ItemPointerData *tids,
 static TransactionId
 pgcolumnar_index_delete_tuples(Relation rel, TM_IndexDeleteOp *delstate)
 {
-	Snapshot	snapshot = ActiveSnapshotSet() ? GetActiveSnapshot()
-		: GetTransactionSnapshot();
-	int			i;
-
-	for (i = 0; i < delstate->ndeltids; i++)
-	{
-		uint64		rowNumber =
-			PgColumnarItemPointerToRowNumber(&delstate->deltids[i].tid);
-
-		/*
-		 * Only liveness matters here, and PgColumnarRowIsLive decodes nothing to
-		 * answer it. This used to reconstruct every column of the row and then
-		 * free the result unread, once per candidate index tuple, on a path
-		 * nbtree drives during deletion (issue #157).
-		 */
-		delstate->status[delstate->deltids[i].id].knowndeletable =
-			!PgColumnarRowIsLive(rel, snapshot, rowNumber);
-	}
+	/*
+	 * The question here is "is this entry dead to EVERYONE", not "is this row
+	 * invisible to me". nbtree acts on the answer in _bt_delitems_delete, which
+	 * removes the items from the leaf page physically, inside a critical
+	 * section, WAL-logged. Nothing restores them, and an abort does not.
+	 *
+	 * heapam answers from a global visibility test (InitNonVacuumableSnapshot
+	 * over GlobalVisTestFor). This used to answer from the calling backend's
+	 * MVCC snapshot, which is a different question with a different answer: a
+	 * row the current, still-uncommitted transaction has deleted reads as "not
+	 * live" while remaining live to everyone else, and PgColumnarRowIsLive
+	 * consults this backend's unflushed delete buffer as well. Entries for live
+	 * rows were therefore erased. Measured on 400 live rows churned on a
+	 * non-indexed column: an index scan reached 0 of them after a ROLLBACK, and
+	 * 228 of 400 after a COMMIT, while `count(*)` at shipped defaults answered
+	 * 228 through an index-only scan and `count(b)` answered 400 through the
+	 * columnar scan, on the same table in the same session.
+	 *
+	 * Native storage carries no per-row xid to compare against a global horizon:
+	 * the delete vector is a bitmap, and its visibility comes from the MVCC
+	 * catalog rows that hold it. So this cannot prove global deadness, and it
+	 * vouches for nothing instead.
+	 *
+	 * For a bottom-up caller that is free: the work is speculative by contract,
+	 * and _bt_delitems_delete_check returns cleanly on an empty deltids array
+	 * (its Assert there is Assert(delstate->bottomup)). The cost is that version
+	 * churn no longer reclaims leaf space on a columnar table, so such an index
+	 * grows where it used to be compacted. That is a space cost, not an answer.
+	 *
+	 * A simple-deletion caller has already marked its entries knowndeletable
+	 * from LP_DEAD hints and is not asking us to discover anything, so its marks
+	 * are left exactly as they arrived. Zeroing ndeltids there would be wrong
+	 * twice over: it would discard the caller's own findings and trip that
+	 * Assert.
+	 */
+	if (delstate->bottomup)
+		delstate->ndeltids = 0;
 
 	return InvalidTransactionId;
 }

--- a/test/index_delete_liveness.sh
+++ b/test/index_delete_liveness.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# nbtree's deletion passes must never destroy an index entry for a LIVE row.
+#
+# table_index_delete_tuples asks "is this entry dead to EVERYONE". nbtree acts on
+# the answer in _bt_delitems_delete: the items are removed from the leaf page
+# physically, inside a critical section, WAL-logged. Nothing puts them back, and
+# a transaction abort does not.
+#
+# heapam answers from a GLOBAL visibility test (InitNonVacuumableSnapshot over
+# GlobalVisTestFor). Answering from the calling backend's MVCC snapshot instead
+# is a different question: a row this very transaction deleted but has not
+# committed reads as "not live to me" while still being live to everyone else.
+#
+# The observable end of that is silent and severe. With version churn on a
+# non-indexed column, so that index_unchanged_by_update() sets nbtree's
+# indexUnchanged hint and triggers the bottom-up pass:
+#
+#     SELECT count(*) FROM cc WHERE a = 1;   -- 228, via Index Only Scan
+#     SELECT count(b) FROM cc WHERE a = 1;   -- 400, via the columnar scan
+#
+# at SHIPPED DEFAULTS, on a table whose 400 rows are all live. The planner picks
+# the index-only scan on its own; no setting is needed to be wrong, only to look.
+#
+# The controls carry the argument. Without them a failing arm would only say that
+# index churn loses rows in general, which is not the claim:
+#
+#   * churn on the INDEXED column makes index_unchanged_by_update() false, so no
+#     bottom-up pass runs. Must stay complete.
+#   * a heap table with a second index, so HOT is defeated and its index takes
+#     the same indexUnchanged hint. Must stay complete.
+#
+# Usage:  test/index_delete_liveness.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+N=400
+ROUNDS=12
+
+churn() {	# churn <table> <set-clause> <COMMIT|ROLLBACK>
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -Atq -c "
+		BEGIN;
+		DO \$\$ BEGIN FOR i IN 1..$ROUNDS LOOP UPDATE $1 SET $2; END LOOP; END \$\$;
+		$3;" >/dev/null 2>&1
+}
+# The truth: a plan that cannot use the index at all.
+truth() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -Atq \
+		-c "SET enable_indexscan=off; SET enable_bitmapscan=off; SET enable_indexonlyscan=off;" \
+		-c "SELECT count(*) FROM $1 WHERE a = 1;" 2>&1 | tail -1
+}
+# The same question through the index.
+viaindex() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -Atq \
+		-c "SET enable_seqscan=off; SET enable_indexonlyscan=off; SET pgcolumnar.enable_custom_scan=off;" \
+		-c "SELECT count(b) FROM $1 WHERE a = 1;" 2>&1 | tail -1
+}
+viaindexplan() {
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -Atq \
+		-c "SET enable_seqscan=off; SET enable_indexonlyscan=off; SET pgcolumnar.enable_custom_scan=off;" \
+		-c "EXPLAIN (COSTS OFF) SELECT count(b) FROM $1 WHERE a = 1;" 2>&1 | tr '\n' ' '
+}
+
+mk() {	# mk <table> <USING clause> [extra index]
+	psql_run "CREATE TABLE $1(a int, b text) $2;"
+	psql_run "CREATE INDEX ${1}i ON $1(a);"
+	[ -n "${3:-}" ] && psql_run "CREATE INDEX ${1}i2 ON $1(b);"
+	psql_run "INSERT INTO $1 SELECT 1, repeat('x',20) FROM generate_series(1,$N);"
+}
+
+# ---- arm A: columnar, churn on the NON-indexed column, ROLLBACK -------------
+mk ca "USING pgcolumnar"
+check_num "premise: arm A holds $N rows before the churn" "$(truth ca)" "$N"
+churn ca "b = b || 'y'" ROLLBACK
+check "premise: arm A really plans an Index Scan, so the arm measures the index" \
+	"$(case "$(viaindexplan ca)" in *"Index Scan"*) echo yes ;; *) echo "no: $(viaindexplan ca)" ;; esac)" "yes"
+a_t="$(truth ca)"; a_i="$(viaindex ca)"
+echo "-- arm A columnar, non-indexed churn, ROLLBACK: rows=$a_t via-index=$a_i"
+check_num "arm A: a ROLLBACK leaves every live row reachable through the index" "$a_i" "$a_t"
+
+# ---- control B: columnar, churn ON the indexed column -----------------------
+mk cb "USING pgcolumnar"
+churn cb "a = a" ROLLBACK
+b_t="$(truth cb)"; b_i="$(viaindex cb)"
+echo "-- control B columnar, INDEXED-column churn: rows=$b_t via-index=$b_i"
+check_num "control B: indexed-column churn triggers no bottom-up pass and loses nothing" "$b_i" "$b_t"
+
+# ---- control C: heap under the same hint ------------------------------------
+mk hb "" second
+churn hb "b = b || 'y'" ROLLBACK
+c_t="$(truth hb)"; c_i="$(viaindex hb)"
+echo "-- control C heap, same indexUnchanged hint: rows=$c_t via-index=$c_i"
+check_num "control C: the heap loses nothing under the same churn" "$c_i" "$c_t"
+
+# ---- arm D: committed churn, and the answer at SHIPPED DEFAULTS -------------
+# An abort is not required, and no setting is required to get a wrong answer.
+mk cc "USING pgcolumnar"
+churn cc "b = b || 'y'" COMMIT
+d_t="$(truth cc)"; d_i="$(viaindex cc)"
+echo "-- arm D columnar, non-indexed churn, COMMIT: rows=$d_t via-index=$d_i"
+check_num "arm D: a COMMIT leaves every live row reachable through the index" "$d_i" "$d_t"
+
+def_star="$(q "SELECT count(*) FROM cc WHERE a = 1;")"
+def_b="$(q "SELECT count(b) FROM cc WHERE a = 1;")"
+echo "-- at shipped defaults: count(*)=$def_star  count(b)=$def_b  (truth $d_t)"
+echo "-- the plan count(*) gets at defaults: $(q "EXPLAIN (COSTS OFF) SELECT count(*) FROM cc WHERE a = 1;" | tr '\n' ' ')"
+check_num "at shipped defaults count(*) is right" "$def_star" "$d_t"
+check_num "at shipped defaults the table answers the same to count(*) and count(b)" \
+	"$def_star" "$def_b"
+
+# ---- heap oracle on the same shape ------------------------------------------
+mk hc "" second
+churn hc "b = b || 'y'" COMMIT
+check_num "oracle: the heap answers count(*) correctly after the same churn" \
+	"$(q "SELECT count(*) FROM hc WHERE a = 1;")" "$N"
+
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -108,6 +108,7 @@ SUITES=(
 	import_deferred
 	import_exclusion
 	import_export_privilege
+	index_delete_liveness
 	index_fetch_penalty_width
 	index_only
 	int8_agg_int128


### PR DESCRIPTION
Closes #838. **This is the most severe defect found in the bug hunt: silent, permanent loss of index entries for live rows, reachable at shipped defaults.**

```
SELECT count(*) FROM cc WHERE a = 1;   -- 228   Aggregate -> Index Only Scan using cci
SELECT count(b) FROM cc WHERE a = 1;   -- 400   Aggregate -> Custom Scan (PgColumnarScan)
```

Same table, same session, nothing set. All 400 rows are live. A heap given the same churn answers 400 to both.

## Cause

`table_index_delete_tuples` asks whether an entry is dead to **everyone**; heapam answers from `InitNonVacuumableSnapshot(SnapshotNonVacuumable, GlobalVisTestFor(rel))`. This answered from the calling backend's MVCC snapshot, a different question with a different answer. nbtree then removes the items in `_bt_delitems_delete` physically, in a critical section, WAL-logged. `ROLLBACK` does not put them back.

## Fix

Native storage has no per-row xid to compare against a global horizon, so the callback cannot prove global deadness. It now vouches for nothing rather than guessing.

For a bottom-up caller that is free: the work is speculative by contract and `_bt_delitems_delete_check` returns cleanly on an empty `deltids` array (its assertion there is `Assert(delstate->bottomup)`). The cost is that version churn no longer reclaims leaf space on a columnar table. That is space, not answers.

A simple-deletion caller has already marked its entries from LP_DEAD hints, so its marks are left as they arrived. Zeroing `ndeltids` there would discard the caller's own findings and trip that assertion.

## Test, with the controls that make it specific

| arm | live rows | via index, before | after |
| --- | ---: | ---: | ---: |
| columnar, non-indexed churn, ROLLBACK | 400 | **0** | 400 |
| columnar, non-indexed churn, COMMIT | 400 | **228** | 400 |
| control: columnar, *indexed*-column churn | 400 | 400 | 400 |
| control: heap, same `indexUnchanged` hint | 400 | 400 | 400 |

Churning the indexed column makes `index_unchanged_by_update()` false so no bottom-up pass runs; a heap with a second index defeats HOT and takes the same hint. Without those two arms a failure would only say that index churn loses rows in general. The suite also asserts the plan under test is an Index Scan, so a green arm cannot come from the index never being consulted.

## Removal proof, and a first attempt that was invalid

Deleting only the new guard leaves a third behaviour that neither marks entries nor compacts the array. That tripped `Assert(ndeletable > 0 || nupdatable > 0)` and put the cluster into recovery: a red for the wrong reason, which proves nothing about row loss. Recorded because the failure text is what caught it.

Restoring the **original** snapshot-based loop gives the right red: arm A 0 of 400, arm D 228 of 400, `count(*)` 228 against `count(b)` 400 at defaults, both controls still clean. Installed `.so` `ece7896a10fc` unfixed against `f425a69f6b87` fixed.

## Regressions

`native_index`, `native_delete_vector_index`, `native_index_projection`, `index_only`, `native_ios`, `native_delete_visibility_paths`, `native_dml`, `native_fetch_cache`, `index_fetch_penalty_width`, `native_index_fetch_stripe_cost`, `isolation`, `unique_conc`, `update_conc`, `concurrency`: all pass unchanged.

## Credit

Surfaced by a reading review of the table-AM callbacks, then reproduced and bounded independently before being believed.