### PR TITLE
docs: the deeper-subshell premise's repair is depth, not a looser count (#961)

### DIFF
--- a/test/selftest/460-the-controller-must-record-the-binary.sh
+++ b/test/selftest/460-the-controller-must-record-the-binary.sh
@@ -96,6 +96,20 @@ check "premise: the controller's stamp block was extracted exactly once" \
 # Counting `if (` at ANY indent is what distinguishes them: the real block has one,
 # the nested shape has two. Cheaper than teaching the anchor to track depth, and it
 # fails closed -- a shape this does not understand is refused rather than driven.
+#
+# THE REPAIR, WHEN THIS EVENTUALLY FIRES ON A LEGITIMATE CHANGE: teach the anchor
+# depth. DO NOT LOOSEN THE COUNT.
+#
+# It refuses legitimate nesting as well as the case it exists for, because it cannot
+# tell them apart -- that is the price of not tracking depth. So one day someone adds
+# a real nested subshell to the controller, this fires, and the cheapest-looking fix
+# is `-ge 1`. That reinstates EXACTLY the hole this closes: a write inside a deeper
+# subshell leaves the opener on the outer block, which holds one one-tab `if (` and
+# one stamp write, so every premise here passes on a block wider than the call site.
+# Measured when this was written: eight lines out, all premises green.
+#
+# Named beside the premise for the same reason the unset `start` above is named: a
+# guard that fires on a valid change invites a repair that looks like tidying up.
 check "premise: nothing opens a deeper subshell inside the extracted block" \
 	"$(printf '%s\n' "$_c961_block" | grep -cE '^[[:space:]]*if \($')" "1"
 check "premise: and it holds exactly one stamp write" \


### PR DESCRIPTION
**Comment only. It names the repair for #985's deeper-subshell premise, because the repair someone will reach for reinstates the hole the premise closes.**

`@jdatcmd` raised this as non-blocking on #985 and I think it is worth a commit on its own rather than a note in a thread, for the reason the `start`-is-load-bearing comment one premise above turned out to be worth it: the guard will eventually fire on a valid change, and the cheapest-looking fix is the wrong one.

## The trap being documented

```
premise: exactly one `if (` at any indent in the extracted block

  refuses the nested-orphan case      <- why it exists
  refuses legitimate nesting too      <- it cannot tell them apart
  the repair someone reaches for:  -ge 1
  which reinstates the nested-orphan case EXACTLY
```

The hole it closes: a write inside a deeper subshell leaves the opener pointing at the **outer** block, which holds one one-tab `if (` and one stamp write — so every other premise in the part passes on a block wider than the call site. Measured when #985 was written: eight lines out, all premises green.

So loosening the count to `-ge 1` is not a partial weakening. It restores the exact failure, and it will look like tidying up a guard that is being fussy.

## What it says instead

**Teach the anchor depth. Do not loosen the count.** With the measurement beside it, so whoever hits the fussiness can see what the cheap fix costs rather than having to reconstruct it.

## Comment only, verified as such

```
14 lines added
 0 non-comment lines changed
859 checks on this branch, 859 on main
ledger and budget untouched (so no census movement, no regeneration)
docs_style  rc=0  0 FAIL
shellcheck  clean
```

I also checked the new comment introduces none of the tokens a guard in this tree greps for — a comment carrying `pgc_summary`, the name of a static checker, or `lcov --list` has tripped three guards today, in three files, by both of us. This one mentions "one stamp write" rather than the function name for exactly that reason.

## Why not fold it into the next #982 file

Different subject. That PR proposes a phrasing rule across eight suites; this is a note about an extraction premise in one part. Bundling them would make the diff harder to review and would attach a comment nobody asked about to a change that needs its own argument.
