### PR TITLE
test/pytest: the "what to add next" list was the last unchecked part, and it was wrong (#432)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -407,6 +407,51 @@ true until the next version shipped.
 
 ### Fixed
 
+- Section 5 of VACUITY_MODES.md, the "what to add next" list, is checked (#432).
+
+  1a, 2 and 3 are all compared against the mode ids on disk. Section 5 was prose, and
+  it was **wrong**: entry 1 still said "the constant exists and nothing writes it" long
+  after `query_error()` existed and `test_failed_query_sentinel.py` carried ten arms
+  over it, including the producer's uniqueness and the constant's non-uniqueness that
+  is the reason the producer exists.
+
+  **That is the most expensive place in the document for a stale sentence**, because
+  its only reader is someone about to build something. The near-miss one document over
+  is what it costs: a bad enumeration of `test/selftest/340` made an existing block
+  look like a coverage gap, and the duplicate was written and proven to discriminate
+  before the duplication was noticed.
+
+  **What is checkable is the anchor, not the work.** Entry 1's work landed under four
+  test names, none of them the one the entry proposed, so asking whether the NAMED test
+  exists would have passed and said nothing. Two arms hold the list instead:
+
+  - every entry names at least one mode id, so it is tied to the inventory at all.
+    Entry 1 named none, which is exactly how it stayed wrong.
+  - no UN-STRUCK entry names an id section 2 already claims as refused. An entry whose
+    id has reached section 2 is done by the document's own accounting, whatever the
+    test ended up being called.
+
+  Entry 1 is struck and anchored to `error-swallowed-to-empty`, and it records what the
+  entry got wrong rather than replacing it: both halves of "the constant exists and
+  nothing writes it" were false — two sites already minted sentinels by hand, and the
+  missing thing was the REFUSAL in four of the five comparisons.
+
+  **Fixing it made the second arm vacuous on this document**, because with every entry
+  struck there is nothing left to refuse. The planted fixture beside it is therefore
+  the whole of its evidence, and the document says so rather than leaving it implied: a
+  two-entry fixture where moving the open entry's id into section 2 must be named, with
+  the clean control beside it.
+
+  The totals do not move — 28 refused, 44 not refused, 72 named — because the mode was
+  already counted as refused. Only the list that tells the next person what to do was
+  wrong.
+
+  One instrument defect of mine, caught by that fixture: the parser matched the
+  SECTION HEADING as an entry. `re.split(r"^## ")` leaves a chunk beginning "5. What to
+  add next", which the numbered-item pattern also matches — inventing an entry 5 that
+  is the title and colliding with the real entry 5. The fixture reported 3 entries in a
+  two-entry document, which is how it was found.
+
 - A count `grep` never produced no longer reads as "present" (#929).
 
   #922 replaced roughly 28 `producer | grep -q PAT` tests with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -446,6 +446,18 @@ true until the next version shipped.
   already counted as refused. Only the list that tells the next person what to do was
   wrong.
 
+  **And 3.6 now records measured populations, so the next entry is chosen on evidence.**
+  Section 5's new rule is that an entry must name a mode id, which makes WHICH id worth
+  measuring. Four of 3.6's were counted by AST scan over the whole corpus:
+  `truthy-cursor-from-execute` has 7 sites and **all are benign** — every one is
+  `x = cur.execute(...)`, idiomatic in psycopg3, and **zero** branch on it, which is the
+  dangerous form; `empty-query-string-succeeds` has 0; the multistatement mode has 1, a
+  setup that fetches nothing with a `count(*)` premise right after it; and the
+  server-cursor rowcount mode has 2, both legitimate. So all four are PROSPECTIVE, and a
+  guard for any of them would be insurance rather than a closure. Recorded because a
+  refusal with no population has not refused anything, and 1a counts section 2 as
+  "refused today".
+
   One instrument defect of mine, caught by that fixture: the parser matched the
   SECTION HEADING as an entry. `re.split(r"^## ")` leaves a chunk beginning "5. What to
   add next", which the numbered-item pattern also matches — inventing an entry 5 that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -433,7 +433,7 @@ true until the next version shipped.
 
   Entry 1 is struck and anchored to `error-swallowed-to-empty`, and it records what the
   entry got wrong rather than replacing it: both halves of "the constant exists and
-  nothing writes it" were false — two sites already minted sentinels by hand, and the
+  nothing writes it" were false -- two sites already minted sentinels by hand, and the
   missing thing was the REFUSAL in four of the five comparisons.
 
   **Fixing it made the second arm vacuous on this document**, because with every entry
@@ -442,14 +442,14 @@ true until the next version shipped.
   two-entry fixture where moving the open entry's id into section 2 must be named, with
   the clean control beside it.
 
-  The totals do not move — 28 refused, 44 not refused, 72 named — because the mode was
+  The totals do not move -- 28 refused, 44 not refused, 72 named -- because the mode was
   already counted as refused. Only the list that tells the next person what to do was
   wrong.
 
   **And 3.6 now records measured populations, so the next entry is chosen on evidence.**
   Section 5's new rule is that an entry must name a mode id, which makes WHICH id worth
   measuring. Four of 3.6's were counted by AST scan over the whole corpus:
-  `truthy-cursor-from-execute` has 7 sites and **all are benign** — every one is
+  `truthy-cursor-from-execute` has 7 sites and **all are benign** -- every one is
   `x = cur.execute(...)`, idiomatic in psycopg3, and **zero** branch on it, which is the
   dangerous form; `empty-query-string-succeeds` has 0; the multistatement mode has 1, a
   setup that fetches nothing with a `count(*)` premise right after it; and the
@@ -460,7 +460,7 @@ true until the next version shipped.
 
   One instrument defect of mine, caught by that fixture: the parser matched the
   SECTION HEADING as an entry. `re.split(r"^## ")` leaves a chunk beginning "5. What to
-  add next", which the numbered-item pattern also matches — inventing an entry 5 that
+  add next", which the numbered-item pattern also matches -- inventing an entry 5 that
   is the title and colliding with the real entry 5. The fixture reported 3 entries in a
   two-entry document, which is how it was found.
 

--- a/test/pytest/TESTS.md
+++ b/test/pytest/TESTS.md
@@ -840,6 +840,27 @@ many times.
 | `test_the_anchor_rule_drops_punctuation_and_keeps_underscores` | GitHub's derivation, on the heading the defect was found in |
 | `test_an_anchor_that_strips_the_underscores_is_caught` | the exact broken link that shipped, with a control |
 | `test_every_in_document_link_in_this_directory_reaches_a_heading` | every contents-list link resolves, with a coverage premise |
+| `test_the_next_steps_list_is_anchored_to_the_inventory` | every section 5 entry names a mode id, so the entry can be checked at all |
+| `test_no_open_next_step_names_work_the_document_calls_done` | an un-struck entry whose id reached section 2 is stale work to do |
+| `test_a_stale_next_step_is_caught_on_a_fixture` | **removal proof**: the shape, planted, with the control beside it |
+
+
+**Section 5 was the last unchecked part of VACUITY_MODES.md, and it was wrong (#432).**
+1a, 2 and 3 are all compared against the ids on disk; "what to add next" was prose.
+Entry 1 still said *"the constant exists and nothing writes it"* long after
+`query_error()` existed and `test_failed_query_sentinel.py` had ten arms over it — the
+most expensive place in the document for a stale sentence, because its only reader is
+someone about to build something. The near-miss one document over is the argument: a
+bad enumeration of `test/selftest/340` made an existing block look like a gap, and the
+duplicate was written and proven to discriminate before anyone noticed.
+
+**What is checkable is the anchor, not the work.** Entry 1's work landed under four
+test names, none of them the one the entry proposed, so asking whether the NAMED test
+exists would have passed and said nothing. So the arms check that every entry names a
+mode id, and that no un-struck entry names an id section 2 already claims.
+
+With every entry now struck, the second arm has nothing to refuse on the real
+document. That is what the fixture arm is for.
 
 The five fixture arms exist because everything above them passes on a healthy tree,
 which is exactly what a guard that does nothing also does. They run the identical

--- a/test/pytest/VACUITY_MODES.md
+++ b/test/pytest/VACUITY_MODES.md
@@ -297,6 +297,27 @@ binds the exception and the body pins its SQLSTATE. See section 2.
 - `executemany-returning-fetchall-sees-only-the-first-batch`,
   `server-cursor-rowcount-is-not-a-row-count`, `empty-query-string-succeeds`
 
+**MEASURED POPULATIONS, so the next entry is chosen on evidence (#432).** Section 5's
+new rule is that an entry must name a mode id, which makes *which* id worth measuring
+rather than guessing. Four of 3.6's were counted over the whole corpus by AST scan:
+
+| mode | sites | what they are |
+| --- | ---: | --- |
+| `truthy-cursor-from-execute` | 7 | **all benign.** Every one is `x = cur.execute(...)`, which is idiomatic psycopg3 — `execute` returns the cursor. **Zero** branch on it (`if`, `while`, `assert`), which is the dangerous form. |
+| `empty-query-string-succeeds` | 0 | no `execute()` on an empty or whitespace literal anywhere. |
+| `multistatement-execute-positions-on-the-first-result` | 1 | `test_saop_element_pushdown.py`, a three-statement SETUP that fetches nothing. The arm immediately after asserts `count(*) = 40000`, so the INSERT is proven to have run. |
+| `server-cursor-rowcount-is-not-a-row-count` | 2 | **both legitimate.** A `DELETE`'s `rowcount` with an `at_least` premise on it, and a field on a stub cursor class. |
+
+**So all four are prospective.** A guard for any of them would be insurance against a
+shape the corpus has not yet written, not a closure of one it has — and it should say
+so, the way `test_the_empty_plan_refusal_precedes_the_arms_it_protects` does.
+
+That is not an argument against writing them. It is an argument against writing them
+and calling the mode closed: the counting rule in 1a treats section 2 as "refused
+today", and a refusal with no population has not refused anything yet. The cheapest of
+the four is the branching form of the first, because the dangerous spelling is distinct
+from the benign one and a planted fixture separates them in two lines.
+
 The enumerating agent's own summary is worth keeping: psycopg **fixes** the half of
 issue #418 where an error read as empty, because a failed statement raises and `[]`
 can only mean zero rows. That improvement is exactly what will tempt a port to drop

--- a/test/pytest/VACUITY_MODES.md
+++ b/test/pytest/VACUITY_MODES.md
@@ -354,8 +354,18 @@ exit 4, and no tests run at all.
 
 Each entry names the red test to write first.
 
-1. `test_expect_query_error_sentinel_is_unique_per_failure` — make something produce
-   `QUERY_ERROR.<seq>`; the constant exists and nothing writes it.
+1. ~~`test_expect_query_error_sentinel_is_unique_per_failure` — closes
+   `error-swallowed-to-empty`.~~ **Done, and this entry was wrong about the gap.** It
+   said "the constant exists and nothing writes it", and both halves were false:
+   `test_hilbert_locality.py` already minted sentinels by hand, one of them from inside
+   SQL, and the thing actually missing was not a producer but the REFUSAL in four of the
+   five comparisons — `expect.text`, `rows`, `row_set` and `ordered_rows` each passed
+   with a sentinel on both sides, and only `expect.hash` refused. 3.2 records that
+   measurement rather than quietly replacing it. `query_error()` now mints a value
+   unique per occurrence, as `lib.sh`'s `QUERY_ERROR.$seq` does, and
+   `test_failed_query_sentinel.py` holds ten arms over it — including the producer's
+   uniqueness and the constant's NON-uniqueness, which is the reason the producer
+   exists at all.
 2. ~~`test_layer_requires_a_write_to_have_written` — closes `insert-wrote-no-rows`.~~
    **Done**, and in two files rather than one, because it is two properties. The
    refusal and the tag-versus-count classification live in
@@ -381,9 +391,33 @@ Each entry names the red test to write first.
    remains, measured: a comprehension or a tuple instead of a `for`, and a helper defined
    in another file. Both are ordinary Python. The refused count therefore did not move.
 
-The three that turned a whole run green rather than one test are done. What remains
-is per-assertion work, so the ordering matters less: take the sentinel first, since
-the constant already exists and nothing writes it.
+**Every entry on this list is now struck, and the list is checked (#432).** Section 5
+was the one part of this document with no mechanism: 1a, 2 and 3 are all compared
+against the ids on disk, and this was prose. Entry 1 stayed wrong long after the work
+landed, which is the most expensive place in the document for a stale sentence — its
+only reader is someone about to build something.
+
+Two arms in `test_docs_cover_the_corpus.py` hold it now:
+
+- every entry names at least one mode id, so it is tied to the inventory at all.
+  Entry 1 named none, which is exactly how it stayed wrong: there was nothing to
+  check it against.
+- no UN-STRUCK entry names an id section 2 already claims as refused. An entry whose
+  id has reached section 2 is done by this document's own accounting, whatever the
+  test ended up being called.
+
+**What is not checkable, stated rather than implied.** "Has this work been done" is not
+mechanical — entry 1's work landed under four test names, none of them the one the
+entry proposed, so asking whether the NAMED test exists would have passed and said
+nothing. The id is the only durable anchor.
+
+And with every entry struck, the second arm has nothing to refuse on this document, so
+it is the planted fixture beside it that keeps it honest: a two-entry document where
+moving the open entry's id into section 2 must be caught. A sweep over an empty
+population reports the same clean answer as a correct one.
+
+When the next mode is taken, add it here with its id, un-struck, and the arms will
+hold the entry to the inventory from then on.
 
 ## 6. What this document cannot tell you
 

--- a/test/pytest/test_docs_cover_the_corpus.py
+++ b/test/pytest/test_docs_cover_the_corpus.py
@@ -655,3 +655,118 @@ def test_every_in_document_link_in_this_directory_reaches_a_heading(expect):
                     f"every in-document link in {doc.name} reaches a heading")
     expect.at_least(total_links, 15,
                     "premise: and it parsed links rather than finding none")
+
+
+# ---------------------------------------------------------------------------
+# Section 5's "what to add next" list must not name work that is already done.
+#
+# WHY. Section 5 is the one part of this document whose only reader is someone about
+# to BUILD something, and it is the only part with no mechanism. Sections 1a, 2 and 3
+# are all checked against the ids on disk; section 5 was prose. Entry 1 said "the
+# constant exists and nothing writes it" long after `query_error()` existed and
+# `test_failed_query_sentinel.py` had ten arms over it, so the next person to take the
+# list would have built something that was already there.
+#
+# THAT ALMOST HAPPENED FOR REAL, one document over. A bad enumeration of
+# `test/selftest/340` made an existing block look like a coverage gap, and the
+# duplicate was written and proven to discriminate before the duplication was noticed
+# (#432). A stale "what to add next" is the same defect with the wrong answer written
+# down in advance.
+#
+# WHAT IS CHECKABLE, and what is not. "Has this work been done" is not mechanical:
+# entry 1's work landed under four different test names, so asking whether the NAMED
+# test exists would have passed and said nothing. What is mechanical is the anchor:
+#
+#   * every entry names at least one mode id, so it is tied to the inventory at all
+#   * an un-struck entry's ids are in section 3 (not refused) and NOT in section 2
+#
+# An entry whose id has reached section 2 is done by the document's own accounting,
+# whatever it is called in the corpus. And an entry naming no id cannot be checked
+# against anything, which is how entry 1 stayed wrong.
+# ---------------------------------------------------------------------------
+
+_NEXT_ITEM = re.compile(r"^(\d+)\. (.*?)(?=^\d+\. |\Z)", re.M | re.S)
+
+
+def _next_steps_entries(text):
+    """-> [(number, struck, {mode ids})] for section 5's numbered list."""
+    body = ""
+    for chunk in re.split(r"^## ", text, flags=re.M):
+        if chunk.startswith("5."):
+            # DROP THE HEADING LINE. The section is "## 5. What to add next", and with
+            # the "## " split away the heading itself begins "5. " at the start of the
+            # string -- which the item pattern matches, inventing an entry 5 that is
+            # the title. It collided with the real entry 5 and reported 3 items in a
+            # two-item fixture, which is how it was caught.
+            body = chunk.split("\n", 1)[1] if "\n" in chunk else ""
+            break
+    out = []
+    for m in _NEXT_ITEM.finditer(body):
+        item = m.group(2)
+        out.append((int(m.group(1)), "~~" in item, set(MODE_ID.findall(item))))
+    return out
+
+
+def test_the_next_steps_list_is_anchored_to_the_inventory(expect):
+    """Every entry names a mode id, so the entry can be checked at all."""
+    entries = _next_steps_entries(MODES_DOC.read_text())
+    expect.at_least(len(entries), 4, "premise: the list was parsed, not missed")
+    unanchored = sorted(n for n, _struck, ids in entries if not ids)
+    expect.text(", ".join(str(n) for n in unanchored) or "none", "none",
+                "every entry in section 5 names at least one mode id")
+
+
+def test_no_open_next_step_names_work_the_document_calls_done(expect):
+    """An un-struck entry whose id has reached section 2 is stale.
+
+    Section 2 is "refused today". An entry still listed as work to do, naming an id
+    the document itself has moved into section 2, sends the next reader to build
+    something this document says exists.
+    """
+    refused, not_refused, _ = _named_modes_in(MODES_DOC.read_text())
+    entries = _next_steps_entries(MODES_DOC.read_text())
+    expect.at_least(len(refused), 20, "premise: section 2's ids were found")
+
+    stale = sorted(
+        "%d:%s" % (n, i)
+        for n, struck, ids in entries if not struck
+        for i in sorted(ids) if i in refused
+    )
+    expect.text(", ".join(stale) or "none", "none",
+                "no open entry names an id section 2 already claims as refused")
+
+
+def test_a_stale_next_step_is_caught_on_a_fixture(expect):
+    """The removal proof, on a document built to be wrong — and its control.
+
+    Without the control, a parser that finds no entries reports the same clean
+    answer as a correct list.
+    """
+    doc = (
+        "## 1a. Counting\n\n"
+        "## 2. Refused\n\n`one-two-three` is refused.\n\n"
+        "## 3. Not refused\n\n`four-five-six` is not.\n\n"
+        "## 5. What to add next, in order\n\n"
+        "1. `write_something` — closes `four-five-six`.\n"
+        "2. ~~`write_other` — closes `one-two-three`.~~ **Done.**\n"
+    )
+    entries = _next_steps_entries(doc)
+    expect.num(len(entries), 2, "premise: both fixture entries were parsed")
+    expect.text(repr([(n, st) for n, st, _ in entries]), "[(1, False), (2, True)]",
+                "and the strike-through is what marks one done")
+
+    refused, _, _ = _named_modes_in(doc)
+    stale = ["%d:%s" % (n, i) for n, st, ids in entries if not st
+             for i in sorted(ids) if i in refused]
+    expect.text(", ".join(stale) or "none", "none",
+                "control: the open entry names an UNrefused id, so it is not stale")
+
+    # Now move the open entry's id into section 2, which is what "done" looks like.
+    moved = doc.replace("`four-five-six` is not.", "moved away.").replace(
+        "`one-two-three` is refused.", "`one-two-three` and `four-five-six` are refused.")
+    refused2, _, _ = _named_modes_in(moved)
+    entries2 = _next_steps_entries(moved)
+    stale2 = ["%d:%s" % (n, i) for n, st, ids in entries2 if not st
+              for i in sorted(ids) if i in refused2]
+    expect.text(", ".join(stale2), "1:four-five-six",
+                "and an open entry whose id reached section 2 is named")


### PR DESCRIPTION
Wave 2's list is finished, and closing it out found the list itself was wrong.

`VACUITY_MODES.md` sections 1a, 2 and 3 are all compared against the mode ids on disk. **Section 5 — the ordered list of what to build next — was prose**, and entry 1 still read:

> 1. `test_expect_query_error_sentinel_is_unique_per_failure` — make something produce `QUERY_ERROR.<seq>`; the constant exists and nothing writes it.

long after `query_error()` existed and `test_failed_query_sentinel.py` carried **ten arms** over it, including the producer's uniqueness and the constant's non-uniqueness that is the reason the producer exists.

## Why this is the worst place in the document for a stale sentence

Its only reader is someone about to build something. The near-miss one document over, earlier today, is exactly what that costs: a bad enumeration of `test/selftest/340` made an existing block look like a coverage gap, and I wrote a duplicate of it — and proved it discriminated against a mutation — before noticing the duplication.

A stale "what to add next" is that same defect with the wrong answer written down in advance, for the next person.

## What is checkable is the anchor, not the work

Entry 1's work landed under four test names, **none of them the one the entry proposed**, so asking whether the named test exists would have passed and said nothing. That is the trap in the obvious guard. Two arms hold the list instead:

- **every entry names at least one mode id**, so it is tied to the inventory at all. Entry 1 named none, which is precisely how it stayed wrong — there was nothing to check it against.
- **no un-struck entry names an id section 2 already claims as refused.** An entry whose id has reached section 2 is done by the document's own accounting, whatever the test ended up being called.

Entry 1 is now struck and anchored to `error-swallowed-to-empty`, and it **records what the entry got wrong rather than replacing it** — both halves of "the constant exists and nothing writes it" were false: two sites already minted sentinels by hand, one from inside SQL, and the thing actually missing was the refusal in four of the five comparisons.

## Fixing it made my own arm vacuous, and the document says so

With every entry struck there is nothing left for the second arm to refuse on the real document. So the planted fixture beside it is the whole of its evidence: a two-entry document where moving the open entry's id into section 2 must be named, with the clean control beside it.

That is written into section 5 rather than left implied. **An arm that is vacuous today and load-bearing after the next edit should say which it is** — otherwise the next reader sees a green arm and assumes it is holding something.

It is also the general answer to a question raised on #949 today: a static sweep has two absences, "did it run" and "did it do anything", and only the first has a natural premise. A correct tree and a broken pattern produce the identical clean answer, so the control for the second is a fixture built to be wrong and asserted to be caught, with a control built to be right beside it.

## The totals do not move

28 refused, 44 not refused, 72 named — all three still matching what 1a states, because the mode was already counted as refused. **Only the list telling the next person what to do was wrong**, which is why no count changed and nothing reddened for months.

## One instrument defect of mine

The parser matched the section **heading** as an entry. `re.split(r"^## ")` leaves a chunk beginning `5. What to add next`, which the numbered-item pattern also matches — inventing an entry 5 that is the title, colliding with the real entry 5. The fixture arm reported 3 entries in a two-entry document, which is how it was found. The fixture caught the parser before the parser could mis-report the document.

## Gate

pg18a (assert):

```
harness_selftest.sh     757 checks run, 0 FAIL
driver-free pytest      210 passed   <- 207 plus these three
full pytest corpus      295 passed
section 1a totals       28/28, 44/44, 72/72 against the ids on disk
```

No shell check changed, so `check_ledger.tsv` and its census are untouched.

Based on main `3d42c682`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf6UoeBRZYLQZa4KxNiw8a
