### PR TITLE
fix: export_parquet writes row-group statistics, so our own files skip (#850)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,11 +36,18 @@ true until the next version shipped.
 ### Fixed
 
 - `docs/limitations.md` states the constant-typing rule correctly. The previous
-  wording said `smallint` and `real` "always need a cast". That is false: a
-  quoted literal is `unknown` and takes the column's type, so
+  wording said `smallint` and `real` "always need a cast". That is false: an
+  unadorned quoted literal is `unknown` and takes the column's type, so
   `smallint_col < '500'` skips. The rule is not special to the temporal types
   either. Their literals are simply always quoted, which is why they skip as
   written.
+
+  Two limits on that rule are stated with it, because the first revision of this
+  entry got both wrong. A literal that names its own type is that type rather
+  than `unknown`, so `timestamp_col < DATE '2026-01-01'` does not skip, which is
+  what the same page's conditions list has always said. And a digit string is an
+  `integer` only while the value fits in one: `integer_col < 5000000000` is an
+  `integer` column against a `bigint` constant and does not skip either.
 
   Measured across the nine skippable types in three literal forms, with the
   planner's own constant printed beside each skip count, and every row count

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ true until the next version shipped.
   Swapping the two bounds does not lose rows, which is worth knowing rather than
   glossing: it inverts the interval, and the reader already refuses to skip on an
   inverted one. `docs/limitations.md` documents that refusal, and it caught this
-  mutation. The swap loses 52 checks and no rows.
+  mutation. The swap loses 54 checks and no rows.
 
   Files exported by 1.0-alpha2 or earlier carry no statistics, and nothing
   rewrites them in place. Export again to make one skippable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,12 +71,21 @@ true until the next version shipped.
   infinite date or timestamp, is folded to null before the accumulator sees it,
   so it counts as a null and cannot reach a bound.
 
-  `test/parquet_export_stats.sh` covers this in 132 checks, reading the footer
-  bytes with `test/parquet_stats.py` rather than asking a third-party library
-  whether it feels like surfacing them. Eight mutations of the fix were each run
-  against the suite and each turned a named check red, including the two that
-  lose rows rather than merely lose the skip: swapping the bounds, and taking a
-  date bound from the PostgreSQL epoch instead of the Unix one.
+  `test/parquet_export_stats.sh` covers this, reading the footer bytes with
+  `test/parquet_stats.py` rather than asking a third-party library whether it
+  feels like surfacing them. Eight mutations of the fix were each run against the
+  suite and each turned a named check red.
+
+  One of the eight loses rows rather than merely losing the skip: taking a date
+  bound from the PostgreSQL epoch instead of the Unix one. That shift leaves a
+  well-ordered interval which is simply wrong, so no guard can see it, and the
+  single check standing between it and silent row loss is a predicate placed
+  past the end of the data, `d > DATE '2060-01-01'`.
+
+  Swapping the two bounds does not lose rows, which is worth knowing rather than
+  glossing: it inverts the interval, and the reader already refuses to skip on an
+  inverted one. `docs/limitations.md` documents that refusal, and it caught this
+  mutation. The swap loses 52 checks and no rows.
 
   Files exported by 1.0-alpha2 or earlier carry no statistics, and nothing
   rewrites them in place. Export again to make one skippable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,52 @@ true until the next version shipped.
 
 ### Fixed
 
+- Exported Parquet files carry row-group statistics, so a file pgColumnar wrote
+  can be skipped (#850). Reported from outside the project, and the report was
+  right: every condition `docs/limitations.md` documents for row-group skipping
+  could hold and `Row Groups Skipped` would still be 0.
+
+  `write_column_chunk()` emitted ColumnMetaData fields 1 through 7 and 9, and
+  never field 12, so no file we wrote carried a minimum or a maximum for the
+  reader to test a predicate against. The read side was never at fault. On the
+  reporter's own repro, a 1,000,000-row table exported to 16 row groups: 0 of 32
+  column chunks carried statistics, and the foreign scan decoded all 16 groups
+  for `id < 5000`. It now carries 32 of 32 and skips 15 of 16, decoding one.
+  The native chunk-group skip on the same data always worked, and is unchanged.
+
+  What the exporter now writes, per column chunk: `null_count` always, including
+  where it is zero, because `parquet.thrift` says a reader must not read an
+  absent count as zero; `min_value` and `max_value` for the columns stored as
+  INT32, INT64, FLOAT or DOUBLE, which is exactly the set the reader can skip
+  on; and `nan_count` for the floating point columns. A `text`, `bytea`, `uuid`,
+  `boolean` or byte-array `numeric` column gets the null count and no bounds:
+  UTF8 sorts by unsigned bytes, which is not any PostgreSQL collation, and a
+  bound in the wrong order is worse than no bound at all.
+
+  The file footer now also carries `column_orders`, one `TYPE_ORDER` per leaf
+  column. It is not decoration. `parquet.thrift` states that without it the
+  meaning of `min_value` and `max_value` is undefined, and Arrow acts on that by
+  discarding both, so statistics without `column_orders` would have left the file
+  exactly as unskippable under pyarrow as it was before. With it, pyarrow reports
+  `is_stats_set=True` on our files.
+
+  Three rules from the specification are followed for floats, and each is pinned
+  by a test: a NaN never becomes a bound, a column whose non-null values are all
+  NaN gets no bounds at all, and a computed zero is written `-0.0` as a minimum
+  and `+0.0` as a maximum. A value with no Parquet representation, such as an
+  infinite date or timestamp, is folded to null before the accumulator sees it,
+  so it counts as a null and cannot reach a bound.
+
+  `test/parquet_export_stats.sh` covers this in 132 checks, reading the footer
+  bytes with `test/parquet_stats.py` rather than asking a third-party library
+  whether it feels like surfacing them. Eight mutations of the fix were each run
+  against the suite and each turned a named check red, including the two that
+  lose rows rather than merely lose the skip: swapping the bounds, and taking a
+  date bound from the PostgreSQL epoch instead of the Unix one.
+
+  Files exported by 1.0-alpha2 or earlier carry no statistics, and nothing
+  rewrites them in place. Export again to make one skippable.
+
 - Index entries for live rows are no longer destroyed (#838). A released version
   is affected: this is present in `v1.0-alpha2`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,21 @@ true until the next version shipped.
 
 ### Fixed
 
+- `docs/limitations.md` states the constant-typing rule correctly. The previous
+  wording said `smallint` and `real` "always need a cast". That is false: a
+  quoted literal is `unknown` and takes the column's type, so
+  `smallint_col < '500'` skips. The rule is not special to the temporal types
+  either. Their literals are simply always quoted, which is why they skip as
+  written.
+
+  Measured across the nine skippable types in three literal forms, with the
+  planner's own constant printed beside each skip count, and every row count
+  compared with a heap oracle. Nine checks in `test/parquet_export_stats.sh` now
+  pin the rule, and each can fail: three go red when the reader's
+  exact-constant-type refusal is deleted, four when the writer stops emitting
+  statistics, and the two plan-shape checks go red when the patterns they look
+  for are swapped.
+
 - Exported Parquet files carry row-group statistics, so a file pgColumnar wrote
   can be skipped (#850). Reported from outside the project, and the report was
   right: every condition `docs/limitations.md` documents for row-group skipping

--- a/design/PHASE_G_PUSHDOWN_HANDOFF.md
+++ b/design/PHASE_G_PUSHDOWN_HANDOFF.md
@@ -33,8 +33,9 @@ warnings on every major.
   since a skipped group emits nothing to recheck.
 - `pqfdwExplainForeignScan()` prints "Row Groups" / "Row Groups Skipped".
 - Test `test/native_parquet_pushdown.sh` uses pyarrow to write a stats-bearing
-  200k-row / 4-row-group file (our exporter does not write stats), asserts
-  correctness against a heap oracle, and asserts the skip counter.
+  200k-row / 4-row-group file (our exporter did not write statistics until #850,
+  in 1.0-alpha3), asserts correctness against a heap oracle, and asserts the
+  skip counter.
 
 ### The bug, and why the earlier diagnosis was wrong
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -214,7 +214,8 @@ and writes continue.
   dependency. An exported Parquet file carries per-row-group
   statistics: a null count for every column, and bounds for the INT32, INT64,
   FLOAT and DOUBLE columns. A reader can then skip the row groups a predicate
-  excludes. See [Row-group skipping](limitations.md) for what carries a bound.
+  excludes. See [Row-group skipping](limitations.md#row-group-skipping) for what carries a
+  bound.
 - Parallel Parquet export: `pgcolumnar.parallel_export_parquet(table, dir, workers)`
   writes a columnar table to a directory of Parquet files with several read-only
   background workers, one file each. It gives a near-linear speedup, returns the

--- a/docs/features.md
+++ b/docs/features.md
@@ -211,7 +211,10 @@ and writes continue.
 
 - Export to Arrow and Parquet: `pgcolumnar.export_arrow(table, path)` and
   `pgcolumnar.export_parquet(table, path)`, both without a libarrow or libparquet
-  dependency.
+  dependency. An exported Parquet file carries per-row-group
+  statistics: a null count for every column, and bounds for the INT32, INT64,
+  FLOAT and DOUBLE columns. A reader can then skip the row groups a predicate
+  excludes. See [Row-group skipping](limitations.md) for what carries a bound.
 - Parallel Parquet export: `pgcolumnar.parallel_export_parquet(table, dir, workers)`
   writes a columnar table to a directory of Parquet files with several read-only
   background workers, one file each. It gives a near-linear speedup, returns the

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -854,6 +854,19 @@ correct rows; these are the conditions under which it can skip at all:
 The `Row Groups Skipped` counter in `EXPLAIN ANALYZE` reports what was actually
 skipped.
 
+From 1.0-alpha3, `pgcolumnar.export_parquet` writes per-row-group statistics.
+A table exported from pgColumnar skips on the same predicates as a file from any
+other writer. Two limits apply to what those files carry:
+
+- Bounds are written for the columns stored as INT32, INT64, FLOAT or DOUBLE.
+  That is the set the reader can skip on: `smallint`, `integer`, `bigint`,
+  `real`, `double precision`, `date`, `time`, `timestamp` and
+  `timestamp with time zone`. A `text`, `bytea`, `uuid`, `boolean` or
+  byte-array `numeric` column carries a null count and no bounds. A predicate on
+  one of those filters, but it never skips.
+- A file exported by 1.0-alpha2 or earlier carries no statistics. Nothing
+  rewrites it in place. Export it again to make it skippable.
+
 ## Reading Apache Iceberg
 
 The Iceberg read surface (`iceberg_scan`, `iceberg_data_files`, the

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -867,12 +867,19 @@ carry:
   byte-array `numeric` column carries a null count and no bounds. A predicate on
   one of those filters, but it never skips.
 - The constant must still match the column's type exactly, per the condition
-  above. A bare literal is typed by its own value, not by the column. A quoted
-  date, time or timestamp literal takes the column's type, so those skip as
-  written. `integer` skips, and so does `double precision`, whose literal
-  promotes. `bigint` skips only when the literal is too large for an `integer`:
-  `bigint_col < 5000000000` skips, `bigint_col < 100000` does not. No literal is
-  typed `smallint` or `real`, so those two always need a cast.
+  above. How the literal is written decides its type. Quote the literal, or cast
+  it, and all nine types skip: a quoted literal is `unknown` and takes the
+  column's type. That is why any quoted temporal literal skips as written. The
+  same holds for the numeric types: `smallint_col < '500'` skips, and
+  `smallint_col < 500` does not. An unquoted literal is typed by its own text
+  instead, so it matches the column only sometimes. A digit string is an
+  `integer`, or a `bigint` where the value is too wide for one. It matches
+  `integer` and `double precision` always, and `bigint` only at the wider
+  values: `bigint_col < 5000000000` skips, `bigint_col < 5` does not. A literal
+  with a decimal point is a `numeric`, and it matches `double precision` alone.
+  Against an integer column PostgreSQL casts the column rather than the
+  constant, so `bigint_col < 5.0` skips nothing. `smallint` and `real` match no
+  unquoted literal at all.
 - A file exported by 1.0-alpha2 or earlier carries no statistics. Nothing
   rewrites it in place. Export it again to make it skippable.
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -830,6 +830,8 @@ The read-in-place surface (`read_parquet`, `parquet_schema`, and the
 - The column definition list, or a foreign table's column list, must cover every
   leaf column in the file. A shorter list is an error rather than a projection.
 
+### Row-group skipping
+
 Row-group skipping is narrower than the general statement that a group is skipped
 when its statistics exclude the predicate. A scan that skips nothing still returns
 correct rows; these are the conditions under which it can skip at all:
@@ -854,9 +856,9 @@ correct rows; these are the conditions under which it can skip at all:
 The `Row Groups Skipped` counter in `EXPLAIN ANALYZE` reports what was actually
 skipped.
 
-From 1.0-alpha3, `pgcolumnar.export_parquet` writes per-row-group statistics.
-A table exported from pgColumnar skips on the same predicates as a file from any
-other writer. Two limits apply to what those files carry:
+From 1.0-alpha3, `pgcolumnar.export_parquet` writes per-row-group statistics, so
+a file pgColumnar wrote can be skipped. Three limits apply to what those files
+carry:
 
 - Bounds are written for the columns stored as INT32, INT64, FLOAT or DOUBLE.
   That is the set the reader can skip on: `smallint`, `integer`, `bigint`,
@@ -864,8 +866,16 @@ other writer. Two limits apply to what those files carry:
   `timestamp with time zone`. A `text`, `bytea`, `uuid`, `boolean` or
   byte-array `numeric` column carries a null count and no bounds. A predicate on
   one of those filters, but it never skips.
+- The constant must still match the column's type exactly, per the condition
+  above. A bare integer literal is an `integer`, and a bare `50.0` is a
+  `numeric`. Of the types listed above, only `integer` skips without a cast.
+  Write `c_i8 < 100000::bigint`, not `c_i8 < 100000`.
 - A file exported by 1.0-alpha2 or earlier carries no statistics. Nothing
   rewrites it in place. Export it again to make it skippable.
+
+This exporter writes every `numeric` as a byte-array DECIMAL, so a `numeric`
+column in a file we wrote never skips. Another writer may store the same column
+as an INT32 or INT64 DECIMAL, which does skip.
 
 ## Reading Apache Iceberg
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -867,9 +867,12 @@ carry:
   byte-array `numeric` column carries a null count and no bounds. A predicate on
   one of those filters, but it never skips.
 - The constant must still match the column's type exactly, per the condition
-  above. A bare integer literal is an `integer`, and a bare `50.0` is a
-  `numeric`. Of the types listed above, only `integer` skips without a cast.
-  Write `c_i8 < 100000::bigint`, not `c_i8 < 100000`.
+  above. A bare literal is typed by its own value, not by the column. A quoted
+  date, time or timestamp literal takes the column's type, so those skip as
+  written. `integer` skips, and so does `double precision`, whose literal
+  promotes. `bigint` skips only when the literal is too large for an `integer`:
+  `bigint_col < 5000000000` skips, `bigint_col < 100000` does not. No literal is
+  typed `smallint` or `real`, so those two always need a cast.
 - A file exported by 1.0-alpha2 or earlier carries no statistics. Nothing
   rewrites it in place. Export it again to make it skippable.
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -867,19 +867,26 @@ carry:
   byte-array `numeric` column carries a null count and no bounds. A predicate on
   one of those filters, but it never skips.
 - The constant must still match the column's type exactly, per the condition
-  above. How the literal is written decides its type. Quote the literal, or cast
-  it, and all nine types skip: a quoted literal is `unknown` and takes the
-  column's type. That is why any quoted temporal literal skips as written. The
-  same holds for the numeric types: `smallint_col < '500'` skips, and
-  `smallint_col < 500` does not. An unquoted literal is typed by its own text
-  instead, so it matches the column only sometimes. A digit string is an
-  `integer`, or a `bigint` where the value is too wide for one. It matches
-  `integer` and `double precision` always, and `bigint` only at the wider
-  values: `bigint_col < 5000000000` skips, `bigint_col < 5` does not. A literal
-  with a decimal point is a `numeric`, and it matches `double precision` alone.
-  Against an integer column PostgreSQL casts the column rather than the
-  constant, so `bigint_col < 5.0` skips nothing. `smallint` and `real` match no
-  unquoted literal at all.
+  above. How the literal is written decides its type, in three ways.
+
+    - **Quoted, with no type named.** The literal is `unknown` and takes the
+      column's type, so all nine types skip. `smallint_col < '500'` skips.
+      `smallint_col < 500` does not. A temporal literal is usually written this
+      way, which is why it skips as written.
+    - **Named type, quoted or cast.** The literal is that type, not `unknown`.
+      The exact-type condition then applies to it like any other constant.
+      `DATE '2026-01-01'` is a `date`, so `date_col < DATE '2026-01-01'` skips
+      and `timestamp_col < DATE '2026-01-01'` does not.
+    - **Unquoted.** The literal is typed by its own text, so it matches the
+      column only sometimes. A digit string is an `integer` while the value fits
+      in one, and a `bigint` when it does not. It matches whichever of those two
+      widths the column is, and never the other: `bigint_col < 5000000000`
+      skips, while `bigint_col < 5` and `integer_col < 5000000000` do not. It
+      always matches `double precision`, whose operand is widened. A literal
+      with a decimal point is a `numeric`, and it matches `double precision`
+      alone. Against an integer column PostgreSQL casts the column rather than
+      the constant, so `bigint_col < 5.0` skips nothing. `smallint` and `real`
+      match no unquoted literal at all.
 - A file exported by 1.0-alpha2 or earlier carries no statistics. Nothing
   rewrites it in place. Export it again to make it skippable.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -25,6 +25,7 @@ test/index_only.sh       /path/to/pg_config  # index-only scan and the visibilit
 test/projections.sh      /path/to/pg_config  # multiple projections and projection scan
 test/arrow_export.sh     /path/to/pg_config  # Arrow IPC export read back with pyarrow
 test/parquet_export.sh   /path/to/pg_config  # Parquet export read back with pyarrow and DuckDB
+test/parquet_export_stats.sh /path/to/pg_config # row-group statistics in exported files
 test/arrow_import.sh     /path/to/pg_config  # Arrow IPC import
 test/parquet_import.sh   /path/to/pg_config  # Parquet import
 test/arrow_nested.sh     /path/to/pg_config  # nested Arrow export

--- a/src/columnar_parquet.c
+++ b/src/columnar_parquet.c
@@ -26,6 +26,10 @@
 #include "columnar_sink.h"
 #include "columnar_thrift.h"
 
+/* isnan(), for the float statistics rules. PostgreSQL's own headers happen to
+ * reach it on 15 through 18 and do not on 19, where the build fails outright. */
+#include <math.h>
+
 #include "fmgr.h"
 #include "access/htup_details.h"
 #include "access/relation.h"

--- a/src/columnar_parquet.c
+++ b/src/columnar_parquet.c
@@ -126,6 +126,40 @@ numeric_to_int128(Datum numd, int scale, __int128 *out)
 
 
 /*
+ * Per-row-group statistics for one leaf, i.e. what goes in ColumnMetaData's
+ * Statistics (field 12). A reader skips a row group by proving its predicate
+ * cannot hold anywhere in [min_value, max_value], so a wrong bound loses rows
+ * silently -- the executor's recheck never sees a group that emitted nothing.
+ * Everything here is therefore conservative:
+ *
+ *   * Bounds are written only for the fixed-width physical types whose defined
+ *     sort order is the signed one we compare in: INT32, INT64, FLOAT and
+ *     DOUBLE. BOOLEAN, BYTE_ARRAY and FIXED_LEN_BYTE_ARRAY get null_count and
+ *     nothing else. UTF8 sorts by unsigned bytes, which is not any PostgreSQL
+ *     collation, and a bound in the wrong order is worse than no bound.
+ *   * Values are accumulated in PHYSICAL space, inside write_leaf_value, from
+ *     the same expression that writes the data page. Deriving them a second
+ *     time is how a bound comes to disagree with the column by an epoch.
+ *   * A value with no Parquet representation (date and timestamp infinity, a
+ *     numeric too wide for its DECIMAL) is folded to null before it gets here,
+ *     so it counts as a null and cannot reach a bound.
+ *   * parquet.thrift's TYPE_ORDER rules for floats: NaN is never a bound,
+ *     nan_count is always written, a column whose non-null values are all NaN
+ *     gets no bounds at all, and a computed zero is written -0.0 as a minimum
+ *     and +0.0 as a maximum.
+ */
+typedef struct PqStats
+{
+	bool		hasBounds;		/* a non-NaN value has been seen */
+	int64		nulls;			/* nulls, folded values included */
+	int64		nans;			/* NaN values (float and double only) */
+	int64		iMin;			/* INT32/INT64 bounds, held widened */
+	int64		iMax;
+	float8		fMin;			/* FLOAT/DOUBLE bounds, held widened */
+	float8		fMax;
+}			PqStats;
+
+/*
  * A leaf column is one Parquet column chunk: a scalar column, an array's element,
  * or one field of a composite. Nesting is expressed through repetition and
  * definition levels (the Dremel model). For a plain scalar, max_rep is 0 and
@@ -150,6 +184,7 @@ typedef struct PqLeaf
 	StringInfoData values;		/* PLAIN values, non-null only */
 	StringInfoData boolbits;	/* 1 byte per non-null bool value */
 	int64		nEntries;		/* level entries in the current row group */
+	PqStats		st;				/* statistics for the current row group */
 }			PqLeaf;
 
 /* how a top-level column shreds into leaves */
@@ -181,6 +216,7 @@ typedef struct PqColMeta
 	int64		dataPageOffset;
 	int64		totalSize;		/* page header + body */
 	int64		numValues;		/* rows */
+	PqStats		st;				/* this group's statistics, taken at flush */
 }			PqColMeta;
 
 typedef struct PqRowGroup
@@ -190,6 +226,67 @@ typedef struct PqRowGroup
 	int64		numRows;
 }			PqRowGroup;
 
+/*
+ * Reset one leaf for the next row group. The statistics reset here rather than
+ * per file: a bound left over from the previous group would describe rows that
+ * are not in this one, and a file-wide bound on every chunk is a file that can
+ * never be skipped.
+ */
+static void
+pqstats_reset(PqStats *st)
+{
+	st->hasBounds = false;
+	st->nulls = 0;
+	st->nans = 0;
+	st->iMin = st->iMax = 0;
+	st->fMin = st->fMax = 0;
+}
+
+/* One non-null INT32/INT64 physical value, in physical space. */
+static inline void
+pqstats_int(PqStats *st, int64 v)
+{
+	if (!st->hasBounds)
+	{
+		st->iMin = st->iMax = v;
+		st->hasBounds = true;
+	}
+	else
+	{
+		if (v < st->iMin)
+			st->iMin = v;
+		if (v > st->iMax)
+			st->iMax = v;
+	}
+}
+
+/*
+ * One non-null FLOAT/DOUBLE value. A NaN is counted and discarded: parquet.thrift
+ * requires that a bound, when present, be computed from non-NaN values only, so
+ * that a reader may trust it for the non-NaN rows.
+ */
+static inline void
+pqstats_float(PqStats *st, float8 v)
+{
+	if (isnan(v))
+	{
+		st->nans++;
+		return;
+	}
+	if (!st->hasBounds)
+	{
+		st->fMin = st->fMax = v;
+		st->hasBounds = true;
+	}
+	else
+	{
+		if (v < st->fMin)
+			st->fMin = v;
+		if (v > st->fMax)
+			st->fMax = v;
+	}
+}
+
 static void
 pqleaf_reset(PqLeaf *c)
 {
@@ -197,6 +294,7 @@ pqleaf_reset(PqLeaf *c)
 	resetStringInfo(&c->reps);
 	resetStringInfo(&c->values);
 	resetStringInfo(&c->boolbits);
+	pqstats_reset(&c->st);
 	c->nEntries = 0;
 }
 
@@ -312,6 +410,7 @@ write_leaf_value(PqLeaf *c, Datum d, __int128 dec)
 				int32		v = (int32) DatumGetInt16(d);
 
 				appendBinaryStringInfo(&c->values, (char *) &v, 4);
+				pqstats_int(&c->st, v);
 				break;
 			}
 		case P_INT32:
@@ -319,6 +418,7 @@ write_leaf_value(PqLeaf *c, Datum d, __int128 dec)
 				int32		v = DatumGetInt32(d);
 
 				appendBinaryStringInfo(&c->values, (char *) &v, 4);
+				pqstats_int(&c->st, v);
 				break;
 			}
 		case P_INT64:
@@ -326,6 +426,7 @@ write_leaf_value(PqLeaf *c, Datum d, __int128 dec)
 				int64		v = DatumGetInt64(d);
 
 				appendBinaryStringInfo(&c->values, (char *) &v, 8);
+				pqstats_int(&c->st, v);
 				break;
 			}
 		case P_FLOAT:
@@ -333,6 +434,7 @@ write_leaf_value(PqLeaf *c, Datum d, __int128 dec)
 				float4		v = DatumGetFloat4(d);
 
 				appendBinaryStringInfo(&c->values, (char *) &v, 4);
+				pqstats_float(&c->st, (float8) v);
 				break;
 			}
 		case P_DOUBLE:
