### PR TITLE
fix: reset the aggregate accumulators in one place, not two (#840)

### DIFF
--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -4224,7 +4224,6 @@ static void
 PgColumnarReScanAggScan(CustomScanState *node)
 {
 	PgColumnarAggScanState *state = (PgColumnarAggScanState *) node;
-	int			a;
 
 	state->done = false;
 	state->haveStats = false;
@@ -4232,27 +4231,27 @@ PgColumnarReScanAggScan(CustomScanState *node)
 	state->foldPayloadLoads = 0;
 	state->foldGroupsDeferred = 0;
 	state->foldGroupsTotal = 0;
-	MemoryContextReset(state->resultContext);
-	for (a = 0; a < state->naggs; a++)
-	{
-		PgColumnarAggSpec *spec = &state->specs[a];
 
-		spec->count = 0;
-		spec->sum = 0;
-		spec->sawValue = false;
-		spec->extreme = (Datum) 0;
-		/*
-		 * Also clear the running float/numeric accumulators. resultContext was
-		 * just reset, so nsum's storage is gone; leaving nsumSet true would make
-		 * the next scan add to (and free) a dangling pointer. Scan-fold mode
-		 * classifies these extended kinds (#289), so this reset is load-bearing on
-		 * a rescan, not only defensive.
-		 */
-		spec->fsum = 0;
-		spec->fsxx = 0;
-		spec->nsum = (Datum) 0;
-		spec->nsumSet = false;
-	}
+	/*
+	 * One reset, not two. This used to open-code the loop that
+	 * pgcolumnar_agg_specs_reset already contains, and the two copies were
+	 * identical except that this one never cleared spec->i128sum. The int8 kinds
+	 * accumulate there, so a rescan carried the previous execution's running
+	 * total into the next one and sum(bigint) came back cumulative: measured
+	 * 800022400060000 then 1600044799119997 then 2400067196179988 over four
+	 * LATERAL iterations whose true answers were all near the first.
+	 *
+	 * The comment on pgcolumnar_batch_agg_ok already said to check that every
+	 * accumulator a kind uses is cleared, and named i128sum. It points at
+	 * pgcolumnar_agg_specs_reset, which was right. Calling that function from
+	 * here is what makes the instruction reach both paths, rather than leaving a
+	 * second copy for the next accumulator to be forgotten in.
+	 *
+	 * The float and numeric clears are load-bearing rather than defensive:
+	 * resultContext has just been reset, so nsum's storage is gone and leaving
+	 * nsumSet true would make the next scan add to a dangling pointer.
+	 */
+	pgcolumnar_agg_specs_reset(state);
 }
 
 static void

--- a/test/int8_agg_int128.sh
+++ b/test/int8_agg_int128.sh
@@ -227,4 +227,67 @@ done
 echo "-- sum(bigint) WHERE k < 50: vectorized $FON ms, scalar $FOFF ms"
 check_ratio "the FILTERED vectorized path is not slower than the scalar one" "$FON" "$FOFF" "1.10"
 
+# ---- the accumulator must be cleared on a RESCAN ---------------------------
+# The int8 kinds accumulate into spec->i128sum. There are two reset sites:
+# pgcolumnar_agg_specs_reset clears nine fields including that one, and
+# PgColumnarReScanAggScan open-coded the same loop with eight and no i128sum. On
+# a rescan the running int128 total was therefore never zeroed and each
+# re-execution added to the previous one.
+#
+# Nothing here reached it. This suite drives the int128 accumulator and never
+# rescans; vector_agg_rescan_memory.sh rescans and aggregates count(*), which
+# does not touch i128sum. Each condition was covered and their intersection was
+# not.
+#
+# A LATERAL over a small driver re-executes the aggregate node once per driver
+# row. enable_material=off keeps core from materialising the inner side, which
+# would hide the rescan entirely.
+psql_run "CREATE TABLE rs_drv(i bigint);"
+psql_run "INSERT INTO rs_drv SELECT g FROM generate_series(1,4) g;"
+RSGUC="$ON; SET enable_material=off; SET max_parallel_workers_per_gather=0;"
+RSLAT="SELECT d.i, s.c FROM rs_drv d, LATERAL (SELECT %A c FROM %T s2 WHERE s2.v > d.i) s ORDER BY d.i"
+
+rs_run() {  # rs_run <table> <agg>
+	# Separate declarations on purpose: bash expands the whole command line
+	# before assigning, so `local t="$1" sql="${RSLAT//%T/$t}"` reads t unset.
+	# Under `set -u` that aborted the function and both sides of a comparison
+	# came back as the SAME error text, which `check` then passed. An arm that
+	# cannot tell an error from an answer is not an arm.
+	local t="$1"
+	local a="$2"
+	local sql="${RSLAT//%T/$t}"
+	sql="${sql//%A/$a}"
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -Atq -c "$RSGUC" -c "$sql" 2>&1
+}
+rs_plan() {
+	local sql="${RSLAT//%T/a8}"; sql="${sql//%A/sum(s2.v)}"
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -Atq -c "$RSGUC" -c "EXPLAIN (ANALYZE, TIMING OFF, SUMMARY OFF, COSTS OFF) $sql" 2>&1
+}
+
+RSPLAN="$(rs_plan)"
+check_num "premise: the rescan shape still takes the vectorized node" \
+	"$(grep -c 'Columnar Vectorized Aggregates' <<<"$RSPLAN")" "1"
+RSLOOPS="$(grep -oE 'loops=[0-9]+' <<<"$RSPLAN" | grep -oE '[0-9]+' | sort -rn | head -1)"
+echo "-- rescan loops observed: ${RSLOOPS:-none}"
+check "premise: the node really is re-executed, so a stale accumulator can show" \
+	"$([ "${RSLOOPS:-0}" -gt 1 ] && echo rescanned || echo "not rescanned")" "rescanned"
+
+# Premise before the comparisons: the rescan query returns one row per driver
+# row. Without it an error on BOTH sides compares equal and passes.
+RSOUT="$(rs_run a8 'sum(s2.v)')"
+check_num "premise: the rescan query returns a row per driver row, not an error" \
+	"$(printf '%s\n' "$RSOUT" | grep -c '^[0-9]')" "4"
+check "sum(bigint) across a rescan matches the heap" \
+	"$RSOUT" "$(rs_run a8_h 'sum(s2.v)')"
+check "avg(bigint) across a rescan matches the heap" \
+	"$(rs_run a8 'avg(s2.v)')" "$(rs_run a8_h 'avg(s2.v)')"
+check "sum(bigint) across a rescan on the >int64 fixture matches the heap" \
+	"$(rs_run big8 'sum(s2.v)')" "$(rs_run big8_h 'sum(s2.v)')"
+# The control: a kind that does NOT use i128sum must be right either way, which
+# places any failure above on the int128 accumulator rather than on rescan.
+check "control: count(*) across the same rescan matches the heap" \
+	"$(rs_run a8 'count(*)')" "$(rs_run a8_h 'count(*)')"
+
 pgc_summary


### PR DESCRIPTION
Closes #840.

`sum(bigint)` and `avg(bigint)` came back cumulative across a rescan:

| driver row | heap | columnar |
| ---: | ---: | ---: |
| 1 | 800022400060000 | 800022400060000 |
| 2 | 800022399059997 | 1600044799119997 |
| 3 | 800022397059991 | 2400067196179988 |
| 4 | 800022394059982 | 3200089590239970 |

## Cause

Two accumulator reset sites, drifted apart:

| function | fields cleared |
| --- | --- |
| `pgcolumnar_agg_specs_reset` | 9, including `spec->i128sum` |
| `PgColumnarReScanAggScan` | 8, **no** `i128sum` |

Otherwise byte-identical. The rescan path now calls the shared function. Adding the missing line to the second copy would fix this instance and leave the next accumulator to be forgotten the same way.

## The part worth reading

A comment on `pgcolumnar_batch_agg_ok` already says to check that every accumulator a kind uses is cleared, names `i128sum` and #786, and ends *"do not rely on a test to catch a missing reset. Read it."*

That comment points at `pgcolumnar_agg_specs_reset` — the copy that was **right**. The rule was written, correct, and still did not fire, because it named one function while the hazard was that there were two. Single-sourcing is what makes the instruction reach both paths.

## Test

`int8_agg_int128.sh` drives the accumulator and never rescanned; `vector_agg_rescan_memory.sh` rescans and aggregates `count(*)`, which does not touch `i128sum`. The intersection is what the new arms add: a LATERAL over a four-row driver with `enable_material=off`, asserting the vectorized node is chosen and really re-executed (`loops=4`) before any answer is compared. `count(*)` across the same rescan is the control that places a failure on the accumulator rather than on rescan.

### A first version of those arms passed while testing nothing

`local t="$1" sql="${RSLAT//%T/$t}"` reads `t` before it is assigned, so under `set -u` the helper aborted and **both sides of every comparison came back as the same error text**, which `check` passed. Recorded because it is the `check "" ""` shape the harness already warns about, reached by a different route.

Fixed by splitting the declarations and adding a premise that the query returns one row per driver row, so an error cannot compare equal to an error.

## Removal proof

| | fixed | open-coded loop restored |
| --- | --- | --- |
| installed `.so` | `ad3949d57b61` | `ad31355476c0` |
| three int8 rescan arms | PASSED | **FAIL** |
| `count(*)` control | PASSED | PASSED |

## Blast radius

Default configuration is unaffected: `enable_ungrouped_vector_agg` ships off. The grouped node is unaffected because it resets whole memory contexts rather than clearing fields individually.

Warning-clean under `gcc -Werror` and under clang against the clang-configured prefix.