### PR TITLE
docs: open [Unreleased] and record the rename fix (#888)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,25 @@ installed, `1.0-alpha`, and `1.0-alpha2`), so a single
 notes in this file describe `default_version` as pinned at an earlier version, each
 true until the next version shipped.
 
+## [Unreleased]
+
+### Fixed
+
+- `ALTER TABLE ... RENAME COLUMN` now carries the new name into
+  `pgcolumnar.projection_declaration`, for the named relation and for every
+  inheritance descendant (#888).
+
+  The materialized projection stores attnums, so it already followed a rename
+  without any catalog change. The declaration deliberately stores NAMES, because
+  a restore assigns new attnums -- so leaving the old name behind broke
+  `pgcolumnar.rebuild_projections()` after a dump and restore, even though the
+  live projection had kept working right up to the backup. The failure was
+  therefore invisible until the moment it mattered.
+
+  The descendant half is held by an arm that was proved able to fail: changing
+  the walk to use the named relation instead of each descendant takes
+  `test/projection_rename_restore.sh` from 8 passed to 6 passed and 2 failed.
+
 ## [1.0-alpha3] - 2026-09-02
 
 ### Added


### PR DESCRIPTION
## Why this is a separate PR

#888 merged without a changelog entry. I flagged that before merging and merged anyway on the
owner's instruction, so this closes the gap rather than leaving it.

It was awkward rather than forgotten: #886 closed the changelog for 1.0-alpha3, so there was no
`[Unreleased]` section to add to and opening one implicitly says the next version has started.

## What the entry says, and why it says that

The title of #888 does not convey the defect. The materialized projection stores **attnums**, so
it followed a rename already, with no catalog change. The declaration deliberately stores
**names**, because a restore assigns new attnums. So the live projection kept working right up to
the backup, and the breakage only surfaced in `rebuild_projections()` after a restore. It was
invisible until the moment it mattered, which is the part a reader of the changelog needs.

The entry also records the number that makes the descendant arm worth having: mutating the walk to
use the named relation instead of each descendant takes `test/projection_rename_restore.sh` from
8 passed to **6 passed and 2 failed**. Measured on this tree, both arms built in the **same**
directory so the `.so` fingerprint reflects the source rather than the build path.

## Verification

`bash test/docs_style.sh` -- 9 checks, PASSED, including "every document citing VERSION quotes the
version VERSION holds" and "CHANGELOG.md carries no em or en dash".

## Note for #892

@OffgridwithJD -- #892 opens its own `## [Unreleased]` heading at the same insertion point, so it
will conflict with this once either lands. **The resolution is one `[Unreleased]` heading with
both entries under it, not two headings.** An orphaned duplicate heading is exactly how this file
has gone wrong before. #892 has to rebase onto main regardless, since #888 already landed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Unuuvh3fRR67SceiGpfeeK
