### PR TITLE
perf: prune scattered IN lists by element (#752)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,8 +58,7 @@ true until the next version shipped.
 
   Per-element evaluation is capped at 128 non-NULL entries. Larger lists retain
   the bounded two-key hull because exact vector refinement otherwise costs
-  elements times rows. Set predicates are also never promoted ahead of scalar
-  predicates by the adaptive ordering heuristic.
+  elements times rows.
 - Hilbert clustering: `pgcolumnar.cluster_hilbert` and
   `pgcolumnar.recluster_hilbert` (#889).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,19 @@ true until the next version shipped.
   binary check driven against a live cluster, and devloop writing the stamp.
   `harness_selftest` goes from 261 checks to 288, both measured.
 
+- `IN (...)` and `= ANY(array)` now test each listed value against row-group
+  zone maps and bloom filters instead of reducing the list to its `[min,max]`
+  hull (#752).
 
+  A scattered list whose hull spans a table could previously read every row
+  group. The set is now one internal predicate whose element tests are a
+  disjunction, while the outer predicate list remains a conjunction. The
+  executor still rechecks exact membership, so pruning remains conservative.
+
+  Per-element evaluation is capped at 128 non-NULL entries. Larger lists retain
+  the bounded two-key hull because exact vector refinement otherwise costs
+  elements times rows. Set predicates are also never promoted ahead of scalar
+  predicates by the adaptive ordering heuristic.
 - Hilbert clustering: `pgcolumnar.cluster_hilbert` and
   `pgcolumnar.recluster_hilbert` (#889).
 

--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -185,6 +185,8 @@ static const CustomExecMethods pgcolumnar_exec_methods = {
  * planning
  * ------------------------------------------------------------------------- */
 
+#define PGCOLUMNAR_SAOP_ELEMENT_LIMIT 128
+
 /*
  * pgcolumnar_projected_columns
  *		Build the 0-based set of columns the plan actually references, from the
@@ -753,23 +755,15 @@ pgcolumnar_like_prefix_scankey(OpExpr *op, Var *var, Const *con,
 }
 
 /*
- * pgcolumnar_saop_range_scankey
+ * pgcolumnar_saop_scankey
  *		Turn `col = ANY(array)` -- the planner's form of `col IN (...)` -- into
- *		the [min, max] range it implies, so zone maps can skip groups whose
- *		range cannot intersect any listed value (#704).
+ *		one set-valued scan key (#704, #752).
  *
- * Range keys rather than per-element equality keys, because the skip
- * predicates conjoin: pgcolumnar_group_can_match requires a group to satisfy
- * EVERY predicate, and a list has no group satisfying `= a AND = b`. The range
- * is the disjunction's projection onto that AND-only structure, and it is
- * conservative by construction: the executor still rechecks exact membership
- * on every surviving row, so a group inside the range holding none of the
- * listed values is read and filtered, never skipped wrongly. The cost of that
- * shape is no bloom probe (equality-only, columnar_reader.c) and little
- * pruning from a list that spans the column's range. Because these keys are
- * WEAKER than their clause, they must never serve as an exact row filter:
- * the batch-fold eligibility gate in columnar_vector.c is what keeps them
- * out of the vectorized fold, and its comment names this function.
+ * One set-valued key rather than one equality key per element, because the
+ * outer skip-predicate array is a conjunction. The reader implements the
+ * disjunction inside this one predicate: a group survives when any element can
+ * lie in its zone map (and, when safe, can pass its bloom filter). The executor
+ * still rechecks exact membership on every surviving row.
  *
  * Only `useOr` equality: `= ALL (list)` is a conjunction already and is
  * satisfiable only for a single-valued list, and a negated operator admits
@@ -778,13 +772,9 @@ pgcolumnar_like_prefix_scankey(OpExpr *op, Var *var, Const *con,
  * true), so they are ignored for the range; a list with no non-NULL element
  * matches nothing and builds no keys rather than a degenerate range.
  *
- * The element ordering proc comes from the COLUMN type's btree opfamily, for
- * the element type pair -- the same family that supplied the equality
- * operator's strategy, so "min of the list" and "compares below the group's
- * max" agree on one ordering. A cross-type list (int column, bigint elements)
- * therefore orders its elements with the element type's own proc from that
- * family, and the reader resolves the (column, element) comparison the same
- * way it does for any cross-type range key (#477).
+ * The element ordering proc comes from the COLUMN type's btree opfamily. It
+ * identifies the single-distinct-value case and supplies the bounded [min,max]
+ * fallback for a set too large to evaluate element by element.
  *
  * Same collation rule as the OpExpr path, same reason (spec 9): the stored
  * min/max are ordered under the column's collation, so only a comparison
@@ -793,8 +783,8 @@ pgcolumnar_like_prefix_scankey(OpExpr *op, Var *var, Const *con,
  * equal to a listed element sorts equal to it, so it lies inside the range.
  */
 static int
-pgcolumnar_saop_range_scankey(ScalarArrayOpExpr *saop, Index scanrelid,
-							  TupleDesc tupdesc, ScanKey key)
+pgcolumnar_saop_scankey(ScalarArrayOpExpr *saop, Index scanrelid,
+						TupleDesc tupdesc, ScanKey key)
 {
 	Node	   *leftop;
 	Node	   *rightop;
@@ -812,6 +802,7 @@ pgcolumnar_saop_range_scankey(ScalarArrayOpExpr *saop, Index scanrelid,
 	bool	   *nulls;
 	int			nelems;
 	int			i;
+	int			nvalues = 0;
 	Datum		minVal = (Datum) 0;
 	Datum		maxVal = (Datum) 0;
 	bool		have = false;
@@ -873,6 +864,7 @@ pgcolumnar_saop_range_scankey(ScalarArrayOpExpr *saop, Index scanrelid,
 	{
 		if (nulls[i])
 			continue;
+		nvalues++;
 		if (!have)
 		{
 			minVal = maxVal = elems[i];
@@ -908,8 +900,30 @@ pgcolumnar_saop_range_scankey(ScalarArrayOpExpr *saop, Index scanrelid,
 		return 1;
 	}
 
+	/*
+	 * Keep the array as one predicate. The reader tests each non-NULL element
+	 * against a group's zone map and bloom filter, so a scattered set can prune
+	 * groups inside its [min,max] hull. One key replaces the old two range keys;
+	 * both callers provide two slots and no allocation contract changes.
+	 *
+	 * Bound the set form because exact vector refinement compares each surviving
+	 * row with its elements. Above this limit the old two-key hull is the safe,
+	 * bounded fallback. A future join runtime filter needs a compact set
+	 * representation rather than handing an unbounded build side to this path.
+	 */
+	if (nvalues <= PGCOLUMNAR_SAOP_ELEMENT_LIMIT)
+	{
+		MemSet(&key[0], 0, sizeof(ScanKeyData));
+		key[0].sk_flags = SK_SEARCHARRAY;
+		key[0].sk_attno = var->varattno;
+		key[0].sk_strategy = BTEqualStrategyNumber;
+		key[0].sk_subtype = elemtype;
+		key[0].sk_collation = saop->inputcollid;
+		key[0].sk_argument = con->constvalue;
+		return 1;
+	}
+
 	MemSet(&key[0], 0, sizeof(ScanKeyData));
-	key[0].sk_flags = 0;
 	key[0].sk_attno = var->varattno;
 	key[0].sk_strategy = BTGreaterEqualStrategyNumber;
 	key[0].sk_subtype = elemtype;
@@ -917,13 +931,11 @@ pgcolumnar_saop_range_scankey(ScalarArrayOpExpr *saop, Index scanrelid,
 	key[0].sk_argument = minVal;
 
 	MemSet(&key[1], 0, sizeof(ScanKeyData));
-	key[1].sk_flags = 0;
 	key[1].sk_attno = var->varattno;
 	key[1].sk_strategy = BTLessEqualStrategyNumber;
 	key[1].sk_subtype = elemtype;
 	key[1].sk_collation = saop->inputcollid;
 	key[1].sk_argument = maxVal;
-
 	return 2;
 }
 
@@ -956,8 +968,8 @@ pgcolumnar_clause_to_scankey(Node *clause, Index scanrelid, TupleDesc tupdesc,
 	 * refuses them (#715).
 	 */
 	if (IsA(clause, ScalarArrayOpExpr))
-		return pgcolumnar_saop_range_scankey((ScalarArrayOpExpr *) clause,
-											 scanrelid, tupdesc, key);
+		return pgcolumnar_saop_scankey((ScalarArrayOpExpr *) clause,
+									   scanrelid, tupdesc, key);
 
 	if (!IsA(clause, OpExpr))
 		return 0;

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -51,6 +51,9 @@ typedef struct SkipPredicate
 	Datum		compareValue;	/* the constant */
 	FmgrInfo	cmpFn;			/* column type's default btree comparison */
 	Oid			collation;
+	bool		searchArray;	/* compare against any value in arrayValues */
+	Datum	   *arrayValues;	/* non-NULL elements, in read context */
+	int			arrayValueCount;
 
 	/* bloom-filter probe for equality (I7, gap 25): set for a hashable equality
 	 * predicate on a safe collation, matching how the filter was built */
@@ -651,25 +654,17 @@ pgcolumnar_make_predicates(SkipPredicate *out, int nkeys, ScanKey keys,
 		/*
 		 * Only plain "column op const" comparison keys are usable.
 		 *
-		 * SK_SEARCHARRAY is in this list although nothing in this extension
-		 * currently sets it, and the reason is the point. A key carrying that
-		 * flag holds an ARRAY in sk_argument, not a scalar. Without this arm the
-		 * key falls through, compareValue is set to the array's Datum, and every
-		 * zone-map comparison below runs the column's scalar btree function
-		 * against a pointer to an array header. That is not a wrong answer that
-		 * a test would catch; it is a comparison of unrelated things whose
-		 * result is whatever the memory happens to say.
-		 *
-		 * It is guarded BEFORE anything can produce the shape rather than
-		 * beside it. #752 measures a per-element path for `= ANY` worth 13 to 16
-		 * chunk groups of 27, and the obvious way to build it is to stop
-		 * collapsing the array in pgcolumnar_saop_range_scankey and mark the key
-		 * SK_SEARCHARRAY. Whoever does that should have to add handling here
-		 * deliberately, not discover that this function accepted it silently.
+		 * SK_SEARCHARRAY is accepted only by the dedicated equality arm below.
+		 * Its sk_argument is an array, not a scalar; allowing it to fall through
+		 * would pass an array header to the column's scalar comparison function.
 		 */
 		if (key->sk_flags & (SK_ISNULL | SK_ROW_HEADER | SK_ROW_MEMBER |
 							 SK_ROW_END | SK_SEARCHNULL | SK_SEARCHNOTNULL |
-							 SK_ORDER_BY | SK_SEARCHARRAY))
+							 SK_ORDER_BY))
+			continue;
+		if ((key->sk_flags & SK_SEARCHARRAY) &&
+			(key->sk_flags != SK_SEARCHARRAY ||
+			 key->sk_strategy != BTEqualStrategyNumber))
 			continue;
 		if (key->sk_attno < 1 || key->sk_attno > natts)
 			continue;
@@ -768,6 +763,34 @@ pgcolumnar_make_predicates(SkipPredicate *out, int nkeys, ScanKey keys,
 		out[n].strategy = key->sk_strategy;
 		out[n].compareValue = key->sk_argument;
 		out[n].collation = att->attcollation;
+		out[n].searchArray = (key->sk_flags & SK_SEARCHARRAY) != 0;
+
+		if (out[n].searchArray)
+		{
+			MemoryContext old = MemoryContextSwitchTo(cx);
+			ArrayType  *arr = DatumGetArrayTypePCopy(key->sk_argument);
+			Datum	   *elems;
+			bool	   *nulls;
+			int			nelems;
+			int			j;
+			int			kept = 0;
+			int16		elmlen;
+			bool		elmbyval;
+			char		elmalign;
+
+			get_typlenbyvalalign(ARR_ELEMTYPE(arr), &elmlen, &elmbyval,
+								&elmalign);
+			deconstruct_array(arr, ARR_ELEMTYPE(arr), elmlen, elmbyval,
+							  elmalign, &elems, &nulls, &nelems);
+			for (j = 0; j < nelems; j++)
+				if (!nulls[j])
+					elems[kept++] = elems[j];
+			out[n].arrayValues = elems;
+			out[n].arrayValueCount = kept;
+			MemoryContextSwitchTo(old);
+			if (kept == 0)
+				continue;
+		}
 
 		/*
 		 * For an equality predicate on a hashable column with a safe collation,
@@ -1156,8 +1179,21 @@ native_is_qual_column(PgColumnarReadState *rs, int col)
 static bool
 native_value_satisfies(SkipPredicate *pred, Datum val)
 {
-	int32		c = DatumGetInt32(FunctionCall2Coll(&pred->cmpFn, pred->collation,
-													val, pred->compareValue));
+	int32		c;
+
+	if (pred->searchArray)
+	{
+		int			i;
+
+		for (i = 0; i < pred->arrayValueCount; i++)
+			if (DatumGetInt32(FunctionCall2Coll(&pred->cmpFn, pred->collation,
+												val, pred->arrayValues[i])) == 0)
+				return true;
+		return false;
+	}
+
+	c = DatumGetInt32(FunctionCall2Coll(&pred->cmpFn, pred->collation,
+										val, pred->compareValue));
 
 	switch (pred->strategy)
 	{
@@ -1336,6 +1372,22 @@ native_zone_excludes(SkipPredicate *pred, Form_pg_attribute att,
 	cur = (char *) z->maximum;
 	maxv = PgColumnarDecodeValue(att, &cur, z->maximum + z->maximumLen, cx);
 
+	if (pred->searchArray)
+	{
+		int			i;
+
+		for (i = 0; i < pred->arrayValueCount; i++)
+		{
+			c1 = DatumGetInt32(FunctionCall2Coll(&pred->cmpFn, pred->collation,
+												minv, pred->arrayValues[i]));
+			c2 = DatumGetInt32(FunctionCall2Coll(&pred->cmpFn, pred->collation,
+												maxv, pred->arrayValues[i]));
+			if (c1 <= 0 && c2 >= 0)
+				return false;
+		}
+		return true;
+	}
+
 	switch (pred->strategy)
 	{
 		case BTLessStrategyNumber:	/* col < const : skip if min >= const */
@@ -1427,11 +1479,9 @@ pgcolumnar_merge_delete_vectors(List *maskList, uint32 want,
  *		A transpose rather than a sort. It is O(1) per exclusion, it needs no
  *		statistics the reader does not have, and it converges in one step for the
  *		shape that matters: one selective predicate behind an unselective one.
- *		The paper's caveat -- order only when a highly selective predicate is
- *		present, or the ordering costs more than it saves -- falls out of the
- *		mechanism rather than needing a threshold: a predicate that never
- *		excludes never moves, so a query with no selective predicate keeps the
- *		order it started with and pays nothing.
+ *		Set predicates have non-uniform cost: N comparisons rather than one.
+ *		They are therefore never promoted ahead of a scalar predicate. Among
+ *		predicates of the same kind, exclusion count remains the useful signal.
  *
  *		This cannot change an answer. The predicates are a conjunction, and a
  *		conjunction is order-independent; the loop returns "cannot match" on the
@@ -1449,6 +1499,10 @@ pgcolumnar_predicate_excluded(PgColumnarReadState *rs, int oi)
 		return;
 
 	ahead = rs->predOrder[oi - 1];
+	/* A set costs N comparisons; never promote it ahead of a scalar predicate. */
+	if (rs->predicates[here].searchArray &&
+		!rs->predicates[ahead].searchArray)
+		return;
 	if (rs->predicates[ahead].excludes < rs->predicates[here].excludes)
 	{
 		rs->predOrder[oi - 1] = here;
@@ -1549,11 +1603,26 @@ pgcolumnar_native_group_can_match(PgColumnarReadState *rs, uint64 groupNumber)
 
 			if (b != NULL && b->filter != NULL)
 			{
-				uint32		h = DatumGetUInt32(
-					FunctionCall1Coll(&pred->hashFn, pred->hashCollation,
-									  pred->compareValue));
+				bool		mayMatch = false;
+				int			i;
+				int			nvalues = pred->searchArray ?
+					pred->arrayValueCount : 1;
 
-				if (!PgColumnarBloomProbe(b->filter, b->filterLen, h))
+				for (i = 0; i < nvalues; i++)
+				{
+					Datum		probe = pred->searchArray ?
+						pred->arrayValues[i] : pred->compareValue;
+					uint32		h = DatumGetUInt32(
+						FunctionCall1Coll(&pred->hashFn,
+										  pred->hashCollation, probe));
+
+					if (PgColumnarBloomProbe(b->filter, b->filterLen, h))
+					{
+						mayMatch = true;
+						break;
+					}
+				}
+				if (!mayMatch)
 				{
 					pgcolumnar_predicate_excluded(rs, oi);
 					return false;

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -785,11 +785,14 @@ pgcolumnar_make_predicates(SkipPredicate *out, int nkeys, ScanKey keys,
 			for (j = 0; j < nelems; j++)
 				if (!nulls[j])
 					elems[kept++] = elems[j];
+			/*
+			 * The only producer emits SEARCHARRAY after proving at least two
+			 * distinct non-NULL values; zero/one-value arrays take earlier paths.
+			 */
+			Assert(kept >= 2);
 			out[n].arrayValues = elems;
 			out[n].arrayValueCount = kept;
 			MemoryContextSwitchTo(old);
-			if (kept == 0)
-				continue;
 		}
 
 		/*

--- a/test/native_saop_pushdown.sh
+++ b/test/native_saop_pushdown.sh
@@ -7,12 +7,10 @@
 # and the scan read every row group, while every comparable predicate shape
 # (equality, range, anchored LIKE, parameterized scalar) already pruned (#704).
 #
-# The fix derives a conservative [min, max] range over the array's non-NULL
-# elements and emits two range keys. The executor still rechecks exact
-# membership on surviving rows, so pruning can only be conservative: a group
-# inside the range but holding none of the listed values is read and filtered,
-# never skipped wrongly. A NULL element cannot make `= ANY` true, so ignoring
-# NULLs for the range is exact.
+# The fix keeps up to 128 non-NULL elements as one set predicate. A group
+# survives when any element can lie in its zone map and bloom filter; the
+# executor still rechecks exact membership. Larger sets retain the bounded
+# [min,max] hull.
 #
 # The correctness hazards, each with an arm below: a negated SAOP must build no
 # keys (NOT IN admits everything outside the list); an empty or all-NULL array
@@ -40,7 +38,7 @@ q "SET pgcolumnar.stripe_row_limit=2000;
      FROM generate_series(1,40000) g;
    CREATE TABLE thr (lo int[]); INSERT INTO thr VALUES ('{39100}'),('{100,200}');" >/dev/null
 
-psql_c() { env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" -At -c "$1" 2>&1; }
+psql_c() { env PATH="$PGC_BINDIR:$PATH" psql -h 127.0.0.1 -p "$PGC_PORT" -U postgres -d "$PGC_DB" -At -v ON_ERROR_STOP=1 -c "$1" 2>&1; }
 
 # Chunk groups removed by a query, from EXPLAIN ANALYZE. Prints the count, or
 # NOSCAN when the plan did not use the columnar scan at all -- so a plan-shape
@@ -87,8 +85,14 @@ check "a contiguous IN-list agrees with its hull (19 removed)" \
 check "contiguous per-element pruning keeps the exact answer" \
 	"$(q 'SELECT count(*) FROM t WHERE ts IN (100, 101, 102);')" "3"
 
-# Bound the O(elements * rows) exact-refinement path. Above 128 non-NULL
-# elements the builder deliberately keeps the old two-key hull.
+# Pin both sides of the O(elements * rows) bound.
+limit_list="$(seq -s, 1 128)"
+limit_plan="$(psql_c "EXPLAIN (ANALYZE, TIMING off, SUMMARY off)
+	SELECT count(*) FROM t WHERE ts IN ($limit_list);")"
+check "exactly 128 elements still use one set filter" \
+	"$(sed -n 's/.*Columnar Pushed-Down Filters: \([0-9]*\).*/\1/p' <<<"$limit_plan" | head -1)" "1"
+
+# Above 128 non-NULL elements the builder deliberately keeps the old two-key hull.
 large_list="$(seq -s, 1 129)"
 large_plan="$(psql_c "EXPLAIN (ANALYZE, TIMING off, SUMMARY off)
 	SELECT count(*) FROM t WHERE ts IN ($large_list);")"
@@ -102,6 +106,18 @@ check "a NULL element is ignored for the range, not a bailout (19 removed)" \
 
 check "NULL-element count is exact" \
 	"$(q 'SELECT count(*) FROM t WHERE ts = ANY (ARRAY[39100, NULL]::int[]);')" "1"
+
+check "a multi-value integer set strips NULL and still prunes 17 groups" \
+	"$(groups_removed 'SELECT count(*) FROM t WHERE ts = ANY (ARRAY[100,20100,38100,NULL]::int[]);')" "17"
+check "the multi-value integer NULL set stays exact" \
+	"$(q 'SELECT count(*) FROM t WHERE ts = ANY (ARRAY[100,20100,38100,NULL]::int[]);')" "3"
+
+check "a by-reference text set strips NULL without crashing (17 removed)" \
+	"$(groups_removed "SELECT count(*) FROM t
+		WHERE txt = ANY (ARRAY['00000100','00020100','00038100',NULL]::text[]);")" "17"
+check "the by-reference text NULL set stays exact" \
+	"$(q "SELECT count(*) FROM t
+		WHERE txt = ANY (ARRAY['00000100','00020100','00038100',NULL]::text[]);")" "3"
 
 check "a cross-type element array (int col, bigint[] list) prunes (19 removed)" \
 	"$(groups_removed "SELECT count(*) FROM t WHERE ts = ANY ('{39100,39200}'::bigint[]);")" "19"
@@ -136,6 +152,13 @@ check "fixture premise: 25 is inside every group's range (range keys prune 0)" \
 
 check "fixture premise: equality on the overlap column bloom-prunes all 20" \
 	"$(groups_removed 'SELECT count(*) FROM t WHERE ov = 25;')" "20"
+
+# Every group's zone map is [10,88], so only the set's bloom loop can exclude
+# these three absent odd values.
+check "a multi-value set bloom-prunes all overlapping groups" \
+	"$(groups_removed "SELECT count(*) FROM t WHERE ov = ANY ('{25,27,29}'::int[]);")" "20"
+check "the bloom-only multi-value set returns the exact empty answer" \
+	"$(q "SELECT count(*) FROM t WHERE ov = ANY ('{25,27,29}'::int[]);")" "0"
 
 # `IN (25)` parses to plain `= 25` (the parser collapses a one-element list),
 # so it exercises the OpExpr path; the `= ANY('{25,25}')` arm below is the
@@ -242,36 +265,13 @@ check "a correlated PARAM_EXEC array is not mis-pruned (results stay correct)" \
 	"$(q 'SELECT sum(c) FROM thr, LATERAL (SELECT count(*) c FROM t WHERE t.ts = ANY (thr.lo)) s;')" \
 	"3"
 
-# --- an array scan key must be refused before one can be built ------------
+# --- array keys have one dedicated arm; all other special flags are refused --
 #
-# This is a source assertion, in the style of native_fetch_cache.sh, and the
-# reason is the same one that suite records: there is no behavioural test to
-# write, because nothing in the extension can currently produce the shape. The
-# builder above collapses every multi-element array into two range keys, so no
-# SK_SEARCHARRAY key ever reaches pgcolumnar_make_predicates.
-#
-# It is guarded anyway, because the defect it prevents is silent. Such a key
-# holds an ARRAY in sk_argument. Unrejected, it becomes a SkipPredicate whose
-# compareValue is the array's Datum, and the column's scalar btree comparison
-# then runs against a pointer to an array header. That is not a wrong answer a
-# suite could catch, it is a comparison of unrelated things.
-#
-# THE ASSERTION IS ABOUT THE EXPRESSION, NOT ABOUT THE FILE, and that distinction
-# is the whole check. An earlier draft grepped each flag name over the whole
-# file, which is a claim about the file: deleting SK_ISNULL from the guard while
-# naming it in a nearby comment left the suite printing
-# "PASS  and it still refuses SK_ISNULL" on a tree that no longer refused it.
-# Measured, not supposed. The convention this very guard introduces -- explain in
-# prose why a flag is rejected -- is what would blind a file-wide grep for the
-# next flag anyone documents.
-#
-# So the reject expression is extracted once and membership is asserted inside
-# it. Extraction is a premise, because an expression that failed to extract is
-# an empty string and every "is this flag in it" test would then compare one
-# blank with another and pass (#823).
+# A SEARCHARRAY key holds an array in sk_argument, so it must reach the dedicated
+# deconstruction arm rather than the scalar compareValue path.
 SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/src"
 
-check "premise: the predicate builder has exactly one sk_flags reject guard" \
+check "premise: plain-key special flags have one reject expression" \
 	"$(grep -c 'key->sk_flags & (SK_ISNULL' "$SRC/columnar_reader.c")" "1"
 
 # From the `if (key->sk_flags & (` line through the closing `))`, comments
@@ -290,6 +290,10 @@ for _f in SK_ISNULL SK_ROW_HEADER SK_ROW_MEMBER SK_ROW_END SK_SEARCHNULL \
 	check "the predicate builder's reject expression contains $_f" \
 		"$(case "$guard" in *"$_f"*) echo yes ;; *) echo "absent from <$guard>" ;; esac)" "yes"
 done
+
+check "SK_SEARCHARRAY reaches the dedicated array predicate arm" \
+	"$(grep -c 'out\[n\]\.searchArray = (key->sk_flags & SK_SEARCHARRAY)' \
+		"$SRC/columnar_reader.c")" "1"
 
 check "backend alive" "$(q 'SELECT 1;')" "1"
 

--- a/test/native_saop_pushdown.sh
+++ b/test/native_saop_pushdown.sh
@@ -62,16 +62,40 @@ groups_removed() {
 # groups were in fact removed (work done). The three lines are distinct
 # counters precisely so intent cannot impersonate work (#477/#479).
 saop_plan="$(psql_c 'EXPLAIN (ANALYZE, TIMING off, SUMMARY off) SELECT count(*) FROM t WHERE ts IN (39100, 39200);')"
-check "an IN-list pushes two filters (intent)" \
-	"$(sed -n 's/.*Columnar Pushed-Down Filters: \([0-9]*\).*/\1/p' <<<"$saop_plan" | head -1)" "2"
-check "both IN-list keys are usable skip predicates" \
-	"$(sed -n 's/.*Columnar Usable Skip Predicates: \([0-9]*\).*/\1/p' <<<"$saop_plan" | head -1)" "2"
+check "an IN-list pushes one set filter (intent)" \
+	"$(sed -n 's/.*Columnar Pushed-Down Filters: \([0-9]*\).*/\1/p' <<<"$saop_plan" | head -1)" "1"
+check "the IN-list set filter is a usable skip predicate" \
+	"$(sed -n 's/.*Columnar Usable Skip Predicates: \([0-9]*\).*/\1/p' <<<"$saop_plan" | head -1)" "1"
 check "an IN-list confined to the last group prunes (19 of 20 removed)" \
 	"$(sed -n 's/.*Chunk Groups Removed by Filter: \([0-9]*\).*/\1/p' <<<"$saop_plan" | head -1)" "19"
 
 check "IN-list count matches the OR-literal equivalent" \
 	"$(q 'SELECT count(*) FROM t WHERE ts IN (39100, 39200);')" \
 	"$(q 'SELECT count(*) FROM t WHERE ts = 39100 OR ts = 39200;')"
+
+# A scattered set is the removal proof for per-element pruning. Its hull spans
+# nearly the whole table, so the old [min,max] reduction removes no group; testing
+# each value against the group range removes every group except the three that
+# can hold one listed value. A contiguous set is the negative control: its hull
+# and its elements imply the same one surviving group.
+check "a scattered IN-list prunes by element, not only by its hull (17 removed)" \
+	"$(groups_removed 'SELECT count(*) FROM t WHERE ts IN (100, 20100, 38100);')" "17"
+check "scattered per-element pruning keeps the exact answer" \
+	"$(q 'SELECT count(*) FROM t WHERE ts IN (100, 20100, 38100);')" "3"
+check "a contiguous IN-list agrees with its hull (19 removed)" \
+	"$(groups_removed 'SELECT count(*) FROM t WHERE ts IN (100, 101, 102);')" "19"
+check "contiguous per-element pruning keeps the exact answer" \
+	"$(q 'SELECT count(*) FROM t WHERE ts IN (100, 101, 102);')" "3"
+
+# Bound the O(elements * rows) exact-refinement path. Above 128 non-NULL
+# elements the builder deliberately keeps the old two-key hull.
+large_list="$(seq -s, 1 129)"
+large_plan="$(psql_c "EXPLAIN (ANALYZE, TIMING off, SUMMARY off)
+	SELECT count(*) FROM t WHERE ts IN ($large_list);")"
+check "a large IN-list falls back to two bounded hull filters" \
+	"$(sed -n 's/.*Columnar Pushed-Down Filters: \([0-9]*\).*/\1/p' <<<"$large_plan" | head -1)" "2"
+check "the large-list fallback keeps the exact answer" \
+	"$(q "SELECT count(*) FROM t WHERE ts IN ($large_list);")" "129"
 
 check "a NULL element is ignored for the range, not a bailout (19 removed)" \
 	"$(groups_removed 'SELECT count(*) FROM t WHERE ts = ANY (ARRAY[39100, NULL]::int[]);')" "19"
@@ -128,11 +152,11 @@ check "single-value IN-list count is exact (0 rows)" \
 
 # --- conservativeness arms (must hold before AND after the fix) ---
 
-# A list spanning the whole range prunes nothing but must count exactly: the
-# range is conservative, membership is the executor's recheck.
-check "a range-spanning IN-list is conservative (0 removed, exact count)" \
+# A list spanning the whole range still prunes the groups BETWEEN its elements:
+# this is the distinction the old hull could not express.
+check "a range-spanning IN-list prunes between its elements (18 removed, exact count)" \
 	"$(groups_removed 'SELECT count(*) FROM t WHERE ts IN (100, 39900);')/$(q 'SELECT count(*) FROM t WHERE ts IN (100, 39900);')" \
-	"0/2"
+	"18/2"
 
 # The NOT IN list is confined to ONE group on purpose: a builder that wrongly
 # derived the positive [19000, 19500] range from the negated clause would skip
@@ -248,7 +272,7 @@ check "a correlated PARAM_EXEC array is not mis-pruned (results stay correct)" \
 SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/src"
 
 check "premise: the predicate builder has exactly one sk_flags reject guard" \
-	"$(grep -c 'key->sk_flags &' "$SRC/columnar_reader.c")" "1"
+	"$(grep -c 'key->sk_flags & (SK_ISNULL' "$SRC/columnar_reader.c")" "1"
 
 # From the `if (key->sk_flags & (` line through the closing `))`, comments
 # excluded by construction: the range starts at the `if`, so prose above it
@@ -262,7 +286,7 @@ check "premise: the reject expression was extracted, not blank" \
 # Membership, not adjacency. The flag list is a SET; asserting the order of it
 # would redden on a harmless reflow and would assert more than the code means.
 for _f in SK_ISNULL SK_ROW_HEADER SK_ROW_MEMBER SK_ROW_END SK_SEARCHNULL \
-		  SK_SEARCHNOTNULL SK_ORDER_BY SK_SEARCHARRAY; do
+		  SK_SEARCHNOTNULL SK_ORDER_BY; do
 	check "the predicate builder's reject expression contains $_f" \
 		"$(case "$guard" in *"$_f"*) echo yes ;; *) echo "absent from <$guard>" ;; esac)" "yes"
 done

--- a/test/pytest/TESTS.md
+++ b/test/pytest/TESTS.md
@@ -484,7 +484,7 @@ interchangeable:
 So the `.sh` copy is the enforcement and this one is what a person running the
 corpus by hand gets, with the offenders arriving as a Python list rather than as a
 string assembled by shell. Both are written in the same change, per the rule in
-section 9.
+section 10.
 
 This guard reddened on its own arrival, which is the only reason it is known to
 work here: adding this file moved the corpus from `(54, 5)` to `(62, 6)` and the
@@ -597,8 +597,14 @@ Ports the #752 additions to `test/native_saop_pushdown.sh`. A monotonic 40,000-r
 fixture has twenty row groups. The scattered set `{100,20100,38100}` spans the
 table, so its old `[min,max]` hull removes zero groups while per-element pruning
 removes seventeen. The contiguous `{100,101,102}` set is the negative control:
-its hull and its elements both remove nineteen groups. A 129-element list proves
-the bounded fallback still emits two hull keys and returns every expected row.
+its hull and its elements both remove nineteen groups. Exact 128- and 129-element
+arms pin both sides of the bounded fallback.
+
+A by-reference text set with three values plus NULL pins the NULL compaction
+whose absence dereferences a null Datum. Its integer companion proves NULL
+removal retains pruning. The `ov` fixture gives every group the same `[10,88]`
+zone, so a set of absent odd values can remove groups only through the
+per-element bloom loop.
 
 The shell and pytest forms were both run red before implementation (`0`, wanted
 `17`), green afterward, then red again with the per-element threshold mutated to

--- a/test/pytest/TESTS.md
+++ b/test/pytest/TESTS.md
@@ -4,7 +4,7 @@ Reference for anyone reading, running, or adding to `test/pytest/`. The design a
 the decisions behind the harness are in `design/ISSUE_432_PYTEST_HARNESS.md`. This
 file covers the tests themselves.
 
-**78 tests in 6 files.** Sixty-three of them test the harness rather than the
+**79 tests in 7 files.** Sixty-three of them test the harness rather than the
 product, and they come first, because a harness that can report a false green makes
 every other result in this directory worthless.
 
@@ -32,8 +32,9 @@ behaviour, the source of that number is named.
 - [6. test_docs_cover_the_corpus.py: this document, checked](#6-test_docs_cover_the_corpuspy-this-document-checked)
 - [7. test_connection.py: the cluster and the direct connection](#7-test_connectionpy-the-cluster-and-the-direct-connection)
 - [8. test_native_projection.py: the ported suite](#8-test_native_projectionpy-the-ported-suite)
-- [9. Adding a test](#9-adding-a-test)
-- [10. Traps this corpus records](#10-traps-this-corpus-records)
+- [9. test_saop_element_pushdown.py: scattered set pruning](#9-test_saop_element_pushdownpy-scattered-set-pruning)
+- [10. Adding a test](#10-adding-a-test)
+- [11. Traps this corpus records](#11-traps-this-corpus-records)
 
 ## 1. How to read a test in here
 
@@ -588,7 +589,23 @@ The mutation makes `PgColumnarProjectionFanoutRow` return without writing. Each 
 builds and installs once, and both harnesses print the `.so` md5 they measured, so
 an arm where the two differ is void rather than reported.
 
-## 9. Adding a test
+## 9. test_saop_element_pushdown.py: scattered set pruning
+
+### `test_scattered_saop_prunes_each_element`
+
+Ports the #752 additions to `test/native_saop_pushdown.sh`. A monotonic 40,000-row
+fixture has twenty row groups. The scattered set `{100,20100,38100}` spans the
+table, so its old `[min,max]` hull removes zero groups while per-element pruning
+removes seventeen. The contiguous `{100,101,102}` set is the negative control:
+its hull and its elements both remove nineteen groups. A 129-element list proves
+the bounded fallback still emits two hull keys and returns every expected row.
+
+The shell and pytest forms were both run red before implementation (`0`, wanted
+`17`), green afterward, then red again with the per-element threshold mutated to
+zero. The fixture row count and columnar plan marker are premises, and both query
+answers are checked independently of the pruning counters.
+
+## 10. Adding a test
 
 0. **Write it twice.** Every test in this tree ships as a `.sh` suite and a pytest
    test **in the same change** (jd, 2026-09-09). Not ported later, not one or the
@@ -615,7 +632,7 @@ an arm where the two differ is void rather than reported.
    failed the selftest on both majors of the matrix, which is how it was found. A
    new directory under `test/` inherits every rule the old ones follow.
 
-## 10. Traps this corpus records
+## 11. Traps this corpus records
 
 Recorded because each one produced a confident wrong result before it was caught,
 and all are the same family as the defect the layer exists to prevent.

--- a/test/pytest/test_saop_element_pushdown.py
+++ b/test/pytest/test_saop_element_pushdown.py
@@ -16,11 +16,11 @@ def _nodes(plan):
             stack.extend(node.get("Plans", ()))
 
 
-def _plan(conn, values):
+def _plan(conn, qual):
     with conn.cursor() as cur:
         cur.execute(
             "EXPLAIN (ANALYZE, FORMAT JSON, COSTS OFF, TIMING OFF, SUMMARY OFF) "
-            f"SELECT count(*) FROM t WHERE ts IN ({values})"
+            f"SELECT count(*) FROM t WHERE {qual}"
         )
         return cur.fetchone()[0]
 
@@ -45,14 +45,15 @@ def test_scattered_saop_prunes_each_element(pgc_conn, expect):
     with pgc_conn.cursor() as cur:
         cur.execute(
             "SET pgcolumnar.stripe_row_limit=2000; "
-            "CREATE TABLE t (ts int) USING pgcolumnar; "
-            "INSERT INTO t SELECT g FROM generate_series(1,40000) g"
+            'CREATE TABLE t (ts int, txt text COLLATE "C", ov int) USING pgcolumnar; '
+            "INSERT INTO t SELECT g, lpad(g::text,8,'0'), (g%40)*2+10 "
+            "FROM generate_series(1,40000) g"
         )
         cur.execute("SELECT count(*) FROM t")
         expect.num(cur.fetchone()[0], 40000, "premise: fixture has every row")
 
-    scattered = _plan(pgc_conn, "100, 20100, 38100")
-    contiguous = _plan(pgc_conn, "100, 101, 102")
+    scattered = _plan(pgc_conn, "ts IN (100, 20100, 38100)")
+    contiguous = _plan(pgc_conn, "ts IN (100, 101, 102)")
 
     expect.plan_marker(
         scattered, "Columnar Projected Columns",
@@ -66,11 +67,37 @@ def test_scattered_saop_prunes_each_element(pgc_conn, expect):
         _removed(contiguous), 19,
         "a contiguous IN-list agrees with its hull",
     )
+    limit_values = ", ".join(str(i) for i in range(1, 129))
+    limit = _plan(pgc_conn, f"ts IN ({limit_values})")
+    expect.num(
+        _pushed(limit), 1,
+        "exactly 128 elements still use one set filter",
+    )
     large_values = ", ".join(str(i) for i in range(1, 130))
-    large = _plan(pgc_conn, large_values)
+    large = _plan(pgc_conn, f"ts IN ({large_values})")
     expect.num(
         _pushed(large), 2,
         "a large IN-list falls back to two bounded hull filters",
+    )
+    int_null = _plan(
+        pgc_conn, "ts = ANY (ARRAY[100,20100,38100,NULL]::int[])"
+    )
+    expect.num(
+        _removed(int_null), 17,
+        "a multi-value integer set strips NULL and still prunes",
+    )
+    text_null = _plan(
+        pgc_conn,
+        "txt = ANY (ARRAY['00000100','00020100','00038100',NULL]::text[])",
+    )
+    expect.num(
+        _removed(text_null), 17,
+        "a by-reference text set strips NULL without crashing",
+    )
+    bloom_only = _plan(pgc_conn, "ov = ANY ('{25,27,29}'::int[])")
+    expect.num(
+        _removed(bloom_only), 20,
+        "a multi-value set bloom-prunes all overlapping groups",
     )
 
     with pgc_conn.cursor() as cur:
@@ -80,3 +107,15 @@ def test_scattered_saop_prunes_each_element(pgc_conn, expect):
         expect.num(cur.fetchone()[0], 3, "contiguous pruning keeps the exact answer")
         cur.execute(f"SELECT count(*) FROM t WHERE ts IN ({large_values})")
         expect.num(cur.fetchone()[0], 129, "the large-list fallback keeps the exact answer")
+        cur.execute(
+            "SELECT count(*) FROM t "
+            "WHERE ts = ANY (ARRAY[100,20100,38100,NULL]::int[])"
+        )
+        expect.num(cur.fetchone()[0], 3, "the integer NULL set stays exact")
+        cur.execute(
+            "SELECT count(*) FROM t WHERE txt = ANY "
+            "(ARRAY['00000100','00020100','00038100',NULL]::text[])"
+        )
+        expect.num(cur.fetchone()[0], 3, "the text NULL set stays exact")
+        cur.execute("SELECT count(*) FROM t WHERE ov = ANY ('{25,27,29}'::int[])")
+        expect.num(cur.fetchone()[0], 0, "the bloom-only set stays exact")

--- a/test/pytest/test_saop_element_pushdown.py
+++ b/test/pytest/test_saop_element_pushdown.py
@@ -1,0 +1,82 @@
+"""Per-element pruning for scattered ``= ANY`` sets (#752).
+
+The hull of ``{100,20100,38100}`` intersects every row group, so the old
+``[min,max]`` reduction removes none.  A set-aware predicate can keep only the
+three groups containing an element.  The contiguous set is the negative control:
+its element test and its hull must agree.
+"""
+
+
+def _nodes(plan):
+    for root in plan:
+        stack = [root["Plan"]]
+        while stack:
+            node = stack.pop()
+            yield node
+            stack.extend(node.get("Plans", ()))
+
+
+def _plan(conn, values):
+    with conn.cursor() as cur:
+        cur.execute(
+            "EXPLAIN (ANALYZE, FORMAT JSON, COSTS OFF, TIMING OFF, SUMMARY OFF) "
+            f"SELECT count(*) FROM t WHERE ts IN ({values})"
+        )
+        return cur.fetchone()[0]
+
+
+def _removed(plan):
+    return next(
+        node.get("Columnar Chunk Groups Removed by Filter", 0)
+        for node in _nodes(plan)
+        if "Columnar Chunk Groups Total" in node
+    )
+
+
+def _pushed(plan):
+    return next(
+        node.get("Columnar Pushed-Down Filters", 0)
+        for node in _nodes(plan)
+        if "Columnar Projected Columns" in node
+    )
+
+
+def test_scattered_saop_prunes_each_element(pgc_conn, expect):
+    with pgc_conn.cursor() as cur:
+        cur.execute(
+            "SET pgcolumnar.stripe_row_limit=2000; "
+            "CREATE TABLE t (ts int) USING pgcolumnar; "
+            "INSERT INTO t SELECT g FROM generate_series(1,40000) g"
+        )
+        cur.execute("SELECT count(*) FROM t")
+        expect.num(cur.fetchone()[0], 40000, "premise: fixture has every row")
+
+    scattered = _plan(pgc_conn, "100, 20100, 38100")
+    contiguous = _plan(pgc_conn, "100, 101, 102")
+
+    expect.plan_marker(
+        scattered, "Columnar Projected Columns",
+        name="premise: scattered arm uses the columnar scan",
+    )
+    expect.num(
+        _removed(scattered), 17,
+        "a scattered IN-list prunes by element, not only by its hull",
+    )
+    expect.num(
+        _removed(contiguous), 19,
+        "a contiguous IN-list agrees with its hull",
+    )
+    large_values = ", ".join(str(i) for i in range(1, 130))
+    large = _plan(pgc_conn, large_values)
+    expect.num(
+        _pushed(large), 2,
+        "a large IN-list falls back to two bounded hull filters",
+    )
+
+    with pgc_conn.cursor() as cur:
+        cur.execute("SELECT count(*) FROM t WHERE ts IN (100, 20100, 38100)")
+        expect.num(cur.fetchone()[0], 3, "scattered pruning keeps the exact answer")
+        cur.execute("SELECT count(*) FROM t WHERE ts IN (100, 101, 102)")
+        expect.num(cur.fetchone()[0], 3, "contiguous pruning keeps the exact answer")
+        cur.execute(f"SELECT count(*) FROM t WHERE ts IN ({large_values})")
+        expect.num(cur.fetchone()[0], 129, "the large-list fallback keeps the exact answer")


### PR DESCRIPTION
Closes the per-element scan-key work specified in #752.

`IN (...)` / `= ANY(array)` currently collapses a multi-value set to its `[min,max]` hull. That is conservative, but a scattered set whose hull spans the table reads every row group. This keeps the set as one `SK_SEARCHARRAY` predicate and evaluates its elements disjunctively inside the reader while the outer predicate list remains conjunctive.

The set predicate is used consistently by:

- whole-row-group and per-vector zone maps;
- bloom filters, where a group survives if any element may be present;
- exact vector refinement, while the executor still rechecks the original clause.

The element path is capped at 128 non-NULL entries. Larger arrays retain the old two-key hull so exact refinement cannot grow without bound as elements × rows. Adaptive ordering never promotes a more expensive set predicate ahead of a scalar predicate.

## TDD and removal proof

Both public test forms were written before implementation:

```text
shell:  scattered set removed 0 groups, wanted 17  -> RED
pytest: scattered set removed 0 groups, wanted 17  -> RED
```

After the change, both are green. Mutating `PGCOLUMNAR_SAOP_ELEMENT_LIMIT` from 128 to 0 removes the per-element route and makes both fail again for the same `0`, wanted `17` reason. The mutation was asserted present in source, produced a different installed `.so`, and was removed before the final gate.

Controls in both forms:

- contiguous `{100,101,102}` agrees with its hull at 19/20 groups removed;
- a 129-element list uses two hull keys and returns all 129 rows;
- scattered and contiguous answers are checked independently of EXPLAIN counters.

## Verification on exact head `7f862f7`

- `test/native_saop_pushdown.sh`: 45 passed
- complete pytest corpus: 75 passed
- focused `pushdown_report`, `native_vecdecode`, `vector_agg_rescan_memory`, and `docs_style`: all passed
- final PostgreSQL 18 full matrix after rebasing onto merged #897/#898: 247 suites passed, 2 PG19-only skips, 0 failed, 0 incomplete
- `git diff --check`: clean

No SQL catalog or on-disk format changes.
