### PR TITLE
test: a BOGUS verdict is refused by name, not by field count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -654,6 +654,8 @@ true until the next version shipped.
 
 ### Fixed
 
+- A BOGUS-verdict ledger record is refused by naming the verdict, not by field count (#1013).
+
 - The star-schema join how-to names clustering on the join key (#752).
 
   Group skip was already measured: 19 of 20 groups when the keys are local,

--- a/test/pytest/TESTS.md
+++ b/test/pytest/TESTS.md
@@ -2253,6 +2253,8 @@ outside `pgc_record`'s vocabulary, an empty check name, one record against
 absorbed as evidence a log that does not parse, which is how an observation gets
 attributed to a check that never ran. Five refusals and a control, because five
 arms all reporting rc=2 prove nothing if the tool has started refusing everything.
+The BOGUS-verdict refusal names the verdict, so a field-count failure cannot satisfy
+the arm.
 
 ### `test_last_red_may_only_move_forward`
 

--- a/test/pytest/test_mutation_ledger.py
+++ b/test/pytest/test_mutation_ledger.py
@@ -507,7 +507,7 @@ def test_a_log_that_does_not_parse_is_not_evidence(tmp_path, expect):
     led = _w(tmp_path, "l.tsv", "")
     cases = {
         "no reason field": "RESULT\tdemo\tpart1\ta name\tPASS\nchecks run: 1\n",
-        "a verdict the emitter cannot emit": "RESULT\tdemo\tpart1\ta name\tBOGUS\t\nchecks run: 1\n",
+        "a verdict the emitter cannot emit": "RESULT\tdemo\tpart1\ta name\tBOGUS\t18\t\nchecks run: 1\n",
         "an empty check name": "RESULT\tdemo\tpart1\t\tPASS\t18\t\nchecks run: 1\n",
         "a count that disagrees with the records": "RESULT\tdemo\tpart1\ta name\tPASS\t18\t\nchecks run: 2\n",
         "no count at all": "RESULT\tdemo\tpart1\ta name\tPASS\t18\t\n",
@@ -516,6 +516,14 @@ def test_a_log_that_does_not_parse_is_not_evidence(tmp_path, expect):
         log = _w(tmp_path, "bad.log", text)
         expect.num(_run("merge", "--ledger", led, "--date", "2026-09-10", log)[1], 2,
                    f"{label} is an integrity failure, not a merge")
+
+    # A six-field BOGUS record is a field-count failure, and that is not this
+    # arm. The message has to name the verdict or the arm stopped testing it.
+    bogus = _w(tmp_path, "bogus.log",
+               cases["a verdict the emitter cannot emit"])
+    out, _rc = _run("merge", "--ledger", led, "--date", "2026-09-10", bogus)
+    expect.num(out.count("'BOGUS'"), 1,
+               "and it names the verdict, so the author knows which record")
 
     # THE CONTROL. Five arms all reporting 2 prove nothing if the tool has simply
     # started refusing every log.


### PR DESCRIPTION
## Summary

- Leftover from #1013: `test_a_log_that_does_not_parse_is_not_evidence` still fed a six-field `BOGUS` record, so merge failed on field count before the verdict was examined. `410-a-check-must-have-been-red.sh` already widened its fixture and greps for `'BOGUS'`.
- The pytest arm now asserts the refusal names the verdict, then uses a seven-field record. Red first (got 0 want 1), then green. Causation: dropping the major field turns that assertion red again.

## Test plan

- [x] `test_mutation_ledger.py::test_a_log_that_does_not_parse_is_not_evidence` red, then green, then causation red, then restored green
- [x] full `test_mutation_ledger.py` 19 passed
- [x] `test_docs_cover_the_corpus.py` passed
- [x] `docs_style.sh` passed


Made with [Cursor](https://cursor.com)