### PR TITLE
Fix projection declarations after column rename

### DIFF
--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -3541,6 +3541,118 @@ PgColumnarRecordProjectionDeclaration(Oid relid, const char *name,
 }
 
 /*
+ * rename_projection_declaration_array
+ *		Replace oldName in one text[] declaration field.
+ */
+static Datum
+rename_projection_declaration_array(Datum value, const char *oldName,
+									const char *newName, bool *changed)
+{
+	ArrayType  *arr = DatumGetArrayTypeP(value);
+	Datum	   *elems;
+	bool	   *nulls;
+	int			nelems;
+	int			i;
+
+	deconstruct_array(arr, TEXTOID, -1, false, TYPALIGN_INT,
+					  &elems, &nulls, &nelems);
+
+	for (i = 0; i < nelems; i++)
+	{
+		char	   *name;
+
+		if (nulls[i])
+			continue;
+
+		name = TextDatumGetCString(elems[i]);
+		if (strcmp(name, oldName) == 0)
+		{
+			elems[i] = CStringGetTextDatum(newName);
+			*changed = true;
+		}
+	}
+
+	return PointerGetDatum(construct_array(elems, nelems, TEXTOID,
+										   -1, false, TYPALIGN_INT));
+}
+
+/*
+ * PgColumnarRenameProjectionDeclarationColumn
+ *		Carry ALTER TABLE ... RENAME COLUMN through dumpable declarations.
+ *
+ * The materialized projection stores attnums, so it follows a rename without
+ * any catalog change. The declaration deliberately stores names because
+ * pg_dump restores a table with newly assigned attnums. Leaving its old name
+ * behind therefore breaks rebuild_projections() after restore even though the
+ * live projection continued to work before the backup.
+ */
+void
+PgColumnarRenameProjectionDeclarationColumn(Oid relid, const char *oldName,
+											 const char *newName)
+{
+	Relation	rel;
+	TupleDesc	tupdesc;
+	ScanKeyData key[1];
+	SysScanDesc scan;
+	HeapTuple	tuple;
+
+	rel = open_columnar_table("projection_declaration", RowExclusiveLock);
+	tupdesc = RelationGetDescr(rel);
+	ScanKeyInit(&key[0], Anum_projection_declaration_rel, BTEqualStrategyNumber,
+				F_OIDEQ, ObjectIdGetDatum(relid));
+	scan = systable_beginscan(rel, InvalidOid, false, NULL, 1, key);
+
+	while (HeapTupleIsValid(tuple = systable_getnext(scan)))
+	{
+		Datum		values[Natts_projection_declaration];
+		bool		nulls[Natts_projection_declaration];
+		bool		replace[Natts_projection_declaration];
+		bool		changed = false;
+		bool		isnull;
+		Datum		d;
+		HeapTuple	newTuple;
+
+		memset(values, 0, sizeof(values));
+		memset(nulls, false, sizeof(nulls));
+		memset(replace, false, sizeof(replace));
+
+		d = heap_getattr(tuple, Anum_projection_declaration_columns,
+						 tupdesc, &isnull);
+		if (!isnull)
+		{
+			values[Anum_projection_declaration_columns - 1] =
+				rename_projection_declaration_array(d, oldName, newName,
+													&changed);
+			replace[Anum_projection_declaration_columns - 1] = changed;
+		}
+
+		d = heap_getattr(tuple, Anum_projection_declaration_sort_key,
+						 tupdesc, &isnull);
+		if (!isnull)
+		{
+			bool		sortChanged = false;
+
+			values[Anum_projection_declaration_sort_key - 1] =
+				rename_projection_declaration_array(d, oldName, newName,
+													&sortChanged);
+			replace[Anum_projection_declaration_sort_key - 1] = sortChanged;
+			changed = changed || sortChanged;
+		}
+
+		if (!changed)
+			continue;
+
+		newTuple = heap_modify_tuple(tuple, tupdesc, values, nulls, replace);
+		CatalogTupleUpdate(rel, &newTuple->t_self, newTuple);
+		heap_freetuple(newTuple);
+	}
+
+	systable_endscan(scan);
+	table_close(rel, RowExclusiveLock);
+	CommandCounterIncrement();
+}
+
+/*
  * PgColumnarDeleteProjectionDeclaration
  *		Forget the declaration for one projection. Called when it is dropped, and
  *		before recording a replacement.

--- a/src/columnar_metadata.c
+++ b/src/columnar_metadata.c
@@ -3572,8 +3572,17 @@ rename_projection_declaration_array(Datum value, const char *oldName,
 		}
 	}
 
-	return PointerGetDatum(construct_array(elems, nelems, TEXTOID,
-										   -1, false, TYPALIGN_INT));
+	/*
+	 * resolve_columns() rejects NULL elements before add_projection() records a
+	 * declaration. Preserve the bitmap anyway, so this helper remains safe if a
+	 * catalog row created outside that path contains one.
+	 */
+	return PointerGetDatum(construct_md_array(elems, nulls,
+											 ARR_NDIM(arr),
+											 ARR_DIMS(arr),
+											 ARR_LBOUND(arr),
+											 TEXTOID, -1, false,
+											 TYPALIGN_INT));
 }
 
 /*
@@ -3639,6 +3648,11 @@ PgColumnarRenameProjectionDeclarationColumn(Oid relid, const char *oldName,
 			changed = changed || sortChanged;
 		}
 
+		/*
+		 * This is an unindexed catalog seqscan updated in place. If it encounters
+		 * its updated tuple again, the old name is absent and this idempotent arm
+		 * prevents a second CatalogTupleUpdate.
+		 */
 		if (!changed)
 			continue;
 

