### PR TITLE
docs: align SAOP exactness comments (#904 follow-up)

### DIFF
--- a/src/columnar_customscan.c
+++ b/src/columnar_customscan.c
@@ -963,9 +963,10 @@ pgcolumnar_clause_to_scankey(Node *clause, Index scanrelid, TupleDesc tupdesc,
 	*exact = false;
 
 	/*
-	 * `col IN (...)` / `col = ANY(array)` becomes a [min, max] range (#704). Its
-	 * keys are conservative, so this returns with exact still false and the fold
-	 * refuses them (#715).
+	 * `col IN (...)` / `col = ANY(array)` becomes one set key, with a bounded
+	 * [min,max] fallback above the element limit (#704, #752). Both forms are
+	 * conservative pruning keys, so exact remains false and the fold refuses
+	 * them as its complete row filter (#715).
 	 */
 	if (IsA(clause, ScalarArrayOpExpr))
 		return pgcolumnar_saop_scankey((ScalarArrayOpExpr *) clause,

--- a/src/columnar_reader.c
+++ b/src/columnar_reader.c
@@ -778,6 +778,7 @@ pgcolumnar_make_predicates(SkipPredicate *out, int nkeys, ScanKey keys,
 			bool		elmbyval;
 			char		elmalign;
 
+			Assert(ARR_ELEMTYPE(arr) == key->sk_subtype);
 			get_typlenbyvalalign(ARR_ELEMTYPE(arr), &elmlen, &elmbyval,
 								&elmalign);
 			deconstruct_array(arr, ARR_ELEMTYPE(arr), elmlen, elmbyval,

--- a/src/columnar_vector.c
+++ b/src/columnar_vector.c
@@ -3367,8 +3367,9 @@ pgcolumnar_batch_gates_ok(const PgColumnarAggSpec *specs, int naggs,
 	 *
 	 * The gate below is exactly the exactness marker the conservative keys need
 	 * kept out of the fold: PgColumnarBuildScanKeys emits keys WEAKER than their
-	 * clause for a ScalarArrayOpExpr ([min, max] range, #704) and for an anchored
-	 * LIKE (#426), and pgcolumnar_clause_to_scankey now reports that inexactness.
+	 * clause for a ScalarArrayOpExpr (a set key with a bounded [min,max]
+	 * fallback, #704/#752) and for an anchored LIKE (#426), and
+	 * pgcolumnar_clause_to_scankey reports that inexactness.
 	 * PgColumnarQualsExactlyKeyed demands one EXACT key per clause, so those keys
 	 * never serve as the fold's WHERE even if pgcolumnar_clause_to_predicate were
 	 * later taught to accept a SAOP. The byval gather guard below is a second,


### PR DESCRIPTION
Follow-up from the post-merge re-review of #904.

Two load-bearing comments still described every `ScalarArrayOpExpr` as a `[min,max]` range. #904 changed the normal path to a set-valued key, retaining the range only above the 128-element limit. The comments now state that shape while preserving the key safety conclusion: both forms are conservative and must remain excluded from the batch fold as complete row filters.

Also asserts the invariant the bloom/cross-type argument depends on: the copied array header's element type equals the scan key's `sk_subtype`. The only producer derives both from the same `Const`; a cassert build now checks that directly beside the existing `kept >= 2` invariant.

Verification on this exact patch composed with merged #904:

- `native_saop_pushdown`: 53/53
- complete pytest corpus: 122/122
- full PG18 matrix: 248 passed, 2 PG19-only skips, 0 failed/incomplete
- `git diff --check`: clean

No behavior, SQL, catalog, or on-disk format change.