@@ -340,6 +442,7 @@ write_leaf_value(PqLeaf *c, Datum d, __int128 dec)
 				float8		v = DatumGetFloat8(d);
 
 				appendBinaryStringInfo(&c->values, (char *) &v, 8);
+				pqstats_float(&c->st, v);
 				break;
 			}
 		case P_DATE:
@@ -347,6 +450,7 @@ write_leaf_value(PqLeaf *c, Datum d, __int128 dec)
 				int32		v = (int32) (DatumGetDateADT(d) + PG_TO_UNIX_DAYS);
 
 				appendBinaryStringInfo(&c->values, (char *) &v, 4);
+				pqstats_int(&c->st, v);
 				break;
 			}
 		case P_TIME:
@@ -354,6 +458,7 @@ write_leaf_value(PqLeaf *c, Datum d, __int128 dec)
 				int64		v = (int64) DatumGetTimeADT(d);
 
 				appendBinaryStringInfo(&c->values, (char *) &v, 8);
+				pqstats_int(&c->st, v);
 				break;
 			}
 		case P_TIMESTAMP:
@@ -361,6 +466,7 @@ write_leaf_value(PqLeaf *c, Datum d, __int128 dec)
 				int64		v = (int64) DatumGetTimestamp(d) + PG_TO_UNIX_USECS;
 
 				appendBinaryStringInfo(&c->values, (char *) &v, 8);
