### PR TITLE
test: the hilbert premises name the table they digest (#982, 3 of 8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1816,6 +1816,39 @@ true until the next version shipped.
   the extracted block holds one and the premise passes. The static caller sweep catches
   it -- injected, both the premise and the arm report `got [4] want [3]`.
 
+- The hilbert premises name the table they digest, so five checks stop sharing three
+  ledger keys (#982, third of eight).
+
+  `hilbert_cluster` held the second-largest loss: a premise repeated before four separate
+  arms, and two pairs of `(d)` checks repeated across two fixtures. Measured against a
+  control run on clean `main`:
+
+      clean main    181 records   176 distinct keys   3 colliding   5 lost
+      this branch   181 records   181 distinct keys   0 colliding   0 lost
+
+  The record count is unchanged, so this renames and nothing else.
+
+  **A third form of the rule, and the files keep supplying them.** #984 said a continuation
+  carries the discriminator its headline interpolates; #989 added that where the headline
+  names none either, it gains one. Here *nothing* interpolates anything -- all eight sites
+  are hand-written -- so the discriminator comes from the check's own **value expression**:
+
+      premise: the plan being digested here is the columnar custom scan too
+        "$(pgc_is_columnar_scan 'SELECT * FROM s3hi')"     -> ... digested for s3hi ...
+        "$(pgc_is_columnar_scan 'SELECT * FROM s5hi')"     -> ... digested for s5hi ...
+        "$(pgc_is_columnar_scan 'SELECT * FROM s6t')"      -> ... digested for s6t ...
+        "$(pgc_is_columnar_scan 'SELECT * FROM av_hi')"    -> ... digested for av_hi ...
+
+  That keeps the name and the assertion in agreement, which is worth more than brevity: a
+  reader can check one against the other without leaving the line. The word doing the
+  colliding was `here`, which named the site to someone reading top to bottom and named
+  nothing at all to a key.
+
+  The two `(d)` pairs take the table their own `count(*)` and `physlayout` name --
+  `moved s4d1's layout`, `no row was lost from s4d2` -- for the same reason.
+
+  No ledger change: `hilbert_cluster` is not one of the two suites the ledger covers.
+
 ## [1.0-alpha3] - 2026-09-02
 
 ### Added

--- a/test/hilbert_cluster.sh
+++ b/test/hilbert_cluster.sh
@@ -517,7 +517,7 @@ S3HI_MOVED="$(changed "$S3HI_SEQ0" "$(scanorder s3hi)")"
 check "premise: vacuum_sorted moved s3lex from its own baseline" "$S3LEX_MOVED" "moved"
 check "premise: cluster moved s3zo from its own baseline" "$S3ZO_MOVED" "moved"
 check "premise: cluster_hilbert moved s3hi from its own baseline" "$S3HI_MOVED" "moved"
-check "premise: the plan being digested here is the columnar custom scan too" \
+check "premise: the plan being digested for s3hi is the columnar custom scan too" \
 	"$(pgc_is_columnar_scan 'SELECT * FROM s3hi')" "yes"
 
 psql_run "ALTER TABLE s3hi OWNER TO h_owner;"
@@ -704,19 +704,19 @@ check_text "premise: the two (d) twins are byte-identical before either is reclu
 S4D1_RET="$(q "SELECT pgcolumnar.recluster_hilbert('s4d1','b','a');")"
 S4D1_MOVED="$([ "$S4D1_RET" -gt 0 ] 2>/dev/null && echo yes || echo no)"
 check "(d) recluster_hilbert over DIFFERENT columns still rewrites (>0)" "$S4D1_MOVED" "yes"
-check "(d) and that rewrite moved the layout" \
+check "(d) and that rewrite moved s4d1's layout" \
 	"$(changed "$S4D1_PHYS" "$(physlayout s4d1)")" "moved"
 check_text "(d) and it is still a hilbert table, now on the new key" "$(skind s4d1)/$(skey s4d1)" "hilbert/{b,a}"
-check_num "(d) and no row was lost" "$(q 'SELECT count(*) FROM s4d1;')" "20000"
+check_num "(d) and no row was lost from s4d1" "$(q 'SELECT count(*) FROM s4d1;')" "20000"
 
 S4D2_RET="$(q "SELECT pgcolumnar.recluster('s4d2','b','a');")"
 S4D2_MOVED="$([ "$S4D2_RET" -gt 0 ] 2>/dev/null && echo yes || echo no)"
 check "(d) plain recluster over DIFFERENT columns rewrites a hilbert table (>0)" "$S4D2_MOVED" "yes"
-check "(d) and that rewrite moved the layout" \
+check "(d) and that rewrite moved s4d2's layout" \
 	"$(changed "$S4D2_PHYS" "$(physlayout s4d2)")" "moved"
 check_text "(d) and naming the plain verb with a NEW key is the explicit switch back to zorder" \
 	"$(skind s4d2)/$(skey s4d2)" "zorder/{b,a}"
-check_num "(d) and no row was lost" "$(q 'SELECT count(*) FROM s4d2;')" "20000"
+check_num "(d) and no row was lost from s4d2" "$(q 'SELECT count(*) FROM s4d2;')" "20000"
 
 # THE ONLINE VERB'S CURVE DEFENCE, and it is gated on both rewrites having
 # happened. Untouched, s4d1 is still on the (a,b) layout while s4d2 is on the
@@ -760,7 +760,7 @@ S5ZO_BEFORE="$(scanorder s5zo)"
 S5HI_SET="$(setof s5hi)"
 S5ZO_SET="$(setof s5zo)"
 check_text "premise: the two single-column fixtures start identical" "$S5HI_BEFORE" "$S5ZO_BEFORE"
-check "premise: the plan being digested here is the columnar custom scan too" \
+check "premise: the plan being digested for s5hi is the columnar custom scan too" \
 	"$(pgc_is_columnar_scan 'SELECT * FROM s5hi')" "yes"
 
 hrun "cluster_hilbert('s5hi','a')" "SELECT pgcolumnar.cluster_hilbert('s5hi','a');"
@@ -801,7 +801,7 @@ check_text "and each records its own verb's kind" "$(skind s5hi)/$(skind s5zo)" 
 mk4 s6t
 hrun "cluster_hilbert('s6t','a','b')" "SELECT pgcolumnar.cluster_hilbert('s6t','a','b');"
 check_text "premise: s6t is a hilbert table before vacuum_sorted touches it" "$(skind s6t)" "hilbert"
-check "premise: the plan being digested here is the columnar custom scan too" \
+check "premise: the plan being digested for s6t is the columnar custom scan too" \
 	"$(pgc_is_columnar_scan 'SELECT * FROM s6t')" "yes"
 # THE ORDER DIGEST IS THE INSTRUMENT HERE, NOT physlayout. vacuum_sorted is an
 # EAGER verb, and an eager rewrite reproduces the stripe geometry exactly, so
@@ -887,7 +887,7 @@ check_text "premise: and the key the daemon will read off it is the one it was c
 check_text "premise: the daemon agrees a recluster is due, and that a compaction is NOT" \
 	"$(q "SELECT recluster_due::text || '/' || compact_rewrite_due::text FROM pgcolumnar.maintenance_due('av_hi');")" \
 	"true/false"
-check "premise: the plan being digested here is the columnar custom scan too" \
+check "premise: the plan being digested for av_hi is the columnar custom scan too" \
 	"$(pgc_is_columnar_scan 'SELECT * FROM av_hi')" "yes"
 
 # The two references, driven by hand while the daemon is still off.


### PR DESCRIPTION
`hilbert_cluster` held the second-largest loss on the #982 list: **five of its 181 checks
share three ledger keys.** One premise is repeated before four separate arms, and two
pairs of `(d)` checks are repeated across two fixtures. This PR gives all eight sites the
table they actually talk about.

## Measured, both trees, same box

I ran the suite on clean `main` (`827f2801`) and on this branch, and counted records
against distinct `(suite, part, name)` keys:

| tree | records | distinct keys | colliding keys | records lost to a collision |
|---|---|---|---|---|
| clean `main` | 181 | 176 | 3 | **5** |
| this branch | 181 | **181** | **0** | **0** |

The three keys that were colliding on `main`:

```
x4  'premise: the plan being digested here is the columnar custom sca'
x2  '(d) and that rewrite moved the layout'
x2  '(d) and no row was lost'
```

**The record count is unchanged at 181, so this renames and nothing else.** Both trees:
`rc=0`, `checks run: 181`, `FAILs=0`.

## A third form of the rule, and the files keep supplying them

#984 established that a continuation carries the discriminator its headline interpolates.
#989 added the case where the headline names none either, so it gains one. Here **nothing
interpolates anything** — all eight sites are hand-written, in a suite with no loop — so
the discriminator comes from the check's own **value expression**: the table it queries.

```
before (x4, one key):  premise: the plan being digested here is the columnar custom scan too
after:                 premise: the plan being digested for s3hi  is the columnar custom scan too
                       premise: the plan being digested for s5hi  is the columnar custom scan too
                       premise: the plan being digested for s6t   is the columnar custom scan too
                       premise: the plan being digested for av_hi is the columnar custom scan too
```

Each of those four asserts `pgc_is_columnar_scan 'SELECT * FROM <that table>'`. The name
now says which. That keeps the name and the assertion in agreement, which is worth more
than brevity: **a reader can check one against the other without leaving the line.**

The word doing the colliding was `here`. It names the site to someone reading the file top
to bottom, and it names nothing at all to a key — the same failure as `it` in #989, in a
suite with no loop to blame.

The two `(d)` pairs take the table their own `count(*)` and `physlayout` name:

```
(d) and that rewrite moved the layout  ->  (d) and that rewrite moved s4d1's layout
                                           (d) and that rewrite moved s4d2's layout
(d) and no row was lost                ->  (d) and no row was lost from s4d1
                                           (d) and no row was lost from s4d2
```

## The eight new names, from the run

```
PASS  premise: the plan being digested for s3hi is the columnar custom scan too
PASS  (d) and that rewrite moved s4d1's layout
PASS  (d) and no row was lost from s4d1
PASS  (d) and that rewrite moved s4d2's layout
PASS  (d) and no row was lost from s4d2
PASS  premise: the plan being digested for s5hi is the columnar custom scan too
PASS  premise: the plan being digested for s6t is the columnar custom scan too
PASS  premise: the plan being digested for av_hi is the columnar custom scan too
```

## Limits of what this proves

- **I measured collisions, not correctness of the new wording.** The count proves 181
  distinct keys. That the name matches the assertion is a claim a reader checks by eye,
  which is exactly why I tied each name to the value expression on its own line.
- **No ledger change.** `hilbert_cluster` is not one of the two suites
  `test/check_ledger.tsv` covers, so `check_ledger.tsv` and `check_ledger_budget.txt` are
  untouched in this PR — verified by an empty `git diff` on both. The 21 remaining
  collisions outside the two covered suites matter for #432's seeding, not for today's
  census.
- **One file.** #982 lists eight; this is the third. The rule's three forms are now
  stated, so the remaining five should be mechanical.

Checks run locally: `hilbert_cluster` 181/0 FAIL on both trees, `docs_style` 9/9,
`shellcheck` 0 findings, `bash -n` clean.

Part of #982 (3 of 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf6UoeBRZYLQZa4KxNiw8a
