### PR TITLE
fix: honour the scan direction, or refuse it (#842)

### DIFF
--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -602,6 +602,37 @@ pgcolumnar_scan_getnextslot(TableScanDesc sscan, ScanDirection direction,
 
 	ExecClearTuple(slot);
 
+	/*
+	 * Honour the direction, or refuse it. This used to ignore the argument
+	 * entirely and advance forward whatever was asked, so a scrollable cursor
+	 * that reached the AM rather than the custom scan answered FETCH BACKWARD
+	 * with more forward rows -- 6 7 8 where the heap gave 4 3 2 -- and FETCH
+	 * LAST with nothing at all.
+	 *
+	 * NoMovement is a real request for no row and is answered as such.
+	 *
+	 * Backward is refused rather than emulated. The reader walks row groups and
+	 * decodes vectors forwards, so scanning the other way is a feature rather
+	 * than a correction, and inventing an answer is the one thing that must not
+	 * happen here. Refusing is visible, and at shipped defaults the custom scan
+	 * serves these cursors, so the refusal is reached only when that path has
+	 * been turned off.
+	 */
+	if (unlikely(direction != ForwardScanDirection))
+	{
+		if (direction == NoMovementScanDirection)
+			return false;
+
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("columnar tables do not support backward scans"),
+				 errdetail("A scrollable cursor over relation \"%s\" asked for a "
+						   "backward fetch, which native storage cannot serve.",
+						   RelationGetRelationName(scan->rs_base.rs_rd)),
+				 errhint("Leave pgcolumnar.enable_custom_scan on, or add an "
+						 "ORDER BY so the cursor is materialized.")));
+	}
+
 	if (!PgColumnarReadNextRow(pgcolumnar_scan_read_state(scan,
 													 slot->tts_tupleDescriptor),
 							 slot->tts_values, slot->tts_isnull, &rowNumber))

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -248,6 +248,7 @@ SUITES=(
 	rls_direct_storage
 	row_triggers
 	scan_decode_cost
+	scan_direction
 	server_file_privilege
 	smoke
 	sort_status

--- a/test/scan_direction.sh
+++ b/test/scan_direction.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+#
+# A scan must not answer a backward fetch with forward rows.
+#
+# pgcolumnar_scan_getnextslot takes a ScanDirection and never read it: every
+# call advanced forward. heap_getnextslot passes direction through to
+# heapgettup, which walks the other way. So a scrollable cursor over a columnar
+# relation, on a plan that reaches the table AM rather than the custom scan,
+# silently returned the wrong rows:
+#
+#     FETCH FORWARD 5   then   FETCH BACKWARD 3
+#     heap:     1 2 3 4 5  then  4 3 2
+#     columnar: 1 2 3 4 5  then  6 7 8
+#
+# and FETCH LAST returned nothing at all where the heap returned row 20.
+#
+# A true backward scan over native storage is a feature, not a bug fix: the
+# reader walks row groups and decodes vectors forwards. What this pins is that
+# the AM never INVENTS an answer. Forward is unchanged, no-movement fetches
+# nothing, and a backward fetch raises 0A000 rather than returning rows that were
+# never asked for.
+#
+# The arms assert SQLSTATE rather than message text. A grep for "not supported"
+# is also satisfied by a dozen unrelated errors, and by a connection failure.
+#
+# Usage:  test/scan_direction.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+make_pair "id int, v text"
+load_pair "SELECT g, 'row' || g FROM generate_series(1,20) g"
+check_num "premise: the pair holds the same row count" \
+	"$(q 'SELECT count(*) FROM t_col')" "$(q 'SELECT count(*) FROM t_heap')"
+
+cur() {  # cur <table> <guc-statement> <cursor-body>
+	env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" -Atq \
+		-c "$2" -c "BEGIN; DECLARE c SCROLL CURSOR FOR SELECT id FROM $1; $3 CLOSE c; COMMIT;" 2>&1
+}
+# psql prints the SQLSTATE ahead of the message under VERBOSITY verbose, which
+# is how these arms assert the code rather than the text. A grep for wording is
+# also satisfied by an unrelated error or by a failed connection.
+state_of() {  # state_of <table> <guc-statement> <cursor-body>
+	local out
+	out="$(env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres \
+		-d "$PGC_DB" -Atq -v VERBOSITY=verbose \
+		-c "\\set VERBOSITY verbose" -c "$2" \
+		-c "BEGIN; DECLARE c SCROLL CURSOR FOR SELECT id FROM $1; $3 CLOSE c; COMMIT;" 2>&1)"
+	# "psql:...: ERROR:  0A000: message"  ->  0A000
+	local code
+	code="$(printf '%s\n' "$out" | sed -n 's/.*ERROR:[[:space:]]*\([0-9A-Z]\{5\}\):.*/\1/p' | head -1)"
+	if [ -n "$code" ]; then printf '%s\n' "$code"; else printf '00000\n'; fi
+}
+
+FWDBACK="FETCH FORWARD 5 FROM c; FETCH BACKWARD 3 FROM c;"
+FWDONLY="FETCH FORWARD 5 FROM c;"
+
+# ---- at shipped defaults the custom scan handles the cursor ----------------
+h_def="$(cur t_heap 'SELECT 1;' "$FWDBACK")"
+c_def="$(cur t_col  'SELECT 1;' "$FWDBACK")"
+check "at shipped defaults the cursor matches heap" \
+	"$([ "$h_def" = "$c_def" ] && echo matches || echo DIFFERS)" "matches"
+[ "$h_def" != "$c_def" ] && { echo "-- heap:     $(printf '%s' "$h_def" | tr '\n' ' ')";
+                              echo "-- columnar: $(printf '%s' "$c_def" | tr '\n' ' ')"; }
+
+# ---- with the custom scan off, the table AM is reached ---------------------
+OFF="SET pgcolumnar.enable_custom_scan=off;"
+plan_off="$(q "SET pgcolumnar.enable_custom_scan=off; EXPLAIN (COSTS OFF) SELECT id FROM t_col;" | tr '\n' ' ')"
+check "premise: with the custom scan off the plan really is a Seq Scan on the AM" \
+	"$(case "$plan_off" in *"Seq Scan"*) echo yes ;; *) echo "no: $plan_off" ;; esac)" "yes"
+
+# forward-only must be unchanged
+check "forward-only fetch still matches heap through the AM" \
+	"$([ "$(cur t_heap "$OFF" "$FWDONLY")" = "$(cur t_col "$OFF" "$FWDONLY")" ] && echo matches || echo DIFFERS)" \
+	"matches"
+
+# a backward fetch must REFUSE, not invent rows
+st_back="$(state_of t_col "$OFF" "FETCH FORWARD 5 FROM c; FETCH BACKWARD 3 FROM c;")"
+echo "-- backward fetch SQLSTATE through the AM: ${st_back:-<none>}"
+check "a backward fetch through the AM raises 0A000 rather than answering" "$st_back" "0A000"
+
+st_last="$(state_of t_col "$OFF" "FETCH LAST FROM c;")"
+echo "-- FETCH LAST SQLSTATE through the AM: ${st_last:-<none>}"
+check "FETCH LAST through the AM raises 0A000 rather than returning nothing" "$st_last" "0A000"
+
+# and the heap, unchanged, must NOT raise
+st_heap="$(state_of t_heap "$OFF" "FETCH FORWARD 5 FROM c; FETCH BACKWARD 3 FROM c;")"
+check "control: the same cursor on a heap table raises nothing" "$st_heap" "00000"
+
+# control: the probe can distinguish states at all
+st_ok="$(state_of t_col "$OFF" "$FWDONLY")"
+check "control: a forward-only fetch reports success, so the probe is not stuck on 0A000" \
+	"$st_ok" "00000"
+
+pgc_summary


### PR DESCRIPTION
Closes #842.

`pgcolumnar_scan_getnextslot` took a `ScanDirection` and never read it, so a backward fetch was answered with more forward rows — and it **succeeded**, SQLSTATE 00000.

| operation, `enable_custom_scan=off` | heap | columnar |
| --- | --- | --- |
| `FETCH FORWARD 5` then `FETCH BACKWARD 3` | 4 3 2 | **6 7 8** |
| `MOVE FORWARD 8` then `FETCH BACKWARD 2` | 7 6 | **9 10** |
| `FETCH LAST` | 20 | *(empty)* |

## Fix

`NoMovement` is answered as what it is, a request for no row. `Backward` is refused with `0A000` rather than emulated: the reader walks row groups and decodes vectors forwards, so scanning the other way is a feature rather than a correction, and inventing an answer is the one outcome that must not stand.

At shipped defaults the custom scan serves these cursors correctly — six query shapes were probed with nothing set and every one gave the columnar relation a Custom Scan — so the refusal is reached only where that path has been turned off.

## Test

Asserts **SQLSTATE**, not message text: a grep for wording is also satisfied by an unrelated error or a failed connection. Two controls:

- the same cursor on a **heap** table must raise nothing (00000)
- a **forward-only** fetch on the columnar table must report success

Without them an arm could pass by the probe being stuck on one answer.

## Removal proof

Without the change the backward arm reports `00000` — the success state. That *is* the defect: the fetch succeeds and the rows are wrong.

## Verification

Full PG18 matrix from a clean `git archive` lane: **ALL VERSIONS PASSED**, 228 of 234 suites ran, zero failures, `scan_direction=PASS`.

An earlier run on a shared lane showed three unrelated failures. They were sibling branches' test files accumulated in that lane, and `harness_selftest` named them exactly (`unregistered: catalog_natts index_delete_liveness`) while its `.so` fingerprint check caught a concurrent overwrite. Recorded rather than reasoned away, because the clean-lane rerun is what makes the green trustworthy.