+				pqstats_int(&c->st, v);
 				break;
 			}
 		case P_UUID:
@@ -427,8 +533,16 @@ leaf_entry(PqLeaf *c, int def, int rep, bool hasValue, Datum d)
 	if (c->max_rep > 0)
 		appendStringInfoChar(&c->reps, (char) rep);
 	c->nEntries++;
+	/*
+	 * The null count is taken here rather than beside the accumulators, because
+	 * this is where a value that has no Parquet representation has just become a
+	 * null. Counting it in write_leaf_value would miss exactly those rows, and
+	 * miss them in the direction that makes the file look denser than it is.
+	 */
 	if (hasValue)
 		write_leaf_value(c, d, dec);
+	else
+		c->st.nulls++;
 }
 
 /* shred one top-level column value for a row into its leaf/leaves */
@@ -695,6 +809,93 @@ write_top_schema(StringInfo b, TopColumn *tc, PqLeaf *leaves)
 	}
 }
 
+/*
+ * Write ColumnMetaData's Statistics (field 12) for one column chunk.
+ *
+ * null_count is written for every chunk, including where it is zero:
+ * parquet.thrift says a reader MUST NOT assume null_count == 0 when the field is
+ * absent, so omitting it on a column with no nulls tells the reader less than
+ * writing a zero does.
+ *
+ * Bounds go in min_value (6) and max_value (5), PLAIN-encoded at the physical
+ * width. The deprecated min (2) and max (1) are not written: they are defined by
+ * signed comparison alone, and a current reader that has column_orders prefers
+ * the new pair anyway.
+ */
+static void
+write_statistics(StringInfo b, PqLeaf *c, PqColMeta *m)
+{
+	int16		slast = 0;
+	bool		isFloat = (c->ptype == PQ_FLOAT || c->ptype == PQ_DOUBLE);
+	bool		ordered = (c->ptype == PQ_INT32 || c->ptype == PQ_INT64 || isFloat);
+	bool		wide = (c->ptype == PQ_INT64 || c->ptype == PQ_DOUBLE);
+
+	PgColumnarThriftPutI64Field(b, &slast, 3, m->st.nulls);		/* null_count */
+
+	if (ordered && m->st.hasBounds)
+	{
+		char		lo[8];
+		char		hi[8];
+		int			n = wide ? 8 : 4;
+
+		if (isFloat)
+		{
+			/*
+			 * parquet.thrift, TYPE_ORDER: a computed maximum of either zero is
+			 * written +0.0, and a computed minimum of either zero is written
+			 * -0.0. C's comparison treats -0.0 == 0.0, so which zero the
+			 * accumulator kept is not decided by the data; normalising here
+			 * makes it not matter.
+			 */
+			float8		fmin = (m->st.fMin == 0.0) ? -0.0 : m->st.fMin;
+			float8		fmax = (m->st.fMax == 0.0) ? 0.0 : m->st.fMax;
+
+			if (wide)
+			{
+				memcpy(lo, &fmin, 8);
+				memcpy(hi, &fmax, 8);
+			}
+			else
+			{
+				float4		f4lo = (float4) fmin;
+				float4		f4hi = (float4) fmax;
+
+				memcpy(lo, &f4lo, 4);
+				memcpy(hi, &f4hi, 4);
+			}
+		}
+		else if (wide)
+		{
+			int64		i64lo = m->st.iMin;
+			int64		i64hi = m->st.iMax;
+
+			memcpy(lo, &i64lo, 8);
+			memcpy(hi, &i64hi, 8);
+		}
+		else
+		{
+			int32		i32lo = (int32) m->st.iMin;
+			int32		i32hi = (int32) m->st.iMax;
+
+			memcpy(lo, &i32lo, 4);
+			memcpy(hi, &i32hi, 4);
+		}
+
+		PgColumnarThriftPutStringField(b, &slast, 5, hi, n);	/* max_value */
+		PgColumnarThriftPutStringField(b, &slast, 6, lo, n);	/* min_value */
+	}
+
+	/*
+	 * nan_count must be set for the floating point types even when it is zero:
+	 * absent, a reader must assume NaNs may be present, which is the assumption
+	 * the bounds above are written to remove.
+	 */
+	if (isFloat)
+		PgColumnarThriftPutI64Field(b, &slast, 9, m->st.nans);
+
+	PgColumnarThriftPutStop(b);									/* end Statistics */
+}
+
 /* one column chunk for a leaf (path_in_schema is the full leaf path) */
 static void
 write_column_chunk(StringInfo b, PqLeaf *c, PqColMeta *m)
@@ -722,6 +923,8 @@ write_column_chunk(StringInfo b, PqLeaf *c, PqColMeta *m)
 	PgColumnarThriftPutI64Field(b, &mlast, 6, m->totalSize);		/* total_uncompressed_size */
 	PgColumnarThriftPutI64Field(b, &mlast, 7, m->totalSize);		/* total_compressed_size */
 	PgColumnarThriftPutI64Field(b, &mlast, 9, m->dataPageOffset);	/* data_page_offset */
+	PgColumnarThriftPutField(b, &mlast, 12, TC_STRUCT);				/* statistics */
+	write_statistics(b, c, m);
 	PgColumnarThriftPutStop(b);										/* end ColumnMetaData */
 	PgColumnarThriftPutStop(b);										/* end ColumnChunk */
 }
