### PR TITLE
Stop the roadmap denying the schedule it now carries (#830 follow-up)

### DIFF
--- a/design/RELEASE_PLAN_1.0.md
+++ b/design/RELEASE_PLAN_1.0.md
@@ -36,8 +36,7 @@ rather than the date work starts.
 ## What is already done
 
 Read this before proposing anything for an alpha, because the list is longer than
-the tracker suggests. The tracker holds seven open issues and exactly one of them
-is a feature.
+the tracker suggests. Exactly one open issue is a feature.
 
 Storage and scan, maintenance, and projections. Arrow and Parquet in both
 directions, and external Parquet with pushdown. Object storage and Apache

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -64,7 +64,8 @@ The large pieces that have shipped:
 
 ## Planned
 
-Nothing here is committed to a release. Each links to the issue that owns it.
+Where an item falls in the series is in the table above; nothing here is a further
+commitment. Each links to the issue that owns it.
 
 | area | item | issue |
 | --- | --- | --- |
@@ -85,5 +86,6 @@ Recorded so the work is visible, without implying it will be built:
 
 ## What this page is not
 
-It is not a commitment, and it is not a schedule. An item here means the work is
-recorded and reasoned about. It does not mean anyone is working on it.
+It is not a commitment. The dates above are the cadence this project has kept, not
+a promise. An item here means the work is recorded and reasoned about. It does not
+mean anyone is working on it.


### PR DESCRIPTION
Three sentences, all true before #830 and false after it. I raised them in review
there; landing them separately because pushing to a branch in this repository is not
something I will do without being asked, and alpha3 is cut on Monday.

## The three

**`docs/roadmap.md`** said, as the last thing on the page:

> It is not a commitment, and it is not a schedule.

on a page whose own commit subject is *publish the schedule*. The commitment half was
already guarded by "Dates are a cadence, not a commitment". The schedule half was not.

**`docs/roadmap.md`** said, opening the Planned section:

> Nothing here is committed to a release.

above a table whose only row is #752, which the release table on the same page dates to
`1.0-alpha5`. The collision is the assignment, not the dates, so the sentence now points
at that table instead of contradicting it.

**`design/RELEASE_PLAN_1.0.md`** said:

> The tracker holds seven open issues and exactly one of them is a feature.

It held eight within hours of that being written, two of them mine from the same day.
The ratio it is arguing is still true and is what the sentence is for, so the total is
dropped and the ratio kept. A hard count in a hand-maintained file is true on the day
and wrong the week after, and the total is a `gh issue list` away.

## Why these were invisible

All three are in lines #830 did not touch. A diff-shaped review cannot see them, and
neither `docs_style` nor the plain-language checker is a consistency checker: both
passed the contradictory page, correctly. Adding a fact can falsify a distant sentence
without touching it.

## Gate

`docs_style` is 9 of 9 on this tree, including the em and en dash rule, checked with
the checker rather than by eye. The full matrix (preflight on five majors, suites on
18 and 19) is queued behind the two changelog gates and I will post its result here.

Both files carry zero em or en dashes.
