### PR TITLE
test: a check record names the PostgreSQL major it was observed under (#1010)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,37 @@ true until the next version shipped.
 
 ### Added
 
+- A check record names the PostgreSQL major it was observed under (#1010).
+
+      RESULT<TAB>suite<TAB>part<TAB>name<TAB>verdict<TAB>major<TAB>reason
+
+  A CHECK'S EXISTENCE DEPENDS ON THE MAJOR, so a record that does not name one
+  identifies a check only partly. `test/analyze_differential.sh:61` emits ONE record on
+  PG15-17 and N on PG18+; `test/fk_referencing.sh:287` emits DIFFERENT CHECK NAMES in
+  its two branches, so the two majors' key sets are disjoint. Measured on a full matrix
+  at `4d7c75ae`: `analyze_differential`, `analyze_function`, `native_repack` and
+  `pg19_vacuum_options` each emit exactly 1 record on PG15 against a suite's worth on
+  PG18.
+
+  A grep for `PGC_MAJOR` does not find all of them, which is why this is a field rather
+  than a convention: `test/native_repack.sh:48`, `test/pg19_vacuum_options.sh:34` and
+  `test/native_dml.sh:61` gate on `server_version_num` and never mention it.
+
+  Before this the tool could only learn the major from whoever invoked it, which is the
+  `--date not-a-date` failure one field over: a PG15 log merged as PG18 is misattributed
+  and nothing in the log can contradict it. The major is VALIDATED rather than stored --
+  `eighteen`, `18.2`, `pg18` and an empty field are each refused -- because a major
+  decides which checks can exist.
+
+  `unknown` is the one non-numeric value, and it is lib.sh's own word for a field the
+  harness did not set (it already uses it for an unset suite and part). It is a real
+  case rather than a courtesy: `harness_selftest` never references `PGC_MAJOR`, so every
+  record it emits says `unknown` truthfully -- 907 of the 1155 committed ledger rows.
+
+  The ledger itself is unchanged: it still keys on `(suite, part, name)` and discards
+  the major. Keying on it is #1010's second step, and it needs a migration this change
+  does not.
+
 - The mutation ledger covers a third suite: `differential`, 204 checks (#752).
 
       suites_not_covered          250 -> 249

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,9 +45,21 @@ true until the next version shipped.
   case rather than a courtesy: `harness_selftest` never references `PGC_MAJOR`, so every
   record it emits says `unknown` truthfully -- 907 of the 1155 committed ledger rows.
 
-  The ledger itself is unchanged: it still keys on `(suite, part, name)` and discards
-  the major. Keying on it is #1010's second step, and it needs a migration this change
-  does not.
+  The ledger itself is unchanged in SHAPE: it still keys on `(suite, part, name)` and
+  discards the major. Keying on it is #1010's second step, and it needs a migration this
+  change does not.
+
+      checks_never_observed_red   1155 -> 1164
+      suites_not_covered          249 (unchanged; no suite was seeded)
+
+  The nine rows are part 400's new arms: four emitter arms driving `pgc_record` with
+  `PGC_MAJOR` set to two different values and unset, one that the reason still follows
+  the major, and five reconciler arms -- four invalid majors and the `unknown` control
+  that keeps them from passing because the reconciler started refusing everything.
+  RE-DERIVED from the committed file by the derivation the budget file states, not
+  computed from 1155:
+
+      awk -F'\t' '$4=="never"' test/check_ledger.tsv | wc -l
 
 - The mutation ledger covers a third suite: `differential`, 204 checks (#752).
 

--- a/test/check_ledger.tsv
+++ b/test/check_ledger.tsv
@@ -793,8 +793,11 @@ harness_selftest	400-a-check-result-must-be-machine	a verdict pgc_record cannot 
 harness_selftest	400-a-check-result-must-be-machine	an empty check name does not reconcile	never	-
 harness_selftest	400-a-check-result-must-be-machine	an unrunnable check emits exactly one record	never	-
 harness_selftest	400-a-check-result-must-be-machine	an unrunnable check still prints its old line	never	-
+harness_selftest	400-a-check-result-must-be-machine	and a different major reaches the same field, so it is read not hardcoded	never	-
+harness_selftest	400-a-check-result-must-be-machine	and a harness that set no major says unknown rather than an empty field	never	-
 harness_selftest	400-a-check-result-must-be-machine	and it is counted	never	-
 harness_selftest	400-a-check-result-must-be-machine	and it is counted, so checks run: reports it	never	-
+harness_selftest	400-a-check-result-must-be-machine	and its major field carries the server major it ran under	never	-
 harness_selftest	400-a-check-result-must-be-machine	and its name field is the check's name, spaces intact	never	-
 harness_selftest	400-a-check-result-must-be-machine	and its verdict field says FAIL	never	-
 harness_selftest	400-a-check-result-must-be-machine	and its verdict field says PASS	never	-
@@ -814,6 +817,7 @@ harness_selftest	400-a-check-result-must-be-machine	and the REASON_CODE travels 
 harness_selftest	400-a-check-result-must-be-machine	and the ratio check is counted as a pass, not a skip	never	-
 harness_selftest	400-a-check-result-must-be-machine	and the ratio check's human line is unchanged	never	-
 harness_selftest	400-a-check-result-must-be-machine	and the ratio check's verdict is SKIP	never	-
+harness_selftest	400-a-check-result-must-be-machine	and the reason still follows the major, so nothing shifted onto it	never	-
 harness_selftest	400-a-check-result-must-be-machine	and the timing check is counted as a pass, not a skip	never	-
 harness_selftest	400-a-check-result-must-be-machine	and the timing check's human line is unchanged	never	-
 harness_selftest	400-a-check-result-must-be-machine	and the timing check's verdict is SKIP	never	-
@@ -827,6 +831,7 @@ harness_selftest	400-a-check-result-must-be-machine	check_ratio with a zero side
 harness_selftest	400-a-check-result-must-be-machine	check_text on an empty side emits one record	never	-
 harness_selftest	400-a-check-result-must-be-machine	check_text's empty-side line is unchanged	never	-
 harness_selftest	400-a-check-result-must-be-machine	control: a well-formed record still reconciles	never	-
+harness_selftest	400-a-check-result-must-be-machine	control: unknown IS a major the reconciler accepts, or the four above prove nothing	never	-
 harness_selftest	400-a-check-result-must-be-machine	fewer records than counted checks is not described as a subshell	never	-
 harness_selftest	400-a-check-result-must-be-machine	lib.sh bumps PGC_CHECKS in exactly one place	never	-
 harness_selftest	400-a-check-result-must-be-machine	more records than counted checks names the cause, not just the arithmetic	never	-
@@ -845,6 +850,10 @@ harness_selftest	400-a-check-result-must-be-machine	premise: the probe ran every
 harness_selftest	400-a-check-result-must-be-machine	premise: the sweep classified a corpus of check-calling files	never	-
 harness_selftest	400-a-check-result-must-be-machine	premise: while a file that calls no check is not its business	never	-
 harness_selftest	400-a-check-result-must-be-machine	the accounting line reconciles four outcomes against the count	never	-
+harness_selftest	400-a-check-result-must-be-machine	the major [18.2] is not a major, so that record does not reconcile	never	-
+harness_selftest	400-a-check-result-must-be-machine	the major [] is not a major, so that record does not reconcile	never	-
+harness_selftest	400-a-check-result-must-be-machine	the major [eighteen] is not a major, so that record does not reconcile	never	-
+harness_selftest	400-a-check-result-must-be-machine	the major [pg18] is not a major, so that record does not reconcile	never	-
 harness_selftest	400-a-check-result-must-be-machine	the reconciliation accepts the verdict FAIL, which pgc_record emits	never	-
 harness_selftest	400-a-check-result-must-be-machine	the reconciliation accepts the verdict PASS, which pgc_record emits	never	-
 harness_selftest	400-a-check-result-must-be-machine	the reconciliation accepts the verdict SKIP, which pgc_record emits	never	-

--- a/test/check_ledger_budget.txt
+++ b/test/check_ledger_budget.txt
@@ -45,4 +45,4 @@ suites_not_covered 249
 #   the number of attacked checks -- and it overcounts from the first moment this
 #   ledger does the job it exists for. The gate prints both quantities side by side
 #   (`rows=N | never observed red=M`) because they are different questions.
-checks_never_observed_red 1155
+checks_never_observed_red 1164

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -1173,11 +1173,24 @@ pgc_record() {	# pgc_record VERDICT NAME DISPLAY [REASON]
 	local _nl_name="${_name//$'\t'/ }" _nl_reason="${_reason//$'\t'/ }"
 	_nl_name="${_nl_name//$'\n'/ }"; _nl_reason="${_nl_reason//$'\n'/ }"
 	_nl_name="${_nl_name//$'\r'/ }"; _nl_reason="${_nl_reason//$'\r'/ }"
-	printf 'RESULT\t%s\t%s\t%s\t%s\t%s\n' \
+	# THE MAJOR THIS CHECK WAS OBSERVED UNDER (#1010). A check's EXISTENCE depends
+	# on it -- analyze_differential.sh emits one record on PG15-17 and N on PG18+,
+	# and fk_referencing.sh's two branches emit different check NAMES -- so a
+	# record that does not name its major identifies a check only partly, and the
+	# ledger keyed on it has to take the major from whoever invoked the tool. That
+	# is the `--date not-a-date` failure one field over: a PG15 log merged as PG18
+	# is misattributed and nothing in the log can contradict it.
+	#
+	# `unknown` is this function's OWN word for a field the harness did not set,
+	# already used two lines down for an unset suite and part, and it is a REAL
+	# case rather than a courtesy: harness_selftest never references PGC_MAJOR, so
+	# every one of its records says `unknown` truthfully.
+	printf 'RESULT\t%s\t%s\t%s\t%s\t%s\t%s\n' \
 		"${PGC_SUITE:-unknown}" \
 		"${_part:-${PGC_SUITE:-unknown}}" \
 		"${_nl_name}" \
 		"$_v" \
+		"${PGC_MAJOR:-unknown}" \
 		"${_nl_reason}"
 }
 

--- a/test/pgc_ledger.py
+++ b/test/pgc_ledger.py
@@ -141,12 +141,30 @@ class LedgerError(Exception):
 # forbids, and the drift is caught by the arm that plants each verdict instead.
 VERDICTS = ("PASS", "FAIL", "UNRUN", "SKIP")
 
-# RESULT plus suite, part, name, verdict, reason.
-RECORD_FIELDS = 6
+# RESULT plus suite, part, name, verdict, major, reason.
+RECORD_FIELDS = 7
+
+# THE MAJOR A RECORD WAS OBSERVED UNDER, and the one word that means "the harness
+# never set one" (#1010).
+#
+# A check's EXISTENCE depends on the major, so the major is part of what a record
+# identifies rather than decoration on it: analyze_differential.sh:61 emits ONE
+# record on PG15-17 and N on PG18+, and fk_referencing.sh:287 emits DIFFERENT CHECK
+# NAMES in its two branches, so the two majors' key sets are disjoint. A grep for
+# PGC_MAJOR does not find all of them either -- native_repack.sh,
+# pg19_vacuum_options.sh and native_dml.sh gate on server_version_num and never
+# mention it -- which is why this is a field and not a convention.
+#
+# `unknown` is lib.sh's OWN word for a field the harness did not set, used there for
+# an unset suite and part, and it is a REAL case rather than a courtesy:
+# harness_selftest never references PGC_MAJOR anywhere, so its 907 committed rows
+# have no major to name even in principle.
+MAJOR_UNKNOWN = "unknown"
+_MAJOR = re.compile(r"^(?:[0-9]+|unknown)$")
 
 
 def read_records(paths, *, require_nonempty=True):
-    """[(suite, part, name, verdict)] for every RESULT line in the given logs.
+    """[(suite, part, name, verdict, major)] for every RESULT line in the given logs.
 
     Fails closed, and VALIDATES rather than merely counting. `len(f) < 5` accepted
     a record missing its reason, a verdict outside the emitter's vocabulary, an
@@ -181,7 +199,7 @@ def read_records(paths, *, require_nonempty=True):
             if len(f) != RECORD_FIELDS:
                 raise LedgerError(
                     f"{p}:{n}: a record has {RECORD_FIELDS - 1} fields -- suite, part, "
-                    f"name, verdict, reason; got {len(f) - 1}")
+                    f"name, verdict, major, reason; got {len(f) - 1}")
             if not f[1] or not f[2] or not f[3]:
                 raise LedgerError(
                     f"{p}:{n}: a record with an empty suite, part or name names no check")
@@ -189,7 +207,18 @@ def read_records(paths, *, require_nonempty=True):
                 raise LedgerError(
                     f"{p}:{n}: verdict {f[4]!r} is not one of {', '.join(VERDICTS)}, "
                     f"so this log was not written by pgc_record")
-            out.append((f[1], f[2], f[3], f[4]))
+            # THE MAJOR IS VALIDATED, not stored verbatim. A free-form --date was
+            # accepted once and a typo became an authoritative observation date;
+            # this is the same field one column over, and the consequence is worse
+            # because a major decides WHICH CHECKS CAN EXIST. `eighteen`, `18.2`
+            # and `pg18` are not majors, and a log carrying one is not evidence
+            # about any major at all.
+            if not _MAJOR.match(f[5]):
+                raise LedgerError(
+                    f"{p}:{n}: major {f[5]!r} is neither a number nor "
+                    f"{MAJOR_UNKNOWN!r}, so this record names no version it was "
+                    f"observed under")
+            out.append((f[1], f[2], f[3], f[4], f[5]))
             found += 1
         if require_nonempty and found == 0:
             raise LedgerError(f"{p}: no RESULT records, so there is nothing to reconcile")
@@ -246,15 +275,15 @@ def _by_run(paths):
     runs = []
     for p in paths:
         seen = {}
-        for suite, part, name, verdict in read_records([p]):
+        for suite, part, name, verdict, _major in read_records([p]):
             seen.setdefault((suite, part, name), []).append(verdict)
         runs.append((p, seen))
     return runs
 
 
 def cmd_census(args):
-    for suite, part, name, verdict in read_records(args.logs):
-        print(f"{suite}\t{part}\t{name}\t{verdict}")
+    for suite, part, name, verdict, major in read_records(args.logs):
+        print(f"{suite}\t{part}\t{name}\t{verdict}\t{major}")
     return 0
 
 
@@ -714,7 +743,7 @@ def cmd_gate(args):
     rows = read_ledger(args.ledger)
     budget = read_budget(args.budget)
     seen = {k for k, _, _ in ((k, None, None) for k in
-                              {(s, p, n) for s, p, n, _ in read_records(args.logs)})}
+                              {(s, p, n) for s, p, n, _, _m in read_records(args.logs)})}
 
     rc = 0
 

--- a/test/pytest/TESTS.md
+++ b/test/pytest/TESTS.md
@@ -2375,6 +2375,28 @@ contradiction — and because every other gate fixture in both harnesses states 
 something else. What holds the committed budget to naming both numbers is the arm
 above.
 
+### `test_a_record_that_does_not_name_its_major_is_not_evidence`
+
+A log can only be trusted about the major it says it came from (#1010). The record
+carried suite, part, name, verdict and reason, so the major was whatever the caller
+asserted -- the `--date not-a-date` failure one field over, and worse, because a major
+decides WHICH CHECKS CAN EXIST. `analyze_differential.sh:61` emits one record on PG15-17
+and a suite's worth on PG18+; `fk_referencing.sh:287` emits different check NAMES in its
+two branches.
+
+The six-field record must stop reconciling, or the field is optional and a log without
+it keeps being merged on the caller's word. Four invalid majors are refused
+(`eighteen`, `18.2`, `pg18`, empty) with a well-formed control, and `unknown` is
+accepted -- `harness_selftest` never references `PGC_MAJOR`, so 907 committed rows have
+no major to name even in principle.
+
+### `test_the_census_reports_the_major_it_read`
+
+Read and discarded is indistinguishable from not read at all. `census` is how a human
+checks a log before merging it, so a major the tool validates and then drops cannot be
+audited. Asserted on the FIELD rather than a substring: `18` appears inside a check name
+or a reason just as happily.
+
 ## 24. test_loop_coverage_premise.py: a loop that never ran asserted nothing
 
 **Why this file exists.** `assert-inside-a-loop-over-zero-rows` in VACUITY_MODES.md 3.5

--- a/test/pytest/test_mutation_ledger.py
+++ b/test/pytest/test_mutation_ledger.py
@@ -29,10 +29,10 @@ REPO = pathlib.Path(__file__).resolve().parents[2]
 TOOL = REPO / "test" / "pgc_ledger.py"
 RUNNER = REPO / "test" / "run_all_versions.sh"
 
-GREEN = ("RESULT\tdemo\tpart1\tfirst check\tPASS\t\n"
-         "RESULT\tdemo\tpart1\tsecond check\tPASS\t\nchecks run: 2\n")
-RED = ("RESULT\tdemo\tpart1\tfirst check\tFAIL\t\n"
-       "RESULT\tdemo\tpart1\tsecond check\tPASS\t\nchecks run: 2\n")
+GREEN = ("RESULT\tdemo\tpart1\tfirst check\tPASS\t18\t\n"
+         "RESULT\tdemo\tpart1\tsecond check\tPASS\t18\t\nchecks run: 2\n")
+RED = ("RESULT\tdemo\tpart1\tfirst check\tFAIL\t18\t\n"
+       "RESULT\tdemo\tpart1\tsecond check\tPASS\t18\t\nchecks run: 2\n")
 
 
 def _run(*args, cwd=None):
@@ -134,8 +134,8 @@ def test_two_runs_of_a_check_are_not_a_duplicate_of_it(tmp_path, expect):
                "the same check in two logs is two runs, not a duplicate")
 
     twice = _w(tmp_path, "twice.log",
-               "RESULT\tdemo\tpart1\tsame\tPASS\t\n"
-               "RESULT\tdemo\tpart1\tsame\tFAIL\t\nchecks run: 2\n")
+               "RESULT\tdemo\tpart1\tsame\tPASS\t18\t\n"
+               "RESULT\tdemo\tpart1\tsame\tFAIL\t18\t\nchecks run: 2\n")
     out, _ = _run("merge", "--reds-are-real", "--ledger", _w(tmp_path, "l2.tsv", ""), "--date", "2026-09-10", twice)
     expect.num(out.count("duplicate check name in one run, so one ledger row covers 2: "
                          "demo\tpart1\tsame"), 1,
@@ -152,12 +152,12 @@ def test_renames_are_grouped_by_part_and_scanned_against_one_run(tmp_path, expec
     """
     ledger = _w(tmp_path, "l.tsv", "")
     before = _w(tmp_path, "b.log",
-                "RESULT\tdemo\tpartA\told A\tFAIL\t\n"
-                "RESULT\tdemo\tpartB\tstable B\tPASS\t\nchecks run: 2\n")
+                "RESULT\tdemo\tpartA\told A\tFAIL\t18\t\n"
+                "RESULT\tdemo\tpartB\tstable B\tPASS\t18\t\nchecks run: 2\n")
     after = _w(tmp_path, "a.log",
-               "RESULT\tdemo\tpartA\tnew A\tPASS\t\n"
-               "RESULT\tdemo\tpartB\tstable B\tPASS\t\n"
-               "RESULT\tdemo\tpartB\tadded B\tPASS\t\nchecks run: 3\n")
+               "RESULT\tdemo\tpartA\tnew A\tPASS\t18\t\n"
+               "RESULT\tdemo\tpartB\tstable B\tPASS\t18\t\n"
+               "RESULT\tdemo\tpartB\tadded B\tPASS\t18\t\nchecks run: 3\n")
     _run("merge", "--reds-are-real", "--ledger", ledger, "--date", "2026-09-01", before)
 
     out, rc = _run("rename-scan", "--ledger", ledger, after)
@@ -188,11 +188,11 @@ def test_an_orphan_row_is_named_and_the_unscanned_rows_are_counted(tmp_path, exp
     """
     ledger = _w(tmp_path, "l.tsv", "")
     before = _w(tmp_path, "b.log",
-                "RESULT\tdemo\tpart1\tstill here\tPASS\t\n"
-                "RESULT\tdemo\tpart1\tgone tomorrow\tPASS\t\n"
-                "RESULT\tdemo\tpartZ\telsewhere\tPASS\t\nchecks run: 3\n")
+                "RESULT\tdemo\tpart1\tstill here\tPASS\t18\t\n"
+                "RESULT\tdemo\tpart1\tgone tomorrow\tPASS\t18\t\n"
+                "RESULT\tdemo\tpartZ\telsewhere\tPASS\t18\t\nchecks run: 3\n")
     after = _w(tmp_path, "a.log",
-               "RESULT\tdemo\tpart1\tstill here\tPASS\t\nchecks run: 1\n")
+               "RESULT\tdemo\tpart1\tstill here\tPASS\t18\t\nchecks run: 1\n")
     _run("merge", "--ledger", ledger, "--date", "2026-09-01", before)
     expect.num(len(_rows(ledger)), 3, "premise: the ledger holds all three rows")
 