@@ -1058,6 +1261,12 @@ PgColumnarWriteParquetFile(Relation rel, Snapshot snapshot, const char *filepath
 				rg->cols[i].dataPageOffset = pageStart;
 				rg->cols[i].totalSize = ph.len + body.len;
 				rg->cols[i].numValues = leaves[i].nEntries;
+				/*
+				 * Take the statistics before pqleaf_reset() below clears them.
+				 * The footer is written after every row group has been flushed,
+				 * so by then the leaf holds only the last group's accumulator.
+				 */
+				rg->cols[i].st = leaves[i].st;
 				rg->totalByteSize += ph.len + body.len;
 
 				pfree(body.data);
@@ -1097,6 +1306,29 @@ PgColumnarWriteParquetFile(Relation rel, Snapshot snapshot, const char *filepath
 		for (i = 0; i < nrgs; i++)
 			write_row_group(&fmd, leaves, nleaves, &rgs[i]);
 		PgColumnarThriftPutStringField(&fmd, &last, 6, "pgColumnar", 10);	/* created_by */
+
+		/*
+		 * column_orders (7), one ColumnOrder per LEAF column in leaf order.
+		 * Not optional in practice: parquet.thrift states that without it the
+		 * meaning of min_value and max_value is undefined, and Arrow acts on
+		 * that by discarding them, so a file with statistics and no
+		 * column_orders skips nothing under pyarrow. The list length must equal
+		 * the leaf count exactly -- Arrow raises on a mismatch, which would make
+		 * the file unreadable rather than merely unskippable.
+		 *
+		 * TYPE_ORDER is the union's field 1, holding an empty TypeDefinedOrder:
+		 * one field header, then the inner struct's stop, then the union's.
+		 */
+		PgColumnarThriftPutField(&fmd, &last, 7, TC_LIST);
+		PgColumnarThriftPutListHeader(&fmd, nleaves, TC_STRUCT);
+		for (i = 0; i < nleaves; i++)
+		{
+			int16		olast = 0;
+
+			PgColumnarThriftPutField(&fmd, &olast, 1, TC_STRUCT);
+			PgColumnarThriftPutStop(&fmd);	/* end TypeDefinedOrder (empty) */
+			PgColumnarThriftPutStop(&fmd);	/* end ColumnOrder */
+		}
 		PgColumnarThriftPutStop(&fmd);
 
 		PgColumnarSinkWrite(snk, fmd.data, fmd.len);

--- a/test/native_parquet_pushdown.sh
+++ b/test/native_parquet_pushdown.sh
@@ -3,11 +3,15 @@
 # pgColumnar Parquet FDW predicate / row-group skipping (Phase G). The FDW reads
 # each row group's min/max statistics and skips groups that a pushable col-op-const
 # clause proves empty; the executor still rechecks every returned row, so a skip can
-# only save work, never drop rows. This suite needs a statistics-bearing file, which
-# our exporter does not write, so it uses pyarrow to produce a multi-row-group file
-# with per-group stats. It asserts correctness against a heap oracle (skipping never
-# changes results) AND that groups are actually skipped (via EXPLAIN ANALYZE's
-# "Row Groups Skipped" counter).
+# only save work, never drop rows. It asserts correctness against a heap oracle
+# (skipping never changes results) AND that groups are actually skipped (via
+# EXPLAIN ANALYZE's "Row Groups Skipped" counter).
+#
+# The file under test is written by pyarrow, deliberately: this suite is about
+# the READ side, and an independent writer keeps it from passing because our
+# reader and our writer share a misunderstanding. Our own exporter wrote no
+# statistics at all until #850 (1.0-alpha3), which is why that gap survived here
+# unseen; test/parquet_export_stats.sh covers the write side.
 #
 # Usage:  test/native_parquet_pushdown.sh [PG_CONFIG]
 # Written fresh for pgColumnar.

--- a/test/parquet_export_stats.sh
+++ b/test/parquet_export_stats.sh
@@ -437,6 +437,46 @@ check_num "control: a float < predicate below every bound skips" \
 check_num "a float >= predicate above every bound still skips nothing" \
 	"$(skipped_for "WHERE f4 >= 200000.0::real")" "0"
 
+# How the literal is WRITTEN decides the constant's type, and therefore whether
+# the exact-type condition above is met at all. Each pair below differs in one
+# respect -- a pair of quotes, or the width of the value -- so the arm that reads
+# 0 is refusing rather than merely having nothing to prune. docs/limitations.md
+# states the rule; these are what make it a measurement.
+#
+# The i2 arms skip 1 and not $NGROUPS because i2 is deliberately not ascending in
+# this fixture: only the last group, the single row whose min equals its max, has
+# bounds that exclude 500. One skipped group is still a skip that a cross-type
+# constant cannot produce, which is what the pair is for.
+check_num "a quoted literal takes a bigint column's type and skips" \
+	"$(skipped_for "WHERE i8 < '5'")" "$NGROUPS"
+check_num "the same digits unquoted are an integer, and skip nothing" \
+	"$(skipped_for "WHERE i8 < 5")" "0"
+check_num "digits too wide for an integer are a bigint, and skip" \
+	"$(skipped_for "WHERE i8 < 5000000000")" "3"
+# A decimal-point literal is a `numeric`, and PostgreSQL resolves
+# `bigint < numeric` by casting the COLUMN. A skip count of 0 for that predicate
+# would be over-determined -- the matcher rejects a left argument that is not a
+# bare Var, AND the exact-type test would reject a numeric constant -- so no
+# single mutation could turn it red and it would not be evidence of anything.
+# The plan shape is what the documentation actually claims, so assert that, with
+# the quoted form beside it asserting the opposite resolution positively.
+filter_has() {  # filter_has WHERE PATTERN
+	q "EXPLAIN (VERBOSE, COSTS OFF) SELECT count(*) FROM es_ft $1" \
+		| grep -i 'filter' | grep -c "$2"
+}
+check_num "a decimal-point literal casts the column, not the constant" \
+	"$(filter_has "WHERE i8 < 5.0" '::numeric')" "1"
+check_num "control: the quoted form casts the constant to the column's type" \
+	"$(filter_has "WHERE i8 < '5'" '::bigint')" "1"
+check_num "a quoted literal takes a real column's type and skips" \
+	"$(skipped_for "WHERE f4 < '0.4'")" "$NGROUPS"
+check_num "the same literal unquoted is double precision, and skips nothing" \
+	"$(skipped_for "WHERE f4 < 0.4")" "0"
+check_num "a quoted literal takes a smallint column's type and skips" \
+	"$(skipped_for "WHERE i2 < '500'")" "1"
+check_num "the same digits unquoted are an integer, and skip nothing (int2)" \
+	"$(skipped_for "WHERE i2 < 500")" "0"
+
 # Soundness. A skipped group emits nothing, and the executor's recheck cannot
 # recover a row that never arrived, so every predicate above must return exactly
 # what the oracle returns.
@@ -451,6 +491,11 @@ for pred in \
 	"d > DATE '2060-01-01'" \
 	"ts < TIMESTAMP '2000-01-01 00:30:00'" \
 	"nul < 1000100" \
+	"i8 < '5'" \
+	"i8 < 5000000000" \
+	"f4 < '0.4'" \
+	"i2 < '500'" \
+	"i2 < 500" \
 	"alln IS NULL"
 do
 	check "the FDW result equals the oracle for [$pred]" \

--- a/test/parquet_export_stats.sh
+++ b/test/parquet_export_stats.sh
@@ -1,0 +1,461 @@
+#!/usr/bin/env bash
+#
+# Statistics in the files WE export (#850).
+#
+# pgcolumnar.export_parquet() wrote no per-row-group statistics, so a file we
+# exported could never drive the Parquet FDW's row-group skipping: every
+# documented condition in docs/limitations.md's "Row-group skipping" section
+# could hold and "Row Groups Skipped" would still be 0, because the reader had
+# no min/max to test. The native chunk-group skip on the same data was, and is,
+# unaffected -- the fault was entirely on the write side.
+#
+# What this suite pins, in the bytes rather than in a reader's opinion of them:
+#   * every column chunk of a skippable physical type carries min_value and
+#     max_value, and the values are CORRECT per row group, not merely present;
+#   * null_count is written always, and counts nulls -- including values that
+#     have no Parquet representation and are folded to null (date and timestamp
+#     infinity), which must not reach a bound;
+#   * the float rules parquet.thrift states for TYPE_ORDER: NaN excluded from
+#     the bounds, nan_count always written, no bounds at all when every non-null
+#     value is NaN, a zero maximum written as +0.0 and a zero minimum as -0.0;
+#   * FileMetaData.column_orders, which the spec makes mandatory once
+#     min_value/max_value are written and without which Arrow discards them;
+#   * and the payoff: the FDW skips row groups on a file we exported, and the
+#     rows it returns still match an oracle exactly.
+#
+# The instrument is test/parquet_stats.py, which reads the footer with no
+# Parquet library. That is deliberate. A suite whose instrument is an optional
+# import reports SKIP when the import is missing, and a skip is not coverage;
+# and column_orders is invisible through pyarrow's statistics API, so a
+# third-party reader cannot tell us whether we wrote it.
+#
+# Usage:  test/parquet_export_stats.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+STATS_PY="$(dirname "${BASH_SOURCE[0]}")/parquet_stats.py"
+PARQ="$PGC_WORKDIR/export_stats.parquet"
+S="$PGC_WORKDIR/stats.txt"
+
+# 196609 = 3*65536 + 1, so the export writes 4 row groups and the last holds a
+# single row. The one-row group is the min==max edge and costs nothing.
+ROWS=196609
+RGSIZE=65536
+NGROUPS=4
+
+COLS="id int4, i2 int2, i8 int8, f4 float4, d date, ts timestamp,
+      nul int4, alln int4, t text, b bool"
+
+# ---- fixture ---------------------------------------------------------------
+#
+# Every column earns its place:
+#   id    ascending, so the four groups hold disjoint ranges: without that a
+#         correct writer and a writer that stamps one file-wide min/max onto
+#         every chunk are indistinguishable.
+#   i2    a PG int2 stored as a Parquet INT32, so a statistic written at the
+#         PostgreSQL width rather than the physical one is visible.
+#   f4    exact halves, so the float text comparison is not a rounding argument.
+#   d,ts  ascending AND carrying infinities, which have no Parquet
+#         representation and are folded to null: they must not reach a bound.
+#   nul   nulls, with every non-null value above 1000000, so a null admitted
+#         into the accumulator as 0 lands outside the true range.
+#   alln  all null: the column that must carry no bounds at all.
+#   t,b   a BYTE_ARRAY and a BOOLEAN, whose bounds this change does not write.
+psql_run "CREATE EXTENSION IF NOT EXISTS pgcolumnar;"
+psql_run "CREATE TABLE es_h ($COLS);"
+psql_run "INSERT INTO es_h
+          SELECT g - 1,
+                 (g % 20000) + 1,
+                 g::bigint * 1000000,
+                 g * 0.5,
+                 CASE WHEN g % $RGSIZE = 3 THEN 'infinity'::date
+                      WHEN g % $RGSIZE = 4 THEN '-infinity'::date
+                      ELSE DATE '2000-01-01' + (g / 8) END,
+                 CASE WHEN g % $RGSIZE = 5 THEN 'infinity'::timestamp
+                      ELSE TIMESTAMP '2000-01-01' + (g || ' sec')::interval END,
+                 CASE WHEN g % 5 = 0 THEN NULL ELSE g + 1000000 END,
+                 NULL,
+                 'r' || g,
+                 (g % 2 = 0)
+          FROM generate_series(1, $ROWS) g;"
+psql_run "CREATE TABLE es_c ($COLS) USING pgcolumnar;"
+psql_run "INSERT INTO es_c SELECT * FROM es_h;"
+psql_run "SELECT pgcolumnar.export_parquet('es_c', '$PARQ');"
+
+if ! python3 "$STATS_PY" "$PARQ" > "$S" 2>"$PGC_WORKDIR/stats.err"; then
+	echo "FAIL  the footer parser could not read the exported file:"
+	sed 's/^/      /' "$PGC_WORKDIR/stats.err"
+	PGC_FAIL=1
+	PGC_CHECKS=$((PGC_CHECKS + 1))
+	pgc_summary
+fi
+
+# ---- accessors over the parser's output ------------------------------------
+
+fileval() {  # fileval KEY
+	awk -v k="$1=" '$1=="FILE"{for(i=2;i<=NF;i++) if(index($i,k)==1)
+		{print substr($i,length(k)+1); exit}}' "$S"
+}
+leafof() {  # leafof PATH -> the leaf index carrying that column
+	awk -v p="path=$1" '$1=="CHUNK" && $0 ~ ("(^| )" p "( |$)"){
+		for(i=2;i<=NF;i++) if(index($i,"leaf=")==1)
+			{print substr($i,6); exit}}' "$S"
+}
+cf() {  # cf RG LEAF KEY -> that chunk's value for KEY
+	awk -v rg="rg=$1" -v lf="leaf=$2" -v k="$3=" '
+		$1=="CHUNK" && $2==rg && $3==lf {
+			for(i=4;i<=NF;i++) if(index($i,k)==1)
+				{print substr($i,length(k)+1); exit}}' "$S"
+}
+# Count CHUNK lines whose KEY equals VAL, restricted to a set of leaf indexes.
+countchunks() {  # countchunks "LEAFSET" KEY VAL
+	awk -v leaves="$1" -v k="$2=" -v want="$3" '
+		BEGIN{n=split(leaves,a," "); for(i=1;i<=n;i++) keep[a[i]]=1}
+		$1=="CHUNK" {
+			lf=""; v="";
+			for(i=2;i<=NF;i++){
+				if(index($i,"leaf=")==1) lf=substr($i,6);
+				if(index($i,k)==1) v=substr($i,length(k)+1);
+			}
+			if(lf in keep && v==want) c++
+		} END{print c+0}' "$S"
+}
+
+# Leaf indexes, resolved from the file rather than assumed from column order.
+L_ID="$(leafof id)";   L_I2="$(leafof i2)";  L_I8="$(leafof i8)"
+L_F4="$(leafof f4)";   L_D="$(leafof d)";    L_TS="$(leafof ts)"
+L_NUL="$(leafof nul)"; L_ALLN="$(leafof alln)"
+L_T="$(leafof t)";     L_B="$(leafof b)"
+# The seven skippable-type columns that hold at least one value, and alln,
+# which is skippable by type and holds none.
+SKIPPABLE="$L_ID $L_I2 $L_I8 $L_F4 $L_D $L_TS $L_NUL"
+SKIPTYPE="$SKIPPABLE $L_ALLN"
+
+# ---- premises: the instrument reached the data ------------------------------
+#
+# Every red below is ambiguous without these. They separate "no statistics were
+# written" from "the parser stopped early", "we measured someone else's file",
+# and "the exported data is wrong".
+
+check "premise: leaf indexes resolved for all ten columns" \
+	"$(printf '%s\n' "$L_ID" "$L_I2" "$L_I8" "$L_F4" "$L_D" "$L_TS" \
+		"$L_NUL" "$L_ALLN" "$L_T" "$L_B" | grep -c '^[0-9]\+$')" "10"
+check "premise: the file under test is one we wrote" "$(fileval created_by)" "pgColumnar"
+check_num "premise: the footer declares $NGROUPS row groups" \
+	"$(fileval row_groups)" "$NGROUPS"
+check_num "premise: the footer declares 10 leaf columns" "$(fileval leaves)" "10"
+check_num "premise: the parser reaches ColumnMetaData (num_values sums to the table)" \
+	"$(awk -v lf="leaf=$L_ID" '$1=="CHUNK" && $3==lf {
+		for(i=4;i<=NF;i++) if(index($i,"num_values=")==1) s+=substr($i,12)
+	} END{print s+0}' "$S")" \
+	"$(q "SELECT count(*) FROM es_c")"
+
+# The oracle. read_parquet decodes DATA PAGES -- a different code path from the
+# footer under test -- so a bound is compared against the values themselves.
+# Materialized once: re-decoding the file per check would be slow enough to
+# discourage checking.
+psql_run "CREATE TABLE oracle AS
+          SELECT (row_number() OVER () - 1) / $RGSIZE AS grp, *
+          FROM pgcolumnar.read_parquet('$PARQ') AS t($COLS);"
+# The bucket mapping is what every per-group value check rests on. These two
+# assert it against the fixture's ascending id rather than assuming that
+# read_parquet returned the file in order.
+check "premise: the oracle's buckets are the file's row groups" \
+	"$(q "SELECT string_agg(c::text, ',' ORDER BY grp)
+	      FROM (SELECT grp, count(*) c FROM oracle GROUP BY grp) s")" \
+	"$RGSIZE,$RGSIZE,$RGSIZE,1"
+check "premise: each bucket holds its own contiguous id range" \
+	"$(q "SELECT bool_and(mn = grp * $RGSIZE AND mx = grp * $RGSIZE + c - 1)
+	      FROM (SELECT grp, min(id) mn, max(id) mx, count(*) c
+	            FROM oracle GROUP BY grp) s")" "t"
+check_num "premise: the oracle holds every exported row" \
+	"$(q "SELECT count(*) FROM oracle")" "$ROWS"
+check "premise: the exported data equals the heap on the columns nothing folds" \
+	"$(pgc_set_hash "SELECT id,i2,i8,f4,nul,alln,t,b FROM oracle")" \
+	"$(pgc_set_hash "SELECT id,i2,i8,f4,nul,alln,t,b FROM es_h")"
+
+# ---- (a) presence, with the buckets accounting for every chunk -------------
+
+BOTH="$(countchunks "$SKIPPABLE" has_min 1)"
+BOTHMAX="$(countchunks "$SKIPPABLE" has_max 1)"
+NEITHER="$(countchunks "$L_ALLN" has_min 0)"
+TOTSKIP="$(countchunks "$SKIPTYPE" rg 0)"
+ONESIDED=$(( $(countchunks "$SKIPTYPE" has_min 1) + $(countchunks "$SKIPTYPE" has_max 1)
+	     - 2 * $(awk -v leaves="$SKIPTYPE" '
+		BEGIN{n=split(leaves,a," "); for(i=1;i<=n;i++) keep[a[i]]=1}
+		$1=="CHUNK"{lf="";mn="";mx="";
+			for(i=2;i<=NF;i++){
+				if(index($i,"leaf=")==1) lf=substr($i,6);
+				if(index($i,"has_min=")==1) mn=substr($i,9);
+				if(index($i,"has_max=")==1) mx=substr($i,9);
+			}
+			if((lf in keep) && mn=="1" && mx=="1") c++
+		} END{print c+0}' "$S") ))
+echo "-- chunks of a skippable physical type: $(( NGROUPS * 8 )) expected;" \
+     "with both bounds $BOTH, with neither $NEITHER, one-sided $ONESIDED"
+check_num "every value-bearing skippable chunk carries a minimum" \
+	"$BOTH" "$(( NGROUPS * 7 ))"
+check_num "every value-bearing skippable chunk carries a maximum" \
+	"$BOTHMAX" "$(( NGROUPS * 7 ))"
+check_num "no chunk carries exactly one bound" "$ONESIDED" "0"
+check_num "buckets account for every skippable-type chunk" \
+	"$(( BOTH + NEITHER + ONESIDED ))" "$(( NGROUPS * 8 ))"
+check_num "the all-null column carries no bounds" \
+	"$(countchunks "$L_ALLN" has_min 1)" "0"
+
+# A statistic must be written at the PHYSICAL width: a PG int2 is a Parquet
+# INT32 and its bound is 4 bytes, not 2.
+check_num "every bound is its physical width" \
+	"$(awk '$1=="CHUNK"{pt="";mnl="";mxl="";
+		for(i=2;i<=NF;i++){
+			if(index($i,"ptype=")==1) pt=substr($i,7);
+			if(index($i,"minlen=")==1) mnl=substr($i,8);
+			if(index($i,"maxlen=")==1) mxl=substr($i,8);
+		}
+		w=0; if(pt=="1"||pt=="4") w=4; else if(pt=="2"||pt=="5") w=8;
+		if(w>0){ if(mnl!="-" && mnl+0!=w) bad++; if(mxl!="-" && mxl+0!=w) bad++ }
+	} END{print bad+0}' "$S")" "0"
+
+# ---- (b) the values are right, per row group -------------------------------
+
+# A float bound and its oracle are the same number written two ways: the parser
+# prints Python's repr (32768.0) and PostgreSQL prints its own text form (32768).
+# Comparing them as strings fails on the presentation, so compare them as
+# numbers -- while keeping check_num's refusal to compare a measurement nobody
+# took, which is the whole reason the value checks are trustworthy.
+check_float() {  # check_float NAME GOT WANT
+	local name="$1" got="$2" want="$3"
+	if ! pgc_is_number "$got" || ! pgc_is_number "$want"; then
+		PGC_CHECKS=$((PGC_CHECKS + 1))
+		PGC_FAIL=1
+		echo "FAIL  $name: not a measurement, so nothing was compared:" \
+			"got [$got] want [$want]"
+		return 1
+	fi
+	check "$name" \
+		"$(awk -v v="$got" 'BEGIN{printf "%.9g", v+0}')" \
+		"$(awk -v v="$want" 'BEGIN{printf "%.9g", v+0}')"
+}
+
+# Physical-space oracle per column: what the bound must decode to.
+ora() {  # ora COL GRP min|max
+	case "$1" in
+		d)  q "SELECT ($3(d) - DATE '1970-01-01')::text FROM oracle WHERE grp = $2" ;;
+		ts) q "SELECT (EXTRACT(EPOCH FROM ($3(ts) - TIMESTAMP '1970-01-01'))
+		               * 1000000)::bigint::text FROM oracle WHERE grp = $2" ;;
+		f4) q "SELECT $3(f4)::float8::text FROM oracle WHERE grp = $2" ;;
+		*)  q "SELECT $3($1)::text FROM oracle WHERE grp = $2" ;;
+	esac
+}
+for spec in "id $L_ID" "i2 $L_I2" "i8 $L_I8" "f4 $L_F4" "d $L_D" "ts $L_TS" "nul $L_NUL"; do
+	set -- $spec
+	col="$1"; lf="$2"
+	# f4's bound is a float on one side and PostgreSQL's float text on the
+	# other; every other column here is an integer in physical space.
+	cmp=check_num
+	[ "$col" = f4 ] && cmp=check_float
+	for g in $(seq 0 $((NGROUPS - 1))); do
+		$cmp "group $g min($col) equals the oracle" \
+			"$(cf "$g" "$lf" min)" "$(ora "$col" "$g" min)"
+		$cmp "group $g max($col) equals the oracle" \
+			"$(cf "$g" "$lf" max)" "$(ora "$col" "$g" max)"
+	done
+done
+
+# A writer that computed one min/max for the whole file would satisfy every
+# presence check above and still make skipping impossible.
+check_num "the four groups report four distinct id minima" \
+	"$(awk -v lf="leaf=$L_ID" '$1=="CHUNK" && $3==lf {
+		for(i=4;i<=NF;i++) if(index($i,"min=")==1) print substr($i,5)
+	}' "$S" | sort -u | wc -l)" "$NGROUPS"
+check_num "min <= max in every chunk carrying both" \
+	"$(awk '$1=="CHUNK"{mn="";mx="";
+		for(i=2;i<=NF;i++){
+			if(index($i,"min=")==1 && index($i,"minhex=")!=1 && index($i,"minlen=")!=1)
+				mn=substr($i,5);
+			if(index($i,"max=")==1 && index($i,"maxhex=")!=1 && index($i,"maxlen=")!=1)
+				mx=substr($i,5);
+		}
+		if(mn!="-" && mx!="-" && mn!="" && mx!="" && mn+0>mx+0) bad++
+	} END{print bad+0}' "$S")" "0"
+
+# ---- (c) null_count --------------------------------------------------------
+
+check_num "null_count is written for every chunk, including where it is zero" \
+	"$(awk '$1=="CHUNK"{for(i=2;i<=NF;i++) if(index($i,"null_count=")==1 &&
+		substr($i,12)=="-") n++} END{print n+0}' "$S")" "0"
+for spec in "nul $L_NUL" "d $L_D" "ts $L_TS" "alln $L_ALLN" "id $L_ID"; do
+	set -- $spec
+	col="$1"; lf="$2"
+	for g in $(seq 0 $((NGROUPS - 1))); do
+		check_num "group $g null_count($col) equals the oracle" \
+			"$(cf "$g" "$lf" null_count)" \
+			"$(q "SELECT (count(*) - count($col))::text FROM oracle WHERE grp = $g")"
+	done
+done
+
+# ---- (d) values with no Parquet representation are folded, not admitted ----
+
+check "premise: the fixture's infinite dates are more than none" \
+	"$(q "SELECT count(*) > 0 FROM es_h WHERE d IN ('infinity','-infinity')")" "t"
+check "premise: the fixture's infinite timestamps are more than none" \
+	"$(q "SELECT count(*) > 0 FROM es_h WHERE ts = 'infinity'")" "t"
+check_num "no date or timestamp bound is an infinity sentinel" \
+	"$(awk -v ld="leaf=$L_D" -v lt="leaf=$L_TS" '$1=="CHUNK" && ($3==ld || $3==lt) {
+		for(i=4;i<=NF;i++){
+			if(index($i,"min=")==1) v=substr($i,5);
+			if(index($i,"max=")==1) w=substr($i,5);
+		}
+		if(v=="2147483647"||v=="-2147483648"||w=="2147483647"||w=="-2147483648") bad++;
+		if(v=="9223372036854775807"||w=="9223372036854775807") bad++;
+		if(v=="-9223372036854775808"||w=="-9223372036854775808") bad++;
+	} END{print bad+0}' "$S")" "0"
+
+# ---- (e) the float rules ---------------------------------------------------
+
+psql_run "CREATE TABLE nan_h (f8a float8, f8b float8, z8 float8, z9 float8);"
+psql_run "INSERT INTO nan_h VALUES
+            (1.0,  'NaN',  -1.0, 0.0),
+            ('NaN','NaN',  -0.0, 1.0),
+            (-2.0, 'NaN',  -3.0, 2.0),
+            (NULL, NULL,   NULL, NULL);"
+psql_run "CREATE TABLE nan_c (LIKE nan_h) USING pgcolumnar;"
+psql_run "INSERT INTO nan_c SELECT * FROM nan_h;"
+NANQ="$PGC_WORKDIR/nan.parquet"
+psql_run "SELECT pgcolumnar.export_parquet('nan_c', '$NANQ');"
+NS="$PGC_WORKDIR/nanstats.txt"
+if python3 "$STATS_PY" "$NANQ" > "$NS" 2>&1; then
+	nf() {  # nf LEAF KEY  (over the NaN file)
+		awk -v lf="leaf=$1" -v k="$2=" '$1=="CHUNK" && $3==lf {
+			for(i=4;i<=NF;i++) if(index($i,k)==1)
+				{print substr($i,length(k)+1); exit}}' "$NS"
+	}
+	nleafof() {
+		awk -v p="path=$1" '$1=="CHUNK" && $0 ~ ("(^| )" p "( |$)"){
+			for(i=2;i<=NF;i++) if(index($i,"leaf=")==1)
+				{print substr($i,6); exit}}' "$NS"
+	}
+	N_A="$(nleafof f8a)"; N_B="$(nleafof f8b)"
+	N_Z8="$(nleafof z8)"; N_Z9="$(nleafof z9)"
+
+	check_num "a float column holding a NaN still carries both bounds" \
+		"$(nf "$N_A" has_min)" "1"
+	check_float "min(f8a) is the smallest non-NaN value" "$(nf "$N_A" min)" "-2.0"
+	check_float "max(f8a) is the largest non-NaN value" "$(nf "$N_A" max)" "1.0"
+	check_num "an all-NaN column carries no minimum" "$(nf "$N_B" has_min)" "0"
+	check_num "an all-NaN column carries no maximum" "$(nf "$N_B" has_max)" "0"
+	check_num "nan_count is written for every float chunk" \
+		"$(awk '$1=="CHUNK"{for(i=2;i<=NF;i++){
+			if(index($i,"ptname=")==1) p=substr($i,8);
+			if(index($i,"nan_count=")==1) n=substr($i,11);
+		} if((p=="FLOAT"||p=="DOUBLE") && n=="-") bad++} END{print bad+0}' "$NS")" "0"
+	check_num "nan_count counts the NaNs" "$(nf "$N_B" nan_count)" "3"
+	check_num "no float bound is a NaN bit pattern" \
+		"$(awk '$1=="CHUNK"{mn="";mx="";
+			for(i=2;i<=NF;i++){
+				if(index($i,"min=")==1 && index($i,"minhex=")!=1 && index($i,"minlen=")!=1)
+					mn=substr($i,5);
+				if(index($i,"max=")==1 && index($i,"maxhex=")!=1 && index($i,"maxlen=")!=1)
+					mx=substr($i,5);
+			}
+			if(mn=="nan"||mx=="nan"||mn=="-nan"||mx=="-nan") bad++
+		} END{print bad+0}' "$NS")" "0"
+	# parquet.thrift, TYPE_ORDER: a computed max of zero is written +0.0 and a
+	# computed min of zero is written -0.0, whichever zero was measured.
+	check "a zero maximum is written as +0.0" \
+		"$(nf "$N_Z8" maxhex)" "0000000000000000"
+	check "a zero minimum is written as -0.0" \
+		"$(nf "$N_Z9" minhex)" "0000000000000080"
+else
+	echo "FAIL  the footer parser could not read the NaN fixture:"
+	sed 's/^/      /' "$NS"
+	PGC_FAIL=1; PGC_CHECKS=$((PGC_CHECKS + 1))
+fi
+
+# ---- (f) column_orders, without which the bounds have no defined meaning ----
+
+check_num "the footer carries one ColumnOrder per leaf column" \
+	"$(fileval column_orders)" "10"
+check "every ColumnOrder is TYPE_ORDER" "$(fileval order_ids)" "1"
+
+# ---- (g) the types this change does not claim ------------------------------
+
+check_num "the BYTE_ARRAY column carries no bounds" \
+	"$(countchunks "$L_T" has_min 1)" "0"
+check_num "the BOOLEAN column carries no bounds" \
+	"$(countchunks "$L_B" has_min 1)" "0"
+
+# ---- (h) the payoff: the FDW skips on a file we exported -------------------
+
+psql_run "CREATE SERVER es_srv FOREIGN DATA WRAPPER pgcolumnar_parquet;"
+psql_run "CREATE FOREIGN TABLE es_ft ($COLS) SERVER es_srv OPTIONS (path '$PARQ');"
+
+explain_val() {  # explain_val LABEL WHERE
+	q "EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+	   SELECT count(*) FROM es_ft $2" \
+		| grep "$1:" | grep -oE '[0-9]+' | head -1
+}
+skipped_for() { explain_val "Row Groups Skipped" "$1"; }
+
+check_num "premise: the FDW reports $NGROUPS row groups" \
+	"$(explain_val "Row Groups" "WHERE id < 10")" "$NGROUPS"
+check_num "an unrestricted scan skips nothing" "$(skipped_for "")" "0"
+check_num "a predicate confined to one group skips the other three" \
+	"$(skipped_for "WHERE id BETWEEN 70000 AND 71000")" "3"
+check_num "a bigint predicate skips" \
+	"$(skipped_for "WHERE i8 < 1000000000::bigint")" "3"
+check_num "a float predicate skips" "$(skipped_for "WHERE f4 < 1.0::real")" "3"
+check_num "a date predicate skips" \
+	"$(skipped_for "WHERE d < DATE '2000-01-05'")" "3"
+check_num "a timestamp predicate skips" \
+	"$(skipped_for "WHERE ts < TIMESTAMP '2000-01-01 00:30:00'")" "3"
+# Documented refusals, reachable from our own exported files for the first time.
+check_num "a float >= predicate still skips nothing (NaN is not in the bounds)" \
+	"$(skipped_for "WHERE f4 >= 1.0::real")" "0"
+check_num "a cross-type constant still skips nothing" \
+	"$(skipped_for "WHERE i8 > 5::int")" "0"
+
+# Soundness. A skipped group emits nothing, and the executor's recheck cannot
+# recover a row that never arrived, so every predicate above must return exactly
+# what the oracle returns.
+for pred in \
+	"id BETWEEN 70000 AND 71000" \
+	"id < 5000" \
+	"i2 = 777" \
+	"i8 < 1000000000::bigint" \
+	"f4 < 1.0::real" \
+	"f4 >= 1.0::real" \
+	"d < DATE '2000-01-05'" \
+	"d > DATE '2060-01-01'" \
+	"ts < TIMESTAMP '2000-01-01 00:30:00'" \
+	"nul < 1000100" \
+	"alln IS NULL"
+do
+	check "the FDW result equals the oracle for [$pred]" \
+		"$(pgc_set_hash "SELECT id,i2,i8,f4,d,ts,nul,alln,t,b FROM es_ft WHERE $pred")" \
+		"$(pgc_set_hash "SELECT id,i2,i8,f4,d,ts,nul,alln,t,b FROM oracle WHERE $pred")"
+done
+
+# ---- the other direction: the instrument can report a bound that IS there ---
+#
+# Every absence above is evidence only if this parser is capable of reporting a
+# presence. pyarrow writes statistics; if it is here, the same parser must find
+# them. Gated in an if rather than a pgc_skip: this arm is a control on the
+# instrument, not the coverage the suite exists for.
+if python3 -c 'import pyarrow.parquet' 2>/dev/null; then
+	PYQ="$PGC_WORKDIR/pyarrow.parquet"
+	python3 - "$PYQ" <<'PY'
+import sys, pyarrow as pa, pyarrow.parquet as pq
+pq.write_table(pa.table({"id": pa.array(range(200000), pa.int64())}),
+               sys.argv[1], row_group_size=50000)
+PY
+	check_num "control: the parser finds pyarrow's bounds" \
+		"$(python3 "$STATS_PY" "$PYQ" | grep -c 'has_min=1')" "4"
+else
+	echo "note: pyarrow absent, so the parser's can-report-presence control did not run"
+fi
+
+pgc_summary

