### PR TITLE
docs: drop_cleanup.sh says which call site its arms actually hold

### DIFF
--- a/test/drop_cleanup.sh
+++ b/test/drop_cleanup.sh
@@ -20,6 +20,27 @@
 # rows are "mostly gone" would pass on a leak of one row per drop, which is
 # exactly the size of this one.
 #
+# WHICH CALL SITE THESE ARMS HOLD, for whoever is picking a gate list after
+# touching the object-access hook. Remove the DROP hook's call to
+# pgcolumnar_delete_storage_tree() -- src/columnar_tableam.c, in the
+# OAT_DROP arm of pgcolumnar_object_access(), :2615 as of 815dd0a -- and five
+# of these eight arms redden, measured on pg18a:
+#
+#   a plain table leaves nothing behind
+#   dropping it takes the projection's metadata too
+#   two projections, one dropped by hand, leave nothing
+#   ten create-and-drop cycles leave nothing
+#   no storage row refers to a missing relation
+#
+# The same mutation reddens four of test/alter_am_cleanup.sh's forty-five. So
+# this file is the one to run for that call site, which is not obvious from
+# either file's subject: alter_am_cleanup is named for SET ACCESS METHOD.
+#
+# Note the shape of the five. The first four are relative -- each compares a
+# snapshot against the previous one, so they cascade once the first leaks. Only
+# "no storage row refers to a missing relation" is absolute (got [25] want [0]),
+# and it is the one that would still redden if the baselines degraded together.
+#
 # Usage:  test/drop_cleanup.sh [PG_CONFIG]
 # Written fresh for pgColumnar.
 


### PR DESCRIPTION
Comment-only, in one file. No arm changes — `test/drop_cleanup.sh`'s executable content is byte-identical with comment lines stripped, and the check count stays at 8.

## Why

Reviewing #878 turned up a coverage fact neither session knew. Remove the object-access DROP hook's call to `pgcolumnar_delete_storage_tree()` and **five of `drop_cleanup.sh`'s eight arms redden**, against **four of `alter_am_cleanup.sh`'s forty-five**:

```
drop_cleanup      3 passed + 5 failed = 8
  a plain table leaves nothing behind
  dropping it takes the projection's metadata too
  two projections, one dropped by hand, leave nothing
  ten create-and-drop cycles leave nothing
  no storage row refers to a missing relation

alter_am_cleanup  41 passed + 4 failed = 45
```

So `drop_cleanup` is the file to run after touching that hook. That is not obvious from either file's subject line: `alter_am_cleanup` is named for `SET ACCESS METHOD`, which is where a reader would look, and it is the weaker holder of the two.

## What the header now says

The five arms by name, rather than a claim that the suite "covers the hook well". A count with named arms can be re-derived by anyone; a claim of adequacy rots quietly.

It also records the **shape** of the five, which is the part that matters if someone later trusts them. Four are relative — each compares a snapshot against the previous one — so they cascade once the first leaks. Only `no storage row refers to a missing relation` is absolute (`got [25] want [0]`), and it is the one that would still redden if the baselines degraded together.

## Measured

Main `815dd0a`, pg18a. The mutation was asserted applied by source md5 (`69623fba996a` → `0e6947b1922b`) and by reading the mutated line back out of the file, then re-derived on this branch with a differently-worded mutation (`→ 28ef0a782ae1`) to check the claim holds on the tree that publishes it — same 5 of 8 and 4 of 45. The md5 is evidence that an edit applied, not a constant a reader reproduces; the two differ because the injected comment text differs.

Unmutated on pg18a **and** pg19a: `drop_cleanup` 8/8, `alter_am_cleanup` 45/45, `docs_style` 9/9. `bash -n` and `shellcheck -S error` clean.

## Not an issue, on purpose

jdatcmd and I agreed this should not be filed on the tracker. A coverage fact has no action attached, so a ticket for it consumes triage attention forever and pays out once. The suite header is read by the person who needs it at the moment they need it, which a ticket is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtQbQUiMSpGWembJV1jxob