### PR TITLE
docs: name join-key clustering as the runtime-filter skip precondition (#752)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -579,6 +579,14 @@ true until the next version shipped.
 
 ### Fixed
 
+- The star-schema join how-to names clustering on the join key (#752).
+
+  Group skip was already measured: 19 of 20 groups when the keys are local,
+  0 of 20 when they cycle. The page named the GUC and not that discriminator.
+  A fact table that is not clustered on the join key still holds every key in
+  every group, so the filter cannot skip. The GUC stays off. The fold over a
+  join is a later slice.
+
 - A skipped arm records under the name it would have used, so a skipped arm and
   a deleted one are no longer indistinguishable (#994).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -208,6 +208,7 @@ Serial join runtime filter. A `set_join_pathlist_hook` wraps a serial inner
 Hash Join whose outer path is a direct columnar scan. Core Hash Join keeps the
 answers. The coordinator drains the build side first. It then attaches a
 conservative key range and a Bloom filter to that scan.
+Group skip needs the fact table clustered on the join key.
 
 ### columnar_vector.c
 The vectorized aggregate path and its shared filter. A column-at-a-time filter

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -76,6 +76,10 @@ the predicate. That test is only as sharp as the data's order. A column whose va
 are scattered across every chunk group cannot be pruned. A column whose values are
 clustered into a few groups prunes the rest. So the most effective layout choice is
 to cluster on the column you filter by ranges. That column is most often a timestamp.
+A star-schema join skips on the join key, not on that timestamp.
+Cluster the fact table on the join key so matching keys sit in few groups.
+A fact table clustered only on a timestamp still holds every join key in every group.
+A runtime filter then cannot drop groups.
 
 - `pgcolumnar.recluster(table)` re-establishes the sort order incrementally and
   online. It runs under `ShareUpdateExclusiveLock`, so reads and writes continue. It

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,7 +61,7 @@ disk. It never changes the values that a table returns.
 | `pgcolumnar.enable_group_vectorization` | boolean | `off` | Use the vectorized aggregate path for `GROUP BY` queries on a columnar table. Off by default; see [why grouped vectorization is off by default](#why-grouped-vectorization-is-off-by-default). |
 | `pgcolumnar.groupagg_max_groups` | integer | `1000000` | Cap on the group count the grouped vectorized aggregate builds. Over the cap the query errors. Range 1 to INT_MAX. |
 | `pgcolumnar.enable_bloom_filter` | boolean | `on` | Skip chunk groups on equality filters using per-chunk bloom filters. |
-| `pgcolumnar.enable_join_runtime_filter` | boolean | `off` | Wrap a serial inner Hash Join so the build keys can skip fact-table groups and reject non-matching rows. Direct columnar scan only. Off until the skip is measured. |
+| `pgcolumnar.enable_join_runtime_filter` | boolean | `off` | Wrap a serial inner Hash Join so the build keys can skip fact-table groups and reject non-matching rows. Direct columnar scan only. Group skip needs the fact table clustered on the join key. Off by default. |
 | `pgcolumnar.enable_read_stream` | boolean | `on` | Prefetch block reads with the read stream API. Effective on PostgreSQL 17 and later. |
 | `pgcolumnar.enable_ungrouped_vector_agg` | boolean | `off` | Answer an ungrouped aggregate (`count`, `sum`, `avg`, `min`, `max` with no `GROUP BY`) with a batch fold over decoded vectors instead of row-at-a-time. Off by default. |
 | `pgcolumnar.enable_parallel_vector_agg` | boolean | `off` | Let the ungrouped batch fold run as a parallel partial aggregate under `Gather`, each worker folding its own row groups. Requires `pgcolumnar.enable_ungrouped_vector_agg`. Off by default. |

--- a/docs/features.md
+++ b/docs/features.md
@@ -74,6 +74,7 @@ settings see the [configuration reference](configuration.md); for constraints se
   A serial inner Hash Join can skip fact-table groups using the build-side key range.
   It can also reject non-matching rows with a Bloom filter of those keys.
   The GUC `pgcolumnar.enable_join_runtime_filter` is off by default.
+  Group skip needs the fact table clustered on the join key.
   It does not wrap LEFT, SEMI, ANTI, CROSS, parallel, or projection scans.
 - Parallel scan across a table's row groups.
 - Read stream prefetch of block reads on PostgreSQL 17 and later

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -144,6 +144,11 @@ EXPLAIN (ANALYZE) SELECT sum(amount) FROM fact JOIN dim ON fact.k = dim.k;
 ```
 
 **Tuning.** It is off by default (`pgcolumnar.enable_join_runtime_filter`).
+Group skip needs the fact table clustered on the join key.
+When the keys sit in few chunk groups, the scan drops the rest.
+When every group holds every key, group skip removes none.
+The Bloom filter can still reject non-matching rows.
+Cluster the fact table on the join key with `pgcolumnar.cluster` or `pgcolumnar.recluster`.
 It applies only to a serial inner Hash Join whose outer path is a direct columnar scan.
 A LEFT, SEMI, ANTI, or CROSS join is unchanged.
 A covering projection is also unchanged.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -690,6 +690,9 @@ A covering projection as the outer path is unchanged.
 A mixed-type or mixed-collation join still hashes both sides.
 It does not attach a key-range skip in those cases.
 A build side past the on-disk bloom saturation cap disables Bloom rather than emitting a saturated filter.
+Group skip needs the fact table clustered on the join key.
+A scattered join key still holds every key in every group.
+Bloom rejection still applies in that case.
 
 ## Skipping and collation
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -138,6 +138,7 @@ controlled by a setting in the [Configuration reference](configuration.md):
   avg, min, or max on a supported type.
 - `count(*)` answered from catalog metadata when there is no filter.
 - Join runtime filter: a serial inner Hash Join can skip fact-table groups and reject non-matching rows using the build-side keys.
+  Cluster the fact table on the join key. Group skip is a no-op when every group holds every key.
 
 #### Reading the filter counters
 

--- a/test/docs_style.sh
+++ b/test/docs_style.sh
@@ -112,6 +112,42 @@ check "no document carries a merge conflict marker" \
 # CHANGELOG.md: dash characters only. See the scope note above.
 dashes=$(grep -c '—\|–' "$SRCDIR/CHANGELOG.md" || true)
 check "CHANGELOG.md carries no em or en dash" "$dashes" "0"
+# ---- a star-schema fact table is clustered on the join key (#752) ----------
+#
+# The runtime-filter how-to named the GUC and not the layout that makes group
+# skip a no-op. native_join_runtime_filter already measured it: 19 of 20 groups
+# removed when the keys are local, 0 of 20 when they cycle. Nothing in docs/
+# said so. These two checks read the published pages, not the test suite.
+_howto_rf() {
+	python3 - "$SRCDIR/docs/how-to.md" <<'PY'
+from pathlib import Path
+import sys
+text = Path(sys.argv[1]).read_text(encoding="utf-8")
+heading = "## Skip fact-table work under a star-schema join"
+start = text.find(heading)
+if start < 0:
+    print("missing-heading")
+    raise SystemExit(0)
+rest = text[start + len(heading):]
+nxt = rest.find("\n## ")
+section = (rest if nxt < 0 else rest[:nxt]).lower()
+print("yes" if ("cluster" in section and "join key" in section) else "no")
+PY
+}
+check "how-to names clustering on the join key for the runtime filter" \
+	"$(_howto_rf)" "yes"
+
+_practices_jk() {
+	python3 - "$SRCDIR/docs/best-practices.md" <<'PY'
+from pathlib import Path
+import sys
+text = Path(sys.argv[1]).read_text(encoding="utf-8").lower()
+print("yes" if "join key" in text else "no")
+PY
+}
+check "best-practices names clustering on the join key" \
+	"$(_practices_jk)" "yes"
+
 # ---- a document that quotes the version must quote the current one ----------
 #
 # Nothing reads the VERSION file mechanically: no Makefile rule, no CI step. Two

--- a/test/pytest/TESTS.md
+++ b/test/pytest/TESTS.md
@@ -73,6 +73,7 @@ behaviour, the source of that number is named.
 - [25. test_join_runtime_filter.py: serial join runtime filter](#25-test_join_runtime_filterpy-serial-join-runtime-filter)
 - [26. test_check_records.py: every counted assertion is a record](#26-test_check_recordspy-every-counted-assertion-is-a-record)
 - [27. test_skip_loop_arms.py: a skipped arm records under its own name](#27-test_skip_loop_armspy-a-skipped-arm-records-under-its-own-name)
+- [28. test_docs_join_clustering.py: the runtime filter's layout precondition](#28-test_docs_join_clusteringpy-the-runtime-filters-layout-precondition)
 
 ## 1. How to read a test in here
 
@@ -2690,3 +2691,19 @@ cheapest to satisfy wrongly: a classifier that filed **everything** as `armless`
 it perfectly. It is load-bearing only because the per-bucket tests assert that a known
 site lands in the right bucket; the identity then says nothing else escaped. Both halves
 or neither.
+
+## 28. test_docs_join_clustering.py: the runtime filter's layout precondition
+
+#752's skip is measured. The how-to named the GUC and not the layout that
+makes group skip a no-op. These two tests read the published pages. They
+do not import the shell suite.
+
+| test | asserts |
+| --- | --- |
+| `test_how_to_names_join_key_clustering_for_the_runtime_filter` | the star-schema how-to section names clustering on the join key |
+| `test_best_practices_names_join_key_clustering_for_a_fact_table` | best-practices names that join key, not only timestamps |
+
+The shell twin is two checks in `test/docs_style.sh`. Documentation may
+identify the two files as counterparts. That is the only cross-reference.
+
+Public seams: `docs/how-to.md` and `docs/best-practices.md`.

--- a/test/pytest/test_docs_join_clustering.py
+++ b/test/pytest/test_docs_join_clustering.py
@@ -1,0 +1,56 @@
+"""Public docs must name the layout that makes a join runtime filter a no-op (#752).
+
+The skip measurement is already in native_join_runtime_filter: 19 of 20 groups
+removed when the keys are local in the stripe, 0 of 20 when they cycle. The
+how-to page named the GUC and not that discriminator. A star-schema fact table
+that is not clustered on the join key still holds every key in every group, so
+sideways information passing cannot skip.
+"""
+
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent.parent
+HOWTO = ROOT / "docs" / "how-to.md"
+PRACTICES = ROOT / "docs" / "best-practices.md"
+
+
+def _section_after(path, heading):
+    text = path.read_text(encoding="utf-8")
+    start = text.find(heading)
+    if start < 0:
+        return ""
+    rest = text[start + len(heading):]
+    nxt = rest.find("\n## ")
+    if nxt < 0:
+        return rest
+    return rest[:nxt]
+
+
+def test_how_to_names_join_key_clustering_for_the_runtime_filter(expect):
+    """The star-schema how-to must say when group skip is a no-op.
+
+    Public seam: docs/how-to.md. Independently of docs_style.sh, this reads the
+    section and requires both the layout verb and the join key in that section.
+    """
+    expect.num(int(HOWTO.is_file()), 1, "premise: how-to.md is in the tree")
+    section = _section_after(HOWTO, "## Skip fact-table work under a star-schema join")
+    expect.num(int(len(section) > 0), 1,
+               "premise: the star-schema join heading is present")
+    low = section.lower()
+    expect.num(int("cluster" in low), 1,
+               "the runtime-filter how-to names clustering")
+    expect.num(int("join key" in low), 1,
+               "and it names the join key as the clustering column")
+
+
+def test_best_practices_names_join_key_clustering_for_a_fact_table(expect):
+    """Layout guidance must cover the star-schema join key, not only timestamps.
+
+    Public seam: docs/best-practices.md. The skipping section told readers to
+    cluster on the column they filter by ranges. A join key is not a range.
+    """
+    expect.num(int(PRACTICES.is_file()), 1, "premise: best-practices.md is in the tree")
+    text = PRACTICES.read_text(encoding="utf-8").lower()
+    expect.num(int("join key" in text), 1,
+               "best-practices names clustering on the join key")

--- a/test/pytest/test_harness_deps.py
+++ b/test/pytest/test_harness_deps.py
@@ -102,6 +102,9 @@ NO_CLUSTER = [
     # tool rather than the shell harness, so it needs neither a cluster nor the
     # driver.
     "test_skip_loop_arms.py",
+    # #752 docs. Reads docs/how-to.md and docs/best-practices.md. No cluster,
+    # no driver: the public seam is the published page.
+    "test_docs_join_clustering.py",
 ]
 
 


### PR DESCRIPTION
## Summary

- Addresses the **docs slice** of #752. A star-schema fact table that is not clustered on the join key still holds every key in every group, so group skip is a no-op. That skip was already measured (`19` of `20` groups removed when the keys are local, `0` of `20` when they cycle). The how-to named the GUC and not that discriminator.
- Independent twins: two checks in `test/docs_style.sh`, and `test/pytest/test_docs_join_clustering.py`. Neither suite reads the other. Causation: reverting the how-to Tuning reddens only the how-to arms; stripping `join key` from best-practices reddens only those arms.
- The GUC `pgcolumnar.enable_join_runtime_filter` **stays off**. The fold over a join is a later slice.

**This does not close #752.** The issue stays open.

## Test plan

- [x] Pytest twins red on unfixed docs, green after the prose, red again under the two independent mutations
- [x] `test/docs_style.sh` matches those outcomes
- [x] `test_docs_cover_the_corpus.py` names the new file and both tests
- [ ] CI suites include `docs_style`


Made with [Cursor](https://cursor.com)