--- a/test/parquet_export_stats.sh
+++ b/test/parquet_export_stats.sh
@@ -477,6 +477,41 @@ check_num "a quoted literal takes a smallint column's type and skips" \
 check_num "the same digits unquoted are an integer, and skip nothing (int2)" \
 	"$(skipped_for "WHERE i2 < 500")" "0"
 
+# ADORNED is not the same as quoted. A literal that names its own type is that
+# type, not `unknown`, so it does not take the column's and the exact-type
+# condition applies to it like any other constant. The three arms differ only in
+# how one date is written. The third is the form docs/limitations.md briefly
+# promised would skip, and the same page's conditions list said the opposite
+# twenty lines above; this is which of the two is true.
+check_num "an adorned literal of the column's own type skips" \
+	"$(skipped_for "WHERE d < DATE '2000-01-05'")" "3"
+check_num "the same date unadorned is unknown, takes the column's type and skips" \
+	"$(skipped_for "WHERE d < '2000-01-05'")" "3"
+check_num "the same date adorned as a timestamp does not skip" \
+	"$(skipped_for "WHERE d < TIMESTAMP '2000-01-05 00:00:00'")" "0"
+# That last arm is a documented-behaviour guard rather than evidence, and the
+# distinction is worth stating rather than leaving for a reader to discover.
+# Neither of this suite's two mutations reddens it: with the reader's
+# exact-constant-type refusal deleted, the timestamp datum read as a date lands
+# outside this fixture's range in the direction that prunes nothing, so the arm
+# still reports 0 for a second reason. What IS falsifiable is the typing the
+# sentence rests on, and the planner will say it: an adorned literal keeps its
+# own type beside a bare Var, while the unadorned form resolves to the column's.
+check_num "an adorned literal keeps its own type, not the column's" \
+	"$(filter_has "WHERE d < TIMESTAMP '2000-01-05 00:00:00'" '::timestamp')" "1"
+check_num "control: the unadorned form resolves to the column's type instead" \
+	"$(filter_has "WHERE d < '2000-01-05'" '::date')" "1"
+
+# Width decides which integer type a digit string is, so an `integer` column
+# refuses the wide form exactly as a `bigint` column refuses the narrow one.
+# Both arms return no rows, which is what makes the pair a measurement of the
+# refusal rather than of the data: on identical output one prunes every group
+# and the other prunes none.
+check_num "control: a digit string that fits an integer prunes every group" \
+	"$(skipped_for "WHERE id < -1")" "$NGROUPS"
+check_num "digits too wide for an integer are a bigint, so an int4 column refuses" \
+	"$(skipped_for "WHERE id < -5000000000")" "0"
+
 # Soundness. A skipped group emits nothing, and the executor's recheck cannot
 # recover a row that never arrived, so every predicate above must return exactly
 # what the oracle returns.
