### PR TITLE
test: the last fifty-eight checks in those ten suites record too (#965)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1492,6 +1492,59 @@ true until the next version shipped.
   differ between majors in at least one suite, the ledger has no major dimension, and
   a gate seeded from one major would refuse runs on another.
 
+- The last fifty-eight checks in those ten suites record too, so all ten are now
+  complete (#965).
+
+  The previous change converted each suite's own `check` helper and recorded 236 of
+  the 293. The rest went through four further helpers with four different displays,
+  which is why they needed a second pass rather than the same substitution:
+
+  | suite | helper | checks |
+  | --- | --- | --- |
+  | `phase6` | `eq_on_off` | 39 |
+  | `phase4` | `expect_fail` 5, `assert_plan` 2, `assert_plan_seq` 1, one written inline | 9 |
+  | `audit` | `expect_error` | 5 |
+  | `phase5` | `assert_plan` | 5 |
+
+  Measured on PG18, each suite's records now equal both its own human check lines and
+  its `checks run:` total, and every human line is byte-for-byte what it was:
+
+      suite    records before -> after   checks run:   human lines
+      audit                26 ->  31             31            31
+      phase4               29 ->  38             38            38
+      phase5               31 ->  36             36            36
+      phase6                4 ->  43             43            43
+
+  `phase6`'s `eq_on_off` has three outcomes and two of them `return` early. Each one
+  records, because a `return` that skips the record leaves the check counted nowhere,
+  which is the state this conversion exists to end.
+
+  Two displays span more than one line -- `assert_plan` in both `phase4` and `phase5`
+  prints the whole plan under a header when it fails. The dump is passed as part of
+  the display rather than echoed after the record, so a failing run's output is also
+  byte-identical instead of having a record line wedged between the header and the
+  plan.
+
+  It also makes a version-gated arm visible to the ledger. `audit.sh` gates its
+  partitioned-parent arm on `server_version_num >= 170000`, because PG16 and earlier
+  refuse `PARTITION BY ... USING pgcolumnar`, and the gated branch printed a bare
+  note and recorded nothing. So on PG16 the ledger received three fewer rows for
+  `audit` with nothing saying why. It now records a SKIP with its reason, the way
+  `unique_conc.sh` already does for its own version gate, and PG16's human output
+  gains that SKIP line in place of the note.
+
+  One SKIP for the block, not one per gated check. Naming each of the four checks in
+  a branch that never runs them would make the count the same on every major, and
+  would also put four check names somewhere nothing exercises them, where they would
+  drift. Comparing counts across majors needs a major dimension in the ledger, which
+  belongs to #432.
+
+  Every count here is a PG18 number. On PG16 the same suites give 28 records for
+  `audit` rather than 31, because that gated arm holds three `check` calls and the
+  `expect_error` above, and one of those records is now the SKIP standing in for all
+  four. The per-major table is in #965, which is where the remainder should be read
+  from rather than from either run alone.
+
 ## [1.0-alpha3] - 2026-09-02
 
 ### Added

--- a/test/audit.sh
+++ b/test/audit.sh
@@ -156,10 +156,10 @@ check() {
 expect_error() {
 	local name="$1" sql="$2"
 	if run_pg "$PSQL -c \"$sql\"" >/dev/null 2>&1; then
-		echo "FAIL  $name: statement unexpectedly succeeded"
+		pgc_record FAIL "$name" "FAIL  $name: statement unexpectedly succeeded"
 		fail=1
 	else
-		echo "PASS  $name (rejected)"
+		pgc_record PASS "$name" "PASS  $name (rejected)"
 	fi
 }
 
@@ -310,7 +310,15 @@ if [ "$audit_srv" -ge 170000 ]; then
 		"$(q "SELECT count(*) FROM pgcolumnar.options WHERE regclass = 'opt_part_1'::regclass;")" "1"
 	q "DROP TABLE opt_part;" >/dev/null
 else
-	echo "-- PG$((audit_srv / 10000)) refuses PARTITION BY ... USING pgcolumnar; parent arm not applicable"
+	# ONE SKIP FOR THE BLOCK, not one per gated check, which is the shape
+	# unique_conc.sh:546 already uses for its own version gate. Naming each of the
+	# four checks here would make the count major-invariant and would also duplicate
+	# four check names in a branch that never runs them, so they would drift. The
+	# real fix for comparing counts across majors is a major dimension in the
+	# ledger, which is #432's problem and not this file's.
+	check_skip "the partitioned-parent arm" \
+		"SKIP  the partitioned-parent arm (PG$((audit_srv / 10000)) refuses PARTITION BY ... USING pgcolumnar)" \
+		"PG$((audit_srv / 10000)) refuses PARTITION BY ... USING pgcolumnar"
 fi
 
 # valid values are accepted, and delete/update work (no divide-by-zero)

--- a/test/phase4.sh
+++ b/test/phase4.sh
@@ -118,10 +118,14 @@ assert_plan() {
 	# index scan so the plan shape can be asserted.
 	plan="$(run_pg "$PSQL -c \"SET enable_seqscan=off; SET pgcolumnar.enable_custom_scan=off; EXPLAIN (COSTS OFF) $sql\"")"
 	if grep -q "$want" <<<"$plan" && ! grep -q "$notwant" <<<"$plan"; then
-		echo "PASS  $name: $(echo "$plan" | grep -E 'Scan' | head -1 | sed 's/^ *//')"
+		pgc_record PASS "$name" "PASS  $name: $(echo "$plan" | grep -E 'Scan' | head -1 | sed 's/^ *//')"
 	else
-		echo "FAIL  $name: plan was:"
-		echo "$plan" | sed 's/^/        /'
+		# The plan dump is part of the display, so the record line lands after the
+		# whole thing rather than between the header and the dump. A red run's output
+		# stays byte-identical that way, which is the property the green runs already
+		# have.
+		pgc_record FAIL "$name" "FAIL  $name: plan was:
+$(echo "$plan" | sed 's/^/        /')"
 		fail=1
 	fi
 }
@@ -130,10 +134,10 @@ assert_plan() {
 expect_fail() {
 	local name="$1" sql="$2"
 	if run_pg "$PSQL -c \"$sql\"" >/dev/null 2>&1; then
-		echo "FAIL  $name: expected error, got success"
+		pgc_record FAIL "$name" "FAIL  $name: expected error, got success"
 		fail=1
 	else
-		echo "PASS  $name: rejected"
+		pgc_record PASS "$name" "PASS  $name: rejected"
 	fi
 }
 
@@ -246,9 +250,10 @@ q "CREATE INDEX ios_a_idx ON ios (a);" >/dev/null
 # The custom scan is turned off so the planner picks the index scan (see assert_plan).
 iosoff_plan="$(run_pg "$PSQL -c \"SET pgcolumnar.enable_index_only_scan=off; SET enable_seqscan=off; SET pgcolumnar.enable_custom_scan=off; EXPLAIN (COSTS OFF) SELECT a FROM ios WHERE a = 100;\"")"
 if grep -q "Index Scan" <<<"$iosoff_plan" && ! grep -q "Index Only Scan" <<<"$iosoff_plan"; then
-	echo "PASS  IOS off: plain index scan"
+	pgc_record PASS "IOS off: plain index scan" "PASS  IOS off: plain index scan"
 else
-	echo "FAIL  IOS off: plain index scan: plan was:"; echo "$iosoff_plan" | sed 's/^/        /'; fail=1
+	pgc_record FAIL "IOS off: plain index scan" "FAIL  IOS off: plain index scan: plan was:
+$(echo "$iosoff_plan" | sed 's/^/        /')"; fail=1
 fi
 check "covering value"    "$(q 'SET enable_seqscan=off; SELECT a FROM ios WHERE a = 100;')" "100"
 # a full-table scan is still available when index/bitmap scans are disabled.
@@ -258,9 +263,9 @@ assert_plan_seq() {
 	local plan
 	plan="$(run_pg "$PSQL -c \"SET enable_indexscan=off; SET enable_bitmapscan=off; EXPLAIN (COSTS OFF) SELECT * FROM ios WHERE a = 100;\"")"
 	if grep -qE "Seq Scan|Custom Scan \(PgColumnarScan\)" <<<"$plan"; then
-		echo "PASS  full-table scan available"
+		pgc_record PASS "full-table scan available" "PASS  full-table scan available"
 	else
-		echo "FAIL  full-table scan available: $plan"; fail=1
+		pgc_record FAIL "full-table scan available" "FAIL  full-table scan available: $plan"; fail=1
 	fi
 }
 assert_plan_seq

--- a/test/phase5.sh
+++ b/test/phase5.sh
@@ -116,10 +116,10 @@ assert_plan() {
 	local plan
 	plan="$(run_pg "$PSQL -c \"$sql\"")"
 	if grep -q "$want" <<<"$plan" && { [ -z "$notwant" ] || ! grep -q "$notwant" <<<"$plan"; }; then
-		echo "PASS  $name"
+		pgc_record PASS "$name" "PASS  $name"
 	else
-		echo "FAIL  $name: plan was:"
-		echo "$plan" | sed 's/^/        /'
+		pgc_record FAIL "$name" "FAIL  $name: plan was:
+$(echo "$plan" | sed 's/^/        /')"
 		fail=1
 	fi
 }