@@ -221,14 +221,14 @@ def test_prune_drops_a_historyless_orphan_and_refuses_one_carrying_history(tmp_p
     partial job for whoever reads the output.
     """
     after = _w(tmp_path, "a.log",
-               "RESULT\tdemo\tpart1\tstill here\tPASS\t\nchecks run: 1\n")
+               "RESULT\tdemo\tpart1\tstill here\tPASS\t18\t\nchecks run: 1\n")
 
     plain = _w(tmp_path, "plain.tsv", "")
     _run("merge", "--ledger", plain, "--date", "2026-09-01",
          _w(tmp_path, "p.log",
-            "RESULT\tdemo\tpart1\tstill here\tPASS\t\n"
-            "RESULT\tdemo\tpart1\tgone tomorrow\tPASS\t\n"
-            "RESULT\tdemo\tpartZ\telsewhere\tPASS\t\nchecks run: 3\n"))
+            "RESULT\tdemo\tpart1\tstill here\tPASS\t18\t\n"
+            "RESULT\tdemo\tpart1\tgone tomorrow\tPASS\t18\t\n"
+            "RESULT\tdemo\tpartZ\telsewhere\tPASS\t18\t\nchecks run: 3\n"))
     out, rc = _run("orphan-scan", "--prune", "--ledger", plain, after)
     expect.num(out.count("pruned: demo\tpart1\tgone tomorrow"), 1,
                "a historyless orphan is pruned, and named as it goes")
@@ -244,8 +244,8 @@ def test_prune_drops_a_historyless_orphan_and_refuses_one_carrying_history(tmp_p
     _run("merge", "--reds-are-real", "--mutation", "drop the guard", "--ledger", hist,
          "--date", "2026-09-01",
          _w(tmp_path, "h.log",
-            "RESULT\tdemo\tpart1\tstill here\tPASS\t\n"
-            "RESULT\tdemo\tpart1\tgone tomorrow\tFAIL\t\nchecks run: 2\n"))
+            "RESULT\tdemo\tpart1\tstill here\tPASS\t18\t\n"
+            "RESULT\tdemo\tpart1\tgone tomorrow\tFAIL\t18\t\nchecks run: 2\n"))
     expect.text({r[2]: r[3] for r in _rows(hist)}["gone tomorrow"], "2026-09-01",
                 "premise: the orphan now carries a date")
 
@@ -280,12 +280,12 @@ def test_a_part_that_skipped_is_unprunable_because_absence_is_not_removal(tmp_pa
     ledger = _w(tmp_path, "l.tsv", "")
     _run("merge", "--ledger", ledger, "--date", "2026-09-01",
          _w(tmp_path, "full.log",
-            "RESULT\tdemo\tpart1\tarm one\tPASS\t\n"
-            "RESULT\tdemo\tpart1\tarm two\tPASS\t\n"
-            "RESULT\tdemo\tpart1\tthe whole thing\tPASS\t\nchecks run: 3\n"))
+            "RESULT\tdemo\tpart1\tarm one\tPASS\t18\t\n"
+            "RESULT\tdemo\tpart1\tarm two\tPASS\t18\t\n"
+            "RESULT\tdemo\tpart1\tthe whole thing\tPASS\t18\t\nchecks run: 3\n"))
     expect.num(len(_rows(ledger)), 3, "premise: the ledger holds all three rows")
     skipped = _w(tmp_path, "skipped.log",
-                 "RESULT\tdemo\tpart1\tthe whole thing\tSKIP\tno fixture on this box\n"
+                 "RESULT\tdemo\tpart1\tthe whole thing\tSKIP\t18\tno fixture on this box\n"
                  "checks run: 1\n")
 
     out, rc = _run("orphan-scan", "--ledger", ledger, skipped)
@@ -302,7 +302,7 @@ def test_a_part_that_skipped_is_unprunable_because_absence_is_not_removal(tmp_pa
                "and it says so rather than declining silently")
 
     passed = _w(tmp_path, "pass.log",
-                "RESULT\tdemo\tpart1\tthe whole thing\tPASS\t\nchecks run: 1\n")
+                "RESULT\tdemo\tpart1\tthe whole thing\tPASS\t18\t\nchecks run: 1\n")
     out, _ = _run("orphan-scan", "--prune", "--ledger", ledger, passed)
     expect.num(out.count("removed 2 row(s)"), 1,
                "control: the same rows ARE pruned when that part's record is a PASS")
@@ -321,7 +321,7 @@ def test_the_gate_refuses_a_new_check_only_in_a_suite_it_covers(tmp_path, expect
     reg = _w(tmp_path, "reg", "demo\nother\n")
     _run("merge", "--ledger", ledger, "--date", "2026-09-10", _w(tmp_path, "g.log", GREEN))
 
-    other = _w(tmp_path, "o.log", "RESULT\tother\tpartX\tsomething\tPASS\t\nchecks run: 1\n")
+    other = _w(tmp_path, "o.log", "RESULT\tother\tpartX\tsomething\tPASS\t18\t\nchecks run: 1\n")
     b1 = _w(tmp_path, "b1.txt", "suites_not_covered 1\n")
     out, rc = _run("gate", "--ledger", ledger, "--budget", b1, "--registered", reg, other)
     expect.num(rc, 0, "a check in an uncovered suite is not refused")
@@ -329,8 +329,8 @@ def test_the_gate_refuses_a_new_check_only_in_a_suite_it_covers(tmp_path, expect
 
     _run("merge", "--ledger", ledger, "--date", "2026-09-10", other)
     other2 = _w(tmp_path, "o2.log",
-                "RESULT\tother\tpartX\tsomething\tPASS\t\n"
-                "RESULT\tother\tpartX\tnewly added\tPASS\t\nchecks run: 2\n")
+                "RESULT\tother\tpartX\tsomething\tPASS\t18\t\n"
+                "RESULT\tother\tpartX\tnewly added\tPASS\t18\t\nchecks run: 2\n")
     b0 = _w(tmp_path, "b0.txt", "suites_not_covered 0\n")
     out, rc = _run("gate", "--ledger", ledger, "--budget", b0, "--registered", reg, other2)
     expect.num(rc, 1, "once the suite is covered, a new check in it IS refused")
@@ -508,9 +508,9 @@ def test_a_log_that_does_not_parse_is_not_evidence(tmp_path, expect):
     cases = {
         "no reason field": "RESULT\tdemo\tpart1\ta name\tPASS\nchecks run: 1\n",
         "a verdict the emitter cannot emit": "RESULT\tdemo\tpart1\ta name\tBOGUS\t\nchecks run: 1\n",
-        "an empty check name": "RESULT\tdemo\tpart1\t\tPASS\t\nchecks run: 1\n",
-        "a count that disagrees with the records": "RESULT\tdemo\tpart1\ta name\tPASS\t\nchecks run: 2\n",
-        "no count at all": "RESULT\tdemo\tpart1\ta name\tPASS\t\n",
+        "an empty check name": "RESULT\tdemo\tpart1\t\tPASS\t18\t\nchecks run: 1\n",
+        "a count that disagrees with the records": "RESULT\tdemo\tpart1\ta name\tPASS\t18\t\nchecks run: 2\n",
+        "no count at all": "RESULT\tdemo\tpart1\ta name\tPASS\t18\t\n",
     }
     for label, text in cases.items():
         log = _w(tmp_path, "bad.log", text)
@@ -561,8 +561,8 @@ def test_a_mutation_names_one_check_not_every_casualty(tmp_path, expect):
     """
     led = _w(tmp_path, "l.tsv", "")
     two = _w(tmp_path, "two.log",
-             "RESULT\tdemo\tpart1\tthe target\tFAIL\t\n"
-             "RESULT\tdemo\tpart1\tcollateral\tFAIL\t\nchecks run: 2\n")
+             "RESULT\tdemo\tpart1\tthe target\tFAIL\t18\t\n"
+             "RESULT\tdemo\tpart1\tcollateral\tFAIL\t18\t\nchecks run: 2\n")
     out, rc = _run("merge", "--ledger", led, "--date", "2026-09-10", "--mutation", "M", two)
     expect.num(rc, 2, "--mutation across two failing checks in one run is refused")
     expect.num(out.count("2 checks failed"), 1,
@@ -619,3 +619,79 @@ def test_a_reconciling_log_with_a_red_is_not_evidence_on_its_own(tmp_path, expec
     green = _w(tmp_path, "green.log", GREEN)
     expect.num(_run("merge", "--ledger", led4, "--date", "2026-09-10", green)[1], 0,
                "control: an all-PASS log still merges with no flag at all")
+
+
+def test_a_record_that_does_not_name_its_major_is_not_evidence(tmp_path, expect):
+    """A log can only be trusted about the major it says it came from (#1010).
+
+    The record carried suite, part, name, verdict and reason, so the major was
+    whatever the caller asserted. That is the `--date not-a-date` failure one field
+    over: a PG15 log merged as PG18 is misattributed silently, and a ledger whose
+    subject is provenance cannot take the major on trust from its invoker.
+
+    A check's EXISTENCE depends on the major -- analyze_differential emits one record
+    on PG15-17 and N on PG18+, and fk_referencing's two branches emit different check
+    NAMES -- so the major is not decoration on the record, it is part of what the
+    record identifies.
+    """
+    ledger = _w(tmp_path, "l.tsv", "")
+    budget = _w(tmp_path, "b.txt", "suites_not_covered 0\n")
+    reg = _w(tmp_path, "reg", "demo\n")
+
+    # The OLD six-field record. It has to stop reconciling, or the new field is
+    # optional and a log without it keeps being merged on the caller's word.
+    old = _w(tmp_path, "old.log",
+             "RESULT\tdemo\tpart1\tfirst check\tPASS\t\nchecks run: 1\n")
+    out, rc = _run("gate", "--ledger", ledger, "--budget", budget,
+                   "--registered", reg, old)
+    expect.num(rc, 2, "a record with no major field is an integrity failure")
+    expect.num(out.count("major"), 1, "and the message says the major is what is missing")
+
+    # A major that is not a major. Refused for the same reason a free-form --date was:
+    # stored verbatim, it becomes an attribution nothing measured.
+    for bad in ("eighteen", "18.2", "", "pg18"):
+        log = _w(tmp_path, "bad.log",
+                 f"RESULT\tdemo\tpart1\tfirst check\tPASS\t{bad}\t\nchecks run: 1\n")
+        out, rc = _run("gate", "--ledger", ledger, "--budget", budget,
+                       "--registered", reg, log)
+        expect.num(rc, 2, f"the major [{bad}] is not a major, so this log is not evidence")
+
+    # And the good form reconciles, or the arm above proves only that everything fails.
+    good = _w(tmp_path, "good.log",
+              "RESULT\tdemo\tpart1\tfirst check\tPASS\t18\t\nchecks run: 1\n")
+    expect.num(_run("gate", "--ledger", ledger, "--budget", budget,
+                    "--registered", reg, good)[1], 1,
+               "a record naming its major reaches the gate's own verdict")
+
+    # `unknown` is the emitter's word for a field the harness never set, and it is a
+    # REAL case rather than a courtesy: harness_selftest does not reference PGC_MAJOR
+    # anywhere, so its 907 rows have no major to name even in principle. It must be
+    # accepted and it must stay distinguishable from a number.
+    unk = _w(tmp_path, "unk.log",
+             "RESULT\tdemo\tpart1\tfirst check\tPASS\tunknown\t\nchecks run: 1\n")
+    expect.num(_run("gate", "--ledger", ledger, "--budget", budget,
+                    "--registered", reg, unk)[1], 1,
+               "a record whose harness never set a major says so and is still evidence")
+
+
+def test_the_census_reports_the_major_it_read(tmp_path, expect):
+    """Read and discarded is indistinguishable from not read at all (#1010).
+
+    `census` is the subcommand that prints what the tool parsed out of a log, and it
+    is how a human checks a log before merging it. A major the tool validates and then
+    drops cannot be audited, and a field nobody can see is a field that goes wrong
+    silently -- measured twice on this tool already (`vanished=N` refusing nothing,
+    and a census that was printed but never compared).
+    """
+    log = _w(tmp_path, "c.log",
+             "RESULT\tdemo\tpart1\tfirst check\tPASS\t18\t\n"
+             "RESULT\tdemo\tpart1\tsecond check\tFAIL\t18\t\n"
+             "RESULT\tdemo\tpart2\tthird check\tPASS\tunknown\t\nchecks run: 3\n")
+    out, rc = _run("census", log)
+    expect.num(rc, 0, "the census reads a log that names its majors")
+    # The FIELD, not a substring. `18` appears inside a check name or a reason just as
+    # happily, and a count that matches anywhere is a claim about the whole line.
+    majors = [l.split("\t")[4] for l in out.splitlines() if l.count("\t") == 4]
+    expect.num(majors.count("18"), 2, "and prints the major for each record that has one")
+    expect.num(majors.count("unknown"), 1,
+               "and prints `unknown` where the harness set none")

--- a/test/run_all_versions.sh
+++ b/test/run_all_versions.sh
@@ -974,10 +974,17 @@ pgc_reconcile_records() {	# pgc_reconcile_records LOGFILE -> 0 ok, 1 mismatch
 	_bad="$(awk -F'\t' '
 		/^RESULT	/ {
 			n++
-			if (NF != 6)                       { why[n] = "has " NF-1 " fields, want 5"; bad++; next }
+			if (NF != 7)                       { why[n] = "has " NF-1 " fields, want 6"; bad++; next }
 			if ($2 == "" || $3 == "" || $4 == "") { why[n] = "has an empty suite, part or name"; bad++; next }
 			if ($5 != "PASS" && $5 != "FAIL" && $5 != "UNRUN" && $5 != "SKIP") {
 				why[n] = "has verdict \"" $5 "\", which pgc_record cannot emit"; bad++; next
+			}
+			# THE MAJOR IS VALIDATED, not merely present (#1010). Stored verbatim a
+			# typo becomes a version the ledger then treats as authoritative --
+			# exactly what a free-form --date did -- and a major decides WHICH
+			# CHECKS CAN EXIST, so the consequence is larger here than for a date.
+			if ($6 !~ /^([0-9]+|unknown)$/) {
+				why[n] = "has major \"" $6 "\", which is neither a number nor \"unknown\""; bad++; next
 			}
 		}
 		END {

--- a/test/selftest/400-a-check-result-must-be-machine.sh
+++ b/test/selftest/400-a-check-result-must-be-machine.sh
@@ -34,7 +34,7 @@ check "and that place is pgc_record" \
 # ---- the record line itself -------------------------------------------------
 #
 # Tab separated, so a name containing spaces survives. Five columns after the
-# RESULT marker: suite, part, name, verdict, reason. The reason carries phase 1's
+# RESULT marker: suite, part, name, verdict, major, reason. The reason carries phase 1's
 # REASON_CODE, which is what makes this more than a reformat: an unrunnable check
 # is distinguishable from a passing one without parsing prose. The verdict is one
 # of PASS, FAIL, UNRUN or SKIP.
@@ -57,6 +57,30 @@ check "and its verdict field says PASS" \
 	"$(_rec check "a name" x x | cut -f5)" "PASS"
 check "and its name field is the check's name, spaces intact" \
 	"$(_rec check "a name" x x | cut -f4)" "a name"
+
+# THE MAJOR FIELD (#1010). A check's existence depends on the major --
+# analyze_differential.sh emits one record on PG15-17 and N on PG18+, and
+# fk_referencing.sh's two branches emit different check NAMES -- so a record that
+# does not name its major identifies a check only partly, and the ledger keyed on it
+# would take the major from whoever invoked the tool.
+#
+# Driven through the emitter with PGC_MAJOR SET and UNSET, because those are two
+# different claims and an arm that only ever runs one of them cannot tell a field
+# that reads the variable from a field hardcoded to either answer.
+check "and its major field carries the server major it ran under" \
+	"$( ( PGC_MAJOR=18; _rec check "a name" x x ) | cut -f6)" "18"
+
+check "and a different major reaches the same field, so it is read not hardcoded" \
+	"$( ( PGC_MAJOR=15; _rec check "a name" x x ) | cut -f6)" "15"
+
+# `unknown` is not a courtesy: harness_selftest -- this very suite -- never
+# references PGC_MAJOR, so every record it emits takes this branch, and the word is
+# lib.sh's own for an unset field (it uses it for suite and part two lines above).
+check "and a harness that set no major says unknown rather than an empty field" \
+	"$( ( unset PGC_MAJOR; _rec check "a name" x x ) | cut -f6)" "unknown"
+
+check "and the reason still follows the major, so nothing shifted onto it" \
+	"$(_rec check_unrunnable "a name" MISSING_DEPENDENCY "no jq" | cut -f7)" "MISSING_DEPENDENCY"
 
 # ---- and WHICH PART asked it ------------------------------------------------
 #
@@ -87,7 +111,7 @@ check "an unrunnable check emits exactly one record" \
 check "and its verdict field says UNRUN, which is neither of the other two" \
 	"$(_rec check_unrunnable "a name" MISSING_DEPENDENCY "no jq" | cut -f5)" "UNRUN"
 check "and the REASON_CODE travels in the reason field, not in prose" \
-	"$(_rec check_unrunnable "a name" MISSING_DEPENDENCY "no jq" | cut -f6)" "MISSING_DEPENDENCY"
+	"$(_rec check_unrunnable "a name" MISSING_DEPENDENCY "no jq" | cut -f7)" "MISSING_DEPENDENCY"
 
 # A reason code the enum does not contain is already a FAIL. It must record that
 # verdict, not the one it was asked for.
@@ -166,23 +190,23 @@ eval "$(sed -n '/^pgc_reconcile_records()/,/^}/p' "$_rv")"
 check "premise: it is callable" "$(type -t pgc_reconcile_records)" "function"
 
 _rl="$PGC_WORKDIR/rec.log"
-printf 'RESULT\ts\tp\ta\tPASS\t\nRESULT\ts\tp\tb\tPASS\t\nchecks run: 2\n' > "$_rl"
+printf 'RESULT\ts\tp\ta\tPASS\t18\t\nRESULT\ts\tp\tb\tPASS\t18\t\nchecks run: 2\n' > "$_rl"
 check "a log whose records match its stated count reconciles" \
 	"$(pgc_reconcile_records "$_rl" >/dev/null 2>&1 && echo ok || echo mismatch)" "ok"
 
-printf 'RESULT\ts\tp\ta\tPASS\t\nchecks run: 2\n' > "$_rl"
+printf 'RESULT\ts\tp\ta\tPASS\t18\t\nchecks run: 2\n' > "$_rl"
 check "a log with fewer records than it claims is caught" \
 	"$(pgc_reconcile_records "$_rl" >/dev/null 2>&1 && echo ok || echo mismatch)" "mismatch"
 check "and the two numbers are named, not just the verdict" \
 	"$(pgc_reconcile_records "$_rl" 2>&1 | grep -c 'records=1 .*checks run: 2')" "1"
 
-printf 'RESULT\ts\tp\ta\tPASS\t\nRESULT\ts\tp\tb\tPASS\t\nRESULT\ts\tp\tc\tPASS\t\nchecks run: 2\n' > "$_rl"
+printf 'RESULT\ts\tp\ta\tPASS\t18\t\nRESULT\ts\tp\tb\tPASS\t18\t\nRESULT\ts\tp\tc\tPASS\t18\t\nchecks run: 2\n' > "$_rl"
 check "a log with more records than it claims is caught too" \
 	"$(pgc_reconcile_records "$_rl" >/dev/null 2>&1 && echo ok || echo mismatch)" "mismatch"
 
 # A log with no `checks run:` line at all did not reach its summary. That is a
 # different fault from a miscount and must not read as a clean reconciliation.
-printf 'RESULT\ts\tp\ta\tPASS\t\n' > "$_rl"
+printf 'RESULT\ts\tp\ta\tPASS\t18\t\n' > "$_rl"
 check "a log that never stated a count is not silently accepted" \
 	"$(pgc_reconcile_records "$_rl" >/dev/null 2>&1 && echo ok || echo mismatch)" "mismatch"
 
@@ -197,7 +221,7 @@ check "the runner calls the record reconciliation, not merely defines it" \
 # The control comes FIRST and is asserted, because five arms that all say
 # "mismatch" prove nothing if the function has simply started refusing
 # everything. That is the shape this suite exists to catch.
-printf 'RESULT\ts\tp\ta\tPASS\t\nchecks run: 1\n' > "$_rl"
+printf 'RESULT\ts\tp\ta\tPASS\t18\t\nchecks run: 1\n' > "$_rl"
 check "control: a well-formed record still reconciles" \
 	"$(pgc_reconcile_records "$_rl" >/dev/null 2>&1 && echo ok || echo mismatch)" "ok"
 
@@ -210,19 +234,35 @@ check "a record missing fields does not reconcile" \
 	"$(_rq_bad "$(printf 'RESULT\ts\tp\ta')")" "mismatch"
 
 check "a record carrying extra fields does not reconcile" \
-	"$(_rq_bad "$(printf 'RESULT\ts\tp\tn\tPASS\tr\textra\tmore')")" "mismatch"
+	"$(_rq_bad "$(printf 'RESULT\ts\tp\tn\tPASS\t18\tr\textra\tmore')")" "mismatch"
 
 check "a verdict pgc_record cannot emit does not reconcile" \
-	"$(_rq_bad "$(printf 'RESULT\ts\tp\tn\tBOGUS\t')")" "mismatch"
+	"$(_rq_bad "$(printf 'RESULT\ts\tp\tn\tBOGUS\t18\t')")" "mismatch"
 
 check "an empty check name does not reconcile" \
-	"$(_rq_bad "$(printf 'RESULT\ts\tp\t\tPASS\t')")" "mismatch"
+	"$(_rq_bad "$(printf 'RESULT\ts\tp\t\tPASS\t18\t')")" "mismatch"
+
+# A MAJOR THAT IS NOT A MAJOR does not reconcile (#1010). Validated rather than
+# stored: a free-form --date was accepted verbatim once and a typo became an
+# observation date the ledger treated as authoritative. A major is worse, because
+# it decides which checks can exist at all.
+#
+# Four shapes, and the empty one matters most: an emitter that loses the value
+# entirely produces it, and an arm that only tries `eighteen` would pass over it.
+for _rq_m in eighteen 18.2 pg18 ''; do
+	check "the major [$_rq_m] is not a major, so that record does not reconcile" \
+		"$(_rq_bad "$(printf 'RESULT\ts\tp\tn\tPASS\t%s\t' "$_rq_m")")" "mismatch"
+done
+unset _rq_m
+
+check "control: unknown IS a major the reconciler accepts, or the four above prove nothing" \
+	"$(_rq_bad "$(printf 'RESULT\ts\tp\tn\tPASS\tunknown\t')")" "ok"
 
 # The four verdicts are the emitter's own list. If pgc_record grows a fifth and
 # this one does not, this arm goes red rather than the vocabulary drifting.
 for _rq_v in PASS FAIL UNRUN SKIP; do
 	check "the reconciliation accepts the verdict $_rq_v, which pgc_record emits" \
-		"$(_rq_bad "$(printf 'RESULT\ts\tp\tn\t%s\t' "$_rq_v")")" "ok"
+		"$(_rq_bad "$(printf 'RESULT\ts\tp\tn\t%s\t18\t' "$_rq_v")")" "ok"
 done
 unset -f _rq_bad
 unset _rq_v
@@ -456,7 +496,7 @@ check "a suite that skipped every check did not pass" \
 
 eval "$(sed -n '/^pgc_reconcile_records()/,/^}/p' "$_rv")"
 _pl="$PGC_WORKDIR/piped.log"
-printf 'RESULT\ts\tp\ta\tPASS\t\nRESULT\ts\tp\tb\tPASS\t\nRESULT\ts\tp\tc\tPASS\t\nchecks run: 1\n' > "$_pl"
+printf 'RESULT\ts\tp\ta\tPASS\t18\t\nRESULT\ts\tp\tb\tPASS\t18\t\nRESULT\ts\tp\tc\tPASS\t18\t\nchecks run: 1\n' > "$_pl"
 check "more records than counted checks names the cause, not just the arithmetic" \
 	"$(pgc_reconcile_records "$_pl" 2>&1 | grep -c 'a check ran in a subshell')" "1"
 check "and still reports the two numbers" \
@@ -464,7 +504,7 @@ check "and still reports the two numbers" \
 
 # Fewer records than checks is the OPPOSITE fault -- a counted check that emitted
 # no record -- and must not be described as a subshell.
-printf 'RESULT\ts\tp\ta\tPASS\t\nchecks run: 3\n' > "$_pl"
+printf 'RESULT\ts\tp\ta\tPASS\t18\t\nchecks run: 3\n' > "$_pl"
 check "fewer records than counted checks is not described as a subshell" \
 	"$(pgc_reconcile_records "$_pl" 2>&1 | grep -c 'a check ran in a subshell')" "0"
 check "and names its own cause instead" \

--- a/test/selftest/410-a-check-must-have-been-red.sh
+++ b/test/selftest/410-a-check-must-have-been-red.sh
@@ -36,8 +36,8 @@ _lw="$PGC_WORKDIR/ledger"; mkdir -p "$_lw"
 _led_run() { python3 "$_led" "$@" 2>&1; }
 _led_rc()  { python3 "$_led" "$@" >/dev/null 2>&1; echo $?; }
 
-printf 'RESULT\tdemo\tpart1\tfirst check\tPASS\t\nRESULT\tdemo\tpart1\tsecond check\tPASS\t\nchecks run: 2\n' > "$_lw/green.log"
-printf 'RESULT\tdemo\tpart1\tfirst check\tFAIL\t\nRESULT\tdemo\tpart1\tsecond check\tPASS\t\nchecks run: 2\n' > "$_lw/red.log"
+printf 'RESULT\tdemo\tpart1\tfirst check\tPASS\t18\t\nRESULT\tdemo\tpart1\tsecond check\tPASS\t18\t\nchecks run: 2\n' > "$_lw/green.log"
+printf 'RESULT\tdemo\tpart1\tfirst check\tFAIL\t18\t\nRESULT\tdemo\tpart1\tsecond check\tPASS\t18\t\nchecks run: 2\n' > "$_lw/red.log"
 printf 'demo\n' > "$_lw/registered"
 printf 'suites_not_covered 0\n' > "$_lw/budget.txt"
 
@@ -58,7 +58,7 @@ check "and a record missing its verdict" \
 	"$(_led_rc gate --ledger "$_lw/l.tsv" --budget "$_lw/budget.txt" --registered "$_lw/registered" "$_lw/short.log")" "2"
 check "each says what was wrong with the input" \
 	"$(_led_run gate --ledger "$_lw/l.tsv" --budget "$_lw/budget.txt" --registered "$_lw/registered" "$_lw/short.log" \
-		| grep -c 'a record has 5 fields')" "1"
+		| grep -c 'a record has 6 fields')" "1"
 
 # ---- the count is not the schema, on INGESTION as well as in the runner ------
 #
@@ -68,9 +68,9 @@ check "each says what was wrong with the input" \
 # that does not parse. The runner reconciles the suite it just ran; this
 # reconciles a log handed to the ledger, possibly from another machine.
 # Reported by @linuxhikerpm on #918.
-printf 'RESULT\tdemo\tpart1\ta name\tBOGUS\t\nchecks run: 1\n' > "$_lw/bogus.log"
-printf 'RESULT\tdemo\tpart1\t\tPASS\t\nchecks run: 1\n'        > "$_lw/noname.log"
-printf 'RESULT\tdemo\tpart1\ta name\tPASS\t\nchecks run: 2\n'  > "$_lw/miscount.log"
+printf 'RESULT\tdemo\tpart1\ta name\tBOGUS\t18\t\nchecks run: 1\n' > "$_lw/bogus.log"
+printf 'RESULT\tdemo\tpart1\t\tPASS\t18\t\nchecks run: 1\n'        > "$_lw/noname.log"
+printf 'RESULT\tdemo\tpart1\ta name\tPASS\t18\t\nchecks run: 2\n'  > "$_lw/miscount.log"
 
 check "a verdict pgc_record cannot emit is an integrity failure" \
 	"$(_led_rc merge --ledger "$_lw/v.tsv" --date 2026-09-10 "$_lw/bogus.log")" "2"
@@ -111,7 +111,7 @@ check "a date that is not a date is refused rather than stored" \
 # A run that mutates one thing can redden several: the target, plus whatever
 # depended on it. Attributing --mutation to every failure records collateral
 # damage as evidence that the mutation kills that check.
-printf 'RESULT\tdemo\tpart1\tthe target\tFAIL\t\nRESULT\tdemo\tpart1\tcollateral\tFAIL\t\nchecks run: 2\n' \
+printf 'RESULT\tdemo\tpart1\tthe target\tFAIL\t18\t\nRESULT\tdemo\tpart1\tcollateral\tFAIL\t18\t\nchecks run: 2\n' \
 	> "$_lw/twofail.log"
 check "--mutation across two failing checks in one run is refused" \
 	"$(_led_rc merge --ledger "$_lw/m2.tsv" --date 2026-09-10 --mutation M "$_lw/twofail.log")" "2"
@@ -179,7 +179,7 @@ check "one --mutation cannot be attributed across several runs at once" \
 : > "$_lw/dup.tsv"
 check "the same check in two logs is two runs, not a duplicate" \
 	"$(_led_run merge --ledger "$_lw/dup.tsv" --date 2026-09-10 "$_lw/green.log" "$_lw/green.log" | grep -c 'duplicate')" "0"
-printf 'RESULT\tdemo\tpart1\tsame\tPASS\t\nRESULT\tdemo\tpart1\tsame\tFAIL\t\nchecks run: 2\n' > "$_lw/twice.log"
+printf 'RESULT\tdemo\tpart1\tsame\tPASS\t18\t\nRESULT\tdemo\tpart1\tsame\tFAIL\t18\t\nchecks run: 2\n' > "$_lw/twice.log"
 : > "$_lw/dup2.tsv"
 check "the same name twice in ONE log is a duplicate, and is named" \
 	"$(_led_run merge --reds-are-real --ledger "$_lw/dup2.tsv" --date 2026-09-10 "$_lw/twice.log" \
@@ -193,8 +193,8 @@ check "the same name twice in ONE log is a duplicate, and is named" \
 # gone -- a scan that silently finds nothing is worse than one that refuses.
 
 : > "$_lw/ren.tsv"
-printf 'RESULT\tdemo\tpart1\tthe old name\tFAIL\t\nRESULT\tdemo\tpart1\ta stable check\tPASS\t\nchecks run: 2\n' > "$_lw/before.log"
-printf 'RESULT\tdemo\tpart1\tthe new name\tPASS\t\nRESULT\tdemo\tpart1\ta stable check\tPASS\t\nchecks run: 2\n' > "$_lw/after.log"
+printf 'RESULT\tdemo\tpart1\tthe old name\tFAIL\t18\t\nRESULT\tdemo\tpart1\ta stable check\tPASS\t18\t\nchecks run: 2\n' > "$_lw/before.log"
+printf 'RESULT\tdemo\tpart1\tthe new name\tPASS\t18\t\nRESULT\tdemo\tpart1\ta stable check\tPASS\t18\t\nchecks run: 2\n' > "$_lw/after.log"
 _led_run merge --reds-are-real --ledger "$_lw/ren.tsv" --date 2026-09-01 "$_lw/before.log" >/dev/null
 check "premise: the check has history before the rename" \
 	"$(awk -F'\t' '$3=="the old name"{print $4}' "$_lw/ren.tsv")" "2026-09-01"
@@ -211,8 +211,8 @@ check "a before-log and an after-log together are refused, not silently empty" \
 # Movement in ANOTHER part must not consume this part's pairing. That is what a
 # global positional zip gets wrong, and it fails silently.
 : > "$_lw/ren2.tsv"
-printf 'RESULT\tdemo\tpartA\told A\tPASS\t\nRESULT\tdemo\tpartB\tstable B\tPASS\t\nchecks run: 2\n' > "$_lw/b2.log"
-printf 'RESULT\tdemo\tpartA\tnew A\tPASS\t\nRESULT\tdemo\tpartB\tstable B\tPASS\t\nRESULT\tdemo\tpartB\tadded B\tPASS\t\nchecks run: 3\n' > "$_lw/a2.log"
+printf 'RESULT\tdemo\tpartA\told A\tPASS\t18\t\nRESULT\tdemo\tpartB\tstable B\tPASS\t18\t\nchecks run: 2\n' > "$_lw/b2.log"
+printf 'RESULT\tdemo\tpartA\tnew A\tPASS\t18\t\nRESULT\tdemo\tpartB\tstable B\tPASS\t18\t\nRESULT\tdemo\tpartB\tadded B\tPASS\t18\t\nchecks run: 3\n' > "$_lw/a2.log"
 _led_run merge --ledger "$_lw/ren2.tsv" --date 2026-09-10 "$_lw/b2.log" >/dev/null
 check "a rename in one part survives an addition in another" \
 	"$(_led_run rename-scan --ledger "$_lw/ren2.tsv" "$_lw/a2.log" \
@@ -221,10 +221,10 @@ check "and the addition in the other part is not called a rename" \
 	"$(_led_run rename-scan --ledger "$_lw/ren2.tsv" "$_lw/a2.log" | grep -c 'added B')" "0"
 
 # A check merely added, or merely removed, is not a rename.
-printf 'RESULT\tdemo\tpart1\tthe old name\tPASS\t\nRESULT\tdemo\tpart1\ta stable check\tPASS\t\nRESULT\tdemo\tpart1\tbrand new\tPASS\t\nchecks run: 3\n' > "$_lw/added.log"
+printf 'RESULT\tdemo\tpart1\tthe old name\tPASS\t18\t\nRESULT\tdemo\tpart1\ta stable check\tPASS\t18\t\nRESULT\tdemo\tpart1\tbrand new\tPASS\t18\t\nchecks run: 3\n' > "$_lw/added.log"
 check "a check merely added is not reported as a rename" \
 	"$(_led_run rename-scan --ledger "$_lw/ren.tsv" "$_lw/added.log" | grep -c 'possible rename')" "0"
-printf 'RESULT\tdemo\tpart1\ta stable check\tPASS\t\nchecks run: 1\n' > "$_lw/removed.log"
+printf 'RESULT\tdemo\tpart1\ta stable check\tPASS\t18\t\nchecks run: 1\n' > "$_lw/removed.log"
 check "nor is one merely removed" \
 	"$(_led_run rename-scan --ledger "$_lw/ren.tsv" "$_lw/removed.log" | grep -c 'possible rename')" "0"
 
@@ -242,8 +242,8 @@ check "nor is one merely removed" \
 # ledger was checked -- the shape of the whole issue family.
 
 : > "$_lw/orph.tsv"
-printf 'RESULT\tdemo\tpart1\tstill here\tPASS\t\nRESULT\tdemo\tpart1\tgone tomorrow\tPASS\t\nRESULT\tdemo\tpartZ\telsewhere\tPASS\t\nchecks run: 3\n' > "$_lw/o_before.log"
-printf 'RESULT\tdemo\tpart1\tstill here\tPASS\t\nchecks run: 1\n' > "$_lw/o_after.log"
+printf 'RESULT\tdemo\tpart1\tstill here\tPASS\t18\t\nRESULT\tdemo\tpart1\tgone tomorrow\tPASS\t18\t\nRESULT\tdemo\tpartZ\telsewhere\tPASS\t18\t\nchecks run: 3\n' > "$_lw/o_before.log"
+printf 'RESULT\tdemo\tpart1\tstill here\tPASS\t18\t\nchecks run: 1\n' > "$_lw/o_after.log"
 _led_run merge --ledger "$_lw/orph.tsv" --date 2026-09-01 "$_lw/o_before.log" >/dev/null
 check "premise: the ledger holds all three rows before the scan" \
 	"$(wc -l < "$_lw/orph.tsv" | tr -d ' ')" "3"
@@ -292,7 +292,7 @@ check "and a prune with nothing left to remove is clean, not an error" \
 # An orphan that has been seen red is the one case where deleting the row loses
 # something no run can recreate.
 : > "$_lw/hist.tsv"
-printf 'RESULT\tdemo\tpart1\tstill here\tPASS\t\nRESULT\tdemo\tpart1\tgone tomorrow\tFAIL\t\nchecks run: 2\n' > "$_lw/h_before.log"
+printf 'RESULT\tdemo\tpart1\tstill here\tPASS\t18\t\nRESULT\tdemo\tpart1\tgone tomorrow\tFAIL\t18\t\nchecks run: 2\n' > "$_lw/h_before.log"
 _led_run merge --reds-are-real --mutation "drop the guard" --ledger "$_lw/hist.tsv" \
 	--date 2026-09-01 "$_lw/h_before.log" >/dev/null
 check "premise: the orphan now carries a date and a mutation" \
@@ -331,8 +331,8 @@ check "the refusal says why, rather than only that it refused" \
 # that whole part, and that is the direction a deleting command should err in.
 
 : > "$_lw/skp.tsv"
-printf 'RESULT\tdemo\tpart1\tarm one\tPASS\t\nRESULT\tdemo\tpart1\tarm two\tPASS\t\nRESULT\tdemo\tpart1\tthe whole thing\tPASS\t\nchecks run: 3\n' > "$_lw/sk_full.log"
-printf 'RESULT\tdemo\tpart1\tthe whole thing\tSKIP\tno fixture on this box\nchecks run: 1\n' > "$_lw/sk_skipped.log"
+printf 'RESULT\tdemo\tpart1\tarm one\tPASS\t18\t\nRESULT\tdemo\tpart1\tarm two\tPASS\t18\t\nRESULT\tdemo\tpart1\tthe whole thing\tPASS\t18\t\nchecks run: 3\n' > "$_lw/sk_full.log"
+printf 'RESULT\tdemo\tpart1\tthe whole thing\tSKIP\t18\tno fixture on this box\nchecks run: 1\n' > "$_lw/sk_skipped.log"
 _led_run merge --ledger "$_lw/skp.tsv" --date 2026-09-01 "$_lw/sk_full.log" >/dev/null
 check "premise: the ledger holds all three of that part's rows" \
 	"$(wc -l < "$_lw/skp.tsv" | tr -d ' ')" "3"
@@ -357,7 +357,7 @@ check "and it says so rather than declining silently" \
 
 # CONTROL. Without this the arms above are satisfied by a tool that refuses to prune
 # anything at all, which is the failure mode of every over-broad guard.
-printf 'RESULT\tdemo\tpart1\tthe whole thing\tPASS\t\nchecks run: 1\n' > "$_lw/sk_pass.log"
+printf 'RESULT\tdemo\tpart1\tthe whole thing\tPASS\t18\t\nchecks run: 1\n' > "$_lw/sk_pass.log"
 check "control: the same two rows ARE pruned when that part's record is a PASS" \
 	"$(_led_run orphan-scan --prune --ledger "$_lw/skp.tsv" "$_lw/sk_pass.log" \
 		| grep -c 'removed 2 row(s)')" "1"
@@ -440,7 +440,7 @@ _led_run merge --ledger "$_lw/g.tsv" --date 2026-09-10 "$_lw/green.log" >/dev/nu
 printf 'suites_not_covered 0\n' > "$_lw/gb.txt"
 check "a run whose checks are all ledgered passes the gate" \
 	"$(_led_rc gate --ledger "$_lw/g.tsv" --budget "$_lw/gb.txt" --registered "$_lw/registered" "$_lw/green.log")" "0"
-printf 'RESULT\tdemo\tpart1\tfirst check\tPASS\t\nRESULT\tdemo\tpart1\tsecond check\tPASS\t\nRESULT\tdemo\tpart1\tbrand new\tPASS\t\nchecks run: 3\n' > "$_lw/new.log"
+printf 'RESULT\tdemo\tpart1\tfirst check\tPASS\t18\t\nRESULT\tdemo\tpart1\tsecond check\tPASS\t18\t\nRESULT\tdemo\tpart1\tbrand new\tPASS\t18\t\nchecks run: 3\n' > "$_lw/new.log"
 check "a check the ledger has never seen is refused" \
 	"$(_led_rc gate --ledger "$_lw/g.tsv" --budget "$_lw/gb.txt" --registered "$_lw/registered" "$_lw/new.log")" "1"
 check "and it is named, so the author knows which one" \
@@ -596,7 +596,7 @@ check "but the gate says so, so the skip is visible rather than silent" \
 # It tightens on its own as suites are seeded, and the ceiling forces that
 # direction.
 
-printf 'RESULT\tother\tpartX\tsomething\tPASS\t\nchecks run: 1\n' > "$_lw/othersuite.log"
+printf 'RESULT\tother\tpartX\tsomething\tPASS\t18\t\nchecks run: 1\n' > "$_lw/othersuite.log"
 printf 'demo\nother\n' > "$_lw/reg_both"
 printf 'suites_not_covered 1\n' > "$_lw/gb1.txt"
 check "a check in an UNCOVERED suite is not refused" \
@@ -608,7 +608,7 @@ check "but that suite is counted as not covered, which is the debt" \
 # And once the suite IS covered, a new check in it is refused again -- the
 # restriction tightens rather than exempting the suite forever.
 _led_run merge --ledger "$_lw/g.tsv" --date 2026-09-10 "$_lw/othersuite.log" >/dev/null
-printf 'RESULT\tother\tpartX\tsomething\tPASS\t\nRESULT\tother\tpartX\tnewly added\tPASS\t\nchecks run: 2\n' > "$_lw/other2.log"
+printf 'RESULT\tother\tpartX\tsomething\tPASS\t18\t\nRESULT\tother\tpartX\tnewly added\tPASS\t18\t\nchecks run: 2\n' > "$_lw/other2.log"
 printf 'suites_not_covered 0\n' > "$_lw/gb2.txt"
 check "once the suite is covered, a new check in it IS refused" \
 	"$(_led_rc gate --ledger "$_lw/g.tsv" --budget "$_lw/gb2.txt" --registered "$_lw/reg_both" "$_lw/other2.log")" "1"
@@ -638,7 +638,7 @@ _mono_budget="$PGC_TESTDIR/check_ledger_budget.txt"
 _mono_reg="$_lw/mono_reg"
 cut -f1 "$_ledger" | sort -u > "$_mono_reg"
 _mono_log="$_lw/mono.log"
-awk -F'\t' 'NR<=2 {printf "RESULT\t%s\t%s\t%s\tPASS\t\n", $1, $2, $3}' "$_ledger" > "$_mono_log"
+awk -F'\t' 'NR<=2 {printf "RESULT\t%s\t%s\t%s\tPASS\t18\t\n", $1, $2, $3}' "$_ledger" > "$_mono_log"
 # A log states its own count. read_records reconciles the two, so a fixture
 # without this line is not a log the ledger will accept -- which is the point.
 printf 'checks run: %s\n' "$(grep -c '^RESULT' "$_mono_log")" >> "$_mono_log"
@@ -803,7 +803,7 @@ _dist="$_lw/dist"; rm -rf "$_dist"; mkdir -p "$_dist"
   git branch -q oldbase
   for i in 1 2 3; do echo "x$i" > f; git add f; git commit -qm "c$i"; done ) >/dev/null 2>&1
 printf 's\tp\ta\tnever\t-\n' > "$_dist/led"
-printf 'RESULT\ts\tp\ta\tPASS\t\nchecks run: 1\n' > "$_dist/log"
+printf 'RESULT\ts\tp\ta\tPASS\t18\t\nchecks run: 1\n' > "$_dist/log"
 printf 's\n' > "$_dist/reg"
 
 check "premise: the scratch prior really is three commits behind" \
@@ -875,7 +875,7 @@ _rr="$_lw/refres"; rm -rf "$_rr"; mkdir -p "$_rr"
   git branch -q nobudget
   git checkout -q hasbudget ) >/dev/null 2>&1
 printf 's\tp\ta\tnever\t-\n' > "$_rr/led"
-printf 'RESULT\ts\tp\ta\tPASS\t\nchecks run: 1\n' > "$_rr/log"
+printf 'RESULT\ts\tp\ta\tPASS\t18\t\nchecks run: 1\n' > "$_rr/log"
 printf 's\n' > "$_rr/reg"
 
 check "premise: the hasbudget branch carries the budget" \
@@ -919,8 +919,8 @@ check "a ref that exists with the budget still compares" \
 # has to say which it is rather than the tool guessing.
 
 _r946="$PGC_WORKDIR/r946"; mkdir -p "$_r946"
-printf 'RESULT\tdemo\tp\tthe check\tFAIL\t\nRESULT\tdemo\tp\tother\tPASS\t\nchecks run: 2\n' > "$_r946/red.log"
-printf 'RESULT\tdemo\tp\tthe check\tPASS\t\nRESULT\tdemo\tp\tother\tPASS\t\nchecks run: 2\n' > "$_r946/green.log"
+printf 'RESULT\tdemo\tp\tthe check\tFAIL\t18\t\nRESULT\tdemo\tp\tother\tPASS\t18\t\nchecks run: 2\n' > "$_r946/red.log"
+printf 'RESULT\tdemo\tp\tthe check\tPASS\t18\t\nRESULT\tdemo\tp\tother\tPASS\t18\t\nchecks run: 2\n' > "$_r946/green.log"
 
 : > "$_r946/a.tsv"
 check "a log carrying a FAIL is refused when no reason is given" \


### PR DESCRIPTION
Step 1 of #1010. **The ledger is not keyed on the major here** -- that is step 2, and it
needs a migration this does not. What this does is make the log say which major it came
from, so the tool stops taking that on trust from its invoker.

    RESULT<TAB>suite<TAB>part<TAB>name<TAB>verdict<TAB>major<TAB>reason

## Why the major belongs in the record

A check's EXISTENCE depends on it, so a record that omits it identifies a check only
partly.

- `test/analyze_differential.sh:61` emits **one** record on PG15-17 (a `check_skip`, then
  `pgc_summary` exits) and a suite's worth on PG18+.
- `test/fk_referencing.sh:287` emits **different check NAMES** in its two branches, so the
  older and newer majors' key sets are disjoint rather than nested.

A grep for `PGC_MAJOR` does not find all of these, which is why this is a field and not a
convention: `test/native_repack.sh:48`, `test/pg19_vacuum_options.sh:34` and
`test/native_dml.sh:61` gate on `server_version_num` and never mention it.

Before this, the major could only come from whoever invoked the tool. That is the
`--date not-a-date` failure one field over -- a PG15 log merged as PG18 is misattributed
and nothing in the log can contradict it -- except worse, because a date is metadata about
an observation while a major decides which checks can exist.

## Measured

Two full matrices at `4d7c75ae`, `ALL VERSIONS PASSED` on both, 252 suite logs each:

```
union of keys     6472        (fuzz excluded, see below)
on both majors    6367
major-specific     105        1.62%, across 8 suites

suite                    pg15only pg18only   shared
analyze_differential            1       26        0
analyze_function                1       54        0
audit                           1        4       27
column_projection               1        1       37
fk_referencing                  1        2       24
generated_columns               0        6        5
native_sort_by                  0        2       16
temporal                        0        5        0
```

`analyze_differential` and `analyze_function` share **zero** keys across the two majors,
which is the shape predicted from reading the suite.

`fuzz` is excluded and that exclusion is its own finding: it interpolates its random
fixture into the check name, so it emits 250 brand-new keys every run -- `shared: 0`
between two runs on the **same** major with the **same** `PGC_SEED`. Filed as #1011.

## Validated, not stored

`eighteen`, `18.2`, `pg18` and an empty field are each refused, in both reconcilers --
`pgc_ledger.py read_records` and `run_all_versions.sh pgc_reconcile_records`, which answer
different questions (a log from another machine vs. the suite just run) and so each need
the check.

`unknown` is the one non-numeric value. It is `lib.sh`'s own word for a field the harness
did not set -- already used there for an unset suite and part -- and it is the common case
rather than a courtesy: **`harness_selftest` never references `PGC_MAJOR` anywhere**, so
all 544 of its records per run say `unknown`, truthfully.

## Test plan

- [x] Full matrix on PG18 and PG19 at `2559f0ec`. Every record carries a valid major:

      pg18: 6753 records, 0 with an invalid major, 0 not 6 fields
            majors seen: 6209 "18", 544 "unknown"
      pg19: 6785 records, 0 with an invalid major, 0 not 6 fields
            majors seen: 6241 "19", 544 "unknown"

- [x] The only matrix failure was the ledger gate naming the 9 new arms, which is the
      designed refusal. Fixed by the second commit, re-derived rather than computed.
- [x] Part 400's nine new arms: 9 PASS, part 400 90 PASS / 0 FAIL on PG18.
- [x] Emitter driven with `PGC_MAJOR` set to **two different values** and unset, so an arm
      cannot pass against a field hardcoded to either answer.
- [x] Four invalid majors each refused, with a well-formed `unknown` control -- without it
      the four prove only that the reconciler started refusing everything.
- [x] `pytest` corpus failure set **identical to main** (106 both, zero delta; all 106 are
      the absent `psycopg` in a guard-only venv).
- [x] `docs_style.sh` PASSED, 9 checks.

## What I had to fix in my own work, since it is the interesting part

Widening 79 record fixtures with one regex corrupted exactly the fixtures that matter:
four **negative** ones (a six-field record whose refusal an arm asserts became valid), the
`BOGUS`-verdict fixture (skipped by the regex, so it silently became a field-count failure
and stopped testing the verdict), and **my own two new tests**, appended minutes earlier,
which got a second major. The controls are what caught it.

## Not in this PR

Keying the ledger on the major, the migration, and the census restatement. Step 2, and
#1010 carries a measured argument about its cost that is worth reading before it lands:
6,367 of 6,472 checks are identical on both majors, so `(major, suite, part, name)` stores
one fact five times for 98% of the ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf6UoeBRZYLQZa4KxNiw8a