--- a/src/columnar_metadata.h
+++ b/src/columnar_metadata.h
@@ -90,6 +90,10 @@ extern void PgColumnarRecordProjectionDeclaration(Oid relid, const char *name,
 												ArrayType *columns,
 												ArrayType *sortKey);
 
+extern void PgColumnarRenameProjectionDeclarationColumn(Oid relid,
+														 const char *oldName,
+														 const char *newName);
+
 extern void PgColumnarDeleteProjectionDeclaration(Oid relid, const char *name);
 
 extern void PgColumnarDeleteProjectionDeclarationsForRel(Oid relid);

--- a/src/columnar_tableam.c
+++ b/src/columnar_tableam.c
@@ -2572,6 +2572,9 @@ pgcolumnar_process_utility(PlannedStmt *pstmt, const char *queryString,
 					 */
 					PgColumnarRenameDeclaredSortByColumn(kid, rs->subname,
 														 rs->newname);
+					PgColumnarRenameProjectionDeclarationColumn(kid,
+																rs->subname,
+																rs->newname);
 				}
 				list_free(kin);
 			}

--- a/test/projection_rename_restore.sh
+++ b/test/projection_rename_restore.sh
@@ -34,15 +34,30 @@ check "the live projection still reads after the rename" \
 	"$(q "SELECT count(*) FROM pgcolumnar.read_projection('prr','by_sort')")" \
 	"2000"
 
+# A rename on a non-columnar partitioned parent reaches a separate columnar
+# relation with its own declaration. This protects the inheritor walk: using
+# the named parent's oid in place of each descendant leaves this arm stale.
+psql_run "CREATE TABLE prr_parent (id int, sort_key int)
+	PARTITION BY RANGE (id);"
+psql_run "CREATE TABLE prr_child PARTITION OF prr_parent
+	FOR VALUES FROM (0) TO (100) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.add_projection(
+	'prr_child', 'child_sort', ARRAY['id','sort_key'], ARRAY['sort_key']);"
+psql_run "INSERT INTO prr_parent SELECT g, g % 10 FROM generate_series(1,99) g;"
+psql_run "ALTER TABLE prr_parent RENAME COLUMN sort_key TO renamed_key;"
+check "the child projection still reads after a parent rename" \
+	"$(q "SELECT count(*) FROM pgcolumnar.read_projection(
+		'prr_child','child_sort')")" "99"
+
 run pg_dump -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" \
-	-f "$DUMP"
-check "pg_dump succeeds" "$?" "0"
+	-f "$DUMP"; dump_rc=$?
+check "pg_dump succeeds" "$dump_rc" "0"
 
 on postgres "DROP DATABASE IF EXISTS $RESTORE_DB;" >/dev/null 2>&1
 on postgres "CREATE DATABASE $RESTORE_DB;" >/dev/null
 run psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$RESTORE_DB" \
-	-v ON_ERROR_STOP=1 -q -f "$DUMP" >/dev/null 2>&1
-check "restore succeeds" "$?" "0"
+	-v ON_ERROR_STOP=1 -q -f "$DUMP" >/dev/null 2>&1; restore_rc=$?
+check "restore succeeds" "$restore_rc" "0"
 
 # Red before the fix: this errors because the declaration still names sort_key.
 rebuilt="$(on "$RESTORE_DB" "SELECT pgcolumnar.rebuild_projections('prr');" 2>&1)"
@@ -51,6 +66,13 @@ check "the rebuilt projection contains every restored row" \
 	"$(on "$RESTORE_DB" \
 		"SELECT count(*) FROM pgcolumnar.read_projection('prr','by_sort');")" \
 	"2000"
