### PR TITLE
test: a symlinked src was the one directory exempt from the module's own rule

### DIFF
--- a/test/pgc_fingerprint.py
+++ b/test/pgc_fingerprint.py
@@ -83,7 +83,20 @@ def build_dirs(root):
     Makefile reaches a separately built module such as objstore/.
     """
     root = pathlib.Path(root)
-    out = [root / "src"]
+    # src is a candidate like any other, and gets the SAME symlink test. It used
+    # to be added unconditionally, which made it the one directory exempt from
+    # the rule stated four lines below: `find -P` does not descend a symlinked
+    # directory argument, so the shell this replaced hashed nothing there while
+    # this module walked it. Measured on a tree whose src/ was a symlink --
+    # old 9861a3f1fbd1, module 9eff36abd48e -- so a stamp written before the
+    # port read `stale` against a clean tree.
+    out = []
+    try:
+        src = root / "src"
+        if src.is_dir() and not src.is_symlink():
+            out.append(src)
+    except OSError:
+        pass
     try:
         entries = sorted(root.iterdir(), key=lambda p: os.fsencode(str(p)))
     except OSError:

--- a/test/pytest/TESTS.md
+++ b/test/pytest/TESTS.md
@@ -4,7 +4,7 @@ Reference for anyone reading, running, or adding to `test/pytest/`. The design a
 the decisions behind the harness are in `design/ISSUE_432_PYTEST_HARNESS.md`. This
 file covers the tests themselves.
 
-**123 tests in 10 files.** One hundred and eight of them test the harness rather than the
+**124 tests in 10 files.** One hundred and nine of them test the harness rather than the
 product, and they come first, because a harness that can report a false green makes
 every other result in this directory worthless.
 
@@ -632,6 +632,14 @@ another route would evade it. It carries three premises of its own — that the 
 recognises a write at `$PGC_SRCDIR`, that it recognises one through `$_bd_root`,
 and that a write into a COPY is *not* flagged — because a pattern that matches
 nothing would otherwise pass this arm silently.
+
+`test_a_symlinked_src_is_skipped_like_any_other_symlinked_build_dir` closes the
+one directory that was exempt from the module's own rule. `build_dirs()` added
+`root/"src"` unconditionally and applied the symlink test to every other
+candidate, so a tree whose `src/` is a symlink hashed differently across the
+port — `find -P` does not descend a symlinked directory argument, so the shell
+hashed nothing there while the module walked it. It carries a control, because
+"skip src entirely" would satisfy the arm without it.
 
 **What is still not guarded**, named here rather than left for someone to find: a
 TRUNCATED manifest — `find` returning fewer files rather than none — would produce

--- a/test/pytest/test_build_refusal.py
+++ b/test/pytest/test_build_refusal.py
@@ -915,3 +915,51 @@ def test_one_tree_hashes_one_way_however_the_locale_is_set(expect):
                    f"one tree, one fingerprint, across {len(wanted)} locales: {seen}")
     finally:
         shutil.rmtree(root, ignore_errors=True)
+
+
+def test_a_symlinked_src_is_skipped_like_any_other_symlinked_build_dir(tmp_path, expect):
+    """`src` was the one directory exempt from the module's own symlink rule.
+
+    `build_dirs()` added `root/"src"` unconditionally and then applied
+    `if not d.is_dir() or d.is_symlink(): continue` to every other candidate.
+    `find -P` does not descend a symlinked directory argument, so the shell this
+    module replaced hashed nothing there while the module walked it. Measured on
+    a tree whose src/ was a symlink:
+
+        find -P on the symlinked src/   printed nothing
+        the module's manifest           src/a.c, src/h.h
+        old shell fingerprint           9861a3f1fbd1
+        module fingerprint              9eff36abd48e
+
+    A stamp written before the port then read `stale` on a clean tree, which is
+    the false FATAL the controller exists to prevent.
+    """
+    real = tmp_path / "real"
+    real.mkdir()
+    (real / "a.c").write_text("int a;\n")
+    (real / "h.h").write_text("void h(void);\n")
+    t = tmp_path / "tree"
+    t.mkdir()
+    (t / "src").symlink_to(real)
+    (t / "Makefile").write_text("all:\n\ttrue\n")
+    (t / "pgcolumnar.control").write_text("x\n")
+
+    expect.text(str((t / "src").is_symlink()), "True", "premise: src really is a symlink")
+    expect.num(len(list(real.iterdir())), 2,
+               "premise: and the target holds sources find would otherwise hash")
+
+    out, _ = _sh_fp(f'pgc_source_manifest "{t}"')
+    lines = [l for l in out.splitlines() if l.strip()]
+    expect.num(len([l for l in lines if l.startswith("src/")]), 0,
+               "a symlinked src contributes nothing, as find -P contributes nothing")
+    expect.num(len(lines), 2, "so the tree fingerprints from its root files alone")
+
+    # CONTROL: without this, "skip src entirely" would satisfy the arm above.
+    real_tree = tmp_path / "realsrc"
+    (real_tree / "src").mkdir(parents=True)
+    (real_tree / "src" / "a.c").write_text("int a;\n")
+    (real_tree / "Makefile").write_text("all:\n\ttrue\n")
+    (real_tree / "pgcolumnar.control").write_text("x\n")
+    out2, _ = _sh_fp(f'pgc_source_manifest "{real_tree}"')
+    expect.num(len([l for l in out2.splitlines() if l.startswith("src/a.c ")]), 1,
+               "control: a real src directory is still hashed")

--- a/test/selftest/340-the-binary-must-be-built-from.sh
+++ b/test/selftest/340-the-binary-must-be-built-from.sh
@@ -775,6 +775,56 @@ check "an unhashable tree has an empty manifest" \
 
 unset _mf _mf_lines _mf_hollow
 
+# ---------------------------------------------------------------------------
+# A SYMLINKED src/ MUST BE SKIPPED, LIKE EVERY OTHER SYMLINKED BUILD DIRECTORY.
+#
+# `build_dirs()` adds `root/"src"` unconditionally and then applies
+# `if not d.is_dir() or d.is_symlink(): continue` to every OTHER candidate --
+# so `src` is the one directory that bypasses its own rule. The shell this
+# replaced ran `find "$d" -maxdepth 1 -type f`, and `find -P` does not descend a
+# symlinked command-line argument, so it hashed nothing there.
+#
+# Measured on a tree whose src/ is a symlink:
+#
+#     find -P on the symlinked src/   printed nothing
+#     the module's manifest           src/a.c, src/h.h
+#     old shell fingerprint           9861a3f1fbd1
+#     module fingerprint              9eff36abd48e     <- diverges
+#
+# A stamp written before the port then reads `stale` on a tree that is clean,
+# which is the false FATAL the whole controller exists to prevent. The module's
+# own comment states the invariant it breaks here.
+
+_sl="$(mktemp -d "${TMPDIR:-/tmp}/pgc-symsrc.XXXXXX")"
+mkdir -p "$_sl/real" "$_sl/tree"
+printf 'int a;\n' > "$_sl/real/a.c"
+printf 'void h(void);\n' > "$_sl/real/h.h"
+ln -s "$_sl/real" "$_sl/tree/src"
+printf 'all:\n\ttrue\n' > "$_sl/tree/Makefile"
+printf 'x\n' > "$_sl/tree/pgcolumnar.control"
+
+check "PREMISE the fixture's src really is a symlink" \
+	"$([ -L "$_sl/tree/src" ] && echo yes || echo no)" "yes"
+check "PREMISE and the target really holds sources find would otherwise hash" \
+	"$(ls "$_sl/real" | tr '\n' ' ')" "a.c h.h "
+
+# find -P is the reference: it prints nothing for a symlinked directory argument.
+check "a symlinked src contributes nothing, as find -P contributes nothing" \
+	"$(pgc_source_manifest "$_sl/tree" | grep -c '^src/')" "0"
+check "so the tree still fingerprints from its root files alone" \
+	"$(pgc_source_manifest "$_sl/tree" | wc -l)" "2"
+
+# CONTROL: a REAL src directory must still be hashed, or the fix is "skip src".
+_slr="$(mktemp -d "${TMPDIR:-/tmp}/pgc-realsrc.XXXXXX")"
+mkdir -p "$_slr/src"
+printf 'int a;\n' > "$_slr/src/a.c"
+printf 'all:\n\ttrue\n' > "$_slr/Makefile"
+printf 'x\n' > "$_slr/pgcolumnar.control"
+check "control: a real src directory is still hashed" \
+	"$(pgc_source_manifest "$_slr" | grep -c '^src/a.c ')" "1"
+
+unset _sl _slr
+
 # The FATAL path's dump, driven rather than grepped for. A report nobody can run
 # is a report nobody knows is empty, and "the source says it calls it" is the kind
 # of claim this suite exists to refuse.


### PR DESCRIPTION
`build_dirs()` added `root/"src"` unconditionally and then applied

    if not d.is_dir() or d.is_symlink(): continue   # find does not descend a
                                                    # symlinked directory

to every OTHER candidate. So `src` bypassed the rule stated four lines below it.

`find -P` does not descend a symlinked directory argument, so the shell
implementation #911 replaced hashed nothing there while the module walked it.
Measured on a tree whose `src/` is a symlink:

    find -P on the symlinked src/    printed nothing
    the module's manifest            src/a.c, src/h.h
    old shell fingerprint            9861a3f1fbd1
    module fingerprint               9eff36abd48e     <- diverges

A stamp written before the port then reads `stale` against a clean tree, which
is the false FATAL the controller exists to prevent, and #911's central claim was
that the port preserves the hash.

## How it got past me

I reviewed and merged #911, and I checked symlinks — a symlinked tree ROOT and a
symlinked FILE, both of which the module handles correctly and both of which I
said were "the ones I would have got wrong". A symlinked BUILD DIRECTORY named
`src` is a third case and I did not construct it. The module guards it for every
directory except the one added before the loop.

## The fix, and the control that keeps it honest

`src` becomes a candidate like any other and takes the same `is_dir() and not
is_symlink()` test. The control matters as much as the arm: **"skip src
entirely" would satisfy "a symlinked src contributes nothing"**, so a real `src`
directory must still be hashed.

Arms first, run RED before the fix existed:

    FAIL  a symlinked src contributes nothing, as find -P contributes nothing: got [2] want [0]
    FAIL  so the tree still fingerprints from its root files alone: got [4] want [2]

with both premises and the control passing, so the arm was measuring the tree
rather than the harness. Then GREEN, then the guard reverted:

    .sh      2 arms red, by name
    pytest   test_a_symlinked_src_is_skipped_like_any_other_symlinked_build_dir FAILED

## The property that must not move, re-checked

    old shell implementation, real tree   557ba50628c8
    fixed module, same tree               557ba50628c8   IDENTICAL

The fix does not change the normal case, which is the whole point of the port.

    harness_selftest   433 passed + 0 failed + 0 unrunnable
    pytest corpus      124 passed, --pgc-expect-tests 124
    docs_style           9 checks PASSED

Found by an adversarial review pass over #911 after it had already merged.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Unuuvh3fRR67SceiGpfeeK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Unuuvh3fRR67SceiGpfeeK