### PR TITLE
docs: the drop_cleanup arms do not cascade, and they re-baseline

### DIFF
--- a/test/drop_cleanup.sh
+++ b/test/drop_cleanup.sh
@@ -36,10 +36,22 @@
 # this file is the one to run for that call site, which is not obvious from
 # either file's subject: alter_am_cleanup is named for SET ACCESS METHOD.
 #
-# Note the shape of the five. The first four are relative -- each compares a
-# snapshot against the previous one, so they cascade once the first leaks. Only
-# "no storage row refers to a missing relation" is absolute (got [25] want [0]),
-# and it is the one that would still redden if the baselines degraded together.
+# Note the shape of the five. Four of them re-capture `base` immediately before
+# their own work. Grep `base="$(snapshot)"` to find them, once per arm: a line
+# number cited here shifts every time this comment is edited, which is how the
+# first draft of this paragraph came to cite four lines that had moved.
+#
+# So each of the four measures the increment its own step adds rather than
+# inheriting an earlier failure. They do NOT cascade: a leak that has already
+# happened is absorbed into the next baseline. That is why all four redden
+# under the mutation instead of one reddening and three following -- every drop
+# leaks and each arm detects its own. The `want` values show it: each is the
+# previous `got`.
+#
+# The fifth, "no storage row refers to a missing relation", is absolute
+# (got [25] want [0]). It covers the case the other four cannot see by
+# construction: a STANDING leak that no single step increases gives every
+# relative arm a zero increment, so all four pass and only this one fires.
 #
 # Usage:  test/drop_cleanup.sh [PG_CONFIG]
 # Written fresh for pgColumnar.


### PR DESCRIPTION
Comment-only, one file, executable content identical to `main`. Fixes a sentence **I** shipped in #879.

## The wrong sentence

> The first four are relative — each compares a snapshot against the previous one, so they cascade once the first leaks.

They do not cascade. `base` is re-captured immediately before each of the four arms, so a leak that has already happened is absorbed into the next baseline rather than inherited. Each arm measures the increment *its own* step adds.

That is why all four redden under the DROP-hook mutation: four independent detections, because every drop leaks — not one detection and three echoes. **The evidence was already in the numbers I published in #879** and I did not read them: every `want` is the previous `got`.

```
a plain table leaves nothing behind      got [1/0/1/2/4/2/1]        want [0/0/0/0/0/0/0]
dropping it takes the projection's ...   got [3/2/3/8/16/8/1]       want [1/0/1/2/4/2/1]
two projections, one dropped by hand     got [5/4/5/15/30/15/1]     want [3/2/3/8/16/8/1]
ten create-and-drop cycles ...           got [25/24/25/55/110/55/1] want [5/4/5/15/30/15/1]
```

If they cascaded, arm 2 would have compared against the clean baseline. It compared against arm 1's leaked state, because it re-took it.

## What did not change, and why that matters

jdatcmd raised this, and half of his objection did not survive. He also read the closing sentence as inverted:

> it is the one that would still redden if the baselines degraded together

That sentence is correct. A standing leak that no single step increases gives every relative arm a zero increment, so all four pass and only the absolute arm — whose expected value is the literal `0` — fires. He withdrew that half himself after testing the scenario it names. I checked both halves against the file rather than taking either.

## No line numbers, and that is deliberate

The suggested edit cited `:44`, `:53`, `:67`, `:80` — main's offsets **before** #879 added twenty-one comment lines. On main today those are a Usage comment, `snapshot()`, an `INSERT`, and a different check.

My own first draft of this fix then cited `:65`, `:74`, `:88`, `:101` — correct before the edit and wrong after it, because the replacement paragraph is longer than what it replaces and shifted the very lines it pointed at. Twice in one file, in opposite directions, within an hour.

The comment now tells the reader to grep `base="$(snapshot)"`, and says why it does not give a line number.

## Green

`drop_cleanup` 8/8 and `docs_style` 9/9 on pg18a and pg19a. `bash -n` and `shellcheck -S error` clean. Executable content byte-identical to `main` with comment lines stripped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtQbQUiMSpGWembJV1jxob