### PR TITLE
test: the ten suites that recorded nothing now record their checks (#965, 10 of 10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1445,6 +1445,35 @@ true until the next version shipped.
   The refusal on a changed source had never been exercised by anyone before this
   change, only read. It is now driven end to end, along with the three other states.
 
+- `smoke.sh` records its checks, so the ledger can see them (#965).
+
+  Ten registered suites print their own `PASS <name>: <value>` lines and their own
+  verdict and emit no machine-readable records at all. Counted across the ten, 293
+  checks were invisible to every mechanism built on that vocabulary: the ledger, the
+  census, the count of checks never observed red, the red-observation record, and the
+  duplicate-name detection. They pass, and nothing that reads records can see them.
+
+  This converts the first of the ten. Its nine checks now emit a record each and a
+  total, measured on PG18: nine records where there were none, and `checks run: 9`
+  where there was no total.
+
+  The human output is unchanged, byte for byte. `pgc_record` takes the display whole,
+  so each line still reads `PASS  count(*): 100000` with the measured value rather
+  than a label. That value is the comparison, not a message, which is why the local
+  helper records through `pgc_record` rather than delegating to `lib.sh`'s own
+  `check` -- the latter composes its own display and would drop the value.
+
+  The suite's own verdict line stays, and so does its exit logic. That line is
+  load-bearing until a reconciliation replaces it: `smoke.sh` runs under
+  `set -euo pipefail`, so a failing command aborts it, and the verdict is what
+  distinguishes a suite that finished from one that stopped. Removing it in the same
+  change would make the suite report less than it did before.
+
+  It does not add the suite to the ledger. Making a suite coverable and covering it
+  are separate decisions, and the second one is blocked on a measurement: check NAMES
+  differ between majors in at least one suite, the ledger has no major dimension, and
+  a gate seeded from one major would refuse runs on another.
+
 ## [1.0-alpha3] - 2026-09-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1480,9 +1480,10 @@ true until the next version shipped.
   `set -uo pipefail`, and the case was reported nowhere at all. It now emits a SKIP
   record with its reason.
 
-  Fifty-seven checks across four of the suites are still not recorded, because those
-  suites have further check-like helpers of their own -- `eq_on_off` in `phase6`
-  alone accounts for thirty-nine -- each printing its own display. Those need a
+  Fifty-eight checks across four of the suites are still not recorded -- fifty-eight
+  on PG18 and fifty-seven on PG16, because one of them sits behind a version gate --
+  since those suites have further check-like helpers of their own, `eq_on_off` in
+  `phase6` alone accounting for thirty-nine, each printing its own display. Those need a
   second pass rather than the same substitution, and the count in #965 should be read
   as the number of checks rather than the number of helpers.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1445,7 +1445,7 @@ true until the next version shipped.
   The refusal on a changed source had never been exercised by anyone before this
   change, only read. It is now driven end to end, along with the three other states.
 
-- `smoke.sh` records its checks, so the ledger can see them (#965).
+- The ten suites that recorded nothing now record their checks (#965).
 
   Ten registered suites print their own `PASS <name>: <value>` lines and their own
   verdict and emit no machine-readable records at all. Counted across the ten, 293
@@ -1468,6 +1468,23 @@ true until the next version shipped.
   `set -euo pipefail`, so a failing command aborts it, and the verdict is what
   distinguishes a suite that finished from one that stopped. Removing it in the same
   change would make the suite report less than it did before.
+
+  This converts nine more of the ten, the same way, after the shape was reviewed on
+  the first. Measured on PG18: 227 records where there were none, and every suite's
+  human output byte-for-byte unchanged.
+
+  It also fixes a call that was failing silently. `unique_conc.sh` calls `check_skip`
+  for the case where the citext extension is absent, and that function lives in
+  `lib.sh`, which the suite did not source -- so the baseline log carries
+  `line 392: check_skip: command not found`, the suite continued under
+  `set -uo pipefail`, and the case was reported nowhere at all. It now emits a SKIP
+  record with its reason.
+
+  Fifty-seven checks across four of the suites are still not recorded, because those
+  suites have further check-like helpers of their own -- `eq_on_off` in `phase6`
+  alone accounts for thirty-nine -- each printing its own display. Those need a
+  second pass rather than the same substitution, and the count in #965 should be read
+  as the number of checks rather than the number of helpers.
 
   It does not add the suite to the ledger. Making a suite coverable and covering it
   are separate decisions, and the second one is blocked on a measurement: check NAMES

--- a/test/audit.sh
+++ b/test/audit.sh
@@ -67,7 +67,10 @@ trap 'rc=$?; if [ "$AUDIT_REACHED_END" = 0 ]; then
 	echo "The checks after the failing command did not run.";
 fi' EXIT
 
-. "$(dirname "${BASH_SOURCE[0]}")/portlib.sh"
+# lib.sh for the check vocabulary (#965). It sources portlib.sh itself
+# (lib.sh:110), so this is a superset of what was here, and its top level is
+# assignments and function definitions only, so sourcing it starts nothing.
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 PG_CONFIG="${1:-/usr/local/pg17/bin/pg_config}"
 BINDIR="$("$PG_CONFIG" --bindir)"
@@ -119,12 +122,32 @@ PSQL="psql -p $PORT -d audit -qAtX -v ON_ERROR_STOP=1"
 q() { run_pg "$PSQL -c \"$1\""; }
 
 fail=0
+# RECORDS RATHER THAN ONLY PRINTING (#965). This suite emitted human PASS lines
+# and no RESULT records, so every mechanism built on the record vocabulary -- the
+# ledger, the census, checks_never_observed_red, the red-observation record,
+# duplicate-name detection -- was blind to all of them. The ledger did not merely
+# return nothing on this log, it REFUSED it: "no RESULT records, so there is
+# nothing to reconcile".
+#
+# `pgc_record` takes the DISPLAY whole, so the human output below is byte-for-byte
+# what it was. NOT lib.sh's own `check`: that composes its own display and would
+# drop the `: $got` suffix, which is the measured value rather than a label.
+#
+# `fail` is still set, so this suite's exit logic is untouched. Its verdict line
+# stays for the same reason: under `set -euo pipefail` a failing command aborts the
+# suite, and the verdict is what distinguishes finished from stopped.
+#
+# The `checks run:` line is READ BY NOTHING YET. The matrix gates reconciliation on
+# the ACCOUNTING line via `pgc_log_shows_accounting`, and this suite emits none
+# because it emits no accounting line. The line is still correct and wanted --
+# it is the total the records reconcile against -- so the remaining step is a gate
+# flip rather than new work (@jdatcmd, #969 review).
 check() {
 	local name="$1" got="$2" want="$3"
 	if [ "$got" = "$want" ]; then
-		echo "PASS  $name: $got"
+		pgc_record PASS "$name" "PASS  $name: $got"
 	else
-		echo "FAIL  $name: got [$got] want [$want]"
+		pgc_record FAIL "$name" "FAIL  $name: got [$got] want [$want]"
 		fail=1
 	fi
 }
@@ -389,8 +412,10 @@ q "DROP TABLE ss_dup;" >/dev/null
 echo
 AUDIT_REACHED_END=1
 if [ "$fail" = "0" ]; then
+	echo "checks run: $PGC_CHECKS"
 	echo "AUDIT TEST PASSED"
 else
+	echo "checks run: $PGC_CHECKS"
 	echo "AUDIT TEST FAILED"
 	echo "---- server log tail ----"
 	run_pg "tail -30 '$LOGFILE'" || true

--- a/test/concurrency.sh
+++ b/test/concurrency.sh
@@ -47,7 +47,10 @@
 
 # portlib.sh alone, not lib.sh: this suite carries its own harness, and the port
 # band is needed before any of it runs. Sourcing portlib twice is harmless.
-. "$(dirname "${BASH_SOURCE[0]}")/portlib.sh"
+# lib.sh for the check vocabulary (#965). It sources portlib.sh itself
+# (lib.sh:110), so this is a superset of what was here, and its top level is
+# assignments and function definitions only, so sourcing it starts nothing.
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 set -uo pipefail
 
@@ -168,12 +171,32 @@ SPSQL="psql -h '$WORKDIR' -p $PORT -d conc -qAtX"
 ctl_q() { run_pg "$PSQL -c \"$1\""; }
 
 fail=0
+# RECORDS RATHER THAN ONLY PRINTING (#965). This suite emitted human PASS lines
+# and no RESULT records, so every mechanism built on the record vocabulary -- the
+# ledger, the census, checks_never_observed_red, the red-observation record,
+# duplicate-name detection -- was blind to all of them. The ledger did not merely
+# return nothing on this log, it REFUSED it: "no RESULT records, so there is
+# nothing to reconcile".
+#
+# `pgc_record` takes the DISPLAY whole, so the human output below is byte-for-byte
+# what it was. NOT lib.sh's own `check`: that composes its own display and would
+# drop the `: $got` suffix, which is the measured value rather than a label.
+#
+# `fail` is still set, so this suite's exit logic is untouched. Its verdict line
+# stays for the same reason: under `set -euo pipefail` a failing command aborts the
+# suite, and the verdict is what distinguishes finished from stopped.
+#
+# The `checks run:` line is READ BY NOTHING YET. The matrix gates reconciliation on
+# the ACCOUNTING line via `pgc_log_shows_accounting`, and this suite emits none
+# because it emits no accounting line. The line is still correct and wanted --
+# it is the total the records reconcile against -- so the remaining step is a gate
+# flip rather than new work (@jdatcmd, #969 review).
 check() {
 	local name="$1" got="$2" want="$3"
 	if [ "$got" = "$want" ]; then
-		echo "PASS  $name: $got"
+		pgc_record PASS "$name" "PASS  $name: $got"
 	else
-		echo "FAIL  $name: got [$got] want [$want]"
+		pgc_record FAIL "$name" "FAIL  $name: got [$got] want [$want]"
 		fail=1
 	fi
 }
@@ -369,8 +392,10 @@ send s2 "\\q"
 
 echo
 if [ "$fail" = 0 ]; then
+	echo "checks run: $PGC_CHECKS"
 	echo "CONCURRENCY TEST PASSED"
 else
+	echo "checks run: $PGC_CHECKS"
 	echo "CONCURRENCY TEST FAILED"
 fi
 exit "$fail"

--- a/test/phase2.sh
+++ b/test/phase2.sh
@@ -15,7 +15,10 @@
 
 set -euo pipefail
 
-. "$(dirname "${BASH_SOURCE[0]}")/portlib.sh"
+# lib.sh for the check vocabulary (#965). It sources portlib.sh itself
+# (lib.sh:110), so this is a superset of what was here, and its top level is
+# assignments and function definitions only, so sourcing it starts nothing.
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 PG_CONFIG="${1:-/usr/local/pg17/bin/pg_config}"
 BINDIR="$("$PG_CONFIG" --bindir)"
@@ -68,12 +71,32 @@ q() { run_pg "$PSQL -c \"$1\""; }
 qq() { run_pg "$PSQL -c \"$1\"" | tr '\n' ',' ; }
 
 fail=0
+# RECORDS RATHER THAN ONLY PRINTING (#965). This suite emitted human PASS lines
+# and no RESULT records, so every mechanism built on the record vocabulary -- the
+# ledger, the census, checks_never_observed_red, the red-observation record,
+# duplicate-name detection -- was blind to all of them. The ledger did not merely
+# return nothing on this log, it REFUSED it: "no RESULT records, so there is
+# nothing to reconcile".
+#
+# `pgc_record` takes the DISPLAY whole, so the human output below is byte-for-byte
+# what it was. NOT lib.sh's own `check`: that composes its own display and would
+# drop the `: $got` suffix, which is the measured value rather than a label.
+#
+# `fail` is still set, so this suite's exit logic is untouched. Its verdict line
+# stays for the same reason: under `set -euo pipefail` a failing command aborts the
+# suite, and the verdict is what distinguishes finished from stopped.
+#
+# The `checks run:` line is READ BY NOTHING YET. The matrix gates reconciliation on
+# the ACCOUNTING line via `pgc_log_shows_accounting`, and this suite emits none
+# because it emits no accounting line. The line is still correct and wanted --
+# it is the total the records reconcile against -- so the remaining step is a gate
+# flip rather than new work (@jdatcmd, #969 review).
 check() {
 	local name="$1" got="$2" want="$3"
 	if [ "$got" = "$want" ]; then
-		echo "PASS  $name: $got"
+		pgc_record PASS "$name" "PASS  $name: $got"
 	else
-		echo "FAIL  $name: got [$got] want [$want]"
+		pgc_record FAIL "$name" "FAIL  $name: got [$got] want [$want]"
 		fail=1
 	fi
 }
@@ -193,8 +216,10 @@ check "orphan chunks"     "$(q 'SELECT count(*) FROM pgcolumnar.column_chunk;')"
 
 echo
 if [ "$fail" = "0" ]; then
+	echo "checks run: $PGC_CHECKS"
 	echo "PHASE 2 TEST PASSED"
 else
+	echo "checks run: $PGC_CHECKS"
 	echo "PHASE 2 TEST FAILED"
 	echo "---- server log tail ----"
 	run_pg "tail -40 '$LOGFILE'" || true

--- a/test/phase3.sh
+++ b/test/phase3.sh
@@ -17,7 +17,10 @@
 
 set -euo pipefail
 
-. "$(dirname "${BASH_SOURCE[0]}")/portlib.sh"
+# lib.sh for the check vocabulary (#965). It sources portlib.sh itself
+# (lib.sh:110), so this is a superset of what was here, and its top level is
+# assignments and function definitions only, so sourcing it starts nothing.
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 PG_CONFIG="${1:-/usr/local/pg17/bin/pg_config}"
 BINDIR="$("$PG_CONFIG" --bindir)"
@@ -77,12 +80,32 @@ q() { run_pg "$PSQL" <<<"$1"; }
 qq() { run_pg "$PSQL" <<<"$1" | tr '\n' ',' ; }
 
 fail=0
+# RECORDS RATHER THAN ONLY PRINTING (#965). This suite emitted human PASS lines
+# and no RESULT records, so every mechanism built on the record vocabulary -- the
+# ledger, the census, checks_never_observed_red, the red-observation record,
+# duplicate-name detection -- was blind to all of them. The ledger did not merely
+# return nothing on this log, it REFUSED it: "no RESULT records, so there is
+# nothing to reconcile".
+#
+# `pgc_record` takes the DISPLAY whole, so the human output below is byte-for-byte
+# what it was. NOT lib.sh's own `check`: that composes its own display and would
+# drop the `: $got` suffix, which is the measured value rather than a label.
+#
+# `fail` is still set, so this suite's exit logic is untouched. Its verdict line
+# stays for the same reason: under `set -euo pipefail` a failing command aborts the
+# suite, and the verdict is what distinguishes finished from stopped.
+#
+# The `checks run:` line is READ BY NOTHING YET. The matrix gates reconciliation on
+# the ACCOUNTING line via `pgc_log_shows_accounting`, and this suite emits none
+# because it emits no accounting line. The line is still correct and wanted --
+# it is the total the records reconcile against -- so the remaining step is a gate
+# flip rather than new work (@jdatcmd, #969 review).
 check() {
 	local name="$1" got="$2" want="$3"
 	if [ "$got" = "$want" ]; then
-		echo "PASS  $name: $got"
+		pgc_record PASS "$name" "PASS  $name: $got"
 	else
-		echo "FAIL  $name: got [$got] want [$want]"
+		pgc_record FAIL "$name" "FAIL  $name: got [$got] want [$want]"
 		fail=1
 	fi
 }
@@ -217,8 +240,10 @@ check "row group cleaned" "$(q 'SELECT count(*) FROM pgcolumnar.row_group;')" "0
 
 echo
 if [ "$fail" = "0" ]; then
+	echo "checks run: $PGC_CHECKS"
 	echo "PHASE 3 TEST PASSED"
 else
+	echo "checks run: $PGC_CHECKS"
 	echo "PHASE 3 TEST FAILED"
 	echo "---- server log tail ----"
 	run_pg "tail -40 '$LOGFILE'" || true

--- a/test/phase4.sh
+++ b/test/phase4.sh
@@ -20,7 +20,10 @@
 
 set -euo pipefail
 
-. "$(dirname "${BASH_SOURCE[0]}")/portlib.sh"
+# lib.sh for the check vocabulary (#965). It sources portlib.sh itself
+# (lib.sh:110), so this is a superset of what was here, and its top level is
+# assignments and function definitions only, so sourcing it starts nothing.
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 PG_CONFIG="${1:-/usr/local/pg17/bin/pg_config}"
 BINDIR="$("$PG_CONFIG" --bindir)"
@@ -74,12 +77,32 @@ q() { run_pg "$PSQL -c \"$1\""; }
 qq() { run_pg "$PSQL -c \"$1\"" | tr '\n' ',' ; }
 
 fail=0
+# RECORDS RATHER THAN ONLY PRINTING (#965). This suite emitted human PASS lines
+# and no RESULT records, so every mechanism built on the record vocabulary -- the
+# ledger, the census, checks_never_observed_red, the red-observation record,
+# duplicate-name detection -- was blind to all of them. The ledger did not merely
+# return nothing on this log, it REFUSED it: "no RESULT records, so there is
+# nothing to reconcile".
+#
+# `pgc_record` takes the DISPLAY whole, so the human output below is byte-for-byte
+# what it was. NOT lib.sh's own `check`: that composes its own display and would
+# drop the `: $got` suffix, which is the measured value rather than a label.
+#
+# `fail` is still set, so this suite's exit logic is untouched. Its verdict line
+# stays for the same reason: under `set -euo pipefail` a failing command aborts the
+# suite, and the verdict is what distinguishes finished from stopped.
+#
+# The `checks run:` line is READ BY NOTHING YET. The matrix gates reconciliation on
+# the ACCOUNTING line via `pgc_log_shows_accounting`, and this suite emits none
+# because it emits no accounting line. The line is still correct and wanted --
+# it is the total the records reconcile against -- so the remaining step is a gate
+# flip rather than new work (@jdatcmd, #969 review).
 check() {
 	local name="$1" got="$2" want="$3"
 	if [ "$got" = "$want" ]; then
-		echo "PASS  $name: $got"
+		pgc_record PASS "$name" "PASS  $name: $got"
 	else
-		echo "FAIL  $name: got [$got] want [$want]"
+		pgc_record FAIL "$name" "FAIL  $name: got [$got] want [$want]"
 		fail=1
 	fi
 }
@@ -244,8 +267,10 @@ assert_plan_seq
 
 echo
 if [ "$fail" = "0" ]; then
+	echo "checks run: $PGC_CHECKS"
 	echo "PHASE 4 TEST PASSED"
 else
+	echo "checks run: $PGC_CHECKS"
 	echo "PHASE 4 TEST FAILED"
 	echo "---- server log tail ----"
 	run_pg "tail -60 '$LOGFILE'" || true

--- a/test/phase5.sh
+++ b/test/phase5.sh
@@ -23,7 +23,10 @@
 
 set -euo pipefail
 
-. "$(dirname "${BASH_SOURCE[0]}")/portlib.sh"
+# lib.sh for the check vocabulary (#965). It sources portlib.sh itself
+# (lib.sh:110), so this is a superset of what was here, and its top level is
+# assignments and function definitions only, so sourcing it starts nothing.
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 PG_CONFIG="${1:-/usr/local/pg17/bin/pg_config}"
 BINDIR="$("$PG_CONFIG" --bindir)"
@@ -76,12 +79,32 @@ PSQL="psql -p $PORT -d p5 -qAtX -v ON_ERROR_STOP=1"
 q() { run_pg "$PSQL -c \"$1\""; }
 
 fail=0
+# RECORDS RATHER THAN ONLY PRINTING (#965). This suite emitted human PASS lines
+# and no RESULT records, so every mechanism built on the record vocabulary -- the
+# ledger, the census, checks_never_observed_red, the red-observation record,
+# duplicate-name detection -- was blind to all of them. The ledger did not merely
+# return nothing on this log, it REFUSED it: "no RESULT records, so there is
+# nothing to reconcile".
+#
+# `pgc_record` takes the DISPLAY whole, so the human output below is byte-for-byte
+# what it was. NOT lib.sh's own `check`: that composes its own display and would
+# drop the `: $got` suffix, which is the measured value rather than a label.
+#
+# `fail` is still set, so this suite's exit logic is untouched. Its verdict line
+# stays for the same reason: under `set -euo pipefail` a failing command aborts the
+# suite, and the verdict is what distinguishes finished from stopped.
+#
+# The `checks run:` line is READ BY NOTHING YET. The matrix gates reconciliation on
+# the ACCOUNTING line via `pgc_log_shows_accounting`, and this suite emits none
+# because it emits no accounting line. The line is still correct and wanted --
+# it is the total the records reconcile against -- so the remaining step is a gate
+# flip rather than new work (@jdatcmd, #969 review).
 check() {
 	local name="$1" got="$2" want="$3"
 	if [ "$got" = "$want" ]; then
-		echo "PASS  $name: $got"
+		pgc_record PASS "$name" "PASS  $name: $got"
 	else
-		echo "FAIL  $name: got [$got] want [$want]"
+		pgc_record FAIL "$name" "FAIL  $name: got [$got] want [$want]"
 		fail=1
 	fi
 }
@@ -277,8 +300,10 @@ check "seq-scan fallback returns correct rows" \
 
 echo
 if [ "$fail" = "0" ]; then
+	echo "checks run: $PGC_CHECKS"
 	echo "PHASE 5 TEST PASSED"
 else
+	echo "checks run: $PGC_CHECKS"
 	echo "PHASE 5 TEST FAILED"
 	echo "---- server log tail ----"
 	run_pg "tail -60 '$LOGFILE'" || true

--- a/test/phase6.sh
+++ b/test/phase6.sh
@@ -27,7 +27,10 @@
 
 set -euo pipefail
 
-. "$(dirname "${BASH_SOURCE[0]}")/portlib.sh"
+# lib.sh for the check vocabulary (#965). It sources portlib.sh itself
+# (lib.sh:110), so this is a superset of what was here, and its top level is
+# assignments and function definitions only, so sourcing it starts nothing.
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 PG_CONFIG="${1:-/usr/local/pg17/bin/pg_config}"
 BINDIR="$("$PG_CONFIG" --bindir)"
@@ -80,12 +83,32 @@ PSQL="psql -p $PORT -d p6 -qAtX -v ON_ERROR_STOP=1"
 q() { run_pg "$PSQL -c \"$1\""; }
 
 fail=0
+# RECORDS RATHER THAN ONLY PRINTING (#965). This suite emitted human PASS lines
+# and no RESULT records, so every mechanism built on the record vocabulary -- the
+# ledger, the census, checks_never_observed_red, the red-observation record,
+# duplicate-name detection -- was blind to all of them. The ledger did not merely
+# return nothing on this log, it REFUSED it: "no RESULT records, so there is
+# nothing to reconcile".
+#
+# `pgc_record` takes the DISPLAY whole, so the human output below is byte-for-byte
+# what it was. NOT lib.sh's own `check`: that composes its own display and would
+# drop the `: $got` suffix, which is the measured value rather than a label.
+#
+# `fail` is still set, so this suite's exit logic is untouched. Its verdict line
+# stays for the same reason: under `set -euo pipefail` a failing command aborts the
+# suite, and the verdict is what distinguishes finished from stopped.
+#
+# The `checks run:` line is READ BY NOTHING YET. The matrix gates reconciliation on
+# the ACCOUNTING line via `pgc_log_shows_accounting`, and this suite emits none
+# because it emits no accounting line. The line is still correct and wanted --
+# it is the total the records reconcile against -- so the remaining step is a gate
+# flip rather than new work (@jdatcmd, #969 review).
 check() {
 	local name="$1" got="$2" want="$3"
 	if [ "$got" = "$want" ]; then
-		echo "PASS  $name: $got"
+		pgc_record PASS "$name" "PASS  $name: $got"
 	else
-		echo "FAIL  $name: got [$got] want [$want]"
+		pgc_record FAIL "$name" "FAIL  $name: got [$got] want [$want]"
 		fail=1
 	fi
 }
@@ -252,8 +275,10 @@ fi
 
 echo
 if [ "$fail" = "0" ]; then
+	echo "checks run: $PGC_CHECKS"
 	echo "PHASE 6 TEST PASSED"
 else
+	echo "checks run: $PGC_CHECKS"
 	echo "PHASE 6 TEST FAILED"
 	echo "---- server log tail ----"
 	run_pg "tail -60 '$LOGFILE'" || true

--- a/test/smoke.sh
+++ b/test/smoke.sh
@@ -122,7 +122,7 @@ fail=0
 # looking for the ACCOUNTING line -- `run_all_versions.sh` calls
 # `pgc_log_shows_accounting`, which greps for
 # `accounting: N passed + N failed + N unrunnable + N skipped = N` -- and this
-# suite emits none, because it does not call `pgc_summary`. Measured: 0 accounting
+# suite emits none, because it emits no accounting line. Measured: 0 accounting
 # lines here against 1 in any suite that does.
 #
 # The line is still correct and still wanted: it is the total the records

--- a/test/smoke.sh
+++ b/test/smoke.sh
@@ -115,6 +115,21 @@ fail=0
 # NOT lib.sh's own `check`: that composes its own display and would drop the
 # `: $got` suffix these lines carry, which is the measured value rather than a
 # label. The name and the value are both wanted.
+#
+# AND THE `checks run:` LINE BELOW IS READ BY NOTHING YET, which is worth saying
+# so the next conversion does not add it believing it wired something up
+# (@jdatcmd, #969 review). The matrix decides whether to reconcile a suite by
+# looking for the ACCOUNTING line -- `run_all_versions.sh` calls
+# `pgc_log_shows_accounting`, which greps for
+# `accounting: N passed + N failed + N unrunnable + N skipped = N` -- and this
+# suite emits none, because it does not call `pgc_summary`. Measured: 0 accounting
+# lines here against 1 in any suite that does.
+#
+# The line is still correct and still wanted: it is the total the records
+# reconcile against, and `pgc_reconcile_records` returns 0 on this log when driven
+# directly. So the remaining step is a gate flip rather than new work -- once
+# whatever replaces the verdict line emits the accounting line, reconciliation
+# starts working for all ten of these suites with no further change to them.
 check() {
 	local name="$1" got="$2" want="$3"
 	if [ "$got" = "$want" ]; then

--- a/test/smoke.sh
+++ b/test/smoke.sh
@@ -15,7 +15,10 @@
 
 set -euo pipefail
 
-. "$(dirname "${BASH_SOURCE[0]}")/portlib.sh"
+# lib.sh for the check vocabulary (#965). It sources portlib.sh itself
+# (lib.sh:110), so this is a superset of what was here. Its top level is
+# assignments and function definitions only, so sourcing it starts nothing.
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 PG_CONFIG="${1:-/usr/local/pg17/bin/pg_config}"
 BINDIR="$("$PG_CONFIG" --bindir)"
@@ -99,12 +102,25 @@ ORPHANS="$(run_pg "$PSQL -c \"SELECT count(*) FROM pgcolumnar.row_group;\"")"
 
 # ---- check -----------------------------------------------------------------
 fail=0
+# RECORDS RATHER THAN ONLY PRINTING (#965). This suite emitted nine human PASS
+# lines and no RESULT records, so every mechanism built on the record vocabulary --
+# the ledger, the census, checks_never_observed_red, the red-observation record,
+# duplicate-name detection -- was blind to all nine. Measured: 0 RESULT lines.
+#
+# `pgc_record` takes the DISPLAY whole, so the human output below is byte-for-byte
+# what it was. `fail` is still set, so this suite's own exit logic is untouched --
+# the verdict line it prints is load-bearing until `checks run:` reconciles, and
+# removing it in the same step would make the suite report less than it did before.
+#
+# NOT lib.sh's own `check`: that composes its own display and would drop the
+# `: $got` suffix these lines carry, which is the measured value rather than a
+# label. The name and the value are both wanted.
 check() {
 	local name="$1" got="$2" want="$3"
 	if [ "$got" = "$want" ]; then
-		echo "PASS  $name: $got"
+		pgc_record PASS "$name" "PASS  $name: $got"
 	else
-		echo "FAIL  $name: got [$got] want [$want]"
+		pgc_record FAIL "$name" "FAIL  $name: got [$got] want [$want]"
 		fail=1
 	fi
 }
@@ -125,8 +141,10 @@ check "native catalog tables" "$NATIVE_TABLES" "4"
 
 echo
 if [ "$fail" = "0" ]; then
+	echo "checks run: $PGC_CHECKS"
 	echo "SMOKE TEST PASSED"
 else
+	echo "checks run: $PGC_CHECKS"
 	echo "SMOKE TEST FAILED"
 	echo "---- server log tail ----"
 	run_pg "tail -30 '$LOGFILE'" || true

--- a/test/unique_conc.sh
+++ b/test/unique_conc.sh
@@ -54,7 +54,10 @@
 
 
 # Own harness rather than lib.sh; portlib carries the port band.
-. "$(dirname "${BASH_SOURCE[0]}")/portlib.sh"
+# lib.sh for the check vocabulary (#965). It sources portlib.sh itself
+# (lib.sh:110), so this is a superset of what was here, and its top level is
+# assignments and function definitions only, so sourcing it starts nothing.
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 set -uo pipefail
 
@@ -158,11 +161,31 @@ ctl_q() { run_pg "$PSQL -c \"$1\""; }
 ctl_qe() { run_pg "$SPSQL -c \"$1\" 2>&1"; }
 
 fail=0
+# RECORDS RATHER THAN ONLY PRINTING (#965). This suite emitted human PASS lines
+# and no RESULT records, so every mechanism built on the record vocabulary -- the
+# ledger, the census, checks_never_observed_red, the red-observation record,
+# duplicate-name detection -- was blind to all of them. The ledger did not merely
+# return nothing on this log, it REFUSED it: "no RESULT records, so there is
+# nothing to reconcile".
+#
+# `pgc_record` takes the DISPLAY whole, so the human output below is byte-for-byte
+# what it was. NOT lib.sh's own `check`: that composes its own display and would
+# drop the `: $got` suffix, which is the measured value rather than a label.
+#
+# `fail` is still set, so this suite's exit logic is untouched. Its verdict line
+# stays for the same reason: under `set -euo pipefail` a failing command aborts the
+# suite, and the verdict is what distinguishes finished from stopped.
+#
+# The `checks run:` line is READ BY NOTHING YET. The matrix gates reconciliation on
+# the ACCOUNTING line via `pgc_log_shows_accounting`, and this suite emits none
+# because it emits no accounting line. The line is still correct and wanted --
+# it is the total the records reconcile against -- so the remaining step is a gate
+# flip rather than new work (@jdatcmd, #969 review).
 check() {  # name got want
 	if [ "$2" = "$3" ]; then
-		echo "PASS  $1: $2"
+		pgc_record PASS "$1" "PASS  $1: $2"
 	else
-		echo "FAIL  $1: got [$2] want [$3]"
+		pgc_record FAIL "$1" "FAIL  $1: got [$2] want [$3]"
 		fail=1
 	fi
 }
@@ -563,8 +586,10 @@ send sh "\\q"
 
 echo
 if [ "$fail" = 0 ]; then
+	echo "checks run: $PGC_CHECKS"
 	echo "UNIQUE_CONC TEST PASSED"
 else
+	echo "checks run: $PGC_CHECKS"
 	echo "UNIQUE_CONC TEST FAILED"
 fi
 exit "$fail"

--- a/test/update_conc.sh
+++ b/test/update_conc.sh
@@ -63,7 +63,10 @@
 
 
 # Own harness rather than lib.sh; portlib carries the port band.
-. "$(dirname "${BASH_SOURCE[0]}")/portlib.sh"
+# lib.sh for the check vocabulary (#965). It sources portlib.sh itself
+# (lib.sh:110), so this is a superset of what was here, and its top level is
+# assignments and function definitions only, so sourcing it starts nothing.
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 set -uo pipefail
 
@@ -156,11 +159,31 @@ SPSQL="psql -h '$WORKDIR' -p $PORT -d upconc -qAtX"
 ctl_q() { run_pg "$PSQL -c \"$1\""; }
 
 fail=0
+# RECORDS RATHER THAN ONLY PRINTING (#965). This suite emitted human PASS lines
+# and no RESULT records, so every mechanism built on the record vocabulary -- the
+# ledger, the census, checks_never_observed_red, the red-observation record,
+# duplicate-name detection -- was blind to all of them. The ledger did not merely
+# return nothing on this log, it REFUSED it: "no RESULT records, so there is
+# nothing to reconcile".
+#
+# `pgc_record` takes the DISPLAY whole, so the human output below is byte-for-byte
+# what it was. NOT lib.sh's own `check`: that composes its own display and would
+# drop the `: $got` suffix, which is the measured value rather than a label.
+#
+# `fail` is still set, so this suite's exit logic is untouched. Its verdict line
+# stays for the same reason: under `set -euo pipefail` a failing command aborts the
+# suite, and the verdict is what distinguishes finished from stopped.
+#
+# The `checks run:` line is READ BY NOTHING YET. The matrix gates reconciliation on
+# the ACCOUNTING line via `pgc_log_shows_accounting`, and this suite emits none
+# because it emits no accounting line. The line is still correct and wanted --
+# it is the total the records reconcile against -- so the remaining step is a gate
+# flip rather than new work (@jdatcmd, #969 review).
 check() {  # name got want
 	if [ "$2" = "$3" ]; then
-		echo "PASS  $1: $2"
+		pgc_record PASS "$1" "PASS  $1: $2"
 	else
-		echo "FAIL  $1: got [$2] want [$3]"
+		pgc_record FAIL "$1" "FAIL  $1: got [$2] want [$3]"
 		fail=1
 	fi
 }
@@ -453,8 +476,10 @@ send s2 "\\q"
 
 echo
 if [ "$fail" = 0 ]; then
+	echo "checks run: $PGC_CHECKS"
 	echo "UPDATE CONCURRENCY TEST PASSED"
 else
+	echo "checks run: $PGC_CHECKS"
 	echo "UPDATE CONCURRENCY TEST FAILED"
 fi
 exit "$fail"


### PR DESCRIPTION
**First of the ten, sent on its own so the shape is reviewed before it is repeated nine times.** @jdatcmd — this is the review worth doing, not the tenth one.

## Measured, before and after, on PG18

```
RESULT lines         0  ->  9
checks run:     absent  ->  9
human PASS lines     9  ->  9   byte-for-byte identical
ledger merge   nothing  ->  9 rows recorded
```

The last line is the point: `pgc_ledger.py merge` now records this suite. Before, it could not see it at all.

```
RESULT  smoke  smoke  count(*)                PASS
RESULT  smoke  smoke  count where a<50        PASS
RESULT  smoke  smoke  order by a limit 3      PASS
...nine in all
```

## The three decisions in the shape, each for a measured reason

**The human output does not change.** These lines carry the measured value — `PASS  count(*): 100000` — which is the comparison, not a label. `lib.sh`'s own `check` composes its own display and would drop the `: $got` suffix, so the local helper records through `pgc_record`, which takes the display whole. Verified by diffing the nine `PASS` lines before and after: identical.

**The suite's own verdict line stays, and so does its exit logic.** `smoke.sh` runs under `set -euo pipefail`, so a failing command aborts it, and `SMOKE TEST PASSED` is what distinguishes a suite that finished from one that stopped — `lib.sh:47` names this suite among those that behave that way. Removing it in the same change would make the suite briefly report less than it did before. It comes out when a reconciliation replaces it, not alongside the conversion.

**Sourcing `lib.sh` instead of `portlib.sh` loses nothing.** lib.sh sources portlib itself at `lib.sh:110`, and its top level is assignments and function definitions only, so it starts nothing.

## It does NOT add the suite to the ledger, deliberately

`suites_not_covered` is unchanged at 250. This suite is now **coverable**, not covered.

Covering it is blocked on a measurement @jdatcmd took: check **names** differ between majors in at least one suite — `fk_referencing` emits 25 checks on PG16 and 26 on PG17, differing in both directions — the ledger keys on `(suite, part, name)` with no major dimension, and the gate refuses an unseen check. So a gate seeded from one major would refuse runs on another, and the refusal would surface in somebody else's PR. Making a suite coverable and covering it are separate decisions and this PR only makes the first.

## What this leaves

Nine suites still emit nothing: `audit`, `concurrency`, `phase2` through `phase6`, `unique_conc`, `update_conc` — 284 of the 293 checks. If this shape is right I will repeat it; if it is wrong, it is wrong once.

## Gate

```
docs_style.sh            9 checks, 0 FAIL
harness_selftest.sh    803 checks, 0 FAIL   unchanged
shellcheck -S error -s bash   clean
smoke.sh itself          9 checks, 0 FAIL
files changed            CHANGELOG.md, test/smoke.sh
ledger / budget          untouched
```

Refs #965

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf6UoeBRZYLQZa4KxNiw8a