+check "the descendant declaration follows the parent rename" \
+	"$(on "$RESTORE_DB" \
+		"SELECT pgcolumnar.rebuild_projections('prr_child');")" "1"
+check "the rebuilt child projection contains every restored row" \
+	"$(on "$RESTORE_DB" \
+		"SELECT count(*) FROM pgcolumnar.read_projection(
+			'prr_child','child_sort');")" "99"
 
 on postgres "DROP DATABASE $RESTORE_DB;" >/dev/null
 pgc_summary

--- a/test/projection_rename_restore.sh
+++ b/test/projection_rename_restore.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# pgColumnar: a projection declaration must follow a column rename.
+#
+# The materialized projection records attnums and survives a rename, but the
+# declaration carried by pg_dump records names. The rename hook maintained the
+# table sort_by option and physical ordering mark, but not projection
+# declarations. A backup therefore restored the old column name and
+# rebuild_projections() failed instead of recreating the projection.
+#
+# This test stays at the public boundary: create, rename, pg_dump, restore,
+# rebuild, and read. It does not infer correctness from internal catalog rows.
+#
+# Usage: test/projection_rename_restore.sh [PG_CONFIG]
+# Written fresh for pgColumnar.
+
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+pgc_setup "${1:-/usr/local/pg17/bin/pg_config}"
+
+DUMP="$PGC_WORKDIR/projection-rename.sql"
+RESTORE_DB="${PGC_DB}_renamed"
+run() { env PATH="$PGC_BINDIR:$PATH" "$@"; }
+on() { run psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$1" -Atq -c "$2"; }
+
+psql_run "CREATE TABLE prr (id int, payload text, sort_key int) USING pgcolumnar;"
+psql_run "SELECT pgcolumnar.add_projection(
+	'prr', 'by_sort', ARRAY['id','sort_key'], ARRAY['sort_key']);"
+psql_run "INSERT INTO prr
+	SELECT g, 'row-' || g, (g * 7) % 100 FROM generate_series(1,2000) g;"
+psql_run "ALTER TABLE prr RENAME COLUMN sort_key TO renamed_key;"
+
+check "the live projection still reads after the rename" \
+	"$(q "SELECT count(*) FROM pgcolumnar.read_projection('prr','by_sort')")" \
+	"2000"
+
+run pg_dump -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" \
+	-f "$DUMP"
+check "pg_dump succeeds" "$?" "0"
+
+on postgres "DROP DATABASE IF EXISTS $RESTORE_DB;" >/dev/null 2>&1
+on postgres "CREATE DATABASE $RESTORE_DB;" >/dev/null
+run psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$RESTORE_DB" \
+	-v ON_ERROR_STOP=1 -q -f "$DUMP" >/dev/null 2>&1
+check "restore succeeds" "$?" "0"
+
+# Red before the fix: this errors because the declaration still names sort_key.
+rebuilt="$(on "$RESTORE_DB" "SELECT pgcolumnar.rebuild_projections('prr');" 2>&1)"
+check "the renamed projection rebuilds after restore" "$rebuilt" "1"
+check "the rebuilt projection contains every restored row" \
+	"$(on "$RESTORE_DB" \
+		"SELECT count(*) FROM pgcolumnar.read_projection('prr','by_sort');")" \
+	"2000"
+
+on postgres "DROP DATABASE $RESTORE_DB;" >/dev/null
+pgc_summary

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -241,6 +241,7 @@ SUITES=(
 	planner_choice_quality
 	preimage_rewrite
 	projection_privilege
+	projection_rename_restore
 	projection_update
 	projections
 	pushdown_report


### PR DESCRIPTION
## Problem

Projection storage records column attnums, so a live projection follows `ALTER TABLE ... RENAME COLUMN`. Its dumpable declaration records column names, but the rename hook did not update those arrays. After backup/restore, `pgcolumnar.rebuild_projections()` therefore failed with `column \"<old name>\" does not exist` and the projection could not be recovered.

## Fix

Carry each column rename through both `columns` and `sort_key` in every declaration for the relation, including inherited/partition descendants already traversed by the rename hook.

## Verification

- New public-boundary regression: create projection, rename column, `pg_dump`, restore, rebuild, and read all 2,000 rows.
- Relevant suites: `sorted_mark_rename`, `pg_dump_roundtrip`, `projections`.
- Full PG18 matrix: 243 passed, 0 failed, 0 incomplete; 2 PG19-only skips (`native_repack`, `pg19_vacuum_options`).

Made with [Cursor](https://cursor.com)