--- a/test/phase6.sh
+++ b/test/phase6.sh
@@ -120,17 +120,20 @@ eq_on_off() {
 	local on off
 	on="$(run_pg "$PSQL -c \"SET pgcolumnar.enable_vectorization=on;  $query\"")"
 	off="$(run_pg "$PSQL -c \"SET pgcolumnar.enable_vectorization=off; $query\"")"
+	# THREE OUTCOMES, ONE RECORD EACH, including both early returns. A `return`
+	# that skips the record would leave the check counted nowhere, which is the
+	# state this whole conversion exists to end.
 	if [ -z "$on" ] || [ "$on" != "$off" ]; then
-		echo "FAIL  $name: vectorized [$on] != scalar [$off]"
+		pgc_record FAIL "$name" "FAIL  $name: vectorized [$on] != scalar [$off]"
 		fail=1
 		return
 	fi
 	if [ -n "$expect" ] && [ "$on" != "$expect" ]; then
-		echo "FAIL  $name: got [$on] want [$expect]"
+		pgc_record FAIL "$name" "FAIL  $name: got [$on] want [$expect]"
 		fail=1
 		return
 	fi
-	echo "PASS  $name: $on"
+	pgc_record PASS "$name" "PASS  $name: $on"
 }
 
 q "CREATE EXTENSION pgcolumnar;" >/dev/null


