### PR TITLE
test: a continuation check carries the discriminator its headline names (#982, 1 of 8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1716,6 +1716,55 @@ true until the next version shipped.
   than nothing, because an empty result reports the same emptiness for "the
   controller is broken" and "this part misspelled a variable".
 
+- A continuation check carries the discriminator its headline already names, so two
+  checks stop sharing one ledger row (#982, first of eight).
+
+  The ledger keys on `(suite, part, name)`. Twenty-four checks across eight suites share
+  a key with another check, so one going red would mark its namesake observed-red for a
+  claim nothing attacked -- the same failure `pgc_record`'s `BASH_SOURCE` part-derivation
+  fixed across parts, one frame further in.
+
+  The cause is a convention rather than carelessness. Suites name a follow-up check as a
+  short continuation of a distinct headline, which reads well:
+
+      PASS  a skipped timing check emits exactly one record
+      PASS  and its verdict is SKIP
+
+  Two parallel blocks in `400-a-check-result-must-be-machine` test `check_timing` and
+  `check_ratio_needs_quiet_machine`. Their headlines say which; only the continuations
+  were short enough to collide.
+
+  **The rule this proposes, for the remaining seven files: a continuation check carries
+  the same discriminator its headline already interpolates.** No new convention, no
+  readability lost, and at loop sites the variable is already in scope:
+
+      before   check_num "and does NOT report it as a missing file"
+      after    check_num "and the s3 URL is NOT reported as a missing file"
+
+  Six renames here, measured on the resulting log rather than asserted, against a control
+  run on clean `main`:
+
+      clean main bf325b34   857 records   854 distinct keys   3 colliding   3 lost
+      this branch           857 records   857 distinct keys   0 colliding   0 lost
+
+  The record count is unchanged, so this adds and removes no checks -- it only renames.
+
+  A rename creates orphan ledger rows, and this removes the three it creates. Each carried
+  verdict `never` and no mutation, which is the criterion `f80ca7d05` established for
+  dropping a row without losing history; a row with a date or a mutation would have had to
+  travel with the rename instead.
+
+  **And a collapsed key cannot be un-collapsed with its history intact.** `rename-scan`
+  pairs each old name with one of the two new ones arbitrarily, because one row cannot
+  become two. It does not matter here -- all three carried nothing -- but if any of those
+  six had ever gone red, the ledger would hold that red against a key covering both, and
+  splitting it would leave nobody able to say which check earned it. That is an argument
+  for fixing collisions before one of them reddens rather than after.
+
+  The orphan check written for this also found two rows whose checks no longer exist
+  anywhere in the tree, removed by #917 with their rows left behind. Those are not created
+  by this change and are filed separately rather than tidied away here.
+
 ## [1.0-alpha3] - 2026-09-02
 
 ### Added

--- a/test/check_ledger.tsv
+++ b/test/check_ledger.tsv
@@ -587,15 +587,12 @@ harness_selftest	400-a-check-result-must-be-machine	a verdict pgc_record cannot 
 harness_selftest	400-a-check-result-must-be-machine	an empty check name does not reconcile	never	-
 harness_selftest	400-a-check-result-must-be-machine	an unrunnable check emits exactly one record	never	-
 harness_selftest	400-a-check-result-must-be-machine	an unrunnable check still prints its old line	never	-
-harness_selftest	400-a-check-result-must-be-machine	and is counted as a pass, not a skip	never	-
 harness_selftest	400-a-check-result-must-be-machine	and it is counted	never	-
 harness_selftest	400-a-check-result-must-be-machine	and it is counted, so checks run: reports it	never	-
-harness_selftest	400-a-check-result-must-be-machine	and its human line is unchanged	never	-
 harness_selftest	400-a-check-result-must-be-machine	and its name field is the check's name, spaces intact	never	-
 harness_selftest	400-a-check-result-must-be-machine	and its verdict field says FAIL	never	-
 harness_selftest	400-a-check-result-must-be-machine	and its verdict field says PASS	never	-
 harness_selftest	400-a-check-result-must-be-machine	and its verdict field says UNRUN, which is neither of the other two	never	-
-harness_selftest	400-a-check-result-must-be-machine	and its verdict is SKIP	never	-
 harness_selftest	400-a-check-result-must-be-machine	and leaves one whose variable is assigned earlier	never	-
 harness_selftest	400-a-check-result-must-be-machine	and leaves one whose variable is the loop it sits in	never	-
 harness_selftest	400-a-check-result-must-be-machine	and names its own cause instead	never	-
@@ -608,6 +605,12 @@ harness_selftest	400-a-check-result-must-be-machine	and records PASS when the ra
 harness_selftest	400-a-check-result-must-be-machine	and still reports the two numbers	never	-
 harness_selftest	400-a-check-result-must-be-machine	and that place is pgc_record	never	-
 harness_selftest	400-a-check-result-must-be-machine	and the REASON_CODE travels in the reason field, not in prose	never	-
+harness_selftest	400-a-check-result-must-be-machine	and the ratio check is counted as a pass, not a skip	never	-
+harness_selftest	400-a-check-result-must-be-machine	and the ratio check's human line is unchanged	never	-
+harness_selftest	400-a-check-result-must-be-machine	and the ratio check's verdict is SKIP	never	-
+harness_selftest	400-a-check-result-must-be-machine	and the timing check is counted as a pass, not a skip	never	-
+harness_selftest	400-a-check-result-must-be-machine	and the timing check's human line is unchanged	never	-
+harness_selftest	400-a-check-result-must-be-machine	and the timing check's verdict is SKIP	never	-
 harness_selftest	400-a-check-result-must-be-machine	and the two numbers are named, not just the verdict	never	-
 harness_selftest	400-a-check-result-must-be-machine	and with timing enabled the skipped term is zero, not absent	never	-
 harness_selftest	400-a-check-result-must-be-machine	check_num on a non-number emits one record	never	-

--- a/test/check_ledger_budget.txt
+++ b/test/check_ledger_budget.txt
@@ -34,4 +34,4 @@ suites_not_covered 250
 #   Without that it is a hand-maintained count that drifts, which is the failure
 #   this repository has spent a day proving. It is not a ceiling; it is a
 #   measurement that must be true.
-checks_never_observed_red 900
+checks_never_observed_red 903

--- a/test/selftest/400-a-check-result-must-be-machine.sh
+++ b/test/selftest/400-a-check-result-must-be-machine.sh
@@ -383,32 +383,32 @@ _tmc() {	# _tmc SKIPFLAG HELPER ARGS... -> "CHECKS/PASSED/SKIPPED"
 
 check "a skipped timing check emits exactly one record" \
 	"$(_tm 1 check_timing "a timing check" 1 1 | wc -l)" "1"
-check "and its verdict is SKIP" \
+check "and the timing check's verdict is SKIP" \
 	"$(_tm 1 check_timing "a timing check" 1 1 | cut -f5)" "SKIP"
 check "and it is counted, so checks run: reports it" \
 	"$(_tmc 1 check_timing "a timing check" 1 1)" "1/0/1"
-check "and its human line is unchanged" \
+check "and the timing check's human line is unchanged" \
 	"$(_tmh 1 check_timing "a timing check" 1 1)" \
 	"SKIP  a timing check (PGC_SKIP_TIMING: wall-clock measurement)"
 
 check "the same timing check, ENABLED, emits one record and passes" \
 	"$(_tm 0 check_timing "a timing check" 1 1 | cut -f5)" "PASS"
-check "and is counted as a pass, not a skip" \
+check "and the timing check is counted as a pass, not a skip" \
 	"$(_tmc 0 check_timing "a timing check" 1 1)" "1/1/0"
 
 check "a skipped ratio check emits exactly one record" \
 	"$(_tm 1 check_ratio_needs_quiet_machine "a ratio check" 1 1 2 | wc -l)" "1"
-check "and its verdict is SKIP" \
+check "and the ratio check's verdict is SKIP" \
 	"$(_tm 1 check_ratio_needs_quiet_machine "a ratio check" 1 1 2 | cut -f5)" "SKIP"
 check "and it is counted" \
 	"$(_tmc 1 check_ratio_needs_quiet_machine "a ratio check" 1 1 2)" "1/0/1"
-check "and its human line is unchanged" \
+check "and the ratio check's human line is unchanged" \
 	"$(_tmh 1 check_ratio_needs_quiet_machine "a ratio check" 1 1 2)" \
 	"SKIP  a ratio check (PGC_SKIP_TIMING: wall-clock ratio)"
 
 check "the same ratio check, ENABLED, emits one record and passes" \
 	"$(_tm 0 check_ratio_needs_quiet_machine "a ratio check" 1 1 2 | cut -f5)" "PASS"
-check "and is counted as a pass, not a skip" \
+check "and the ratio check is counted as a pass, not a skip" \
 	"$(_tmc 0 check_ratio_needs_quiet_machine "a ratio check" 1 1 2)" "1/1/0"
 
 # ---- and the accounting line carries the fourth term ------------------------


### PR DESCRIPTION
**One file of #982's eight, as a pattern-setter, proposing the rule for the other seven. Six renames, collisions measured to zero against a control run on clean `main`.**

#982 is twenty-four checks across eight suites sharing a ledger key with another check. The reviewer and I agreed one file first, for a reason that is not about size: **a wording style applied to twenty sites without review cannot be diff-checked and never gets re-litigated.** #965's `smoke.sh` is the precedent — it went first, review found its `checks run:` line was read by nothing, and nine files did not repeat the mistake.

`400-a-check-result-must-be-machine` is the file we have **both measured independently** — `@jdatcmd` on PG16 across three trees, me on PG18 — so the shape is agreed on ground neither of us is guessing about.

## The rule this proposes

**A continuation check carries the same discriminator its headline already interpolates.**

```
before   check_num "and does NOT report it as a missing file"
after    check_num "and the s3 URL is NOT reported as a missing file"
```

No new convention, no readability lost, and at loop sites the variable is already in scope.

## Why the cause matters for the remedy

I expected copy-paste and it is a **convention**. Suites name a follow-up as a short continuation of a distinct headline, and the log genuinely is better for it:

```
PASS  a skipped timing check emits exactly one record
PASS  and its verdict is SKIP
```

Two parallel blocks here test `check_timing` and `check_ratio_needs_quiet_machine`. Their **headlines** say which; only the continuations were short enough to collide. `pgc_record`'s own comment praises `harness_selftest`'s premises for being *"phrased to be COPIED"* — so the convention is endorsed, and it is the keying that has to accommodate it.

Six renames, all of the form "name the check the headline already named":

```
and its verdict is SKIP               ->  and the timing check's verdict is SKIP
                                      ->  and the ratio check's verdict is SKIP
and its human line is unchanged       ->  and the timing check's human line is unchanged
                                      ->  and the ratio check's human line is unchanged
and is counted as a pass, not a skip  ->  and the timing check is counted as a pass, not a skip
                                      ->  and the ratio check is counted as a pass, not a skip
```

## Measured, against a control on clean main

`@jdatcmd` asked for the collisions re-measured on the resulting log with records and keys side by side, so it is a number and not a claim. I ran clean `main` as the control rather than comparing against an older saved log, because the saved one predated two merges and the totals would not have been comparable:

```
clean main bf325b34   857 records   854 distinct keys   3 colliding   3 lost
this branch           857 records   857 distinct keys   0 colliding   0 lost
```

**The record count is unchanged at 857**, which is how you can see this adds and removes no checks — it only renames.

## A rename creates orphan ledger rows, and this removes the three it creates

Each carried verdict `never` and no mutation, which is the criterion `f80ca7d05` established for dropping a row without losing history. A row with a date or a mutation would have had to **travel** with the rename instead.

```
ledger rows 900 -> 903   (+6 new names, -3 orphans)
census DERIVED 903, partition closes, gate rc=0
```

**And a collapsed key cannot be un-collapsed with its history intact.** `rename-scan` pairs each old name with one of the two new ones *arbitrarily*, because one row cannot become two:

```
possible rename: and its verdict is SKIP -> and the ratio check's verdict is SKIP  (history: last red never)
```

It does not matter here — all three carried nothing. But had any of those six ever gone red, the ledger would hold that red against a key covering **both**, and nobody could say which check earned it. That is an argument for fixing collisions **before** one of them reddens rather than after, and it is the strongest reason not to leave the remaining seven indefinitely.

## Two rows I found and deliberately did not touch

The orphan check written for this reported **five** rows with no matching check, not three. The other two name checks that no longer exist anywhere in the tree — `grep -rlF` finds them only in `check_ledger.tsv`, and `git log -S` points at #917 removing the checks and leaving the rows.

Filed as **#983**. Not touched here: this PR removes the orphans **it creates**, and tidying away two unrelated ones would widen a diff whose purpose is to propose a phrasing rule — and would remove the evidence for the issue.

## Gate

```
harness_selftest   rc=0   857 checks   0 FAIL
docs_style         rc=0   9 checks     0 FAIL
shellcheck         5 SC2034, PRE-EXISTING: same count on clean main, and no line
                   in this diff touches a variable assignment
ledger             rows 900 -> 903, census DERIVED, gate rc=0
```

## What this does not do

Seven files and eighteen sites remain, and they are the ones needing a phrase chosen per site — the loop cases are the cheap quarter. **It also adds no guard.** Whether the debt is bounded by a committed list of colliding keys or by a count is a gate-contract question with three reviewer questions on #982, and the renames stand either way.

Part of #982. Does not close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf6UoeBRZYLQZa4KxNiw8a
