### PR TITLE
test: pin the block compression default to the measurement that justifies it (#890)

### DIFF
--- a/test/encode_invariants.sh
+++ b/test/encode_invariants.sh
@@ -224,4 +224,27 @@ done
 check "no vector selects FSST at or below the distinct cap, so skipping its build cannot change output" \
 	"$([ -z "$lofail" ] && echo none || echo "selected:$lofail")" "none"
 
+# ---- the block compression default is pinned to its measurement (#890) -------
+#
+# The roadmap proposed making this default depend on a storage tier, on the premise
+# that block compression trades CPU for I/O. Phase 1 refuted the premise ON THIS
+# ENGINE: the cascade runs lightweight encodings first, so zstd works on
+# already-reduced bytes and its remaining cost is small against the memory traffic
+# it removes. PG 17.10, 400k rows, minimum of 12, arms round-robined, and the
+# none/zstd ranges do not overlap on any shape:
+#
+#     shape   marginal bytes saved   scan time vs none
+#     rep                   +76.6%   0.92  (faster)
+#     rand                   -1.7%   1.14  (slower -- incompressible)
+#     mix                   +12.0%   0.92  (faster)
+#
+# Warm cache, which UNDERSTATES the saving because no physical read happens on
+# either arm. A pin, not a discovery: changing this default should be a deliberate
+# act with a new measurement attached. Incompressible data is a real cost and the
+# answer there is the per-table override, not a different global default.
+check "the block compression default is zstd, pinned to #890 phase 1" \
+	"$(q "SHOW pgcolumnar.compression")" "zstd"
+check "and its level is 3" \
+	"$(q "SHOW pgcolumnar.compression_level")" "3"
+
 pgc_summary

--- a/test/encode_invariants.sh
+++ b/test/encode_invariants.sh
@@ -238,8 +238,16 @@ check "no vector selects FSST at or below the distinct cap, so skipping its buil
 #     rand                   -1.7%   1.14  (slower -- incompressible)
 #     mix                   +12.0%   0.92  (faster)
 #
-# Warm cache, which UNDERSTATES the saving because no physical read happens on
-# either arm. A pin, not a discovery: changing this default should be a deliberate
+#
+# WARM CACHE, which understates the saving ON THE SHAPES THAT COMPRESS: no physical
+# read happens on either arm, so a cold run adds an I/O term proportional to bytes
+# read and rep and mix can only widen.
+#
+# NOT SO ON rand. There zstd writes 148,076 MORE bytes than none, so cold makes it
+# worse on both terms at once -- more bytes to read AND the same decompression CPU.
+# The incompressible shape degrading cold is a SECOND, independent reason for the
+# per-table override rather than a global change.
+# A pin, not a discovery: changing this default should be a deliberate
 # act with a new measurement attached. Incompressible data is a real cost and the
 # answer there is the per-table override, not a different global default.
 check "the block compression default is zstd, pinned to #890 phase 1" \

--- a/test/pytest/TESTS.md
+++ b/test/pytest/TESTS.md
@@ -879,6 +879,7 @@ written.
 | --- | --- |
 | `test_cluster_fixture_gives_a_typed_connection` | `count(*)` arrives as a Python `int`, and its type is `int` |
 | `test_the_extension_is_installed_and_columnar` | the fixture's cluster has `pgcolumnar` at the expected version |
+| `test_the_block_compression_default_is_pinned_to_its_measurement` | `zstd:3` is still the default, pinned to #890 phase 1: the cascade runs first, so zstd works on already-reduced bytes and is +76.6% smaller at 0.92x the scan time on `rep` and +12.0% at 0.92x on `mix`. A pin, so changing it is deliberate |
 | `test_a_columnar_table_round_trips_with_real_types` | `numeric` is `Decimal`, `float8` is `float`, `bytea` is `bytes`, an array is a `list` |
 | `test_the_plan_shows_a_columnar_scan` | the plan arrives as parsed Python, and the scan ran |
 | `test_the_provider_name_does_not_identify_a_scan` | **pins a trap**; see below |

--- a/test/pytest/test_connection.py
+++ b/test/pytest/test_connection.py
@@ -291,3 +291,35 @@ def test_the_acknowledgement_is_by_cursor_against_the_real_driver(pgc_conn, expe
         expect.num(int(writes[1].acknowledged), 1, "acknowledges the second write")
         expect.num(int(writes[0].acknowledged), 0, "and leaves the first unnamed")
         expect.wrote(first, 0, "so name the first explicitly too")
+
+
+def test_the_block_compression_default_is_pinned_to_its_measurement(pgc_conn, expect):
+    """#890: zstd:3 stays the default until a measurement says otherwise.
+
+    The roadmap proposed making this default depend on a storage tier, on the
+    premise that block compression trades CPU for I/O. Phase 1 refuted the premise
+    ON THIS ENGINE: our cascade runs lightweight encodings first, so zstd works on
+    already-reduced bytes and its remaining cost is small against the memory traffic
+    it removes. Measured on PG 17.10, 400k rows, minimum of 12, arms round-robined,
+    and the none/zstd ranges do not overlap on any shape:
+
+        shape   marginal bytes saved   scan time vs none
+        rep                   +76.6%   0.92   (faster)
+        rand                   -1.7%   1.14   (slower -- incompressible)
+        mix                   +12.0%   0.92   (faster)
+
+    Warm cache, which UNDERSTATES the saving because no physical read happens on
+    either arm, so a cold measurement can only move further toward compression.
+
+    This arm is a pin, not a discovery. It exists so that changing the default is a
+    deliberate act with a new measurement attached, rather than a line edit nobody
+    has to defend. Incompressible data is a real cost and the answer there is the
+    per-table override, not a different global default.
+    """
+    with pgc_conn.cursor() as cur:
+        cur.execute("SHOW pgcolumnar.compression")
+        method = cur.fetchone()[0]
+        cur.execute("SHOW pgcolumnar.compression_level")
+        level = cur.fetchone()[0]
+    expect.text(method, "zstd", "the block compression default is zstd (#890 phase 1)")
+    expect.num(int(level), 3, "and its level is 3")

--- a/test/pytest/test_connection.py
+++ b/test/pytest/test_connection.py
@@ -308,8 +308,18 @@ def test_the_block_compression_default_is_pinned_to_its_measurement(pgc_conn, ex
         rand                   -1.7%   1.14   (slower -- incompressible)
         mix                   +12.0%   0.92   (faster)
 
-    Warm cache, which UNDERSTATES the saving because no physical read happens on
-    either arm, so a cold measurement can only move further toward compression.
+    Warm cache, which understates the saving ON THE SHAPES THAT COMPRESS: no
+    physical read happens on either arm, so a cold run adds an I/O term proportional
+    to bytes read and `rep` and `mix` can only widen.
+
+    NOT SO ON `rand`, AND THE DIFFERENCE MATTERS. There zstd writes 148,076 MORE
+    bytes than none, so cold makes it worse on both terms at once -- more bytes to
+    read AND the same decompression CPU -- and C(cold) > 1.14. An earlier version of
+    this comment said a cold measurement "can only move further toward compression",
+    full stop. That is true only where compression reduces bytes, and stating it
+    unconditionally gave away the stronger argument: the incompressible shape
+    degrading cold is a SECOND, independent reason for the per-table override rather
+    than a global change. Reported by @OffgridwithJD.
 
     This arm is a pin, not a discovery. It exists so that changing the default is a
     deliberate act with a new measurement attached, rather than a line edit nobody


### PR DESCRIPTION
Answers #890, and the answer is **change nothing**. This PR is the pin that makes that decision durable.

## The premise is refuted on this engine

#890 proposed making the block compression default depend on a storage tier, on the roadmap's premise that block compression trades CPU for I/O. Phase 1 measured it. **On two of three corpus shapes zstd is both smaller and faster than no block compression** — there is no trade to resolve.

PG 17.10, main `d05e3c3`, 400,000 rows, minimum of 12, arms round-robined so drift moves all arms together. Bytes are the engine's own `pgcolumnar.stats()` accounting.

```
shape   bytes(none)  bytes(zstd)   saved    scan min ms       vs none
rep         653,960      153,150   +76.6%   29.06 -> 26.80    0.92 faster
rand      8,854,604    9,002,680    -1.7%   46.31 -> 52.67    1.14 slower
mix       3,509,389    3,087,751   +12.0%   46.75 -> 43.02    0.92 faster
```

**The none/zstd ranges do not overlap on any shape**, so the direction is not noise:

```
rep   none 29.06..31.65   zstd 26.80..28.58
rand  none 46.31..47.87   zstd 52.67..55.66
mix   none 46.75..48.77   zstd 43.02..45.31
```

**Why it is faster, and why the cited result does not transfer.** Our cascade runs lightweight encodings first, so zstd operates on already-reduced bytes and its remaining work is small against the memory traffic it removes. The warm cache **understates** the saving — no physical read happens on either arm — so a cold measurement can only move further toward compression.

The full write-up, including the decision rule fixed **before** any number was read, is on #890.

## What this PR adds

A pin in both harnesses, independently implemented: the shell twin asks its own cluster through `q "SHOW ..."`, the pytest twin through its own connection, and neither names the other. Both carry the measurement as their reason, so the next person to consider changing this default finds the evidence rather than a bare assertion.

Incompressible data **is** a real cost — 1.7% larger and 14% slower — and the answer there is the per-table override that already exists, not a different global default.

## Proved by removal, and the first mutation was void

```
changing ONLY the C initializer       postmaster REFUSES TO START
                                      TRAP: failed Assert("check_GUC_init(variable)")
initializer AND the bootValue         FAIL ... got [lz4] want [zstd]
                                      12 passed + 1 failed of 13
control, unmutated                    13 passed + 0 failed
```

PostgreSQL asserts that a custom GUC's C initializer matches its `bootValue`, so the two sites cannot drift on an assert build. My first mutation touched one of them and produced a startup crash rather than a failing check — **a mutation that does not leave the artifact well-formed tests nothing**, which is the second time that shape has cost me a round today.

One defect in my own edit, caught before it shipped: I appended the checks **after** `pgc_summary`, where they would have run outside the accounting. They are above it now, verified by line number rather than by eye.

## Scope

No production code changes. If the recommendation is rejected and the default should move, this PR is the thing to revert first — deliberately, which is the point.

Based on main `d05e3c3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EbyGSaU93XYQr8aH4NrUiw