### PR DESCRIPTION
**Closes the remainder of #965: all ten suites now record every check they run.** Second and final pass, after #969 converted each suite's own `check` helper.

**Stacked on #969.** Its parent is #969's head `19ddb4a3`, so until #969 merges the diff on this page also shows #969's eleven files. The commit that belongs to this PR is the single one on top; after #969 lands, the diff reduces to it.

## What was left and why it needed a second pass

#969 converted one helper per file and recorded 236 of the 293. The other 58 go through four further helpers, **each printing a different display**, so the same substitution would not reach them:

| suite | helper | checks |
|---|---|---|
| `phase6` | `eq_on_off` | 39 |
| `phase4` | `expect_fail` 5, `assert_plan` 2, `assert_plan_seq` 1, **and one check written inline in no helper at all** | 9 |
| `audit` | `expect_error` | 5 |
| `phase5` | `assert_plan` | 5 |
| | | **58** |

The inline one is `phase4.sh:249`. It was not in any helper, so it does not appear in a helper census — I found it only because `phase4`'s four helpers account for 8 and the measurement says 9. A count that does not close is the only reason it was found, which is the same way #969 found the citext bug.

## Measured, PG18, four suites

Baseline is #969's head, same box, each tree building its own `.so`:

```
suite    records before -> after   checks run:   human lines   rc   human output
audit                26 ->  31             31            31     0   identical
phase4               29 ->  38             38            38     0   identical
phase5               31 ->  36             36            36     0   identical
phase6                4 ->  43             43            43     0   identical
                          +58
```

