### PR TITLE
chore: add META.json so the distribution can be published on PGXN

### DIFF
--- a/META.json
+++ b/META.json
@@ -1,0 +1,52 @@
+{
+   "name": "pgcolumnar",
+   "abstract": "Analytic column storage for PostgreSQL, built as a native table access method",
+   "description": "pgColumnar is a columnar storage table access method for PostgreSQL, written as a clean-room, MIT-licensed implementation. It reads and writes its own native format, PGCN v1, and supports chunk-group skipping from zone maps and bloom filters, vectorized aggregation, projections, retention, online compaction and reclustering, parallel bulk ingest and export, Apache Arrow and Parquet import and export, Apache Iceberg, and object storage.",
+   "version": "1.0.0alpha3",
+   "maintainer": [
+      "Joshua D. Drake <jd@commandprompt.com>"
+   ],
+   "license": "mit",
+   "release_status": "unstable",
+   "provides": {
+      "pgcolumnar": {
+         "file": "pgcolumnar--1.0-alpha3.sql",
+         "docfile": "docs/index.md",
+         "version": "1.0.0alpha3",
+         "abstract": "Analytic column storage for PostgreSQL, built as a native table access method"
+      }
+   },
+   "prereqs": {
+      "runtime": {
+         "requires": {
+            "PostgreSQL": "15.0.0"
+         }
+      }
+   },
+   "resources": {
+      "homepage": "https://commandprompt.github.io/pgcolumnar/",
+      "bugtracker": {
+         "web": "https://github.com/commandprompt/pgcolumnar/issues"
+      },
+      "repository": {
+         "url": "https://github.com/commandprompt/pgcolumnar.git",
+         "web": "https://github.com/commandprompt/pgcolumnar",
+         "type": "git"
+      }
+   },
+   "generated_by": "Command Prompt, Inc.",
+   "tags": [
+      "columnar",
+      "analytics",
+      "table access method",
+      "olap",
+      "compression",
+      "parquet",
+      "arrow",
+      "iceberg"
+   ],
+   "meta-spec": {
+      "version": "1.0.0",
+      "url": "https://pgxn.org/meta/spec.txt"
+   }
+}


### PR DESCRIPTION
Required for a PGXN release. v1.0.0 meta-spec form, all seven required fields present
(`name`, `abstract`, `version`, `maintainer`, `license`, `provides`, `meta-spec`).

**The version deliberately differs from the control file, and it has to.** The spec requires a
semantic version — *"three positive integers separated by full stop characters"*, with a special
version *"appending an arbitrary ASCII string immediately following the patch version"*. Its own
examples are `2.0.0alpha3`, `2.0.0beta1`.

| | value |
| --- | --- |
| `pgcolumnar.control` `default_version` | `1.0-alpha3` — two parts, not a semantic version |
| `META.json` `version` and `provides.pgcolumnar.version` | `1.0.0alpha3` — valid |

So PGXN will list `1.0.0alpha3` while `CREATE EXTENSION` reports `1.0-alpha3`. The alternative is
renaming the extension's version scheme, which touches `VERSION`, the control file and every
upgrade-script filename — not a thing to do inside a release. The commit message records this so
nobody later "fixes" one to match the other.

`release_status` is `unstable`, which the spec defines as *"an 'alpha' release that is under
active development, but has been released for early feedback"*.

Every field format was read from https://pgxn.org/spec/ rather than recalled — the required-field
list, the version grammar and its pre-release examples, the permitted `license` strings, and the
`release_status` values. `provides.file` (`pgcolumnar--1.0-alpha3.sql`) and `docfile`
(`docs/index.md`) both exist in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017V7PhZ1TzoVVNsACFXTbdT