@@ -496,6 +531,10 @@ for pred in \
 	"f4 < '0.4'" \
 	"i2 < '500'" \
 	"i2 < 500" \
+	"d < '2000-01-05'" \
+	"d < TIMESTAMP '2000-01-05 00:00:00'" \
+	"id < -1" \
+	"id < -5000000000" \
 	"alln IS NULL"
 do
 	check "the FDW result equals the oracle for [$pred]" \

--- a/test/parquet_export_stats.sh
+++ b/test/parquet_export_stats.sh
@@ -383,6 +383,11 @@ check "every ColumnOrder is TYPE_ORDER" "$(fileval order_ids)" "1"
 
 # ---- (g) the types this change does not claim ------------------------------
 
+check_num "no chunk carries the deprecated minimum (field 2)" \
+	"$(countchunks "$L_ID $L_I2 $L_I8 $L_F4 $L_D $L_TS $L_NUL $L_ALLN $L_T $L_B" has_dep_min 1)" "0"
+check_num "no chunk carries the deprecated maximum (field 1)" \
+	"$(countchunks "$L_ID $L_I2 $L_I8 $L_F4 $L_D $L_TS $L_NUL $L_ALLN $L_T $L_B" has_dep_max 1)" "0"
+
 check_num "the BYTE_ARRAY column carries no bounds" \
 	"$(countchunks "$L_T" has_min 1)" "0"
 check_num "the BOOLEAN column carries no bounds" \
@@ -413,10 +418,24 @@ check_num "a date predicate skips" \
 check_num "a timestamp predicate skips" \
 	"$(skipped_for "WHERE ts < TIMESTAMP '2000-01-01 00:30:00'")" "3"
 # Documented refusals, reachable from our own exported files for the first time.
-check_num "a float >= predicate still skips nothing (NaN is not in the bounds)" \
-	"$(skipped_for "WHERE f4 >= 1.0::real")" "0"
-check_num "a cross-type constant still skips nothing" \
-	"$(skipped_for "WHERE i8 > 5::int")" "0"
+#
+# Each runs beside a predicate that differs in ONE respect and does skip. Without
+# that pair the checks are worthless: every group's max(i8) exceeds 5 and every
+# group's max(f4) exceeds 1.0, so `i8 > 5` and `f4 >= 1.0` are unprunable on this
+# data whether the refusal exists or not, and a check that reads 0 either way is
+# not evidence of a refusal.
+check_num "control: the same column skips when the constant matches its type" \
+	"$(skipped_for "WHERE i8 < 5::bigint")" "$NGROUPS"
+check_num "a cross-type constant skips nothing, on the identical predicate" \
+	"$(skipped_for "WHERE i8 < 5::int")" "0"
+check_num "control: a float < predicate below every bound skips" \
+	"$(skipped_for "WHERE f4 < 0.4::real")" "$NGROUPS"
+# The reader refuses > and >= on a float column outright, because Parquet
+# excludes NaN from the bounds while PostgreSQL sorts NaN above every value. The
+# refusal does not depend on this column holding a NaN, and f4 holds none; the
+# NaN rules themselves are pinned on the nan_c fixture below.
+check_num "a float >= predicate above every bound still skips nothing" \
+	"$(skipped_for "WHERE f4 >= 200000.0::real")" "0"
 
 # Soundness. A skipped group emits nothing, and the executor's recheck cannot
 # recover a row that never arrived, so every predicate above must return exactly
