### PR TITLE
test: the accounting breakdown says which LINE it means, because twelve suites were called unseedable and ten of them record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2055,6 +2055,38 @@ true until the next version shipped.
   not unwrite it, and rewriting `main` is not something a stray artifact justifies. What this
   stops is the tree carrying them, and the next `git add -A` re-adding them.
 
+- The matrix runner's accounting breakdown says which LINE it means, because the old
+  wording produced a wrong planning number twice in one night.
+
+  It printed:
+
+      N via lib.sh's accounting; by their own mechanism: audit bench_guards concurrency ...
+
+  and "by their own mechanism" was read -- by two different readers, hours apart -- as *emits
+  no RESULT records*, which would make those twelve suites impossible to seed into the
+  mutation ledger. A bound on how far `suites_not_covered` can fall was derived from that
+  reading.
+
+  **It is false. Measured by running all twelve and counting:**
+
+      audit 31   smoke 9   phase2 42   phase3 32   phase4 38   phase5 36
+      phase6 43  concurrency 7   unique_conc 31   update_conc 25
+      bench_guards 0   docs_style 0
+
+  **Ten of the twelve emit records.** The set is the suites whose log lacks lib.sh's
+  `accounting:` line and carries their own `checks run:` instead -- a statement about the
+  accounting LINE and nothing else. Only `bench_guards` and `docs_style` emit no records, for
+  the reason `pgc_log_shows_any_accounting`'s comment already gives: those two never source
+  `lib.sh` at all. Defining a private `check` is orthogonal -- `audit` does it and records 31.
+
+  So the bound is **two suites, not twelve**, with about 294 records sitting in the other ten.
+
+  The label now names the line and disclaims the records in the same breath. The selftest arm
+  that pins it follows the reword; widening that arm to pin the disclaimer separately needs
+  either a new ledger row or a rename that would orphan an existing one, and `main` has no
+  tool to remove an orphan until #983 lands -- so the sequencing is written into the arm's
+  comment rather than quietly skipped.
+
 ## [1.0-alpha3] - 2026-09-02
 
 ### Added

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -1474,7 +1474,16 @@ pgc_tally_suite() {	# pgc_tally_suite NAME VERDICT LOGFILE
 	echo "  suites that ran: $suites_ran of ${#SUITES[@]} (skipped: $suites_skipped, incomplete: $suites_incomplete)"
 	echo "  of those, $_acc_any accounted for their checks and $((suites_ran - _acc_any)) did not"
 	if [ -n "${_acc_own// /}" ]; then
-		echo "    $_acc_ran via lib.sh's accounting; by their own mechanism:${_acc_own% }"
+		# SAY WHICH LINE, because "by their own mechanism" was read twice in one night
+		# as "emits no RESULT records" and produced a wrong planning number from it.
+		# This set is the suites whose log lacks lib.sh's `accounting:` line and has
+		# their own `checks run:` instead. That is a statement about the ACCOUNTING
+		# LINE and nothing else: measured over all twelve of them, ten emit RESULT
+		# records perfectly well (audit 31, phase4 38, unique_conc 31, ...) and only
+		# bench_guards and docs_style emit none -- which is the pair the comment on
+		# pgc_log_shows_any_accounting already names, for the real reason: those two
+		# never source lib.sh at all.
+		echo "    $_acc_ran printed lib.sh's accounting line; these printed their own \`checks run:\` instead (a different accounting LINE, not a missing RESULT record):${_acc_own% }"
 	fi
 	if [ "$suites_skipped" != 0 ]; then
 		echo "  skipped:${skipped_names}"

--- a/test/selftest/390-a-registered-suite-must-account.sh
+++ b/test/selftest/390-a-registered-suite-must-account.sh
@@ -695,5 +695,18 @@ check "the breakdown headline counts the wide set, not the narrow one" \
 	"$(grep -c 'of those, \$_acc_any accounted for their checks' "$_rv")" "1"
 check "and the population reconciliation counts that same file" \
 	"$(grep -c '_acc_any="\$(grep -c \. "\$_acc_accounted"' "$_rv")" "1"
+# THE LABEL WAS REWORDED AND THIS ARM FOLLOWS IT. It used to grep "by their own
+# mechanism", which was read as "emits no RESULT records" twice in one night by two
+# different readers, and a planning number came out of the misreading: twelve suites
+# called unseedable when ten of them emit records and only two do not.
+#
+# THE DISCLAIMER IN THAT LABEL IS NOT SEPARATELY PINNED, and the reason is worth
+# stating rather than leaving as an omission. Pinning it means either a second check
+# or renaming this one to match a wider assertion. A second check costs a ledger row;
+# renaming this one ORPHANS its existing row -- and `main` currently has no tool to
+# remove an orphan, which is exactly what #983 is about. So the honest sequence is:
+# #993 lands the prune, and then this arm can be renamed and widened in the change
+# that regenerates the ledger anyway. Until then the reword is protected by this grep
+# breaking on any further edit, and by the comment at the echo itself.
 check "premise: and the narrow count is still printed, as the lib.sh half" \
-	"$(grep -c 'via lib.sh.s accounting; by their own mechanism' "$_rv")" "1"
+	"$(grep -c "printed lib.sh's accounting line" "$_rv")" "1"


### PR DESCRIPTION
**A label in the runner's output was read as saying something it does not say, by two different readers hours apart, and a planning number was derived from the misreading. This says what it means instead.**

The runner printed:

```
N via lib.sh's accounting; by their own mechanism: audit bench_guards concurrency ...
```

`by their own mechanism` was taken to mean *emits no RESULT records*, which would make those twelve suites impossible to seed into the mutation ledger — and a bound on how far `suites_not_covered` can fall came out of that reading.

## It is false, and here is the measurement

Every one of the twelve, run, counting `RESULT` records:

| suite | records | | suite | records |
|---|---|---|---|---|
| `audit` | **31** | | `phase4` | **38** |
| `bench_guards` | **0** | | `phase5` | **36** |
| `concurrency` | **7** | | `phase6` | **43** |
| `docs_style` | **0** | | `smoke` | **9** |
| `phase2` | **42** | | `unique_conc` | **31** |
| `phase3` | **32** | | `update_conc` | **25** |

**Ten of the twelve emit records.** The set is the suites whose log lacks lib.sh's `accounting:` line and carries their own `checks run:` instead — a statement about the **accounting line** and nothing else.

Only `bench_guards` and `docs_style` emit none, and the tree already knows why. `pgc_log_shows_any_accounting`'s own comment says it:

> `bench_guards` and `docs_style` keep private counters and print their own `checks run: N`; they never source `lib.sh`

**That** is the discriminator — sourcing `lib.sh`, which is what reaches `pgc_record`. Defining a private `check` is orthogonal: `audit` does it and records 31 anyway.

So the bound on how far the ceiling can fall before anything needs converting is **two suites, not twelve**, with roughly **294 records** sitting in the other ten.

## Why a wording change is worth a PR

The label is computed from a real set difference and is correct about that difference. What it lacked was a statement of which difference, and the consequence was not cosmetic: two readers independently reached the same wrong conclusion and one of them put it in a PR body as a constraint on the project's next step.

Both of my own attempts to check it statically were also wrong, in opposite directions — a grep for "contains a `check` call" returned one suite (a false positive: `harness_selftest` sources parts that do the calling), and a predictor built on "defines its own recorder" agreed with the claim on **0 of 12**. What settled it was two runtime spot-checks that could not both fit the story: `docs_style` 0 against `smoke` 9.

## What is not done, stated rather than omitted

**The disclaimer in the new label is not separately pinned.** Pinning it needs either a second check — a ledger row — or renaming the existing arm to match a wider assertion, and a rename **orphans** that arm's existing row. `main` has no tool to remove an orphan until #983 lands. So the arm keeps its name, greps the reworded label, and its comment records the sequence: #993 lands the prune, then this arm can be renamed and widened in the change that regenerates the ledger anyway.

Choosing the ledger-free option here is deliberate — there are already two PRs in flight touching `check_ledger.tsv`, and a third would buy a conflict for a wording fix.

## No ledger change, measured not assumed

```
this branch   rc=0  checks run 867  records 867  FAIL 0
main          rc=0  checks run 867                FAIL 0
-> the check set does not move, so no regeneration
```

The arm that follows the reword passes, and its grep discriminates: it matches the new label once and `main`'s old label zero times, so it is a pin rather than a tautology.

`shellcheck -S error -s bash` over both changed files: 0. `bash -n` clean.

Context: #752, and the framing this corrects appears in #1002.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf6UoeBRZYLQZa4KxNiw8a
