### PR TITLE
test: the stamp-block extraction anchors on the write, not on file position (#961 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1765,6 +1765,57 @@ true until the next version shipped.
   anywhere in the tree, removed by #917 with their rows left behind. Those are not created
   by this change and are filed separately rather than tidied away here.
 
+- The controller-stamp extraction anchors on the write rather than on file position
+  (#961 follow-up).
+
+  Selftest 460 took the **first** one-tab `if (` in `run_all_versions.sh`. There is
+  exactly one today, so it was unambiguous, and the premises would have caught it if
+  that stopped being true -- the extracted block would hold zero or two stamp writes.
+  It was the premises doing the work rather than the anchor.
+
+  The anchor now finds the stamp write and walks back to the `if (` enclosing it, then
+  forward to the first terminator at or after it. A subshell added elsewhere at the same
+  indent cannot move the range, because the range is defined by the line it is about.
+
+  **A subshell that NESTS around the write can still widen it, and that is a premise
+  rather than a fix.** The anchor matches `if (` at one tab, so a write inside a deeper
+  subshell leaves the opener pointing at the outer block -- which holds exactly one
+  one-tab `if (` and exactly one stamp write, so every other premise passes on a block
+  wider than the call site. Measured on a fixture with the write two tabs in: eight lines
+  out, all premises green. A premise counting `if (` at ANY indent distinguishes them --
+  one in the real block, two in the nested shape -- which is cheaper than teaching the
+  anchor to track depth and fails closed, refusing a shape it does not understand rather
+  than driving it.
+
+  Proven in both directions, because either half alone says nothing. Identical on
+  today's input -- the extracted block hashes `47b4f1a9193c` before and after -- and
+  different on the input that motivated the change:
+
+      a second one-tab subshell injected ABOVE the stamp block
+        OLD anchor   4 lines, 0 stamp writes, so it extracted the WRONG block and the
+                     `exactly one stamp write` premise reads 0: loudly wrong
+        NEW anchor   7 lines, 1 stamp write, unchanged
+
+  md5-only would prove the change does nothing that matters; injection-only would prove
+  it does something without showing what else moved.
+
+  **And it closes a boundary the new design could open rather than one the old one
+  had.** A backward walk has to decide what to do when it runs off the top of the file,
+  and one of the three possible behaviours satisfies every guard in the part: emitting
+  the write alone gives exactly one stamp write, so both premises pass on a block that
+  is not the call site. This emits nothing instead, because `open` is never assigned and
+  the guard exits before the print loop -- a property that arrived from the guard's
+  shape rather than from foresight, now written into the code as load-bearing so the
+  next reader does not default `start` to 1 as a tidy-up.
+
+  One premise added, `the extraction produced a block at all`, because an awk whose
+  condition never fires prints nothing and an empty block would otherwise read as a
+  block with no stamp write in it -- two different failures arriving at the same number.
+
+  Two stamp writes in **separate** subshells is the case the count premise cannot see:
+  the extracted block holds one and the premise passes. The static caller sweep catches
+  it -- injected, both the premise and the arm report `got [4] want [3]`.
+
 ## [1.0-alpha3] - 2026-09-02
 
 ### Added

--- a/test/check_ledger.tsv
+++ b/test/check_ledger.tsv
@@ -851,7 +851,9 @@ harness_selftest	460-the-controller-must-record-the-binary	control: without that
 harness_selftest	460-the-controller-must-record-the-binary	every caller records the installed library's digest (#961)	never	-
 harness_selftest	460-the-controller-must-record-the-binary	premise: all three stamp call sites were found with their arguments joined	never	-
 harness_selftest	460-the-controller-must-record-the-binary	premise: and it holds exactly one stamp write	never	-
+harness_selftest	460-the-controller-must-record-the-binary	premise: nothing opens a deeper subshell inside the extracted block	never	-
 harness_selftest	460-the-controller-must-record-the-binary	premise: the controller's stamp block was extracted exactly once	never	-
+harness_selftest	460-the-controller-must-record-the-binary	premise: the extraction produced a block at all	never	-
 harness_selftest	460-the-controller-must-record-the-binary	premise: the matrix controller is present and parses	never	-
 harness_selftest	460-the-controller-must-record-the-binary	premise: the mutation removed the installed-digest argument	never	-
 harness_selftest	460-the-controller-must-record-the-binary	premise: this part was given an executable pg_config to read the prefix from	never	-

--- a/test/check_ledger_budget.txt
+++ b/test/check_ledger_budget.txt
@@ -34,4 +34,4 @@ suites_not_covered 250
 #   Without that it is a hand-maintained count that drifts, which is the failure
 #   this repository has spent a day proving. It is not a ceiling; it is a
 #   measurement that must be true.
-checks_never_observed_red 903
+checks_never_observed_red 905

--- a/test/selftest/460-the-controller-must-record-the-binary.sh
+++ b/test/selftest/460-the-controller-must-record-the-binary.sh
@@ -45,11 +45,59 @@ check "premise: this part was given an executable pg_config to read the prefix f
 # The subshell block, from `if (` to `); then`. A LITERAL TAB, not `\t`: GNU grep's
 # BRE does not read `\t` as a tab, and the first version of this premise counted 0
 # and would have let the arms below run against an empty block.
+# ANCHORED ON THE STAMP WRITE, NOT ON FILE POSITION. The first version took the
+# FIRST one-tab `if (` in the controller. There is exactly one today -- so it was
+# unambiguous, and the premises below would have caught it if it stopped being so
+# (the extracted block would hold zero or two stamp writes). @jdatcmd raised that
+# while approving #961: it is the premises doing the work rather than the anchor.
+#
+# So the anchor now finds the stamp write and walks BACK to the `if (` that encloses
+# it, then forward to the first terminator at or after it. A second subshell added
+# anywhere in the file cannot move the range, because the range is defined by the
+# line it is about.
+#
+# `start` BEING UNSET WHEN NOTHING ENCLOSES THE WRITE IS LOAD-BEARING, not an
+# oversight to tidy up. A backward walk has to decide what to do when it runs off
+# the top, and one of the three possibilities satisfies every guard below:
+#
+#     walks to line 1, emitting everything above   a block that parses and is WRONG
+#     emits the write alone                        ONE stamp write, so both premises
+#                                                  PASS on a block that is not the
+#                                                  call site
+#     emits nothing                                the premises catch it
+#
+# This takes the third because `open` is never assigned, `!start` is true for an
+# unassigned awk variable, and the guard exits before the print loop. Defaulting
+# `start` to 1 would look like a tidy-up and would buy the first case. Measured on a
+# fixture with two lines above the write and no enclosing `if (`: zero lines out.
 _c961_block="$(awk -v t="$_c961_tab" '
-	$0 == t "if (" {f=1} f {print} f && $0 == t "); then" {exit}' "$_c961_rav")"
+	{ line[NR] = $0 }
+	$0 == t "if (" { open = NR }
+	/pgc_write_source_stamp/ && !stamp { stamp = NR; start = open }
+	END {
+		if (!start || !stamp) exit
+		for (i = start; i <= NR; i++) {
+			print line[i]
+			if (i >= stamp && line[i] == t "); then") exit
+		}
+	}' "$_c961_rav")"
 
+check "premise: the extraction produced a block at all" \
+	"$([ -n "$_c961_block" ] && echo yes || echo empty)" "yes"
 check "premise: the controller's stamp block was extracted exactly once" \
 	"$(printf '%s\n' "$_c961_block" | grep -c "^${_c961_tab}if ($")" "1"
+# AND NO SUBSHELL OPENS BETWEEN THE OPENER AND THE WRITE, at any depth. The anchor
+# matches `if (` at ONE tab, so a write nested inside a DEEPER subshell leaves `open`
+# pointing at the outer block -- and that block holds exactly one one-tab `if (` and
+# exactly one stamp write, so every premise above it passes on a block WIDER than the
+# call site. Measured on a fixture with the write in a two-tab subshell inside a
+# one-tab one: 8 lines out, 1 one-tab `if (`, 1 write, all premises green.
+#
+# Counting `if (` at ANY indent is what distinguishes them: the real block has one,
+# the nested shape has two. Cheaper than teaching the anchor to track depth, and it
+# fails closed -- a shape this does not understand is refused rather than driven.
+check "premise: nothing opens a deeper subshell inside the extracted block" \
+	"$(printf '%s\n' "$_c961_block" | grep -cE '^[[:space:]]*if \($')" "1"
 check "premise: and it holds exactly one stamp write" \
 	"$(printf '%s\n' "$_c961_block" | grep -c 'pgc_write_source_stamp')" "1"
 


### PR DESCRIPTION
**The follow-up `@jdatcmd` raised while approving #961, opened as its own PR rather than folded into the approved one. The extraction now anchors on the stamp write instead of on file position — and the interesting part is a boundary this design could open that the old one could not.**

## What the note was

Part 460 took the **first** one-tab `if (` in `run_all_versions.sh`. There is exactly one today (line 729, with the stamp write at 731), so it was unambiguous. A second one added *above* it would have shifted the range, and because the `exit` fires on the first terminator it would have stopped at the wrong one.

Their reading was right, including the part that made this non-blocking: **it was the premises doing the work, not the anchor.** The extracted block would hold zero or two stamp writes, so the part failed loudly rather than silently. This makes the anchor not need catching, and demotes the premises to a backstop.

## Proven in both directions, because either half says nothing alone

**Necessary** — identical on today's input, or it changes behaviour while claiming not to:

```
old anchor, extracted block md5   47b4f1a9193c
new anchor, extracted block md5   47b4f1a9193c
```

**Sufficient** — a second one-tab subshell injected above the stamp block, which is the edit that motivated the change:

```
OLD anchor   4 lines, 0 stamp writes   extracted the WRONG block; the premise
                                       "holds exactly one stamp write" reads 0
NEW anchor   7 lines, 1 stamp write    unchanged
```

and the part run against that injected controller: `rc=0`, 0 FAILs, all four arms pass.

`md5`-only would prove the change does nothing that matters; injection-only would prove it does *something* without showing what else moved.

## The boundary this design could open, which the old one did not have

A backward walk has to decide what to do when it runs off the top of the file, and **one of the three possible behaviours satisfies every guard in the part**:

```
walks to line 1, emitting everything above   a block that parses and is WRONG
emits the write alone                        ONE stamp write, so BOTH premises PASS
                                             on a block that is not the call site
emits nothing                                the premises catch it, as before
```

Measured on a fixture with two lines above the write and no enclosing `if (`: **zero lines out.** `open` is never assigned, `!start` is true for an unassigned awk variable, and the guard exits before the print loop.

**That property came from the guard's shape rather than from foresight**, so it is now written into the code as load-bearing — because defaulting `start` to 1 would look like a tidy-up and would buy the first case. A safety property arrived at accidentally is still a safety property, but the next reader has to know it is one.

## One premise added

`the extraction produced a block at all` — because an awk whose condition never fires prints nothing, and an empty block would otherwise read as *a block with no stamp write in it*. Two different failures arriving at the same number, which is the shape the `driver-could-not-run` sentinel already guards one level in.

## Two stamp writes in separate subshells: the case the count premise cannot see

The extracted block holds one, so `holds exactly one stamp write` passes. The **static caller sweep** catches it — injected, both the premise and the arm report `got [4] want [3]`:

```
FAIL  premise: all three stamp call sites were found with their arguments joined: got [4] want [3]
FAIL  every caller records the installed library's digest (#961): got [4] want [3]
```

Worth noting the **premise** fired alongside the arm — a premise acting as a tripwire on its own population rather than only gating what is below it. Between this and the same-block case (where the count premise fires), the two-writes shape is covered.

## Gate

```
harness_selftest   rc=0   858 checks   858 records   0 FAIL
                   guard incl. records == checks run, the one a truncated log cannot satisfy
collisions         0 colliding keys on this tree (858 records, 858 distinct keys)
docs_style         rc=0   9 checks     0 FAIL
shellcheck         clean on the changed file
ledger             rows 903 -> 904, census DERIVED 904, partition closes, gate rc=0
```

## Two rows the orphan check reports, untouched

```
330-the-incomplete-path-must-run-whole  'premise: all three runner functions were extracted, not empty ranges'
330-the-incomplete-path-must-run-whole  'premise: and all three are callable'
```

Those are **#983** — checks removed by #917 with their ledger rows left behind. This PR creates no orphans, so it removes none; tidying unrelated ones would widen a diff about an extraction anchor and delete that issue's evidence.

## What this does not do

It does not change what the part asserts. The four arms, both controls and the static sweep are untouched — only how the block under test is located, plus one premise about the locating itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf6UoeBRZYLQZa4KxNiw8a