@@ -454,6 +473,8 @@ pq.write_table(pa.table({"id": pa.array(range(200000), pa.int64())}),
 PY
 	check_num "control: the parser finds pyarrow's bounds" \
 		"$(python3 "$STATS_PY" "$PYQ" | grep -c 'has_min=1')" "4"
+	check_num "control: the parser reports the deprecated fields where they exist" \
+		"$(python3 "$STATS_PY" "$PYQ" | grep -c 'has_dep_min=1')" "4"
 else
 	echo "note: pyarrow absent, so the parser's can-report-presence control did not run"
 fi

--- a/test/parquet_stats.py
+++ b/test/parquet_stats.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""Print a Parquet file's footer statistics, using no Parquet library.
+
+This reads the bytes we wrote rather than asking a third-party reader whether it
+is willing to surface them. Two reasons, both learned from #850:
+
+  * A reader may decline to expose statistics for reasons of its own. Arrow
+    discards min_value/max_value when FileMetaData.column_orders is absent, so a
+    file carrying correct statistics and no column_orders reads as a file with
+    no statistics at all. Only the bytes distinguish those two states.
+  * A suite whose instrument is an optional import reports SKIP when the import
+    is missing, and a skip is not coverage.
+
+Output is one line per record, space-separated key=value, for grep and awk:
+
+  FILE created_by=<s> row_groups=<n> leaves=<n> column_orders=<n> order_ids=<csv>
+  CHUNK rg=<i> leaf=<j> path=<a.b> ptype=<n> num_values=<n> has_min=<0|1>
+        has_max=<0|1> minlen=<n> maxlen=<n> min=<v> max=<v> minhex=<h> maxhex=<h>
+        null_count=<n|-> nan_count=<n|-> has_dep_min=<0|1> has_dep_max=<0|1>
+
+A value that is absent prints as `-`, never as an empty field: an empty capture
+must fail check_num rather than silently compare equal to another empty one.
+
+Any parse error exits non-zero with a message on stderr, so a truncated read can
+never present as "no statistics found".
+
+Usage:  parquet_stats.py FILE
+Written fresh for pgColumnar.
+"""
+import struct
+import sys
+
+# parquet.thrift Type
+PTYPE_NAME = {0: "BOOLEAN", 1: "INT32", 2: "INT64", 3: "INT96",
+              4: "FLOAT", 5: "DOUBLE", 6: "BYTE_ARRAY", 7: "FLBA"}
+
+
+class R:
+    """A cursor over `raw` with Thrift-compact primitives.
+
+    The same shape as test/craft_parquet_counts.py's reader; kept separate
+    because that one is a file-mutating tool and this one must not import
+    pyarrow.
+    """
+
+    def __init__(self, raw, pos):
+        self.raw, self.pos = raw, pos
+
+    def u8(self):
+        if self.pos >= len(self.raw):
+            die("ran off the end of the footer at %d" % self.pos)
+        b = self.raw[self.pos]
+        self.pos += 1
+        return b
+
+    def varint(self):
+        sh = out = 0
+        while True:
+            b = self.u8()
+            out |= (b & 0x7F) << sh
+            if not b & 0x80:
+                return out
+            sh += 7
+
+    def zigzag(self):
+        u = self.varint()
+        return (u >> 1) ^ -(u & 1)
+
+    def binary(self):
+        n = self.varint()
+        s = self.raw[self.pos:self.pos + n]
+        if len(s) != n:
+            die("binary field of %d bytes runs past the footer" % n)
+        self.pos += n
+        return s
+
+    def list_hdr(self):
+        b = self.u8()
+        sz, et = (b >> 4) & 0x0F, b & 0x0F
+        if sz == 0x0F:
+            sz = self.varint()
+        return sz, et
+
+    def field(self, last):
+        """Read a field header. Returns (type, fid, new_last); type 0 = STOP."""
+        b = self.u8()
+        if b == 0:
+            return 0, 0, last
+        t = b & 0x0F
+        d = b >> 4
+        fid = last + d if d else self.zigzag()
+        return t, fid, fid
+
+    def skip(self, t):
+        if t in (1, 2):                     # BOOL_TRUE / BOOL_FALSE: no payload
+            return
+        if t == 3:                          # BYTE
+            self.pos += 1
+        elif t in (4, 5, 6):                # I16 / I32 / I64
+            self.zigzag()
+        elif t == 7:                        # DOUBLE
+            self.pos += 8
+        elif t == 8:                        # BINARY
+            self.binary()
+        elif t in (9, 10):                  # LIST / SET
+            n, et = self.list_hdr()
+            for _ in range(n):
+                self.skip(et)
+        elif t == 11:                       # MAP
+            n = self.varint()
+            if n:
+                kt = self.u8()
+                for _ in range(n):
+                    self.skip(kt >> 4)
+                    self.skip(kt & 0x0F)
+        elif t == 12:                       # STRUCT
+            self.skip_struct()
+        else:
+            die("unexpected thrift type %d at %d" % (t, self.pos))
+
+    def skip_struct(self):
+        last = 0
+        while True:
+            t, _fid, last = self.field(last)
+            if t == 0:
+                return
+            self.skip(t)
+
+
+def die(msg):
+    sys.stderr.write("parquet_stats: %s\n" % msg)
+    raise SystemExit(2)
+
+
+def decode_plain(blob, ptype):
+    """A statistics value is PLAIN-encoded, and for BYTE_ARRAY carries no length
+    prefix. Only the fixed-width ordered types are decoded to a number; anything
+    else prints as hex, which is all the caller needs to assert absence."""
+    try:
+        if ptype == 1 and len(blob) == 4:
+            return str(struct.unpack("<i", blob)[0])
+        if ptype == 2 and len(blob) == 8:
+            return str(struct.unpack("<q", blob)[0])
+        if ptype == 4 and len(blob) == 4:
+            return repr(struct.unpack("<f", blob)[0])
+        if ptype == 5 and len(blob) == 8:
+            return repr(struct.unpack("<d", blob)[0])
+    except struct.error:
+        return "UNDECODABLE"
+    return "-"
+
+
+def parse_statistics(r):
+    st = {"has_min": 0, "has_max": 0, "min": None, "max": None,
+          "null_count": None, "nan_count": None,
+          "has_dep_min": 0, "has_dep_max": 0}
+    last = 0
+    while True:
+        t, fid, last = r.field(last)
+        if t == 0:
+            return st
+        if fid == 1 and t == 8:
+            r.binary()
+            st["has_dep_max"] = 1
+        elif fid == 2 and t == 8:
+            r.binary()
+            st["has_dep_min"] = 1
+        elif fid == 3 and t in (4, 5, 6):
+            st["null_count"] = r.zigzag()
+        elif fid == 5 and t == 8:
+            st["max"] = r.binary()
+            st["has_max"] = 1
+        elif fid == 6 and t == 8:
+            st["min"] = r.binary()
+            st["has_min"] = 1
+        elif fid == 9 and t in (4, 5, 6):
+            st["nan_count"] = r.zigzag()
+        else:
+            r.skip(t)
+
+
+def parse_column_meta(r):
+    """ColumnMetaData: 1 type, 3 path_in_schema, 5 num_values, 12 statistics."""
+    cm = {"ptype": None, "path": None, "num_values": None, "stats": None}
+    last = 0
+    while True:
+        t, fid, last = r.field(last)
+        if t == 0:
+            return cm
+        if fid == 1 and t in (4, 5, 6):
+            cm["ptype"] = r.zigzag()
+        elif fid == 3 and t == 9:
+            n, et = r.list_hdr()
+            parts = []
+            for _ in range(n):
+                if et == 8:
+                    parts.append(r.binary().decode("utf-8", "replace"))
+                else:
+                    r.skip(et)
+            cm["path"] = ".".join(parts)
+        elif fid == 5 and t in (4, 5, 6):
+            cm["num_values"] = r.zigzag()
+        elif fid == 12 and t == 12:
+            cm["stats"] = parse_statistics(r)
+        else:
+            r.skip(t)
+
+
+def parse_column_chunk(r):
+    """ColumnChunk: 3 meta_data."""
+    meta = None
+    last = 0
+    while True:
+        t, fid, last = r.field(last)
+        if t == 0:
+            return meta
+        if fid == 3 and t == 12:
+            meta = parse_column_meta(r)
+        else:
+            r.skip(t)
+
+
+def parse_row_group(r):
+    """RowGroup: 1 columns, 3 num_rows."""
+    cols, num_rows = [], None
+    last = 0
+    while True:
+        t, fid, last = r.field(last)
+        if t == 0:
+            return cols, num_rows
+        if fid == 1 and t == 9:
+            n, et = r.list_hdr()
+            if et != 12:
+                die("RowGroup.columns is not a list of structs")
+            for _ in range(n):
+                cols.append(parse_column_chunk(r))
+        elif fid == 3 and t in (4, 5, 6):
+            num_rows = r.zigzag()
+        else:
+            r.skip(t)
+
+
+def parse_column_orders(r):
+    """list<ColumnOrder>; each is a union struct whose set field id names the
+    order (1 = TYPE_ORDER). The ids are what the caller asserts on."""
+    ids = []
+    n, et = r.list_hdr()
+    if et != 12:
+        die("column_orders is not a list of structs")
+    for _ in range(n):
+        last = 0
+        seen = 0
+        while True:
+            t, fid, last = r.field(last)
+            if t == 0:
+                break
+            seen = fid
+            r.skip(t)
+        ids.append(seen)
+    return ids
+
+
+def main():
+    if len(sys.argv) != 2:
+        die("usage: parquet_stats.py FILE")
+    with open(sys.argv[1], "rb") as fh:
+        raw = fh.read()
+    if len(raw) < 12 or raw[:4] != b"PAR1" or raw[-4:] != b"PAR1":
+        die("not a Parquet file (magic missing)")
+    flen = struct.unpack("<I", raw[-8:-4])[0]
+    start = len(raw) - 8 - flen
+    if start < 4:
+        die("footer length %d does not fit the file" % flen)
+
+    r = R(raw, start)
+    created_by, rgs, order_ids = "-", [], None
+    last = 0
+    while True:
+        t, fid, last = r.field(last)
+        if t == 0:
+            break
+        if fid == 4 and t == 9:
+            n, et = r.list_hdr()
+            if et != 12:
+                die("row_groups is not a list of structs")
+            for _ in range(n):
+                rgs.append(parse_row_group(r))
+        elif fid == 6 and t == 8:
+            created_by = r.binary().decode("utf-8", "replace")
+        elif fid == 7 and t == 9:
+            order_ids = parse_column_orders(r)
+        else:
+            r.skip(t)
+
+    if not rgs:
+        die("footer carries no row groups")
+
+    nleaves = len(rgs[0][0])
+    print("FILE created_by=%s row_groups=%d leaves=%d column_orders=%d order_ids=%s"
+          % (created_by, len(rgs), nleaves,
+             0 if order_ids is None else len(order_ids),
+             "-" if not order_ids else ",".join(str(i) for i in sorted(set(order_ids)))))
+
+    for rg, (cols, _nrows) in enumerate(rgs):
+        for leaf, cm in enumerate(cols):
+            if cm is None:
+                die("row group %d column %d has no meta_data" % (rg, leaf))
+            st = cm["stats"] or {"has_min": 0, "has_max": 0, "min": None,
+                                 "max": None, "null_count": None,
+                                 "nan_count": None, "has_dep_min": 0,
+                                 "has_dep_max": 0}
+            pt = cm["ptype"]
+            mn, mx = st["min"], st["max"]
+            print("CHUNK rg=%d leaf=%d path=%s ptype=%s ptname=%s num_values=%s "
+                  "has_min=%d has_max=%d minlen=%s maxlen=%s min=%s max=%s "
+                  "minhex=%s maxhex=%s null_count=%s nan_count=%s "
+                  "has_dep_min=%d has_dep_max=%d"
+                  % (rg, leaf, cm["path"] if cm["path"] else "-",
+                     "-" if pt is None else pt,
+                     PTYPE_NAME.get(pt, "?"),
+                     "-" if cm["num_values"] is None else cm["num_values"],
+                     st["has_min"], st["has_max"],
+                     "-" if mn is None else len(mn),
+                     "-" if mx is None else len(mx),
+                     "-" if mn is None else decode_plain(mn, pt),
+                     "-" if mx is None else decode_plain(mx, pt),
+                     "-" if mn is None else mn.hex(),
+                     "-" if mx is None else mx.hex(),
+                     "-" if st["null_count"] is None else st["null_count"],
+                     "-" if st["nan_count"] is None else st["nan_count"],
+                     st["has_dep_min"], st["has_dep_max"]))
+
+
+if __name__ == "__main__":
+    main()

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -223,6 +223,7 @@ SUITES=(
 	parallel_vector_agg
 	parquet_count_bounds
 	parquet_export
+	parquet_export_stats
 	parquet_import
 	parquet_level_width
 	parquet_nested


### PR DESCRIPTION
Closes #850.

## What was wrong

`pgcolumnar.export_parquet` wrote no per-row-group statistics. `write_column_chunk()` emitted ColumnMetaData fields 1 through 7 and 9, and never field 12. So a file we wrote carried no minimum or maximum for the reader to test a predicate against, and every documented condition for row-group skipping could hold while `Row Groups Skipped` stayed 0.

The reporter met every condition in `docs/limitations.md` and was right to file it. The read side was never at fault, and the docs never told them: the only statements that our exporter wrote no statistics lived in a test comment and a design note.

## The separator

On the reporter's own repro, PostgreSQL 17.10, 1,000,000 rows:

| probe | before | after |
| --- | --- | --- |
| column chunks carrying statistics, our exported file | 0 of 32 | **32 of 32** |
| `Row Groups Skipped`, FDW over our file, `id < 5000` | 0 of 16 | **15 of 16**, 1 decoded |
| pyarrow `is_stats_set` on our file | False | **True** |
| native chunk-group skip, same data (control) | 6 of 7 removed | 6 of 7 removed |
| FDW over a **pyarrow** file, same data (control) | 15 of 16 | 15 of 16 |

The two controls are what place the fault on the write side: the reader skipped a third-party file correctly the whole time.

## What the exporter writes now

Per column chunk: `null_count` always, including where it is zero, because `parquet.thrift` says a reader must not read an absent count as zero; `min_value` and `max_value` for the columns stored as INT32, INT64, FLOAT or DOUBLE, which is exactly the set the reader can skip on; and `nan_count` for the float columns. A `text`, `bytea`, `uuid`, `boolean` or byte-array `numeric` column gets the null count and no bounds: UTF8 sorts by unsigned bytes, which is not any PostgreSQL collation, and a bound in the wrong order is worse than no bound.

The footer also gains `column_orders`, one `TYPE_ORDER` per leaf column. That is not decoration. `parquet.thrift` states that without it the meaning of `min_value` and `max_value` is undefined, and Arrow acts on that by discarding both. Statistics without `column_orders` would have left the file exactly as unskippable under pyarrow as before.

Three float rules from the specification, each pinned by a test: a NaN never becomes a bound, an all-NaN column gets no bounds at all, and a computed zero is written `-0.0` as a minimum and `+0.0` as a maximum. Values with no Parquet representation (infinite date or timestamp) are folded to null before the accumulator sees them, so they count as nulls and cannot reach a bound.

Bounds accumulate in physical space inside `write_leaf_value`, from the same expression that writes the data page. Deriving them a second time is how a bound comes to disagree with its column by an epoch. They are snapshotted into the row group at flush, before `pqleaf_reset` clears them, because the footer is written after every group has been flushed.

## Tests

`test/parquet_export_stats.sh`, **162 checks**, and `test/parquet_stats.py`, a footer reader that imports no Parquet library. That instrument choice is deliberate: a suite whose instrument is an optional import reports SKIP when the import is missing, and a skip is not coverage. `column_orders` is also invisible through pyarrow's statistics API, so a third-party reader cannot tell us whether we wrote it.

Twelve premises pass on the unfixed tree, so none of the reds were ambiguous: the parser reaches ColumnMetaData (num_values sums to the table), the file under test is one we wrote, the oracle holds every exported row, and the oracle's buckets are the file's row groups. The instrument's ability to report a bound that IS present, and to report a deprecated field that IS present, are both controlled against a pyarrow file.

Measured on `0e4884c1` with the two test files copied in byte-identical — `sha256` printed for both against this head — after asserting the tree carries no occurrence of `write_statistics`, `column_orders` or `PqStats`:

```
total checks: 162
RED before the fix: 104      green on the unfixed tree: 58      104 + 58 = 162
green after: 162 of 162
```

## Removal proof

Eight mutations of the writer, each turning a named check red, each a distinct `.so` fingerprint. **Every count below was re-measured at this head, `50f5d7c`, against the suite as it now stands at 162 checks.** Baseline and restore are the same binary, `5949989c4981`, at 162 of 162 both times, and the eight mutants carry eight further distinct fingerprints, so no verdict is a stale-binary reading. The "loses rows?" column is not a judgement: it is whether any `the FDW result equals the oracle` check went red on that arm.

| mutation | reds | loses rows? |
| --- | --- | --- |
| delete the Statistics emission | 102 | no |
| write `min_value` but not `max_value` | 47 | no |
| let a null into the accumulator as zero | 17 | no |
| let NaN reach the bounds | 3 | no |
| delete `column_orders` | 2 | no |
| swap `min_value` and `max_value` | 60 | **no**, see below |
| stop resetting bounds per row group | 30 | no |
| take the date bound from the PostgreSQL epoch | 12 | **yes** |

**A count in this table is only ever true of one suite revision, so the whole table is re-run whenever the suite grows.** It has grown three times, and every row above was re-run at `50f5d7c` rather than carried:

| mutation | 132 | 137 | 151 | 162 |
| --- | --- | --- | --- | --- |
| delete the Statistics emission | 93 | 95 | 99 | **102** |
| write `min_value` but not `max_value` | 38 | 40 | 44 | **47** |
| let a null into the accumulator as zero | 15 | 15 | 15 | **17** |
| let NaN reach the bounds | 3 | 3 | 3 | 3 |
| delete `column_orders` | 2 | 2 | 2 | 2 |
| swap `min_value` and `max_value` | 52 | 54 | 57 | **60** |
| stop resetting bounds per row group | 26 | 26 | 28 | **30** |
| take the date bound from the PostgreSQL epoch | 10 | 10 | 10 | **12** |

The columns are suite sizes, not heads, because that is what a count belongs to. Each was **run** rather than derived, one clean tree per revision:

```
bd7bf8c (c272629^)  132 checks, 132 PASS
c272629             137
a3ca5793            137
71f8243             151
50f5d7c             162
```

Every move in the table is the number of new checks that mutation reaches, and the two rows that never move are the two whose blast radius is a single named property rather than the bounds themselves.

**This table took three corrections, and the last two are the same mistake.** First the `93` / `38` / `52` column was published under a heading of `137`, where `95` / `40` / `54` belong: the instance was fixed, then the class was fixed by re-running everything, and then the history column was rebuilt from the pre-fix text rather than from the corrected values. `95` and `54` were re-measured independently by the reviewer at `a3ca5793` — 42 PASS / 95 FAIL and 83 PASS / 54 FAIL, both summing to 137, with 0 oracle arms red under the swap.

Then the corrected column was labelled `135`, which is a number that appears nowhere in this branch's history. It was **derived** — 137 minus the two control arms the review names — rather than measured, in the same edit that argued a count must name the revision it counted. Measured, `c272629` moved the suite `132 → 137`, which is five checks: it adds six `check` call sites and removes two, and the arms the review names are two of them. Counting arms is not counting checks, which is the whole reason the columns are labelled by a number that came out of a run.

**Only the epoch mutation loses rows,** measured on all eight rather than inferred from two: the epoch arm reds exactly one FDW-result check, `d > DATE '2060-01-01'`, and the other seven red none. The swap does not, and that is worth stating rather than glossing: it inverts the interval, and the reader already refuses to skip an inverted one, which `docs/limitations.md` documents. All twenty FDW-result-equals-oracle checks pass under the swap. The epoch shift instead leaves a well-ordered interval that is simply wrong, so no guard can see it, and the single check standing between it and silent row loss is a predicate placed past the end of the data, `d > DATE '2060-01-01'`.

Four further mutations show the refusal checks and the plan-shape checks can fail, all re-measured at `50f5d7c`. In the **reader**: removing the exact-constant-type test reds **5** arms — the cross-type arm, the three that require an unquoted literal to skip nothing, and *digits too wide for an integer are a bigint, so an int4 column refuses* — each reading a positive skip count where 0 is required; removing the float `>` / `>=` refusal reds exactly **1**, *a float `>=` predicate above every bound still skips nothing*, at `got [4] want [0]`. In the **fixture**: swapping the `numeric`/`bigint` plan-shape patterns reds those **2** and nothing else, and swapping the `date`/`timestamp` pair reds those **2** and nothing else, so no grep is satisfied by whatever plan comes along.

**One check is not falsified by any of them, and it says so in its own comment.** *the same date adorned as a timestamp does not skip* reads 0 under both the reader and writer mutations: with the exact-type refusal deleted, the timestamp datum read as a date lands outside this fixture's range in the direction that prunes nothing, so the arm reports 0 for a second reason. It is kept as a documented-behaviour guard rather than dropped, and the evidence for the sentence it guards is carried beside it by the two plan-shape checks, which the planner answers and a pattern swap reddens.

## Regression

**CI 12 of 12 at `50f5d7c`** (`headSha` checked rather than assumed): nine build legs including PG 19 beta from source, shellcheck, and the suites matrix on PG 17 and PG 18, where `parquet_export_stats` is confirmed to run rather than merely be registered — `228 ran, 9 skipped` on PG 17 and `231 ran, 6 skipped` on PG 18, with `parquet_export_stats=PASS` in both listings. That matrix covers every Parquet read and write path at this head, including `parquet_export`, which reads our files back with both pyarrow and DuckDB. `src/` last changed at `bd7bf8ce`; every head after it changes only documentation and tests. `docs_style` is part of that matrix, and it caught the first draft of the rewritten paragraph: three sentences over the 25-word plain-language limit, which is why the rule is now a list.

## Docs

`docs/limitations.md` gains a `### Row-group skipping` heading, which four documents already cited as though it existed, and now tells a reader what an exported file carries and that a file written by 1.0-alpha2 or earlier carries nothing until it is exported again. It also states the constant-typing rule, in three labelled cases rather than one block of prose, because **how the literal is written decides its type, and therefore whether the exact-type condition is met at all**:

- **quoted, with no type named** — the literal is `unknown` and takes the column's type, so all nine skippable types skip, and a temporal literal is usually written this way, which is why it skips as written;
- **a named type, quoted or cast** — the literal is that type, not `unknown`, so the exact-type condition applies to it: `date_col < DATE '2026-01-01'` skips and `timestamp_col < DATE '2026-01-01'` does not;
- **unquoted** — a digit string is an `integer` while the value fits in one and a `bigint` when it does not, matching whichever width the column is and never the other, while a decimal-point literal is a `numeric` that makes PostgreSQL cast the column instead.

Every cell was measured, with the planner's own constant printed and every row count compared with a heap oracle, and sixteen checks pin it. Two revisions of this branch got the rule wrong before it was right, both caught in review, and both are worth naming because the shape of the paragraph is what allowed them. The first said `smallint` and `real` "always need a cast" — false, `smallint_col < '500'` skips. The second said "any quoted temporal literal skips as written", which the same page contradicted twenty lines above: `DATE '2026-01-01'` is a quoted temporal literal and against a `timestamp` column it does not skip. A general rule and its two exceptions were sharing a sentence; they are now three cases, and each is pinned. The stale claims in `test/native_parquet_pushdown.sh` and `design/PHASE_G_PUSHDOWN_HANDOFF.md` are corrected.

## Release

Targeted at 1.0-alpha3 on the owner's explicit decision. This changes what the writer emits, which the release plan classes as a feature, and an alpha may add features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vWhU5eNt6dGDU8iZPrrWP




