### PR TITLE
docs: record #891, and correct two claims in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,13 +36,19 @@ true until the next version shipped.
 - `ALTER TABLE ... DROP COLUMN` is now refused when a projection depends on the
   column, instead of leaving the table unreadable (#891).
 
-  Dropping a column that any projection stores produced
-  `ERROR: type with OID 0 does not exist` on the next `INSERT`, and the table
-  stayed in that state. The refusal raises `2BP01`
-  (`dependent_objects_still_exist`) and names the projection, so the remedy is
-  to drop the projection first. One loop covers sort keys too, because
-  `add_projection()` requires every sort-key column to appear in the stored
-  columns. `DROP COLUMN IF EXISTS` of a column that is not there is unaffected.
+  Dropping a column any projection stores left the table broken, in one of two
+  ways. Dropping the **sort-key** column produced
+  `ERROR: type with OID 0 does not exist` on the next `INSERT`. Dropping any
+  other stored column let writes continue while `pgcolumnar.read_projection`
+  raised `cache lookup failed for type 0` and `pgcolumnar.rebuild_projections()`
+  reported repairing nothing -- the quieter and worse half, because it tells an
+  operator there was nothing to do.
+
+  The refusal raises `2BP01` (`dependent_objects_still_exist`) and names the
+  projection, so the remedy is to drop the projection first. One loop covers
+  sort keys too, because `add_projection()` requires every sort-key column to
+  appear in the stored columns. `DROP COLUMN IF EXISTS` of a column that is not
+  there is unaffected.
 
 ## [1.0-alpha3] - 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ pre-release; the version marker is `1.0-alpha3`, recorded in `VERSION`. New tabl
 are written in the native on-disk format, PGCN v1. For the forward-looking plan see
 [design/ROADMAP.md](design/ROADMAP.md); for full history see the git log.
 
-The extension's `default_version` is `1.0-alpha3`, which is in development and not
-yet tagged; the latest published pre-release is `v1.0-alpha2`. Upgrade scripts from
+The extension's `default_version` is `1.0-alpha3`, which is tagged as
+`v1.0-alpha3` and is the latest published pre-release. Upgrade scripts from
 every previously shipped version ship with it (`1.0-dev`, which the v1.0-alpha tag
 installed, `1.0-alpha`, and `1.0-alpha2`), so a single
 `ALTER EXTENSION pgcolumnar UPDATE` reaches `1.0-alpha3` from any of them. Older
@@ -20,7 +20,7 @@ true until the next version shipped.
 
 - `ALTER TABLE ... RENAME COLUMN` now carries the new name into
   `pgcolumnar.projection_declaration`, for the named relation and for every
-  inheritance descendant (#888).
+  inheritance descendant, including a `PARTITION OF` child (#888).
 
   The materialized projection stores attnums, so it already followed a rename
   without any catalog change. The declaration deliberately stores NAMES, because
@@ -32,6 +32,17 @@ true until the next version shipped.
   The descendant half is held by an arm that was proved able to fail: changing
   the walk to use the named relation instead of each descendant takes
   `test/projection_rename_restore.sh` from 8 passed to 6 passed and 2 failed.
+
+- `ALTER TABLE ... DROP COLUMN` is now refused when a projection depends on the
+  column, instead of leaving the table unreadable (#891).
+
+  Dropping a column that any projection stores produced
+  `ERROR: type with OID 0 does not exist` on the next `INSERT`, and the table
+  stayed in that state. The refusal raises `2BP01`
+  (`dependent_objects_still_exist`) and names the projection, so the remedy is
+  to drop the projection first. One loop covers sort keys too, because
+  `add_projection()` requires every sort-key column to appear in the stored
+  columns. `DROP COLUMN IF EXISTS` of a column that is not there is unaffected.
 
 ## [1.0-alpha3] - 2026-09-02
 


### PR DESCRIPTION
Three changes to `CHANGELOG.md`, all closing gaps I opened or found.

## 1. #891 gets an entry

It merged without one, the same gap #888 had — except the excuse is gone. #893 opened
`[Unreleased]`, so there was a section to add to this time.

**One thing I got wrong in the draft and corrected against the merged code**, rather than shipping
the review summary of it. I first wrote "a column named in a projection's **sort key**". The guard
loops over `projection->columns` — every column a projection **stores** — and its own comment
explains why that also covers sort keys:

> add_projection() requires every sort-key column to appear in columns, so this one loop covers
> both stored-only columns and the sort keys whose dropped type would break the writer.

So the refusal is broader than "sort key" and the entry now says so. The SQLSTATE is read from
`ERRCODE_DEPENDENT_OBJECTS_STILL_EXIST` at `src/columnar_tableam.c:2582`, not from the PR
description.

## 2. The intro claimed alpha3 is untagged

It read:

> `default_version` is `1.0-alpha3`, which is in development and **not yet tagged**; the latest
> published pre-release is `v1.0-alpha2`.

`v1.0-alpha3` exists and is correct. I found this while filing #894, a release-integrity issue
that was itself wrong: `git fetch` does not update a tag ref that already exists locally, so
`git rev-parse` showed me a position the tag had been deliberately moved off days earlier. #894 is
closed with the full correction. This sentence was the one true thing in it, so it is fixed here
rather than lost with the issue.

## 3. #888's entry said "every inheritance descendant"

The arm proves a `PARTITION OF` child, and a reader with a partitioned table searches for that
word. Both are covered by `find_all_inheritors`; the entry now names both.
(@OffgridwithJD, #893 review.)

## Verification

`bash test/docs_style.sh` — 9 checks, PASSED, including "every document citing VERSION quotes the
version VERSION holds" and "CHANGELOG.md carries no em or en dash".

## Note for #892

@OffgridwithJD — this touches the same `### Fixed` list you are rebasing onto. It appends after
#888's entry and does not add a heading, so your entry should land third under the one
`[Unreleased]` / `### Fixed` pair. No new conflict shape beyond the one you have already resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Unuuvh3fRR67SceiGpfeeK