Every suite's record count now equals **both** its own human check lines **and** its `checks run:` total. Human output is byte-identical in all four: `diff` on the `PASS`/`FAIL`/`SKIP` lines is empty.

## Three things in the conversion that are not mechanical

**`eq_on_off` has three outcomes and two of them `return` early.** Each one records. A `return` that skips the record leaves the check counted nowhere, which is precisely the state #965 exists to end, and it would have been the easy thing to miss in the 39 largest population here.

**Two displays span more than one line.** `assert_plan` in `phase4` and `phase5` prints the whole plan under a header when it fails. The dump is passed as **part of the display** rather than echoed after the record, so a failing run's output is byte-identical too — not just a passing one. Echoing it after would wedge the `RESULT` line between the header and the plan.

**`expect_error` prints `PASS <name> (rejected)`.** `(rejected)` is kept verbatim. `pgc_record` takes the display whole, which is the property that made #969's conversions lossless, and it is the reason none of these delegate to `lib.sh`'s own `check`.

## A version-gated arm was invisible to the ledger, and now records a SKIP

`audit.sh:293` gates its partitioned-parent arm on `server_version_num >= 170000`, because PG16 and earlier refuse `PARTITION BY ... USING pgcolumnar`. **The gated branch printed a bare note and recorded nothing**, so PG16 handed the ledger three fewer rows for `audit` with nothing saying why — a reader reconciling against a PG18 figure sees three checks that look lost.

It now records a SKIP with its reason, the way `unique_conc.sh:546` already does for its own version gate. Driven on PG16, in its own build tree:

```
PG16 audit: rc=0  records=28  checks run: 28  human=28

SKIP  the partitioned-parent arm (PG16 refuses PARTITION BY ... USING pgcolumnar)
RESULT	audit	audit	the partitioned-parent arm	SKIP	PG16 refuses PARTITION BY ... USING pgcolumnar
```

23 + 4 `expect_error` + 1 SKIP = 28, and PG16's human output gains that SKIP line in place of the `--` note.

**One SKIP for the block, not one per gated check.** Naming each of the four would make the count identical on every major, which is tempting and wrong here: it puts four check names in a branch that never runs them, where they drift from the four it is standing in for. Comparing counts across majors needs a major dimension in the ledger, which is #432's problem, not this file's.

## Gate

```
docs_style           rc=0   checks run: 9     FAILs=0
harness_selftest     rc=0   checks run: 803   FAILs=0
bash -n              all four parse
shellcheck -S warning   one SC2154 at audit.sh:65, PRE-EXISTING
ledger + budget      untouched (no rows, no census, no budget)
four suites PG18     rc=0 each, verdict lines unchanged
audit on PG16        rc=0, 28 records
```

The `shellcheck` warning is `rc is referenced but not assigned` in `audit.sh`'s `EXIT` trap at line 65, which this PR does not touch. Verified present on `upstream/main` and on #969's head as well as here, so it is pre-existing and not introduced. I am not fixing it in this PR because a trap's `rc=$?` assignment is a different change with its own argument.

## Ledger

No rows, no census change, no budget change. A shell suite becoming **coverable** is not the same as covering it, and seeding these is still blocked on the major dimension — now with a second measured instance, since `audit`'s own count differs by major.

## What this closes and what it does not

After this, the remainder of #965 is **zero** — all 293 checks across the ten suites record, plus the citext SKIP #969 added and the gate SKIP this one adds. What #965 still asks for, and what neither PR does, is put these suites in the ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf6UoeBRZYLQZa4KxNiw8a
